### PR TITLE
test: fix server shutdown logic in IntegrationTestServerImpl destructor

### DIFF
--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -297,7 +297,7 @@ IntegrationTestServerImpl::~IntegrationTestServerImpl() {
       server_gone_.WaitForNotification();
     }
   } else {
-    if (server_) {
+    if (!server_gone_.HasBeenNotified()) {
       server_->dispatcher().post([this]() { server_->shutdown(); });
       server_gone_.WaitForNotification();
     }


### PR DESCRIPTION
Commit Message: test: fix server shutdown logic in IntegrationTestServerImpl destructor

Additional Description:
This fixes the logic in ~IntegrationTestServerImpl() that determines whether or not the test server needs to be shut down during test cleanup. Previously, it is assumed that if the server was started, it will not have been shut down during the test, however this may not always be the case.

For example, I needed to write an integration test to exercise a callback registered to the `ServerLifecycleNotifier`'s ShutdownExit stage. In the body of the integration test, the following code would trigger a manual server shutdown:
```cc
test_server_->server().dispatcher().post([this] {
  test_server_->server().shutdown();
});
```
When the server is shut down during the test, `createAndRunEnvoyServer()` running in a background thread exits after `server.run()` returns, causing `IntegrationTestServerImpl::server_` to now point to garbage. It also signals the `server_gone_` notification.

When the test completes and is torn down, `~IntegrationTestServerImpl()` does not check to see if `server_gone_` was already notified during the test, and attempts to call `server_->dispatcher()` and crashes. 

Risk Level: moderate (this code path is probably reached in every integration test)

Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
