### PR TITLE
docs: replace deprecated match_config with match in tap filter examples

### DIFF
--- a/docs/root/configuration/http/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http/http_filters/tap_filter.rst
@@ -72,7 +72,7 @@ An example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       and_match:
         rules:
           - http_request_headers_match:
@@ -99,7 +99,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       or_match:
         rules:
           - http_request_headers_match:
@@ -126,7 +126,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       any_match: true
     output_config:
       sinks:
@@ -141,7 +141,7 @@ Another example POST body:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       and_match:
         rules:
           - http_request_headers_match:
@@ -192,7 +192,7 @@ An example of a streaming admin tap configuration that uses the :ref:`JSON_BODY_
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       any_match: true
     output_config:
       sinks:
@@ -227,7 +227,7 @@ An example of a buffered admin tap configuration:
 
   config_id: test_config_id
   tap_config:
-    match_config:
+    match:
       any_match: true
     output_config:
       sinks:
@@ -267,7 +267,7 @@ An static filter configuration to enable streaming output looks like:
     "@type": type.googleapis.com/envoy.extensions.filters.http.tap.v3.Tap
     common_config:
       static_config:
-        match_config:
+        match:
           http_response_headers_match:
             headers:
               - name: bar


### PR DESCRIPTION
## Summary
- Replace the deprecated `match_config` field with `match` in all 7 YAML examples in the tap filter documentation
- `match_config` has been deprecated since v3.0 (see `api/envoy/config/tap/v3/common.proto`)
- Both fields use the same `MatchPredicate` type so the YAML structure is unchanged

Fixes #20190
Continues the work from #20194.

Risk Level: Low (docs only)
Testing: N/A
Docs Changes: Updated all tap filter examples
Release Notes: N/A

Signed-off-by: Kit <kit@kovan.dev>

🤖 Generated with [Claude Code](https://claude.com/claude-code)