### PR TITLE
Allow setting USER_UID and USER_GID in run_envoy_docker.sh

### DIFF
--- a/ci/run_envoy_docker.sh
+++ b/ci/run_envoy_docker.sh
@@ -7,8 +7,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # User/group IDs
-USER_UID="$(id -u)"
-USER_GID="$(id -g)"
+USER_UID="${USER_UID:-$(id -u)}"
+USER_GID="${USER_GID:-$(id -g)}"
 export USER_UID
 export USER_GID
 


### PR DESCRIPTION
Commit Message: Allow setting USER_UID and USER_GID in run_envoy_docker.sh

Additional Description:
On macOS, the primary group for regular users is GID 20 (staff). run_envoy_docker.sh always unconditionally overwrites USER_GID with the result of id -g, then passes that value into the Docker container entrypoint. The entrypoint runs groupmod -g "$USER_GID" envoybuild to remap the envoybuild group to match the host user's GID so that volume-mounted file permissions work correctly. However, GID 20 is already assigned to a different group inside the Linux-based build container (e.g. dialout), so groupmod fails with:
```
groupmod: GID '20' already exists
```
Because USER_GID was unconditionally assigned, any attempt to override it by prefixing the command (e.g. USER_GID=1000 ./ci/run_envoy_docker.sh bash) had no effect — the script always clobbered the value.

Fix

Changed the USER_UID and USER_GID assignments in run_envoy_docker.sh to use the existing environment variable value if already set, falling back to id -u / id -g only when not provided:
```
USER_UID="${USER_UID:-$(id -u)}"
USER_GID="${USER_GID:-$(id -g)}"
```
This allows macOS users to override the GID with one that doesn't conflict with groups already present inside the container:
```
USER_GID=1000 ./ci/run_envoy_docker.sh bash
```

Risk Level: Low
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

