### PR TITLE
http: add jitter support for max_connection_duration

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -273,7 +273,7 @@ message AlternateProtocolsCacheOptions {
   repeated string canonical_suffixes = 5;
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message HttpProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HttpProtocolOptions";
@@ -380,6 +380,18 @@ message HttpProtocolOptions {
   // Setting this parameter to ``1`` will effectively disable keep alive.
   // For HTTP/2 and HTTP/3, due to concurrent stream processing, the limit is approximate.
   google.protobuf.UInt32Value max_requests_per_connection = 6;
+
+  // Percentage-based jitter for :ref:`max_connection_duration
+  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>`.
+  // The jitter value increases the effective ``max_connection_duration`` by a random amount
+  // (up to the provided percentage of the base duration) to avoid thundering herd problems
+  // when many connections are established simultaneously. For example, setting
+  // ``max_connection_duration`` to 10s with a 25% jitter means connections will be
+  // drained after a uniformly random duration between 10s and 12.5s.
+  //
+  // This field is ignored if ``max_connection_duration`` is not set. If not set, no jitter
+  // is applied.
+  type.v3.Percent max_connection_duration_jitter_percent = 8;
 }
 
 // [#next-free-field: 12]

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -391,7 +391,12 @@ message HttpProtocolOptions {
   //
   // This field is ignored if ``max_connection_duration`` is not set. If not set, no jitter
   // is applied.
-  type.v3.Percent max_connection_duration_jitter_percent = 8;
+  //
+  // .. note::
+  //   This field is only effective for HTTP/1.1 and HTTP/2 connections. Support for
+  //   upstream clusters is not implemented and the jitter will not be applied.
+  type.v3.Percent max_connection_duration_jitter_percent = 8
+      [(validate.rules).message = {required: true}];
 }
 
 // [#next-free-field: 12]

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -294,6 +294,13 @@ public:
   virtual absl::optional<std::chrono::milliseconds> maxConnectionDuration() const PURE;
 
   /**
+   * @return optional jitter percentage to apply to maxConnectionDuration, in range [0, 100].
+   *         When set, the effective max_connection_duration is extended by a random amount
+   *         up to (jitter_percent / 100) * max_connection_duration.
+   */
+  virtual absl::optional<double> maxConnectionDurationJitterPercent() const PURE;
+
+  /**
    * @return whether maxConnectionDuration allows HTTP1 clients to choose when to close connection
    *         (rather than Envoy closing the connection itself when there are no active streams).
    */

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -205,7 +205,16 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
     connection_duration_timer_ =
         dispatcher_->createScaledTimer(Event::ScaledTimerType::HttpDownstreamMaxConnectionTimeout,
                                        [this]() -> void { onConnectionDurationTimeout(); });
-    connection_duration_timer_->enableTimer(config_->maxConnectionDuration().value());
+    std::chrono::milliseconds effective_duration = config_->maxConnectionDuration().value();
+    if (const auto jitter_pct = config_->maxConnectionDurationJitterPercent();
+        jitter_pct.has_value() && jitter_pct.value() > 0.0) {
+      const uint64_t max_jitter_ms =
+          static_cast<uint64_t>(std::ceil(effective_duration.count() * (jitter_pct.value() / 100.0)));
+      if (max_jitter_ms > 0) {
+        effective_duration += std::chrono::milliseconds(random_generator_.random() % max_jitter_ms);
+      }
+    }
+    connection_duration_timer_->enableTimer(effective_duration);
   }
 
   read_callbacks_->connection().setDelayedCloseTimeout(config_->delayedCloseTimeout());

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -392,6 +392,13 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), idle_timeout)),
       max_connection_duration_(
           PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), max_connection_duration)),
+      max_connection_duration_jitter_percent_(
+          config.common_http_protocol_options().has_max_connection_duration_jitter_percent()
+              ? absl::optional<double>(
+                    config.common_http_protocol_options()
+                        .max_connection_duration_jitter_percent()
+                        .value())
+              : absl::nullopt),
       http1_safe_max_connection_duration_(config.http1_safe_max_connection_duration()),
       max_stream_duration_(
           PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), max_stream_duration)),

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -178,6 +178,9 @@ public:
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
     return max_connection_duration_;
   }
+  absl::optional<double> maxConnectionDurationJitterPercent() const override {
+    return max_connection_duration_jitter_percent_;
+  }
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
   }
@@ -338,6 +341,7 @@ private:
   const uint32_t max_request_headers_count_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
+  absl::optional<double> max_connection_duration_jitter_percent_;
   const bool http1_safe_max_connection_duration_;
   absl::optional<std::chrono::milliseconds> max_stream_duration_;
   std::chrono::milliseconds stream_idle_timeout_;

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -155,6 +155,9 @@ public:
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
     return max_connection_duration_;
   }
+  absl::optional<double> maxConnectionDurationJitterPercent() const override {
+    return absl::nullopt;
+  }
   bool http1SafeMaxConnectionDuration() const override { return false; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -147,6 +147,9 @@ public:
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
     return max_connection_duration_;
   }
+  absl::optional<double> maxConnectionDurationJitterPercent() const override {
+    return absl::nullopt;
+  }
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
   }

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -670,6 +670,43 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionDurationSafeHttp1) {
   filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
 }
 
+// Verify that max_connection_duration_jitter_percent applies a deterministic
+// random offset to the connection duration timer.
+TEST_F(HttpConnectionManagerImplTest, ConnectionDurationWithJitter) {
+  // Not used in the test.
+  delete codec_;
+
+  // Base duration 100ms, 50% jitter → max_jitter_ms = ceil(100 * 0.5) = 50.
+  max_connection_duration_ = std::chrono::milliseconds(100);
+  max_connection_duration_jitter_percent_ = 50.0;
+
+  // random() % 50 == 30 → effective timer = 100 + 30 = 130ms.
+  EXPECT_CALL(random_, random()).WillOnce(Return(30UL));
+
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer,
+              enableTimer(std::chrono::milliseconds(130), _));
+  setup();
+
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
+// Verify that jitter is not applied when max_connection_duration is unset.
+TEST_F(HttpConnectionManagerImplTest, ConnectionDurationJitterNoBaseIgnored) {
+  // Not used in the test.
+  delete codec_;
+
+  // jitter_percent is set but max_connection_duration is absent — no timer expected.
+  max_connection_duration_jitter_percent_ = 50.0;
+  setup();
+
+  EXPECT_EQ(0U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
 TEST_F(HttpConnectionManagerImplTest, IntermediateBufferingEarlyResponse) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(

--- a/test/common/http/conn_manager_impl_test_base.cc
+++ b/test/common/http/conn_manager_impl_test_base.cc
@@ -53,6 +53,9 @@ public:
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
     return parent_.maxConnectionDuration();
   }
+  absl::optional<double> maxConnectionDurationJitterPercent() const override {
+    return parent_.maxConnectionDurationJitterPercent();
+  }
   bool http1SafeMaxConnectionDuration() const override {
     return parent_.http1SafeMaxConnectionDuration();
   }

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -118,6 +118,9 @@ public:
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
     return max_connection_duration_;
   }
+  absl::optional<double> maxConnectionDurationJitterPercent() const override {
+    return absl::nullopt;
+  }
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
   }

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -119,7 +119,7 @@ public:
     return max_connection_duration_;
   }
   absl::optional<double> maxConnectionDurationJitterPercent() const override {
-    return absl::nullopt;
+    return max_connection_duration_jitter_percent_;
   }
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
@@ -299,6 +299,7 @@ public:
   uint32_t max_requests_per_connection_{};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
+  absl::optional<double> max_connection_duration_jitter_percent_;
   bool http1_safe_max_connection_duration_{false};
   std::chrono::milliseconds stream_idle_timeout_{};
   absl::optional<std::chrono::milliseconds> stream_flush_timeout_;

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -645,6 +645,7 @@ public:
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, idleTimeout, (), (const));
   MOCK_METHOD(bool, isRoutable, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxConnectionDuration, (), (const));
+  MOCK_METHOD(absl::optional<double>, maxConnectionDurationJitterPercent, (), (const));
   MOCK_METHOD(bool, http1SafeMaxConnectionDuration, (), (const));
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, maxStreamDuration, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, streamIdleTimeout, (), (const));


### PR DESCRIPTION
## Description

Fixes #42410.

TCP connections already support `max_downstream_connection_duration_jitter_percentage` (merged in #40686). This PR adds the equivalent feature for HTTP connections via a new `max_connection_duration_jitter_percent` field in `HttpProtocolOptions`.

### Problem

When many HTTP/2 connections are established simultaneously (e.g. during a pod restart or rolling deploy), they all reach `max_connection_duration` at the same time, triggering simultaneous drain → reconnect storms ("thundering herd").

### Solution

Add `max_connection_duration_jitter_percent` to `HttpProtocolOptions`. When configured, the effective `max_connection_duration` for each connection is individually extended by a random amount uniformly distributed in `[0, jitter_percent/100 * base_duration]`, spreading connection drains over a window rather than synchronizing them.

**Example**: `max_connection_duration = 10s`, `max_connection_duration_jitter_percent = 25` → each connection drains at a random time in `[10s, 12.5s]`.

### Changes

| File | Change |
|---|---|
| `api/envoy/config/core/v3/protocol.proto` | Add `max_connection_duration_jitter_percent` (field 8) to `HttpProtocolOptions` |
| `source/common/http/conn_manager_config.h` | Add `maxConnectionDurationJitterPercent()` pure virtual method |
| `source/extensions/filters/network/http_connection_manager/config.{h,cc}` | Parse and store the new proto field |
| `source/common/http/conn_manager_impl.cc` | Apply jitter when arming the connection duration timer |
| `source/server/admin/admin.h` | Stub: returns `absl::nullopt` (no jitter for admin connections) |
| `test/mocks/http/mocks.h` | Add `MOCK_METHOD` for new interface method |
| `test/common/http/conn_manager_impl_test_base.{h,cc}` | Add stub forwarding delegates |
| `test/common/http/conn_manager_impl_fuzz_test.cc` | Add stub returning `absl::nullopt` |

### Prior art

The TCP proxy implementation in `source/common/tcp_proxy/tcp_proxy.cc` (method `Config::calculateMaxDownstreamConnectionDurationWithJitter()`) provides the exact same pattern — this PR follows it faithfully.

AI Disclosure: Used GitHub Copilot for coding assistance.
---

**AI disclosure:** GitHub Copilot was used during implementation and test writing. I fully understand all changes made in this PR.

**Commit Message:** See PR title
**Risk Level:** Low
**Testing:** Unit tests added/verified
**Docs Changes:** N/A
**Release Notes:** N/A
**Platform Specific Features:** N/A
