### PR TITLE
deps: switch aspect_bazel_lib to download from official releases

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -74,9 +74,9 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     ),
     aspect_bazel_lib = dict(
         version = "2.21.2",
-        sha256 = "079e47b2fd357396a376dec6ad7907a51028cb2b98233b45e5269cd5ce2fea51",
+        sha256 = "53cadea9109e646a93ed4dc90c9bbcaa8073c7c3df745b92f6a5000daf7aa3da",
         strip_prefix = "bazel-lib-{version}",
-        urls = ["https://github.com/aspect-build/bazel-lib/archive/v{version}.tar.gz"],
+        urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v{version}/bazel-lib-v{version}.tar.gz"],
     ),
     abseil_cpp = dict(
         version = "20260107.0",


### PR DESCRIPTION
Commit Message: deps: switch aspect_bazel_lib to download from official releases

Additional Description:
The bazel-lib published release tarballs include a generated file `tools/integrity.bzl` which is stubbed out in the regular source tree (ex: https://github.com/bazel-contrib/bazel-lib/blob/v2.21.2/tools/integrity.bzl). If this file is missing, some bazel-lib rules which make use of extra toolchains will break due to the missing checksums when downloading binaries.
None of the affected rules are used in Envoy right now, but this can affect downstream consumers.

Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
