### PR TITLE
adaptive_concurrency: add upstream HTTP filter support via DualFactor…

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -285,6 +285,7 @@ envoy.filters.http.a2a:
 envoy.filters.http.adaptive_concurrency:
   categories:
   - envoy.filters.http
+  - envoy.filters.http.upstream
   security_posture: unknown
   status: stable
   type_urls:

--- a/source/extensions/filters/http/adaptive_concurrency/config.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/config.cc
@@ -40,11 +40,30 @@ Http::FilterFactoryCb AdaptiveConcurrencyFilterFactory::createFilterFactory(
   };
 }
 
+absl::StatusOr<Http::FilterFactoryCb>
+AdaptiveConcurrencyFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency& config,
+    const std::string& stats_prefix, DualInfo info,
+    Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, stats_prefix, context, info.scope);
+}
+
+Envoy::Http::FilterFactoryCb
+AdaptiveConcurrencyFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+    const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency& config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, stats_prefix, context, context.scope());
+}
+
 /**
  * Static registration for the adaptive_concurrency filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(AdaptiveConcurrencyFilterFactory,
-                 Server::Configuration::NamedHttpFilterConfigFactory);
+LEGACY_REGISTER_FACTORY(AdaptiveConcurrencyFilterFactory,
+                        Server::Configuration::NamedHttpFilterConfigFactory,
+                        "envoy.filters.http.adaptive_concurrency");
+LEGACY_REGISTER_FACTORY(UpstreamAdaptiveConcurrencyFilterFactory,
+                        Server::Configuration::UpstreamHttpFilterConfigFactory,
+                        "envoy.filters.http.adaptive_concurrency");
 
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters

--- a/source/extensions/filters/http/adaptive_concurrency/config.h
+++ b/source/extensions/filters/http/adaptive_concurrency/config.h
@@ -14,33 +14,35 @@ namespace AdaptiveConcurrency {
  * Config registration for the adaptive concurrency limit filter. @see NamedHttpFilterConfigFactory.
  */
 class AdaptiveConcurrencyFilterFactory
-    : public Common::FactoryBase<
+    : public Common::DualFactoryBase<
           envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency> {
 public:
-  AdaptiveConcurrencyFilterFactory() : FactoryBase("envoy.filters.http.adaptive_concurrency") {}
+  AdaptiveConcurrencyFilterFactory()
+      : DualFactoryBase("envoy.filters.http.adaptive_concurrency") {}
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
-    return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
-                               context.scope());
-  }
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+      const std::string& stats_prefix, DualInfo info,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+private:
+  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override {
-    return createFilterFactory(proto_config, stats_prefix, context, context.scope());
-  }
+      Server::Configuration::ServerFactoryContext& context) override;
 
-private:
-  Http::FilterFactoryCb createFilterFactory(
+  static Http::FilterFactoryCb createFilterFactory(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
       Stats::Scope& scope);
 };
+
+using UpstreamAdaptiveConcurrencyFilterFactory = AdaptiveConcurrencyFilterFactory;
+DECLARE_FACTORY(AdaptiveConcurrencyFilterFactory);
+DECLARE_FACTORY(UpstreamAdaptiveConcurrencyFilterFactory);
 
 } // namespace AdaptiveConcurrency
 } // namespace HttpFilters


### PR DESCRIPTION
…yBase

Convert AdaptiveConcurrencyFilterFactory from FactoryBase to DualFactoryBase so the filter can be used as an upstream HTTP filter. Register the factory for both downstream and upstream filter chains.

When configured at the cluster level (HttpProtocolOptions.http_filters), each cluster gets its own factory invocation and thus its own GradientController — providing per-cluster concurrency isolation naturally.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
