### PR TITLE
stream info: to return const ref of cluster info rather than pointer

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1190,9 +1190,8 @@ CAPIStatus Filter::getStringValue(int id, uint64_t* value_data, int* value_len) 
     }
     break;
   case EnvoyValue::UpstreamClusterName:
-    if (streamInfo().upstreamClusterInfo().has_value() &&
-        streamInfo().upstreamClusterInfo().value()) {
-      req_->strValue = streamInfo().upstreamClusterInfo().value()->name();
+    if (streamInfo().upstreamClusterInfo() != nullptr) {
+      req_->strValue = streamInfo().upstreamClusterInfo()->name();
     } else {
       return CAPIStatus::CAPIValueNotFound;
     }

--- a/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
+++ b/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
@@ -981,16 +981,16 @@ private:
     } else if (info.getRouteName() == "allow_any") {
       service_host_name = "PassthroughCluster";
     } else {
-      const auto cluster_info = info.upstreamClusterInfo();
-      if (cluster_info && cluster_info.value()) {
-        const auto& cluster_name = cluster_info.value()->name();
+      const auto& cluster_info = info.upstreamClusterInfo();
+      if (cluster_info) {
+        const auto& cluster_name = cluster_info->name();
         if (cluster_name == "BlackHoleCluster" || cluster_name == "PassthroughCluster" ||
             cluster_name == "InboundPassthroughCluster" ||
             cluster_name == "InboundPassthroughClusterIpv4" ||
             cluster_name == "InboundPassthroughClusterIpv6") {
           service_host_name = cluster_name;
         } else {
-          const auto& filter_metadata = cluster_info.value()->metadata().filter_metadata();
+          const auto& filter_metadata = cluster_info->metadata().filter_metadata();
           const auto& it = filter_metadata.find("istio");
           if (it != filter_metadata.end()) {
             const auto& services_it = it->second.fields().find("services");

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -300,13 +300,13 @@ bool MXPropagationMethod::skipMXHeaders(const bool skip_external_clusters,
   // We skip metadata in two cases.
   // 1. skip_external_clusters is enabled, and we detect the upstream as external.
   const auto& cluster_info = info.upstreamClusterInfo();
-  if (cluster_info && cluster_info.value()) {
-    const auto& cluster_name = cluster_info.value()->name();
+  if (cluster_info) {
+    const auto& cluster_name = cluster_info->name();
     // PassthroughCluster is always considered external
     if (skip_external_clusters && cluster_name == "PassthroughCluster") {
       return true;
     }
-    const auto& filter_metadata = cluster_info.value()->metadata().filter_metadata();
+    const auto& filter_metadata = cluster_info->metadata().filter_metadata();
     const auto& it = filter_metadata.find("istio");
     // Otherwise, cluster must be tagged as external
     if (it != filter_metadata.end()) {

--- a/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
+++ b/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
@@ -436,14 +436,13 @@ TEST_F(PeerMetadataTest, UpstreamMXPropagationSkipNoMatch) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamMXPropagationSkip) {
-  std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
-      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
+  auto cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  stream_info_.upstream_cluster_info_ = cluster_info_;
   auto metadata = TestUtility::parseYaml<envoy::config::core::v3::Metadata>(R"EOF(
       filter_metadata:
         istio:
           external: true
     )EOF");
-  ON_CALL(stream_info_, upstreamClusterInfo()).WillByDefault(testing::Return(cluster_info_));
   ON_CALL(*cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
   initialize(R"EOF(
     upstream_propagation:
@@ -457,10 +456,9 @@ TEST_F(PeerMetadataTest, UpstreamMXPropagationSkip) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamMXPropagationSkipPassthrough) {
-  std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
-      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
+  auto cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
   cluster_info_->name_ = "PassthroughCluster";
-  ON_CALL(stream_info_, upstreamClusterInfo()).WillByDefault(testing::Return(cluster_info_));
+  stream_info_.upstream_cluster_info_ = cluster_info_;
   initialize(R"EOF(
     upstream_propagation:
       - istio_headers:

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -981,11 +981,9 @@ public:
   setUpstreamClusterInfo(const Upstream::ClusterInfoConstSharedPtr& upstream_cluster_info) PURE;
 
   /**
-   * @return Upstream Connection's ClusterInfo.
-   * This returns an optional to differentiate between unset(absl::nullopt),
-   * no route or cluster does not exist(nullptr), and set to a valid cluster(not nullptr).
+   * @return Upstream Connection's ClusterInfo, or nullptr if not set.
    */
-  virtual absl::optional<Upstream::ClusterInfoConstSharedPtr> upstreamClusterInfo() const PURE;
+  virtual const Upstream::ClusterInfoConstSharedPtr& upstreamClusterInfo() const PURE;
 
   /**
    * @param provider The unique id implementation this stream uses.

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -168,11 +168,11 @@ ClusterMetadataFormatter::ClusterMetadataFormatter(absl::string_view filter_name
     : MetadataFormatter(filter_namespace, path, max_length,
                         [](const StreamInfo::StreamInfo& stream_info)
                             -> const envoy::config::core::v3::Metadata* {
-                          auto cluster_info = stream_info.upstreamClusterInfo();
-                          if (!cluster_info.has_value() || cluster_info.value() == nullptr) {
+                          const auto& cluster_info = stream_info.upstreamClusterInfo();
+                          if (cluster_info == nullptr) {
                             return nullptr;
                           }
-                          return &cluster_info.value()->metadata();
+                          return &cluster_info->metadata();
                         }) {}
 
 UpstreamHostMetadataFormatter::UpstreamHostMetadataFormatter(
@@ -1504,11 +1504,9 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                  return std::make_unique<StreamInfoStringFormatterProvider>(
                                      [](const StreamInfo::StreamInfo& stream_info) {
                                        std::string upstream_cluster_name;
-                                       if (stream_info.upstreamClusterInfo().has_value() &&
-                                           stream_info.upstreamClusterInfo().value() != nullptr) {
-                                         upstream_cluster_name = stream_info.upstreamClusterInfo()
-                                                                     .value()
-                                                                     ->observabilityName();
+                                       if (stream_info.upstreamClusterInfo() != nullptr) {
+                                         upstream_cluster_name =
+                                             stream_info.upstreamClusterInfo()->observabilityName();
                                        }
 
                                        return upstream_cluster_name.empty()
@@ -1523,10 +1521,9 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                  return std::make_unique<StreamInfoStringFormatterProvider>(
                                      [](const StreamInfo::StreamInfo& stream_info) {
                                        std::string upstream_cluster_name;
-                                       if (stream_info.upstreamClusterInfo().has_value() &&
-                                           stream_info.upstreamClusterInfo().value() != nullptr) {
+                                       if (stream_info.upstreamClusterInfo() != nullptr) {
                                          upstream_cluster_name =
-                                             stream_info.upstreamClusterInfo().value()->name();
+                                             stream_info.upstreamClusterInfo()->name();
                                        }
 
                                        return upstream_cluster_name.empty()

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -147,11 +147,7 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
 
   stream_info_.healthCheck(parent_.callbacks()->streamInfo().healthCheck());
   stream_info_.setIsShadow(parent_.callbacks()->streamInfo().isShadow());
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info =
-      parent_.callbacks()->streamInfo().upstreamClusterInfo();
-  if (cluster_info.has_value()) {
-    stream_info_.setUpstreamClusterInfo(*cluster_info);
-  }
+  stream_info_.setUpstreamClusterInfo(parent_.callbacks()->streamInfo().upstreamClusterInfo());
 
   // Set up the upstream HTTP filter manager.
   filter_manager_callbacks_ = std::make_unique<UpstreamRequestFilterManagerCallbacks>(*this);

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -382,7 +382,7 @@ struct StreamInfoImpl : public StreamInfo {
     upstream_cluster_info_ = upstream_cluster_info;
   }
 
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstreamClusterInfo() const override {
+  const Upstream::ClusterInfoConstSharedPtr& upstreamClusterInfo() const override {
     return upstream_cluster_info_;
   }
 
@@ -560,7 +560,7 @@ private:
   const Http::RequestHeaderMap* request_headers_{};
   StreamIdProviderSharedPtr stream_id_provider_;
   absl::optional<DownstreamTiming> downstream_timing_;
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
+  Upstream::ClusterInfoConstSharedPtr upstream_cluster_info_;
   // Default construct the object because upstream stream is not constructed in some cases.
   BytesMeterSharedPtr upstream_bytes_meter_{std::make_shared<BytesMeter>()};
   BytesMeterSharedPtr downstream_bytes_meter_;

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -236,11 +236,9 @@ void HttpTracerUtility::setCommonTags(Span& span, const StreamInfo::StreamInfo& 
   span.setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
 
   // Cluster info.
-  if (auto cluster_info = stream_info.upstreamClusterInfo();
-      cluster_info.has_value() && cluster_info.value() != nullptr) {
-    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info.value()->name());
-    span.setTag(Tracing::Tags::get().UpstreamClusterName,
-                cluster_info.value()->observabilityName());
+  if (const auto& cluster_info = stream_info.upstreamClusterInfo(); cluster_info != nullptr) {
+    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info->name());
+    span.setTag(Tracing::Tags::get().UpstreamClusterName, cluster_info->observabilityName());
   }
 
   setSpanHttpStatusCode(span, stream_info);

--- a/source/common/tracing/tracer_impl.cc
+++ b/source/common/tracing/tracer_impl.cc
@@ -99,11 +99,9 @@ void TracerUtility::finalizeSpan(Span& span, const StreamInfo::StreamInfo& strea
   }
 
   // Cluster info.
-  if (auto cluster_info = stream_info.upstreamClusterInfo();
-      cluster_info.has_value() && cluster_info.value() != nullptr) {
-    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info.value()->name());
-    span.setTag(Tracing::Tags::get().UpstreamClusterName,
-                cluster_info.value()->observabilityName());
+  if (const auto& cluster_info = stream_info.upstreamClusterInfo(); cluster_info != nullptr) {
+    span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info->name());
+    span.setTag(Tracing::Tags::get().UpstreamClusterName, cluster_info->observabilityName());
   }
 
   // Upstream info.

--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -407,12 +407,12 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_cluster(
     envoy_dynamic_module_type_envoy_buffer* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
   // upstreamClusterInfo is on StreamInfo, not UpstreamInfo.
-  const auto cluster_info = logger->stream_info_->upstreamClusterInfo();
-  if (!cluster_info.has_value() || cluster_info.value() == nullptr) {
+  const auto& cluster_info = logger->stream_info_->upstreamClusterInfo();
+  if (cluster_info == nullptr) {
     return false;
   }
 
-  const auto& name = cluster_info.value()->name();
+  const auto& name = cluster_info->name();
   *result = {const_cast<char*>(name.data()), name.size()};
   return true;
 }

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -416,12 +416,9 @@ const UpstreamLookupValues& UpstreamLookupValues::get() {
              return CelValue::CreateUint64(wrapper.info_.attemptCount().value_or(0));
            }},
           {UpstreamNumEndpoints, [](const UpstreamWrapper& wrapper) -> absl::optional<CelValue> {
-             if (wrapper.info_.upstreamClusterInfo().value_or(nullptr) != nullptr) {
-               return CelValue::CreateUint64(wrapper.info_.upstreamClusterInfo()
-                                                 .value()
-                                                 .get()
-                                                 ->endpointStats()
-                                                 .membership_total_.value());
+             if (wrapper.info_.upstreamClusterInfo() != nullptr) {
+               return CelValue::CreateUint64(
+                   wrapper.info_.upstreamClusterInfo()->endpointStats().membership_total_.value());
              }
              return {};
            }}});
@@ -444,9 +441,9 @@ const XDSLookupValues& XDSLookupValues::get() {
              if (wrapper.info_ == nullptr) {
                return {};
              }
-             const auto cluster_info = wrapper.info_->upstreamClusterInfo();
-             if (cluster_info && cluster_info.value()) {
-               return CelValue::CreateString(&cluster_info.value()->name());
+             const auto& cluster_info = wrapper.info_->upstreamClusterInfo();
+             if (cluster_info) {
+               return CelValue::CreateString(&cluster_info->name());
              }
              return {};
            }},
@@ -455,10 +452,9 @@ const XDSLookupValues& XDSLookupValues::get() {
              if (wrapper.info_ == nullptr) {
                return {};
              }
-             const auto cluster_info = wrapper.info_->upstreamClusterInfo();
-             if (cluster_info && cluster_info.value()) {
-               return CelProtoWrapper::CreateMessage(&cluster_info.value()->metadata(),
-                                                     &wrapper.arena_);
+             const auto& cluster_info = wrapper.info_->upstreamClusterInfo();
+             if (cluster_info) {
+               return CelProtoWrapper::CreateMessage(&cluster_info->metadata(), &wrapper.arena_);
              }
              return {};
            }},

--- a/source/extensions/filters/http/alternate_protocols_cache/filter.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/filter.cc
@@ -38,9 +38,9 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
     return Http::FilterHeadersStatus::Continue;
   }
   Http::HttpServerPropertiesCacheSharedPtr cache;
-  auto info = encoder_callbacks_->streamInfo().upstreamClusterInfo();
+  const auto& info = encoder_callbacks_->streamInfo().upstreamClusterInfo();
   if (info) {
-    const auto& alternate_options = (*info)->httpProtocolOptions().alternateProtocolsCacheOptions();
+    const auto& alternate_options = info->httpProtocolOptions().alternateProtocolsCacheOptions();
     if (alternate_options) {
       cache = config_->alternateProtocolCacheManager().getCache(*alternate_options, dispatcher_);
     }

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -608,11 +608,7 @@ void Filter::updateLoggingInfo(const absl::optional<Grpc::Status::GrpcStatus>& g
   if (stream_info->upstreamInfo().has_value()) {
     logging_info_->setUpstreamHost(stream_info->upstreamInfo()->upstreamHost());
   }
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info =
-      stream_info->upstreamClusterInfo();
-  if (cluster_info) {
-    logging_info_->setClusterInfo(std::move(*cluster_info));
-  }
+  logging_info_->setClusterInfo(stream_info->upstreamClusterInfo());
 }
 
 void Filter::setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) {

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1540,10 +1540,9 @@ void Filter::addDynamicMetadata(const ProcessorState& state, ProcessingRequest& 
   envoy::config::core::v3::Metadata forwarding_metadata;
 
   // Forward cluster metadata if so configured.
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info =
-      cb->streamInfo().upstreamClusterInfo();
-  if (cluster_info.has_value() && cluster_info.value() != nullptr) {
-    const auto& cluster_metadata = cluster_info.value()->metadata().filter_metadata();
+  const auto& cluster_info = cb->streamInfo().upstreamClusterInfo();
+  if (cluster_info != nullptr) {
+    const auto& cluster_metadata = cluster_info->metadata().filter_metadata();
     for (const auto& context_key : state.untypedClusterMetadataForwardingNamespaces()) {
       if (const auto metadata_it = cluster_metadata.find(context_key);
           metadata_it != cluster_metadata.end()) {
@@ -1551,7 +1550,7 @@ void Filter::addDynamicMetadata(const ProcessorState& state, ProcessingRequest& 
       }
     }
 
-    const auto& cluster_typed_metadata = cluster_info.value()->metadata().typed_filter_metadata();
+    const auto& cluster_typed_metadata = cluster_info->metadata().typed_filter_metadata();
     for (const auto& context_key : state.typedClusterMetadataForwardingNamespaces()) {
       if (const auto metadata_it = cluster_typed_metadata.find(context_key);
           metadata_it != cluster_typed_metadata.end()) {

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1129,19 +1129,17 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("UPSTREAM_CLUSTER");
     const std::string observable_cluster_name = "observability_name";
     auto cluster_info_mock = std::make_shared<Upstream::MockClusterInfo>();
-    absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info = cluster_info_mock;
-    EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
+    stream_info.upstream_cluster_info_ = cluster_info_mock;
     EXPECT_CALL(*cluster_info_mock, observabilityName())
         .WillRepeatedly(ReturnRef(observable_cluster_name));
     EXPECT_EQ("observability_name", upstream_format.format({}, stream_info));
     EXPECT_THAT(upstream_format.formatValue({}, stream_info),
                 ProtoEq(ValueUtil::stringValue("observability_name")));
+    stream_info.upstream_cluster_info_ = nullptr;
   }
 
   {
     StreamInfoFormatter upstream_format("UPSTREAM_CLUSTER");
-    absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info = nullptr;
-    EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
     EXPECT_EQ(absl::nullopt, upstream_format.format({}, stream_info));
     EXPECT_THAT(upstream_format.formatValue({}, stream_info), ProtoEq(ValueUtil::nullValue()));
   }
@@ -1150,18 +1148,16 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     StreamInfoFormatter upstream_format("UPSTREAM_CLUSTER_RAW");
     const std::string raw_cluster_name = "raw_name";
     auto cluster_info_mock = std::make_shared<Upstream::MockClusterInfo>();
-    absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info = cluster_info_mock;
-    EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
+    stream_info.upstream_cluster_info_ = cluster_info_mock;
     EXPECT_CALL(*cluster_info_mock, name()).WillRepeatedly(ReturnRef(raw_cluster_name));
     EXPECT_EQ("raw_name", upstream_format.format({}, stream_info));
     EXPECT_THAT(upstream_format.formatValue({}, stream_info),
                 ProtoEq(ValueUtil::stringValue("raw_name")));
+    stream_info.upstream_cluster_info_ = nullptr;
   }
 
   {
     StreamInfoFormatter upstream_format("UPSTREAM_CLUSTER_RAW");
-    absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info = nullptr;
-    EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
     EXPECT_EQ(absl::nullopt, upstream_format.format({}, stream_info));
     EXPECT_THAT(upstream_format.formatValue({}, stream_info), ProtoEq(ValueUtil::nullValue()));
   }
@@ -4537,11 +4533,9 @@ TEST(SubstitutionFormatterTest, JsonFormatterClusterMetadataTest) {
 
   envoy::config::core::v3::Metadata metadata;
   populateMetadataTestData(metadata);
-  absl::optional<std::shared_ptr<NiceMock<Upstream::MockClusterInfo>>> cluster =
-      std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-  EXPECT_CALL(**cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
-  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
-  EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(*cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
+  stream_info.upstream_cluster_info_ = cluster;
 
   const std::string expected_json_map = R"EOF({
     "test_key": "test_value",
@@ -4582,15 +4576,8 @@ TEST(SubstitutionFormatterTest, JsonFormatterClusterMetadataNoClusterInfoTest) {
                             key_mapping);
   JsonFormatterImpl formatter(key_mapping, false);
 
-  // Empty optional (absl::nullopt)
+  // No cluster info (nullptr)
   {
-    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
-    EXPECT_TRUE(TestUtility::jsonStringEqual(formatter.format(formatter_context, stream_info),
-                                             expected_json_map));
-  }
-  // Empty cluster info (nullptr)
-  {
-    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(nullptr));
     EXPECT_TRUE(TestUtility::jsonStringEqual(formatter.format(formatter_context, stream_info),
                                              expected_json_map));
   }

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -103,9 +103,7 @@ public:
 class AsyncClientImplTracingTest : public AsyncClientImplTest {
 public:
   AsyncClientImplTracingTest() {
-    ON_CALL(stream_info_, upstreamClusterInfo())
-        .WillByDefault(Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(
-            cm_.thread_local_cluster_.cluster_.info_)));
+    stream_info_.upstream_cluster_info_ = cm_.thread_local_cluster_.cluster_.info_;
   }
 
   Tracing::MockSpan parent_span_;

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -415,9 +415,7 @@ class RouterTestChildSpan : public RouterTestBase {
 public:
   RouterTestChildSpan()
       : RouterTestBase(true, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
-    ON_CALL(callbacks_.stream_info_, upstreamClusterInfo())
-        .WillByDefault(Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(
-            cm_.thread_local_cluster_.cluster_.info_)));
+    callbacks_.stream_info_.upstream_cluster_info_ = cm_.thread_local_cluster_.cluster_.info_;
   }
 };
 

--- a/test/common/router/router_upstream_filter_test.cc
+++ b/test/common/router/router_upstream_filter_test.cc
@@ -62,7 +62,7 @@ public:
     cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
     ON_CALL(*cluster_info_, name()).WillByDefault(ReturnRef(cluster_name));
     ON_CALL(*cluster_info_, observabilityName()).WillByDefault(ReturnRef(cluster_name));
-    ON_CALL(callbacks_.stream_info_, upstreamClusterInfo()).WillByDefault(Return(cluster_info_));
+    callbacks_.stream_info_.upstream_cluster_info_ = cluster_info_;
     EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_).Times(testing::AnyNumber());
     for (const auto& filter : upstream_filters) {
       *router_proto.add_upstream_http_filters() = filter;

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -93,7 +93,7 @@ public:
     cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
     ON_CALL(*cluster_info_, name()).WillByDefault(ReturnRef(cluster_name));
     ON_CALL(*cluster_info_, observabilityName()).WillByDefault(ReturnRef(observability_name));
-    ON_CALL(callbacks_.stream_info_, upstreamClusterInfo()).WillByDefault(Return(cluster_info_));
+    callbacks_.stream_info_.upstream_cluster_info_ = cluster_info_;
     callbacks_.stream_info_.downstream_bytes_meter_ = std::make_shared<StreamInfo::BytesMeter>();
     EXPECT_CALL(callbacks_.dispatcher_, deferredDelete_).Times(testing::AnyNumber());
 

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -352,11 +352,11 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
                      ->getDataReadOnly<TestIntAccessor>("test")
                      ->access());
 
-    EXPECT_EQ(absl::nullopt, stream_info.upstreamClusterInfo());
+    EXPECT_EQ(nullptr, stream_info.upstreamClusterInfo());
     Upstream::ClusterInfoConstSharedPtr cluster_info(new NiceMock<Upstream::MockClusterInfo>());
     stream_info.setUpstreamClusterInfo(cluster_info);
-    EXPECT_NE(absl::nullopt, stream_info.upstreamClusterInfo());
-    EXPECT_EQ("fake_cluster", stream_info.upstreamClusterInfo().value()->name());
+    EXPECT_NE(nullptr, stream_info.upstreamClusterInfo());
+    EXPECT_EQ("fake_cluster", stream_info.upstreamClusterInfo()->name());
 
     const std::string session_id =
         "D62A523A65695219D46FE1FFE285A4C371425ACE421B110B5B8D11D3EB4D5F0B";
@@ -506,7 +506,7 @@ TEST_F(StreamInfoImplTest, SetFrom) {
             s2.filterState()->getDataReadOnly<TestIntAccessor>("test")->access());
   EXPECT_EQ(*s1.getRequestHeaders(), headers1);
   EXPECT_EQ(*s2.getRequestHeaders(), headers2);
-  EXPECT_TRUE(s2.upstreamClusterInfo().has_value());
+  EXPECT_NE(nullptr, s2.upstreamClusterInfo());
   EXPECT_EQ(s1.upstreamClusterInfo(), s2.upstreamClusterInfo());
   EXPECT_EQ(s1.getStreamIdProvider().value().get().toStringView().value(),
             s2.getStreamIdProvider().value().get().toStringView().value());

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -864,18 +864,14 @@ TEST_F(TcpProxyNonDeprecatedConfigRoutingTest, ClusterNameSet) {
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _, _))
       .WillOnce(Return(absl::nullopt));
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> cluster_info;
   EXPECT_CALL(connection_.stream_info_, setUpstreamClusterInfo(_))
-      .WillOnce(
-          Invoke([&cluster_info](const Upstream::ClusterInfoConstSharedPtr& upstream_cluster_info) {
-            cluster_info = upstream_cluster_info;
-          }));
-  EXPECT_CALL(connection_.stream_info_, upstreamClusterInfo())
-      .WillOnce(ReturnPointee(&cluster_info));
+      .WillOnce(Invoke([this](const Upstream::ClusterInfoConstSharedPtr& upstream_cluster_info) {
+        connection_.stream_info_.upstream_cluster_info_ = upstream_cluster_info;
+      }));
 
   filter_->onNewConnection();
 
-  EXPECT_EQ(connection_.stream_info_.upstreamClusterInfo().value()->name(), "fake_cluster");
+  EXPECT_EQ(connection_.stream_info_.upstreamClusterInfo()->name(), "fake_cluster");
 }
 
 class TcpProxyHashingTest : public testing::Test {

--- a/test/common/tcp_proxy/tcp_proxy_test_base.h
+++ b/test/common/tcp_proxy/tcp_proxy_test_base.h
@@ -69,7 +69,7 @@ public:
           upstream_cluster_ = cluster_info;
         }));
     ON_CALL(filter_callbacks_.connection_.stream_info_, upstreamClusterInfo())
-        .WillByDefault(ReturnPointee(&upstream_cluster_));
+        .WillByDefault(ReturnRef(upstream_cluster_));
     factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
         {"fake_cluster"});
   }

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -45,9 +45,7 @@ protected:
   HttpConnManFinalizerImplTest() {
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info.upstreamInfo()->setUpstreamHost(shared_host);
-    ON_CALL(stream_info, upstreamClusterInfo())
-        .WillByDefault(
-            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
+    stream_info.upstream_cluster_info_ = cluster_info_;
   }
   struct CustomTagCase {
     std::string custom_tag;
@@ -198,7 +196,7 @@ TEST_F(HttpConnManFinalizerImplTest, NullRequestHeadersAndNullRouteEntry) {
   stream_info.upstreamInfo()->setUpstreamHost(nullptr);
   EXPECT_CALL(stream_info, route()).WillRepeatedly(Return(nullptr));
   // No cluster info.
-  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
+  stream_info.upstream_cluster_info_ = nullptr;
 
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Error), Eq(Tracing::Tags::get().True)));
@@ -301,7 +299,7 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSetAlthoughNoUpstreamInfo
 
 TEST_F(HttpConnManFinalizerImplTest, NoUpstreamClusterTagSetWhenNoClusterInfo) {
   // No cluster info.
-  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
+  stream_info.upstream_cluster_info_ = nullptr;
 
   EXPECT_CALL(stream_info, bytesReceived()).WillOnce(Return(10));
   EXPECT_CALL(stream_info, bytesSent()).WillOnce(Return(11));

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -94,9 +94,7 @@ protected:
   FinalizerImplTest() {
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info.upstreamInfo()->setUpstreamHost(shared_host);
-    ON_CALL(stream_info, upstreamClusterInfo())
-        .WillByDefault(
-            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
+    stream_info.upstream_cluster_info_ = cluster_info_;
   }
   struct CustomTagCase {
     std::string custom_tag;
@@ -380,9 +378,7 @@ public:
     Upstream::HostDescriptionConstSharedPtr shared_host(host_);
     stream_info_.upstreamInfo()->setUpstreamHost(shared_host);
 
-    ON_CALL(stream_info_, upstreamClusterInfo())
-        .WillByDefault(
-            Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(cluster_info_)));
+    stream_info_.upstream_cluster_info_ = cluster_info_;
   }
 
   Http::TestRequestHeaderMapImpl request_headers_{

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -587,11 +587,9 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterClusterMetadataTest) {
 
   envoy::config::core::v3::Metadata metadata;
   populateMetadataTestData(metadata);
-  absl::optional<std::shared_ptr<NiceMock<Upstream::MockClusterInfo>>> cluster =
-      std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-  EXPECT_CALL(**cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
-  EXPECT_CALL(stream_info, upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
-  EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillRepeatedly(ReturnPointee(cluster));
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(*cluster, metadata()).WillRepeatedly(ReturnRef(metadata));
+  stream_info.upstream_cluster_info_ = cluster;
 
   OpenTelemetryFormatMap expected = {
       {"test_key", "test_value"},
@@ -642,16 +640,9 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterClusterMetadataNoClusterIn
                             key_mapping);
   OpenTelemetryFormatter formatter(key_mapping, {});
 
-  // Empty optional (absl::nullopt)
+  // No cluster info (nullptr)
   {
-    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(absl::nullopt));
-    verifyOpenTelemetryOutput(
-        formatter.format({&request_header, &response_header, &response_trailer}, stream_info),
-        expected);
-  }
-  // Empty cluster info (nullptr)
-  {
-    EXPECT_CALL(Const(stream_info), upstreamClusterInfo()).WillOnce(Return(nullptr));
+    stream_info.upstream_cluster_info_ = nullptr;
     verifyOpenTelemetryOutput(
         formatter.format({&request_header, &response_header, &response_trailer}, stream_info),
         expected);

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -540,7 +540,7 @@ TEST(Context, ConnectionAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info(
       new NiceMock<Upstream::MockClusterInfo>());
-  EXPECT_CALL(info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
+  info.upstream_cluster_info_ = cluster_info;
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> upstream_host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   auto downstream_ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
@@ -874,7 +874,7 @@ TEST(Context, ConnectionAttributes) {
   }
 
   {
-    EXPECT_CALL(info, upstreamClusterInfo()).WillRepeatedly(Return(absl::nullopt));
+    info.upstream_cluster_info_ = nullptr;
     auto value = upstream[CelValue::CreateStringView(UpstreamNumEndpoints)];
     EXPECT_FALSE(value.has_value());
   }
@@ -963,7 +963,7 @@ TEST(Context, XDSAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info(
       new NiceMock<Upstream::MockClusterInfo>());
-  EXPECT_CALL(info, upstreamClusterInfo()).WillRepeatedly(Return(cluster_info));
+  info.upstream_cluster_info_ = cluster_info;
   std::shared_ptr<NiceMock<Envoy::Upstream::MockHostDescription>> upstream_host(
       new NiceMock<Envoy::Upstream::MockHostDescription>());
   auto host_metadata = std::make_shared<const envoy::config::core::v3::Metadata>();
@@ -1075,12 +1075,10 @@ TEST(Context, XDSAttributes) {
 TEST(Context, XDSAttributesEdgeCases) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   NiceMock<StreamInfo::MockStreamInfo> info;
-  std::shared_ptr<NiceMock<Upstream::MockClusterInfo>> cluster_info(
-      new NiceMock<Upstream::MockClusterInfo>());
-  EXPECT_CALL(info, upstreamClusterInfo()).WillRepeatedly(Return(nullptr));
   std::shared_ptr<NiceMock<Router::MockRoute>> route{new NiceMock<Router::MockRoute>()};
   EXPECT_CALL(info, route()).WillRepeatedly(Return(route));
   info.downstream_connection_info_provider_->setListenerInfo(nullptr);
+  // upstream_cluster_info_ defaults to nullptr
 
   Protobuf::Arena arena;
   XDSWrapper wrapper(arena, &info, &local_info);

--- a/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/filter_test.cc
@@ -126,9 +126,6 @@ TEST_F(FilterTest, ValidAltSvc) {
   EXPECT_CALL(callbacks_, streamInfo())
       .Times(testing::AtLeast(1))
       .WillRepeatedly(ReturnRef(callbacks_.stream_info_));
-  EXPECT_CALL(callbacks_.stream_info_, upstreamClusterInfo())
-      .Times(testing::AtLeast(1))
-      .WillRepeatedly(Return(info));
   EXPECT_CALL(callbacks_.stream_info_, upstreamInfo()).Times(testing::AtLeast(1));
   // Get the pointer to MockHostDescription.
   std::shared_ptr<const Upstream::MockHostDescription> hd =
@@ -180,9 +177,6 @@ TEST_F(FilterTest, ValidAltSvcMissingPort) {
   EXPECT_CALL(callbacks_, streamInfo())
       .Times(testing::AtLeast(1))
       .WillRepeatedly(ReturnRef(callbacks_.stream_info_));
-  EXPECT_CALL(callbacks_.stream_info_, upstreamClusterInfo())
-      .Times(testing::AtLeast(1))
-      .WillRepeatedly(Return(info));
   EXPECT_CALL(callbacks_.stream_info_, upstreamInfo()).Times(testing::AtLeast(1));
   // Get the pointer to MockHostDescription.
   std::shared_ptr<const Upstream::MockHostDescription> hd =

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1933,7 +1933,7 @@ TEST_P(WasmHttpFilterTest, ClusterMetadata) {
   EXPECT_CALL(*cluster, metadata()).WillRepeatedly(ReturnRef(*cluster_metadata));
   EXPECT_CALL(request_stream_info_, requestComplete)
       .WillRepeatedly(Return(std::chrono::milliseconds(30)));
-  EXPECT_CALL(request_stream_info_, upstreamClusterInfo()).WillRepeatedly(Return(cluster));
+  request_stream_info_.upstream_cluster_info_ = cluster;
   EXPECT_CALL(filter(),
               log_(spdlog::level::warn, Eq(absl::string_view("cluster metadata: cluster"))));
   filter().log({&request_headers}, request_stream_info_);

--- a/test/extensions/formatter/metadata/metadata_test.cc
+++ b/test/extensions/formatter/metadata/metadata_test.cc
@@ -122,10 +122,9 @@ TEST_F(MetadataFormatterTest, DynamicMetadataWithLegacyConfigurationAndLength) {
 // cluster's metadata object.
 TEST_F(MetadataFormatterTest, ClusterMetadata) {
   // Make sure that formatter accesses cluster metadata.
-  absl::optional<std::shared_ptr<NiceMock<Upstream::MockClusterInfo>>> cluster =
-      std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
-  EXPECT_CALL(**cluster, metadata()).WillRepeatedly(testing::ReturnRef(*metadata_));
-  EXPECT_CALL(stream_info_, upstreamClusterInfo()).WillRepeatedly(testing::ReturnPointee(cluster));
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(*cluster, metadata()).WillRepeatedly(testing::ReturnRef(*metadata_));
+  stream_info_.upstream_cluster_info_ = cluster;
 
   EXPECT_EQ("test_value",
             getTestMetadataFormatter("CLUSTER")->format(formatter_context_, stream_info_));

--- a/test/mocks/stream_info/mocks.cc
+++ b/test/mocks/stream_info/mocks.cc
@@ -238,7 +238,7 @@ MockStreamInfo::MockStreamInfo()
       .WillByDefault(Invoke([this](const Upstream::ClusterInfoConstSharedPtr& cluster_info) {
         upstream_cluster_info_ = std::move(cluster_info);
       }));
-  ON_CALL(*this, upstreamClusterInfo()).WillByDefault(ReturnPointee(&upstream_cluster_info_));
+  ON_CALL(*this, upstreamClusterInfo()).WillByDefault(ReturnRef(upstream_cluster_info_));
   ON_CALL(*this, addCustomFlag(_)).WillByDefault(Invoke([this](absl::string_view flag) {
     if (stream_flags_.empty()) {
       stream_flags_.append(flag);

--- a/test/mocks/stream_info/mocks.h
+++ b/test/mocks/stream_info/mocks.h
@@ -163,8 +163,7 @@ public:
   MOCK_METHOD(void, setRequestHeaders, (const Http::RequestHeaderMap&));
   MOCK_METHOD(const Http::RequestHeaderMap*, getRequestHeaders, (), (const));
   MOCK_METHOD(void, setUpstreamClusterInfo, (const Upstream::ClusterInfoConstSharedPtr&));
-  MOCK_METHOD(absl::optional<Upstream::ClusterInfoConstSharedPtr>, upstreamClusterInfo, (),
-              (const));
+  MOCK_METHOD(const Upstream::ClusterInfoConstSharedPtr&, upstreamClusterInfo, (), (const));
   MOCK_METHOD(OptRef<const StreamIdProvider>, getStreamIdProvider, (), (const));
   MOCK_METHOD(void, setStreamIdProvider, (StreamIdProviderSharedPtr provider));
   MOCK_METHOD(void, setTraceReason, (Tracing::Reason reason));
@@ -205,7 +204,7 @@ public:
   absl::optional<uint32_t> response_code_;
   absl::optional<std::string> response_code_details_;
   absl::optional<std::string> connection_termination_details_;
-  absl::optional<Upstream::ClusterInfoConstSharedPtr> upstream_cluster_info_;
+  Upstream::ClusterInfoConstSharedPtr upstream_cluster_info_;
   std::shared_ptr<UpstreamInfo> upstream_info_;
   absl::InlinedVector<ResponseFlag, 4> response_flags_;
   envoy::config::core::v3::Metadata metadata_;


### PR DESCRIPTION
Commit Message: stream info: to return const ref of cluster info rather than pointer
Additional Description:

Keep consistence with route() and virtualHost(). This also fixed a bug of `alternate_protocols_cache` filter. In that filter, it may access a null cluster directly.

Risk Level: mid.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
