### PR TITLE
deps: fix @zstd//:zstd_cli not building with multithreading support

### DIFF
--- a/bazel/external/zstd.BUILD
+++ b/bazel/external/zstd.BUILD
@@ -53,10 +53,7 @@ cc_library(
         "lib/zstd.h",
         "lib/zstd_errors.h",
     ],
-    includes = ["lib"],
-    linkopts = ["-pthread"],
-    linkstatic = True,
-    local_defines = [
+    defines = [
         "XXH_NAMESPACE=ZSTD_",
         "ZSTD_MULTITHREAD",
         "ZSTD_BUILD_SHARED=OFF",
@@ -65,6 +62,9 @@ cc_library(
         "@platforms//os:windows": ["ZSTD_DISABLE_ASM"],
         "//conditions:default": [],
     }),
+    includes = ["lib"],
+    linkopts = ["-pthread"],
+    linkstatic = True,
 )
 
 cc_binary(


### PR DESCRIPTION
Commit Message:
This fixes the zstd_cli binary not being built with multithreading support, though it was definitely intended to be. There are some usages of this target that pass e.g. -T0 in args, which is currently a no-op.

Additional Description:
As far as I can tell, the switch from `local_defines` to `defines` in the zstd library target only affects the zstd_cli target, as nothing else depends on @zstd//:zstd directly. 

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
