### PR TITLE
hickory_dns: add statistics

### DIFF
--- a/api/envoy/extensions/network/dns_resolver/hickory/v3/hickory_dns_resolver.proto
+++ b/api/envoy/extensions/network/dns_resolver/hickory/v3/hickory_dns_resolver.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/network/dns_resolver/hickory/v3;hickoryv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
-// [#protodoc-title: Hickory DNS Resolver]
+// [#protodoc-title: Hickory DNS resolver]
 // [#extension: envoy.network.dns_resolver.hickory]
 
 // Configuration for DNS-over-TLS (DoT) servers.

--- a/docs/root/intro/arch_overview/upstream/dns_resolution.rst
+++ b/docs/root/intro/arch_overview/upstream/dns_resolution.rst
@@ -57,6 +57,18 @@ The Apple-based DNS resolver emits the following statistics rooted in the ``dns.
     socket_failure, Counter, Number of failed attempts to obtain a file descriptor to the socket to the DNS server
     timeout, Counter, Number of queries that resulted in a timeout
 
+The Hickory DNS resolver emits the following statistics rooted in the ``dns.hickory`` stats tree:
+
+  .. csv-table::
+    :header: Name, Type, Description
+    :widths: 1, 1, 2
+
+    resolve_total, Counter, Number of completed DNS queries
+    pending_resolutions, Gauge, Number of DNS queries currently in flight
+    not_found, Counter, Number of DNS queries that returned ``NXDOMAIN`` or ``NODATA`` responses
+    get_addr_failure, Counter, Number of general failures during DNS queries
+    timeouts, Counter, Number of DNS queries that resulted in a timeout
+
 .. note::
 
-   The Hickory DNS and getaddrinfo resolvers do not currently emit resolver-specific statistics.
+   The getaddrinfo resolver does not currently emit resolver-specific statistics.

--- a/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.cc
+++ b/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.cc
@@ -4,6 +4,8 @@
 
 #include "source/common/network/utility.h"
 
+#include "absl/strings/match.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -93,9 +95,15 @@ void HickoryPendingResolution::cancel(CancelReason) {
 
 // -- HickoryDnsResolver -------------------------------------------------------
 
+HickoryDnsResolverStats HickoryDnsResolver::generateHickoryDnsResolverStats(Stats::Scope& scope) {
+  return {ALL_HICKORY_DNS_RESOLVER_STATS(POOL_COUNTER(scope), POOL_GAUGE(scope))};
+}
+
 HickoryDnsResolver::HickoryDnsResolver(HickoryDnsResolverConfigSharedPtr config,
-                                       Event::Dispatcher& dispatcher)
-    : config_(std::move(config)), dispatcher_(dispatcher) {
+                                       Event::Dispatcher& dispatcher, Stats::Scope& root_scope)
+    : config_(std::move(config)), dispatcher_(dispatcher),
+      scope_(root_scope.createScope("dns.hickory.")),
+      stats_(generateHickoryDnsResolverStats(*scope_)) {
   resolver_module_ptr_ =
       config_->on_dns_resolver_new_(config_->in_module_config_, static_cast<const void*>(this));
   ASSERT(resolver_module_ptr_ != nullptr);
@@ -113,8 +121,10 @@ HickoryDnsResolver::~HickoryDnsResolver() {
 
   // Step 3: Free Rust-side query objects for all remaining pending queries, and delete
   // the C++ pending resolution objects. Already-cancelled queries have their Rust-side
-  // objects freed by the cancel() call, so only free non-cancelled ones.
+  // objects freed by the cancel() call, so only free non-cancelled ones. Decrement the
+  // pending_resolutions gauge for each query since their callbacks will never arrive.
   for (auto& [id, pending] : pending_queries_) {
+    stats_.pending_resolutions_.dec();
     if (!pending->cancelled_) {
       // Safe: on_dns_resolve_cancel_ does not dereference the resolver pointer.
       config_->on_dns_resolve_cancel_(resolver_module_ptr_, pending->query_module_ptr_);
@@ -143,7 +153,9 @@ HickoryDnsResolver::toLookupFamily(DnsLookupFamily dns_lookup_family) {
 
 ActiveDnsQuery* HickoryDnsResolver::resolve(const std::string& dns_name,
                                             DnsLookupFamily dns_lookup_family, ResolveCb callback) {
-  ENVOY_LOG(trace, "resolving [{}] via Hickory DNS", dns_name);
+  ENVOY_LOG(debug, "resolving [{}] via Hickory DNS", dns_name);
+
+  stats_.pending_resolutions_.inc();
 
   const uint64_t query_id = next_query_id_++;
   auto* pending = new HickoryPendingResolution(*this, std::move(callback), query_id, dns_name);
@@ -175,8 +187,11 @@ void HickoryDnsResolver::onResolveComplete(uint64_t query_id,
   HickoryPendingResolution* pending = it->second;
   pending_queries_.erase(it);
 
+  stats_.resolve_total_.inc();
+  stats_.pending_resolutions_.dec();
+
   if (pending->cancelled_) {
-    ENVOY_LOG(trace, "dropping cancelled query [{}]", pending->dns_name_);
+    ENVOY_LOG(debug, "dropping cancelled query [{}]", pending->dns_name_);
     delete pending;
     return;
   }
@@ -185,8 +200,13 @@ void HickoryDnsResolver::onResolveComplete(uint64_t query_id,
                                 ? ResolutionStatus::Completed
                                 : ResolutionStatus::Failure;
 
-  ENVOY_LOG(trace, "Hickory DNS resolution complete for [{}]: status={}", pending->dns_name_,
-            static_cast<int>(envoy_status));
+  if (envoy_status == ResolutionStatus::Failure) {
+    chargeGetAddrInfoErrorStats(details);
+    ENVOY_LOG(debug, "Hickory DNS resolution failed for [{}]: {}", pending->dns_name_, details);
+  } else {
+    ENVOY_LOG(debug, "Hickory DNS resolution complete for [{}]: {} address(es)", pending->dns_name_,
+              response.size());
+  }
 
   // Free the Rust-side query object. The cancel ABI function takes ownership and drops it.
   // Calling cancel on an already-completed query is harmless (it only sets the AtomicBool).
@@ -197,16 +217,28 @@ void HickoryDnsResolver::onResolveComplete(uint64_t query_id,
   delete pending;
 }
 
+void HickoryDnsResolver::chargeGetAddrInfoErrorStats(absl::string_view details) {
+  // The detail string from the Hickory Rust module contains identifiable patterns from the
+  // underlying hickory-resolver library that allow categorizing the error.
+  if (absl::StrContains(details, "no record")) {
+    stats_.not_found_.inc();
+  } else if (absl::StrContains(details, "timed out") || absl::StrContains(details, "timeout")) {
+    stats_.timeouts_.inc();
+  } else {
+    stats_.get_addr_failure_.inc();
+  }
+}
+
 // -- HickoryDnsResolverFactory ------------------------------------------------
 
 absl::StatusOr<DnsResolverSharedPtr> HickoryDnsResolverFactory::createDnsResolver(
-    Event::Dispatcher& dispatcher, Api::Api&,
+    Event::Dispatcher& dispatcher, Api::Api& api,
     const envoy::config::core::v3::TypedExtensionConfig& typed_config) const {
   envoy::extensions::network::dns_resolver::hickory::v3::HickoryDnsResolverConfig proto_config;
   RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(typed_config.typed_config(), proto_config));
 
   auto config = HickoryDnsResolverConfig::create(proto_config);
-  return std::make_shared<HickoryDnsResolver>(std::move(config), dispatcher);
+  return std::make_shared<HickoryDnsResolver>(std::move(config), dispatcher, api.rootScope());
 }
 
 REGISTER_FACTORY(HickoryDnsResolverFactory, DnsResolverFactory);

--- a/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.h
+++ b/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/network/dns.h"
 #include "envoy/network/dns_resolver.h"
 #include "envoy/registry/registry.h"
+#include "envoy/stats/stats_macros.h"
 
 #include "source/common/common/logger.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -20,6 +21,23 @@ namespace Envoy {
 namespace Network {
 
 class HickoryDnsResolver;
+
+/**
+ * All Hickory DNS resolver stats. @see stats_macros.h
+ */
+#define ALL_HICKORY_DNS_RESOLVER_STATS(COUNTER, GAUGE)                                             \
+  COUNTER(resolve_total)                                                                           \
+  GAUGE(pending_resolutions, NeverImport)                                                          \
+  COUNTER(not_found)                                                                               \
+  COUNTER(get_addr_failure)                                                                        \
+  COUNTER(timeouts)
+
+/**
+ * Struct definition for all Hickory DNS resolver stats. @see stats_macros.h
+ */
+struct HickoryDnsResolverStats {
+  ALL_HICKORY_DNS_RESOLVER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+};
 
 // Function pointer types for the DNS resolver ABI event hooks.
 using OnDnsResolverConfigNewType = decltype(&envoy_dynamic_module_on_dns_resolver_config_new);
@@ -96,8 +114,11 @@ public:
  */
 class HickoryDnsResolver : public DnsResolver, protected Logger::Loggable<Logger::Id::dns> {
 public:
-  HickoryDnsResolver(HickoryDnsResolverConfigSharedPtr config, Event::Dispatcher& dispatcher);
+  HickoryDnsResolver(HickoryDnsResolverConfigSharedPtr config, Event::Dispatcher& dispatcher,
+                     Stats::Scope& root_scope);
   ~HickoryDnsResolver() override;
+
+  static HickoryDnsResolverStats generateHickoryDnsResolverStats(Stats::Scope& scope);
 
   // DnsResolver
   ActiveDnsQuery* resolve(const std::string& dns_name, DnsLookupFamily dns_lookup_family,
@@ -121,6 +142,8 @@ private:
   static envoy_dynamic_module_type_dns_lookup_family
   toLookupFamily(DnsLookupFamily dns_lookup_family);
 
+  void chargeGetAddrInfoErrorStats(absl::string_view details);
+
   HickoryDnsResolverConfigSharedPtr config_;
   Event::Dispatcher& dispatcher_;
   envoy_dynamic_module_type_dns_resolver_module_ptr resolver_module_ptr_;
@@ -129,6 +152,8 @@ private:
   // Checked by the ABI callback from `Tokio` threads to avoid posting to the dispatcher
   // after the resolver begins destruction.
   std::atomic<bool> shutting_down_{false};
+  Stats::ScopeSharedPtr scope_;
+  HickoryDnsResolverStats stats_;
 };
 
 /**

--- a/test/extensions/network/dns_resolver/hickory/BUILD
+++ b/test/extensions/network/dns_resolver/hickory/BUILD
@@ -46,6 +46,7 @@ envoy_extension_cc_test(
     ],
     deps = [
         "//source/extensions/network/dns_resolver/hickory:config",
+        "//test/common/stats:stat_test_utility_lib",
         "//test/mocks/api:api_mocks",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/network/dns_resolver/hickory/v3:pkg_cc_proto",

--- a/test/extensions/network/dns_resolver/hickory/hickory_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/hickory/hickory_dns_impl_test.cc
@@ -3,6 +3,7 @@
 #include "source/common/network/dns_resolver/dns_factory_util.h"
 #include "source/extensions/network/dns_resolver/hickory/hickory_dns_impl.h"
 
+#include "test/common/stats/stat_test_utility.h"
 #include "test/mocks/api/mocks.h"
 #include "test/test_common/test_runtime.h"
 
@@ -19,7 +20,8 @@ namespace {
 class HickoryDnsImplTest : public testing::Test {
 public:
   HickoryDnsImplTest()
-      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {}
+      : api_(Api::createApiForTest(stats_store_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")) {}
 
   void
   initialize(const envoy::extensions::network::dns_resolver::hickory::v3::HickoryDnsResolverConfig&
@@ -36,6 +38,19 @@ public:
     resolver_ = std::move(*resolver_or);
   }
 
+  void checkStats(uint64_t resolve_total, uint64_t pending_resolutions, uint64_t not_found,
+                  uint64_t get_addr_failure, uint64_t timeouts) {
+    EXPECT_EQ(resolve_total, stats_store_.counter("dns.hickory.resolve_total").value());
+    EXPECT_EQ(
+        pending_resolutions,
+        stats_store_.gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+            .value());
+    EXPECT_EQ(not_found, stats_store_.counter("dns.hickory.not_found").value());
+    EXPECT_EQ(get_addr_failure, stats_store_.counter("dns.hickory.get_addr_failure").value());
+    EXPECT_EQ(timeouts, stats_store_.counter("dns.hickory.timeouts").value());
+  }
+
+  Stats::TestUtil::TestStore stats_store_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
   DnsResolverSharedPtr resolver_;
@@ -84,6 +99,7 @@ TEST_F(HickoryDnsImplTest, CreateResolverWithCustomOptions) {
 
 TEST_F(HickoryDnsImplTest, ResolveLocalhost) {
   initialize();
+  checkStats(0, 0, 0, 0, 0);
 
   bool callback_called = false;
   auto* query =
@@ -98,6 +114,8 @@ TEST_F(HickoryDnsImplTest, ResolveLocalhost) {
   EXPECT_NE(query, nullptr);
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   EXPECT_TRUE(callback_called);
+  checkStats(1 /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             0 /*get_addr_failure*/, 0 /*timeouts*/);
 }
 
 TEST_F(HickoryDnsImplTest, ResolveLocalhostV4Only) {
@@ -182,21 +200,36 @@ TEST_F(HickoryDnsImplTest, ResolveNonExistentDomain) {
   initialize();
 
   bool callback_called = false;
-  auto* query = resolver_->resolve(
-      "this-domain-does-not-exist-at-all.invalid", DnsLookupFamily::All,
-      [this, &callback_called](DnsResolver::ResolutionStatus status, absl::string_view,
-                               std::list<DnsResponse>&& response) {
-        callback_called = true;
-        // Non-existent domain should fail or return empty results.
-        if (status == DnsResolver::ResolutionStatus::Failure) {
-          EXPECT_TRUE(response.empty());
-        }
-        dispatcher_->exit();
-      });
+  DnsResolver::ResolutionStatus result_status;
+  auto* query =
+      resolver_->resolve("this-domain-does-not-exist-at-all.invalid", DnsLookupFamily::All,
+                         [this, &callback_called,
+                          &result_status](DnsResolver::ResolutionStatus status, absl::string_view,
+                                          std::list<DnsResponse>&& response) {
+                           callback_called = true;
+                           result_status = status;
+                           if (status == DnsResolver::ResolutionStatus::Failure) {
+                             EXPECT_TRUE(response.empty());
+                           }
+                           dispatcher_->exit();
+                         });
 
   EXPECT_NE(query, nullptr);
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   EXPECT_TRUE(callback_called);
+  // The query completed, so resolve_total should be incremented and pending_resolutions
+  // should be back to zero.
+  EXPECT_EQ(1, stats_store_.counter("dns.hickory.resolve_total").value());
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+  // On failure, exactly one error category stat should be incremented.
+  if (result_status == DnsResolver::ResolutionStatus::Failure) {
+    const uint64_t total_errors = stats_store_.counter("dns.hickory.not_found").value() +
+                                  stats_store_.counter("dns.hickory.get_addr_failure").value() +
+                                  stats_store_.counter("dns.hickory.timeouts").value();
+    EXPECT_EQ(1, total_errors);
+  }
 }
 
 TEST_F(HickoryDnsImplTest, CancelQuery) {
@@ -267,6 +300,8 @@ TEST_F(HickoryDnsImplTest, MultipleSimultaneousQueries) {
 
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   EXPECT_EQ(callbacks_received, num_queries);
+  checkStats(num_queries /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             0 /*get_addr_failure*/, 0 /*timeouts*/);
 }
 
 TEST_F(HickoryDnsImplTest, ActiveDnsQueryTracing) {
@@ -288,15 +323,17 @@ TEST_F(HickoryDnsImplTest, ActiveDnsQueryTracing) {
 
 TEST_F(HickoryDnsImplTest, OnResolveCompleteWithUnknownQueryId) {
   initialize();
+  checkStats(0, 0, 0, 0, 0);
 
   // Call onResolveComplete with a query ID that does not exist in pending_queries_.
-  // This exercises the early return on line 164-166.
+  // This exercises the early return in onResolveComplete.
   auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
   ASSERT_NE(hickory_resolver, nullptr);
 
-  // This should silently return without crashing.
+  // This should silently return without crashing or affecting stats.
   hickory_resolver->onResolveComplete(
       999999, envoy_dynamic_module_type_dns_resolution_status_Completed, "should_be_ignored", {});
+  checkStats(0, 0, 0, 0, 0);
 }
 
 TEST_F(HickoryDnsImplTest, AbiCallbackWithNullAddress) {
@@ -436,6 +473,144 @@ TEST_F(HickoryDnsImplTest, DestroyWithPendingQueries) {
   // Destroy the resolver immediately. The destructor should cancel all pending queries
   // and shut down the `Tokio` runtime cleanly.
   resolver_.reset();
+}
+
+TEST_F(HickoryDnsImplTest, StatsNotFoundOnDirectCallback) {
+  initialize();
+  auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
+  ASSERT_NE(hickory_resolver, nullptr);
+
+  bool callback_called = false;
+  resolver_->resolve("localhost", DnsLookupFamily::All,
+                     [this, &callback_called](DnsResolver::ResolutionStatus, absl::string_view,
+                                              std::list<DnsResponse>&&) {
+                       callback_called = true;
+                       dispatcher_->exit();
+                     });
+  dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
+  EXPECT_TRUE(callback_called);
+  checkStats(1 /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             0 /*get_addr_failure*/, 0 /*timeouts*/);
+
+  // Simulate a not-found resolution by directly calling onResolveComplete with a "no record
+  // found" detail string matching the pattern produced by the Hickory Rust module.
+  callback_called = false;
+  auto* query2 =
+      resolver_->resolve("example.invalid", DnsLookupFamily::All,
+                         [this, &callback_called](DnsResolver::ResolutionStatus status,
+                                                  absl::string_view, std::list<DnsResponse>&&) {
+                           callback_called = true;
+                           EXPECT_EQ(status, DnsResolver::ResolutionStatus::Failure);
+                           dispatcher_->exit();
+                         });
+  EXPECT_NE(query2, nullptr);
+  // Override the async resolution by posting a direct onResolveComplete. Query ID is 2
+  // (second query on this resolver).
+  hickory_resolver->onResolveComplete(
+      2, envoy_dynamic_module_type_dns_resolution_status_Failure,
+      "A lookup failed: no record found for Query { name: Name(\"example.invalid.\"), "
+      "query_type: A, query_class: IN }",
+      {});
+  EXPECT_TRUE(callback_called);
+  checkStats(2 /*resolve_total*/, 0 /*pending_resolutions*/, 1 /*not_found*/,
+             0 /*get_addr_failure*/, 0 /*timeouts*/);
+}
+
+TEST_F(HickoryDnsImplTest, StatsTimeoutOnDirectCallback) {
+  initialize();
+  auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
+  ASSERT_NE(hickory_resolver, nullptr);
+
+  bool callback_called = false;
+  auto* query =
+      resolver_->resolve("timeout.example", DnsLookupFamily::All,
+                         [this, &callback_called](DnsResolver::ResolutionStatus status,
+                                                  absl::string_view, std::list<DnsResponse>&&) {
+                           callback_called = true;
+                           EXPECT_EQ(status, DnsResolver::ResolutionStatus::Failure);
+                           dispatcher_->exit();
+                         });
+  EXPECT_NE(query, nullptr);
+  hickory_resolver->onResolveComplete(
+      1, envoy_dynamic_module_type_dns_resolution_status_Failure,
+      "A lookup failed: DNS request timed out for Name(\"timeout.example.\")", {});
+  EXPECT_TRUE(callback_called);
+  checkStats(1 /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             0 /*get_addr_failure*/, 1 /*timeouts*/);
+}
+
+TEST_F(HickoryDnsImplTest, StatsGetAddrFailureOnDirectCallback) {
+  initialize();
+  auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
+  ASSERT_NE(hickory_resolver, nullptr);
+
+  bool callback_called = false;
+  auto* query =
+      resolver_->resolve("fail.example", DnsLookupFamily::All,
+                         [this, &callback_called](DnsResolver::ResolutionStatus status,
+                                                  absl::string_view, std::list<DnsResponse>&&) {
+                           callback_called = true;
+                           EXPECT_EQ(status, DnsResolver::ResolutionStatus::Failure);
+                           dispatcher_->exit();
+                         });
+  EXPECT_NE(query, nullptr);
+  hickory_resolver->onResolveComplete(1, envoy_dynamic_module_type_dns_resolution_status_Failure,
+                                      "A lookup failed: connection refused", {});
+  EXPECT_TRUE(callback_called);
+  checkStats(1 /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             1 /*get_addr_failure*/, 0 /*timeouts*/);
+}
+
+TEST_F(HickoryDnsImplTest, StatsPendingResolutionsGauge) {
+  initialize();
+  checkStats(0, 0, 0, 0, 0);
+
+  // Issue a query. The pending_resolutions gauge is incremented synchronously in resolve().
+  resolver_->resolve("localhost", DnsLookupFamily::All,
+                     [this](DnsResolver::ResolutionStatus, absl::string_view,
+                            std::list<DnsResponse>&&) { dispatcher_->exit(); });
+
+  // After resolve() but before the async callback, the gauge should reflect at least 1
+  // pending resolution. However, since the `Tokio` task may complete extremely quickly, we
+  // verify the gauge is correct after the dispatcher runs.
+  dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
+  checkStats(1 /*resolve_total*/, 0 /*pending_resolutions*/, 0 /*not_found*/,
+             0 /*get_addr_failure*/, 0 /*timeouts*/);
+}
+
+TEST_F(HickoryDnsImplTest, StatsOnCancelledQuery) {
+  initialize();
+
+  auto* query = resolver_->resolve(
+      "localhost", DnsLookupFamily::All,
+      [](DnsResolver::ResolutionStatus, absl::string_view, std::list<DnsResponse>&&) {});
+  EXPECT_NE(query, nullptr);
+  query->cancel(ActiveDnsQuery::CancelReason::QueryAbandoned);
+
+  // Resolve a second query and wait for it to complete.
+  bool second_callback_called = false;
+  resolver_->resolve("localhost", DnsLookupFamily::All,
+                     [this, &second_callback_called](DnsResolver::ResolutionStatus,
+                                                     absl::string_view, std::list<DnsResponse>&&) {
+                       second_callback_called = true;
+                       dispatcher_->exit();
+                     });
+  dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
+  EXPECT_TRUE(second_callback_called);
+
+  // The second query is guaranteed to complete. The cancelled query's `Tokio` task may or may
+  // not have posted a result before seeing the cancel flag, so resolve_total is at least 1.
+  EXPECT_GE(stats_store_.counter("dns.hickory.resolve_total").value(), 1);
+  EXPECT_EQ(0, stats_store_.counter("dns.hickory.not_found").value());
+  EXPECT_EQ(0, stats_store_.counter("dns.hickory.get_addr_failure").value());
+  EXPECT_EQ(0, stats_store_.counter("dns.hickory.timeouts").value());
+
+  // Destroying the resolver ensures that any remaining pending queries have their
+  // pending_resolutions gauge decremented in the destructor.
+  resolver_.reset();
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
 }
 
 TEST_F(HickoryDnsImplTest, ResolveIpAddressV4) {


### PR DESCRIPTION
## Description

This PR add statistics to the Hickory DNS resolver.

---

**Commit Message:** hickory_dns: add statistics
**Additional Description**: Added statistics to the Hickory DNS resolver.
**Risk Level**: Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes**: N/A