### PR TITLE
[quic] Set end_stream properly in decodeHeaders()

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -174,7 +174,9 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
   }
 
   ENVOY_STREAM_LOG(debug, "Received headers: {}.", *this, header_list.DebugString());
-  if (fin) {
+  const bool headers_only = fin_received() && highest_received_byte_offset() == NumBytesConsumed();
+  const bool end_stream = fin || headers_only;
+  if (end_stream) {
     end_stream_decoded_ = true;
   }
   saw_regular_headers_ = false;
@@ -215,7 +217,7 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
     // In case the status is invalid or missing, the response_decoder_.decodeHeaders() will fail the
     // request
     if (Http::ResponseDecoder* decoder = getResponseDecoder()) {
-      decoder->decodeHeaders(std::move(headers), fin);
+      decoder->decodeHeaders(std::move(headers), end_stream);
     } else {
       onResponseDecoderDead();
     }
@@ -243,7 +245,7 @@ void EnvoyQuicClientStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
   } else if (!is_special_1xx) {
     if (Http::ResponseDecoder* decoder = getResponseDecoder()) {
       decoder->decodeHeaders(std::move(headers),
-                             /*end_stream=*/fin);
+                             /*end_stream=*/end_stream);
     } else {
       onResponseDecoderDead();
     }

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -227,7 +227,7 @@ TEST_F(EnvoyQuicClientStreamTest, GetRequestAndHeaderOnlyResponse) {
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/28053.
 // Verify that when a header-only response arrives (FIN on the QUIC stream frame),
-// decodeHeaders is called with end_stream=true even if QUICHE's OnInitialHeadersComplete
+// decodeHeaders is called with end_stream=true even if QUICHE OnInitialHeadersComplete
 // passes fin=false. The fix uses fin_received() to properly detect end-of-stream.
 TEST_F(EnvoyQuicClientStreamTest, HeaderOnlyResponseSetsEndStreamCorrectly) {
   const auto result = quic_stream_->encodeHeaders(request_headers_, /*end_stream=*/false);

--- a/test/common/quic/envoy_quic_client_stream_test.cc
+++ b/test/common/quic/envoy_quic_client_stream_test.cc
@@ -212,13 +212,39 @@ TEST_F(EnvoyQuicClientStreamTest, GetRequestAndHeaderOnlyResponse) {
 
   quic_stream_->setFlushTimeout(std::chrono::milliseconds(100)); // No-op
 
-  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/false))
+  // With the fix for https://github.com/envoyproxy/envoy/issues/28053, FIN on the QUIC stream
+  // frame is properly detected via fin_received(), so decodeHeaders receives end_stream=true
+  // directly, without an extra empty-body decodeData call.
+  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/true))
       .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
         EXPECT_EQ("200", headers->getStatusValue());
       }));
-  EXPECT_CALL(stream_decoder_, decodeData(BufferStringEqual(""), /*end_stream=*/true));
   std::string payload = spdyHeaderToHttp3StreamPayload(spdy_response_headers_);
   quic::QuicStreamFrame frame(stream_id_, true, 0, payload);
+  quic_stream_->OnStreamFrame(frame);
+  EXPECT_TRUE(quic_stream_->FinishedReadingHeaders());
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/28053.
+// Verify that when a header-only response arrives (FIN on the QUIC stream frame),
+// decodeHeaders is called with end_stream=true even if QUICHE's OnInitialHeadersComplete
+// passes fin=false. The fix uses fin_received() to properly detect end-of-stream.
+TEST_F(EnvoyQuicClientStreamTest, HeaderOnlyResponseSetsEndStreamCorrectly) {
+  const auto result = quic_stream_->encodeHeaders(request_headers_, /*end_stream=*/false);
+  EXPECT_TRUE(result.ok());
+  quic_stream_->encodeData(request_body_, true);
+
+  // Receive a header-only response (FIN set on stream frame).
+  // decodeHeaders should be called with end_stream=true.
+  EXPECT_CALL(stream_decoder_, decodeHeaders_(_, /*end_stream=*/true))
+      .WillOnce(Invoke([](const Http::ResponseHeaderMapPtr& headers, bool) {
+        EXPECT_EQ("200", headers->getStatusValue());
+      }));
+  // No decodeData call expected - end_stream is signaled via decodeHeaders.
+  EXPECT_CALL(stream_decoder_, decodeData(_, _)).Times(0);
+
+  std::string payload = spdyHeaderToHttp3StreamPayload(spdy_response_headers_);
+  quic::QuicStreamFrame frame(stream_id_, /*fin=*/true, 0, payload);
   quic_stream_->OnStreamFrame(frame);
   EXPECT_TRUE(quic_stream_->FinishedReadingHeaders());
 }


### PR DESCRIPTION
Fix end_stream propagation in decodeHeaders in quic client stream. Instead of using `fin` argument in `OnInitialHeadersComplete`  in quic client stream, the code computes end_stream based on `fin_received()+byte offset check` and passes that value into decodeHeaders().

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #28053
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
