### PR TITLE
Update QUICHE from 3a1960c51 to e8bbb3961

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-03-13"
+  release_date: "2026-03-18"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "3a1960c518a0201b1b34384bcc89ea81add484cf",
-        sha256 = "edc92981797fddf5ff355cba9b83e00b1e0ce180812c5ca0fd139a2120482e0c",
+        version = "e8bbb3961767439b802073e1034fb07b313dc929",
+        sha256 = "0734b8cedb4a824e15e81a23f5d7f08517b57c6f602c52dcb112021a0d0b10e0",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/3a1960c51..e8bbb3961

```
$ git log 3a1960c51..e8bbb3961 --date=short --no-merges --format="%ad %al %s"

2026-03-18 wub No public description
2026-03-18 rch Add a non-const tls_connection() getter to TlsHandshaker.
2026-03-17 haoyuewang Correctly handle ignore_read_data case when sequencer gets unblocked.
2026-03-17 quiche-dev Add mutable_ssl_config to QuicCryptoServerConfigPeer
2026-03-16 reubent Add HttpValidationPolicy for rejecting RFC non-compliant status codes
2026-03-16 quiche-dev Disable flaky test cases in  //third_party/quic/core/io:socket_test until resolved
2026-03-16 birenroy Deprecates --gfe2_reloadable_flag_http2_avoid_decompose_representation
2026-03-16 haoyuewang Add a regression test for b/488057588.
2026-03-13 vasilvv Turn off flaky test QuicEventLoopFactoryTest.WakeUp/libevent_epoll_
```

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
