### PR TITLE
dynamic_modules: added host information callbacks for dynamic module clusters LB

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -31,6 +31,38 @@ getContext(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_
   return static_cast<Envoy::Upstream::LoadBalancerContext*>(context_envoy_ptr);
 }
 
+// Helper to look up a metadata value by filter name and key for a host in the cluster priority set.
+const Envoy::Protobuf::Value*
+getClusterHostMetadataValue(envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+                            uint32_t priority, size_t index,
+                            envoy_dynamic_module_type_module_buffer filter_name,
+                            envoy_dynamic_module_type_module_buffer key) {
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return nullptr;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return nullptr;
+  }
+  const auto& metadata = hosts[index]->metadata();
+  if (metadata == nullptr) {
+    return nullptr;
+  }
+  const auto& filter_metadata = metadata->filter_metadata();
+  absl::string_view filter_name_view(filter_name.ptr, filter_name.length);
+  auto filter_it = filter_metadata.find(filter_name_view);
+  if (filter_it == filter_metadata.end()) {
+    return nullptr;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  auto field_it = filter_it->second.fields().find(key_view);
+  if (field_it == filter_it->second.fields().end()) {
+    return nullptr;
+  }
+  return &field_it->second;
+}
+
 Envoy::Stats::StatNameTagVector buildTagsForClusterMetric(
     Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterConfig& config,
     const Envoy::Stats::StatNameVec& label_names,
@@ -90,27 +122,450 @@ void envoy_dynamic_module_callback_cluster_pre_init_complete(
 
 size_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority) {
-  auto* lb = getLb(lb_envoy_ptr);
-  const auto& priority_set = lb->prioritySet();
-  if (priority >= priority_set.hostSetsPerPriority().size()) {
+  if (lb_envoy_ptr == nullptr) {
     return 0;
   }
-  return priority_set.hostSetsPerPriority()[priority]->healthyHosts().size();
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  return host_sets[priority]->healthyHosts().size();
 }
 
 envoy_dynamic_module_type_cluster_host_envoy_ptr
 envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
-  auto* lb = getLb(lb_envoy_ptr);
-  const auto& priority_set = lb->prioritySet();
-  if (priority >= priority_set.hostSetsPerPriority().size()) {
+  if (lb_envoy_ptr == nullptr) {
     return nullptr;
   }
-  const auto& healthy_hosts = priority_set.hostSetsPerPriority()[priority]->healthyHosts();
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return nullptr;
+  }
+  const auto& healthy_hosts = host_sets[priority]->healthyHosts();
   if (index >= healthy_hosts.size()) {
     return nullptr;
   }
   return const_cast<Envoy::Upstream::Host*>(healthy_hosts[index].get());
+}
+
+// =============================================================================
+// Cluster LB Host Information Callbacks
+// =============================================================================
+
+void envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return;
+  }
+  const auto& name = getLb(lb_envoy_ptr)->handle()->cluster()->info()->observabilityName();
+  result->ptr = name.data();
+  result->length = name.size();
+}
+
+size_t envoy_dynamic_module_callback_cluster_lb_get_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  return host_sets[priority]->hosts().size();
+}
+
+size_t envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  return host_sets[priority]->degradedHosts().size();
+}
+
+size_t envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  return getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority().size();
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& healthy_hosts = host_sets[priority]->healthyHosts();
+  if (index >= healthy_hosts.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& address_str = healthy_hosts[index]->address()->asStringView();
+  result->ptr = address_str.data();
+  result->length = address_str.size();
+  return true;
+}
+
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto& healthy_hosts = host_sets[priority]->healthyHosts();
+  if (index >= healthy_hosts.size()) {
+    return 0;
+  }
+  return healthy_hosts[index]->weight();
+}
+
+envoy_dynamic_module_type_host_health envoy_dynamic_module_callback_cluster_lb_get_host_health(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
+  if (lb_envoy_ptr == nullptr) {
+    return envoy_dynamic_module_type_host_health_Unhealthy;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return envoy_dynamic_module_type_host_health_Unhealthy;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return envoy_dynamic_module_type_host_health_Unhealthy;
+  }
+  switch (hosts[index]->coarseHealth()) {
+  case Envoy::Upstream::Host::Health::Unhealthy:
+    return envoy_dynamic_module_type_host_health_Unhealthy;
+  case Envoy::Upstream::Host::Health::Degraded:
+    return envoy_dynamic_module_type_host_health_Degraded;
+  case Envoy::Upstream::Host::Health::Healthy:
+    return envoy_dynamic_module_type_host_health_Healthy;
+  }
+  return envoy_dynamic_module_type_host_health_Unhealthy;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer address,
+    envoy_dynamic_module_type_host_health* result) {
+  if (result == nullptr) {
+    return false;
+  }
+  *result = envoy_dynamic_module_type_host_health_Unhealthy;
+
+  if (lb_envoy_ptr == nullptr || address.ptr == nullptr) {
+    return false;
+  }
+  const auto host_map = getLb(lb_envoy_ptr)->prioritySet().crossPriorityHostMap();
+  if (host_map == nullptr) {
+    return false;
+  }
+  std::string address_str(address.ptr, address.length);
+  const auto it = host_map->find(address_str);
+  if (it == host_map->end()) {
+    return false;
+  }
+  switch (it->second->coarseHealth()) {
+  case Envoy::Upstream::Host::Health::Unhealthy:
+    *result = envoy_dynamic_module_type_host_health_Unhealthy;
+    break;
+  case Envoy::Upstream::Host::Health::Degraded:
+    *result = envoy_dynamic_module_type_host_health_Degraded;
+    break;
+  case Envoy::Upstream::Host::Health::Healthy:
+    *result = envoy_dynamic_module_type_host_health_Healthy;
+    break;
+  }
+  return true;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& address_str = hosts[index]->address()->asStringView();
+  result->ptr = address_str.data();
+  result->length = address_str.size();
+  return true;
+}
+
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return 0;
+  }
+  return hosts[index]->weight();
+}
+
+uint64_t envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_host_stat stat) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return 0;
+  }
+  const auto& host_stats = hosts[index]->stats();
+  switch (stat) {
+  case envoy_dynamic_module_type_host_stat_CxConnectFail:
+    return host_stats.cx_connect_fail_.value();
+  case envoy_dynamic_module_type_host_stat_CxTotal:
+    return host_stats.cx_total_.value();
+  case envoy_dynamic_module_type_host_stat_RqError:
+    return host_stats.rq_error_.value();
+  case envoy_dynamic_module_type_host_stat_RqSuccess:
+    return host_stats.rq_success_.value();
+  case envoy_dynamic_module_type_host_stat_RqTimeout:
+    return host_stats.rq_timeout_.value();
+  case envoy_dynamic_module_type_host_stat_RqTotal:
+    return host_stats.rq_total_.value();
+  case envoy_dynamic_module_type_host_stat_CxActive:
+    return host_stats.cx_active_.value();
+  case envoy_dynamic_module_type_host_stat_RqActive:
+    return host_stats.rq_active_.value();
+  }
+  return 0;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_locality(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* region, envoy_dynamic_module_type_envoy_buffer* zone,
+    envoy_dynamic_module_type_envoy_buffer* sub_zone) {
+  if (lb_envoy_ptr == nullptr) {
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return false;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return false;
+  }
+  const auto& locality = hosts[index]->locality();
+  if (region != nullptr) {
+    region->ptr = locality.region().data();
+    region->length = locality.region().size();
+  }
+  if (zone != nullptr) {
+    zone->ptr = locality.zone().data();
+    zone->length = locality.zone().size();
+  }
+  if (sub_zone != nullptr) {
+    sub_zone->ptr = locality.sub_zone().data();
+    sub_zone->length = locality.sub_zone().size();
+  }
+  return true;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_set_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    uintptr_t data) {
+  if (lb_envoy_ptr == nullptr) {
+    return false;
+  }
+  return getLb(lb_envoy_ptr)->setHostData(priority, index, data);
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    uintptr_t* data) {
+  if (lb_envoy_ptr == nullptr || data == nullptr) {
+    if (data != nullptr) {
+      *data = 0;
+    }
+    return false;
+  }
+  return getLb(lb_envoy_ptr)->getHostData(priority, index, data);
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return false;
+  }
+  const auto* value = getClusterHostMetadataValue(lb_envoy_ptr, priority, index, filter_name, key);
+  if (value == nullptr || !value->has_string_value()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& str = value->string_value();
+  result->ptr = str.data();
+  result->length = str.size();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, double* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    return false;
+  }
+  const auto* value = getClusterHostMetadataValue(lb_envoy_ptr, priority, index, filter_name, key);
+  if (value == nullptr || !value->has_number_value()) {
+    return false;
+  }
+  *result = value->number_value();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, bool* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    return false;
+  }
+  const auto* value = getClusterHostMetadataValue(lb_envoy_ptr, priority, index, filter_name, key);
+  if (value == nullptr || !value->has_bool_value()) {
+    return false;
+  }
+  *result = value->bool_value();
+  return true;
+}
+
+size_t envoy_dynamic_module_callback_cluster_lb_get_locality_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  return host_sets[priority]->healthyHostsPerLocality().get().size();
+}
+
+size_t envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto& localities = host_sets[priority]->healthyHostsPerLocality().get();
+  if (locality_index >= localities.size()) {
+    return 0;
+  }
+  return localities[locality_index].size();
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index, size_t host_index, envoy_dynamic_module_type_envoy_buffer* result) {
+  if (lb_envoy_ptr == nullptr || result == nullptr) {
+    if (result != nullptr) {
+      result->ptr = nullptr;
+      result->length = 0;
+    }
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& localities = host_sets[priority]->healthyHostsPerLocality().get();
+  if (locality_index >= localities.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& hosts = localities[locality_index];
+  if (host_index >= hosts.size()) {
+    result->ptr = nullptr;
+    result->length = 0;
+    return false;
+  }
+  const auto& address_str = hosts[host_index]->address()->asStringView();
+  result->ptr = address_str.data();
+  result->length = address_str.size();
+  return true;
+}
+
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_locality_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index) {
+  if (lb_envoy_ptr == nullptr) {
+    return 0;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return 0;
+  }
+  const auto weights = host_sets[priority]->localityWeights();
+  if (weights == nullptr || locality_index >= weights->size()) {
+    return 0;
+  }
+  return (*weights)[locality_index];
 }
 
 bool envoy_dynamic_module_callback_cluster_lb_context_compute_hash_key(

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -409,6 +409,42 @@ const Upstream::PrioritySet& DynamicModuleLoadBalancer::prioritySet() const {
   return handle_->cluster_->prioritySet();
 }
 
+bool DynamicModuleLoadBalancer::setHostData(uint32_t priority, size_t index, uintptr_t data) {
+  const auto& host_sets = prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return false;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return false;
+  }
+  if (data == 0) {
+    per_host_data_.erase({priority, index});
+  } else {
+    per_host_data_[{priority, index}] = data;
+  }
+  return true;
+}
+
+bool DynamicModuleLoadBalancer::getHostData(uint32_t priority, size_t index,
+                                            uintptr_t* data) const {
+  const auto& host_sets = prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return false;
+  }
+  const auto& hosts = host_sets[priority]->hosts();
+  if (index >= hosts.size()) {
+    return false;
+  }
+  auto it = per_host_data_.find({priority, index});
+  if (it != per_host_data_.end()) {
+    *data = it->second;
+  } else {
+    *data = 0;
+  }
+  return true;
+}
+
 // =================================================================================================
 // DynamicModuleClusterFactory
 // =================================================================================================

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -446,9 +446,16 @@ public:
   // Access the handle for async host selection completion.
   const DynamicModuleClusterHandleSharedPtr& handle() const { return handle_; }
 
+  // Per-host custom data storage.
+  bool setHostData(uint32_t priority, size_t index, uintptr_t data);
+  bool getHostData(uint32_t priority, size_t index, uintptr_t* data) const;
+
 private:
   const DynamicModuleClusterHandleSharedPtr handle_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
+
+  // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
+  absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;
 };
 
 /**

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -7752,6 +7752,45 @@ bool envoy_dynamic_module_callback_bootstrap_extension_remove_admin_handler(
     envoy_dynamic_module_type_module_buffer path_prefix);
 
 // =============================================================================
+// Common Host Types (shared by cluster and standalone load balancer extensions)
+// =============================================================================
+
+/**
+ * envoy_dynamic_module_type_host_health represents the health status of an upstream host.
+ */
+typedef enum {
+  // Host is unhealthy and should not be used for traffic.
+  envoy_dynamic_module_type_host_health_Unhealthy = 0,
+  // Host is healthy but degraded. It can receive traffic but healthy hosts are preferred.
+  envoy_dynamic_module_type_host_health_Degraded = 1,
+  // Host is healthy and can receive traffic.
+  envoy_dynamic_module_type_host_health_Healthy = 2,
+} envoy_dynamic_module_type_host_health;
+
+/**
+ * envoy_dynamic_module_type_host_stat identifies a per-host stat.
+ * These correspond to the counters and gauges in Envoy's HostStats struct.
+ */
+typedef enum {
+  // Counter: total connection connect failures.
+  envoy_dynamic_module_type_host_stat_CxConnectFail = 0,
+  // Counter: total connections opened.
+  envoy_dynamic_module_type_host_stat_CxTotal = 1,
+  // Counter: total request errors (used for EDS load reporting).
+  envoy_dynamic_module_type_host_stat_RqError = 2,
+  // Counter: total successful requests (used for EDS load reporting).
+  envoy_dynamic_module_type_host_stat_RqSuccess = 3,
+  // Counter: total request timeouts.
+  envoy_dynamic_module_type_host_stat_RqTimeout = 4,
+  // Counter: total requests sent.
+  envoy_dynamic_module_type_host_stat_RqTotal = 5,
+  // Gauge: current active connections.
+  envoy_dynamic_module_type_host_stat_CxActive = 6,
+  // Gauge: current active requests.
+  envoy_dynamic_module_type_host_stat_RqActive = 7,
+} envoy_dynamic_module_type_host_stat;
+
+// =============================================================================
 // ============================ Cluster Extension ==============================
 // =============================================================================
 
@@ -8143,6 +8182,312 @@ size_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(
 envoy_dynamic_module_type_cluster_host_envoy_ptr
 envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
+
+// =============================================================================
+// Cluster LB Host Information Callbacks
+// =============================================================================
+//
+// These callbacks provide the cluster load balancer with access to host
+// information from the cluster's priority set. They mirror the standalone load
+// balancer's host information callbacks (envoy_dynamic_module_callback_lb_*)
+// but operate on the cluster_lb_envoy_ptr instead.
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_cluster_name returns the name of the cluster.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param result is the output for the cluster name. The buffer is owned by Envoy.
+ */
+void envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_hosts_count returns the number of all hosts
+ * at a given priority level, regardless of health status.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level to query.
+ * @return the number of all hosts at the given priority.
+ */
+size_t envoy_dynamic_module_callback_cluster_lb_get_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count returns the number of degraded
+ * hosts at a given priority level.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level to query.
+ * @return the number of degraded hosts at the given priority.
+ */
+size_t envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_priority_set_size returns the number of priority
+ * levels in the cluster.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @return the number of priority levels.
+ */
+size_t envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address returns the address of a host
+ * by index within the healthy hosts at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within healthy hosts.
+ * @param result is the output for the host address as a string.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight returns the load balancing
+ * weight of a host by index within the healthy hosts at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within healthy hosts.
+ * @return the weight of the host (1-128), or 0 if the host was not found.
+ */
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_health returns the health status of a host
+ * by index within all hosts at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @return the health status of the host.
+ */
+envoy_dynamic_module_type_host_health envoy_dynamic_module_callback_cluster_lb_get_host_health(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address looks up a host by its
+ * address string across all priorities and returns the health status. This uses the cross-priority
+ * host map internally, providing O(1) lookup by address.
+ *
+ * The address string must match the format ``ip:port`` (e.g., ``10.0.0.1:8080``).
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param address is the address string to look up, owned by the module.
+ * @param result is the output for the health status of the host.
+ * @return true if the host was found, false if the address is not in the host map.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer address, envoy_dynamic_module_type_host_health* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_address returns the address of a host
+ * by index within all hosts at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param result is the output for the host address as a string.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_weight returns the load balancing weight
+ * of a host by index within all hosts at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @return the weight of the host (1-128), or 0 if the host was not found.
+ */
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_stat returns the value of a per-host stat
+ * identified by the stat enum. This provides access to host-level counters and gauges such as
+ * total connections, request errors, active requests, and active connections.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param stat is the host stat to query.
+ * @return the stat value, or 0 if the host was not found or the stat is invalid.
+ */
+uint64_t envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_host_stat stat);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_locality returns the locality information
+ * (region, zone, sub_zone) for a host by index within all hosts at a given priority.
+ * This enables zone-aware and locality-aware load balancing algorithms.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param region is the output for the region string. Can be null if not needed.
+ * @param zone is the output for the zone string. Can be null if not needed.
+ * @param sub_zone is the output for the sub-zone string. Can be null if not needed.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_locality(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_envoy_buffer* region, envoy_dynamic_module_type_envoy_buffer* zone,
+    envoy_dynamic_module_type_envoy_buffer* sub_zone);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_set_host_data stores a module-defined opaque value on a
+ * host identified by priority and index within all hosts. This data is stored per load balancer
+ * instance (i.e., per worker thread) and can be used to attach per-host state for load balancing
+ * decisions such as moving averages or request tracking.
+ *
+ * The data is only valid for the lifetime of the load balancer instance. It is not shared across
+ * worker threads. Callers are responsible for managing the memory pointed to by the stored value
+ * if it represents a pointer.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param data is the opaque value to store. Use 0 to clear the data.
+ * @return true if the data was stored successfully, false if the host was not found.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_set_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    uintptr_t data);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_data retrieves a module-defined opaque value
+ * previously stored on a host via envoy_dynamic_module_callback_cluster_lb_set_host_data.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param data is the output for the stored opaque value. Set to 0 if no data was stored.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    uintptr_t* data);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string is called by the module to get
+ * the string value of a host's endpoint metadata by looking up the given filter name and key.
+ * If the key does not exist or the value is not a string, this returns false.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param filter_name is the filter namespace to look up (e.g., ``envoy.lb``).
+ * @param key is the key within the filter namespace.
+ * @param result is the output for the string value. The buffer is owned by Envoy and is valid
+ * until the end of the current event hook.
+ * @return true if the key was found and the value is a string, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number is called by the module to get
+ * the number value of a host's endpoint metadata by looking up the given filter name and key.
+ * If the key does not exist or the value is not a number, this returns false.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param filter_name is the filter namespace to look up (e.g., ``envoy.lb``).
+ * @param key is the key within the filter namespace.
+ * @param result is the output for the number value.
+ * @return true if the key was found and the value is a number, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, double* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool is called by the module to get
+ * the bool value of a host's endpoint metadata by looking up the given filter name and key.
+ * If the key does not exist or the value is not a bool, this returns false.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param index is the index of the host within all hosts.
+ * @param filter_name is the filter namespace to look up (e.g., ``envoy.lb``).
+ * @param key is the key within the filter namespace.
+ * @param result is the output for the bool value.
+ * @return true if the key was found and the value is a bool, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer key, bool* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_locality_count returns the number of locality
+ * buckets for the healthy hosts at a given priority. Each bucket groups hosts that share the same
+ * locality.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @return the number of locality buckets at the given priority.
+ */
+size_t envoy_dynamic_module_callback_cluster_lb_get_locality_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_locality_host_count returns the number of healthy
+ * hosts in a specific locality bucket at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param locality_index is the index of the locality bucket.
+ * @return the number of hosts in the locality bucket, or 0 if the index is out of bounds.
+ */
+size_t envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_locality_host_address returns the address of a host
+ * within a specific locality bucket at a given priority.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param locality_index is the index of the locality bucket.
+ * @param host_index is the index of the host within the locality bucket.
+ * @param result is the output for the host address as a string.
+ * @return true if the host was found, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index, size_t host_index, envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_locality_weight returns the weight of a locality
+ * bucket at a given priority. Locality weights are used for locality-aware load balancing.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param priority is the priority level.
+ * @param locality_index is the index of the locality bucket.
+ * @return the weight of the locality, or 0 if the index is out of bounds or weights are not set.
+ */
+uint32_t envoy_dynamic_module_callback_cluster_lb_get_locality_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    size_t locality_index);
 
 /**
  * envoy_dynamic_module_callback_cluster_scheduler_new creates a new scheduler for the given
@@ -8554,37 +8899,6 @@ typedef const void* envoy_dynamic_module_type_lb_module_ptr;
  */
 typedef void* envoy_dynamic_module_type_lb_context_envoy_ptr;
 
-/**
- * envoy_dynamic_module_type_host_health represents the health status of an upstream host.
- */
-typedef enum {
-  // Host is unhealthy and should not be used for traffic.
-  envoy_dynamic_module_type_host_health_Unhealthy = 0,
-  // Host is healthy but degraded. It can receive traffic but healthy hosts are preferred.
-  envoy_dynamic_module_type_host_health_Degraded = 1,
-  // Host is healthy and can receive traffic.
-  envoy_dynamic_module_type_host_health_Healthy = 2,
-} envoy_dynamic_module_type_host_health;
-
-/**
- * envoy_dynamic_module_type_host_counter_stat identifies a per-host counter stat.
- * These correspond to the counters in Envoy's HostStats struct.
- */
-typedef enum {
-  // Total connection connect failures.
-  envoy_dynamic_module_type_host_counter_stat_CxConnectFail = 0,
-  // Total connections opened.
-  envoy_dynamic_module_type_host_counter_stat_CxTotal = 1,
-  // Total request errors (used for EDS load reporting).
-  envoy_dynamic_module_type_host_counter_stat_RqError = 2,
-  // Total successful requests (used for EDS load reporting).
-  envoy_dynamic_module_type_host_counter_stat_RqSuccess = 3,
-  // Total request timeouts.
-  envoy_dynamic_module_type_host_counter_stat_RqTimeout = 4,
-  // Total requests sent.
-  envoy_dynamic_module_type_host_counter_stat_RqTotal = 5,
-} envoy_dynamic_module_type_host_counter_stat;
-
 // =============================================================================
 // Load Balancer Event Hooks
 // =============================================================================
@@ -8813,32 +9127,6 @@ bool envoy_dynamic_module_callback_lb_get_host_address(
  * @return the weight of the host (1-128), or 0 if the host was not found.
  */
 uint32_t envoy_dynamic_module_callback_lb_get_host_weight(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
-
-/**
- * envoy_dynamic_module_callback_lb_get_host_active_requests returns the number of active
- * requests for a host by index within all hosts at a given priority. This is essential for
- * implementing least-request, peak EWMA, and similar load balancing algorithms.
- *
- * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
- * @param priority is the priority level.
- * @param index is the index of the host within all hosts.
- * @return the number of active requests, or 0 if the host was not found.
- */
-uint64_t envoy_dynamic_module_callback_lb_get_host_active_requests(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
-
-/**
- * envoy_dynamic_module_callback_lb_get_host_active_connections returns the number of active
- * connections for a host by index within all hosts at a given priority. This is useful for
- * connection-aware load balancing decisions.
- *
- * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
- * @param priority is the priority level.
- * @param index is the index of the host within all hosts.
- * @return the number of active connections, or 0 if the host was not found.
- */
-uint64_t envoy_dynamic_module_callback_lb_get_host_active_connections(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
 
 /**
@@ -9128,19 +9416,20 @@ bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
     envoy_dynamic_module_type_envoy_buffer* result);
 
 /**
- * envoy_dynamic_module_callback_lb_get_host_counter_stat returns the value of a per-host counter
- * stat identified by the stat enum. This provides access to host-level counters such as total
- * connections, request errors, and request totals.
+ * envoy_dynamic_module_callback_lb_get_host_stat returns the value of a per-host stat
+ * identified by the stat enum. This provides access to host-level counters and gauges such as
+ * total connections, request errors, active requests, and active connections.
  *
  * @param lb_envoy_ptr is the pointer to the Envoy load balancer object.
  * @param priority is the priority level.
  * @param index is the index of the host within all hosts.
- * @param stat is the counter stat to query.
- * @return the counter value, or 0 if the host was not found or the stat is invalid.
+ * @param stat is the host stat to query.
+ * @return the stat value, or 0 if the host was not found or the stat is invalid.
  */
-uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
-    envoy_dynamic_module_type_host_counter_stat stat);
+uint64_t
+envoy_dynamic_module_callback_lb_get_host_stat(envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+                                               uint32_t priority, size_t index,
+                                               envoy_dynamic_module_type_host_stat stat);
 
 // =============================================================================
 // Load Balancer Callbacks - Metrics

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -396,6 +396,164 @@ envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   return nullptr;
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_cluster_name: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_lb_get_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_hosts_count: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_priority_set_size: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) uint32_t envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) envoy_dynamic_module_type_host_health
+envoy_dynamic_module_callback_cluster_lb_get_host_health(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_health: "
+               "not implemented in this context");
+  return envoy_dynamic_module_type_host_health_Unhealthy;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_host_health*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_address: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) uint32_t envoy_dynamic_module_callback_cluster_lb_get_host_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_weight: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) uint64_t envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_host_stat) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_stat: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_locality(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_envoy_buffer*, envoy_dynamic_module_type_envoy_buffer*,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_locality: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_set_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t, uintptr_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_set_host_data: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_data(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t, uintptr_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_data: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer, double*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer, bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_lb_get_locality_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_locality_count: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_locality_host_count: "
+               "not implemented in this context");
+  return 0;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t, size_t,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_locality_host_address: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) uint32_t envoy_dynamic_module_callback_cluster_lb_get_locality_weight(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_locality_weight: "
+               "not implemented in this context");
+  return 0;
+}
+
 __attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_context_compute_hash_key(
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr, uint64_t*) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_context_compute_hash_key: "
@@ -646,20 +804,6 @@ __attribute__((weak)) uint32_t envoy_dynamic_module_callback_lb_get_host_weight(
   return 0;
 }
 
-__attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_active_requests(
-    envoy_dynamic_module_type_lb_envoy_ptr, uint32_t, size_t) {
-  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_active_requests: "
-               "not implemented in this context");
-  return 0;
-}
-
-__attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_active_connections(
-    envoy_dynamic_module_type_lb_envoy_ptr, uint32_t, size_t) {
-  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_active_connections: "
-               "not implemented in this context");
-  return 0;
-}
-
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_lb_get_host_locality(envoy_dynamic_module_type_lb_envoy_ptr, uint32_t,
                                                    size_t, envoy_dynamic_module_type_envoy_buffer*,
@@ -800,11 +944,9 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_lb_get_member_update_ho
   return false;
 }
 
-__attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
-    envoy_dynamic_module_type_lb_envoy_ptr, uint32_t, size_t,
-    envoy_dynamic_module_type_host_counter_stat) {
-  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_counter_stat: "
-               "not implemented in this context");
+__attribute__((weak)) uint64_t envoy_dynamic_module_callback_lb_get_host_stat(
+    envoy_dynamic_module_type_lb_envoy_ptr, uint32_t, size_t, envoy_dynamic_module_type_host_stat) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_lb_get_host_stat: not implemented in this context");
   return 0;
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -243,6 +243,10 @@ pub trait EnvoyCluster: Send + Sync {
 }
 
 /// Envoy-side load balancer operations available to the module.
+///
+/// This trait provides access to the cluster's host set for load balancing decisions.
+/// It mirrors the standalone load balancer's [`EnvoyLoadBalancer`] trait, operating on the
+/// cluster's priority set.
 #[automock]
 pub trait EnvoyClusterLoadBalancer: Send {
   /// Get the number of healthy hosts at the given priority level.
@@ -256,6 +260,118 @@ pub trait EnvoyClusterLoadBalancer: Send {
     priority: u32,
     index: usize,
   ) -> Option<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>;
+
+  /// Returns the cluster name.
+  fn get_cluster_name(&self) -> String;
+
+  /// Returns the number of all hosts at a given priority, regardless of health status.
+  fn get_hosts_count(&self, priority: u32) -> usize;
+
+  /// Returns the number of degraded hosts at a given priority.
+  fn get_degraded_hosts_count(&self, priority: u32) -> usize;
+
+  /// Returns the number of priority levels in the cluster.
+  fn get_priority_set_size(&self) -> usize;
+
+  /// Returns the address of a healthy host by index at a given priority.
+  fn get_healthy_host_address(&self, priority: u32, index: usize) -> Option<String>;
+
+  /// Returns the weight of a healthy host by index at a given priority.
+  fn get_healthy_host_weight(&self, priority: u32, index: usize) -> u32;
+
+  /// Returns the health status of a host by index within all hosts at a given priority.
+  fn get_host_health(
+    &self,
+    priority: u32,
+    index: usize,
+  ) -> abi::envoy_dynamic_module_type_host_health;
+
+  /// Looks up a host by its address string across all priorities and returns its health status.
+  /// This provides O(1) lookup by address using the cross-priority host map.
+  ///
+  /// The address must match the format "ip:port" (e.g., "10.0.0.1:8080").
+  fn get_host_health_by_address(
+    &self,
+    address: &str,
+  ) -> Option<abi::envoy_dynamic_module_type_host_health>;
+
+  /// Returns the address of a host by index within all hosts at a given priority.
+  fn get_host_address(&self, priority: u32, index: usize) -> Option<String>;
+
+  /// Returns the weight of a host by index within all hosts at a given priority.
+  fn get_host_weight(&self, priority: u32, index: usize) -> u32;
+
+  /// Returns the value of a per-host stat. This provides access to host-level counters and gauges
+  /// such as total connections, request errors, active requests, and active connections.
+  fn get_host_stat(
+    &self,
+    priority: u32,
+    index: usize,
+    stat: abi::envoy_dynamic_module_type_host_stat,
+  ) -> u64;
+
+  /// Returns the locality information (region, zone, sub_zone) for a host by index within all
+  /// hosts at a given priority. This enables zone-aware and locality-aware load balancing.
+  fn get_host_locality(&self, priority: u32, index: usize) -> Option<(String, String, String)>;
+
+  /// Stores an opaque value on a host identified by priority and index. This data is stored per
+  /// load balancer instance (per worker thread) and can be used for per-host state such as moving
+  /// averages or request tracking. Use 0 to clear the data.
+  fn set_host_data(&self, priority: u32, index: usize, data: usize) -> bool;
+
+  /// Retrieves a previously stored opaque value for a host. Returns `None` if the host was not
+  /// found. Returns `Some(0)` if the host exists but no data was stored.
+  fn get_host_data(&self, priority: u32, index: usize) -> Option<usize>;
+
+  /// Returns the string metadata value for a host by looking up the given filter name and key in
+  /// the host's endpoint metadata. Returns `None` if the key was not found or the value is not a
+  /// string.
+  fn get_host_metadata_string(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<String>;
+
+  /// Returns the number metadata value for a host by looking up the given filter name and key in
+  /// the host's endpoint metadata. Returns `None` if the key was not found or the value is not a
+  /// number.
+  fn get_host_metadata_number(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<f64>;
+
+  /// Returns the bool metadata value for a host by looking up the given filter name and key in
+  /// the host's endpoint metadata. Returns `None` if the key was not found or the value is not a
+  /// bool.
+  fn get_host_metadata_bool(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<bool>;
+
+  /// Returns the number of locality buckets for the healthy hosts at a given priority.
+  fn get_locality_count(&self, priority: u32) -> usize;
+
+  /// Returns the number of healthy hosts in a specific locality bucket at a given priority.
+  fn get_locality_host_count(&self, priority: u32, locality_index: usize) -> usize;
+
+  /// Returns the address of a host within a specific locality bucket at a given priority.
+  fn get_locality_host_address(
+    &self,
+    priority: u32,
+    locality_index: usize,
+    host_index: usize,
+  ) -> Option<String>;
+
+  /// Returns the weight of a locality bucket at a given priority.
+  fn get_locality_weight(&self, priority: u32, locality_index: usize) -> u32;
 }
 
 /// Envoy-side scheduler that dispatches events to the main thread.
@@ -526,6 +642,373 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
       None
     } else {
       Some(host)
+    }
+  }
+
+  fn get_cluster_name(&self) -> String {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_cluster_name(self.raw, &mut result);
+    }
+    if result.ptr.is_null() || result.length == 0 {
+      String::new()
+    } else {
+      unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const u8,
+          result.length,
+        ))
+        .to_string()
+      }
+    }
+  }
+
+  fn get_hosts_count(&self, priority: u32) -> usize {
+    unsafe { abi::envoy_dynamic_module_callback_cluster_lb_get_hosts_count(self.raw, priority) }
+  }
+
+  fn get_degraded_hosts_count(&self, priority: u32) -> usize {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(self.raw, priority)
+    }
+  }
+
+  fn get_priority_set_size(&self) -> usize {
+    unsafe { abi::envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(self.raw) }
+  }
+
+  fn get_healthy_host_address(&self, priority: u32, index: usize) -> Option<String> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(
+        self.raw,
+        priority,
+        index,
+        &mut result,
+      )
+    };
+    if found && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const u8,
+          result.length,
+        ))
+        .to_string()
+      })
+    } else {
+      None
+    }
+  }
+
+  fn get_healthy_host_weight(&self, priority: u32, index: usize) -> u32 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(
+        self.raw, priority, index,
+      )
+    }
+  }
+
+  fn get_host_health(
+    &self,
+    priority: u32,
+    index: usize,
+  ) -> abi::envoy_dynamic_module_type_host_health {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_health(self.raw, priority, index)
+    }
+  }
+
+  fn get_host_health_by_address(
+    &self,
+    address: &str,
+  ) -> Option<abi::envoy_dynamic_module_type_host_health> {
+    let address_buf = str_to_module_buffer(address);
+    let mut result = abi::envoy_dynamic_module_type_host_health::Unhealthy;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+        self.raw,
+        address_buf,
+        &mut result,
+      )
+    };
+    if found {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn get_host_address(&self, priority: u32, index: usize) -> Option<String> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_address(
+        self.raw,
+        priority,
+        index,
+        &mut result,
+      )
+    };
+    if found && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const u8,
+          result.length,
+        ))
+        .to_string()
+      })
+    } else {
+      None
+    }
+  }
+
+  fn get_host_weight(&self, priority: u32, index: usize) -> u32 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_weight(self.raw, priority, index)
+    }
+  }
+
+  fn get_host_stat(
+    &self,
+    priority: u32,
+    index: usize,
+    stat: abi::envoy_dynamic_module_type_host_stat,
+  ) -> u64 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_stat(self.raw, priority, index, stat)
+    }
+  }
+
+  fn get_host_locality(&self, priority: u32, index: usize) -> Option<(String, String, String)> {
+    let mut region = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let mut zone = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let mut sub_zone = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_locality(
+        self.raw,
+        priority,
+        index,
+        &mut region,
+        &mut zone,
+        &mut sub_zone,
+      )
+    };
+    if found {
+      unsafe {
+        let region_str = if region.ptr.is_null() || region.length == 0 {
+          String::new()
+        } else {
+          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            region.ptr as *const u8,
+            region.length,
+          ))
+          .to_string()
+        };
+        let zone_str = if zone.ptr.is_null() || zone.length == 0 {
+          String::new()
+        } else {
+          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            zone.ptr as *const u8,
+            zone.length,
+          ))
+          .to_string()
+        };
+        let sub_zone_str = if sub_zone.ptr.is_null() || sub_zone.length == 0 {
+          String::new()
+        } else {
+          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            sub_zone.ptr as *const u8,
+            sub_zone.length,
+          ))
+          .to_string()
+        };
+        Some((region_str, zone_str, sub_zone_str))
+      }
+    } else {
+      None
+    }
+  }
+
+  fn set_host_data(&self, priority: u32, index: usize, data: usize) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_set_host_data(self.raw, priority, index, data)
+    }
+  }
+
+  fn get_host_data(&self, priority: u32, index: usize) -> Option<usize> {
+    let mut data: usize = 0;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_data(
+        self.raw, priority, index, &mut data,
+      )
+    };
+    if found {
+      Some(data)
+    } else {
+      None
+    }
+  }
+
+  fn get_host_metadata_string(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<String> {
+    let filter_buf = str_to_module_buffer(filter_name);
+    let key_buf = str_to_module_buffer(key);
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+        self.raw,
+        priority,
+        index,
+        filter_buf,
+        key_buf,
+        &mut result,
+      )
+    };
+    if found && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const u8,
+          result.length,
+        ))
+        .to_string()
+      })
+    } else {
+      None
+    }
+  }
+
+  fn get_host_metadata_number(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<f64> {
+    let filter_buf = str_to_module_buffer(filter_name);
+    let key_buf = str_to_module_buffer(key);
+    let mut result: f64 = 0.0;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+        self.raw,
+        priority,
+        index,
+        filter_buf,
+        key_buf,
+        &mut result,
+      )
+    };
+    if found {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn get_host_metadata_bool(
+    &self,
+    priority: u32,
+    index: usize,
+    filter_name: &str,
+    key: &str,
+  ) -> Option<bool> {
+    let filter_buf = str_to_module_buffer(filter_name);
+    let key_buf = str_to_module_buffer(key);
+    let mut result: bool = false;
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+        self.raw,
+        priority,
+        index,
+        filter_buf,
+        key_buf,
+        &mut result,
+      )
+    };
+    if found {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn get_locality_count(&self, priority: u32) -> usize {
+    unsafe { abi::envoy_dynamic_module_callback_cluster_lb_get_locality_count(self.raw, priority) }
+  }
+
+  fn get_locality_host_count(&self, priority: u32, locality_index: usize) -> usize {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(
+        self.raw,
+        priority,
+        locality_index,
+      )
+    }
+  }
+
+  fn get_locality_host_address(
+    &self,
+    priority: u32,
+    locality_index: usize,
+    host_index: usize,
+  ) -> Option<String> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let found = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(
+        self.raw,
+        priority,
+        locality_index,
+        host_index,
+        &mut result,
+      )
+    };
+    if found && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+          result.ptr as *const u8,
+          result.length,
+        ))
+        .to_string()
+      })
+    } else {
+      None
+    }
+  }
+
+  fn get_locality_weight(&self, priority: u32, locality_index: usize) -> u32 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_locality_weight(
+        self.raw,
+        priority,
+        locality_index,
+      )
     }
   }
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3545,6 +3545,207 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
 }
 
 #[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) {
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_hosts_count(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+) -> u32 {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_health(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+) -> abi::envoy_dynamic_module_type_host_health {
+  abi::envoy_dynamic_module_type_host_health::Unhealthy
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _address: abi::envoy_dynamic_module_type_module_buffer,
+  _result: *mut abi::envoy_dynamic_module_type_host_health,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_address(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_weight(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+) -> u32 {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _stat: abi::envoy_dynamic_module_type_host_stat,
+) -> u64 {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_locality(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _region: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+  _zone: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+  _sub_zone: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_set_host_data(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _data: usize,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_data(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _data: *mut usize,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _filter_name: abi::envoy_dynamic_module_type_module_buffer,
+  _key: abi::envoy_dynamic_module_type_module_buffer,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _filter_name: abi::envoy_dynamic_module_type_module_buffer,
+  _key: abi::envoy_dynamic_module_type_module_buffer,
+  _result: *mut f64,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _index: usize,
+  _filter_name: abi::envoy_dynamic_module_type_module_buffer,
+  _key: abi::envoy_dynamic_module_type_module_buffer,
+  _result: *mut bool,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_locality_count(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _locality_index: usize,
+) -> usize {
+  0
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _locality_index: usize,
+  _host_index: usize,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_locality_weight(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _priority: u32,
+  _locality_index: usize,
+) -> u32 {
+  0
+}
+
+#[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_cluster_scheduler_new(
   _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_cluster_scheduler_module_ptr {

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -66,21 +66,13 @@ pub trait EnvoyLoadBalancer {
   /// Returns the weight of a host by index within all hosts at a given priority.
   fn get_host_weight(&self, priority: u32, index: usize) -> u32;
 
-  /// Returns the number of active requests for a host by index within all hosts at a given
-  /// priority. This is essential for implementing least-request, peak EWMA, and similar algorithms.
-  fn get_host_active_requests(&self, priority: u32, index: usize) -> u64;
-
-  /// Returns the number of active connections for a host by index within all hosts at a given
-  /// priority. This is useful for connection-aware load balancing decisions.
-  fn get_host_active_connections(&self, priority: u32, index: usize) -> u64;
-
-  /// Returns the value of a per-host counter stat. This provides access to host-level counters
-  /// such as total connections, request errors, and request totals.
-  fn get_host_counter_stat(
+  /// Returns the value of a per-host stat. This provides access to host-level counters and gauges
+  /// such as total connections, request errors, active requests, and active connections.
+  fn get_host_stat(
     &self,
     priority: u32,
     index: usize,
-    stat: abi::envoy_dynamic_module_type_host_counter_stat,
+    stat: abi::envoy_dynamic_module_type_host_stat,
   ) -> u64;
 
   /// Returns the locality information (region, zone, sub_zone) for a host by index within all
@@ -355,35 +347,14 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     unsafe { abi::envoy_dynamic_module_callback_lb_get_host_weight(self.lb_ptr, priority, index) }
   }
 
-  fn get_host_active_requests(&self, priority: u32, index: usize) -> u64 {
-    unsafe {
-      abi::envoy_dynamic_module_callback_lb_get_host_active_requests(self.lb_ptr, priority, index)
-    }
-  }
-
-  fn get_host_active_connections(&self, priority: u32, index: usize) -> u64 {
-    unsafe {
-      abi::envoy_dynamic_module_callback_lb_get_host_active_connections(
-        self.lb_ptr,
-        priority,
-        index,
-      )
-    }
-  }
-
-  fn get_host_counter_stat(
+  fn get_host_stat(
     &self,
     priority: u32,
     index: usize,
-    stat: abi::envoy_dynamic_module_type_host_counter_stat,
+    stat: abi::envoy_dynamic_module_type_host_stat,
   ) -> u64 {
     unsafe {
-      abi::envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        self.lb_ptr,
-        priority,
-        index,
-        stat,
-      )
+      abi::envoy_dynamic_module_callback_lb_get_host_stat(self.lb_ptr, priority, index, stat)
     }
   }
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -262,38 +262,6 @@ uint32_t envoy_dynamic_module_callback_lb_get_host_weight(
   return hosts[index]->weight();
 }
 
-uint64_t envoy_dynamic_module_callback_lb_get_host_active_requests(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
-  if (lb_envoy_ptr == nullptr) {
-    return 0;
-  }
-  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
-  if (priority >= host_sets.size()) {
-    return 0;
-  }
-  const auto& hosts = host_sets[priority]->hosts();
-  if (index >= hosts.size()) {
-    return 0;
-  }
-  return hosts[index]->stats().rq_active_.value();
-}
-
-uint64_t envoy_dynamic_module_callback_lb_get_host_active_connections(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index) {
-  if (lb_envoy_ptr == nullptr) {
-    return 0;
-  }
-  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
-  if (priority >= host_sets.size()) {
-    return 0;
-  }
-  const auto& hosts = host_sets[priority]->hosts();
-  if (index >= hosts.size()) {
-    return 0;
-  }
-  return hosts[index]->stats().cx_active_.value();
-}
-
 bool envoy_dynamic_module_callback_lb_get_host_locality(
     envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
     envoy_dynamic_module_type_envoy_buffer* region, envoy_dynamic_module_type_envoy_buffer* zone,
@@ -628,9 +596,10 @@ bool envoy_dynamic_module_callback_lb_get_member_update_host_address(
   return true;
 }
 
-uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
-    envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index,
-    envoy_dynamic_module_type_host_counter_stat stat) {
+uint64_t
+envoy_dynamic_module_callback_lb_get_host_stat(envoy_dynamic_module_type_lb_envoy_ptr lb_envoy_ptr,
+                                               uint32_t priority, size_t index,
+                                               envoy_dynamic_module_type_host_stat stat) {
   if (lb_envoy_ptr == nullptr) {
     return 0;
   }
@@ -644,18 +613,22 @@ uint64_t envoy_dynamic_module_callback_lb_get_host_counter_stat(
   }
   const auto& host_stats = hosts[index]->stats();
   switch (stat) {
-  case envoy_dynamic_module_type_host_counter_stat_CxConnectFail:
+  case envoy_dynamic_module_type_host_stat_CxConnectFail:
     return host_stats.cx_connect_fail_.value();
-  case envoy_dynamic_module_type_host_counter_stat_CxTotal:
+  case envoy_dynamic_module_type_host_stat_CxTotal:
     return host_stats.cx_total_.value();
-  case envoy_dynamic_module_type_host_counter_stat_RqError:
+  case envoy_dynamic_module_type_host_stat_RqError:
     return host_stats.rq_error_.value();
-  case envoy_dynamic_module_type_host_counter_stat_RqSuccess:
+  case envoy_dynamic_module_type_host_stat_RqSuccess:
     return host_stats.rq_success_.value();
-  case envoy_dynamic_module_type_host_counter_stat_RqTimeout:
+  case envoy_dynamic_module_type_host_stat_RqTimeout:
     return host_stats.rq_timeout_.value();
-  case envoy_dynamic_module_type_host_counter_stat_RqTotal:
+  case envoy_dynamic_module_type_host_stat_RqTotal:
     return host_stats.rq_total_.value();
+  case envoy_dynamic_module_type_host_stat_CxActive:
+    return host_stats.cx_active_.value();
+  case envoy_dynamic_module_type_host_stat_RqActive:
+    return host_stats.rq_active_.value();
   }
   return 0;
 }

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -19,6 +19,7 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/config:metadata_lib",
         "//source/extensions/clusters/dynamic_modules:cluster_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/load_balancing_policies/cluster_provided:config",

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.h"
 
+#include "source/common/config/metadata.h"
 #include "source/extensions/clusters/dynamic_modules/cluster.h"
 
 #include "test/common/upstream/utility.h"
@@ -447,6 +448,432 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
   EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(dm_lb, 0, 2));
   // Invalid priority.
   EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(dm_lb, 99, 0));
+}
+
+// Test the LB host information ABI callbacks.
+TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Add hosts with different weights.
+  std::vector<Upstream::HostSharedPtr> hosts;
+  ASSERT_TRUE(cluster->addHosts({"127.0.0.1:10001", "127.0.0.1:10002", "127.0.0.1:10003"},
+                                {10, 20, 30}, hosts));
+  ASSERT_EQ(3, hosts.size());
+
+  // Create the LB.
+  auto& talb = result->second;
+  EXPECT_TRUE(talb->initialize().ok());
+  auto lb_factory = talb->factory();
+  NiceMock<Upstream::MockPrioritySet> mock_ps;
+  auto lb = lb_factory->create({mock_ps});
+  auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
+  ASSERT_NE(nullptr, dm_lb);
+
+  // Test get_cluster_name.
+  envoy_dynamic_module_type_envoy_buffer name_buf = {};
+  envoy_dynamic_module_callback_cluster_lb_get_cluster_name(dm_lb, &name_buf);
+  EXPECT_GT(name_buf.length, 0);
+
+  // Test get_hosts_count.
+  EXPECT_EQ(3, envoy_dynamic_module_callback_cluster_lb_get_hosts_count(dm_lb, 0));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_hosts_count(dm_lb, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_hosts_count(nullptr, 0));
+
+  // Test get_healthy_host_count (existing).
+  EXPECT_EQ(3, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(dm_lb, 0));
+
+  // Test get_degraded_hosts_count.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(dm_lb, 0));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(dm_lb, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(nullptr, 0));
+
+  // Test get_priority_set_size.
+  EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(dm_lb));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(nullptr));
+
+  // Test get_healthy_host_address.
+  envoy_dynamic_module_type_envoy_buffer addr_buf = {};
+  EXPECT_TRUE(
+      envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(dm_lb, 0, 0, &addr_buf));
+  EXPECT_EQ("127.0.0.1:10001", std::string(addr_buf.ptr, addr_buf.length));
+  // Out of bounds.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(dm_lb, 0, 99, &addr_buf));
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(dm_lb, 99, 0, &addr_buf));
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(nullptr, 0, 0, &addr_buf));
+
+  // Test get_healthy_host_weight.
+  EXPECT_EQ(10, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(dm_lb, 0, 0));
+  EXPECT_EQ(20, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(dm_lb, 0, 1));
+  EXPECT_EQ(30, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(dm_lb, 0, 2));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(dm_lb, 0, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(nullptr, 0, 0));
+
+  // Test get_host_address.
+  envoy_dynamic_module_type_envoy_buffer host_addr_buf = {};
+  EXPECT_TRUE(
+      envoy_dynamic_module_callback_cluster_lb_get_host_address(dm_lb, 0, 1, &host_addr_buf));
+  EXPECT_EQ("127.0.0.1:10002", std::string(host_addr_buf.ptr, host_addr_buf.length));
+  // Out of bounds.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_host_address(dm_lb, 0, 99, &host_addr_buf));
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_host_address(nullptr, 0, 0, &host_addr_buf));
+
+  // Test get_host_weight.
+  EXPECT_EQ(10, envoy_dynamic_module_callback_cluster_lb_get_host_weight(dm_lb, 0, 0));
+  EXPECT_EQ(20, envoy_dynamic_module_callback_cluster_lb_get_host_weight(dm_lb, 0, 1));
+  EXPECT_EQ(30, envoy_dynamic_module_callback_cluster_lb_get_host_weight(dm_lb, 0, 2));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_weight(dm_lb, 0, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_weight(nullptr, 0, 0));
+
+  // Test get_host_health.
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Healthy,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(dm_lb, 0, 0));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(dm_lb, 0, 99));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(nullptr, 0, 0));
+
+  // Test get_host_health_by_address.
+  envoy_dynamic_module_type_host_health health_result;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      nullptr, {nullptr, 0}, &health_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      dm_lb, {nullptr, 0}, &health_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      nullptr, {nullptr, 0}, nullptr));
+
+  // Test get_host_stat with all enum values (counters and gauges).
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_CxConnectFail));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_CxTotal));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_RqError));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_RqSuccess));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_RqTimeout));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_CxActive));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 0, envoy_dynamic_module_type_host_stat_RqActive));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 0, 99, envoy_dynamic_module_type_host_stat_RqTotal));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   nullptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal));
+
+  // Test get_host_locality.
+  envoy_dynamic_module_type_envoy_buffer region = {}, zone = {}, sub_zone = {};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(dm_lb, 0, 0, &region,
+                                                                         &zone, &sub_zone));
+  // Default locality is empty.
+  EXPECT_EQ(0, region.length);
+  // Out of bounds.
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(dm_lb, 0, 99, &region,
+                                                                          &zone, &sub_zone));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(nullptr, 0, 0, &region,
+                                                                          &zone, &sub_zone));
+  // Null output parameters are allowed.
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(dm_lb, 0, 0, nullptr,
+                                                                         nullptr, nullptr));
+
+  // Test set_host_data and get_host_data.
+  uintptr_t data = 0;
+  // Initially no data.
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_data(dm_lb, 0, 0, &data));
+  EXPECT_EQ(0, data);
+  // Set data.
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_set_host_data(dm_lb, 0, 0, 12345));
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_data(dm_lb, 0, 0, &data));
+  EXPECT_EQ(12345, data);
+  // Clear data by setting to 0.
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_set_host_data(dm_lb, 0, 0, 0));
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_data(dm_lb, 0, 0, &data));
+  EXPECT_EQ(0, data);
+  // Out of bounds.
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_set_host_data(dm_lb, 0, 99, 1));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_data(dm_lb, 0, 99, &data));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_set_host_data(nullptr, 0, 0, 1));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_data(nullptr, 0, 0, &data));
+
+  // Test get_host_metadata_string (no metadata set, should return false).
+  envoy_dynamic_module_type_module_buffer filter_name = {"envoy.lb", 8};
+  envoy_dynamic_module_type_module_buffer key = {"shard", 5};
+  envoy_dynamic_module_type_envoy_buffer meta_result = {};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 0, 0, filter_name, key, &meta_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      nullptr, 0, 0, filter_name, key, &meta_result));
+
+  // Test get_host_metadata_number.
+  double num_result = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+      dm_lb, 0, 0, filter_name, key, &num_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+      nullptr, 0, 0, filter_name, key, &num_result));
+
+  // Test get_host_metadata_bool.
+  bool bool_result = false;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+      dm_lb, 0, 0, filter_name, key, &bool_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+      nullptr, 0, 0, filter_name, key, &bool_result));
+
+  // Test get_locality_count.
+  EXPECT_GE(envoy_dynamic_module_callback_cluster_lb_get_locality_count(dm_lb, 0), 0);
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_count(dm_lb, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_count(nullptr, 0));
+
+  // Test get_locality_host_count.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(dm_lb, 0, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(nullptr, 0, 0));
+
+  // Test get_locality_host_address.
+  envoy_dynamic_module_type_envoy_buffer locality_addr = {};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(dm_lb, 0, 99, 0,
+                                                                                  &locality_addr));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(nullptr, 0, 0, 0,
+                                                                                  &locality_addr));
+
+  // Test get_locality_weight.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_weight(dm_lb, 0, 99));
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_weight(nullptr, 0, 0));
+}
+
+// Test the LB host information callbacks with hosts that have metadata and locality data.
+// This exercises code paths not reachable via addHosts() which creates hosts without metadata
+// and with empty locality.
+TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Build metadata with string, number, and bool fields under filter "envoy.lb".
+  envoy::config::core::v3::Metadata metadata;
+  Config::Metadata::mutableMetadataValue(metadata, "envoy.lb", "region_tag")
+      .set_string_value("us-east-1");
+  Config::Metadata::mutableMetadataValue(metadata, "envoy.lb", "shard_weight")
+      .set_number_value(42.5);
+  Config::Metadata::mutableMetadataValue(metadata, "envoy.lb", "is_canary").set_bool_value(true);
+
+  // Build locality data.
+  envoy::config::core::v3::Locality zone_a;
+  zone_a.set_region("us-east");
+  zone_a.set_zone("us-east-1a");
+  zone_a.set_sub_zone("rack-1");
+
+  envoy::config::core::v3::Locality zone_b;
+  zone_b.set_region("us-west");
+  zone_b.set_zone("us-west-2b");
+  zone_b.set_sub_zone("rack-2");
+
+  // Create hosts with metadata and locality using the test helper.
+  auto host_a1 =
+      Upstream::makeTestHost(cluster->info(), "tcp://10.0.0.1:8080", metadata, zone_a, 10);
+  auto host_a2 =
+      Upstream::makeTestHost(cluster->info(), "tcp://10.0.0.2:8080", metadata, zone_a, 20);
+  auto host_b1 =
+      Upstream::makeTestHost(cluster->info(), "tcp://10.0.0.3:8080", metadata, zone_b, 30);
+
+  // Group hosts by locality.
+  Upstream::HostVector zone_a_hosts = {host_a1, host_a2};
+  Upstream::HostVector zone_b_hosts = {host_b1};
+  std::vector<Upstream::HostVector> locality_hosts = {zone_a_hosts, zone_b_hosts};
+  auto hosts_per_locality =
+      std::make_shared<Upstream::HostsPerLocalityImpl>(std::move(locality_hosts), false);
+
+  // Build all-hosts vector.
+  auto all_hosts =
+      std::make_shared<Upstream::HostVector>(Upstream::HostVector{host_a1, host_a2, host_b1});
+
+  // Set up locality weights.
+  auto locality_weights =
+      std::make_shared<const Upstream::LocalityWeights>(Upstream::LocalityWeights{50, 50});
+
+  // Update the cluster's priority set directly with locality data.
+  cluster->prioritySet().updateHosts(
+      0, Upstream::HostSetImpl::partitionHosts(all_hosts, hosts_per_locality), locality_weights,
+      {host_a1, host_a2, host_b1}, {}, absl::nullopt, absl::nullopt);
+
+  // Create the LB.
+  auto& talb = result->second;
+  EXPECT_TRUE(talb->initialize().ok());
+  auto lb_factory = talb->factory();
+  NiceMock<Upstream::MockPrioritySet> mock_ps;
+  auto lb = lb_factory->create({mock_ps});
+  auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
+  ASSERT_NE(nullptr, dm_lb);
+
+  // ---- Test get_cluster_name with nullptr lb. ----
+  envoy_dynamic_module_type_envoy_buffer name_buf = {};
+  envoy_dynamic_module_callback_cluster_lb_get_cluster_name(nullptr, &name_buf);
+  EXPECT_EQ(nullptr, name_buf.ptr);
+  EXPECT_EQ(0, name_buf.length);
+
+  // ---- Test metadata string lookup (success path). ----
+  envoy_dynamic_module_type_module_buffer filter_name = {"envoy.lb", 8};
+  envoy_dynamic_module_type_module_buffer str_key = {"region_tag", 10};
+  envoy_dynamic_module_type_envoy_buffer meta_result = {};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 0, 0, filter_name, str_key, &meta_result));
+  EXPECT_EQ("us-east-1", std::string(meta_result.ptr, meta_result.length));
+
+  // Test metadata string with wrong key (key not found).
+  envoy_dynamic_module_type_module_buffer bad_key = {"nonexistent", 11};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 0, 0, filter_name, bad_key, &meta_result));
+
+  // Test metadata string with wrong filter name (filter not found).
+  envoy_dynamic_module_type_module_buffer bad_filter = {"wrong.filter", 12};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 0, 0, bad_filter, str_key, &meta_result));
+
+  // ---- Test metadata number lookup (success path). ----
+  envoy_dynamic_module_type_module_buffer num_key = {"shard_weight", 12};
+  double num_result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+      dm_lb, 0, 0, filter_name, num_key, &num_result));
+  EXPECT_DOUBLE_EQ(42.5, num_result);
+
+  // Test metadata number with a key that has a string value (type mismatch).
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(
+      dm_lb, 0, 0, filter_name, str_key, &num_result));
+
+  // ---- Test metadata bool lookup (success path). ----
+  envoy_dynamic_module_type_module_buffer bool_key = {"is_canary", 9};
+  bool bool_result = false;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+      dm_lb, 0, 0, filter_name, bool_key, &bool_result));
+  EXPECT_TRUE(bool_result);
+
+  // Test metadata bool with a key that has a string value (type mismatch).
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(
+      dm_lb, 0, 0, filter_name, str_key, &bool_result));
+
+  // ---- Test metadata with out-of-bounds priority and index. ----
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 99, 0, filter_name, str_key, &meta_result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(
+      dm_lb, 0, 99, filter_name, str_key, &meta_result));
+
+  // ---- Test locality count. ----
+  EXPECT_EQ(2, envoy_dynamic_module_callback_cluster_lb_get_locality_count(dm_lb, 0));
+
+  // ---- Test locality host count. ----
+  EXPECT_EQ(2, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(dm_lb, 0, 0));
+  EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(dm_lb, 0, 1));
+  // Out of bounds locality index.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(dm_lb, 0, 99));
+  // Out of bounds priority.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(dm_lb, 99, 0));
+
+  // ---- Test locality host address (success path). ----
+  envoy_dynamic_module_type_envoy_buffer locality_addr = {};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(dm_lb, 0, 0, 0,
+                                                                                 &locality_addr));
+  EXPECT_EQ("10.0.0.1:8080", std::string(locality_addr.ptr, locality_addr.length));
+
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(dm_lb, 0, 1, 0,
+                                                                                 &locality_addr));
+  EXPECT_EQ("10.0.0.3:8080", std::string(locality_addr.ptr, locality_addr.length));
+
+  // Out of bounds host_index within a locality.
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(dm_lb, 0, 1, 99,
+                                                                                  &locality_addr));
+  // Out of bounds priority.
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(dm_lb, 99, 0, 0,
+                                                                                  &locality_addr));
+
+  // ---- Test locality weight (success path). ----
+  EXPECT_EQ(50, envoy_dynamic_module_callback_cluster_lb_get_locality_weight(dm_lb, 0, 0));
+  EXPECT_EQ(50, envoy_dynamic_module_callback_cluster_lb_get_locality_weight(dm_lb, 0, 1));
+  // Out of bounds priority.
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_locality_weight(dm_lb, 99, 0));
+
+  // ---- Test host locality (verify region/zone/sub_zone data). ----
+  envoy_dynamic_module_type_envoy_buffer region = {}, zone = {}, sub_zone = {};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(dm_lb, 0, 0, &region,
+                                                                         &zone, &sub_zone));
+  EXPECT_EQ("us-east", std::string(region.ptr, region.length));
+  EXPECT_EQ("us-east-1a", std::string(zone.ptr, zone.length));
+  EXPECT_EQ("rack-1", std::string(sub_zone.ptr, sub_zone.length));
+  // Out of bounds priority.
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_locality(dm_lb, 99, 0, &region,
+                                                                          &zone, &sub_zone));
+
+  // ---- Test host weight with out-of-bounds priority. ----
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_weight(dm_lb, 99, 0));
+
+  // ---- Test healthy host weight with out-of-bounds priority. ----
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(dm_lb, 99, 0));
+
+  // ---- Test host address with out-of-bounds priority. ----
+  envoy_dynamic_module_type_envoy_buffer addr_buf = {};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_address(dm_lb, 99, 0, &addr_buf));
+
+  // ---- Test host health with out-of-bounds priority. ----
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(dm_lb, 99, 0));
+
+  // ---- Test host stat with out-of-bounds priority. ----
+  EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   dm_lb, 99, 0, envoy_dynamic_module_type_host_stat_RqTotal));
+
+  // ---- Test get_host_health_by_address using crossPriorityHostMap. ----
+  // The MainPrioritySetImpl populates the cross-priority host map when updateHosts is called.
+  envoy_dynamic_module_type_host_health health_result;
+  envoy_dynamic_module_type_module_buffer host_addr = {"10.0.0.1:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(dm_lb, host_addr,
+                                                                                  &health_result));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Healthy, health_result);
+
+  // Test with an address that does not exist in the host map.
+  envoy_dynamic_module_type_module_buffer unknown_addr = {"10.0.0.99:8080", 14};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      dm_lb, unknown_addr, &health_result));
+
+  // ---- Test get_host_health with degraded and unhealthy hosts. ----
+  auto degraded_host = Upstream::makeTestHost(cluster->info(), "tcp://10.0.0.4:8080", zone_a, 1, 0,
+                                              envoy::config::core::v3::DEGRADED);
+  auto unhealthy_host = Upstream::makeTestHost(cluster->info(), "tcp://10.0.0.5:8080", zone_b, 1, 0,
+                                               envoy::config::core::v3::UNHEALTHY);
+
+  // Add degraded and unhealthy hosts to priority 1.
+  auto p1_hosts =
+      std::make_shared<Upstream::HostVector>(Upstream::HostVector{degraded_host, unhealthy_host});
+  auto p1_hosts_per_locality = std::make_shared<Upstream::HostsPerLocalityImpl>(
+      Upstream::HostVector{degraded_host, unhealthy_host});
+  cluster->prioritySet().updateHosts(
+      1, Upstream::HostSetImpl::partitionHosts(p1_hosts, p1_hosts_per_locality), nullptr,
+      {degraded_host, unhealthy_host}, {}, absl::nullopt, absl::nullopt);
+
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Degraded,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(dm_lb, 1, 0));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy,
+            envoy_dynamic_module_callback_cluster_lb_get_host_health(dm_lb, 1, 1));
+
+  // Also verify get_host_health_by_address for degraded and unhealthy hosts.
+  envoy_dynamic_module_type_module_buffer degraded_addr = {"10.0.0.4:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      dm_lb, degraded_addr, &health_result));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Degraded, health_result);
+
+  envoy_dynamic_module_type_module_buffer unhealthy_addr = {"10.0.0.5:8080", 13};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(
+      dm_lb, unhealthy_addr, &health_result));
+  EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy, health_result);
 }
 
 // Test that a module missing cluster symbols fails with an error.

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -224,6 +224,61 @@ WEAK_STUB(ClusterLbContextGetOverrideHost,
 WEAK_STUB(ClusterLbContextGetDownstreamConnectionSni,
           envoy_dynamic_module_callback_cluster_lb_context_get_downstream_connection_sni(nullptr,
                                                                                          nullptr))
+WEAK_STUB(ClusterLbGetClusterName,
+          envoy_dynamic_module_callback_cluster_lb_get_cluster_name(nullptr, nullptr))
+WEAK_STUB(ClusterLbGetHostsCount,
+          envoy_dynamic_module_callback_cluster_lb_get_hosts_count(nullptr, 0))
+WEAK_STUB(ClusterLbGetDegradedHostsCount,
+          envoy_dynamic_module_callback_cluster_lb_get_degraded_hosts_count(nullptr, 0))
+WEAK_STUB(ClusterLbGetPrioritySetSize,
+          envoy_dynamic_module_callback_cluster_lb_get_priority_set_size(nullptr))
+WEAK_STUB(ClusterLbGetHealthyHostAddress,
+          envoy_dynamic_module_callback_cluster_lb_get_healthy_host_address(nullptr, 0, 0, nullptr))
+WEAK_STUB(ClusterLbGetHealthyHostWeight,
+          envoy_dynamic_module_callback_cluster_lb_get_healthy_host_weight(nullptr, 0, 0))
+WEAK_STUB(ClusterLbGetHostHealth,
+          envoy_dynamic_module_callback_cluster_lb_get_host_health(nullptr, 0, 0))
+WEAK_STUB(ClusterLbGetHostHealthByAddress,
+          envoy_dynamic_module_callback_cluster_lb_get_host_health_by_address(nullptr, {nullptr, 0},
+                                                                              nullptr))
+WEAK_STUB(ClusterLbGetHostAddress,
+          envoy_dynamic_module_callback_cluster_lb_get_host_address(nullptr, 0, 0, nullptr))
+WEAK_STUB(ClusterLbGetHostWeight,
+          envoy_dynamic_module_callback_cluster_lb_get_host_weight(nullptr, 0, 0))
+WEAK_STUB(ClusterLbGetHostStat, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                                    nullptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal))
+WEAK_STUB(ClusterLbGetHostLocality,
+          envoy_dynamic_module_callback_cluster_lb_get_host_locality(nullptr, 0, 0, nullptr,
+                                                                     nullptr, nullptr))
+WEAK_STUB(ClusterLbSetHostData,
+          envoy_dynamic_module_callback_cluster_lb_set_host_data(nullptr, 0, 0, 0))
+WEAK_STUB(ClusterLbGetHostData,
+          envoy_dynamic_module_callback_cluster_lb_get_host_data(nullptr, 0, 0, nullptr))
+WEAK_STUB(ClusterLbGetHostMetadataString,
+          envoy_dynamic_module_callback_cluster_lb_get_host_metadata_string(nullptr, 0, 0,
+                                                                            {nullptr, 0},
+                                                                            {nullptr, 0}, nullptr))
+WEAK_STUB(ClusterLbGetHostMetadataNumber,
+          envoy_dynamic_module_callback_cluster_lb_get_host_metadata_number(nullptr, 0, 0,
+                                                                            {nullptr, 0},
+                                                                            {nullptr, 0}, nullptr))
+WEAK_STUB(ClusterLbGetHostMetadataBool,
+          envoy_dynamic_module_callback_cluster_lb_get_host_metadata_bool(nullptr, 0, 0,
+                                                                          {nullptr, 0},
+                                                                          {nullptr, 0}, nullptr))
+WEAK_STUB(ClusterLbGetLocalityCount,
+          envoy_dynamic_module_callback_cluster_lb_get_locality_count(nullptr, 0))
+WEAK_STUB(ClusterLbGetLocalityHostCount,
+          envoy_dynamic_module_callback_cluster_lb_get_locality_host_count(nullptr, 0, 0))
+WEAK_STUB(ClusterLbGetLocalityHostAddress,
+          envoy_dynamic_module_callback_cluster_lb_get_locality_host_address(nullptr, 0, 0, 0,
+                                                                             nullptr))
+WEAK_STUB(ClusterLbGetLocalityWeight,
+          envoy_dynamic_module_callback_cluster_lb_get_locality_weight(nullptr, 0, 0))
+WEAK_STUB(ClusterLbAsyncHostSelectionComplete,
+          envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(nullptr, nullptr,
+                                                                                 nullptr,
+                                                                                 {nullptr, 0}))
 WEAK_STUB(ClusterSchedulerNew, envoy_dynamic_module_callback_cluster_scheduler_new(nullptr))
 WEAK_STUB(ClusterSchedulerDelete, envoy_dynamic_module_callback_cluster_scheduler_delete(nullptr))
 WEAK_STUB(ClusterSchedulerCommit,
@@ -267,10 +322,6 @@ WEAK_STUB(LbGetHostHealthByAddress,
 WEAK_STUB(LbGetHostAddress,
           envoy_dynamic_module_callback_lb_get_host_address(nullptr, 0, 0, nullptr))
 WEAK_STUB(LbGetHostWeight, envoy_dynamic_module_callback_lb_get_host_weight(nullptr, 0, 0))
-WEAK_STUB(LbGetHostActiveRequests,
-          envoy_dynamic_module_callback_lb_get_host_active_requests(nullptr, 0, 0))
-WEAK_STUB(LbGetHostActiveConnections,
-          envoy_dynamic_module_callback_lb_get_host_active_connections(nullptr, 0, 0))
 WEAK_STUB(LbGetHostLocality,
           envoy_dynamic_module_callback_lb_get_host_locality(nullptr, 0, 0, nullptr, nullptr,
                                                              nullptr))
@@ -310,9 +361,8 @@ WEAK_STUB(LbGetLocalityWeight, envoy_dynamic_module_callback_lb_get_locality_wei
 WEAK_STUB(LbGetMemberUpdateHostAddress,
           envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0, true,
                                                                           nullptr))
-WEAK_STUB(LbGetHostCounterStat,
-          envoy_dynamic_module_callback_lb_get_host_counter_stat(
-              nullptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal))
+WEAK_STUB(LbGetHostStat, envoy_dynamic_module_callback_lb_get_host_stat(
+                             nullptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal))
 
 WEAK_STUB(LbConfigDefineCounter,
           envoy_dynamic_module_callback_lb_config_define_counter(nullptr, {"counter", 7}, nullptr,

--- a/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/lb_callbacks_test.c
@@ -127,32 +127,30 @@ bool envoy_dynamic_module_on_lb_choose_host(
         lb_envoy_ptr, 0, 0);
     (void)host_weight;
 
-    uint64_t active_rq = envoy_dynamic_module_callback_lb_get_host_active_requests(
-        lb_envoy_ptr, 0, 0);
+    // Test host stats (counters and gauges).
+    uint64_t active_rq = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqActive);
     (void)active_rq;
-
-    uint64_t active_cx = envoy_dynamic_module_callback_lb_get_host_active_connections(
-        lb_envoy_ptr, 0, 0);
+    uint64_t active_cx = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxActive);
     (void)active_cx;
-
-    // Test host counter stats.
-    uint64_t cx_total = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxTotal);
+    uint64_t cx_total = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxTotal);
     (void)cx_total;
-    uint64_t rq_total = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal);
+    uint64_t rq_total = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal);
     (void)rq_total;
-    uint64_t rq_error = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqError);
+    uint64_t rq_error = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqError);
     (void)rq_error;
-    uint64_t rq_success = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqSuccess);
+    uint64_t rq_success = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqSuccess);
     (void)rq_success;
-    uint64_t rq_timeout = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTimeout);
+    uint64_t rq_timeout = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTimeout);
     (void)rq_timeout;
-    uint64_t cx_fail = envoy_dynamic_module_callback_lb_get_host_counter_stat(
-        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxConnectFail);
+    uint64_t cx_fail = envoy_dynamic_module_callback_lb_get_host_stat(
+        lb_envoy_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxConnectFail);
     (void)cx_fail;
 
     envoy_dynamic_module_type_envoy_buffer region = {NULL, 0};

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -529,8 +529,6 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   // Test new all-hosts callbacks with null lb_envoy_ptr.
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_address(nullptr, 0, 0, &result));
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_weight(nullptr, 0, 0), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(nullptr, 0, 0), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(nullptr, 0, 0), 0);
   EXPECT_FALSE(
       envoy_dynamic_module_callback_lb_get_host_locality(nullptr, 0, 0, nullptr, nullptr, nullptr));
 
@@ -556,9 +554,9 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithNullPointers) {
   EXPECT_FALSE(
       envoy_dynamic_module_callback_lb_get_member_update_host_address(nullptr, 0, true, &result));
 
-  // Test host counter stat callback with null.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                nullptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+  // Test host stat callback with null.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                nullptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal),
             0);
 }
 
@@ -599,14 +597,12 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
   // Test new all-hosts callbacks with invalid priority.
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_address(lb_ptr, 999, 0, &result));
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_weight(lb_ptr, 999, 0), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(lb_ptr, 999, 0), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 999, 0), 0);
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 999, 0, nullptr, nullptr,
                                                                   nullptr));
 
-  // Test host counter stat with invalid priority.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 999, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+  // Test host stat with invalid priority.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 999, 0, envoy_dynamic_module_type_host_stat_RqTotal),
             0);
 }
 
@@ -642,14 +638,12 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidHostIndex) {
   // Test new all-hosts callbacks with invalid host index.
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_address(lb_ptr, 0, 999, &result));
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_weight(lb_ptr, 0, 999), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(lb_ptr, 0, 999), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 0, 999), 0);
   EXPECT_FALSE(envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 0, 999, nullptr, nullptr,
                                                                   nullptr));
 
-  // Test host counter stat with invalid host index.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 999, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+  // Test host stat with invalid host index.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 999, envoy_dynamic_module_type_host_stat_RqTotal),
             0);
 }
 
@@ -716,9 +710,13 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksSuccessfulCases) {
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_weight(lb_ptr, 0, 1), 2);
   EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_weight(lb_ptr, 0, 2), 3);
 
-  // Test active requests callback.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(lb_ptr, 0, 0), 0);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 0, 0), 0);
+  // Test host stat callback (gauges).
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqActive),
+            0);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxActive),
+            0);
 
   // Test locality callback.
   envoy_dynamic_module_type_envoy_buffer region_result = {nullptr, 0};
@@ -772,13 +770,21 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
 
   auto* lb_ptr = static_cast<DynamicModuleLoadBalancer*>(lb.get());
 
-  // Verify active requests.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(lb_ptr, 0, 0), 5);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_requests(lb_ptr, 0, 1), 10);
+  // Verify active requests via get_host_stat.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqActive),
+            5);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 1, envoy_dynamic_module_type_host_stat_RqActive),
+            10);
 
-  // Verify active connections.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 0, 0), 3);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_active_connections(lb_ptr, 0, 1), 7);
+  // Verify active connections via get_host_stat.
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxActive),
+            3);
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 1, envoy_dynamic_module_type_host_stat_CxActive),
+            7);
 
   // Verify locality.
   envoy_dynamic_module_type_envoy_buffer region = {nullptr, 0};
@@ -795,29 +801,29 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
       envoy_dynamic_module_callback_lb_get_host_locality(lb_ptr, 0, 0, &region, nullptr, nullptr));
   EXPECT_EQ(absl::string_view(region.ptr, region.length), "us-east");
 
-  // Verify host counter stats.
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxConnectFail),
+  // Verify host stats (counters).
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxConnectFail),
             2);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_CxTotal),
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxTotal),
             100);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqError),
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqError),
             3);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqSuccess),
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqSuccess),
             42);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTimeout),
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTimeout),
             1);
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 0, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal),
             46);
 
-  // Verify host2 counter stats are 0 (not set).
-  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_counter_stat(
-                lb_ptr, 0, 1, envoy_dynamic_module_type_host_counter_stat_RqTotal),
+  // Verify host2 stats are 0 (not set).
+  EXPECT_EQ(envoy_dynamic_module_callback_lb_get_host_stat(
+                lb_ptr, 0, 1, envoy_dynamic_module_type_host_stat_RqTotal),
             0);
 }
 


### PR DESCRIPTION
## Description

This PR adds host information callbacks for dynamic module cluster load balancers, providing parity with the standalone load balancer's host information API. 

This includes host address, weight, health, locality, metadata, active requests/connections, per-host counter stats, host data get/set, and locality-aware routing callbacks.

---

**Commit Message:** dynamic_modules: added host information callbacks for dynamic module clusters LB
**Additional Description:** Added host information callbacks for dynamic module cluster load balancers
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A