### PR TITLE
matcher: add a stat action to prepend a metric prefix

### DIFF
--- a/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
+++ b/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
@@ -36,11 +36,13 @@ message SinkConfig {
 
     // Static metric labels to use for the metric.
     repeated opentelemetry.proto.common.v1.KeyValue static_metric_labels = 3;
+
+    // Metric prefix to prepend to the metric name. Cannot be used together with ``metric_name``.
+    string metric_prefix = 4;
   }
 
   // DropAction is an action that, when matched, will prevent the stat from being converted to an OTLP metric and flushed.
-  message DropAction {
-  }
+  message DropAction {}
 
   oneof protocol_specifier {
     option (validate.required) = true;
@@ -92,6 +94,7 @@ message SinkConfig {
   // The supported actions are
   // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.DropAction``.
   // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.ConversionAction``.
+  // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.PrependPrefixAction``.
   // If stats are not matched, they will be directly converted to OTLP metrics as usual.
   xds.type.matcher.v3.Matcher custom_metric_conversions = 8;
 }

--- a/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
+++ b/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
@@ -94,7 +94,6 @@ message SinkConfig {
   // The supported actions are
   // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.DropAction``.
   // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.ConversionAction``.
-  // - ``envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.PrependPrefixAction``.
   // If stats are not matched, they will be directly converted to OTLP metrics as usual.
   xds.type.matcher.v3.Matcher custom_metric_conversions = 8;
 }

--- a/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
+++ b/api/envoy/extensions/stat_sinks/open_telemetry/v3/open_telemetry.proto
@@ -42,7 +42,8 @@ message SinkConfig {
   }
 
   // DropAction is an action that, when matched, will prevent the stat from being converted to an OTLP metric and flushed.
-  message DropAction {}
+  message DropAction {
+  }
 
   oneof protocol_specifier {
     option (validate.required) = true;

--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -122,7 +122,7 @@ using ActionConstSharedPtr = std::shared_ptr<const Action>;
 
 template <class ActionFactoryContext> class ActionFactory : public Config::TypedFactory {
 public:
-  virtual ActionConstSharedPtr
+  virtual absl::StatusOr<ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ActionFactoryContext& action_factory_context,
                ProtobufMessage::ValidationVisitor& validation_visitor) PURE;
 

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -49,9 +49,9 @@ class FilterChainNameActionFactory : public Matcher::ActionFactory<FilterChainAc
                                      Logger::Loggable<Logger::Id::config> {
 public:
   std::string name() const override { return "filter-chain-name"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message& config,
-                                             FilterChainActionFactoryContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message& config, FilterChainActionFactoryContext&,
+               ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<FilterChainNameAction>(
         dynamic_cast<const Protobuf::StringValue&>(config).value());
   }

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -322,11 +322,10 @@ private:
           on_match.action().typed_config(), server_factory_context_.messageValidationVisitor(),
           factory);
 
-      // TODO(taoxuy): try to pass message by moving and let the created action take ownership
-      // of the message if needed, which avoid copy.
-      auto action = factory.createAction(*message, action_factory_context_,
-                                         server_factory_context_.messageValidationVisitor());
-      return [action, keep_matching = on_match.keep_matching()] {
+      auto action_status = factory.createAction(*message, action_factory_context_,
+                                                server_factory_context_.messageValidationVisitor());
+      THROW_IF_NOT_OK_REF(action_status.status());
+      return [action = std::move(action_status).value(), keep_matching = on_match.keep_matching()] {
         return OnMatch<DataType>{action, {}, keep_matching};
       };
     }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -2192,21 +2192,20 @@ const Envoy::Config::TypedMetadata& NullConfigImpl::typedMetadata() const {
   return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActionContext& context,
                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_config =
       MessageUtil::downcastAndValidate<const envoy::config::route::v3::Route&>(config,
                                                                                validation_visitor);
-  auto route = THROW_OR_RETURN_VALUE(
-      RouteCreator::createAndValidateRoute(route_config, context.vhost, context.factory_context,
-                                           validation_visitor, false),
-      RouteEntryImplBaseConstSharedPtr);
-  return route;
+  auto route_status = RouteCreator::createAndValidateRoute(
+      route_config, context.vhost, context.factory_context, validation_visitor, false);
+  RETURN_IF_NOT_OK_REF(route_status.status());
+  return route_status.value();
 }
 REGISTER_FACTORY(RouteMatchActionFactory, Matcher::ActionFactory<RouteActionContext>);
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 RouteListMatchActionFactory::createAction(const Protobuf::Message& config,
                                           RouteActionContext& context,
                                           ProtobufMessage::ValidationVisitor& validation_visitor) {
@@ -2215,11 +2214,12 @@ RouteListMatchActionFactory::createAction(const Protobuf::Message& config,
           config, validation_visitor);
 
   std::vector<RouteEntryImplBaseConstSharedPtr> routes;
+  routes.reserve(route_config.routes().size());
   for (const auto& route : route_config.routes()) {
-    routes.emplace_back(THROW_OR_RETURN_VALUE(
-        RouteCreator::createAndValidateRoute(route, context.vhost, context.factory_context,
-                                             validation_visitor, false),
-        RouteEntryImplBaseConstSharedPtr));
+    auto route_status = RouteCreator::createAndValidateRoute(
+        route, context.vhost, context.factory_context, validation_visitor, false);
+    RETURN_IF_NOT_OK_REF(route_status.status());
+    routes.emplace_back(std::move(route_status).value());
   }
   return std::make_shared<RouteListMatchAction>(std::move(routes));
 }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1150,7 +1150,7 @@ private:
 // Registered factory for RouteMatchAction.
 class RouteMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, RouteActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route"; }
@@ -1176,7 +1176,7 @@ private:
 // Registered factory for RouteListMatchAction.
 class RouteListMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, RouteActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route_match_action"; }

--- a/source/extensions/filters/common/rbac/engine_impl.cc
+++ b/source/extensions/filters/common/rbac/engine_impl.cc
@@ -11,7 +11,7 @@ namespace Filters {
 namespace Common {
 namespace RBAC {
 
-Envoy::Matcher::ActionConstSharedPtr
+absl::StatusOr<Envoy::Matcher::ActionConstSharedPtr>
 ActionFactory::createAction(const Protobuf::Message& config, ActionContext& context,
                             ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& action_config =

--- a/source/extensions/filters/common/rbac/engine_impl.h
+++ b/source/extensions/filters/common/rbac/engine_impl.h
@@ -50,7 +50,7 @@ private:
 
 class ActionFactory : public Envoy::Matcher::ActionFactory<ActionContext> {
 public:
-  Envoy::Matcher::ActionConstSharedPtr
+  absl::StatusOr<Envoy::Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "envoy.filters.rbac.action"; }

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -40,7 +40,7 @@ bool ExecuteFilterAction::actionSkip() const {
              : false;
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 ExecuteFilterActionFactory::createAction(const Protobuf::Message& config,
                                          Http::Matching::HttpFilterActionContext& context,
                                          ProtobufMessage::ValidationVisitor& validation_visitor) {
@@ -84,11 +84,12 @@ ExecuteFilterActionFactory::createAction(const Protobuf::Message& config,
   }
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createDynamicActionDownstream(
+absl::StatusOr<Matcher::ActionConstSharedPtr>
+ExecuteFilterActionFactory::createDynamicActionDownstream(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context) {
   if (!context.factory_context_.has_value() || !context.server_factory_context_.has_value()) {
-    throw EnvoyException(
+    return absl::InvalidArgumentError(
         fmt::format("Failed to get downstream factory context or server factory context."));
   }
   auto provider_manager =
@@ -98,12 +99,13 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createDynamicActionDow
       composite_action, context, "http", context.factory_context_.value(), provider_manager);
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createDynamicActionUpstream(
+absl::StatusOr<Matcher::ActionConstSharedPtr>
+ExecuteFilterActionFactory::createDynamicActionUpstream(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context) {
   if (!context.upstream_factory_context_.has_value() ||
       !context.server_factory_context_.has_value()) {
-    throw EnvoyException(
+    return absl::InvalidArgumentError(
         fmt::format("Failed to get upstream factory context or server factory context."));
   }
   auto provider_manager =
@@ -114,14 +116,14 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createDynamicActionUps
       provider_manager);
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createActionCommon(
+absl::StatusOr<Matcher::ActionConstSharedPtr> ExecuteFilterActionFactory::createActionCommon(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context, Envoy::Http::FilterFactoryCb& callback,
     bool is_downstream) {
   const std::string stream_str = is_downstream ? "downstream" : "upstream";
 
   if (callback == nullptr) {
-    throw EnvoyException(
+    return absl::InvalidArgumentError(
         fmt::format("Failed to get {} filter factory creation function", stream_str));
   }
   std::string name = composite_action.typed_config().name();
@@ -137,7 +139,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createActionCommon(
       runtime);
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionDownstream(
+absl::StatusOr<Matcher::ActionConstSharedPtr>
+ExecuteFilterActionFactory::createStaticActionDownstream(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context,
     ProtobufMessage::ValidationVisitor& validation_visitor) {
@@ -167,7 +170,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionDown
   return createActionCommon(composite_action, context, callback, true);
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionUpstream(
+absl::StatusOr<Matcher::ActionConstSharedPtr>
+ExecuteFilterActionFactory::createStaticActionUpstream(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context,
     ProtobufMessage::ValidationVisitor& validation_visitor) {
@@ -191,13 +195,13 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionUpst
   return createActionCommon(composite_action, context, callback, false);
 }
 
-Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainAction(
+absl::StatusOr<Matcher::ActionConstSharedPtr> ExecuteFilterActionFactory::createFilterChainAction(
     const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
     Http::Matching::HttpFilterActionContext& context,
     ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& filter_chain_config = composite_action.filter_chain();
   if (filter_chain_config.typed_config().empty()) {
-    throw EnvoyException("filter_chain must contain at least one filter.");
+    return absl::InvalidArgumentError("filter_chain must contain at least one filter.");
   }
 
   FilterFactoryCbList filter_factories;
@@ -229,7 +233,7 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
       }
 
       if (callback == nullptr) {
-        throw EnvoyException(fmt::format(
+        return absl::InvalidArgumentError(fmt::format(
             "Failed to create downstream filter factory for filter '{}'", filter_config.name()));
       }
     } else {
@@ -247,8 +251,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
       }
 
       if (callback == nullptr) {
-        throw EnvoyException(fmt::format("Failed to create upstream filter factory for filter '{}'",
-                                         filter_config.name()));
+        return absl::InvalidArgumentError(fmt::format(
+            "Failed to create upstream filter factory for filter '{}'", filter_config.name()));
       }
     }
 

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -87,7 +87,7 @@ class ExecuteFilterActionFactory
 public:
   std::string name() const override { return "composite-action"; }
 
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, Http::Matching::HttpFilterActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
@@ -96,7 +96,7 @@ public:
   }
 
 private:
-  Matcher::ActionConstSharedPtr createActionCommon(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createActionCommon(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context, Envoy::Http::FilterFactoryCb& callback,
       bool is_downstream);
@@ -127,26 +127,26 @@ private:
         runtime);
   }
 
-  Matcher::ActionConstSharedPtr createDynamicActionDownstream(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createDynamicActionDownstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context);
 
-  Matcher::ActionConstSharedPtr createDynamicActionUpstream(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createDynamicActionUpstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context);
 
-  Matcher::ActionConstSharedPtr createStaticActionDownstream(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createStaticActionDownstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
-  Matcher::ActionConstSharedPtr createStaticActionUpstream(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createStaticActionUpstream(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);
 
   // Create an action for filter chain configuration.
-  Matcher::ActionConstSharedPtr createFilterChainAction(
+  absl::StatusOr<Matcher::ActionConstSharedPtr> createFilterChainAction(
       const envoy::extensions::filters::http::composite::v3::ExecuteFilterAction& composite_action,
       Http::Matching::HttpFilterActionContext& context,
       ProtobufMessage::ValidationVisitor& validation_visitor);

--- a/source/extensions/filters/http/custom_response/policy.h
+++ b/source/extensions/filters/http/custom_response/policy.h
@@ -52,9 +52,9 @@ template <typename PolicyConfig>
 class PolicyMatchActionFactory : public Matcher::ActionFactory<CustomResponseActionFactoryContext>,
                                  Logger::Loggable<Logger::Id::config> {
 public:
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message& config,
-                                             CustomResponseActionFactoryContext& context,
-                                             ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message& config, CustomResponseActionFactoryContext& context,
+               ProtobufMessage::ValidationVisitor&) override {
     return createPolicy(config, context.server_, context.stats_prefix_);
   }
 

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -24,9 +24,9 @@ class SkipActionFactory
     : public Matcher::ActionFactory<Envoy::Http::Matching::HttpFilterActionContext> {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&,
-                                             Envoy::Http::Matching::HttpFilterActionContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message&, Envoy::Http::Matching::HttpFilterActionContext&,
+               ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<SkipAction>();
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/filters/http/proto_api_scrubber/filter_config.h
+++ b/source/extensions/filters/http/proto_api_scrubber/filter_config.h
@@ -393,9 +393,9 @@ class RemoveFieldAction : public Matcher::ActionBase<ProtoApiScrubberRemoveField
 // ActionFactory for the RemoveFieldAction.
 class RemoveFilterActionFactory : public Matcher::ActionFactory<ProtoApiScrubberRemoveFieldAction> {
 public:
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&,
-                                             ProtoApiScrubberRemoveFieldAction&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message&, ProtoApiScrubberRemoveFieldAction&,
+               ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<RemoveFieldAction>();
   }
 

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -51,7 +51,7 @@ class RateLimitOnMatchActionFactory : public Matcher::ActionFactory<RateLimitOnM
 public:
   std::string name() const override { return "rate_limit_quota"; }
 
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, RateLimitOnMatchActionContext&,
                ProtobufMessage::ValidationVisitor& validation_visitor) override {
     // Validate and then retrieve the bucket settings from config.

--- a/source/extensions/filters/network/generic_proxy/route_impl.cc
+++ b/source/extensions/filters/network/generic_proxy/route_impl.cc
@@ -61,7 +61,7 @@ RouteEntryImpl::RouteEntryImpl(const ProtoRouteAction& route_action,
   }
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActionContext& context,
                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_action =

--- a/source/extensions/filters/network/generic_proxy/route_impl.h
+++ b/source/extensions/filters/network/generic_proxy/route_impl.h
@@ -87,7 +87,7 @@ public:
 // Registered factory for RouteMatchAction.
 class RouteMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, RouteActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "envoy.matching.action.generic_proxy.route"; }

--- a/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
+++ b/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
@@ -51,7 +51,7 @@ std::vector<Http::ClientCertDetailsType> convertSetCurrentClientCertDetails(
   return result;
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 ForwardClientCertActionFactory::createAction(const Protobuf::Message& config,
                                              ForwardClientCertActionFactoryContext&,
                                              ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.h
+++ b/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.h
@@ -56,9 +56,9 @@ class ForwardClientCertActionFactory
 public:
   std::string name() const override { return "forward_client_cert"; }
 
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message& config,
-                                             ForwardClientCertActionFactoryContext&,
-                                             ProtobufMessage::ValidationVisitor&) override;
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message& config, ForwardClientCertActionFactoryContext&,
+               ProtobufMessage::ValidationVisitor&) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::filters::network::http_connection_manager::v3::

--- a/source/extensions/filters/network/match_delegate/config.cc
+++ b/source/extensions/filters/network/match_delegate/config.cc
@@ -18,8 +18,9 @@ namespace Factory {
 class SkipActionFactory : public Matcher::ActionFactory<NetworkFilterActionContext> {
 public:
   std::string name() const override { return "skip"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message&, NetworkFilterActionContext&,
-                                             ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message&, NetworkFilterActionContext&,
+               ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<SkipAction>();
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
+++ b/source/extensions/filters/udp/udp_proxy/router/router_impl.cc
@@ -15,7 +15,7 @@ namespace UdpFilters {
 namespace UdpProxy {
 namespace Router {
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 RouteMatchActionFactory::createAction(const Protobuf::Message& config, RouteActionContext& context,
                                       ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& route_config = MessageUtil::downcastAndValidate<

--- a/source/extensions/filters/udp/udp_proxy/router/router_impl.h
+++ b/source/extensions/filters/udp/udp_proxy/router/router_impl.h
@@ -32,7 +32,7 @@ private:
 
 class RouteMatchActionFactory : public Matcher::ActionFactory<RouteActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, RouteActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "route"; }

--- a/source/extensions/matching/actions/format_string/config.cc
+++ b/source/extensions/matching/actions/format_string/config.cc
@@ -23,7 +23,7 @@ ActionImpl::get(const Server::Configuration::FilterChainsByName& filter_chains_b
   return nullptr;
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 ActionFactory::createAction(const Protobuf::Message& proto_config,
                             FilterChainActionFactoryContext& context,
                             ProtobufMessage::ValidationVisitor& validator) {
@@ -32,10 +32,10 @@ ActionFactory::createAction(const Protobuf::Message& proto_config,
           proto_config, validator);
 
   Server::GenericFactoryContextImpl generic_context(context, validator);
-  Formatter::FormatterConstSharedPtr formatter = THROW_OR_RETURN_VALUE(
-      Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, generic_context),
-      Formatter::FormatterPtr);
-  return std::make_shared<ActionImpl>(std::move(formatter));
+  auto formatter_status =
+      Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config, generic_context);
+  RETURN_IF_NOT_OK_REF(formatter_status.status());
+  return std::make_shared<ActionImpl>(std::move(formatter_status).value());
 }
 
 REGISTER_FACTORY(ActionFactory, Matcher::ActionFactory<FilterChainActionFactoryContext>);

--- a/source/extensions/matching/actions/format_string/config.h
+++ b/source/extensions/matching/actions/format_string/config.h
@@ -30,7 +30,7 @@ using FilterChainActionFactoryContext = Server::Configuration::ServerFactoryCont
 class ActionFactory : public Matcher::ActionFactory<FilterChainActionFactoryContext> {
 public:
   std::string name() const override { return "envoy.matching.actions.format_string"; }
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& proto_config, FilterChainActionFactoryContext& context,
                ProtobufMessage::ValidationVisitor& validator) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/matching/actions/transform_stat/config.cc
+++ b/source/extensions/matching/actions/transform_stat/config.cc
@@ -11,7 +11,7 @@ namespace TransformStat {
 
 class TransformStatActionFactory : public Matcher::ActionFactory<ActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ActionContext& /*context*/,
                ProtobufMessage::ValidationVisitor& validation_visitor) override {
     const auto& action_config =

--- a/source/extensions/matching/common_inputs/transport_socket/config.cc
+++ b/source/extensions/matching/common_inputs/transport_socket/config.cc
@@ -171,7 +171,7 @@ ProtobufTypes::MessagePtr FilterStateInputFactory::createEmptyConfigProto() {
       envoy::extensions::matching::common_inputs::transport_socket::v3::FilterStateInput>();
 }
 
-Matcher::ActionConstSharedPtr
+absl::StatusOr<Matcher::ActionConstSharedPtr>
 TransportSocketNameActionFactory::createAction(const Protobuf::Message& config,
                                                Server::Configuration::ServerFactoryContext&,
                                                ProtobufMessage::ValidationVisitor&) {

--- a/source/extensions/matching/common_inputs/transport_socket/config.h
+++ b/source/extensions/matching/common_inputs/transport_socket/config.h
@@ -155,9 +155,9 @@ class TransportSocketNameActionFactory
     : public Matcher::ActionFactory<Server::Configuration::ServerFactoryContext> {
 public:
   std::string name() const override { return "envoy.matching.action.transport_socket.name"; }
-  Matcher::ActionConstSharedPtr createAction(const Protobuf::Message& config,
-                                             Server::Configuration::ServerFactoryContext&,
-                                             ProtobufMessage::ValidationVisitor&) override;
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
+  createAction(const Protobuf::Message& config, Server::Configuration::ServerFactoryContext&,
+               ProtobufMessage::ValidationVisitor&) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 };
 

--- a/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.cc
@@ -10,7 +10,7 @@ namespace Extensions {
 namespace Router {
 namespace Matcher {
 
-Envoy::Matcher::ActionConstSharedPtr
+absl::StatusOr<Envoy::Matcher::ActionConstSharedPtr>
 ClusterActionFactory::createAction(const Protobuf::Message& config, ClusterActionContext&,
                                    ProtobufMessage::ValidationVisitor& validation_visitor) {
   const auto& proto_config =

--- a/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/matcher/matcher_cluster_specifier.h
@@ -38,7 +38,7 @@ private:
 // from opaque config.
 class ClusterActionFactory : public Envoy::Matcher::ActionFactory<ClusterActionContext> {
 public:
-  Envoy::Matcher::ActionConstSharedPtr
+  absl::StatusOr<Envoy::Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ClusterActionContext& context,
                ProtobufMessage::ValidationVisitor& validation_visitor) override;
   std::string name() const override { return "cluster"; }

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
@@ -299,10 +299,17 @@ OtlpMetricsFlusherImpl::getMetricConfig(const StatType& stat) const {
 template <class StatType>
 std::string OtlpMetricsFlusherImpl::getMetricName(
     const StatType& stat, OptRef<const SinkConfig::ConversionAction> conversion_config) const {
+  absl::string_view prefix = config_->statPrefix();
   if (conversion_config.has_value()) {
-    return conversion_config->metric_name();
+    if (auto name = conversion_config->metric_name(); !name.empty()) {
+      return name;
+    }
+    if (absl::string_view metric_prefix = conversion_config->metric_prefix();
+        !metric_prefix.empty()) {
+      prefix = metric_prefix;
+    }
   }
-  return absl::StrCat(config_->statPrefix(),
+  return absl::StrCat(prefix,
                       config_->useTagExtractedName() ? stat.tagExtractedName() : stat.name());
 }
 

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
@@ -220,25 +220,6 @@ private:
   Protobuf::RepeatedPtrField<opentelemetry::proto::common::v1::KeyValue>
   getCombinedAttributes(const StatType& stat,
                         OptRef<const SinkConfig::ConversionAction> conversion_config) const;
-  template <class GaugeType>
-  void addGaugeDataPoint(opentelemetry::proto::metrics::v1::Metric& metric,
-                         const GaugeType& gauge_stat, int64_t snapshot_time_ns) const;
-
-  template <class CounterType>
-  void addCounterDataPoint(opentelemetry::proto::metrics::v1::Metric& metric,
-                           const CounterType& counter, uint64_t value, uint64_t delta,
-                           int64_t snapshot_time_ns) const;
-
-  void addHistogramDataPoint(opentelemetry::proto::metrics::v1::Metric& metric,
-                             const Stats::ParentHistogram& parent_histogram,
-                             int64_t snapshot_time_ns) const;
-
-  template <class StatType>
-  void setMetricCommon(opentelemetry::proto::metrics::v1::NumberDataPoint& data_point,
-                       int64_t snapshot_time_ns, const StatType& stat) const;
-
-  void setMetricCommon(opentelemetry::proto::metrics::v1::HistogramDataPoint& data_point,
-                       int64_t snapshot_time_ns, const Stats::Metric& stat) const;
 
   const OtlpOptionsSharedPtr config_;
   const std::function<bool(const Stats::Metric&)> predicate_;

--- a/source/extensions/stat_sinks/open_telemetry/stat_match_action.cc
+++ b/source/extensions/stat_sinks/open_telemetry/stat_match_action.cc
@@ -5,6 +5,23 @@ namespace Extensions {
 namespace StatSinks {
 namespace OpenTelemetry {
 
+absl::StatusOr<std::shared_ptr<ConversionAction>> ConversionAction::create(
+    const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction& config) {
+  if (!config.metric_name().empty() && !config.metric_prefix().empty()) {
+    return absl::InvalidArgumentError("Cannot specify both metric_name and metric_prefix.");
+  }
+  return std::shared_ptr<ConversionAction>(new ConversionAction(config));
+}
+
+absl::StatusOr<Matcher::ActionConstSharedPtr>
+ConversionActionFactory::createAction(const Protobuf::Message& config, ActionContext&,
+                                      ProtobufMessage::ValidationVisitor& validation_visitor) {
+  const auto& action_config = MessageUtil::downcastAndValidate<
+      const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction&>(
+      config, validation_visitor);
+  return ConversionAction::create(action_config);
+}
+
 REGISTER_FACTORY(ConversionActionFactory, Envoy::Matcher::ActionFactory<ActionContext>);
 REGISTER_FACTORY(DropActionFactory, Envoy::Matcher::ActionFactory<ActionContext>);
 

--- a/source/extensions/stat_sinks/open_telemetry/stat_match_action.h
+++ b/source/extensions/stat_sinks/open_telemetry/stat_match_action.h
@@ -21,9 +21,9 @@ class ConversionAction
     : public Matcher::ActionBase<
           envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction> {
 public:
-  explicit ConversionAction(
-      const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction& config)
-      : config_(config) {}
+  static absl::StatusOr<std::shared_ptr<ConversionAction>>
+  create(const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction&
+             config);
 
   const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction*
   config() const {
@@ -31,6 +31,9 @@ public:
   }
 
 private:
+  explicit ConversionAction(
+      const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction& config)
+      : config_(config) {}
   const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction config_;
 };
 
@@ -52,14 +55,9 @@ public:
 
 class ConversionActionFactory : public Matcher::ActionFactory<ActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ActionContext&,
-               ProtobufMessage::ValidationVisitor& validation_visitor) override {
-    const auto& action_config = MessageUtil::downcastAndValidate<
-        const envoy::extensions::stat_sinks::open_telemetry::v3::SinkConfig::ConversionAction&>(
-        config, validation_visitor);
-    return std::make_shared<ConversionAction>(action_config);
-  }
+               ProtobufMessage::ValidationVisitor& validation_visitor) override;
 
   std::string name() const override { return "otlp_metric_conversion_action_factory"; }
 
@@ -71,7 +69,7 @@ public:
 
 class DropActionFactory : public Matcher::ActionFactory<ActionContext> {
 public:
-  Matcher::ActionConstSharedPtr
+  absl::StatusOr<Matcher::ActionConstSharedPtr>
   createAction(const Protobuf::Message& config, ActionContext&,
                ProtobufMessage::ValidationVisitor& validation_visitor) override {
     const auto& action_config = MessageUtil::downcastAndValidate<

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -170,8 +170,9 @@ struct StringAction : public ActionBase<Protobuf::StringValue> {
 // Factory for StringAction.
 class StringActionFactory : public ActionFactory<absl::string_view> {
 public:
-  ActionConstSharedPtr createAction(const Protobuf::Message& config, absl::string_view&,
-                                    ProtobufMessage::ValidationVisitor&) override {
+  absl::StatusOr<ActionConstSharedPtr> createAction(const Protobuf::Message& config,
+                                                    absl::string_view&,
+                                                    ProtobufMessage::ValidationVisitor&) override {
     const auto& string = dynamic_cast<const Protobuf::StringValue&>(config);
     return std::make_shared<StringAction>(string.value());
   }

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -487,10 +487,11 @@ TEST_F(TransportSocketMatcherTest, TransportSocketNameActionFactoryAndTypeUrl) {
   cfg.set_name("tls");
   auto& visitor = ProtobufMessage::getNullValidationVisitor();
   auto action = factory.createAction(cfg, mock_factory_context_.serverFactoryContext(), visitor);
-  ASSERT_NE(action, nullptr);
+  ASSERT_TRUE(action.ok());
+  ASSERT_NE(action.value(), nullptr);
 
   // Verify the action holds the expected name and exposes the declared type URL.
-  const auto& typed = action->getTyped<TransportSocketNameAction>();
+  const auto& typed = action.value()->getTyped<TransportSocketNameAction>();
   EXPECT_EQ(typed.name(), "tls");
 }
 

--- a/test/extensions/filters/http/composite/BUILD
+++ b/test/extensions/filters/http/composite/BUILD
@@ -28,6 +28,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/server:instance_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -407,7 +407,8 @@ TEST(ConfigTest, CreateFilterFromServerContextDual) {
   };
   ExecuteFilterActionFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
+      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor())
+          .IgnoreError(),
       EnvoyException,
       "DualFactoryBase: creating filter factory from server factory context is not supported");
 }
@@ -489,7 +490,8 @@ TEST(ConfigTest, TestDownstreamFilterNoOverridingServerContext) {
   };
   ExecuteFilterActionFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
+      factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor())
+          .IgnoreError(),
       EnvoyException, "Creating filter factory from server factory context is not supported");
 }
 

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -16,6 +16,7 @@
 #include "test/mocks/server/instance.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/status_utility.h"
 
 #include "gtest/gtest.h"
 
@@ -26,6 +27,8 @@ namespace Composite {
 namespace {
 
 using Envoy::Protobuf::util::MessageDifferencer;
+using StatusHelpers::HasStatusMessage;
+using ::testing::HasSubstr;
 
 class CompositeFilterTest : public ::testing::Test {
 public:
@@ -344,9 +347,10 @@ TEST(ConfigTest, TestDynamicConfigInDownstream) {
       .server_factory_context_ = server_factory_context,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "Failed to get downstream factory context or server factory context.");
+      HasStatusMessage(
+          HasSubstr("Failed to get downstream factory context or server factory context.")));
 }
 
 TEST(ConfigTest, TestDynamicConfigInUpstream) {
@@ -373,9 +377,10 @@ TEST(ConfigTest, TestDynamicConfigInUpstream) {
       .server_factory_context_ = absl::nullopt,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "Failed to get upstream factory context or server factory context.");
+      HasStatusMessage(
+          HasSubstr("Failed to get upstream factory context or server factory context.")));
 }
 
 // For dual filter in downstream, if not overriding
@@ -429,9 +434,9 @@ TEST(ConfigTest, DualFilterNoUpstreamFactoryContext) {
       .server_factory_context_ = server_factory_context,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "Failed to get upstream filter factory creation function");
+      HasStatusMessage(HasSubstr("Failed to get upstream filter factory creation function")));
 }
 
 // For downstream filter, Envoy exception will be thrown if no factory_context
@@ -455,9 +460,9 @@ TEST(ConfigTest, DownstreamFilterNoFactoryContext) {
       .server_factory_context_ = absl::nullopt,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "Failed to get downstream filter factory creation function");
+      HasStatusMessage(HasSubstr("Failed to get downstream filter factory creation function")));
 }
 
 // For downstream filter, if not overriding
@@ -516,7 +521,8 @@ TEST(ConfigTest, TestSamplePercentNotSpecifiedl) {
   auto action =
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
-  EXPECT_FALSE(action->getTyped<ExecuteFilterAction>().actionSkip());
+  EXPECT_OK(action);
+  EXPECT_FALSE(action.value()->getTyped<ExecuteFilterAction>().actionSkip());
 }
 
 // Config test to check if sample_percent config is in place and feature enabled.
@@ -555,7 +561,8 @@ TEST(ConfigTest, TestSamplePercentInPlaceFeatureEnabled) {
               featureEnabled(_, testing::A<const envoy::type::v3::FractionalPercent&>()))
       .WillOnce(testing::Return(true));
 
-  EXPECT_FALSE(action->getTyped<ExecuteFilterAction>().actionSkip());
+  EXPECT_OK(action);
+  EXPECT_FALSE(action.value()->getTyped<ExecuteFilterAction>().actionSkip());
 }
 
 // Config test to check if sample_percent config is in place and feature not enabled.
@@ -594,7 +601,8 @@ TEST(ConfigTest, TestSamplePercentInPlaceFeatureNotEnabled) {
               featureEnabled(_, testing::A<const envoy::type::v3::FractionalPercent&>()))
       .WillOnce(testing::Return(false));
 
-  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().actionSkip());
+  EXPECT_OK(action);
+  EXPECT_TRUE(action.value()->getTyped<ExecuteFilterAction>().actionSkip());
 }
 
 TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingActionForDynamicConfig) {
@@ -625,7 +633,8 @@ TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingActionForDynamicConf
   auto action =
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
-  EXPECT_EQ("actionName", action->getTyped<ExecuteFilterAction>().actionName());
+  EXPECT_OK(action);
+  EXPECT_EQ("actionName", action.value()->getTyped<ExecuteFilterAction>().actionName());
 }
 
 TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingActionForTypedConfig) {
@@ -657,7 +666,8 @@ TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingActionForTypedConfig
   auto action =
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
-  EXPECT_EQ("actionName", action->getTyped<ExecuteFilterAction>().actionName());
+  EXPECT_OK(action);
+  EXPECT_EQ("actionName", action.value()->getTyped<ExecuteFilterAction>().actionName());
 }
 
 TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingAction) {
@@ -1532,9 +1542,9 @@ TEST(ConfigTest, TestEmptyFilterChainThrowsException) {
       .server_factory_context_ = server_factory_context,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "filter_chain must contain at least one filter.");
+      HasStatusMessage(HasSubstr("filter_chain must contain at least one filter.")));
 }
 
 // Test filter chain configuration for upstream filters.
@@ -1564,8 +1574,9 @@ TEST(ConfigTest, TestUpstreamFilterChainConfiguration) {
   auto action =
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
-  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().isFilterChain());
-  EXPECT_EQ("filter_chain", action->getTyped<ExecuteFilterAction>().actionName());
+  EXPECT_OK(action);
+  EXPECT_TRUE(action.value()->getTyped<ExecuteFilterAction>().isFilterChain());
+  EXPECT_EQ("filter_chain", action.value()->getTyped<ExecuteFilterAction>().actionName());
 }
 
 // Test filter chain configuration for upstream filters when upstream factory context is missing.
@@ -1591,9 +1602,10 @@ TEST(ConfigTest, TestUpstreamFilterChainNoUpstreamFactoryContext) {
       .server_factory_context_ = server_factory_context,
   };
   ExecuteFilterActionFactory factory;
-  EXPECT_THROW_WITH_MESSAGE(
+  EXPECT_THAT(
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor()),
-      EnvoyException, "Failed to create upstream filter factory for filter 'set-response-code'");
+      HasStatusMessage(
+          HasSubstr("Failed to create upstream filter factory for filter 'set-response-code'")));
 }
 
 // Test filter_chain_name creates a named filter chain lookup action.
@@ -1619,9 +1631,10 @@ TEST(ConfigTest, TestFilterChainNameCreatesLookupAction) {
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
   // Action should be a named filter chain lookup, not a filter chain.
-  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().isNamedFilterChainLookup());
-  EXPECT_FALSE(action->getTyped<ExecuteFilterAction>().isFilterChain());
-  EXPECT_EQ("my-chain", action->getTyped<ExecuteFilterAction>().filterChainName());
+  EXPECT_OK(action);
+  EXPECT_TRUE(action.value()->getTyped<ExecuteFilterAction>().isNamedFilterChainLookup());
+  EXPECT_FALSE(action.value()->getTyped<ExecuteFilterAction>().isFilterChain());
+  EXPECT_EQ("my-chain", action.value()->getTyped<ExecuteFilterAction>().filterChainName());
 }
 
 // Test filter_chain_name with sample_percent configuration.
@@ -1650,13 +1663,14 @@ TEST(ConfigTest, TestFilterChainNameWithSamplePercent) {
   auto action =
       factory.createAction(config, action_context, ProtobufMessage::getStrictValidationVisitor());
 
-  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().isNamedFilterChainLookup());
+  EXPECT_OK(action);
+  EXPECT_TRUE(action.value()->getTyped<ExecuteFilterAction>().isNamedFilterChainLookup());
 
   // Test sampling enabled.
   EXPECT_CALL(server_factory_context.runtime_loader_.snapshot_,
               featureEnabled(_, testing::A<const envoy::type::v3::FractionalPercent&>()))
       .WillOnce(testing::Return(false));
-  EXPECT_TRUE(action->getTyped<ExecuteFilterAction>().actionSkip());
+  EXPECT_TRUE(action.value()->getTyped<ExecuteFilterAction>().actionSkip());
 }
 
 // Test filter chain (inline) with multiple filters is still working.

--- a/test/extensions/filters/network/generic_proxy/route_test.cc
+++ b/test/extensions/filters/network/generic_proxy/route_test.cc
@@ -314,8 +314,9 @@ TEST(RouteMatchActionFactoryTest, SimpleRouteMatchActionFactoryTest) {
   auto action =
       factory.createAction(proto_config, context, server_context.messageValidationVisitor());
 
-  EXPECT_NE(action, nullptr);
-  EXPECT_EQ(action->getTyped<RouteEntryImpl>().clusterName(), "cluster_0");
+  EXPECT_TRUE(action.ok());
+  EXPECT_NE(action.value(), nullptr);
+  EXPECT_EQ(action.value()->getTyped<RouteEntryImpl>().clusterName(), "cluster_0");
 }
 
 class RouteMatcherImplTest : public testing::Test {

--- a/test/extensions/matching/actions/format_string/config_test.cc
+++ b/test/extensions/matching/actions/format_string/config_test.cc
@@ -25,8 +25,10 @@ TEST(ConfigTest, TestConfig) {
   ActionFactory factory;
   auto action =
       factory.createAction(config, factory_context, ProtobufMessage::getStrictValidationVisitor());
-  ASSERT_NE(nullptr, action);
-  const auto& typed_action = action->getTyped<Server::Configuration::FilterChainBaseAction>();
+  ASSERT_TRUE(action.ok());
+  ASSERT_NE(nullptr, action.value());
+  const auto& typed_action =
+      action.value()->getTyped<Server::Configuration::FilterChainBaseAction>();
 
   Server::Configuration::FilterChainsByName chains;
   auto chain = std::make_shared<testing::NiceMock<Network::MockFilterChain>>();

--- a/test/extensions/matching/actions/transform_stat/transform_stat_test.cc
+++ b/test/extensions/matching/actions/transform_stat/transform_stat_test.cc
@@ -25,7 +25,7 @@ public:
     auto& factory =
         Config::Utility::getAndCheckFactoryByName<Matcher::ActionFactory<ActionContext>>(
             "envoy.extensions.matching.actions.transform_stat.v3.TransformStat");
-    action_ = factory.createAction(config, action_context_, validation_visitor_);
+    action_ = factory.createAction(config, action_context_, validation_visitor_).value();
   }
 
   Stats::SymbolTable symbol_table_;

--- a/test/extensions/stats_sinks/open_telemetry/open_telemetry_impl_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/open_telemetry_impl_test.cc
@@ -1193,6 +1193,90 @@ TEST_F(OtlpMetricsFlusherTests, OnNoMatchDrop) {
   EXPECT_EQ(nullptr, findMetric(metrics, getTagExtractedName("drop_via_on_no_match_counter")));
 }
 
+TEST_F(OtlpMetricsFlusherTests, PrependPrefixAction) {
+  OtlpMetricsFlusherImpl flusher(otlpOptions(false, false, true, true, "", {},
+                                             R"pb(
+        matcher_list {
+          matchers {
+            predicate {
+              single_predicate {
+                input {
+                  name: "stat_full_name_match_input"
+                  typed_config {
+                    [type.googleapis.com/
+                     envoy.extensions.matching.common_inputs.stats.v3.StatFullNameMatchInput] {}
+                  }
+                }
+                value_match {
+                  safe_regex {
+                    regex: "test_counter"
+                  }
+                }
+              }
+            }
+            on_match {
+              action {
+                name: "otlp_metric_prepend_prefix_action"
+                typed_config {
+                  [type.googleapis.com/envoy.extensions.stat_sinks
+                       .open_telemetry.v3.SinkConfig.ConversionAction] {
+                         metric_prefix: "custom_prefix."
+                       }
+                }
+              }
+            }
+          }
+        }
+      )pb"));
+
+  addCounterToSnapshot("test_counter", 1, 1);
+
+  MetricsExportRequestSharedPtr metrics =
+      flusher.flush(snapshot_, delta_start_time_ns_, cumulative_start_time_ns_);
+  expectMetricsCount(metrics, 1);
+
+  EXPECT_NE(nullptr, findMetric(metrics, "custom_prefix.test_counter-tagged"));
+}
+
+TEST_F(OtlpMetricsFlusherTests, PrependPrefixActionValidation) {
+  EXPECT_THROW_WITH_REGEX(OtlpMetricsFlusherImpl(otlpOptions(false, false, true, true, "", {},
+                                                             R"pb(
+        matcher_list {
+          matchers {
+            predicate {
+              single_predicate {
+                input {
+                  name: "stat_full_name_match_input"
+                  typed_config {
+                    [type.googleapis.com/
+                     envoy.extensions.matching.common_inputs.stats.v3.StatFullNameMatchInput] {}
+                  }
+                }
+                value_match {
+                  safe_regex {
+                    regex: "test_counter"
+                  }
+                }
+              }
+            }
+            on_match {
+              action {
+                name: "otlp_metric_prepend_prefix_action"
+                typed_config {
+                  [type.googleapis.com/envoy.extensions.stat_sinks
+                       .open_telemetry.v3.SinkConfig.ConversionAction] {
+                         metric_name: "custom_name"
+                         metric_prefix: "custom_prefix."
+                       }
+                }
+              }
+            }
+          }
+        }
+      )pb")),
+                          EnvoyException, "metric_name.*metric_prefix");
+}
+
 TEST_F(OtlpMetricsFlusherTests, SetResourceAttributes) {
   OtlpMetricsFlusherImpl flusher(
       otlpOptions(true, false, true, true, "", {{"key_foo", "val_foo"}}));


### PR DESCRIPTION
Commit Message: This requires refactoring the action factory to return a `StatusOr` in case of an error.
Additional Description: None
Risk Level: Low
Testing: Done
Docs Changes: None
Release Notes: None
Gemini was used during development.