### PR TITLE
dynamic_modules: mark the DM ABI Test as 'large'

### DIFF
--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -45,6 +45,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "abi_impl_test",
+    size = "large",
     srcs = ["abi_impl_test.cc"],
     deps = [
         "//source/extensions/dynamic_modules:abi_impl",


### PR DESCRIPTION
## Description

This PR marks the DM ABI Test as "large" to prevent it from being timing out.

---

**Commit Message:** dynamic_modules: mark the DM ABI Test as 'large'
**Additional Description:** marking the DM ABI Test as "large" to prevent it from being timing out.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes**: N/A