### PR TITLE
fix: guard against integer underflow in grpc_http1_reverse_bridge

### DIFF
--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -104,7 +104,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
 
     if (withhold_grpc_frames_) {
       // Adjust the content-length header to account for us removing the gRPC frame header.
-      adjustContentLength(headers, [](auto size) { return size - Grpc::GRPC_FRAME_HEADER_SIZE; });
+      adjustContentLength(headers, [](auto size) {
+        if (size < Grpc::GRPC_FRAME_HEADER_SIZE) {
+          return size; // Avoid underflow; decodeData will fail if body too small
+        }
+        return size - Grpc::GRPC_FRAME_HEADER_SIZE;
+      });
     }
 
     // Clear the route cache to recompute the cache. This provides additional


### PR DESCRIPTION
## Summary
Fixes #43866.
**Root cause:** `adjustContentLength` subtracted `GRPC_FRAME_HEADER_SIZE` (5) from Content-Length without checking for values < 5, causing `uint64_t` underflow to ~1.8e19.
**Fix:** Added a guard to check that Content-Length >= GRPC_FRAME_HEADER_SIZE before subtraction.
## Changes
- `source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc`: Added underflow guard in Content-Length adjustment callback
## Testing
- Verified fix prevents integer underflow for small Content-Length values
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)