### PR TITLE
reverse_tunnels: disable flaky integration test

### DIFF
--- a/test/extensions/clusters/reverse_connection/BUILD
+++ b/test/extensions/clusters/reverse_connection/BUILD
@@ -55,6 +55,8 @@ envoy_extension_cc_test(
         "envoy.transport_sockets.tls",
     ],
     rbe_pool = "6gig",
+    # TODO(agrawroh): Temporarily disabled due to flakiness. Re-enable after stabilizing.
+    tags = ["manual"],
     deps = [
         "//source/common/protobuf:utility_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_resolver_lib",


### PR DESCRIPTION
## Description

This PR disables the Reverse Tunnels integration test as it's very flaky and need more work.

---

**Commit Message:** reverse_tunnels: disable flaky integration test
**Additional Description:** Disables the Reverse Tunnels integration test as it's very flaky and need more work.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A