### PR TITLE
docs: remove references to non-existent bazel/setup_clang.sh (#43808)

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -17,10 +17,6 @@ tasks:
     platform: ubuntu2004
     shell_commands:
     - "sudo apt -y update && sudo apt -y install automake autotools-dev cmake libtool m4 ninja-build"
-    - "wget https://apt.llvm.org/llvm.sh && sudo bash llvm.sh 14"
-    - "bazel/setup_clang.sh /usr/lib/llvm-14"
-    # TODO(keith): Remove once we use clang 15+ on CI
-    - "sudo apt-get install -y libclang-rt-14-dev"
     test_targets:
     - "//test/common/common/..."
     - "//test/integration/..."

--- a/.bazelrc
+++ b/.bazelrc
@@ -266,7 +266,7 @@ build:asan-common --build_tag_filters=-no_san
 build:asan-common --test_tag_filters=-no_san
 build:asan-common --copt -fsanitize=address,undefined
 build:asan-common --linkopt -fsanitize=address,undefined
-# vptr and function sanitizer are enabled in asan if it is set up via bazel/setup_clang.sh.
+# vptr and function sanitizer are enabled in asan when using --config=clang.
 build:asan-common --copt -fno-sanitize=vptr,function
 build:asan-common --linkopt -fno-sanitize=vptr,function
 build:asan-common --copt -DADDRESS_SANITIZER=1

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -98,14 +98,13 @@ for how to update or override dependencies.
     ```
 
     ### Linux
-    On Linux, we recommend using the prebuilt Clang+LLVM package from [LLVM official site](http://releases.llvm.org/download.html) for Clang 18.
-
-    Extract the tar.xz and run the following:
+    Envoy uses a hermetic Clang toolchain that is automatically downloaded by Bazel, so you do not
+    need to install Clang manually. To use it, add `--config=clang` to your build command:
     ```console
-    bazel/setup_clang.sh <PATH_TO_EXTRACTED_CLANG_LLVM>
+    bazel build --config=clang envoy
     ```
 
-    This will setup a `clang.bazelrc` file in Envoy source root. If you want to make clang as default, run the following:
+    If you want to make clang the default, add it to your `user.bazelrc`:
     ```console
     echo "build --config=clang" >> user.bazelrc
     ```


### PR DESCRIPTION
Commit Message: docs: remove references to non-existent bazel/setup_clang.sh
Additional Description: The clang toolchain is now hermetic and automatically downloaded by Bazel, so bazel/setup_clang.sh no longer exists. Updated `bazel/README.md` to reflect the current setup process, fixed a stale comment in `.bazelrc`, and removed outdated shell_commands in `.bazelci/presubmit.yml`.
Risk Level: Low (docs only)
Testing:N/A
Docs Changes:  Updated bazel/README.md
Release Notes: N/A
Platform Specific Features: N/A
Fixes: [43808](https://github.com/envoyproxy/envoy/issues/43808 )
Signed-off-by: stekole [stefan@sandnetworks.com](mailto:stefan@sandnetworks.com)

CC: @phlax