### PR TITLE
memory: add disable_usermode_hugepage_collapse config option to MemoryAllocatorManager

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -777,7 +777,7 @@ message CustomInlineHeader {
   InlineHeaderType inline_header_type = 2 [(validate.rules).enum = {defined_only: true}];
 }
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message MemoryAllocatorManager {
   // Configures tcmalloc to perform background release of free memory in amount of bytes per ``memory_release_interval`` interval.
   // If equals to ``0``, no memory release will occur. Defaults to ``0``.
@@ -812,4 +812,13 @@ message MemoryAllocatorManager {
   //
   // Defaults to ``104857600`` (100 MB).
   uint64 max_unfreed_memory_bytes = 5;
+
+  // Controls whether tcmalloc's userspace hugepage collapse is disabled. When set to ``true``,
+  // tcmalloc will not call ``MADV_COLLAPSE`` to consolidate regular pages into huge pages.
+  // Defaults to ``false`` (hugepage collapse is enabled).
+  //
+  // .. note::
+  //     This is currently only supported with tcmalloc and not with ``gperftools``.
+  //
+  bool disable_usermode_hugepage_collapse = 6;
 }

--- a/bazel/tcmalloc.patch
+++ b/bazel/tcmalloc.patch
@@ -1,7 +1,8 @@
 diff --git a/tcmalloc/BUILD b/tcmalloc/BUILD
---- a/tcmalloc/BUILD	2025-01-28 16:41:20.424424728 +0000
-+++ b/tcmalloc/BUILD	2025-01-28 16:41:09.408433981 +0000
-@@ -24,7 +24,7 @@
+index 60bf5418..23279af2 100644
+--- a/tcmalloc/BUILD
++++ b/tcmalloc/BUILD
+@@ -24,7 +24,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
  load("//tcmalloc:copts.bzl", "TCMALLOC_DEFAULT_COPTS", "TCMALLOC_DEFAULT_CXXOPTS")
  load("//tcmalloc:variants.bzl", "create_tcmalloc_benchmark", "create_tcmalloc_libraries", "create_tcmalloc_testsuite")
  
@@ -10,3 +11,78 @@ diff --git a/tcmalloc/BUILD b/tcmalloc/BUILD
  
  licenses(["notice"])
  
+diff --git a/tcmalloc/internal_malloc_extension.h b/tcmalloc/internal_malloc_extension.h
+index a399b986..f5f34e11 100644
+--- a/tcmalloc/internal_malloc_extension.h
++++ b/tcmalloc/internal_malloc_extension.h
+@@ -106,6 +106,9 @@ ABSL_ATTRIBUTE_WEAK void MallocExtension_Internal_GetStats(std::string* ret);
+ ABSL_ATTRIBUTE_WEAK void MallocExtension_Internal_SetMaxPerCpuCacheSize(
+     int32_t value);
+ ABSL_ATTRIBUTE_WEAK void
++MallocExtension_Internal_SetUsermodeHugepageCollapse(bool value);
++ABSL_ATTRIBUTE_WEAK bool MallocExtension_Internal_GetUsermodeHugepageCollapse();
++ABSL_ATTRIBUTE_WEAK void
+ MallocExtension_Internal_SetBackgroundProcessActionsEnabled(bool value);
+ ABSL_ATTRIBUTE_WEAK void
+ MallocExtension_Internal_SetBackgroundProcessSleepInterval(
+diff --git a/tcmalloc/malloc_extension.cc b/tcmalloc/malloc_extension.cc
+index 468e67a2..d388305b 100644
+--- a/tcmalloc/malloc_extension.cc
++++ b/tcmalloc/malloc_extension.cc
+@@ -435,6 +435,23 @@ void MallocExtension::SetMaxPerCpuCacheSize(int32_t value) {
+ #endif
+ }
+ 
++bool MallocExtension::GetUsermodeHugepageCollapse() {
++#if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
++  if (MallocExtension_Internal_GetUsermodeHugepageCollapse != nullptr) {
++    return MallocExtension_Internal_GetUsermodeHugepageCollapse();
++  }
++#endif
++  return false;
++}
++
++void MallocExtension::SetUsermodeHugepageCollapse(bool value) {
++#if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
++  if (MallocExtension_Internal_SetUsermodeHugepageCollapse != nullptr) {
++    MallocExtension_Internal_SetUsermodeHugepageCollapse(value);
++  }
++#endif
++}
++
+ int64_t MallocExtension::GetMaxTotalThreadCacheBytes() {
+ #if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
+   if (MallocExtension_Internal_GetMaxTotalThreadCacheBytes == nullptr) {
+diff --git a/tcmalloc/malloc_extension.h b/tcmalloc/malloc_extension.h
+index 14035c9e..6cb79f32 100644
+--- a/tcmalloc/malloc_extension.h
++++ b/tcmalloc/malloc_extension.h
+@@ -536,6 +536,11 @@ class MallocExtension final {
+   static void SetMaxPerCpuCacheSize(int32_t value);
+ 
+   // Gets the current maximum thread cache.
++
++  // Controls whether tcmalloc's userspace hugepage collapse is enabled.
++  static bool GetUsermodeHugepageCollapse();
++  static void SetUsermodeHugepageCollapse(bool value);
++
+   static int64_t GetMaxTotalThreadCacheBytes();
+   // Sets the maximum thread cache size.  This is a whole-process limit.
+   static void SetMaxTotalThreadCacheBytes(int64_t value);
+diff --git a/tcmalloc/parameters.cc b/tcmalloc/parameters.cc
+index e6f254b4..c475b215 100644
+--- a/tcmalloc/parameters.cc
++++ b/tcmalloc/parameters.cc
+@@ -679,4 +679,12 @@ void TCMalloc_Internal_SetUseUserspaceCollapseHeuristics(bool v) {
+ 
+ }  // extern "C"
+ 
++bool MallocExtension_Internal_GetUsermodeHugepageCollapse() {
++  return tcmalloc::tcmalloc_internal::Parameters::usermode_hugepage_collapse();
++}
++
++void MallocExtension_Internal_SetUsermodeHugepageCollapse(bool v) {
++  TCMalloc_Internal_SetUsermodeHugepageCollapse(v);
++}
++
+ GOOGLE_MALLOC_SECTION_END

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -39,6 +39,13 @@ minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
 - area: memory
   change: |
+    Added :ref:`disable_usermode_hugepage_collapse
+    <envoy_v3_api_field_config.bootstrap.v3.MemoryAllocatorManager.disable_usermode_hugepage_collapse>`
+    option to ``MemoryAllocatorManager`` to control tcmalloc's userspace hugepage collapse feature.
+    When set to ``true``, tcmalloc will not call ``MADV_COLLAPSE`` to consolidate regular pages into
+    huge pages. Defaults to ``false`` (hugepage collapse is enabled).
+- area: memory
+  change: |
     Replaced the custom timer-based tcmalloc memory release with tcmalloc's native
     ``ProcessBackgroundActions`` and ``SetBackgroundReleaseRate`` APIs. This provides more comprehensive
     background memory management including per-CPU cache reclamation, cache shuffling, and size class

--- a/source/common/memory/stats.cc
+++ b/source/common/memory/stats.cc
@@ -197,6 +197,10 @@ void AllocatorManager::configureTcmallocOptions(
     ENVOY_LOG_MISC(info, "Set tcmalloc max per-CPU cache size to {} bytes.",
                    config.max_per_cpu_cache_size_bytes().value());
   }
+  if (config.disable_usermode_hugepage_collapse()) {
+    tcmalloc::MallocExtension::SetUsermodeHugepageCollapse(false);
+    ENVOY_LOG_MISC(info, "Disabled tcmalloc usermode hugepage collapse.");
+  }
 #else
   if (config.has_soft_memory_limit_bytes()) {
     ENVOY_LOG_MISC(warn, "Soft memory limit is only supported with Google's tcmalloc, ignoring.");
@@ -204,6 +208,10 @@ void AllocatorManager::configureTcmallocOptions(
   if (config.has_max_per_cpu_cache_size_bytes()) {
     ENVOY_LOG_MISC(warn,
                    "Max per-CPU cache size is only supported with Google's tcmalloc, ignoring.");
+  }
+  if (config.disable_usermode_hugepage_collapse()) {
+    ENVOY_LOG_MISC(
+        warn, "Usermode hugepage collapse is only supported with Google's tcmalloc, ignoring.");
   }
 #endif
 }

--- a/test/common/memory/memory_release_test.cc
+++ b/test/common/memory/memory_release_test.cc
@@ -203,6 +203,23 @@ TEST_F(MemoryReleaseTest, MaxPerCpuCacheSizeConfigured) {
 #endif
 }
 
+TEST_F(MemoryReleaseTest, UsermodeHugepageCollapseDisabled) {
+  const std::string yaml_config = R"EOF(
+  disable_usermode_hugepage_collapse: true
+)EOF";
+  const auto proto_config =
+      TestUtility::parseYaml<envoy::config::bootstrap::v3::MemoryAllocatorManager>(yaml_config);
+#if defined(TCMALLOC)
+  EXPECT_LOG_CONTAINS("info", "Disabled tcmalloc usermode hugepage collapse.",
+                      allocator_manager_ =
+                          std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#else
+  EXPECT_LOG_CONTAINS(
+      "warn", "Usermode hugepage collapse is only supported with Google's tcmalloc, ignoring.",
+      allocator_manager_ = std::make_unique<Memory::AllocatorManager>(*api_, proto_config));
+#endif
+}
+
 } // namespace
 } // namespace Memory
 } // namespace Envoy

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -937,6 +937,7 @@ hostset
 hotrestart
 hrefs
 htpasswd
+hugepage
 huffman
 hystrix
 idempotency
@@ -1560,6 +1561,7 @@ useragent
 userdata
 userinfo
 username
+userspace
 usr
 util
 utils


### PR DESCRIPTION
Commit Message: Adds `disable_usermode_hugepage_collapse` option to control tcmalloc usermode hugepage collapse.
Additional Description:

tcmalloc [has moved](https://github.com/google/tcmalloc/commit/ed182cdc3834a59ac9a4f4fb768d603e0cf525ee) to automatically triggering "[hugepage collapse](https://lwn.net/Articles/887753/)" by periodically calling madvise(MADV_COLLAPSE), which can cause unexpected memory increase. This adds an option to disable this functionality.

Risk Level: Low - disabled by default (hugepage collapse default enabled)
Testing: Enabled and saw 1) `AnonHugePages` did not increase from 0 and 2) `sudo bpftrace -e 'tracepoint:syscalls:sys_enter_madvise /args->behavior == 25/ { printf("MADV_COLLAPSE pid=%d comm=%s addr=%p len=%lu\n", pid, comm, args->start, args->len_in); }'` showed no calls for MADV_COLLAPSE
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]