### PR TITLE
fix uhv underscore header sanitization use-after-free path

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -8,6 +8,7 @@
 #include "source/common/runtime/runtime_features.h"
 #include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_set.h"
 #include "absl/strings/match.h"
 
@@ -634,19 +635,23 @@ void HeaderValidator::sanitizeHeadersWithUnderscores(::Envoy::Http::HeaderMap& h
     return;
   }
 
-  std::vector<absl::string_view> drop_headers;
+  // Store owning copies because removing one duplicate header can free the
+  // underlying storage for another matching entry. Using absl::string_view
+  // would still be unsafe here as the view may dangle after the first removal.
+  // We only need unique names.
+  absl::flat_hash_set<std::string> drop_headers;
   header_map.iterate([&drop_headers](const ::Envoy::Http::HeaderEntry& header_entry)
                          -> ::Envoy::Http::HeaderMap::Iterate {
     const absl::string_view header_name = header_entry.key().getStringView();
     if (absl::StrContains(header_name, '_')) {
-      drop_headers.push_back(header_name);
+      drop_headers.emplace(header_name);
     }
 
     return ::Envoy::Http::HeaderMap::Iterate::Continue;
   });
 
   ASSERT(drop_headers.empty() || underscore_action == HeaderValidatorConfig::DROP_HEADER);
-  for (auto& name : drop_headers) {
+  for (const auto& name : drop_headers) {
     stats_.incDroppedHeadersWithUnderscores();
     header_map.remove(::Envoy::Http::LowerCaseString(name));
   }

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -652,8 +652,10 @@ void HeaderValidator::sanitizeHeadersWithUnderscores(::Envoy::Http::HeaderMap& h
 
   ASSERT(drop_headers.empty() || underscore_action == HeaderValidatorConfig::DROP_HEADER);
   for (const auto& name : drop_headers) {
-    stats_.incDroppedHeadersWithUnderscores();
-    header_map.remove(::Envoy::Http::LowerCaseString(name));
+    const size_t removed_headers = header_map.remove(::Envoy::Http::LowerCaseString(name));
+    for (size_t i = 0; i < removed_headers; ++i) {
+      stats_.incDroppedHeadersWithUnderscores();
+    }
   }
 }
 

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -497,6 +497,23 @@ TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderMapDropUnderscoreHeaders) 
           {{":scheme", "https"}, {":method", "GET"}, {":path", "/"}, {":authority", "envoy.com"}}));
 }
 
+TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderMapDropDuplicateUnderscoreHeaders) {
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
+                                                  {":method", "GET"},
+                                                  {":path", "/"},
+                                                  {":authority", "envoy.com"},
+                                                  {"x_foo", "bar"}};
+  headers.addCopy("x_foo", "baz");
+  auto uhv = createH1(drop_headers_with_underscores_config);
+
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_ACCEPT(uhv->transformRequestHeaders(headers));
+  EXPECT_EQ(
+      headers,
+      TestRequestHeaderMapImpl(
+          {{":scheme", "https"}, {":method", "GET"}, {":path", "/"}, {":authority", "envoy.com"}}));
+}
+
 TEST_F(Http1HeaderValidatorTest, RejectUnderscoreHeadersFromRequestHeadersWhenConfigured) {
   ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
                                                   {":method", "GET"},

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -260,6 +260,23 @@ TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapDropUnderscoreHeaders) 
           {{":scheme", "https"}, {":method", "GET"}, {":path", "/"}, {":authority", "envoy.com"}}));
 }
 
+TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapDropDuplicateUnderscoreHeaders) {
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
+                                                  {":method", "GET"},
+                                                  {":path", "/"},
+                                                  {":authority", "envoy.com"},
+                                                  {"x_foo", "bar"}};
+  headers.addCopy("x_foo", "baz");
+  auto uhv = createH2ServerUhv(drop_headers_with_underscores_config);
+
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_ACCEPT(uhv->transformRequestHeaders(headers));
+  EXPECT_EQ(
+      headers,
+      ::Envoy::Http::TestRequestHeaderMapImpl(
+          {{":scheme", "https"}, {":method", "GET"}, {":path", "/"}, {":authority", "envoy.com"}}));
+}
+
 TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderMapRejectUnderscoreHeaders) {
   ::Envoy::Http::TestRequestHeaderMapImpl headers{{":scheme", "https"},
                                                   {":method", "GET"},


### PR DESCRIPTION
## Summary

This PR fixes a potential use-after-free path in underscore-header sanitization for Envoy default UHV when `headers_with_underscores_action` is `DROP_HEADER`.

In `sanitizeHeadersWithUnderscores()`, header names were collected as non-owning `absl::string_view` values and then removed from the same header map. With duplicate underscore headers (for example, `x_foo` appearing multiple times), removing one header can invalidate storage referenced by later views.

This change stores owning copies of header names (`std::string`) before mutation, preventing reads from dangling references during removal.

Fixes: #44032

## Changes

- Updated:
  - `source/extensions/http/header_validators/envoy_default/header_validator.cc`
- Replaced:
  - `std::vector<absl::string_view>` with `std::vector<std::string>`
  - `push_back(header_name)` with `emplace_back(header_name)`
- Added regression tests for duplicate underscore headers:
  - `test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc`
  - `test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc`

## Test Plan

- Ran:
  - `//test/extensions/http/header_validators/envoy_default:http1_header_validator_test`
  - `//test/extensions/http/header_validators/envoy_default:http2_header_validator_test`
- Both passed locally.