### PR TITLE
cgroup: Do not fail tests when run on linux machines without cgroup

### DIFF
--- a/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.cc
+++ b/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.cc
@@ -175,7 +175,7 @@ LinuxContainerCpuStatsReader::create(Filesystem::Instance& fs, TimeSource& time_
     return std::make_unique<CgroupV1CpuStatsReader>(fs, time_source);
   }
 
-  throw EnvoyException("No supported cgroup CPU implementation found");
+  throw EnvoyException(std::string(NoSupportedCGroupMessage));
 }
 
 CgroupV1CpuStatsReader::CgroupV1CpuStatsReader(Filesystem::Instance& fs, TimeSource& time_source)

--- a/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
+++ b/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
@@ -10,10 +10,15 @@
 #include "source/extensions/resource_monitors/cpu_utilization/cpu_paths.h"
 #include "source/extensions/resource_monitors/cpu_utilization/cpu_stats_reader.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace ResourceMonitors {
 namespace CpuUtilizationMonitor {
+
+constexpr absl::string_view NoSupportedCGroupMessage =
+    "No supported cgroup CPU implementation found";
 
 // Internal struct for LinuxCpuStatsReader and CgroupV1CpuStatsReader
 // (shared implementation without effective_cores)

--- a/test/extensions/resource_monitors/cpu_utilization/BUILD
+++ b/test/extensions/resource_monitors/cpu_utilization/BUILD
@@ -46,8 +46,10 @@ envoy_extension_cc_test(
     tags = ["skip_on_windows"],
     deps = [
         "//envoy/registry",
+        "//source/common/common:thread_lib",
         "//source/common/stats:isolated_store_lib",
         "//source/extensions/resource_monitors/cpu_utilization:config",
+        "//source/extensions/resource_monitors/cpu_utilization:linux_cpu_stats_reader",
         "//source/server:resource_monitor_config_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:options_mocks",

--- a/test/extensions/resource_monitors/cpu_utilization/config_test.cc
+++ b/test/extensions/resource_monitors/cpu_utilization/config_test.cc
@@ -1,7 +1,9 @@
 #include "envoy/extensions/resource_monitors/cpu_utilization/v3/cpu_utilization.pb.h"
 #include "envoy/registry/registry.h"
 
+#include "source/common/common/thread.h"
 #include "source/extensions/resource_monitors/cpu_utilization/config.h"
+#include "source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h"
 #include "source/server/resource_monitor_config_impl.h"
 
 #include "test/mocks/event/mocks.h"
@@ -85,8 +87,7 @@ TEST(CpuUtilizationMonitorFactoryTest, CreateContainerCPUMonitor) {
   END_TRY
   CATCH(EnvoyException & e, {
     // If we did throw it must have been because of cgroup.
-    ASSERT_THAT(std::string(e.what()),
-                ::testing::Eq("No supported cgroup CPU implementation found"));
+    ASSERT_THAT(std::string(e.what()), ::testing::Eq(NoSupportedCGroupMessage));
     GTEST_SKIP() << "Skipping test because the current machine does not support cgroup";
   });
 #else
@@ -147,8 +148,7 @@ TEST(CpuUtilizationMonitorFactoryTest, ContainerMonitorFunctional) {
   END_TRY
   CATCH(EnvoyException & e, {
     // If we did throw it must have been because of cgroup.
-    ASSERT_THAT(std::string(e.what()),
-                ::testing::Eq("No supported cgroup CPU implementation found"));
+    ASSERT_THAT(std::string(e.what()), ::testing::Eq(NoSupportedCGroupMessage));
     GTEST_SKIP() << "Skipping test because the current machine does not support cgroup";
   });
 }


### PR DESCRIPTION
Commit Message: I believe that when you check out a repo and run tests, they should work. Tests that do not make sense on the platform you are running should be skipped.

In this case the underlying system throws if you don't have the right processor, so I changed the test to just catch it, check the exception string is what's expected, and stop.

Additional Description:
Risk Level: low (test-only)
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
