### PR TITLE
Revert "dynamic_modules: add gRPC capability to HTTP module (#43827)"

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -264,11 +264,6 @@ new_features:
     When disabled, QUIC retains zlib-only compression, while TCP TLS has no compression.
 - area: dynamic_modules
   change: |
-    Added gRPC status support for the HTTP dynamic module filter SDKs. The ``send_response`` SDK
-    methods now accept an optional gRPC status code which is passed as a ``grpc-status`` header,
-    and the ``ResponseGrpcStatus`` attribute is now available to read gRPC status from responses.
-- area: dynamic_modules
-  change: |
     Added custom metrics (counters, gauges, histograms) support to load balancer dynamic modules.
     Modules can now define metrics during configuration and record them during host selection.
 - area: golang

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -470,15 +470,11 @@ public:
   /**
    * Sends a local response with status code, body, and detail.
    * @param status The HTTP status code.
-   * @param headers The response headers.
    * @param body The response body.
-   * @param grpc_status The gRPC status code for gRPC requests. Use -1 to indicate no gRPC status
-   * (Envoy will infer from the HTTP status code). Values 0-16 are standard gRPC status codes.
    * @param detail The response detail.
    */
   virtual void sendLocalResponse(uint32_t status, std::span<const HeaderView> headers,
-                                 std::string_view body, int32_t grpc_status,
-                                 std::string_view detail) = 0;
+                                 std::string_view body, std::string_view detail) = 0;
 
   /**
    * Sends response headers. This is used for streaming local replies.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -384,26 +384,12 @@ public:
   }
 
   void sendLocalResponse(uint32_t status, std::span<const HeaderView> headers,
-                         std::string_view body, int32_t grpc_status,
-                         std::string_view detail) override {
-    // When gRPC status is specified, include it as a grpc-status header so Envoy's sendLocalReply
-    // picks it up via modify_headers without requiring an ABI change.
-    std::string grpc_status_str;
-    std::vector<HeaderView> merged_headers;
-    const HeaderView* headers_ptr = headers.data();
-    size_t headers_size = headers.size();
-    if (grpc_status >= 0) {
-      grpc_status_str = std::to_string(grpc_status);
-      merged_headers.assign(headers.begin(), headers.end());
-      merged_headers.emplace_back("grpc-status", grpc_status_str);
-      headers_ptr = merged_headers.data();
-      headers_size = merged_headers.size();
-    }
+                         std::string_view body, std::string_view detail) override {
     envoy_dynamic_module_callback_http_send_response(
         host_plugin_ptr_, status,
         const_cast<envoy_dynamic_module_type_module_http_header*>(
-            reinterpret_cast<const envoy_dynamic_module_type_module_http_header*>(headers_ptr)),
-        headers_size, envoy_dynamic_module_type_module_buffer{body.data(), body.size()},
+            reinterpret_cast<const envoy_dynamic_module_type_module_http_header*>(headers.data())),
+        headers.size(), envoy_dynamic_module_type_module_buffer{body.data(), body.size()},
         envoy_dynamic_module_type_module_buffer{detail.data(), detail.size()});
   }
 

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -720,17 +720,11 @@ func (h *dymHttpFilterHandle) SendLocalResponse(
 	statusCode uint32,
 	headers [][2]string,
 	body []byte,
-	grpcStatus int32,
 	detail string,
 ) {
 	h.localResponseSent = true
 
-	// When gRPC status is specified, include it as a grpc-status header so Envoy's sendLocalReply
-	// picks it up via modify_headers without requiring an ABI change.
-	if grpcStatus >= 0 {
-		headers = append(headers, [2]string{"grpc-status", strconv.Itoa(int(grpcStatus))})
-	}
-
+	// Prepare headers.
 	headerViews := headersToModuleHttpHeaderSlice(headers)
 	C.envoy_dynamic_module_callback_http_send_response(
 		h.hostPluginPtr,

--- a/source/extensions/dynamic_modules/sdk/go/shared/base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/base.go
@@ -414,10 +414,8 @@ type HttpFilterHandle interface {
 	// @Param status the HTTP status code.
 	// @Param headers the response headers.
 	// @Param body the response body.
-	// @Param grpcStatus the gRPC status code for gRPC requests. Use -1 to indicate no gRPC status
-	// (Envoy will infer from the HTTP status code). Values 0-16 are standard gRPC status codes.
 	// @Param detail a short description to the response for debugging purposes.
-	SendLocalResponse(status uint32, headers [][2]string, body []byte, grpcStatus int32, detail string)
+	SendLocalResponse(status uint32, headers [][2]string, body []byte, detail string)
 
 	// SendResponseHeaders sends response headers to the client. This is used for
 	// streaming local replies.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
@@ -946,15 +946,15 @@ func (mr *MockHttpFilterHandleMockRecorder) SendHttpStreamTrailers(streamID, tra
 }
 
 // SendLocalResponse mocks base method.
-func (m *MockHttpFilterHandle) SendLocalResponse(status uint32, headers [][2]string, body []byte, grpcStatus int32, detail string) {
+func (m *MockHttpFilterHandle) SendLocalResponse(status uint32, headers [][2]string, body []byte, detail string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SendLocalResponse", status, headers, body, grpcStatus, detail)
+	m.ctrl.Call(m, "SendLocalResponse", status, headers, body, detail)
 }
 
 // SendLocalResponse indicates an expected call of SendLocalResponse.
-func (mr *MockHttpFilterHandleMockRecorder) SendLocalResponse(status, headers, body, grpcStatus, detail any) *gomock.Call {
+func (mr *MockHttpFilterHandleMockRecorder) SendLocalResponse(status, headers, body, detail any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendLocalResponse", reflect.TypeOf((*MockHttpFilterHandle)(nil).SendLocalResponse), status, headers, body, grpcStatus, detail)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendLocalResponse", reflect.TypeOf((*MockHttpFilterHandle)(nil).SendLocalResponse), status, headers, body, detail)
 }
 
 // SendResponseData mocks base method.

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -846,16 +846,11 @@ pub trait EnvoyHttpFilter {
   /// Send a response to the downstream with the given status code, headers, and body.
   ///
   /// The headers are passed as a list of key-value pairs.
-  ///
-  /// The `grpc_status` parameter is the gRPC status code for gRPC requests. Use `None` to indicate
-  /// no gRPC status (Envoy will infer from the HTTP status code). Values 0-16 are standard gRPC
-  /// status codes. This is only meaningful when the downstream request is a gRPC request.
   fn send_response<'a>(
     &mut self,
     status_code: u32,
     headers: &'a [(&'a str, &'a [u8])],
     body: Option<&'a [u8]>,
-    grpc_status: Option<i32>,
     details: Option<&'a str>,
   );
 
@@ -1220,14 +1215,6 @@ pub trait EnvoyHttpFilter {
     &self,
     attribute_id: abi::envoy_dynamic_module_type_attribute_id,
   ) -> Option<bool>;
-
-  /// Get the gRPC status code from the response.
-  ///
-  /// This checks response trailers, response headers, and infers from the HTTP status code.
-  /// Returns `None` if no gRPC status is available (e.g., the response is not a gRPC response).
-  fn get_response_grpc_status(&self) -> Option<i64> {
-    self.get_attribute_int(abi::envoy_dynamic_module_type_attribute_id::ResponseGrpcStatus)
-  }
 
   /// Send an HTTP callout to the given cluster with the given headers and body.
   /// Multiple callouts can be made from the same filter. Different callouts can be
@@ -2140,7 +2127,6 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     status_code: u32,
     headers: &[(&str, &[u8])],
     body: Option<&[u8]>,
-    grpc_status: Option<i32>,
     details: Option<&str>,
   ) {
     let body_ptr = body.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
@@ -2148,29 +2134,14 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     let details_ptr = details.map(|s| s.as_ptr()).unwrap_or(std::ptr::null());
     let details_length = details.map(|s| s.len()).unwrap_or(0);
 
-    // When gRPC status is specified, include it as a grpc-status header so Envoy's sendLocalReply
-    // picks it up via modify_headers without requiring an ABI change.
-    let grpc_status_str;
-    let merged_headers;
-    let (final_headers_ptr, final_headers_len) = if let Some(status) = grpc_status {
-      grpc_status_str = status.to_string();
-      let mut h: Vec<(&str, &[u8])> = Vec::with_capacity(headers.len() + 1);
-      h.extend_from_slice(headers);
-      h.push(("grpc-status", grpc_status_str.as_bytes()));
-      merged_headers = h;
-      let HeaderPairSlice(ptr, len) = merged_headers.as_slice().into();
-      (ptr, len)
-    } else {
-      let HeaderPairSlice(ptr, len) = headers.into();
-      (ptr, len)
-    };
+    let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
 
     unsafe {
       abi::envoy_dynamic_module_callback_http_send_response(
         self.raw_ptr,
         status_code,
-        final_headers_ptr as *mut _,
-        final_headers_len,
+        headers_ptr as *mut _,
+        headers_len,
         abi::envoy_dynamic_module_type_module_buffer {
           ptr: body_ptr as *mut _,
           length: body_length,

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -58,7 +58,6 @@ envoy_cc_library(
     deps = [
         ":filter_lib",
         "//envoy/registry",
-        "//source/common/grpc:common_lib",
         "//source/common/http:utility_lib",
         "//source/common/network:upstream_socket_options_filter_state_lib",
         "//source/common/router:string_accessor_lib",

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -5,7 +5,6 @@
 #include "envoy/config/core/v3/socket_option.pb.h"
 #include "envoy/registry/registry.h"
 
-#include "source/common/grpc/common.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/message_impl.h"
 #include "source/common/http/utility.h"
@@ -666,8 +665,8 @@ void envoy_dynamic_module_callback_http_send_response(
     details_view = "dynamic_module";
   }
 
-  filter->sendLocalReply(static_cast<Http::Code>(status_code), body_view, modify_headers,
-                         absl::nullopt, details_view);
+  filter->sendLocalReply(static_cast<Http::Code>(status_code), body_view, modify_headers, 0,
+                         details_view);
 }
 
 void envoy_dynamic_module_callback_http_send_response_headers(
@@ -1423,22 +1422,6 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
     if (connection) {
       *result = connection->id();
       ok = true;
-    }
-    break;
-  }
-  case envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus: {
-    auto* stream_info = filter->streamInfo();
-    if (stream_info) {
-      auto trailers = filter->responseTrailers();
-      auto headers = filter->responseHeaders();
-      auto grpc_status = Grpc::Common::getGrpcStatus(
-          trailers.has_value() ? *trailers : *Http::StaticEmptyHeaders::get().response_trailers,
-          headers.has_value() ? *headers : *Http::StaticEmptyHeaders::get().response_headers,
-          *stream_info);
-      if (grpc_status.has_value()) {
-        *result = grpc_status.value();
-        ok = true;
-      }
     }
     break;
   }

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -403,9 +403,8 @@ TEST_P(DynamicModuleHttpFilterHeaderTest, GetHeaders) {
 }
 
 TEST_F(DynamicModuleHttpFilterTest, SendResponseNullptr) {
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _, testing::Eq(absl::nullopt),
-                             testing::Eq("dynamic_module")));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _,
+                                                 testing::Eq(0), testing::Eq("dynamic_module")));
   envoy_dynamic_module_callback_http_send_response(filter_.get(), 200, nullptr, 0, {nullptr, 0},
                                                    {nullptr, 0});
 }
@@ -416,9 +415,8 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseEmptyResponse) {
       .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
 
   // Test with empty response.
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _, testing::Eq(absl::nullopt),
-                             testing::Eq("dynamic_module")));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _,
+                                                 testing::Eq(0), testing::Eq("dynamic_module")));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
 
   envoy_dynamic_module_callback_http_send_response(filter_.get(), 200, nullptr, 0, {nullptr, 0},
@@ -440,9 +438,8 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponse) {
     header_array[index].value_ptr = const_cast<char*>(value.c_str());
     ++index;
   }
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _, testing::Eq(absl::nullopt),
-                             testing::Eq("dynamic_module")));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq(""), _,
+                                                 testing::Eq(0), testing::Eq("dynamic_module")));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _)).WillOnce(Invoke([](auto& headers, auto) {
     EXPECT_EQ(headers.get(Http::LowerCaseString("single"))[0]->value().getStringView(), "value");
     EXPECT_EQ(headers.get(Http::LowerCaseString("multi"))[0]->value().getStringView(), "value1");
@@ -470,9 +467,8 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseWithBody) {
   }
 
   const std::string body_str = "body";
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::OK, testing::Eq("body"), _,
-                             testing::Eq(absl::nullopt), testing::Eq("dynamic_module")));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq("body"), _,
+                                                 testing::Eq(0), testing::Eq("dynamic_module")));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _)).WillOnce(Invoke([](auto& headers, auto) {
     EXPECT_EQ(headers.get(Http::LowerCaseString("single"))[0]->value().getStringView(), "value");
     EXPECT_EQ(headers.get(Http::LowerCaseString("multi"))[0]->value().getStringView(), "value1");
@@ -485,39 +481,11 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseWithBody) {
 TEST_F(DynamicModuleHttpFilterTest, SendResponseWithCustomResponseCodeDetails) {
   const std::string body_str = "body";
   absl::string_view test_details = "test_details";
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::OK, testing::Eq("body"), _,
-                             testing::Eq(absl::nullopt), testing::Eq("test_details")));
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Envoy::Http::Code::OK, testing::Eq("body"), _,
+                                                 testing::Eq(0), testing::Eq("test_details")));
   envoy_dynamic_module_callback_http_send_response(filter_.get(), 200, nullptr, 0,
                                                    {body_str.data(), body_str.size()},
                                                    {test_details.data(), test_details.size()});
-}
-
-TEST_F(DynamicModuleHttpFilterTest, SendResponseWithGrpcStatusHeader) {
-  // Verify that grpc-status passed as a header is forwarded via modify_headers.
-  std::string grpc_status_key = "grpc-status";
-  std::string grpc_status_value = "14";
-  envoy_dynamic_module_type_module_http_header header_array[1];
-  header_array[0].key_ptr = grpc_status_key.data();
-  header_array[0].key_length = grpc_status_key.size();
-  header_array[0].value_ptr = grpc_status_value.data();
-  header_array[0].value_length = grpc_status_value.size();
-
-  EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
-                             testing::Eq(absl::nullopt), testing::Eq("dynamic_module")))
-      .WillOnce(Invoke([](Http::Code, absl::string_view,
-                          std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
-                          absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
-        Http::TestResponseHeaderMapImpl headers;
-        if (modify_headers) {
-          modify_headers(headers);
-        }
-        EXPECT_EQ(headers.get(Http::LowerCaseString("grpc-status"))[0]->value().getStringView(),
-                  "14");
-      }));
-  envoy_dynamic_module_callback_http_send_response(filter_.get(), 503, header_array, 1,
-                                                   {nullptr, 0}, {nullptr, 0});
 }
 
 TEST_F(DynamicModuleHttpFilterTest, AddCustomFlag) {
@@ -2014,67 +1982,6 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_ConnectionId, &result_number));
   EXPECT_EQ(result_number, 8386);
-}
-
-TEST(ABIImpl, GetAttributeResponseGrpcStatus) {
-  Stats::SymbolTableImpl symbol_table;
-  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
-  StreamInfo::MockStreamInfo stream_info;
-  EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
-  filter.setDecoderFilterCallbacks(decoder_callbacks);
-  filter.setEncoderFilterCallbacks(encoder_callbacks);
-
-  uint64_t result = 0;
-
-  // Without response trailers or headers, gRPC status should be inferred from HTTP response code.
-  EXPECT_CALL(encoder_callbacks, responseTrailers())
-      .WillRepeatedly(testing::Return(ResponseTrailerMapOptRef()));
-  EXPECT_CALL(encoder_callbacks, responseHeaders())
-      .WillRepeatedly(testing::Return(ResponseHeaderMapOptRef()));
-  EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(testing::Return(503));
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
-      &filter, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
-  // HTTP 503 maps to gRPC Unavailable (14).
-  EXPECT_EQ(result, 14);
-}
-
-TEST(ABIImpl, GetAttributeResponseGrpcStatusFromTrailers) {
-  Stats::SymbolTableImpl symbol_table;
-  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
-  StreamInfo::MockStreamInfo stream_info;
-  EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
-  filter.setDecoderFilterCallbacks(decoder_callbacks);
-  filter.setEncoderFilterCallbacks(encoder_callbacks);
-
-  uint64_t result = 0;
-
-  // With grpc-status in response trailers, that should take precedence.
-  Http::TestResponseTrailerMapImpl trailers{{"grpc-status", "7"}};
-  EXPECT_CALL(encoder_callbacks, responseTrailers())
-      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(trailers)));
-  EXPECT_CALL(encoder_callbacks, responseHeaders())
-      .WillRepeatedly(testing::Return(ResponseHeaderMapOptRef()));
-  EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(testing::Return(200));
-  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
-      &filter, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
-  // grpc-status: 7 = PermissionDenied.
-  EXPECT_EQ(result, 7);
-}
-
-TEST(ABIImpl, GetAttributeResponseGrpcStatusNotAvailable) {
-  Stats::SymbolTableImpl symbol_table;
-  DynamicModuleHttpFilter filter_without_callbacks{nullptr, symbol_table, 0};
-
-  uint64_t result = 0;
-
-  // Without callbacks, stream info is not available.
-  EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
-      &filter_without_callbacks, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus,
-      &result));
 }
 
 TEST(ABIImpl, HttpCallout) {

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -576,56 +576,6 @@ TEST_P(DynamicModuleHttpLanguageTests, BodyCallbacks) {
   EXPECT_EQ(response_body.toString(), "barend");
 }
 
-TEST_P(DynamicModuleHttpLanguageTests, SendResponseWithGrpcStatus) {
-  const std::string filter_name = "send_response_grpc";
-  const std::string filter_config = "";
-  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  if (!dynamic_module.ok()) {
-    ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
-  }
-  EXPECT_TRUE(dynamic_module.ok());
-
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Stats::IsolatedStoreImpl stats_store;
-  auto filter_config_or_status =
-      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
-          filter_name, filter_config, DefaultMetricsNamespace, false,
-          std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  EXPECT_TRUE(filter_config_or_status.ok());
-
-  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
-                                                          stats_store.symbolTable(), 0);
-  filter->initializeInModuleFilter();
-
-  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
-  StreamInfo::MockStreamInfo stream_info;
-  EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
-  filter->setDecoderFilterCallbacks(decoder_callbacks);
-  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
-  filter->setEncoderFilterCallbacks(encoder_callbacks);
-
-  // The SDK passes gRPC status as a grpc-status header via modify_headers rather than using an
-  // ABI-level gRPC status parameter.
-  EXPECT_CALL(decoder_callbacks,
-              sendLocalReply(Envoy::Http::Code::ServiceUnavailable, testing::Eq(""), _,
-                             testing::Eq(absl::nullopt), testing::Eq("dynamic_module")))
-      .WillOnce(Invoke([](Http::Code, absl::string_view,
-                          std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
-                          absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
-        Http::TestResponseHeaderMapImpl headers;
-        if (modify_headers) {
-          modify_headers(headers);
-        }
-        EXPECT_EQ(headers.get(Http::LowerCaseString("grpc-status"))[0]->value().getStringView(),
-                  "14");
-      }));
-
-  Http::TestRequestHeaderMapImpl request_headers;
-  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter->decodeHeaders(request_headers, false));
-
-  filter->onDestroy();
-}
-
 TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_non_existing_cluster) {
   const std::string filter_name = "http_callouts";
   NiceMock<Server::Configuration::MockServerFactoryContext> context;

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -418,43 +418,6 @@ TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnResponseHeaders) {
       response->headers().get(Http::LowerCaseString("some_header"))[0]->value().getStringView());
 }
 
-TEST_P(DynamicModulesIntegrationTest, SendResponseWithGrpcStatus) {
-  initializeFilter("send_response_grpc", "\"14\"");
-
-  // Use a gRPC request via makeSingleRequest which handles the full request-response lifecycle.
-  BufferingStreamDecoderPtr response = IntegrationUtil::makeSingleRequest(
-      lookupPort("http"), "POST", "/test/long/url", "", downstream_protocol_, version_,
-      "sni.lyft.com", Http::Headers::get().ContentTypeValues.Grpc);
-  ASSERT_TRUE(response->complete());
-  // gRPC trailers-only response always has HTTP status 200.
-  EXPECT_EQ("200", response->headers().getStatusValue());
-  EXPECT_EQ(Http::Headers::get().ContentTypeValues.Grpc, response->headers().getContentTypeValue());
-  // Verify the gRPC status is set in the response headers (trailers-only response).
-  EXPECT_EQ("14", response->headers().getGrpcStatusValue());
-}
-
-TEST_P(DynamicModulesIntegrationTest, ResponseGrpcStatusAttribute) {
-  initializeFilter("grpc_status_attribute", "");
-  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-
-  auto encoder_decoder = codec_client_->startRequest(default_request_headers_, true);
-  auto response = std::move(encoder_decoder.second);
-
-  waitForNextUpstreamRequest();
-  Http::TestResponseHeaderMapImpl response_headers{
-      {":status", "200"}, {"grpc-status", "7"}, {"content-type", "application/grpc"}};
-  upstream_request_->encodeHeaders(response_headers, true);
-  ASSERT_TRUE(response->waitForEndStream());
-
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  // Verify the filter read the gRPC status from the response headers.
-  EXPECT_EQ("7", response->headers()
-                     .get(Http::LowerCaseString("x-grpc-status-from-attr"))[0]
-                     ->value()
-                     .getStringView());
-}
-
 TEST_P(DynamicModulesIntegrationTest, HttpCalloutsNonExistentCluster) {
   initializeFilter("http_callouts", "missing");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
+++ b/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
@@ -112,7 +112,7 @@ public:
   MOCK_METHOD(void, setFilterState, (std::string_view key, std::string_view value), (override));
   MOCK_METHOD(void, sendLocalResponse,
               (uint32_t status, std::span<const HeaderView> headers, std::string_view body,
-               int32_t grpc_status, std::string_view detail),
+               std::string_view detail),
               (override));
   MOCK_METHOD(void, sendResponseHeaders, (std::span<const HeaderView> headers, bool end_stream),
               (override));

--- a/test/extensions/dynamic_modules/test_data/cpp/http.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http.cc
@@ -247,7 +247,7 @@ public:
     std::vector<HeaderView> headers;
     headers.push_back(HeaderView("header1", "value1"));
     headers.push_back(HeaderView("header2", "value2"));
-    handle_.sendLocalResponse(200, headers, "Hello, World!", -1, "");
+    handle_.sendLocalResponse(200, headers, "Hello, World!", "");
     return HeadersStatus::Stop;
   }
 
@@ -278,47 +278,6 @@ public:
 };
 
 REGISTER_HTTP_FILTER_CONFIG_FACTORY(SendResponseConfigFactory, "send_response");
-
-// --- send_response_grpc ---
-
-class SendResponseGrpcFilter : public HttpFilter {
-public:
-  SendResponseGrpcFilter(HttpFilterHandle& handle) : handle_(handle) {}
-
-  HeadersStatus onRequestHeaders(HeaderMap&, bool) override {
-    std::vector<HeaderView> h;
-    h.push_back(HeaderView("grpc-message", "service unavailable"));
-    handle_.sendLocalResponse(503, h, "", 14, "");
-    return HeadersStatus::Stop;
-  }
-
-  BodyStatus onRequestBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
-  TrailersStatus onRequestTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
-  HeadersStatus onResponseHeaders(HeaderMap&, bool) override { return HeadersStatus::Continue; }
-  BodyStatus onResponseBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
-  TrailersStatus onResponseTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
-  void onStreamComplete() override {}
-  void onDestroy() override {}
-
-private:
-  HttpFilterHandle& handle_;
-};
-
-class SendResponseGrpcFactory : public HttpFilterFactory {
-public:
-  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
-    return std::make_unique<SendResponseGrpcFilter>(handle);
-  }
-};
-
-class SendResponseGrpcConfigFactory : public HttpFilterConfigFactory {
-public:
-  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle&, std::string_view) override {
-    return std::make_unique<SendResponseGrpcFactory>();
-  }
-};
-
-REGISTER_HTTP_FILTER_CONFIG_FACTORY(SendResponseGrpcConfigFactory, "send_response_grpc");
 
 // --- dynamic_metadata_callbacks ---
 

--- a/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
@@ -615,7 +615,7 @@ public:
   HeadersStatus onRequestHeaders(HeaderMap& headers, bool end_stream) override {
     if (mode_ == "on_request_headers") {
       std::vector<HeaderView> h = {{"some_header", "some_value"}};
-      handle_.sendLocalResponse(200, h, "local_response_body_from_on_request_headers", -1,
+      handle_.sendLocalResponse(200, h, "local_response_body_from_on_request_headers",
                                 "test_details");
       return HeadersStatus::StopAllAndBuffer;
     }
@@ -625,7 +625,7 @@ public:
   BodyStatus onRequestBody(BodyBuffer& body, bool end_stream) override {
     if (mode_ == "on_request_body") {
       std::vector<HeaderView> h = {{"some_header", "some_value"}};
-      handle_.sendLocalResponse(200, h, "local_response_body_from_on_request_body", -1, "");
+      handle_.sendLocalResponse(200, h, "local_response_body_from_on_request_body", "");
       return BodyStatus::StopAndBuffer;
     }
     return BodyStatus::Continue;
@@ -634,7 +634,7 @@ public:
   HeadersStatus onResponseHeaders(HeaderMap& headers, bool end_stream) override {
     if (mode_ == "on_response_headers") {
       std::vector<HeaderView> h = {{"some_header", "some_value"}};
-      handle_.sendLocalResponse(500, h, "local_response_body_from_on_response_headers", -1, "");
+      handle_.sendLocalResponse(500, h, "local_response_body_from_on_response_headers", "");
       return HeadersStatus::StopAllAndBuffer;
     }
     return HeadersStatus::Continue;
@@ -680,122 +680,6 @@ public:
 REGISTER_HTTP_FILTER_CONFIG_FACTORY(SendResponseConfigFactory, "send_response");
 
 // -----------------------------------------------------------------------------
-// SendResponseGrpc
-// -----------------------------------------------------------------------------
-
-class SendResponseGrpcFilter : public HttpFilter {
-public:
-  SendResponseGrpcFilter(HttpFilterHandle& handle, int32_t grpc_status)
-      : handle_(handle), grpc_status_(grpc_status) {}
-
-  HeadersStatus onRequestHeaders(HeaderMap& headers, bool end_stream) override {
-    std::vector<HeaderView> h = {{"x-grpc-test", "true"}};
-    handle_.sendLocalResponse(200, h, "grpc_response", grpc_status_, "");
-    return HeadersStatus::StopAllAndBuffer;
-  }
-
-  BodyStatus onRequestBody(BodyBuffer& body, bool end_stream) override {
-    return BodyStatus::Continue;
-  }
-  TrailersStatus onRequestTrailers(HeaderMap& trailers) override {
-    return TrailersStatus::Continue;
-  }
-  HeadersStatus onResponseHeaders(HeaderMap& headers, bool end_stream) override {
-    return HeadersStatus::Continue;
-  }
-  BodyStatus onResponseBody(BodyBuffer& body, bool end_stream) override {
-    return BodyStatus::Continue;
-  }
-  TrailersStatus onResponseTrailers(HeaderMap& trailers) override {
-    return TrailersStatus::Continue;
-  }
-  void onStreamComplete() override {}
-  void onDestroy() override {}
-
-private:
-  HttpFilterHandle& handle_;
-  int32_t grpc_status_;
-};
-
-class SendResponseGrpcFilterFactory : public HttpFilterFactory {
-public:
-  SendResponseGrpcFilterFactory(int32_t grpc_status) : grpc_status_(grpc_status) {}
-
-  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
-    return std::make_unique<SendResponseGrpcFilter>(handle, grpc_status_);
-  }
-
-private:
-  int32_t grpc_status_;
-};
-
-class SendResponseGrpcConfigFactory : public HttpFilterConfigFactory {
-public:
-  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle& handle,
-                                            std::string_view config_view) override {
-    int32_t grpc_status = static_cast<int32_t>(std::stol(std::string(config_view)));
-    return std::make_unique<SendResponseGrpcFilterFactory>(grpc_status);
-  }
-};
-
-REGISTER_HTTP_FILTER_CONFIG_FACTORY(SendResponseGrpcConfigFactory, "send_response_grpc");
-
-// -----------------------------------------------------------------------------
-// GrpcStatusAttribute
-// -----------------------------------------------------------------------------
-
-class GrpcStatusAttributeFilter : public HttpFilter {
-public:
-  GrpcStatusAttributeFilter(HttpFilterHandle& handle) : handle_(handle) {}
-
-  HeadersStatus onRequestHeaders(HeaderMap& headers, bool end_stream) override {
-    return HeadersStatus::Continue;
-  }
-
-  BodyStatus onRequestBody(BodyBuffer& body, bool end_stream) override {
-    return BodyStatus::Continue;
-  }
-  TrailersStatus onRequestTrailers(HeaderMap& trailers) override {
-    return TrailersStatus::Continue;
-  }
-  HeadersStatus onResponseHeaders(HeaderMap& headers, bool end_stream) override {
-    auto grpc_status = handle_.getAttributeNumber(AttributeID::ResponseGrpcStatus);
-    if (grpc_status.has_value()) {
-      headers.set("x-grpc-status-from-attr", std::to_string(grpc_status.value()));
-    }
-    return HeadersStatus::Continue;
-  }
-  BodyStatus onResponseBody(BodyBuffer& body, bool end_stream) override {
-    return BodyStatus::Continue;
-  }
-  TrailersStatus onResponseTrailers(HeaderMap& trailers) override {
-    return TrailersStatus::Continue;
-  }
-  void onStreamComplete() override {}
-  void onDestroy() override {}
-
-private:
-  HttpFilterHandle& handle_;
-};
-
-class GrpcStatusAttributeFilterFactory : public HttpFilterFactory {
-public:
-  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
-    return std::make_unique<GrpcStatusAttributeFilter>(handle);
-  }
-};
-
-class GrpcStatusAttributeConfigFactory : public HttpFilterConfigFactory {
-public:
-  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle& handle,
-                                            std::string_view config_view) override {
-    return std::make_unique<GrpcStatusAttributeFilterFactory>();
-  }
-};
-
-REGISTER_HTTP_FILTER_CONFIG_FACTORY(GrpcStatusAttributeConfigFactory, "grpc_status_attribute");
-
-// -----------------------------------------------------------------------------
 // HttpCallouts
 // -----------------------------------------------------------------------------
 
@@ -813,7 +697,7 @@ public:
                                               // plugin and we stop, we should be fine.
     if (result.first != HttpCalloutInitResult::Success) {
       std::vector<HeaderView> h = {{"foo", "bar"}};
-      handle_.sendLocalResponse(500, h, "", -1, "");
+      handle_.sendLocalResponse(500, h, "", "");
     }
     callout_handle_ = result.second;
     return HeadersStatus::Stop;
@@ -843,7 +727,7 @@ public:
     assertEq(full_body, "response_body_from_callout", "resp body");
 
     std::vector<HeaderView> h = {{"some_header", "some_value"}};
-    handle_.sendLocalResponse(200, h, "local_response_body", -1, "callout_success");
+    handle_.sendLocalResponse(200, h, "local_response_body", "callout_success");
   }
 
   TrailersStatus onRequestTrailers(HeaderMap& trailers) override {
@@ -983,7 +867,7 @@ public:
     if (key == "existing") {
       sched->schedule([this]() {
         std::vector<HeaderView> h = {{"cached", "yes"}};
-        handle_.sendLocalResponse(200, h, "cached_response_body", -1, "");
+        handle_.sendLocalResponse(200, h, "cached_response_body", "");
       });
     } else {
       sched->schedule([this]() {
@@ -1326,7 +1210,7 @@ public:
     auto result = handle_.startHttpStream(cluster_, h, "", true, 5000, *this);
     if (result.first != HttpCalloutInitResult::Success) {
       std::vector<HeaderView> rh = {{"x-error", "stream_init_failed"}};
-      handle_.sendLocalResponse(500, rh, "", -1, "");
+      handle_.sendLocalResponse(500, rh, "", "");
       return HeadersStatus::StopAllAndBuffer;
     }
     stream_id_ = result.second;
@@ -1360,7 +1244,7 @@ public:
     assertEq(stream_id, stream_id_, "stream id");
     complete_ = true;
     std::vector<HeaderView> h = {{"x-stream-test", "basic"}};
-    handle_.sendLocalResponse(200, h, "stream_callout_success", -1, "");
+    handle_.sendLocalResponse(200, h, "stream_callout_success", "");
   }
 
   void onHttpStreamReset(uint64_t stream_id, HttpStreamResetReason reason) override {}
@@ -1433,7 +1317,7 @@ public:
     auto result = handle_.startHttpStream(cluster_, h, "", false, 10000, *this);
     if (result.first != HttpCalloutInitResult::Success) {
       std::vector<HeaderView> rh = {{"x-error", "stream_init_failed"}};
-      handle_.sendLocalResponse(500, rh, "", -1, "");
+      handle_.sendLocalResponse(500, rh, "", "");
       return HeadersStatus::StopAllAndBuffer;
     }
     stream_id_ = result.second;
@@ -1470,7 +1354,7 @@ public:
         {"x-chunks-sent", std::to_string(sent_chunks_)},
         {"x-chunks-received", std::to_string(recv_chunks_)},
     };
-    handle_.sendLocalResponse(200, h, "bidirectional_success", -1, "");
+    handle_.sendLocalResponse(200, h, "bidirectional_success", "");
   }
 
   void onHttpStreamReset(uint64_t stream_id, HttpStreamResetReason reason) override {}
@@ -1547,7 +1431,7 @@ public:
     auto result = handle_.startHttpStream(cluster_, h, "", true, 5000, *this);
     if (result.first != HttpCalloutInitResult::Success) {
       std::vector<HeaderView> rh = {{"x-error", "stream_init_failed"}};
-      handle_.sendLocalResponse(500, rh, "", -1, "");
+      handle_.sendLocalResponse(500, rh, "", "");
       return HeadersStatus::StopAllAndBuffer;
     }
     stream_id_ = result.second;
@@ -1557,7 +1441,7 @@ public:
   void onHttpStreamReset(uint64_t stream_id, HttpStreamResetReason reason) override {
     assertEq(stream_id, stream_id_, "id");
     std::vector<HeaderView> rh = {{"x-reset", "true"}};
-    handle_.sendLocalResponse(200, rh, "upstream_reset", -1, "");
+    handle_.sendLocalResponse(200, rh, "upstream_reset", "");
   }
 
   void onHttpStreamHeaders(uint64_t stream_id, std::span<const HeaderView> headers,
@@ -1624,10 +1508,10 @@ public:
   HeadersStatus onRequestHeaders(HeaderMap& headers, bool end_stream) override {
     if (callout_done_->load()) {
       std::vector<HeaderView> h = {{"x-config-callout", "success"}};
-      handle_.sendLocalResponse(200, h, "", -1, "");
+      handle_.sendLocalResponse(200, h, "", "");
     } else {
       std::vector<HeaderView> h = {{"x-config-callout", "pending"}};
-      handle_.sendLocalResponse(503, h, "", -1, "");
+      handle_.sendLocalResponse(503, h, "", "");
     }
     return HeadersStatus::Stop;
   }
@@ -1704,10 +1588,10 @@ public:
   HeadersStatus onRequestHeaders(HeaderMap& headers, bool end_stream) override {
     if (stream_done_->load()) {
       std::vector<HeaderView> h = {{"x-config-stream", "success"}};
-      handle_.sendLocalResponse(200, h, "", -1, "");
+      handle_.sendLocalResponse(200, h, "", "");
     } else {
       std::vector<HeaderView> h = {{"x-config-stream", "pending"}};
-      handle_.sendLocalResponse(503, h, "", -1, "");
+      handle_.sendLocalResponse(503, h, "", "");
     }
     return HeadersStatus::Stop;
   }

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -13,7 +13,6 @@ func init() {
 		"stats_callbacks":            &statsCallbacksConfigFactory{},
 		"header_callbacks":           &headerCallbacksConfigFactory{},
 		"send_response":              &sendResponseConfigFactory{},
-		"send_response_grpc":         &sendResponseGrpcConfigFactory{},
 		"dynamic_metadata_callbacks": &dynamicMetadataCallbacksConfigFactory{},
 		"filter_state_callbacks":     &filterStateCallbacksConfigFactory{},
 		"body_callbacks":             &bodyCallbacksConfigFactory{},
@@ -224,35 +223,7 @@ func (f *sendResponseFactory) Create(handle shared.HttpFilterHandle) shared.Http
 func (p *sendResponseFilter) OnRequestHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
 	p.handle.SendLocalResponse(200, [][2]string{{"header1", "value1"}, {"header2", "value2"}},
-		[]byte("Hello, World!"), -1, "")
-	return shared.HeadersStatusStop
-}
-
-// --- send_response_grpc ---
-type sendResponseGrpcConfigFactory struct {
-	shared.EmptyHttpFilterConfigFactory
-}
-type sendResponseGrpcFactory struct {
-	shared.EmptyHttpFilterFactory
-}
-
-func (f *sendResponseGrpcConfigFactory) Create(handle shared.HttpFilterConfigHandle,
-	config []byte) (shared.HttpFilterFactory, error) {
-	return &sendResponseGrpcFactory{}, nil
-}
-
-type sendResponseGrpcFilter struct {
-	handle shared.HttpFilterHandle
-	shared.EmptyHttpFilter
-}
-
-func (f *sendResponseGrpcFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
-	return &sendResponseGrpcFilter{handle: handle}
-}
-
-func (p *sendResponseGrpcFilter) OnRequestHeaders(headers shared.HeaderMap,
-	endOfStream bool) shared.HeadersStatus {
-	p.handle.SendLocalResponse(503, [][2]string{{"grpc-message", "service unavailable"}}, nil, 14, "")
+		[]byte("Hello, World!"), "")
 	return shared.HeadersStatusStop
 }
 

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -24,8 +24,6 @@ func init() {
 		"body_callbacks":               &BodyCallbacksConfigFactory{},
 		"http_callouts":                &HttpCalloutsConfigFactory{},
 		"send_response":                &SendResponseConfigFactory{},
-		"send_response_grpc":           &SendResponseGrpcConfigFactory{},
-		"grpc_status_attribute":        &GrpcStatusAttributeConfigFactory{},
 		"http_filter_scheduler":        &HttpFilterSchedulerConfigFactory{},
 		"fake_external_cache":          &FakeExternalCacheConfigFactory{},
 		"stats_callbacks":              &StatsCallbacksConfigFactory{},
@@ -516,7 +514,7 @@ func (p *SendResponseFilter) OnRequestHeaders(headers shared.HeaderMap,
 	if p.mode == "on_request_headers" {
 		p.handle.SendLocalResponse(200,
 			[][2]string{{"some_header", "some_value"}},
-			[]byte("local_response_body_from_on_request_headers"), -1, "test_details")
+			[]byte("local_response_body_from_on_request_headers"), "test_details")
 		return shared.HeadersStatusStop
 	}
 	return shared.HeadersStatusContinue
@@ -527,7 +525,7 @@ func (p *SendResponseFilter) OnRequestBody(body shared.BodyBuffer,
 	if p.mode == "on_request_body" {
 		p.handle.SendLocalResponse(200,
 			[][2]string{{"some_header", "some_value"}},
-			[]byte("local_response_body_from_on_request_body"), -1, "")
+			[]byte("local_response_body_from_on_request_body"), "")
 		return shared.BodyStatusStopAndBuffer
 	}
 	return shared.BodyStatusContinue
@@ -538,82 +536,8 @@ func (p *SendResponseFilter) OnResponseHeaders(headers shared.HeaderMap,
 	if p.mode == "on_response_headers" {
 		p.handle.SendLocalResponse(500,
 			[][2]string{{"some_header", "some_value"}},
-			[]byte("local_response_body_from_on_response_headers"), -1, "")
+			[]byte("local_response_body_from_on_response_headers"), "")
 		return shared.HeadersStatusStop
-	}
-	return shared.HeadersStatusContinue
-}
-
-// -----------------------------------------------------------------------------
-// SendResponseGrpc
-// -----------------------------------------------------------------------------
-
-type SendResponseGrpcConfigFactory struct {
-	shared.EmptyHttpFilterConfigFactory
-}
-
-func (f *SendResponseGrpcConfigFactory) Create(handle shared.HttpFilterConfigHandle,
-	config []byte) (shared.HttpFilterFactory, error) {
-	grpcStatus, err := strconv.ParseInt(string(config), 10, 32)
-	if err != nil {
-		return nil, fmt.Errorf("invalid grpc status config: %v", err)
-	}
-	return &SendResponseGrpcFilterFactory{grpcStatus: int32(grpcStatus)}, nil
-}
-
-type SendResponseGrpcFilterFactory struct {
-	shared.EmptyHttpFilterFactory
-	grpcStatus int32
-}
-
-func (f *SendResponseGrpcFilterFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
-	return &SendResponseGrpcFilter{handle: handle, grpcStatus: f.grpcStatus}
-}
-
-type SendResponseGrpcFilter struct {
-	shared.EmptyHttpFilter
-	handle     shared.HttpFilterHandle
-	grpcStatus int32
-}
-
-func (p *SendResponseGrpcFilter) OnRequestHeaders(headers shared.HeaderMap,
-	endOfStream bool) shared.HeadersStatus {
-	p.handle.SendLocalResponse(200,
-		[][2]string{{"x-grpc-test", "true"}},
-		[]byte("grpc_response"), p.grpcStatus, "")
-	return shared.HeadersStatusStop
-}
-
-// -----------------------------------------------------------------------------
-// GrpcStatusAttribute
-// -----------------------------------------------------------------------------
-
-type GrpcStatusAttributeConfigFactory struct {
-	shared.EmptyHttpFilterConfigFactory
-}
-
-func (f *GrpcStatusAttributeConfigFactory) Create(handle shared.HttpFilterConfigHandle,
-	config []byte) (shared.HttpFilterFactory, error) {
-	return &GrpcStatusAttributeFilterFactory{}, nil
-}
-
-type GrpcStatusAttributeFilterFactory struct {
-	shared.EmptyHttpFilterFactory
-}
-
-func (f *GrpcStatusAttributeFilterFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
-	return &GrpcStatusAttributeFilter{handle: handle}
-}
-
-type GrpcStatusAttributeFilter struct {
-	shared.EmptyHttpFilter
-	handle shared.HttpFilterHandle
-}
-
-func (p *GrpcStatusAttributeFilter) OnResponseHeaders(headers shared.HeaderMap,
-	endOfStream bool) shared.HeadersStatus {
-	if val, ok := p.handle.GetAttributeNumber(shared.AttributeIDResponseGrpcStatus); ok {
-		headers.Set("x-grpc-status-from-attr", strconv.FormatInt(int64(val), 10))
 	}
 	return shared.HeadersStatusContinue
 }
@@ -657,7 +581,7 @@ func (p *HttpCalloutsFilter) OnRequestHeaders(headers shared.HeaderMap,
 		p,
 	)
 	if res != shared.HttpCalloutInitSuccess {
-		p.handle.SendLocalResponse(500, [][2]string{{"foo", "bar"}}, nil, -1, "")
+		p.handle.SendLocalResponse(500, [][2]string{{"foo", "bar"}}, nil, "")
 	}
 	p.calloutHandle = id
 	return shared.HeadersStatusStop
@@ -688,7 +612,7 @@ func (p *HttpCalloutsFilter) OnHttpCalloutDone(calloutID uint64, result shared.H
 	assertEq(fullBody, "response_body_from_callout", "resp body")
 
 	p.handle.SendLocalResponse(200, [][2]string{{"some_header", "some_value"}},
-		[]byte("local_response_body"), -1, "callout_success")
+		[]byte("local_response_body"), "callout_success")
 }
 
 // -----------------------------------------------------------------------------
@@ -804,7 +728,7 @@ func (p *FakeExternalCacheFilter) OnRequestHeaders(headers shared.HeaderMap, end
 		if key.ToUnsafeString() == "existing" {
 			// Simulate hit
 			sched.Schedule(func() {
-				p.handle.SendLocalResponse(200, [][2]string{{"cached", "yes"}}, []byte("cached_response_body"), -1, "")
+				p.handle.SendLocalResponse(200, [][2]string{{"cached", "yes"}}, []byte("cached_response_body"), "")
 			})
 		} else {
 			// Simulate miss
@@ -1079,7 +1003,7 @@ func (p *HttpStreamBasicFilter) OnRequestHeaders(h shared.HeaderMap, end bool) s
 		nil, true, 5000, p)
 	if res != shared.HttpCalloutInitSuccess {
 		p.handle.SendLocalResponse(500,
-			[][2]string{{"x-error", "stream_init_failed"}}, nil, -1, "")
+			[][2]string{{"x-error", "stream_init_failed"}}, nil, "")
 		return shared.HeadersStatusStop
 	}
 	p.streamID = id
@@ -1110,7 +1034,7 @@ func (p *HttpStreamBasicFilter) OnHttpStreamComplete(id uint64) {
 	p.complete = true
 	p.handle.SendLocalResponse(200,
 		[][2]string{{"x-stream-test", "basic"}},
-		[]byte("stream_callout_success"), -1, "")
+		[]byte("stream_callout_success"), "")
 }
 func (p *HttpStreamBasicFilter) OnHttpStreamReset(id uint64, reason shared.HttpStreamResetReason) {}
 
@@ -1157,7 +1081,7 @@ func (p *HttpStreamBidiFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sh
 		[][2]string{{":path", "/stream"}, {":method", "POST"}, {"host", "example.com"}},
 		nil, false, 10000, p)
 	if res != shared.HttpCalloutInitSuccess {
-		p.handle.SendLocalResponse(500, [][2]string{{"x-error", "stream_init_failed"}}, nil, -1, "")
+		p.handle.SendLocalResponse(500, [][2]string{{"x-error", "stream_init_failed"}}, nil, "")
 		return shared.HeadersStatusStop
 	}
 	p.streamID = id
@@ -1188,7 +1112,7 @@ func (p *HttpStreamBidiFilter) OnHttpStreamComplete(id uint64) {
 		{"x-stream-test", "bidirectional"},
 		{"x-chunks-sent", strconv.Itoa(p.sentChunks)},
 		{"x-chunks-received", strconv.Itoa(p.recvChunks)},
-	}, []byte("bidirectional_success"), -1, "")
+	}, []byte("bidirectional_success"), "")
 }
 func (p *HttpStreamBidiFilter) OnHttpStreamReset(id uint64, reason shared.HttpStreamResetReason) {}
 
@@ -1231,7 +1155,7 @@ func (p *UpstreamResetFilter) OnRequestHeaders(h shared.HeaderMap, end bool) sha
 		[][2]string{{":path", "/reset"}, {":method", "GET"}, {"host", "example.com"}},
 		nil, true, 5000, p)
 	if res != shared.HttpCalloutInitSuccess {
-		p.handle.SendLocalResponse(500, [][2]string{{"x-error", "stream_init_failed"}}, nil, -1, "")
+		p.handle.SendLocalResponse(500, [][2]string{{"x-error", "stream_init_failed"}}, nil, "")
 		return shared.HeadersStatusStop
 	}
 	p.streamID = id
@@ -1246,7 +1170,7 @@ func (p *UpstreamResetFilter) OnHttpStreamTrailers(id uint64, trailers [][2]shar
 func (p *UpstreamResetFilter) OnHttpStreamComplete(id uint64) {}
 func (p *UpstreamResetFilter) OnHttpStreamReset(id uint64, reason shared.HttpStreamResetReason) {
 	assertEq(id, p.streamID, "id")
-	p.handle.SendLocalResponse(200, [][2]string{{"x-reset", "true"}}, []byte("upstream_reset"), -1, "")
+	p.handle.SendLocalResponse(200, [][2]string{{"x-reset", "true"}}, []byte("upstream_reset"), "")
 }
 
 // -----------------------------------------------------------------------------
@@ -1301,9 +1225,9 @@ type HttpConfigCalloutFilter struct {
 func (p *HttpConfigCalloutFilter) OnRequestHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
 	if p.calloutDone.Load() {
-		p.handle.SendLocalResponse(200, [][2]string{{"x-config-callout", "success"}}, nil, -1, "")
+		p.handle.SendLocalResponse(200, [][2]string{{"x-config-callout", "success"}}, nil, "")
 	} else {
-		p.handle.SendLocalResponse(503, [][2]string{{"x-config-callout", "pending"}}, nil, -1, "")
+		p.handle.SendLocalResponse(503, [][2]string{{"x-config-callout", "pending"}}, nil, "")
 	}
 	return shared.HeadersStatusStop
 }
@@ -1372,9 +1296,9 @@ type HttpConfigStreamFilter struct {
 func (p *HttpConfigStreamFilter) OnRequestHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
 	if p.streamDone.Load() {
-		p.handle.SendLocalResponse(200, [][2]string{{"x-config-stream", "success"}}, nil, -1, "")
+		p.handle.SendLocalResponse(200, [][2]string{{"x-config-stream", "success"}}, nil, "")
 	} else {
-		p.handle.SendLocalResponse(503, [][2]string{{"x-config-stream", "pending"}}, nil, -1, "")
+		p.handle.SendLocalResponse(503, [][2]string{{"x-config-stream", "pending"}}, nil, "")
 	}
 	return shared.HeadersStatusStop
 }

--- a/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/bootstrap_http_combined_test.rs
@@ -208,7 +208,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
           503,
           &[("x-error-reason", b"function_not_registered")],
           Some(b"routing function not registered"),
-          None,
           Some("function_not_registered"),
         );
         return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
@@ -244,7 +243,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for CombinedHttpFilter {
             503,
             &[("x-error-reason", b"service_not_onboarded")],
             Some(format!("service '{}' is not onboarded", svc).as_bytes()),
-            None,
             Some("service_not_onboarded"),
           );
           abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -44,7 +44,6 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     })),
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
     "send_response" => Some(Box::new(SendResponseFilterConfig {})),
-    "send_response_grpc" => Some(Box::new(SendResponseGrpcFilterConfig {})),
     "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     "filter_state_callbacks" => Some(Box::new(FilterStateCallbacksFilterConfig {})),
     "typed_filter_state_callbacks" => Some(Box::new(TypedFilterStateCallbacksFilterConfig {})),
@@ -447,35 +446,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseFilter {
         ("header2", "value2".as_bytes()),
       ],
       Some(b"Hello, World!"),
-      None,
-      None,
-    );
-    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
-  }
-}
-
-/// A HTTP filter configuration to test `send_response()` with a gRPC status code.
-struct SendResponseGrpcFilterConfig {}
-
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for SendResponseGrpcFilterConfig {
-  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(SendResponseGrpcFilter {})
-  }
-}
-
-struct SendResponseGrpcFilter {}
-
-impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseGrpcFilter {
-  fn on_request_headers(
-    &mut self,
-    envoy_filter: &mut EHF,
-    _end_of_stream: bool,
-  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-    envoy_filter.send_response(
-      503,
-      &[("grpc-message", b"service unavailable")],
-      None,
-      Some(14), // Unavailable.
       None,
     );
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -40,13 +40,6 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       cluster_name: String::from_utf8(config.to_owned()).unwrap(),
     })),
     "send_response" => Some(Box::new(SendResponseHttpFilterConfig::new(config))),
-    "send_response_grpc" => Some(Box::new(SendResponseGrpcFilterConfig {
-      grpc_status: String::from_utf8(config.to_owned())
-        .unwrap()
-        .parse::<i32>()
-        .unwrap(),
-    })),
-    "grpc_status_attribute" => Some(Box::new(GrpcStatusAttributeFilterConfig {})),
     "http_filter_scheduler" => Some(Box::new(HttpFilterSchedulerConfig {})),
     "fake_external_cache" => Some(Box::new(FakeExternalCachingFilterConfig {})),
     "stats_callbacks" => {
@@ -233,9 +226,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ConfigCalloutFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     if self.callout_done.load(Ordering::SeqCst) {
-      envoy_filter.send_response(200, &[("x-config-callout", b"success")], None, None, None);
+      envoy_filter.send_response(200, &[("x-config-callout", b"success")], None, None);
     } else {
-      envoy_filter.send_response(503, &[("x-config-callout", b"pending")], None, None, None);
+      envoy_filter.send_response(503, &[("x-config-callout", b"pending")], None, None);
     }
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
@@ -286,9 +279,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ConfigStreamFilter {
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     if self.stream_done.load(Ordering::SeqCst) {
-      envoy_filter.send_response(200, &[("x-config-stream", b"success")], None, None, None);
+      envoy_filter.send_response(200, &[("x-config-stream", b"success")], None, None);
     } else {
-      envoy_filter.send_response(503, &[("x-config-stream", b"pending")], None, None, None);
+      envoy_filter.send_response(503, &[("x-config-stream", b"pending")], None, None);
     }
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
@@ -823,7 +816,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
         200,
         &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_request_headers"),
-        None,
         Some("test_details"),
       );
       envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
@@ -843,7 +835,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
         &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_request_body"),
         None,
-        None,
       );
       envoy_dynamic_module_type_on_http_filter_request_body_status::StopIterationAndBuffer
     } else {
@@ -862,70 +853,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseHttpFilter {
         &[("some_header", b"some_value")],
         Some(b"local_response_body_from_on_response_headers"),
         None,
-        None,
       );
       return envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration;
     }
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
-  }
-}
-
-struct SendResponseGrpcFilterConfig {
-  grpc_status: i32,
-}
-
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for SendResponseGrpcFilterConfig {
-  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(SendResponseGrpcFilter {
-      grpc_status: self.grpc_status,
-    })
-  }
-}
-
-struct SendResponseGrpcFilter {
-  grpc_status: i32,
-}
-
-impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SendResponseGrpcFilter {
-  fn on_request_headers(
-    &mut self,
-    envoy_filter: &mut EHF,
-    _end_of_stream: bool,
-  ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
-    envoy_filter.send_response(
-      200,
-      &[("x-grpc-test", b"true")],
-      Some(b"grpc_response"),
-      Some(self.grpc_status),
-      None,
-    );
-    envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
-  }
-}
-
-struct GrpcStatusAttributeFilterConfig {}
-
-impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for GrpcStatusAttributeFilterConfig {
-  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(GrpcStatusAttributeFilter {})
-  }
-}
-
-struct GrpcStatusAttributeFilter {}
-
-impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for GrpcStatusAttributeFilter {
-  fn on_response_headers(
-    &mut self,
-    envoy_filter: &mut EHF,
-    _end_of_stream: bool,
-  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
-    if let Some(grpc_status) = envoy_filter.get_response_grpc_status() {
-      envoy_filter.set_response_header(
-        "x-grpc-status-from-attr",
-        grpc_status.to_string().as_bytes(),
-      );
-    }
-    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }
 
@@ -964,7 +895,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpCalloutsFilter {
       1000,
     );
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("foo", b"bar")], None, None, None);
+      envoy_filter.send_response(500, &[("foo", b"bar")], None, None);
     }
     self.callout_handle = handle;
     envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
@@ -1010,7 +941,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpCalloutsFilter {
       200,
       &[("some_header", b"some_value")],
       Some(b"local_response_body"),
-      None,
       Some("callout_success"),
     );
   }
@@ -1148,13 +1078,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FakeExternalCachingFilter {
       // Event from the on_scheduled when the cache key was found.
       1 => {
         let result = self.rx.take().unwrap().recv().unwrap();
-        envoy_filter.send_response(
-          200,
-          &[("cached", b"yes")],
-          Some(result.as_bytes()),
-          None,
-          None,
-        );
+        envoy_filter.send_response(200, &[("cached", b"yes")], Some(result.as_bytes()), None);
       },
       // Event from the on_response_headers.
       2 => {
@@ -1624,7 +1548,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBasicFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1678,7 +1602,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBasicFilter {
       200,
       &[("x-stream-test", b"basic")],
       Some(b"stream_callout_success"),
-      None,
       None,
     );
   }
@@ -1742,7 +1665,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1817,7 +1740,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HttpStreamBidirectionalFilter {
       ],
       Some(b"bidirectional_success"),
       None,
-      None,
     );
   }
 }
@@ -1871,7 +1793,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -1919,12 +1841,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     _reason: envoy_dynamic_module_type_http_stream_reset_reason,
   ) {
     assert_eq!(stream_handle, self.stream_handle);
-    envoy_filter.send_response(
-      200,
-      &[("x-reset", b"true")],
-      Some(b"upstream_reset"),
-      None,
-      None,
-    );
+    envoy_filter.send_response(200, &[("x-reset", b"true")], Some(b"upstream_reset"), None);
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_stream_callouts_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_stream_callouts_test.rs
@@ -86,7 +86,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BasicStreamLifecycleFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -122,7 +122,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BasicStreamLifecycleFilter {
       200,
       &[("x-stream", b"success")],
       Some(b"stream_callout_success"),
-      None,
       None,
     );
   }
@@ -184,7 +183,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -226,7 +225,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BidirectionalStreamingFilter {
       200,
       &[("x-chunks-received", chunks_str.as_bytes())],
       Some(b"bidirectional_success"),
-      None,
       None,
     );
   }
@@ -284,7 +282,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MultipleStreamsFilter {
     }
 
     if self.stream_handles.len() != 3 {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
     }
 
     envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
@@ -295,7 +293,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MultipleStreamsFilter {
     self.completed_streams += 1;
 
     if self.completed_streams == 3 {
-      envoy_filter.send_response(200, &[("x-stream", b"all_success")], None, None, None);
+      envoy_filter.send_response(200, &[("x-stream", b"all_success")], None, None);
     }
   }
 }
@@ -347,7 +345,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -385,7 +383,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamResetFilter {
       200,
       &[("x-stream", b"reset_ok")],
       Some(b"stream_was_reset"),
-      None,
       None,
     );
   }
@@ -441,7 +438,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     );
 
     if result != envoy_dynamic_module_type_http_callout_init_result::Success {
-      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None, None);
+      envoy_filter.send_response(500, &[("x-error", b"stream_init_failed")], None, None);
       return envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
     }
 
@@ -456,12 +453,6 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamResetFilter {
     _reason: envoy_dynamic_module_type_http_stream_reset_reason,
   ) {
     assert_eq!(stream_handle, self.stream_handle);
-    envoy_filter.send_response(
-      200,
-      &[("x-reset", b"true")],
-      Some(b"upstream_reset"),
-      None,
-      None,
-    );
+    envoy_filter.send_response(200, &[("x-reset", b"true")], Some(b"upstream_reset"), None);
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -122,7 +122,7 @@ fn test_send_response_filter() {
 
   envoy_filter
     .expect_send_response()
-    .withf(|status_code, headers, body, grpc_status, details| {
+    .withf(|status_code, headers, body, details| {
       *status_code == 200
         && *headers
           == vec![
@@ -130,7 +130,6 @@ fn test_send_response_filter() {
             ("header2", "value2".as_bytes()),
           ]
         && *body == Some(b"Hello, World!")
-        && grpc_status.is_none()
         && details.is_none()
     })
     .once()


### PR DESCRIPTION
This reverts commit 559dfff3e1a039a7ecc6a97c55d87ad45b37a750.

We have a consensus on moving these to a utility instead.