### PR TITLE
format: reject raw pointer type aliases

### DIFF
--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -722,6 +722,8 @@ class FormatChecker:
             report_error("Don't use 'using testing::Test;, elaborate the type instead")
         if line.startswith("using testing::TestWithParams;"):
             report_error("Don't use 'using testing::Test;, elaborate the type instead")
+        if re.match(r"^\s*using\s+\w+\s*=\s*[^;]*\*[^;]*;", line) and "(" not in line:
+            report_error("Don't type alias raw pointers")
         if "[[fallthrough]];" in line:
             report_error("Use 'FALLTHRU;' instead like the other parts of the code")
         if self.config.re["test_name_starting_lc"].search(line):

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -722,7 +722,7 @@ class FormatChecker:
             report_error("Don't use 'using testing::Test;, elaborate the type instead")
         if line.startswith("using testing::TestWithParams;"):
             report_error("Don't use 'using testing::Test;, elaborate the type instead")
-        if re.match(r"^\s*using\s+\w+\s*=\s*[^;]*\*[^;]*;", line) and "(" not in line:
+        if re.match(r"^\s*using\s+\w*Ptr\s*=\s*[^;]*\*\s*(?:const|volatile)?\s*;", line) and "(" not in line:
             report_error("Don't type alias raw pointers")
         if "[[fallthrough]];" in line:
             report_error("Use 'FALLTHRU;' instead like the other parts of the code")


### PR DESCRIPTION
## Summary
Adds a check_format validation for a STYLE.md type-alias rule: regular raw pointers should not be type aliased.

Fixes #9840.

## What changed
- Added a code-format check in tools/code_format/check_format.py to flag lines like:
  - using BadPtr = int*;
- The check skips function pointer aliases (for example using Fn = void(*)(int);).

## Validation
- Ran check_format on synthetic samples:
  - bad sample with raw pointer alias is flagged with: "Don't type alias raw pointers"
  - good sample with unique_ptr alias and function-pointer alias did not trigger the new rule
- Note: local check_format invocation also reported clang-format permission issues in this environment, unrelated to this logic change.
