### PR TITLE
Simplify StreamRateLimiter and make its stats more flexible

### DIFF
--- a/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
+++ b/source/extensions/filters/http/bandwidth_limit/bandwidth_limit.cc
@@ -77,9 +77,9 @@ FilterConfig::FilterConfig(const BandwidthLimit& config, Stats::Scope& scope,
   // The token bucket is configured with a max token count of the number of
   // bytes per second, and refills at the same rate, so that we have a per
   // second limit which refills gradually in 1/fill_interval increments.
-  token_bucket_ = std::make_shared<SharedTokenBucketImpl>(
-      StreamRateLimiter::kiloBytesToBytes(limit_kbps_), time_source,
-      StreamRateLimiter::kiloBytesToBytes(limit_kbps_));
+  uint64_t max_tokens = StreamRateLimiter::kiloBytesToBytes(limit_kbps_);
+  token_bucket_ = std::make_shared<SharedTokenBucketImpl>(max_tokens, time_source, max_tokens);
+  token_bucket_->maybeReset(max_tokens * fill_interval_.count() / 1000);
 }
 
 BandwidthLimitStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope& scope) {
@@ -97,7 +97,7 @@ Http::FilterHeadersStatus BandwidthLimiter::decodeHeaders(Http::RequestHeaderMap
   if (config.enabled() && (config.enableMode() & BandwidthLimit::REQUEST)) {
     config.stats().request_enabled_.inc();
     request_limiter_ = std::make_unique<StreamRateLimiter>(
-        config.limit(), decoder_callbacks_->bufferLimit(),
+        decoder_callbacks_->bufferLimit(),
         [this] { decoder_callbacks_->onDecoderFilterAboveWriteBufferHighWatermark(); },
         [this] { decoder_callbacks_->onDecoderFilterBelowWriteBufferLowWatermark(); },
         [this](Buffer::Instance& data, bool end_stream) {
@@ -110,16 +110,16 @@ Http::FilterHeadersStatus BandwidthLimiter::decodeHeaders(Http::RequestHeaderMap
           updateStatsOnDecodeFinish();
           decoder_callbacks_->continueDecoding();
         },
-        [&config, this](uint64_t len, bool limit_enforced, std::chrono::milliseconds delay) {
+        [&config, this](uint64_t len, uint64_t bytes_buffered, std::chrono::milliseconds delay) {
           config.stats().request_allowed_size_.set(len);
           config.stats().request_allowed_total_size_.add(len);
-          if (limit_enforced) {
+          if (bytes_buffered) {
             config.stats().request_enforced_.inc();
             request_delay_ += delay;
           }
         },
-        const_cast<FilterConfig*>(&config)->timeSource(), decoder_callbacks_->dispatcher(),
-        decoder_callbacks_->scope(), config.tokenBucket(), config.fillInterval());
+        decoder_callbacks_->dispatcher(), decoder_callbacks_->scope(), config.tokenBucket(),
+        config.fillInterval());
   }
 
   return Http::FilterHeadersStatus::Continue;
@@ -164,7 +164,7 @@ Http::FilterHeadersStatus BandwidthLimiter::encodeHeaders(Http::ResponseHeaderMa
     config.stats().response_enabled_.inc();
 
     response_limiter_ = std::make_unique<StreamRateLimiter>(
-        config.limit(), encoder_callbacks_->bufferLimit(),
+        encoder_callbacks_->bufferLimit(),
         [this] { encoder_callbacks_->onEncoderFilterAboveWriteBufferHighWatermark(); },
         [this] { encoder_callbacks_->onEncoderFilterBelowWriteBufferLowWatermark(); },
         [this](Buffer::Instance& data, bool end_stream) {
@@ -177,16 +177,16 @@ Http::FilterHeadersStatus BandwidthLimiter::encodeHeaders(Http::ResponseHeaderMa
           updateStatsOnEncodeFinish();
           encoder_callbacks_->continueEncoding();
         },
-        [&config, this](uint64_t len, bool limit_enforced, std::chrono::milliseconds delay) {
+        [&config, this](uint64_t len, uint64_t buffered_bytes, std::chrono::milliseconds delay) {
           config.stats().response_allowed_size_.set(len);
           config.stats().response_allowed_total_size_.add(len);
-          if (limit_enforced) {
+          if (buffered_bytes) {
             config.stats().response_enforced_.inc();
             response_delay_ += delay;
           }
         },
-        const_cast<FilterConfig*>(&config)->timeSource(), encoder_callbacks_->dispatcher(),
-        encoder_callbacks_->scope(), config.tokenBucket(), config.fillInterval());
+        encoder_callbacks_->dispatcher(), encoder_callbacks_->scope(), config.tokenBucket(),
+        config.fillInterval());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/http/common/stream_rate_limiter.cc
+++ b/source/extensions/filters/http/common/stream_rate_limiter.cc
@@ -13,12 +13,20 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Common {
 
+std::shared_ptr<TokenBucket> StreamRateLimiter::simpleTokenBucket(uint64_t limit_kbps,
+                                                                  TimeSource& time_source) {
+  uint64_t max_tokens = kiloBytesToBytes(limit_kbps);
+  auto token_bucket = std::make_shared<TokenBucketImpl>(max_tokens, time_source, max_tokens);
+  token_bucket->maybeReset(max_tokens * StreamRateLimiter::DefaultFillInterval.count() / 1000);
+  return token_bucket;
+}
+
 StreamRateLimiter::StreamRateLimiter(
-    uint64_t max_kbps, uint64_t max_buffered_data, std::function<void()> pause_data_cb,
+    uint64_t max_buffered_data, std::function<void()> pause_data_cb,
     std::function<void()> resume_data_cb,
     std::function<void(Buffer::Instance&, bool)> write_data_cb, std::function<void()> continue_cb,
-    std::function<void(uint64_t, bool, std::chrono::milliseconds)> write_stats_cb,
-    TimeSource& time_source, Event::Dispatcher& dispatcher, const ScopeTrackedObject& scope,
+    std::function<void(uint64_t, uint64_t, std::chrono::milliseconds)> write_stats_cb,
+    Event::Dispatcher& dispatcher, const ScopeTrackedObject& scope,
     std::shared_ptr<TokenBucket> token_bucket, std::chrono::milliseconds fill_interval)
     : fill_interval_(std::move(fill_interval)), write_data_cb_(write_data_cb),
       continue_cb_(continue_cb), write_stats_cb_(std::move(write_stats_cb)), scope_(scope),
@@ -29,22 +37,8 @@ StreamRateLimiter::StreamRateLimiter(
   ASSERT(max_buffered_data > 0);
   ASSERT(fill_interval_.count() > 0);
   ASSERT(fill_interval_.count() <= 1000);
-  auto max_tokens = kiloBytesToBytes(max_kbps);
-  if (!token_bucket_) {
-    // Initialize a  new token bucket if caller didn't provide one.
-    // The token bucket is configured with a max token count of the number of bytes per second,
-    // and refills at the same rate, so that we have a per second limit which refills gradually
-    // in one fill_interval_ at a time.
-    token_bucket_ = std::make_shared<TokenBucketImpl>(max_tokens, time_source, max_tokens);
-  }
-  // Reset the bucket to contain only one fill_interval worth of tokens.
-  // If the token bucket is shared, only first reset call will work.
-  auto initial_tokens = max_tokens * fill_interval_.count() / 1000;
-  token_bucket_->maybeReset(initial_tokens);
-  ENVOY_LOG(debug,
-            "StreamRateLimiter <Ctor>: fill_interval={}ms "
-            "initial_tokens={} max_tokens={}",
-            fill_interval_.count(), initial_tokens, max_tokens);
+  ASSERT(token_bucket_);
+  ENVOY_LOG(debug, "StreamRateLimiter <Ctor>: fill_interval={}ms", fill_interval_.count());
   buffer_.setWatermarks(max_buffered_data);
 }
 
@@ -63,7 +57,7 @@ void StreamRateLimiter::onTokenTimer() {
   // Move the data to write into the output buffer with as little copying as possible.
   // NOTE: This might be moving zero bytes, but that should work fine.
   data_to_write.move(buffer_, bytes_to_write);
-  write_stats_cb_(bytes_to_write, buffer_.length() > 0, fill_interval_);
+  write_stats_cb_(bytes_to_write, buffer_.length(), fill_interval_);
 
   // If the buffer still contains data in it, we couldn't get enough tokens, so schedule the next
   // token available time.

--- a/source/extensions/filters/http/common/stream_rate_limiter.h
+++ b/source/extensions/filters/http/common/stream_rate_limiter.h
@@ -34,27 +34,30 @@ public:
 
   static constexpr uint64_t kiloBytesToBytes(const uint64_t val) { return val * 1024; }
 
+  static std::shared_ptr<TokenBucket> simpleTokenBucket(uint64_t limit_kbps,
+                                                        TimeSource& time_source);
+
   /**
-   * @param max_kbps maximum rate in KiB/s.
    * @param max_buffered_data maximum data to buffer before invoking the pause callback.
    * @param pause_data_cb callback invoked when the limiter has buffered too much data.
    * @param resume_data_cb callback invoked when the limiter has gone under the buffer limit.
    * @param write_data_cb callback invoked to write data to the stream.
    * @param continue_cb callback invoked to continue the stream. This is only used to continue
    *                    trailers that have been paused during body flush.
-   * @param time_source the time source to run the token bucket with.
    * @param dispatcher the stream's dispatcher to use for creating timers.
    * @param scope the stream's scope
+   * @param token_bucket the token bucket to use
+   * @param fill_interval time to wait between attempts to draw tokens from the bucket
    */
-  StreamRateLimiter(uint64_t max_kbps, uint64_t max_buffered_data,
-                    std::function<void()> pause_data_cb, std::function<void()> resume_data_cb,
-                    std::function<void(Buffer::Instance&, bool)> write_data_cb,
-                    std::function<void()> continue_cb,
-                    std::function<void(uint64_t, bool, std::chrono::milliseconds)> write_stats_cb,
-                    TimeSource& time_source, Event::Dispatcher& dispatcher,
-                    const ScopeTrackedObject& scope,
-                    std::shared_ptr<TokenBucket> token_bucket = nullptr,
-                    std::chrono::milliseconds fill_interval = DefaultFillInterval);
+  StreamRateLimiter(
+      uint64_t max_buffered_data, std::function<void()> pause_data_cb,
+      std::function<void()> resume_data_cb,
+      std::function<void(Buffer::Instance&, bool)> write_data_cb, std::function<void()> continue_cb,
+      std::function<void(uint64_t bytes_sent, uint64_t bytes_buffered, std::chrono::milliseconds)>
+          write_stats_cb,
+      Event::Dispatcher& dispatcher, const ScopeTrackedObject& scope,
+      std::shared_ptr<TokenBucket> token_bucket,
+      std::chrono::milliseconds fill_interval = DefaultFillInterval);
 
   /**
    * Called by the stream to write data. All data writes happen asynchronously, the stream should

--- a/source/extensions/filters/http/fault/fault_filter.cc
+++ b/source/extensions/filters/http/fault/fault_filter.cc
@@ -210,18 +210,19 @@ void FaultFilter::maybeSetupResponseRateLimit(const Http::RequestHeaderMap& requ
 
   config_->stats().response_rl_injected_.inc();
 
-  response_limiter_ = std::make_unique<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter>(
-      rate_kbps.value(), encoder_callbacks_->bufferLimit(),
+  response_limiter_ = std::make_unique<Common::StreamRateLimiter>(
+      encoder_callbacks_->bufferLimit(),
       [this] { encoder_callbacks_->onEncoderFilterAboveWriteBufferHighWatermark(); },
       [this] { encoder_callbacks_->onEncoderFilterBelowWriteBufferLowWatermark(); },
       [this](Buffer::Instance& data, bool end_stream) {
         encoder_callbacks_->injectEncodedDataToFilterChain(data, end_stream);
       },
       [this] { encoder_callbacks_->continueEncoding(); },
-      [](uint64_t, bool, std::chrono::milliseconds) {
+      [](uint64_t, uint64_t, std::chrono::milliseconds) {
         // write stats callback.
       },
-      config_->timeSource(), decoder_callbacks_->dispatcher(), decoder_callbacks_->scope());
+      decoder_callbacks_->dispatcher(), decoder_callbacks_->scope(),
+      Common::StreamRateLimiter::simpleTokenBucket(rate_kbps.value(), config_->timeSource()));
 }
 
 bool FaultFilter::faultOverflow() {

--- a/test/extensions/filters/http/common/stream_rate_limiter_test.cc
+++ b/test/extensions/filters/http/common/stream_rate_limiter_test.cc
@@ -27,42 +27,23 @@ namespace Common {
 
 class StreamRateLimiterTest : public testing::Test {
 public:
-  void setUpTest(uint16_t limit_kbps, uint16_t fill_interval,
-                 std::shared_ptr<TokenBucket> token_bucket = nullptr) {
-    EXPECT_CALL(decoder_callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
-    EXPECT_CALL(decoder_callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
-
-    limiter_ = std::make_unique<StreamRateLimiter>(
-        limit_kbps, decoder_callbacks_.bufferLimit(),
-        [this] { decoder_callbacks_.onDecoderFilterAboveWriteBufferHighWatermark(); },
-        [this] { decoder_callbacks_.onDecoderFilterBelowWriteBufferLowWatermark(); },
-        [this](Buffer::Instance& data, bool end_stream) {
-          decoder_callbacks_.injectDecodedDataToFilterChain(data, end_stream);
-        },
-        [this] { decoder_callbacks_.continueDecoding(); },
-        [](uint64_t /*len*/, bool, std::chrono::milliseconds) {
-          // config->stats().decode_allowed_size_.set(len);
-        },
-        time_system_, decoder_callbacks_.dispatcher_, decoder_callbacks_.scope(), token_bucket,
-        std::chrono::milliseconds(fill_interval));
-  }
-
   void setUpTest(uint16_t limit_kbps) {
     EXPECT_CALL(decoder_callbacks_.dispatcher_, pushTrackedObject(_)).Times(AnyNumber());
     EXPECT_CALL(decoder_callbacks_.dispatcher_, popTrackedObject(_)).Times(AnyNumber());
 
     limiter_ = std::make_unique<StreamRateLimiter>(
-        limit_kbps, decoder_callbacks_.bufferLimit(),
+        decoder_callbacks_.bufferLimit(),
         [this] { decoder_callbacks_.onDecoderFilterAboveWriteBufferHighWatermark(); },
         [this] { decoder_callbacks_.onDecoderFilterBelowWriteBufferLowWatermark(); },
         [this](Buffer::Instance& data, bool end_stream) {
           decoder_callbacks_.injectDecodedDataToFilterChain(data, end_stream);
         },
         [this] { decoder_callbacks_.continueDecoding(); },
-        [](uint64_t /*len*/, bool, std::chrono::milliseconds) {
+        [](uint64_t /*len*/, uint64_t /*buffered*/, std::chrono::milliseconds) {
           // config->stats().decode_allowed_size_.set(len);
         },
-        time_system_, decoder_callbacks_.dispatcher_, decoder_callbacks_.scope());
+        decoder_callbacks_.dispatcher_, decoder_callbacks_.scope(),
+        StreamRateLimiter::simpleTokenBucket(limit_kbps, time_system_));
   }
 
   uint64_t fillInterval() { return limiter_->fill_interval_.count(); }


### PR DESCRIPTION
Commit Message: Simplify StreamRateLimiter and make its stats more flexible
Additional Description: The constructor of StreamRateLimiter only conditionally uses two of its mandatory input arguments (if a TokenBucket is provided those args are ignored). Instead of doing that, it makes more sense to have the TokenBucket be mandatory, and provide a helper function to convert those other two args into a TokenBucket argument - that way clients that want to use the TokenBucket method aren't forced to provide those unused args.

And the stats callback of StreamRateLimiter exposes "there is stuff in the buffer" where it's just as easy to provide "there is this much stuff in the buffer" - doing the latter allows the client to construct more valuable stats.

A test setup function that was never called was also removed.
Risk Level: Very low - existing behavior is effectively unchanged. (External extensions using StreamRateLimiter will need to update to the new API.)
Testing: Existing test coverage covers this just as well as it did the old version.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
