### PR TITLE
compressor: remove comment about phantom `header_gzip` counter

### DIFF
--- a/source/extensions/filters/http/compressor/compressor_filter.h
+++ b/source/extensions/filters/http/compressor/compressor_filter.h
@@ -38,9 +38,6 @@ namespace Compressor {
  *
  * "header_compressor_overshadowed" is a number of requests skipped by this filter instance because
  * they were handled by another filter in the same filter chain.
- *
- * "header_gzip" is specific to the gzip filter and is deprecated since it duplicates
- * "header_compressor_used".
  */
 #define RESPONSE_COMPRESSOR_STATS(COUNTER)                                                         \
   COUNTER(no_accept_header)                                                                        \


### PR DESCRIPTION
It was removed somewhere between 1.18 and 1.19.