### PR TITLE
Update QUICHE from 73d3b6e2e to 243b50d55

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-03-03"
+  release_date: "2026-03-10"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "73d3b6e2ed78b304e41fae23fe50b237b4c9b78a",
-        sha256 = "e395ce8b3bcf5a1af7cede3e8f0c9a5f9417f20c89a836a4a739e6fe4fbb3c26",
+        version = "243b50d551188e6bd4bd929c8cb57730a59679bb",
+        sha256 = "0941983a9205ffe1b1d1b6ff8983d272b4d45d9e1b678f45d666762518069511",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/73d3b6e2e..243b50d55

```
$ git log 73d3b6e2e..243b50d55 --date=short --no-merges --format="%ad %al %s"

2026-03-09 quiche-dev Fix 1 ClangInliner finding: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is absl::Base64Escape.
2026-03-09 quiche-dev Enabling rolled out flags.
2026-03-06 martinduke Implement FETCH object serialization flags.
2026-03-06 dmcardle Fix includes in bbr_sender.cc and related files
2026-03-04 quiche-dev Add GetSize() and GetMaxSize() to the SessionCache interface.
2026-03-03 haoyuewang No public description
```

Risk Level: Low
Testing: Existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
