### PR TITLE
generic proxy: propagate shared downstream filter state objects to upstream

### DIFF
--- a/source/extensions/filters/network/generic_proxy/router/BUILD
+++ b/source/extensions/filters/network/generic_proxy/router/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
         "//source/common/common:linked_object",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:well_known_names",
+        "//source/common/network:transport_socket_options_lib",
         "//source/common/router:metadatamatchcriteria_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tracing:tracer_lib",

--- a/source/extensions/filters/network/generic_proxy/router/router.cc
+++ b/source/extensions/filters/network/generic_proxy/router/router.cc
@@ -11,6 +11,7 @@
 #include "source/common/tracing/tracer_impl.h"
 #include "source/extensions/filters/network/generic_proxy/interface/filter.h"
 #include "source/extensions/filters/network/generic_proxy/tracing.h"
+#include "source/common/network/transport_socket_options_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -438,6 +439,9 @@ void RouterFilter::kickOffNewUpstreamRequest() {
     completeAndSendLocalReply(Status(StatusCode::kUnavailable, "cluster_maintain_mode"), {});
     return;
   }
+
+  transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
+      downstreamConnection()->streamInfo().filterState());
 
   GenericUpstreamSharedPtr generic_upstream = generic_upstream_factory_->createGenericUpstream(
       *thread_local_cluster, this, const_cast<Network::Connection&>(*callbacks_->connection()),

--- a/source/extensions/filters/network/generic_proxy/router/router.h
+++ b/source/extensions/filters/network/generic_proxy/router/router.h
@@ -159,7 +159,9 @@ public:
   // Upstream::LoadBalancerContextBase
   const Envoy::Router::MetadataMatchCriteria* metadataMatchCriteria() override;
   const Network::Connection* downstreamConnection() const override;
-
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
+    return transport_socket_options_;
+  }
   // RequestFramesHandler
   void onRequestCommonFrame(RequestCommonFramePtr frame) override;
 
@@ -207,6 +209,7 @@ private:
   // changed in the future.
   UpstreamRequestPtr upstream_request_;
   Envoy::Event::TimerPtr timeout_timer_;
+  Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
 
   DecoderFilterCallback* callbacks_{};
 


### PR DESCRIPTION
Commit Message: generic proxy: propagate shared downstream filter state objects to upstream

Additional Description:
Propagates downstream filter state objects tagged with `SharedWithUpstreamConnection`/`SharedWithUpstreamConnectionOnce` to the upstream via implementation of `LoadBalancerContext::upstreamTransportSocketOptions()` in the RouterFilter.

Risk Level: moderate; this might impact other codec implementations, though if no other implementations are using these filter state sharing modes then this should have no effect. If other codecs are using these modes, they previously did not do anything, so this would be a change in behavior.

Testing: no tests yet (will move out of draft once tests are added)

Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
