### PR TITLE
vhds: refactor tests that use vhds so they can use static-routes later

### DIFF
--- a/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_integration_test.cc
@@ -347,8 +347,8 @@ class OnDemandVhdsIntegrationTest : public VhdsIntegrationTest {
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, OnDemandVhdsIntegrationTest,
-                         UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, OnDemandVhdsIntegrationTest, VHDS_INTEGRATION_PARAMS,
+                         vhdsTestParamsToString);
 // tests a scenario when:
 //  - a spontaneous VHDS DiscoveryResponse adds two virtual hosts
 //  - the next spontaneous VHDS DiscoveryResponse removes newly added virtual hosts
@@ -792,8 +792,10 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsWildcardUpgradeOnReconnect) {
   EXPECT_EQ("200", response->headers().getStatusValue());
   cleanupUpstreamAndDownstream();
 
-  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
-                                      {"my_route"}, {}, {}, true));
+  if (routeConfigType() == RouteConfigType::Rds) {
+    EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
+                                        {"my_route"}, {}, {}, true));
+  }
 
   // Disconnect VHDS stream and reconnect.
   vhds_stream_->finishGrpcStream(Grpc::Status::Internal);
@@ -809,16 +811,18 @@ TEST_P(OnDemandVhdsIntegrationTest, VhdsWildcardUpgradeOnReconnect) {
 
 // Test class for VHDS on-demand updates with request bodies
 class OnDemandVhdsWithBodyIntegrationTest
-    : public testing::TestWithParam<
-          std::tuple<HttpProtocolTestParams, std::tuple<Network::Address::IpVersion,
-                                                        Grpc::ClientType, Grpc::LegacyOrUnified>>>,
+    : public testing::TestWithParam<std::tuple<HttpProtocolTestParams, VhdsIntegrationTestParam>>,
       public HttpIntegrationTest {
 public:
-  using ParamType =
-      std::tuple<HttpProtocolTestParams,
-                 std::tuple<Network::Address::IpVersion, Grpc::ClientType, Grpc::LegacyOrUnified>>;
+  using ParamType = std::tuple<HttpProtocolTestParams, VhdsIntegrationTestParam>;
 
   const HttpProtocolTestParams& httpProtocolParams() const { return std::get<0>(GetParam()); }
+  const VhdsIntegrationTestParam& vhdsParams() const { return std::get<1>(GetParam()); }
+
+  Network::Address::IpVersion ipVersion() const { return std::get<0>(vhdsParams()); }
+  Grpc::ClientType clientType() const { return std::get<1>(vhdsParams()); }
+  bool isUnified() const { return std::get<2>(vhdsParams()) == Grpc::LegacyOrUnified::Unified; }
+  RouteConfigType routeConfigType() const { return std::get<3>(vhdsParams()); }
 
   OnDemandVhdsWithBodyIntegrationTest()
       : HttpIntegrationTest(httpProtocolParams().downstream_protocol, httpProtocolParams().version,
@@ -830,9 +834,8 @@ public:
     config_helper_.addRuntimeOverride("envoy.reloadable_features.enable_universal_header_validator",
                                       use_universal_header_validator_ ? "true" : "false");
     use_lds_ = false;
-    config_helper_.addRuntimeOverride(
-        "envoy.reloadable_features.unified_mux",
-        std::get<2>(std::get<1>(GetParam())) == Grpc::LegacyOrUnified::Unified ? "true" : "false");
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
+                                      isUnified() ? "true" : "false");
     config_helper_.prependFilter(R"EOF(
     name: envoy.filters.http.on_demand
     )EOF");
@@ -871,7 +874,7 @@ routes:
     setUpstreamProtocol(Http::CodecType::HTTP2); // xDS uses gRPC uses HTTP2
 
     const auto ip_version = httpProtocolParams().version;
-    config_helper_.addConfigModifier([ip_version](
+    config_helper_.addConfigModifier([this, ip_version](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       // Add xds_cluster for VHDS
       auto* xds_cluster = bootstrap.mutable_static_resources()->add_clusters();
@@ -889,17 +892,32 @@ routes:
           envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager>(
           *config_blob);
 
-      // Use RDS instead of static route_config so Envoy connects to xDS server
-      hcm_config.clear_route_config();
-      auto* rds_config = hcm_config.mutable_rds();
-      rds_config->set_route_config_name("my_route");
-      auto* rds_config_source = rds_config->mutable_config_source();
-      rds_config_source->mutable_api_config_source()->set_api_type(
-          envoy::config::core::v3::ApiConfigSource::GRPC);
-      rds_config_source->mutable_api_config_source()
-          ->add_grpc_services()
-          ->mutable_envoy_grpc()
-          ->set_cluster_name("xds_cluster");
+      if (routeConfigType() == RouteConfigType::Rds) {
+        // Use RDS instead of static route_config so Envoy connects to xDS server.
+        hcm_config.clear_route_config();
+        auto* rds_config = hcm_config.mutable_rds();
+        rds_config->set_route_config_name("my_route");
+        auto* rds_config_source = rds_config->mutable_config_source();
+        rds_config_source->mutable_api_config_source()->set_api_type(
+            envoy::config::core::v3::ApiConfigSource::GRPC);
+        rds_config_source->mutable_api_config_source()
+            ->add_grpc_services()
+            ->mutable_envoy_grpc()
+            ->set_cluster_name("xds_cluster");
+      } else {
+        // Use static route, and set the VHDS so it uses the xds_cluster.
+        hcm_config.clear_rds();
+        auto* route_config = hcm_config.mutable_route_config();
+        route_config->set_name("my_route");
+        route_config->clear_virtual_hosts();
+        auto* vhds_config_source = route_config->mutable_vhds()->mutable_config_source();
+        vhds_config_source->mutable_api_config_source()->set_api_type(
+            envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
+        vhds_config_source->mutable_api_config_source()
+            ->add_grpc_services()
+            ->mutable_envoy_grpc()
+            ->set_cluster_name("xds_cluster");
+      }
 
       config_blob->PackFrom(hcm_config);
     });
@@ -912,23 +930,27 @@ routes:
     // Set up xDS connection (xds_cluster is the second cluster, so it maps to fake_upstreams_[1])
     auto result = fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, xds_connection_);
     RELEASE_ASSERT(result, result.message());
-    result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
-    RELEASE_ASSERT(result, result.message());
-    xds_stream_->startGrpcStream();
 
-    EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
-                                            {"my_route"}, true));
-    envoy::config::route::v3::RouteConfiguration route_config;
-    route_config.set_name("my_route");
-    auto* vhds_config_source = route_config.mutable_vhds()->mutable_config_source();
-    vhds_config_source->mutable_api_config_source()->set_api_type(
-        envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
-    vhds_config_source->mutable_api_config_source()
-        ->add_grpc_services()
-        ->mutable_envoy_grpc()
-        ->set_cluster_name("xds_cluster");
-    sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
-        Config::TestTypeUrl::get().RouteConfiguration, {route_config}, "1");
+    if (routeConfigType() == RouteConfigType::Rds) {
+      result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+      RELEASE_ASSERT(result, result.message());
+      xds_stream_->startGrpcStream();
+
+      EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
+                                              {"my_route"}, true));
+      // Set a RouteConfiguration with dynamic VHDS.
+      envoy::config::route::v3::RouteConfiguration route_config;
+      route_config.set_name("my_route");
+      auto* vhds_config_source = route_config.mutable_vhds()->mutable_config_source();
+      vhds_config_source->mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::DELTA_GRPC);
+      vhds_config_source->mutable_api_config_source()
+          ->add_grpc_services()
+          ->mutable_envoy_grpc()
+          ->set_cluster_name("xds_cluster");
+      sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+          Config::TestTypeUrl::get().RouteConfiguration, {route_config}, "1");
+    }
 
     result = xds_connection_->waitForNewStream(*dispatcher_, vhds_stream_);
     RELEASE_ASSERT(result, result.message());
@@ -948,26 +970,21 @@ INSTANTIATE_TEST_SUITE_P(
     ProtocolsAndGrpcTypes, OnDemandVhdsWithBodyIntegrationTest,
     testing::Combine(
         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
-        UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS),
-    [](const testing::TestParamInfo<
-        std::tuple<HttpProtocolTestParams, std::tuple<Network::Address::IpVersion, Grpc::ClientType,
-                                                      Grpc::LegacyOrUnified>>>& info) {
+        VHDS_INTEGRATION_PARAMS),
+    [](const testing::TestParamInfo<std::tuple<HttpProtocolTestParams, VhdsIntegrationTestParam>>&
+           info) {
       return absl::StrCat(
           HttpProtocolIntegrationTest::protocolTestParamsToString(
               testing::TestParamInfo<HttpProtocolTestParams>(std::get<0>(info.param), 0)),
           "_",
-          Grpc::UnifiedOrLegacyMuxIntegrationParamTest::protocolTestParamsToString(
-              testing::TestParamInfo<
-                  std::tuple<Network::Address::IpVersion, Grpc::ClientType, Grpc::LegacyOrUnified>>(
-                  std::get<1>(info.param), 0)));
+          vhdsTestParamsToString(
+              testing::TestParamInfo<VhdsIntegrationTestParam>(std::get<1>(info.param), 0)));
     });
 
 // Test VHDS on-demand update with a request body
 TEST_P(OnDemandVhdsWithBodyIntegrationTest, VhdsOnDemandUpdateWithBody) {
   // TODO(wdauchy): Fix Unified mux to properly handle on-demand VHDS updates.
-  const bool is_unified_mux =
-      std::get<2>(std::get<1>(GetParam())) == Grpc::LegacyOrUnified::Unified;
-  if (is_unified_mux) {
+  if (isUnified()) {
     GTEST_SKIP() << "Unified mux times out when processing on-demand VHDS updates";
   }
   initialize();

--- a/test/integration/vhds.h
+++ b/test/integration/vhds.h
@@ -134,14 +134,24 @@ vhds:
           cluster_name: xds_cluster
 )EOF";
 
+enum class RouteConfigType { Rds, Static };
+
+using VhdsIntegrationTestParam = std::tuple<Network::Address::IpVersion, Grpc::ClientType,
+                                            Grpc::LegacyOrUnified, RouteConfigType>;
+
 class VhdsIntegrationTest : public HttpIntegrationTest,
-                            public Grpc::UnifiedOrLegacyMuxIntegrationParamTest {
+                            public testing::TestWithParam<VhdsIntegrationTestParam> {
 public:
   VhdsIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP2, ipVersion(), config()) {
     use_lds_ = false;
     config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
                                       isUnified() ? "true" : "false");
   }
+
+  Network::Address::IpVersion ipVersion() const { return std::get<0>(GetParam()); }
+  Grpc::ClientType clientType() const { return std::get<1>(GetParam()); }
+  bool isUnified() const { return std::get<2>(GetParam()) == Grpc::LegacyOrUnified::Unified; }
+  RouteConfigType routeConfigType() const { return std::get<3>(GetParam()); }
 
   void TearDown() override { cleanUpXdsConnection(); }
 
@@ -173,6 +183,18 @@ public:
   // Overridden to insert this stuff into the initialize() at the very beginning of
   // HttpIntegrationTest::testRouterRequestAndResponseWithBody().
   void initialize() override {
+    if (routeConfigType() == RouteConfigType::Static) {
+      // Static route config - remove the "rds" configuration in the HCM, and
+      // set the contents statically in "route_config".
+      config_helper_.addConfigModifier(
+          [&](envoy::extensions::filters::network::http_connection_manager::v3::
+                  HttpConnectionManager& hcm) -> void {
+            hcm.clear_rds();
+            auto* route_config = hcm.mutable_route_config();
+            route_config->CopyFrom(rdsConfig());
+          });
+    }
+
     // Controls how many addFakeUpstream() will happen in
     // BaseIntegrationTest::createUpstreams() (which is part of initialize()).
     // Make sure this number matches the size of the 'clusters' repeated field in the bootstrap
@@ -197,14 +219,17 @@ public:
     AssertionResult result = // xds_connection_ is filled with the new FakeHttpConnection.
         fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, xds_connection_);
     RELEASE_ASSERT(result, result.message());
-    result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
-    RELEASE_ASSERT(result, result.message());
-    xds_stream_->startGrpcStream();
 
-    EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
-                                            {"my_route"}, true));
-    sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
-        Config::TestTypeUrl::get().RouteConfiguration, {rdsConfig()}, "1");
+    if (routeConfigType() == RouteConfigType::Rds) {
+      result = xds_connection_->waitForNewStream(*dispatcher_, xds_stream_);
+      RELEASE_ASSERT(result, result.message());
+      xds_stream_->startGrpcStream();
+
+      EXPECT_TRUE(compareSotwDiscoveryRequest(Config::TestTypeUrl::get().RouteConfiguration, "",
+                                              {"my_route"}, true));
+      sendSotwDiscoveryResponse<envoy::config::route::v3::RouteConfiguration>(
+          Config::TestTypeUrl::get().RouteConfiguration, {rdsConfig()}, "1");
+    }
 
     result = xds_connection_->waitForNewStream(*dispatcher_, vhds_stream_);
     RELEASE_ASSERT(result, result.message());
@@ -283,5 +308,32 @@ public:
   FakeStreamPtr vhds_stream_;
   bool use_rds_with_vhosts{false};
 };
+
+// VHDS Integration tests are similar to other xDS-dynamic config tests, but
+// also validate a dynamic-route config update (RDS) and a static-route config
+// settings.
+// TODO(adisuissa): enable the 'RouteConfigType::Static' testing option once its
+// support is added.
+/*
+#define VHDS_INTEGRATION_PARAMS                                                                    \
+  testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),                     \
+                   testing::Values(Grpc::ClientType::EnvoyGrpc),                                   \
+                   testing::Values(Grpc::LegacyOrUnified::Legacy, Grpc::LegacyOrUnified::Unified), \
+                   testing::Values(RouteConfigType::Rds, RouteConfigType::Static))
+*/
+#define VHDS_INTEGRATION_PARAMS                                                                    \
+  testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),                     \
+                   testing::Values(Grpc::ClientType::EnvoyGrpc),                                   \
+                   testing::Values(Grpc::LegacyOrUnified::Legacy, Grpc::LegacyOrUnified::Unified), \
+                   testing::Values(RouteConfigType::Rds))
+
+inline std::string
+vhdsTestParamsToString(const testing::TestParamInfo<VhdsIntegrationTestParam>& info) {
+  return absl::StrCat(
+      (std::get<0>(info.param) == Network::Address::IpVersion::v4 ? "IPv4_" : "IPv6_"),
+      (std::get<1>(info.param) == Grpc::ClientType::EnvoyGrpc ? "EnvoyGrpc_" : "GoogleGrpc_"),
+      (std::get<2>(info.param) == Grpc::LegacyOrUnified::Unified ? "Unified_" : "Legacy_"),
+      (std::get<3>(info.param) == RouteConfigType::Rds ? "Rds" : "Static"));
+}
 
 } // namespace Envoy

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -134,10 +134,13 @@ TEST_P(VhdsInitializationTest, InitializeVhdsAfterRdsHasBeenInitialized) {
   ASSERT_TRUE(codec_client_->waitForDisconnect());
 }
 
-INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, VhdsIntegrationTest,
-                         UNIFIED_LEGACY_GRPC_CLIENT_INTEGRATION_PARAMS);
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, VhdsIntegrationTest, VHDS_INTEGRATION_PARAMS,
+                         vhdsTestParamsToString);
 
 TEST_P(VhdsIntegrationTest, RdsUpdateWithoutVHDSChangesDoesNotRestartVHDS) {
+  if (routeConfigType() != RouteConfigType::Rds) {
+    GTEST_SKIP() << "This test requires RDS update";
+  }
   testRouterHeaderOnlyRequestAndResponse(nullptr, 1, "/", "sni.lyft.com");
   cleanupUpstreamAndDownstream();
   ASSERT_TRUE(codec_client_->waitForDisconnect());


### PR DESCRIPTION
Commit Message: vhds: refactor tests that use vhds so they can use static-routes later
Additional Description:
Currently VHDS can only be used for dynamic routes (fetched over RDS).
This PR refactors the integration tests so they can test both dynamic-routes (RDS) and static-routes.
The static-route validation is not yet enabled (parameterized test is constrained to RDS only), because the code-base currently doesn't support VHDS in a static-route. This will be enabled in the future.

Risk Level: low - tests only
Testing: Updated the tests, did not add any new test.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A