### PR TITLE
Add changelog for bugfixes in peak_ewma load balancer (contrib) #43526

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -248,6 +248,10 @@ bug_fixes:
     Fixed RBAC header matcher to validate each header value individually instead of concatenating multiple header values
     into a single string. This prevents potential bypasses when requests contain multiple values for the same header.
     The new behavior is enabled by the runtime guard ``envoy.reloadable_features.rbac_match_headers_individually``.
+- area: contrib
+  change: |
+    Fixed segfault from timer thread-safety violation, a ring buffer overflow and alpha calculation in
+    peak_ewma loadbalancer.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`


### PR DESCRIPTION
As discussed with @phlax in Slack this adds a changelog for the bugfix PR #43526 by @rroblak already merged to main.
This commit intended to be backported together with the bugfix to release/1.37 then.