### PR TITLE
Avoid the use of modulo in building maglev table

### DIFF
--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -159,6 +159,8 @@ void OriginalMaglevTable::constructImplementationInternals(
   for (uint32_t iteration = 1; table_index < table_size_; ++iteration) {
     for (uint64_t i = 0; i < table_build_entries.size() && table_index < table_size_; i++) {
       TableBuildEntry& entry = table_build_entries[i];
+      ASSERT(entry.skip_ < table_size_, "skip must be less than table size");
+
       // To understand how target_weight_ and weight_ are used below, consider a host with weight
       // equal to max_normalized_weight. This would be picked on every single iteration. If it had
       // weight equal to max_normalized_weight / 3, then it would only be picked every 3 iterations,
@@ -167,14 +169,21 @@ void OriginalMaglevTable::constructImplementationInternals(
         continue;
       }
       entry.target_weight_ += max_normalized_weight;
-      uint64_t c = permutation(entry);
+      uint64_t c = entry.current_permutation_;
       while (table_[c] != nullptr) {
         entry.next_++;
-        c = permutation(entry);
+        c += entry.skip_;
+        if (c >= table_size_) {
+          c -= table_size_;
+        }
       }
 
       table_[c] = entry.host_;
       entry.next_++;
+      entry.current_permutation_ = c + entry.skip_;
+      if (entry.current_permutation_ >= table_size_) {
+        entry.current_permutation_ -= table_size_;
+      }
       entry.count_++;
       table_index++;
     }
@@ -209,6 +218,8 @@ void CompactMaglevTable::constructImplementationInternals(
   for (uint32_t iteration = 1; table_index < table_size_; ++iteration) {
     for (uint32_t i = 0; i < table_build_entries.size() && table_index < table_size_; i++) {
       TableBuildEntry& entry = table_build_entries[i];
+      ASSERT(entry.skip_ < table_size_, "skip must be less than table size");
+
       // To understand how target_weight_ and weight_ are used below, consider a host with weight
       // equal to max_normalized_weight. This would be picked on every single iteration. If it had
       // weight equal to max_normalized_weight / 3, then it would only be picked every 3 iterations,
@@ -219,10 +230,13 @@ void CompactMaglevTable::constructImplementationInternals(
       entry.target_weight_ += max_normalized_weight;
       // As we're using the compact implementation, our table size is limited to
       // 32-bit, hence static_cast here should be safe.
-      uint32_t c = static_cast<uint32_t>(permutation(entry));
+      uint32_t c = static_cast<uint32_t>(entry.current_permutation_);
       while (occupied[c]) {
         entry.next_++;
-        c = static_cast<uint32_t>(permutation(entry));
+        c += entry.skip_;
+        if (c >= table_size_) {
+          c -= table_size_;
+        }
       }
 
       // Record the index of the given host.
@@ -230,6 +244,10 @@ void CompactMaglevTable::constructImplementationInternals(
       occupied[c] = true;
 
       entry.next_++;
+      entry.current_permutation_ = c + entry.skip_;
+      if (entry.current_permutation_ >= table_size_) {
+        entry.current_permutation_ -= table_size_;
+      }
       entry.count_++;
       table_index++;
     }
@@ -290,10 +308,6 @@ HostSelectionResponse CompactMaglevTable::chooseHost(uint64_t hash, uint32_t att
   const uint32_t index = table_.get(hash % table_size_);
   ASSERT(index < host_table_.size(), "Compact MaglevTable index into host table out of range");
   return {host_table_[index]};
-}
-
-uint64_t MaglevTable::permutation(const TableBuildEntry& entry) {
-  return (entry.offset_ + (entry.skip_ * entry.next_)) % table_size_;
 }
 
 MaglevLoadBalancer::MaglevLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats,

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.h
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.h
@@ -75,7 +75,8 @@ public:
 protected:
   struct TableBuildEntry {
     TableBuildEntry(const HostConstSharedPtr& host, uint64_t offset, uint64_t skip, double weight)
-        : host_(host), offset_(offset), skip_(skip), weight_(weight) {}
+        : host_(host), offset_(offset), skip_(skip), weight_(weight), current_permutation_(offset) {
+    }
 
     HostConstSharedPtr host_;
     const uint64_t offset_;
@@ -84,9 +85,8 @@ protected:
     double target_weight_{};
     uint64_t next_{};
     uint64_t count_{};
+    uint64_t current_permutation_{};
   };
-
-  uint64_t permutation(const TableBuildEntry& entry);
 
   /**
    * Template method for constructing the Maglev table.


### PR DESCRIPTION
Local benchmark run shows possible performance improvement of ~15% by avoiding the use of modulo.

A table build entry iterates through its permutations via `MaglevTable::permutation` which is implemented as follows:

`(entry.offset_ + (entry.skip_ * entry.next_)) % table_size_`

`offset_` and `skip_` are static, and `next_` is only incremented by 1 within `constructImplementationInternals`. Thus, we can avoid the expensive modulo `% table_size_` by keeping track of the `current_permutation` value and incrementing by `skip_` each iteration until `current_permutation` exceeds the `table_size_`, at which point we set `current_permutation = current_permutation - table_size_`, which is equivalent to the modulo operation, maintaining mathematical equivalence to the existing implementation while improving performance.

`bazel run -c opt //test/extensions/load_balancing_policies/maglev:maglev_lb_benchmark -- --benchmark_filter=benchmarkMaglevLoadBalancerBuildTable`

## Baseline
Benchmark | Time | CPU | Iterations | Memory | Memory per Host
-- | -- | -- | -- | -- | --
BuildTable/100 | 2.68 ms | 2.67 ms | 266 | 67.8k | 678
BuildTable/200 | 2.42 ms | 2.42 ms | 284 | 77.656k | 388
BuildTable/500 | 2.60 ms | 2.60 ms | 269 | 90.584k | 181

## Avoid use of modulo

Benchmark | Time | CPU | Iterations | Memory | Memory per Host
-- | -- | -- | -- | -- | --
BuildTable/100 | 2.22 ms | 2.22 ms | 322 | 67.8k | 678
BuildTable/200 | 2.05 ms | 2.05 ms | 342 | 77.656k | 388
BuildTable/500 | 2.22 ms | 2.21 ms | 314 | 90.584k | 181

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
Fixes #44167
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
