### PR TITLE
Limit http/set_metadata source files to one logger ID

### DIFF
--- a/source/extensions/filters/http/set_metadata/BUILD
+++ b/source/extensions/filters/http/set_metadata/BUILD
@@ -10,12 +10,23 @@ licenses(["notice"])  # Apache 2
 envoy_extension_package()
 
 envoy_cc_library(
+    name = "filter_config_lib",
+    srcs = ["filter_config.cc"],
+    hdrs = ["filter_config.h"],
+    deps = [
+        "//envoy/router:router_interface",
+        "//envoy/server:filter_config_interface",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "set_metadata_filter_lib",
     srcs = ["set_metadata_filter.cc"],
     hdrs = ["set_metadata_filter.h"],
     deps = [
-        "//envoy/server:filter_config_interface",
-        "//source/common/config:well_known_names",
+        ":filter_config_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/extensions/filters/http/set_metadata/filter_config.cc
+++ b/source/extensions/filters/http/set_metadata/filter_config.cc
@@ -1,0 +1,43 @@
+#include "source/extensions/filters/http/set_metadata/filter_config.h"
+
+#include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SetMetadataFilter {
+
+Config::Config(const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
+               Stats::Scope& scope, const std::string& stats_prefix)
+    : stats_(generateStats(stats_prefix, scope)) {
+  if (proto_config.has_value() && !proto_config.metadata_namespace().empty()) {
+    UntypedMetadataEntry deprecated_api_val{true, proto_config.metadata_namespace(),
+                                            proto_config.value()};
+    untyped_.emplace_back(deprecated_api_val);
+  }
+
+  for (const auto& metadata : proto_config.metadata()) {
+    if (metadata.has_value()) {
+      UntypedMetadataEntry untyped_entry{metadata.allow_overwrite(), metadata.metadata_namespace(),
+                                         metadata.value()};
+      untyped_.emplace_back(untyped_entry);
+    } else if (metadata.has_typed_value()) {
+      TypedMetadataEntry typed_entry{metadata.allow_overwrite(), metadata.metadata_namespace(),
+                                     metadata.typed_value()};
+      typed_.emplace_back(typed_entry);
+    } else {
+      ENVOY_LOG(warn, "set_metadata filter configuration contains metadata entries without value "
+                      "or typed_value");
+    }
+  }
+}
+
+FilterStats Config::generateStats(const std::string& prefix, Stats::Scope& scope) {
+  std::string final_prefix = prefix + "set_metadata.";
+  return {ALL_SET_METADATA_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
+}
+
+} // namespace SetMetadataFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/set_metadata/filter_config.h
+++ b/source/extensions/filters/http/set_metadata/filter_config.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
+#include "envoy/router/router.h"
+#include "envoy/stats/stats_macros.h"
+
+#include "source/common/common/logger.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SetMetadataFilter {
+
+#define ALL_SET_METADATA_FILTER_STATS(COUNTER) COUNTER(overwrite_denied)
+
+struct FilterStats {
+  ALL_SET_METADATA_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+struct UntypedMetadataEntry {
+  bool allow_overwrite{};
+  std::string metadata_namespace;
+  Protobuf::Struct value;
+};
+struct TypedMetadataEntry {
+  bool allow_overwrite{};
+  std::string metadata_namespace;
+  Protobuf::Any value;
+};
+class Config : public Envoy::Router::RouteSpecificFilterConfig,
+               public Logger::Loggable<Logger::Id::config> {
+public:
+  Config(const envoy::extensions::filters::http::set_metadata::v3::Config& config,
+         Stats::Scope& scope, const std::string& stats_prefix);
+
+  const std::vector<UntypedMetadataEntry>& untyped() { return untyped_; }
+  const std::vector<TypedMetadataEntry>& typed() { return typed_; }
+  const FilterStats& stats() const { return stats_; }
+
+private:
+  static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
+
+  std::vector<UntypedMetadataEntry> untyped_;
+  std::vector<TypedMetadataEntry> typed_;
+  FilterStats stats_;
+};
+
+using ConfigSharedPtr = std::shared_ptr<Config>;
+
+} // namespace SetMetadataFilter
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
+++ b/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
@@ -1,47 +1,11 @@
 #include "source/extensions/filters/http/set_metadata/set_metadata_filter.h"
 
-#include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
-
-#include "source/common/config/well_known_names.h"
-#include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
-
-#include "absl/strings/str_format.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace SetMetadataFilter {
-
-Config::Config(const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-               Stats::Scope& scope, const std::string& stats_prefix)
-    : stats_(generateStats(stats_prefix, scope)) {
-  if (proto_config.has_value() && !proto_config.metadata_namespace().empty()) {
-    UntypedMetadataEntry deprecated_api_val{true, proto_config.metadata_namespace(),
-                                            proto_config.value()};
-    untyped_.emplace_back(deprecated_api_val);
-  }
-
-  for (const auto& metadata : proto_config.metadata()) {
-    if (metadata.has_value()) {
-      UntypedMetadataEntry untyped_entry{metadata.allow_overwrite(), metadata.metadata_namespace(),
-                                         metadata.value()};
-      untyped_.emplace_back(untyped_entry);
-    } else if (metadata.has_typed_value()) {
-      TypedMetadataEntry typed_entry{metadata.allow_overwrite(), metadata.metadata_namespace(),
-                                     metadata.typed_value()};
-      typed_.emplace_back(typed_entry);
-    } else {
-      ENVOY_LOG(warn, "set_metadata filter configuration contains metadata entries without value "
-                      "or typed_value");
-    }
-  }
-}
-
-FilterStats Config::generateStats(const std::string& prefix, Stats::Scope& scope) {
-  std::string final_prefix = prefix + "set_metadata.";
-  return {ALL_SET_METADATA_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
-}
 
 SetMetadataFilter::SetMetadataFilter(const ConfigSharedPtr config) : config_(config) {}
 

--- a/source/extensions/filters/http/set_metadata/set_metadata_filter.h
+++ b/source/extensions/filters/http/set_metadata/set_metadata_filter.h
@@ -1,58 +1,13 @@
 #pragma once
 
-#include <cstdint>
-#include <string>
-#include <vector>
-
-#include "envoy/extensions/filters/http/set_metadata/v3/set_metadata.pb.h"
-#include "envoy/stats/stats_macros.h"
-
 #include "source/common/common/logger.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
-
-#include "absl/strings/string_view.h"
-#include "absl/types/variant.h"
+#include "source/extensions/filters/http/set_metadata/filter_config.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace SetMetadataFilter {
-
-#define ALL_SET_METADATA_FILTER_STATS(COUNTER) COUNTER(overwrite_denied)
-
-struct FilterStats {
-  ALL_SET_METADATA_FILTER_STATS(GENERATE_COUNTER_STRUCT)
-};
-
-struct UntypedMetadataEntry {
-  bool allow_overwrite{};
-  std::string metadata_namespace;
-  Protobuf::Struct value;
-};
-struct TypedMetadataEntry {
-  bool allow_overwrite{};
-  std::string metadata_namespace;
-  Protobuf::Any value;
-};
-class Config : public ::Envoy::Router::RouteSpecificFilterConfig,
-               public Logger::Loggable<Logger::Id::config> {
-public:
-  Config(const envoy::extensions::filters::http::set_metadata::v3::Config& config,
-         Stats::Scope& scope, const std::string& stats_prefix);
-
-  const std::vector<UntypedMetadataEntry>& untyped() { return untyped_; }
-  const std::vector<TypedMetadataEntry>& typed() { return typed_; }
-  const FilterStats& stats() const { return stats_; }
-
-private:
-  static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
-
-  std::vector<UntypedMetadataEntry> untyped_;
-  std::vector<TypedMetadataEntry> typed_;
-  FilterStats stats_;
-};
-
-using ConfigSharedPtr = std::shared_ptr<Config>;
 
 class SetMetadataFilter : public Http::PassThroughDecoderFilter,
                           public Logger::Loggable<Logger::Id::filter> {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
