### PR TITLE
dynamic_modules: fix a bug for metrics_namespace in various DMs

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.cc
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.cc
@@ -4,6 +4,8 @@
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/utility.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace AccessLoggers {
@@ -11,8 +13,9 @@ namespace DynamicModules {
 
 DynamicModuleAccessLogConfig::DynamicModuleAccessLogConfig(
     const absl::string_view logger_name, const absl::string_view logger_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope)
-    : stats_scope_(stats_scope.createScope(std::string(AccessLogStatsNamespace) + ".")),
+    : stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), logger_name_(logger_name),
       logger_config_(logger_config), dynamic_module_(std::move(dynamic_module)) {}
 
@@ -24,6 +27,7 @@ DynamicModuleAccessLogConfig::~DynamicModuleAccessLogConfig() {
 
 absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr> newDynamicModuleAccessLogConfig(
     const absl::string_view logger_name, const absl::string_view logger_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
 
@@ -53,7 +57,7 @@ absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr> newDynamicModuleAccessLogC
       "envoy_dynamic_module_on_access_logger_flush");
 
   auto config = std::make_shared<DynamicModuleAccessLogConfig>(
-      logger_name, logger_config, std::move(dynamic_module), stats_scope);
+      logger_name, logger_config, metrics_namespace, std::move(dynamic_module), stats_scope);
 
   // Store the resolved function pointers.
   config->on_config_destroy_ = on_config_destroy.value();

--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.h
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.h
@@ -24,8 +24,9 @@ using OnAccessLoggerLogType = decltype(&envoy_dynamic_module_on_access_logger_lo
 using OnAccessLoggerDestroyType = decltype(&envoy_dynamic_module_on_access_logger_destroy);
 using OnAccessLoggerFlushType = decltype(&envoy_dynamic_module_on_access_logger_flush);
 
-// Custom namespace prefix for access logger stats.
-constexpr char AccessLogStatsNamespace[] = "dynamic_module_access_logger";
+// The default custom stat namespace which prepends all user-defined metrics.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
 
 /**
  * Configuration for dynamic module access loggers. This resolves and holds the symbols used for
@@ -41,11 +42,13 @@ public:
    * Constructor for the config. Symbol resolution is done in newDynamicModuleAccessLogConfig().
    * @param logger_name the name of the logger.
    * @param logger_config the configuration bytes for the logger.
+   * @param metrics_namespace the namespace prefix for metrics emitted by this module.
    * @param dynamic_module the dynamic module to use.
    * @param stats_scope the stats scope for metrics.
    */
   DynamicModuleAccessLogConfig(const absl::string_view logger_name,
                                const absl::string_view logger_config,
+                               const absl::string_view metrics_namespace,
                                Extensions::DynamicModules::DynamicModulePtr dynamic_module,
                                Stats::Scope& stats_scope);
 
@@ -146,6 +149,7 @@ private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleAccessLogConfig>>
   newDynamicModuleAccessLogConfig(const absl::string_view logger_name,
                                   const absl::string_view logger_config,
+                                  const absl::string_view metrics_namespace,
                                   Extensions::DynamicModules::DynamicModulePtr dynamic_module,
                                   Stats::Scope& stats_scope);
 
@@ -170,12 +174,14 @@ using DynamicModuleAccessLogConfigSharedPtr = std::shared_ptr<DynamicModuleAcces
  * Creates a new DynamicModuleAccessLogConfig for the given configuration.
  * @param logger_name the name of the logger.
  * @param logger_config the configuration bytes for the logger.
+ * @param metrics_namespace the namespace prefix for metrics emitted by this module.
  * @param dynamic_module the dynamic module to use.
  * @param stats_scope the stats scope for metrics.
  * @return a shared pointer to the new config object or an error if symbol resolution failed.
  */
 absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr> newDynamicModuleAccessLogConfig(
     const absl::string_view logger_name, const absl::string_view logger_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope);
 
 } // namespace DynamicModules

--- a/source/extensions/access_loggers/dynamic_modules/config.cc
+++ b/source/extensions/access_loggers/dynamic_modules/config.cc
@@ -4,6 +4,7 @@
 
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/extensions/access_loggers/dynamic_modules/access_log.h"
 
 namespace Envoy {
@@ -39,13 +40,27 @@ AccessLog::InstanceSharedPtr DynamicModuleAccessLogFactory::createAccessLogInsta
     logger_config_str = std::move(config_or_error.value());
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace = module_config.metrics_namespace().empty()
+                                            ? std::string(DefaultMetricsNamespace)
+                                            : module_config.metrics_namespace();
+
   auto access_log_config = newDynamicModuleAccessLogConfig(
-      proto_config.logger_name(), logger_config_str, std::move(dynamic_module_or_error.value()),
-      context.serverFactoryContext().scope());
+      proto_config.logger_name(), logger_config_str, metrics_namespace,
+      std::move(dynamic_module_or_error.value()), context.serverFactoryContext().scope());
 
   if (!access_log_config.ok()) {
     throw EnvoyException("Failed to create access logger config: " +
                          std::string(access_log_config.status().message()));
+  }
+
+  // When the runtime guard is enabled, register the metrics namespace as a custom stat namespace.
+  // This causes the namespace prefix to be stripped from prometheus output and no envoy_ prefix
+  // is added. This is the legacy behavior for backward compatibility.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix")) {
+    context.serverFactoryContext().api().customStatNamespaces().registerStatNamespace(
+        metrics_namespace);
   }
 
   return std::make_shared<DynamicModuleAccessLog>(std::move(filter),

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.cc
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.cc
@@ -9,17 +9,15 @@ namespace Extensions {
 namespace Bootstrap {
 namespace DynamicModules {
 
-// The default custom stat namespace which prepends all user-defined bootstrap metrics.
-constexpr absl::string_view DefaultBootstrapMetricsNamespace = "dynamicmodulesbootstrap";
-
 DynamicModuleBootstrapExtensionConfig::DynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
     Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
     Stats::Store& stats_store)
     : dynamic_module_(std::move(dynamic_module)), main_thread_dispatcher_(main_thread_dispatcher),
       context_(context), stats_store_(stats_store),
-      stats_scope_(stats_store.createScope(absl::StrCat(DefaultBootstrapMetricsNamespace, "."))),
+      stats_scope_(stats_store.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()) {
   ASSERT(dynamic_module_ != nullptr);
   ASSERT(extension_name.data() != nullptr);
@@ -164,6 +162,7 @@ void DynamicModuleBootstrapExtensionConfig::HttpCalloutCallback::onFailure(
 absl::StatusOr<DynamicModuleBootstrapExtensionConfigSharedPtr>
 newDynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
     Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
     Stats::Store& stats_store) {
@@ -249,8 +248,8 @@ newDynamicModuleBootstrapExtensionConfig(
   }
 
   auto config = std::make_shared<DynamicModuleBootstrapExtensionConfig>(
-      extension_name, extension_config, std::move(dynamic_module), main_thread_dispatcher, context,
-      stats_store);
+      extension_name, extension_config, metrics_namespace, std::move(dynamic_module),
+      main_thread_dispatcher, context, stats_store);
 
   // Always register an init target so that Envoy blocks traffic until the module signals readiness.
   // This must happen before calling the module constructor so the module can call

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -24,6 +24,10 @@ namespace Extensions {
 namespace Bootstrap {
 namespace DynamicModules {
 
+// The default custom stat namespace which prepends all user-defined metrics.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
+
 using OnBootstrapExtensionConfigDestroyType =
     decltype(&envoy_dynamic_module_on_bootstrap_extension_config_destroy);
 using OnBootstrapExtensionNewType = decltype(&envoy_dynamic_module_on_bootstrap_extension_new);
@@ -60,6 +64,7 @@ public:
    * Constructor for the config.
    * @param extension_name the name of the extension.
    * @param extension_config the configuration for the module.
+   * @param metrics_namespace the namespace prefix for metrics emitted by this module.
    * @param dynamic_module the dynamic module to use.
    * @param main_thread_dispatcher the main thread dispatcher.
    * @param context the server factory context for accessing cluster manager lazily.
@@ -67,6 +72,7 @@ public:
    */
   DynamicModuleBootstrapExtensionConfig(const absl::string_view extension_name,
                                         const absl::string_view extension_config,
+                                        const absl::string_view metrics_namespace,
                                         Extensions::DynamicModules::DynamicModulePtr dynamic_module,
                                         Event::Dispatcher& main_thread_dispatcher,
                                         Server::Configuration::ServerFactoryContext& context,
@@ -435,6 +441,7 @@ private:
  * Creates a new DynamicModuleBootstrapExtensionConfig from the given module and configuration.
  * @param extension_name the name of the extension.
  * @param extension_config the configuration for the module.
+ * @param metrics_namespace the namespace prefix for metrics emitted by this module.
  * @param dynamic_module the dynamic module to use.
  * @param main_thread_dispatcher the main thread dispatcher.
  * @param context the server factory context for accessing cluster manager lazily.
@@ -445,6 +452,7 @@ private:
 absl::StatusOr<DynamicModuleBootstrapExtensionConfigSharedPtr>
 newDynamicModuleBootstrapExtensionConfig(
     const absl::string_view extension_name, const absl::string_view extension_config,
+    const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
     Event::Dispatcher& main_thread_dispatcher, Server::Configuration::ServerFactoryContext& context,
     Stats::Store& stats_store);

--- a/source/extensions/bootstrap/dynamic_modules/factory.cc
+++ b/source/extensions/bootstrap/dynamic_modules/factory.cc
@@ -6,6 +6,7 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
 namespace Envoy {
@@ -38,13 +39,27 @@ Server::BootstrapExtensionPtr DynamicModuleBootstrapExtensionFactory::createBoot
     extension_config_str = std::move(config_or_error.value());
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace = module_config.metrics_namespace().empty()
+                                            ? std::string(DefaultMetricsNamespace)
+                                            : module_config.metrics_namespace();
+
   auto extension_config = newDynamicModuleBootstrapExtensionConfig(
-      proto_config.extension_name(), extension_config_str, std::move(dynamic_module.value()),
-      context.mainThreadDispatcher(), context, context.serverScope().store());
+      proto_config.extension_name(), extension_config_str, metrics_namespace,
+      std::move(dynamic_module.value()), context.mainThreadDispatcher(), context,
+      context.serverScope().store());
 
   if (!extension_config.ok()) {
     throwEnvoyExceptionOrPanic("Failed to create extension config: " +
                                std::string(extension_config.status().message()));
+  }
+
+  // When the runtime guard is enabled, register the metrics namespace as a custom stat namespace.
+  // This causes the namespace prefix to be stripped from prometheus output and no envoy_ prefix
+  // is added. This is the legacy behavior for backward compatibility.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix")) {
+    context.api().customStatNamespaces().registerStatNamespace(metrics_namespace);
   }
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(extension_config.value());

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -10,8 +10,11 @@
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/common/upstream/upstream_impl.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
+
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -54,9 +57,10 @@ struct DynamicModuleThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBa
 
 absl::StatusOr<std::shared_ptr<DynamicModuleClusterConfig>> DynamicModuleClusterConfig::create(
     const std::string& cluster_name, const std::string& cluster_config,
+    const std::string& metrics_namespace,
     Envoy::Extensions::DynamicModules::DynamicModulePtr module, Stats::Scope& stats_scope) {
-  auto config = std::shared_ptr<DynamicModuleClusterConfig>(
-      new DynamicModuleClusterConfig(cluster_name, cluster_config, std::move(module), stats_scope));
+  auto config = std::shared_ptr<DynamicModuleClusterConfig>(new DynamicModuleClusterConfig(
+      cluster_name, cluster_config, metrics_namespace, std::move(module), stats_scope));
 
   // Resolve all required function pointers from the dynamic module.
 #define RESOLVE_SYMBOL(name, type, member)                                                         \
@@ -138,8 +142,9 @@ absl::StatusOr<std::shared_ptr<DynamicModuleClusterConfig>> DynamicModuleCluster
 
 DynamicModuleClusterConfig::DynamicModuleClusterConfig(
     const std::string& cluster_name, const std::string& cluster_config,
+    const std::string& metrics_namespace,
     Envoy::Extensions::DynamicModules::DynamicModulePtr module, Stats::Scope& stats_scope)
-    : stats_scope_(stats_scope.createScope("dynamicmodulescustom.")),
+    : stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), cluster_name_(cluster_name),
       cluster_config_(cluster_config), dynamic_module_(std::move(module)) {}
 
@@ -719,12 +724,26 @@ DynamicModuleClusterFactory::createClusterWithConfig(
                                                   module_or_error.status().message()));
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace = module_config.metrics_namespace().empty()
+                                            ? std::string(DefaultMetricsNamespace)
+                                            : module_config.metrics_namespace();
+
   // Create the cluster configuration.
   auto config_or_error = DynamicModuleClusterConfig::create(
-      proto_config.cluster_name(), cluster_config_bytes, std::move(module_or_error.value()),
-      context.serverFactoryContext().serverScope());
+      proto_config.cluster_name(), cluster_config_bytes, metrics_namespace,
+      std::move(module_or_error.value()), context.serverFactoryContext().serverScope());
   if (!config_or_error.ok()) {
     return config_or_error.status();
+  }
+
+  // When the runtime guard is enabled, register the metrics namespace as a custom stat namespace.
+  // This causes the namespace prefix to be stripped from prometheus output and no envoy_ prefix
+  // is added. This is the legacy behavior for backward compatibility.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix")) {
+    context.serverFactoryContext().api().customStatNamespaces().registerStatNamespace(
+        metrics_namespace);
   }
 
   // Create the cluster.

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -31,6 +31,10 @@ namespace Extensions {
 namespace Clusters {
 namespace DynamicModules {
 
+// The default custom stat namespace which prepends all user-defined metrics.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
+
 class DynamicModuleCluster;
 class DynamicModuleClusterScheduler;
 class DynamicModuleClusterTestPeer;
@@ -66,12 +70,14 @@ public:
    *
    * @param cluster_name the name identifying the cluster implementation in the module.
    * @param cluster_config the configuration bytes to pass to the module.
+   * @param metrics_namespace the namespace prefix for metrics emitted by this module.
    * @param module the loaded dynamic module.
    * @param stats_scope the stats scope for creating custom metrics.
    * @return a shared pointer to the config, or an error status.
    */
   static absl::StatusOr<std::shared_ptr<DynamicModuleClusterConfig>>
   create(const std::string& cluster_name, const std::string& cluster_config,
+         const std::string& metrics_namespace,
          Envoy::Extensions::DynamicModules::DynamicModulePtr module, Stats::Scope& stats_scope);
 
   ~DynamicModuleClusterConfig();
@@ -262,6 +268,7 @@ public:
 
 private:
   DynamicModuleClusterConfig(const std::string& cluster_name, const std::string& cluster_config,
+                             const std::string& metrics_namespace,
                              Envoy::Extensions::DynamicModules::DynamicModulePtr module,
                              Stats::Scope& stats_scope);
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/config.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/config.cc
@@ -3,6 +3,7 @@
 #include "envoy/server/factory_context.h"
 
 #include "source/common/protobuf/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h"
 
@@ -75,6 +76,11 @@ Factory::loadConfig(Server::Configuration::ServerFactoryContext& context,
                                                   module_name, module_or_error.status().message()));
   }
 
+  // Use configured metrics namespace or fall back to the default.
+  const std::string metrics_namespace = module_config.metrics_namespace().empty()
+                                            ? std::string(DefaultMetricsNamespace)
+                                            : module_config.metrics_namespace();
+
   // Create the load balancer configuration.
   std::string config_bytes;
   if (typed_config.has_lb_policy_config()) {
@@ -83,12 +89,20 @@ Factory::loadConfig(Server::Configuration::ServerFactoryContext& context,
     config_bytes = std::move(config_or_error.value());
   }
   auto lb_config_or_error =
-      DynamicModuleLbConfig::create(typed_config.lb_policy_name(), config_bytes,
+      DynamicModuleLbConfig::create(typed_config.lb_policy_name(), config_bytes, metrics_namespace,
                                     std::move(module_or_error.value()), context.serverScope());
   if (!lb_config_or_error.ok()) {
     return absl::InvalidArgumentError(
         fmt::format("failed to create load balancer config for module '{}': {}", module_name,
                     lb_config_or_error.status().message()));
+  }
+
+  // When the runtime guard is enabled, register the metrics namespace as a custom stat namespace.
+  // This causes the namespace prefix to be stripped from prometheus output and no envoy_ prefix
+  // is added. This is the legacy behavior for backward compatibility.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix")) {
+    context.api().customStatNamespaces().registerStatNamespace(metrics_namespace);
   }
 
   return std::make_unique<TypedDynamicModuleLbConfig>(std::move(lb_config_or_error.value()));

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/load_balancing_policies/dynamic_modules/lb_config.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace LoadBalancingPolicies {
@@ -7,10 +9,11 @@ namespace DynamicModules {
 
 absl::StatusOr<DynamicModuleLbConfigSharedPtr>
 DynamicModuleLbConfig::create(const std::string& lb_policy_name, const std::string& lb_config,
+                              const std::string& metrics_namespace,
                               Envoy::Extensions::DynamicModules::DynamicModulePtr module,
                               Stats::Scope& stats_scope) {
-  std::shared_ptr<DynamicModuleLbConfig> config(
-      new DynamicModuleLbConfig(lb_policy_name, lb_config, std::move(module), stats_scope));
+  std::shared_ptr<DynamicModuleLbConfig> config(new DynamicModuleLbConfig(
+      lb_policy_name, lb_config, metrics_namespace, std::move(module), stats_scope));
 
   // Resolve all required function pointers from the dynamic module.
 #define RESOLVE_SYMBOL(name, type, member)                                                         \
@@ -50,8 +53,10 @@ DynamicModuleLbConfig::create(const std::string& lb_policy_name, const std::stri
 
 DynamicModuleLbConfig::DynamicModuleLbConfig(
     const std::string& lb_policy_name, const std::string& lb_config,
+    const std::string& metrics_namespace,
     Envoy::Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope)
-    : in_module_config_(nullptr), stats_scope_(stats_scope.createScope("dynamicmodulescustom.")),
+    : in_module_config_(nullptr),
+      stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), lb_policy_name_(lb_policy_name),
       lb_config_(lb_config), dynamic_module_(std::move(dynamic_module)) {}
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
@@ -18,6 +18,10 @@ namespace Extensions {
 namespace LoadBalancingPolicies {
 namespace DynamicModules {
 
+// The default custom stat namespace which prepends all user-defined metrics.
+// This can be overridden via the ``metrics_namespace`` field in ``DynamicModuleConfig``.
+constexpr absl::string_view DefaultMetricsNamespace = "dynamicmodulescustom";
+
 class DynamicModuleLbConfig;
 using DynamicModuleLbConfigSharedPtr = std::shared_ptr<DynamicModuleLbConfig>;
 
@@ -43,12 +47,14 @@ public:
    *
    * @param lb_policy_name the name identifying the load balancer implementation in the module.
    * @param lb_config the configuration bytes to pass to the module.
+   * @param metrics_namespace the namespace prefix for metrics emitted by this module.
    * @param dynamic_module the loaded dynamic module.
    * @param stats_scope the stats scope for creating custom metrics.
    * @return a shared pointer to the config, or an error status.
    */
   static absl::StatusOr<DynamicModuleLbConfigSharedPtr>
   create(const std::string& lb_policy_name, const std::string& lb_config,
+         const std::string& metrics_namespace,
          Envoy::Extensions::DynamicModules::DynamicModulePtr dynamic_module,
          Stats::Scope& stats_scope);
 
@@ -231,6 +237,7 @@ public:
 
 private:
   DynamicModuleLbConfig(const std::string& lb_policy_name, const std::string& lb_config,
+                        const std::string& metrics_namespace,
                         Envoy::Extensions::DynamicModules::DynamicModulePtr dynamic_module,
                         Stats::Scope& stats_scope);
 

--- a/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
@@ -35,8 +35,9 @@ public:
         Extensions::DynamicModules::testSharedObjectPath("access_log_no_op", "c"), false);
     EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-    auto config = newDynamicModuleAccessLogConfig(
-        "test_logger", "config", std::move(dynamic_module.value()), *stats_.rootScope());
+    auto config =
+        newDynamicModuleAccessLogConfig("test_logger", "config", DefaultMetricsNamespace,
+                                        std::move(dynamic_module.value()), *stats_.rootScope());
     EXPECT_TRUE(config.ok()) << config.status().message();
     config_ = std::move(config.value());
   }
@@ -226,8 +227,9 @@ TEST_F(DynamicModuleAccessLogTest, FactoryFunctionMissingSymbol) {
       false);
   EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
 
-  auto config = newDynamicModuleAccessLogConfig(
-      "test_logger", "config", std::move(dynamic_module.value()), *stats_.rootScope());
+  auto config =
+      newDynamicModuleAccessLogConfig("test_logger", "config", DefaultMetricsNamespace,
+                                      std::move(dynamic_module.value()), *stats_.rootScope());
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(), testing::HasSubstr("config_new"));
 }
@@ -242,8 +244,9 @@ TEST_F(DynamicModuleAccessLogTest, FactoryFunctionModuleReturnsNull) {
     GTEST_SKIP() << "Test module access_log_config_new_fail not available";
   }
 
-  auto config = newDynamicModuleAccessLogConfig(
-      "test_logger", "config", std::move(dynamic_module.value()), *stats_.rootScope());
+  auto config =
+      newDynamicModuleAccessLogConfig("test_logger", "config", DefaultMetricsNamespace,
+                                      std::move(dynamic_module.value()), *stats_.rootScope());
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(), testing::HasSubstr("Failed to initialize"));
 }
@@ -263,7 +266,7 @@ TEST_F(DynamicModuleAccessLogTest, MetricsCounterDefineAndIncrement) {
                 static_cast<void*>(config_.get()), counter_id, 5));
 
   // Verify the counter value.
-  auto counter = TestUtility::findCounter(stats_, "dynamic_module_access_logger.test_counter");
+  auto counter = TestUtility::findCounter(stats_, "dynamicmodulescustom.test_counter");
   ASSERT_NE(nullptr, counter);
   EXPECT_EQ(5, counter->value());
 }
@@ -291,7 +294,7 @@ TEST_F(DynamicModuleAccessLogTest, MetricsGaugeDefineAndManipulate) {
                 static_cast<void*>(config_.get()), gauge_id, 5));
 
   // Verify the gauge value: 100 + 10 - 5 = 105.
-  auto gauge = TestUtility::findGauge(stats_, "dynamic_module_access_logger.test_gauge");
+  auto gauge = TestUtility::findGauge(stats_, "dynamicmodulescustom.test_gauge");
   ASSERT_NE(nullptr, gauge);
   EXPECT_EQ(105, gauge->value());
 }

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -35,8 +35,9 @@ TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a scheduler via the ABI callback.
@@ -54,8 +55,9 @@ TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a scheduler via the ABI callback.
@@ -85,8 +87,9 @@ TEST_F(BootstrapAbiImplTest, OnScheduledCallback) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a scheduler via the ABI callback.
@@ -119,9 +122,9 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
         testDataDir() + "/libbootstrap_no_op.so", false);
     ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-    auto config = newDynamicModuleBootstrapExtensionConfig("test", "config",
-                                                           std::move(dynamic_module.value()),
-                                                           dispatcher_, context_, context_.store_);
+    auto config = newDynamicModuleBootstrapExtensionConfig(
+        "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
+        context_, context_.store_);
     ASSERT_TRUE(config.ok()) << config.status();
 
     // Create a scheduler via the ABI callback.
@@ -154,8 +157,9 @@ TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Call onScheduled directly - this should call the in-module hook.
@@ -176,8 +180,9 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
   // The init manager should receive an add call during config creation.
   EXPECT_CALL(context_.init_manager_, add(_));
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // The C no-op module already called signal_init_complete during config creation.
@@ -196,8 +201,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock to return nullptr for the cluster lookup.
@@ -228,8 +234,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Headers missing :method, :path, and host.
@@ -254,8 +261,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -312,8 +320,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -360,8 +369,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -409,8 +419,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -446,8 +457,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -502,8 +514,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -553,8 +566,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutWithBody) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Setup mock cluster manager to return a valid cluster.
@@ -617,8 +631,9 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -640,8 +655,9 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueNonExistent) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -665,8 +681,9 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -688,8 +705,9 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueNonExistent) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -715,8 +733,9 @@ TEST_F(BootstrapAbiImplTest, IterateCounters) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -751,8 +770,9 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -787,8 +807,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a counter without labels.
@@ -820,8 +841,9 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Try to increment a counter with an invalid ID.
@@ -836,8 +858,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a gauge without labels.
@@ -874,8 +897,9 @@ TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Try to set, increment, and decrement a gauge with an invalid ID.
@@ -896,8 +920,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a histogram without labels.
@@ -925,8 +950,9 @@ TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Try to record a histogram value with an invalid ID.
@@ -941,8 +967,9 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define multiple counters.
@@ -998,8 +1025,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a counter vec with labels.
@@ -1028,8 +1056,9 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a counter vec with 2 labels.
@@ -1053,8 +1082,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a gauge vec with labels.
@@ -1090,8 +1120,9 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define a histogram vec with labels.
@@ -1120,8 +1151,9 @@ TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Define vec metrics with a single label each.
@@ -1195,8 +1227,9 @@ TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
   // The MockDispatcher's createTimer_ returns a NiceMock<MockTimer> by default.
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a timer via the ABI callback.
@@ -1228,8 +1261,9 @@ TEST_F(BootstrapAbiImplTest, TimerFired) {
   // Use MockTimer to capture the timer callback.
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a timer via the ABI callback. This will use the MockTimer we set up.
@@ -1266,9 +1300,9 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
       return new testing::NiceMock<Event::MockTimer>();
     }));
 
-    auto config = newDynamicModuleBootstrapExtensionConfig("test", "config",
-                                                           std::move(dynamic_module.value()),
-                                                           dispatcher_, context_, context_.store_);
+    auto config = newDynamicModuleBootstrapExtensionConfig(
+        "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
+        context_, context_.store_);
     ASSERT_TRUE(config.ok()) << config.status();
 
     // Create a timer via the ABI callback.
@@ -1298,8 +1332,9 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Expect the admin handler to be registered.
@@ -1319,8 +1354,9 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Expect the admin handler registration to fail.
@@ -1343,8 +1379,9 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
@@ -1360,8 +1397,9 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   EXPECT_CALL(context_.admin_, removeHandler("/test_prefix")).WillOnce(testing::Return(true));
@@ -1378,8 +1416,9 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   EXPECT_CALL(context_.admin_, removeHandler("/nonexistent")).WillOnce(testing::Return(false));
@@ -1399,8 +1438,9 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
@@ -1415,8 +1455,9 @@ TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Capture the handler callback when addHandler is called.
@@ -1462,8 +1503,9 @@ TEST_F(BootstrapAbiImplTest, TimerReEnable) {
 
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   // Create a timer via the ABI callback.

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -27,8 +27,9 @@ TEST_F(ExtensionConfigTest, LoadOK) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
   EXPECT_NE(config.value()->in_module_config_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_config_destroy_, nullptr);
@@ -49,8 +50,9 @@ TEST_F(ExtensionConfigTest, ConfigNewFail) {
       testDataDir() + "/libbootstrap_no_config_new.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_EQ(config.status().message(), "Failed to initialize dynamic module");
 }
@@ -60,8 +62,9 @@ TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
       testDataDir() + "/libbootstrap_no_config_destroy.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_destroy"));
@@ -72,8 +75,9 @@ TEST_F(ExtensionConfigTest, MissingExtensionNew) {
       testDataDir() + "/libbootstrap_no_extension_new.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_new"));
@@ -84,8 +88,9 @@ TEST_F(ExtensionConfigTest, MissingServerInitialized) {
       testDataDir() + "/libbootstrap_no_server_initialized.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_server_initialized"));
@@ -96,8 +101,9 @@ TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
       testDataDir() + "/libbootstrap_no_worker_initialized.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(
       config.status().message(),
@@ -109,8 +115,9 @@ TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
       testDataDir() + "/libbootstrap_no_extension_destroy.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_destroy"));
@@ -123,8 +130,9 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
       testDataDir() + "/libbootstrap_no_constructor.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_new"));
@@ -135,8 +143,9 @@ TEST_F(ExtensionConfigTest, MissingDrainStarted) {
       testDataDir() + "/libbootstrap_no_drain_started.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_drain_started"));
@@ -147,8 +156,9 @@ TEST_F(ExtensionConfigTest, MissingShutdown) {
       testDataDir() + "/libbootstrap_no_shutdown.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_shutdown"));
@@ -161,8 +171,9 @@ TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
       testDataDir() + "/libbootstrap_no_config_scheduled.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_scheduled"));
@@ -175,8 +186,9 @@ TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
       testDataDir() + "/libbootstrap_no_http_callout_done.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_http_callout_done"));
@@ -189,8 +201,9 @@ TEST_F(ExtensionConfigTest, MissingTimerFired) {
       testDataDir() + "/libbootstrap_no_timer_fired.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_timer_fired"));
@@ -203,8 +216,9 @@ TEST_F(ExtensionConfigTest, MissingAdminRequest) {
       testDataDir() + "/libbootstrap_no_admin_request.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_admin_request"));

--- a/test/extensions/dynamic_modules/bootstrap/extension_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_test.cc
@@ -31,8 +31,9 @@ TEST_F(ExtensionTest, NullInModuleExtension) {
       testDataDir() + "/libbootstrap_extension_new_null.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -58,8 +59,9 @@ TEST_F(ExtensionTest, IsDestroyedAndGetExtensionConfig) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -84,8 +86,9 @@ TEST_F(ExtensionTest, LifecycleWithValidExtension) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -125,8 +128,9 @@ TEST_F(ExtensionTest, DrainCallbackInvoked) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -158,8 +162,9 @@ TEST_F(ExtensionTest, ShutdownCallbackWithCompletion) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
@@ -191,8 +196,9 @@ TEST_F(ExtensionTest, ShutdownCallbackAfterDestroy) {
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
   ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
 
-  auto config = newDynamicModuleBootstrapExtensionConfig(
-      "test", "config", std::move(dynamic_module.value()), dispatcher_, context_, context_.store_);
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());


### PR DESCRIPTION
## Description

This PR fixes an issue where `metrics_namespace` is available in proto but not implemented for a lot of DM extensions.

---

**Commit Message:** dynamic_modules: fix a bug for metrics_namespace in various DMs
**Additional Description:** Fixed an issue to make `metrics_namespace` available to all existing DM extensions.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A