### PR TITLE
docs: styling nits in the hickory_dns docs for consistency

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/hickory/v3/hickory_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/hickory/v3/hickory_dns_resolver.proto
@@ -16,21 +16,21 @@ option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/network/dns_resolver/hickory/v3;hickoryv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
-// [#protodoc-title: Hickory DNS resolver]
+// [#protodoc-title: Hickory DNS Resolver]
 // [#extension: envoy.network.dns_resolver.hickory]
 
 // Configuration for DNS-over-TLS (DoT) servers.
 message DnsOverTlsConfig {
-  // DNS-over-TLS server addresses. The port should typically be 853.
+  // The list of DNS-over-TLS server addresses. The port should typically be 853.
   repeated config.core.v3.Address servers = 1;
 
-  // The SNI hostname to use for TLS verification. Required when servers are specified.
+  // The SNI hostname to use for TLS verification. Required when ``servers`` are specified.
   string tls_server_name = 2 [(validate.rules).string = {min_len: 1}];
 }
 
 // Configuration for DNS-over-HTTPS (DoH) servers.
 message DnsOverHttpsConfig {
-  // DNS-over-HTTPS endpoint URLs (e.g., ``https://dns.google/dns-query``).
+  // The list of DNS-over-HTTPS endpoint URLs (e.g., ``https://dns.google/dns-query``).
   repeated string server_urls = 1 [(validate.rules).repeated = {items {string {min_len: 1}}}];
 }
 
@@ -43,7 +43,7 @@ message DnsOverHttpsConfig {
 // [#next-free-field: 10]
 message HickoryDnsResolverConfig {
   // A list of DNS resolver addresses for standard UDP/TCP resolution.
-  // If not specified and ``use_system_config`` is not explicitly set to false, the system
+  // If not specified and ``use_system_config`` is not explicitly set to ``false``, the system
   // configuration (``/etc/resolv.conf`` on Unix) will be used.
   repeated config.core.v3.Address resolvers = 1;
 
@@ -55,40 +55,40 @@ message HickoryDnsResolverConfig {
   // HTTPS to the configured endpoints.
   DnsOverHttpsConfig dns_over_https = 3;
 
-  // Enable ``DNSSEC`` validation for DNS responses. When enabled, the resolver will validate
+  // Enables ``DNSSEC`` validation for DNS responses. When enabled, the resolver will validate
   // ``DNSSEC`` signatures and reject responses that fail validation.
   //
-  // Defaults to false.
+  // Defaults to ``false``.
   bool enable_dnssec = 4;
 
   // Maximum number of entries in the DNS response cache. The cache uses an LRU eviction
-  // policy and supports negative caching (caching of NXDOMAIN/NODATA responses).
+  // policy and supports negative caching (caching of ``NXDOMAIN``/``NODATA`` responses).
   //
-  // Defaults to 1024.
+  // Defaults to ``1024``.
   google.protobuf.UInt32Value cache_size = 5;
 
   // Number of threads in the ``Tokio`` runtime used for asynchronous DNS resolution.
   // Each resolver instance runs its own ``Tokio`` runtime.
   //
-  // Defaults to 2. Maximum is 16.
+  // Defaults to ``2``. Maximum is ``16``.
   google.protobuf.UInt32Value num_resolver_threads = 6 [(validate.rules).uint32 = {lte: 16 gte: 1}];
 
-  // If true, read the system DNS configuration (``/etc/resolv.conf`` on Unix) for name server
+  // If ``true``, read the system DNS configuration (``/etc/resolv.conf`` on Unix) for name server
   // addresses and search domains. When ``resolvers`` are also specified, they take precedence
   // over the system configuration.
   //
-  // If not specified, defaults to true when no ``resolvers``, ``dns_over_tls``, or
+  // If not specified, defaults to ``true`` when no ``resolvers``, ``dns_over_tls``, or
   // ``dns_over_https`` are configured.
   google.protobuf.BoolValue use_system_config = 7;
 
   // Timeout for each individual DNS query attempt.
   //
-  // Defaults to 5 seconds.
+  // Defaults to ``5`` seconds.
   google.protobuf.Duration query_timeout = 8 [(validate.rules).duration = {gte {nanos: 1000000}}];
 
   // Maximum number of query attempts before the resolver gives up. Each attempt may use
   // a different name server.
   //
-  // Defaults to 3.
+  // Defaults to ``3``.
   google.protobuf.UInt32Value query_tries = 9 [(validate.rules).uint32 = {gte: 1}];
 }

--- a/docs/root/intro/arch_overview/upstream/dns_resolution.rst
+++ b/docs/root/intro/arch_overview/upstream/dns_resolution.rst
@@ -8,38 +8,43 @@ Many Envoy components resolve DNS: different cluster types (
 :ref:`logical dns <arch_overview_service_discovery_types_logical_dns>`);
 the :ref:`dynamic forward proxy <arch_overview_http_dynamic_forward_proxy>` system (which is
 composed of a cluster and a filter);
-the udp :ref:`dns filter <arch_overview_dns_filter>`, etc.
-Envoy uses `c-ares <https://github.com/c-ares/c-ares>`_ as a third party DNS resolution library.
-On Apple OSes Envoy additionally offers resolution using Apple specific APIs via the
+the UDP :ref:`dns filter <arch_overview_dns_filter>`, etc.
+
+Envoy provides DNS resolution through pluggable extensions. By default, Envoy uses
+`c-ares <https://github.com/c-ares/c-ares>`_ as its DNS resolution library. On Apple OSes, Envoy
+additionally offers resolution using Apple-specific APIs via the
 ``envoy.restart_features.use_apple_api_for_dns_lookups`` runtime feature.
 
-Envoy provides DNS resolution through extensions, and contains 4 built-in extensions:
+Envoy contains 4 built-in DNS resolver extensions:
 
-1) c-ares: :ref:`CaresDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>`
+* c-ares: :ref:`CaresDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig>`
+* Apple (iOS/macOS only): :ref:`AppleDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>`
+* getaddrinfo: :ref:`GetAddrInfoDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig>`
+* Hickory DNS: :ref:`HickoryDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.hickory.v3.HickoryDnsResolverConfig>`
 
-2) Apple (iOS/macOS only): :ref:`AppleDnsResolverConfig<envoy_v3_api_msg_extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig>`
+  A pure Rust DNS resolver built on the `Hickory DNS <https://github.com/hickory-dns/hickory-dns>`_
+  library. It supports standard DNS (UDP/TCP), DNS-over-TLS (DoT), DNS-over-HTTPS (DoH), and
+  DNSSEC validation. The resolver runs asynchronously on its own Tokio runtime threads, separate
+  from Envoy's event loop, which means DNS resolution does not block the dispatcher thread.
+  Hickory DNS is integrated via the dynamic modules framework.
 
-3) getaddrinfo: :ref:`GetAddrInfoDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig>`
+For an example of a built-in DNS typed configuration, see the
+:ref:`HTTP filter configuration documentation <config_http_filters_dynamic_forward_proxy>`.
 
-4) Hickory DNS: :ref:`HickoryDnsResolverConfig <envoy_v3_api_msg_extensions.network.dns_resolver.hickory.v3.HickoryDnsResolverConfig>`
-   A pure Rust DNS resolver supporting standard DNS (UDP/TCP), DNS-over-TLS (DoT), DNS-over-HTTPS (DoH),
-   and DNSSEC validation. It runs on its own Tokio runtime threads via the dynamic modules framework.
-
-For an example of a built-in DNS typed configuration see the :ref:`HTTP filter configuration documentation <config_http_filters_dynamic_forward_proxy>`.
-
-The c-ares based DNS Resolver emits the following stats rooted in the ``dns.cares`` stats tree:
+The c-ares-based DNS resolver emits the following statistics rooted in the ``dns.cares`` stats tree:
 
   .. csv-table::
     :header: Name, Type, Description
     :widths: 1, 1, 2
 
-    resolve_total, Count, Number of DNS queries
+    resolve_total, Counter, Number of DNS queries
     pending_resolutions, Gauge, Number of pending DNS queries
-    not_found, Counter, Number of DNS queries that returned NXDOMAIN or NODATA response
-    timeout, Counter, Number of DNS queries that resulted in timeout
-    get_addr_failure, Counter, Number of general failures during DNS quries
+    not_found, Counter, Number of DNS queries that returned ``NXDOMAIN`` or ``NODATA`` response
+    get_addr_failure, Counter, Number of general failures during DNS queries
+    timeouts, Counter, Number of DNS queries that resulted in a timeout
+    reinits, Counter, Number of c-ares channel reinitializations
 
-The Apple-based DNS Resolver emits the following stats rooted in the ``dns.apple`` stats tree:
+The Apple-based DNS resolver emits the following statistics rooted in the ``dns.apple`` stats tree:
 
   .. csv-table::
     :header: Name, Type, Description
@@ -51,3 +56,7 @@ The Apple-based DNS Resolver emits the following stats rooted in the ``dns.apple
     processing_failure, Counter, Number of failures when processing data from the DNS server
     socket_failure, Counter, Number of failed attempts to obtain a file descriptor to the socket to the DNS server
     timeout, Counter, Number of queries that resulted in a timeout
+
+.. note::
+
+   The Hickory DNS and getaddrinfo resolvers do not currently emit resolver-specific statistics.


### PR DESCRIPTION
## Description

This PR have some styling nits in the `hickory_dns` docs for consistency.

---

**Commit Message:** docs: styling nits in the hickory_dns docs for consistency
**Additional Description:** Added some styling nits in the `hickory_dns` docs for consistency.
**Risk Level:** N/A
**Testing**: CI
**Docs Changes**: N/A
**Release Notes**: N/A