### PR TITLE
benchmarking: added a suite for hickory dns benchmarks

### DIFF
--- a/test/extensions/network/dns_resolver/benchmark/BUILD
+++ b/test/extensions/network/dns_resolver/benchmark/BUILD
@@ -1,0 +1,59 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+# ABI callback implementations required for linking the Hickory DNS Rust static library.
+# Mirrors the list in test/extensions/network/dns_resolver/hickory/BUILD.
+HICKORY_ABI_IMPL_DEPS = [
+    "//source/extensions/access_loggers/dynamic_modules:access_log_lib",
+    "//source/extensions/bootstrap/dynamic_modules:abi_impl",
+    "//source/extensions/clusters/dynamic_modules:cluster_lib",
+    "//source/extensions/dynamic_modules:abi_impl",
+    "//source/extensions/filters/http/dynamic_modules:abi_impl",
+    "//source/extensions/filters/listener/dynamic_modules:filter_lib",
+    "//source/extensions/filters/network/dynamic_modules:filter_lib",
+    "//source/extensions/filters/udp/dynamic_modules:filter_lib",
+    "//source/extensions/load_balancing_policies/dynamic_modules:abi_impl",
+    "//source/extensions/matching/input_matchers/dynamic_modules:matcher_lib",
+    "//source/extensions/upstreams/http/dynamic_modules:abi_impl",
+]
+
+envoy_cc_benchmark_binary(
+    name = "dns_resolver_benchmark",
+    srcs = ["dns_resolver_benchmark.cc"],
+    rbe_pool = "6gig",
+    tags = [
+        # FakeUdpDnsServer uses POSIX-only APIs (poll, fcntl, etc.).
+        "fails_on_clang_cl",
+        # Hickory uses a Rust/Tokio runtime that is not instrumented for TSAN.
+        "no_tsan",
+    ],
+    deps = [
+        "//source/common/event:libevent_lib",
+        "//source/common/network/dns_resolver:dns_factory_util_lib",
+        "//source/extensions/network/dns_resolver/cares:config",
+        "//source/extensions/network/dns_resolver/hickory:config",
+        "//test/extensions/network/dns_resolver/common:fake_udp_dns_server_lib",
+        "//test/test_common:utility_lib",
+        "@benchmark",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/cares/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/hickory/v3:pkg_cc_proto",
+    ] + HICKORY_ABI_IMPL_DEPS,
+)
+
+envoy_benchmark_test(
+    name = "dns_resolver_benchmark_test",
+    benchmark_binary = "dns_resolver_benchmark",
+    tags = [
+        "fails_on_clang_cl",
+        "no_tsan",
+    ],
+)

--- a/test/extensions/network/dns_resolver/benchmark/dns_resolver_benchmark.cc
+++ b/test/extensions/network/dns_resolver/benchmark/dns_resolver_benchmark.cc
@@ -1,0 +1,281 @@
+#include "envoy/config/core/v3/address.pb.h"
+#include "envoy/extensions/network/dns_resolver/cares/v3/cares_dns_resolver.pb.h"
+#include "envoy/extensions/network/dns_resolver/hickory/v3/hickory_dns_resolver.pb.h"
+#include "envoy/network/dns.h"
+
+#include "source/common/event/libevent.h"
+#include "source/common/network/dns_resolver/dns_factory_util.h"
+
+#include "test/benchmark/main.h"
+#include "test/extensions/network/dns_resolver/common/fake_udp_dns_server.h"
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+#include "fmt/format.h"
+
+namespace Envoy {
+namespace {
+
+envoy::config::core::v3::TypedExtensionConfig
+createCaresTypedConfig(const std::string& server_address, uint16_t port) {
+  envoy::extensions::network::dns_resolver::cares::v3::CaresDnsResolverConfig cares;
+  auto* resolver = cares.add_resolvers();
+  auto* addr = resolver->mutable_socket_address();
+  addr->set_address(server_address);
+  addr->set_port_value(port);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  typed_config.set_name("envoy.network.dns_resolver.cares");
+  typed_config.mutable_typed_config()->PackFrom(cares);
+  return typed_config;
+}
+
+envoy::config::core::v3::TypedExtensionConfig
+createHickoryTypedConfig(const std::string& server_address, uint16_t port) {
+  envoy::extensions::network::dns_resolver::hickory::v3::HickoryDnsResolverConfig hickory;
+  auto* resolver = hickory.add_resolvers();
+  auto* addr = resolver->mutable_socket_address();
+  addr->set_address(server_address);
+  addr->set_port_value(port);
+  // Disable caching for fair comparison with c-ares (which has no built-in cache).
+  hickory.mutable_cache_size()->set_value(0);
+  // Prevent reading /etc/resolv.conf.
+  hickory.mutable_use_system_config()->set_value(false);
+  // Single `Tokio` thread to isolate resolver overhead from thread pool scaling.
+  hickory.mutable_num_resolver_threads()->set_value(1);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  typed_config.set_name("envoy.network.dns_resolver.hickory");
+  typed_config.mutable_typed_config()->PackFrom(hickory);
+  return typed_config;
+}
+
+void ensureLibeventInitialized() {
+  if (!Event::Libevent::Global::initialized()) {
+    Event::Libevent::Global::initialize();
+  }
+}
+
+Network::DnsResolverSharedPtr
+createDnsResolver(Event::Dispatcher& dispatcher, Api::Api& api,
+                  const envoy::config::core::v3::TypedExtensionConfig& typed_config) {
+  Network::DnsResolverFactory& factory =
+      Network::createDnsResolverFactoryFromTypedConfig(typed_config);
+  auto resolver_or = factory.createDnsResolver(dispatcher, api, typed_config);
+  RELEASE_ASSERT(resolver_or.ok(), std::string(resolver_or.status().message()));
+  return std::move(*resolver_or);
+}
+
+// ---------------------------------------------------------------------------
+// Single Query Latency
+// Measures the full round-trip of one DNS resolution from the resolve ->
+// fake-server response -> callback.
+// ---------------------------------------------------------------------------
+
+static void BM_CaresSingleQueryLatency(::benchmark::State& state) {
+  ensureLibeventInitialized();
+  Network::Test::FakeUdpDnsServer dns_server;
+  dns_server.setDefaultAResponse("1.2.3.4");
+  dns_server.start();
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("cares_bench");
+  auto typed_config = createCaresTypedConfig(dns_server.address(), dns_server.port());
+  auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    bool resolved = false;
+    resolver->resolve("benchmark.example.com", Network::DnsLookupFamily::V4Only,
+                      [&resolved, &dispatcher](Network::DnsResolver::ResolutionStatus,
+                                               absl::string_view /*details*/,
+                                               std::list<Network::DnsResponse>&& /*responses*/) {
+                        resolved = true;
+                        dispatcher->exit();
+                      });
+    dispatcher->run(Event::Dispatcher::RunType::RunUntilExit);
+    RELEASE_ASSERT(resolved, "c-ares DNS resolution did not complete.");
+  }
+
+  dns_server.stop();
+}
+
+static void BM_HickorySingleQueryLatency(::benchmark::State& state) {
+  if (benchmark::skipExpensiveBenchmarks()) {
+    state.SkipWithError("Skipping expensive Hickory benchmark.");
+    return;
+  }
+
+  ensureLibeventInitialized();
+  Network::Test::FakeUdpDnsServer dns_server;
+  dns_server.setDefaultAResponse("1.2.3.4");
+  dns_server.start();
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("hickory_bench");
+  auto typed_config = createHickoryTypedConfig(dns_server.address(), dns_server.port());
+  auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    bool resolved = false;
+    resolver->resolve("benchmark.example.com", Network::DnsLookupFamily::V4Only,
+                      [&resolved, &dispatcher](Network::DnsResolver::ResolutionStatus,
+                                               absl::string_view /*details*/,
+                                               std::list<Network::DnsResponse>&& /*responses*/) {
+                        resolved = true;
+                        dispatcher->exit();
+                      });
+    dispatcher->run(Event::Dispatcher::RunType::RunUntilExit);
+    RELEASE_ASSERT(resolved, "Hickory DNS resolution did not complete.");
+  }
+
+  dns_server.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent Query Throughput
+// Fires N queries simultaneously and measures the total time until all the
+// queries are completed. Reports items/second.
+// ---------------------------------------------------------------------------
+
+static void BM_CaresConcurrentQueries(::benchmark::State& state) {
+  const int concurrent = static_cast<int>(state.range(0));
+
+  if (benchmark::skipExpensiveBenchmarks() && concurrent > 50) {
+    state.SkipWithError("Skipping expensive c-ares concurrent benchmark.");
+    return;
+  }
+
+  ensureLibeventInitialized();
+  Network::Test::FakeUdpDnsServer dns_server;
+  dns_server.setDefaultAResponse("1.2.3.4");
+  dns_server.start();
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("cares_bench");
+  auto typed_config = createCaresTypedConfig(dns_server.address(), dns_server.port());
+  auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    int completed = 0;
+    for (int i = 0; i < concurrent; i++) {
+      resolver->resolve(fmt::format("host{}.example.com", i), Network::DnsLookupFamily::V4Only,
+                        [&completed, concurrent, &dispatcher](
+                            Network::DnsResolver::ResolutionStatus, absl::string_view /*details*/,
+                            std::list<Network::DnsResponse>&& /*responses*/) {
+                          if (++completed == concurrent) {
+                            dispatcher->exit();
+                          }
+                        });
+    }
+    dispatcher->run(Event::Dispatcher::RunType::RunUntilExit);
+    RELEASE_ASSERT(completed == concurrent, "Not all c-ares concurrent queries completed.");
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * concurrent);
+
+  dns_server.stop();
+}
+
+static void BM_HickoryConcurrentQueries(::benchmark::State& state) {
+  const int concurrent = static_cast<int>(state.range(0));
+
+  if (benchmark::skipExpensiveBenchmarks() && concurrent > 10) {
+    state.SkipWithError("Skipping expensive Hickory concurrent benchmark.");
+    return;
+  }
+
+  ensureLibeventInitialized();
+  Network::Test::FakeUdpDnsServer dns_server;
+  dns_server.setDefaultAResponse("1.2.3.4");
+  dns_server.start();
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("hickory_bench");
+  auto typed_config = createHickoryTypedConfig(dns_server.address(), dns_server.port());
+  auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    int completed = 0;
+    for (int i = 0; i < concurrent; i++) {
+      resolver->resolve(fmt::format("host{}.example.com", i), Network::DnsLookupFamily::V4Only,
+                        [&completed, concurrent, &dispatcher](
+                            Network::DnsResolver::ResolutionStatus, absl::string_view /*details*/,
+                            std::list<Network::DnsResponse>&& /*responses*/) {
+                          if (++completed == concurrent) {
+                            dispatcher->exit();
+                          }
+                        });
+    }
+    dispatcher->run(Event::Dispatcher::RunType::RunUntilExit);
+    RELEASE_ASSERT(completed == concurrent, "Not all Hickory concurrent queries completed.");
+  }
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * concurrent);
+
+  dns_server.stop();
+}
+
+// ---------------------------------------------------------------------------
+// Resolver Creation Time
+// Measures the cost of constructing a resolver instance through the factory.
+// It is relevant for dynamic cluster creation.
+// ---------------------------------------------------------------------------
+
+static void BM_CaresResolverCreation(::benchmark::State& state) {
+  ensureLibeventInitialized();
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("cares_bench");
+  auto typed_config = createCaresTypedConfig("127.0.0.1", 53);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+    ::benchmark::DoNotOptimize(resolver.get());
+  }
+}
+
+static void BM_HickoryResolverCreation(::benchmark::State& state) {
+  if (benchmark::skipExpensiveBenchmarks()) {
+    state.SkipWithError("Skipping expensive Hickory resolver creation benchmark.");
+    return;
+  }
+
+  ensureLibeventInitialized();
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("hickory_bench");
+  auto typed_config = createHickoryTypedConfig("127.0.0.1", 53);
+
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    auto resolver = createDnsResolver(*dispatcher, *api, typed_config);
+    ::benchmark::DoNotOptimize(resolver.get());
+  }
+}
+
+// --- Registration ---
+
+BENCHMARK(BM_CaresSingleQueryLatency)->Unit(::benchmark::kMicrosecond);
+BENCHMARK(BM_HickorySingleQueryLatency)->Unit(::benchmark::kMicrosecond);
+
+BENCHMARK(BM_CaresConcurrentQueries)
+    ->Arg(1)
+    ->Arg(10)
+    ->Arg(50)
+    ->Arg(100)
+    ->Arg(500)
+    ->Unit(::benchmark::kMicrosecond);
+BENCHMARK(BM_HickoryConcurrentQueries)
+    ->Arg(1)
+    ->Arg(10)
+    ->Arg(50)
+    ->Arg(100)
+    ->Arg(500)
+    ->Unit(::benchmark::kMicrosecond);
+
+BENCHMARK(BM_CaresResolverCreation)->Unit(::benchmark::kMicrosecond);
+BENCHMARK(BM_HickoryResolverCreation)->Unit(::benchmark::kMicrosecond);
+
+} // namespace
+} // namespace Envoy

--- a/test/extensions/network/dns_resolver/common/BUILD
+++ b/test/extensions/network/dns_resolver/common/BUILD
@@ -1,0 +1,18 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test_library",
+    "envoy_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test_library(
+    name = "fake_udp_dns_server_lib",
+    srcs = ["fake_udp_dns_server.cc"],
+    hdrs = ["fake_udp_dns_server.h"],
+    deps = [
+        "//source/common/common:assert_lib",
+    ],
+)

--- a/test/extensions/network/dns_resolver/common/fake_udp_dns_server.cc
+++ b/test/extensions/network/dns_resolver/common/fake_udp_dns_server.cc
@@ -1,0 +1,236 @@
+#include "test/extensions/network/dns_resolver/common/fake_udp_dns_server.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
+
+#include "source/common/common/assert.h"
+
+namespace Envoy {
+namespace Network {
+namespace Test {
+
+FakeUdpDnsServer::FakeUdpDnsServer(bool ipv6) {
+  const int family = ipv6 ? AF_INET6 : AF_INET;
+  fd_ = socket(family, SOCK_DGRAM, 0);
+  RELEASE_ASSERT(fd_ >= 0, "Failed to create UDP socket for FakeUdpDnsServer.");
+
+  // Set non-blocking.
+  const int flags = fcntl(fd_, F_GETFL, 0);
+  RELEASE_ASSERT(flags >= 0, "fcntl F_GETFL failed.");
+  RELEASE_ASSERT(fcntl(fd_, F_SETFL, flags | O_NONBLOCK) == 0, "fcntl F_SETFL failed.");
+
+  if (ipv6) {
+    struct sockaddr_in6 addr {};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_addr = in6addr_loopback;
+    RELEASE_ASSERT(bind(fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
+                   "Failed to bind IPv6 UDP socket.");
+
+    struct sockaddr_in6 bound {};
+    socklen_t len = sizeof(bound);
+    getsockname(fd_, reinterpret_cast<struct sockaddr*>(&bound), &len);
+    port_ = ntohs(bound.sin6_port);
+    address_ = "::1";
+  } else {
+    struct sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    RELEASE_ASSERT(bind(fd_, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == 0,
+                   "Failed to bind IPv4 UDP socket.");
+
+    struct sockaddr_in bound {};
+    socklen_t len = sizeof(bound);
+    getsockname(fd_, reinterpret_cast<struct sockaddr*>(&bound), &len);
+    port_ = ntohs(bound.sin_port);
+    address_ = "127.0.0.1";
+  }
+}
+
+FakeUdpDnsServer::~FakeUdpDnsServer() {
+  stop();
+  if (fd_ >= 0) {
+    ::close(fd_);
+  }
+}
+
+void FakeUdpDnsServer::setDefaultAResponse(const std::string& ipv4_address, uint32_t ttl) {
+  default_a_ = {ipv4_address, ttl, true};
+}
+
+void FakeUdpDnsServer::setDefaultAAAAResponse(const std::string& ipv6_address, uint32_t ttl) {
+  default_aaaa_ = {ipv6_address, ttl, true};
+}
+
+void FakeUdpDnsServer::start() {
+  RELEASE_ASSERT(!running_.load(), "FakeUdpDnsServer already running.");
+  running_.store(true);
+  thread_ = std::thread([this] { serve(); });
+}
+
+void FakeUdpDnsServer::stop() {
+  if (running_.exchange(false)) {
+    thread_.join();
+  }
+}
+
+void FakeUdpDnsServer::serve() {
+  uint8_t buf[512];
+  struct sockaddr_storage client_addr {};
+  struct pollfd pfd {};
+  pfd.fd = fd_;
+  pfd.events = POLLIN;
+
+  while (running_.load(std::memory_order_relaxed)) {
+    const int poll_ret = poll(&pfd, 1, /*timeout_ms=*/1);
+    if (poll_ret <= 0) {
+      continue;
+    }
+
+    socklen_t client_len = sizeof(client_addr);
+    const ssize_t n = recvfrom(fd_, buf, sizeof(buf), 0,
+                               reinterpret_cast<struct sockaddr*>(&client_addr), &client_len);
+    if (n <= 0) {
+      continue;
+    }
+
+    queries_received_.fetch_add(1, std::memory_order_relaxed);
+    const auto response = buildResponse(buf, static_cast<size_t>(n));
+    if (!response.empty()) {
+      sendto(fd_, response.data(), response.size(), 0,
+             reinterpret_cast<const struct sockaddr*>(&client_addr), client_len);
+      responses_sent_.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+std::string FakeUdpDnsServer::parseDnsName(const uint8_t* data, size_t len, size_t& offset) {
+  std::string name;
+  while (offset < len) {
+    const uint8_t label_len = data[offset++];
+    if (label_len == 0) {
+      break;
+    }
+    if ((label_len & 0xC0) == 0xC0) {
+      // Compression pointer — skip the second byte and stop.
+      if (offset < len) {
+        offset++;
+      }
+      break;
+    }
+    if (offset + label_len > len) {
+      break;
+    }
+    if (!name.empty()) {
+      name += ".";
+    }
+    name.append(reinterpret_cast<const char*>(data + offset), label_len);
+    offset += label_len;
+  }
+  return name;
+}
+
+std::vector<uint8_t> FakeUdpDnsServer::buildResponse(const uint8_t* query, size_t query_len) const {
+  static constexpr size_t kDnsHeaderSize = 12;
+  if (query_len < kDnsHeaderSize) {
+    return {};
+  }
+
+  // Parse the question by skipping the header, read name + `QTYPE` + `QCLASS`.
+  size_t offset = kDnsHeaderSize;
+  parseDnsName(query, query_len, offset);
+  if (offset + 4 > query_len) {
+    return {};
+  }
+  const uint16_t qtype =
+      (static_cast<uint16_t>(query[offset]) << 8) | static_cast<uint16_t>(query[offset + 1]);
+  const size_t question_end = offset + 4; // `QTYPE`(2) + `QCLASS`(2).
+
+  // Select response data.
+  const DefaultRecord* record = nullptr;
+  uint16_t rdlength = 0;
+  if (qtype == kDnsTypeA && default_a_.enabled) {
+    record = &default_a_;
+    rdlength = 4;
+  } else if (qtype == kDnsTypeAAAA && default_aaaa_.enabled) {
+    record = &default_aaaa_;
+    rdlength = 16;
+  }
+
+  const bool has_answer = (record != nullptr);
+
+  std::vector<uint8_t> resp;
+  resp.reserve(question_end + (has_answer ? 16 + rdlength : 0));
+
+  // Header: copy ID, set response flags.
+  resp.push_back(query[0]);
+  resp.push_back(query[1]);
+  // Byte 2: QR=1 OPCODE=0000 AA=1 TC=0 RD=1 → 0x85.
+  resp.push_back(0x85);
+  // Byte 3: RA=1 Z=000 `RCODE`: 0 (`NOERROR`) or 3 (`NXDOMAIN`).
+  resp.push_back(has_answer ? static_cast<uint8_t>(0x80) : static_cast<uint8_t>(0x83));
+
+  // QDCOUNT=1.
+  resp.push_back(0x00);
+  resp.push_back(0x01);
+  // `ANCOUNT`.
+  resp.push_back(0x00);
+  resp.push_back(has_answer ? static_cast<uint8_t>(0x01) : static_cast<uint8_t>(0x00));
+  // `NSCOUNT`=0, `ARCOUNT`=0.
+  resp.push_back(0x00);
+  resp.push_back(0x00);
+  resp.push_back(0x00);
+  resp.push_back(0x00);
+
+  // Echo the question section.
+  resp.insert(resp.end(), query + kDnsHeaderSize, query + question_end);
+
+  if (has_answer) {
+    // Name: pointer to question name at offset 0x0C.
+    resp.push_back(0xC0);
+    resp.push_back(0x0C);
+
+    // TYPE.
+    resp.push_back(static_cast<uint8_t>(qtype >> 8));
+    resp.push_back(static_cast<uint8_t>(qtype & 0xFF));
+
+    // CLASS = IN (1).
+    resp.push_back(0x00);
+    resp.push_back(0x01);
+
+    // TTL (network byte order).
+    const uint32_t ttl = record->ttl;
+    resp.push_back(static_cast<uint8_t>((ttl >> 24) & 0xFF));
+    resp.push_back(static_cast<uint8_t>((ttl >> 16) & 0xFF));
+    resp.push_back(static_cast<uint8_t>((ttl >> 8) & 0xFF));
+    resp.push_back(static_cast<uint8_t>(ttl & 0xFF));
+
+    // `RDLENGTH`.
+    resp.push_back(static_cast<uint8_t>(rdlength >> 8));
+    resp.push_back(static_cast<uint8_t>(rdlength & 0xFF));
+
+    // `RDATA`.
+    if (qtype == kDnsTypeA) {
+      struct in_addr addr {};
+      inet_pton(AF_INET, record->address.c_str(), &addr);
+      const auto* bytes = reinterpret_cast<const uint8_t*>(&addr);
+      resp.insert(resp.end(), bytes, bytes + 4);
+    } else {
+      struct in6_addr addr6 {};
+      inet_pton(AF_INET6, record->address.c_str(), &addr6);
+      const auto* bytes = reinterpret_cast<const uint8_t*>(&addr6);
+      resp.insert(resp.end(), bytes, bytes + 16);
+    }
+  }
+
+  return resp;
+}
+
+} // namespace Test
+} // namespace Network
+} // namespace Envoy

--- a/test/extensions/network/dns_resolver/common/fake_udp_dns_server.h
+++ b/test/extensions/network/dns_resolver/common/fake_udp_dns_server.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace Envoy {
+namespace Network {
+namespace Test {
+
+// Minimal threaded UDP DNS server for benchmarking and testing DNS resolvers.
+// Responds to A/AAAA queries with configurable default addresses on loopback.
+// The server runs in a background thread and processes queries sequentially
+// via non-blocking I/O with poll().
+class FakeUdpDnsServer {
+public:
+  static constexpr uint16_t kDnsTypeA = 1;
+  static constexpr uint16_t kDnsTypeAAAA = 28;
+
+  // Binds a UDP socket to loopback on a random port. Use ipv6=true for [::1].
+  explicit FakeUdpDnsServer(bool ipv6 = false);
+  ~FakeUdpDnsServer();
+
+  // Not copyable or movable.
+  FakeUdpDnsServer(const FakeUdpDnsServer&) = delete;
+  FakeUdpDnsServer& operator=(const FakeUdpDnsServer&) = delete;
+
+  // Set the default A record returned for any A query.
+  void setDefaultAResponse(const std::string& ipv4_address, uint32_t ttl = 300);
+
+  // Set the default AAAA record returned for any AAAA query.
+  void setDefaultAAAAResponse(const std::string& ipv6_address, uint32_t ttl = 300);
+
+  // Start/stop the server thread.
+  void start();
+  void stop();
+
+  // Bound port (available immediately after construction).
+  uint16_t port() const { return port_; }
+
+  // Loopback address string matching the socket family.
+  const std::string& address() const { return address_; }
+
+  // Counters (thread-safe, relaxed ordering).
+  uint64_t queriesReceived() const { return queries_received_.load(std::memory_order_relaxed); }
+  uint64_t responsesSent() const { return responses_sent_.load(std::memory_order_relaxed); }
+
+private:
+  // Background thread entry point.
+  void serve();
+
+  // Parse a DNS label-encoded name starting at offset. Advances offset past the name.
+  static std::string parseDnsName(const uint8_t* data, size_t len, size_t& offset);
+
+  // Build a DNS response for the given query. Returns empty vector on parse failure.
+  std::vector<uint8_t> buildResponse(const uint8_t* query, size_t query_len) const;
+
+  struct DefaultRecord {
+    std::string address;
+    uint32_t ttl{300};
+    bool enabled{false};
+  };
+
+  int fd_{-1};
+  uint16_t port_{0};
+  std::string address_;
+
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+  std::atomic<uint64_t> queries_received_{0};
+  std::atomic<uint64_t> responses_sent_{0};
+
+  DefaultRecord default_a_;
+  DefaultRecord default_aaaa_;
+};
+
+} // namespace Test
+} // namespace Network
+} // namespace Envoy


### PR DESCRIPTION
## Description

This PR adds a suite for benchmarking the DNS resolvers. It has a comparison for Hickory vs. c-ares which shows that queries are slightly slower with Hickory as there is a x-thread dispatch involved but the overall throughput is much higher (3-10x) as compared to c-ares. It make sense as Hickory uses Tokio threads and not the main thread to do resolutions.

We can use this suite to measure any further improvements in the resolvers.

```
Run on (16 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x16)
Load Average: 8.82, 12.92, 10.06

---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_CaresSingleQueryLatency_mean              92.4 us         42.8 us            3
BM_CaresSingleQueryLatency_median            96.1 us         42.9 us            3
BM_CaresSingleQueryLatency_stddev            11.8 us         3.61 us            3
BM_CaresSingleQueryLatency_cv               12.76 %          8.44 %             3
BM_HickorySingleQueryLatency_mean             135 us         3.73 us            3
BM_HickorySingleQueryLatency_median           134 us         3.69 us            3
BM_HickorySingleQueryLatency_stddev          8.82 us        0.228 us            3
BM_HickorySingleQueryLatency_cv              6.55 %          6.11 %             3
BM_CaresConcurrentQueries/1_mean             80.3 us         36.5 us            3 items_per_second=27.5383k/s
BM_CaresConcurrentQueries/1_median           86.0 us         38.2 us            3 items_per_second=26.1955k/s
BM_CaresConcurrentQueries/1_stddev           10.8 us         3.03 us            3 items_per_second=2.39884k/s
BM_CaresConcurrentQueries/1_cv              13.47 %          8.29 %             3 items_per_second=8.71%
BM_CaresConcurrentQueries/10_mean             162 us          121 us            3 items_per_second=82.3794k/s
BM_CaresConcurrentQueries/10_median           161 us          122 us            3 items_per_second=82.2754k/s
BM_CaresConcurrentQueries/10_stddev          7.87 us         1.73 us            3 items_per_second=1.17678k/s
BM_CaresConcurrentQueries/10_cv              4.85 %          1.43 %             3 items_per_second=1.43%
BM_CaresConcurrentQueries/50_mean             507 us          483 us            3 items_per_second=103.559k/s
BM_CaresConcurrentQueries/50_median           496 us          479 us            3 items_per_second=104.349k/s
BM_CaresConcurrentQueries/50_stddev          41.5 us         16.0 us            3 items_per_second=3.38484k/s
BM_CaresConcurrentQueries/50_cv              8.19 %          3.31 %             3 items_per_second=3.27%
BM_CaresConcurrentQueries/100_mean            944 us          939 us            3 items_per_second=106.542k/s
BM_CaresConcurrentQueries/100_median          935 us          931 us            3 items_per_second=107.443k/s
BM_CaresConcurrentQueries/100_stddev         24.9 us         24.4 us            3 items_per_second=2.73549k/s
BM_CaresConcurrentQueries/100_cv             2.64 %          2.60 %             3 items_per_second=2.57%
BM_CaresConcurrentQueries/500_mean           5157 us         5146 us            3 items_per_second=97.1661k/s
BM_CaresConcurrentQueries/500_median         5174 us         5163 us            3 items_per_second=96.8462k/s
BM_CaresConcurrentQueries/500_stddev         42.3 us         44.5 us            3 items_per_second=843.295/s
BM_CaresConcurrentQueries/500_cv             0.82 %          0.86 %             3 items_per_second=0.87%
BM_HickoryConcurrentQueries/1_mean            135 us         3.55 us            3 items_per_second=281.445k/s
BM_HickoryConcurrentQueries/1_median          134 us         3.56 us            3 items_per_second=280.576k/s
BM_HickoryConcurrentQueries/1_stddev         2.83 us        0.040 us            3 items_per_second=3.20738k/s
BM_HickoryConcurrentQueries/1_cv             2.10 %          1.13 %             3 items_per_second=1.14%
BM_HickoryConcurrentQueries/10_mean          1064 us         32.9 us            3 items_per_second=304.12k/s
BM_HickoryConcurrentQueries/10_median        1071 us         32.5 us            3 items_per_second=307.597k/s
BM_HickoryConcurrentQueries/10_stddev        57.1 us        0.767 us            3 items_per_second=7.00308k/s
BM_HickoryConcurrentQueries/10_cv            5.37 %          2.33 %             3 items_per_second=2.30%
BM_HickoryConcurrentQueries/50_mean          4211 us          156 us            3 items_per_second=319.552k/s
BM_HickoryConcurrentQueries/50_median        4514 us          156 us            3 items_per_second=319.591k/s
BM_HickoryConcurrentQueries/50_stddev         611 us         1.91 us            3 items_per_second=3.89165k/s
BM_HickoryConcurrentQueries/50_cv           14.52 %          1.22 %             3 items_per_second=1.22%
BM_HickoryConcurrentQueries/100_mean         9585 us          334 us            3 items_per_second=299.201k/s
BM_HickoryConcurrentQueries/100_median       9605 us          333 us            3 items_per_second=300.381k/s
BM_HickoryConcurrentQueries/100_stddev        533 us         2.85 us            3 items_per_second=2.54233k/s
BM_HickoryConcurrentQueries/100_cv           5.56 %          0.85 %             3 items_per_second=0.85%
BM_HickoryConcurrentQueries/500_mean        43008 us         1658 us            3 items_per_second=301.582k/s
BM_HickoryConcurrentQueries/500_median      44188 us         1667 us            3 items_per_second=299.922k/s
BM_HickoryConcurrentQueries/500_stddev       2466 us         15.8 us            3 items_per_second=2.88381k/s
BM_HickoryConcurrentQueries/500_cv           5.73 %          0.95 %             3 items_per_second=0.96%
BM_CaresResolverCreation_mean                89.7 us         47.7 us            3
BM_CaresResolverCreation_median              89.5 us         47.7 us            3
BM_CaresResolverCreation_stddev             0.473 us        0.145 us            3
BM_CaresResolverCreation_cv                  0.53 %          0.30 %             3
BM_HickoryResolverCreation_mean               166 us          148 us            3
BM_HickoryResolverCreation_median             166 us          148 us            3
BM_HickoryResolverCreation_stddev           0.679 us        0.486 us            3
BM_HickoryResolverCreation_cv                0.41 %          0.33 %             3
```

---

**Commit Message:** benchmarking: added a suite for hickory dns benchmarks
**Additional Description:** Added a new benchmarking suite to compare the DNS resolvers.
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A