### PR TITLE
Inherit on-demand stats when recreating scope

### DIFF
--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -180,7 +180,28 @@ ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable
 }
 
 void ThreadLocalStoreImpl::addScope(std::shared_ptr<ScopeImpl>& new_scope) {
+  ScopeImplSharedPtr superseded_scope;
   Thread::LockGuard lock(lock_);
+
+  // Inherit stats from any existing scope with the same prefix. This will ensure that counters
+  // created on-demand (e.g. upstream_rq_2xx) survive scope recreation during xDS updates.
+  // See https://github.com/envoyproxy/envoy/issues/43984
+  for (auto& [_, weak] : scopes_) {
+    if (auto existing = weak.lock()) {
+      if (existing->prefix() == new_scope->prefix()) {
+        const auto& src = existing->centralCacheNoThreadAnalysis();
+        const auto& dst = new_scope->centralCacheNoThreadAnalysis();
+        dst->counters_.insert(src->counters_.begin(), src->counters_.end());
+        dst->gauges_.insert(src->gauges_.begin(), src->gauges_.end());
+        dst->histograms_.insert(src->histograms_.begin(), src->histograms_.end());
+        dst->text_readouts_.insert(src->text_readouts_.begin(), src->text_readouts_.end());
+        // Keep old scope alive to prevent deadlock during destruction with lock held.
+        superseded_scope = std::move(existing);
+        break;
+      }
+    }
+  }
+
   scopes_[new_scope.get()] = std::weak_ptr<ScopeImpl>(new_scope);
 }
 

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -917,6 +917,59 @@ TEST_F(StatsThreadLocalStoreTest, OverlappingScopes) {
   tls_.shutdownThread();
 }
 
+// Stats created on-demand (e.g. upstream_rq_2xx) should be inherited by a new scope with the
+// same prefix, so that their values survive scope recreation during xDS updates.
+// See https://github.com/envoyproxy/envoy/issues/43984
+TEST_F(StatsThreadLocalStoreTest, OverlappingScopesInheritOnDemandCounters) {
+  InSequence s;
+  store_->initializeThreading(main_thread_dispatcher_, tls_);
+
+  ScopeSharedPtr scope1 = store_->createScope("scope1.");
+
+  // Create on-demand stats.
+  scope1->counterFromString("on_demand_counter").add(42);
+  scope1->gaugeFromString("on_demand_gauge", Gauge::ImportMode::Accumulate).set(100);
+  Histogram& h1 = scope1->histogramFromString("on_demand_histogram", Histogram::Unit::Unspecified);
+  EXPECT_CALL(sink_, onHistogramComplete(Ref(h1), 7));
+  h1.recordValue(7);
+  scope1->textReadoutFromString("on_demand_text_readout").set("hello");
+  EXPECT_EQ(1UL, store_->counters().size());
+  EXPECT_EQ(1UL, store_->gauges().size());
+  EXPECT_EQ(1UL, store_->histograms().size());
+  EXPECT_EQ(1UL, store_->textReadouts().size());
+
+  // Create scope2 with the same prefix to simulate CDS update creating a new cluster with the same
+  // prefix.
+  ScopeSharedPtr scope2 = store_->createScope("scope1.");
+
+  // Destroy scope1 (simulates old cluster being torn down).
+  scope1.reset();
+
+  // The on-demand stats should be still there.
+  Counter& c = scope2->counterFromString("on_demand_counter");
+  EXPECT_EQ(42UL, c.value());
+
+  Gauge& g = scope2->gaugeFromString("on_demand_gauge", Gauge::ImportMode::Accumulate);
+  EXPECT_EQ(100UL, g.value());
+
+  Histogram& h2 = scope2->histogramFromString("on_demand_histogram", Histogram::Unit::Unspecified);
+  EXPECT_EQ(&h1, &h2);
+
+  TextReadout& t = scope2->textReadoutFromString("on_demand_text_readout");
+  EXPECT_EQ("hello", t.value());
+
+  // After scope2 is also destroyed, stats should be cleaned up.
+  scope2.reset();
+  EXPECT_EQ(0UL, store_->counters().size());
+  EXPECT_EQ(0UL, store_->gauges().size());
+  EXPECT_EQ(0UL, store_->histograms().size());
+  EXPECT_EQ(0UL, store_->textReadouts().size());
+
+  tls_.shutdownGlobalThreading();
+  store_->shutdownThreading();
+  tls_.shutdownThread();
+}
+
 TEST_F(StatsThreadLocalStoreTest, TextReadoutAllLengths) {
   store_->initializeThreading(main_thread_dispatcher_, tls_);
 
@@ -1974,7 +2027,9 @@ TEST(ThreadLocalStoreThreadTest, ConstructDestruct) {
   ThreadLocalStoreImpl store(alloc);
 
   store.initializeThreading(*dispatcher, tls);
-  { ScopeSharedPtr scope1 = store.createScope("scope1."); }
+  {
+    ScopeSharedPtr scope1 = store.createScope("scope1.");
+  }
   tls.shutdownGlobalThreading();
   store.shutdownThreading();
   tls.shutdownThread();


### PR DESCRIPTION
When creating a new cluster to replace an existing one, a new scope is created for statistics.

The intent is to preserve existing statistics. While pre-allocated stats like `upstream_rq_total` are "inherited" at creation, stats created later, such as response code related stats like `upstream_rq_2xx` were not. This caused those metrics to reset after a cluster update.

This PR ensures all existing statistics from a scope with a matching prefix are inherited when recreating a new scope to replace an old one.

Fixes #43984

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
