### PR TITLE
regex-replace: remove unused default c'tor

### DIFF
--- a/source/common/matcher/regex_replace.h
+++ b/source/common/matcher/regex_replace.h
@@ -11,7 +11,6 @@ namespace Matcher {
 
 class RegexReplace {
 public:
-  RegexReplace() = default;
   RegexReplace(Regex::CompiledMatcherPtr regex, std::string&& substitution)
       : regex_(std::move(regex)), substitution_(std::move(substitution)) {}
 


### PR DESCRIPTION
Commit Message: regex-replace: remove unused default c'tor
Additional Description:
Minor change - removing the default c'tor of RegexReplace that wasn't used.
This c'tor doesn't initialize 'regex_' and may cause a nullptr deref if 'apply()' is invoked.

Risk Level: low - not being used.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
