### PR TITLE
Update QUICHE from e8bbb3961 to 603f7ea47

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -284,7 +284,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-03-18"
+  release_date: "2026-03-23"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -542,8 +542,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "e8bbb3961767439b802073e1034fb07b313dc929",
-        sha256 = "0734b8cedb4a824e15e81a23f5d7f08517b57c6f602c52dcb112021a0d0b10e0",
+        version = "603f7ea475700dcdac7b58f5a05d6ccec70396f4",
+        sha256 = "4b3cd50cef5034eb0b5d49fa7345ec3414fbd1d4430af44a59a7645acfd12029",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/e8bbb3961..603f7ea47

```
$ git log e8bbb3961..603f7ea47 --date=short --no-merges --format="%ad %al %s"

2026-03-23 quiche-dev QBONE Tun device: open file descriptors with `O_NONBLOCK`.
2026-03-23 ericorth Add tun_device_integration_test
2026-03-20 haoyuewang False deprecate --gfe2_reloadable_flag_quic_fix_ignore_read_data_when_unblocked as it does not work per b/488057588#comment14.
2026-03-18 quiche-dev Add support for the latency spin bit (RFC 9000 section 17.4) to Quiche, storing spin state on a per-path basis
```

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
