### PR TITLE
docs: document admin allow_paths for gating access

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -12,24 +12,38 @@ modify different aspects of the server:
 
 .. attention::
 
-  The administration interface in its current form both allows destructive operations to be
-  performed (e.g., shutting down the server) as well as potentially exposes private information
-  (e.g., stats, cluster names, cert info, etc.). It is **critical** that access to the
-  administration interface is only allowed via a secure network. It is also **critical** that hosts
-  that access the administration interface are **only** attached to the secure network (i.e., to
-  avoid CSRF attacks). This involves setting up an appropriate firewall or optimally only allowing
-  access to the administration listener via localhost. This can be accomplished with a v2
-  configuration like the following:
+  The administration interface both allows destructive operations to be performed (e.g., shutting
+  down the server) as well as potentially exposes private information (e.g., stats, cluster names,
+  cert info, etc.). It is **critical** that access to the administration interface is only allowed
+  via a secure network. It is also **critical** that hosts that access the administration interface
+  are **only** attached to the secure network (i.e., to avoid CSRF attacks). This involves setting
+  up an appropriate firewall or optimally only allowing access to the administration listener via
+  localhost. This can be accomplished with a configuration like the following:
 
   .. code-block:: yaml
 
     admin:
-      profile_path: /tmp/envoy.prof
       address:
         socket_address: { address: 127.0.0.1, port_value: 9901 }
 
-  In the future additional security options will be added to the administration interface. This
-  work is tracked in `this <https://github.com/envoyproxy/envoy/issues/2763>`_ issue.
+  In addition to network-level restrictions, the
+  :ref:`allow_paths <envoy_v3_api_field_config.bootstrap.v3.Admin.allow_paths>` field can restrict
+  which admin endpoints are accessible. When configured, only paths matching the specified string
+  matchers are served; all other requests receive HTTP 403 Forbidden. For example, to expose only
+  the health check and stats endpoints:
+
+  .. code-block:: yaml
+
+    admin:
+      address:
+        socket_address: { address: 127.0.0.1, port_value: 9901 }
+      allow_paths:
+      - exact: /ready
+      - exact: /stats
+      - prefix: /healthcheck
+
+  This is particularly useful when the admin endpoint must be reachable for readiness probes or
+  monitoring but destructive operations like ``/quitquitquit`` should not be exposed.
 
   All mutations must be sent as HTTP POST operations. When a mutation is requested via GET,
   the request has no effect, and an HTTP 400 (Invalid Request) response is returned.

--- a/docs/root/start/quick-start/admin.rst
+++ b/docs/root/start/quick-start/admin.rst
@@ -50,6 +50,35 @@ In this example, the logs are simply discarded.
    You may wish to restrict the network address the admin server listens to in your own deployment as part
    of your strategy to limit access to this endpoint.
 
+.. _start_quick_start_admin_access:
+
+Restricting admin access
+------------------------
+
+Beyond binding to localhost, you can use
+:ref:`allow_paths <envoy_v3_api_field_config.bootstrap.v3.Admin.allow_paths>` to restrict which
+admin endpoints are available. Requests to paths not in the allow list receive HTTP 403 Forbidden.
+
+For example, to only expose readiness and stats endpoints:
+
+.. code-block:: yaml
+
+   admin:
+     address:
+       socket_address:
+         address: 127.0.0.1
+         port_value: 9901
+     allow_paths:
+     - exact: /ready
+     - exact: /stats
+     - prefix: /healthcheck
+
+This is useful in production deployments where the admin endpoint must be reachable for health
+checks or monitoring, but destructive endpoints like ``/quitquitquit`` or ``/config_dump`` should
+not be exposed.
+
+See the :ref:`operations admin docs <operations_admin_interface_security>` for more information on
+securing the admin interface.
 
 ``stat_prefix``
 ---------------


### PR DESCRIPTION
## Summary
- Update the operations admin docs to replace the outdated "future security options" note (referencing #2763) with documentation for the `allow_paths` field added in #42367
- Add a configuration example showing how to restrict admin to only readiness, stats, and healthcheck endpoints
- Add a "Restricting admin access" section to the getting-started admin guide with a practical example
- Cross-link between getting-started and operations docs

## Motivation
The `allow_paths` field was added in commit 7b59e3ef11 (Dec 2025, fixing #36729 and #42347) but is not documented in either the operations or getting-started guides. The operations docs still say "In the future additional security options will be added."

## Test plan
- [ ] Documentation builds correctly
- [ ] RST cross-references resolve

Fixes #43446