### PR TITLE
docs: fix typo "anda" -> "and a" in threading model overview

### DIFF
--- a/docs/root/intro/arch_overview/intro/threading_model.rst
+++ b/docs/root/intro/arch_overview/intro/threading_model.rst
@@ -12,7 +12,7 @@ High-Level Overview
 
 .. note::
   Matt Klein wrote a `detailed blog post <https://blog.envoyproxy.io/envoy-threading-model-a8d44b922310>`_
-  on the Envoy threading model. Though it is a bit old, it is still accurate anda great companion to this
+  on the Envoy threading model. Though it is a bit old, it is still accurate and a great companion to this
   document.
 
 At a high level, the threading model consists of three main components:


### PR DESCRIPTION
Commit Message: docs: fix typo in threading_model.rst ("anda" → "and a")
Additional Description: Fix a missing space typo in the threading model architecture overview.
Risk Level: Low
Testing: N/A (documentation only)
Docs Changes: Fix typo "anda" → "and a" in docs/root/intro/arch_overview/intro/threading_model.rst
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional API Considerations:] N/A