### PR TITLE
Add a new workflow for building the mobile/library/python whl and uploading to pypi

### DIFF
--- a/.github/workflows/_load_env.yml
+++ b/.github/workflows/_load_env.yml
@@ -110,5 +110,5 @@ jobs:
     needs: request
     if: ${{ inputs.cache-docker }}
     with:
-      request: ${{ toJSON(needs.request.outputs) }}
+      caches: ${{ needs.request.outputs.caches }}
       image-tag: ${{ fromJSON(needs.request.outputs.build-image).default }}

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -5,6 +5,16 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      job_to_run:
+        description: 'Select the job to run'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - android
+          - python
   schedule:
   # Mondays at 1pm UTC (8am EST)
   - cron: "0 13 * * 1"
@@ -18,16 +28,14 @@ jobs:
       contents: read
     uses: ./.github/workflows/_load_env.yml
 
-  release:
+  android-release:
     permissions:
       contents: read
       packages: read
     if: >-
-      ${{
-          github.repository == 'envoyproxy/envoy'
-          && (github.event.schedule
-              || !contains(github.actor, '[bot]'))
-      }}
+      ${{ github.repository == 'envoyproxy/envoy' && 
+          (github.event.schedule || !contains(github.actor, '[bot]')) &&
+          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'android' || github.event_name == 'schedule') }}
     needs: env
     uses: ./.github/workflows/_mobile_container_ci.yml
     with:
@@ -76,8 +84,12 @@ jobs:
             //:android_dist
           output: envoy
 
-  deploy:
-    needs: release
+  android-deploy:
+    needs: android-release
+    if: >-
+      ${{ always() && 
+          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'android' || github.event_name == 'schedule') &&
+          (needs.android-release.result == 'success') }}
     permissions:
       contents: read
       packages: read
@@ -141,3 +153,79 @@ jobs:
             ${{ matrix.output }}-pom.xml.asc \
             ${{ matrix.output }}-sources.jar.asc \
             ${{ matrix.output }}-javadoc.jar.asc
+  python-release:
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    if: >-
+      ${{ github.repository == 'envoyproxy/envoy' && 
+          (github.event_name == 'workflow_dispatch') &&
+          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'python') }}
+    needs: env      
+    name: Build and Publish Python Wheel
+    uses: ./.github/workflows/_mobile_container_ci.yml
+    with:
+      args: ${{ matrix.args }}
+      container: ${{ fromJSON(needs.env.outputs.build-image).mobile }}
+      container-output: |
+        "bazel-bin/library/python/": build/
+      request: ${{ needs.env.outputs.request }}
+      steps-post: |
+        - name: Repair wheel
+          run: |
+            mkdir -p /tmp/dist
+            WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
+            
+            if [ -z "$WHEEL_PATH" ]; then
+              echo "p Error: No wheel file found in /tmp/container-output/build"
+              ls -R /tmp/container-output/
+              exit 1
+            fi
+            python3 -m venv envoy_wheel
+            source envoy_wheel/bin/activate
+            pip install patchelf auditwheel
+            
+            auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
+          shell: bash
+      target: ${{ matrix.target }}
+      upload-name: python-wheel
+      upload-path: /tmp/dist/*.whl
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: envoy_mobile_wheel
+            args: >-
+              build
+              --config=ci
+              --config=mobile-rbe
+              --config=mobile-release
+              -c opt --strip=always
+              //library/python:envoy_mobile_wheel
+              --//library/python:python_platform="manylinux2014_x86_64"
+              --@rules_python//python/config_settings:python_version="3.13.1"
+  python-publish:
+    needs: python-release
+    if: >-
+      ${{ always() && 
+          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'python') &&
+          (needs.python-release.result == 'success') }}
+    permissions: 
+      contents: read
+      id-token: write
+      packages: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<your-package-name>
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-wheel
+          path: .
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -174,7 +174,7 @@ jobs:
     uses: ./.github/workflows/_mobile_container_ci.yml
     with:
       args: ${{ matrix.args }}
-      container: ${{ fromJSON(needs.env.outputs.build-image).mobile }}
+      container: ${{ fromJSON(needs.env.outputs.build-image).default }}
       container-output: |
         "bazel-bin/library/python/": build/
       request: ${{ needs.env.outputs.request }}

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -30,6 +30,7 @@ jobs:
 
   android-release:
     permissions:
+      actions: read
       contents: read
       packages: read
     if: >-

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -222,7 +222,6 @@ jobs:
     permissions: 
       contents: read
       id-token: write
-      packages: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/_load_env.yml
+    with:
+      cache-docker: false
 
   android-release:
     permissions:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -210,7 +210,6 @@ jobs:
             -c opt --strip=always
             //library/python:envoy_mobile_wheel
             --//library/python:python_platform="manylinux2014_x86_64"
-            --@rules_python//python/config_settings:python_version="3.13.1"
   python-publish:
     needs: python-release
     if: >-

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -158,6 +158,7 @@ jobs:
             ${{ matrix.output }}-pom.xml.asc \
             ${{ matrix.output }}-sources.jar.asc \
             ${{ matrix.output }}-javadoc.jar.asc
+            
   python-release:
     permissions:
       actions: read
@@ -210,6 +211,7 @@ jobs:
             -c opt --strip=always
             //library/python:envoy_mobile_wheel
             --//library/python:python_platform="manylinux2014_x86_64"
+            
   python-publish:
     needs: python-release
     if: >-

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -35,10 +35,10 @@ jobs:
       packages: read
     if: >-
       github.repository == 'envoyproxy/envoy'
-      && (github.event.schedule 
+      && (github.event.schedule
              || !contains(github.actor, '[bot]'))
-      && (github.event.inputs.job_to_run == 'all' 
-             || github.event.inputs.job_to_run == 'android' 
+      && (github.event.inputs.job_to_run == 'all'
+             || github.event.inputs.job_to_run == 'android'
              || github.event_name == 'schedule')
     needs: env
     uses: ./.github/workflows/_mobile_container_ci.yml
@@ -159,7 +159,7 @@ jobs:
             ${{ matrix.output }}-pom.xml.asc \
             ${{ matrix.output }}-sources.jar.asc \
             ${{ matrix.output }}-javadoc.jar.asc
-            
+
   python-release:
     permissions:
       actions: read
@@ -170,7 +170,7 @@ jobs:
       && (github.event_name == 'workflow_dispatch')
       && (github.event.inputs.job_to_run == 'all'
              || github.event.inputs.job_to_run == 'python')
-    needs: env      
+    needs: env
     name: Build and Publish Python Wheel
     uses: ./.github/workflows/_mobile_container_ci.yml
     with:
@@ -184,7 +184,7 @@ jobs:
           run: |
             mkdir -p /tmp/dist
             WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
-            
+
             if [[ -z "$WHEEL_PATH" ]]; then
                 echo "Error: No wheel file found in /tmp/container-output/build"
                 ls -R /tmp/container-output/
@@ -193,7 +193,7 @@ jobs:
             python3 -m venv envoy_wheel
             source envoy_wheel/bin/activate
             pip install patchelf auditwheel
-            
+
             auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
           shell: bash
       target: ${{ matrix.target }}
@@ -212,7 +212,7 @@ jobs:
             -c opt --strip=always
             //library/python:envoy_mobile_wheel
             --//library/python:python_platform="manylinux2014_x86_64"
-            
+
   python-publish:
     needs: python-release
     if: >-
@@ -220,7 +220,7 @@ jobs:
         && (github.event.inputs.job_to_run == 'all'
                || github.event.inputs.job_to_run == 'python')
         && (needs.python-release.result == 'success')
-    permissions: 
+    permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -184,7 +184,7 @@ jobs:
             WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
             
             if [[ -z "$WHEEL_PATH" ]]; then
-                echo "p Error: No wheel file found in /tmp/container-output/build"
+                echo "Error: No wheel file found in /tmp/container-output/build"
                 ls -R /tmp/container-output/
                 exit 1
             fi

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -232,6 +232,6 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: python-wheel
-        path: .
+        path: dist/
     - name: Publish to PyPi
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -201,16 +201,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: envoy_mobile_wheel
-            args: >-
-              build
-              --config=ci
-              --config=mobile-rbe
-              --config=mobile-release
-              -c opt --strip=always
-              //library/python:envoy_mobile_wheel
-              --//library/python:python_platform="manylinux2014_x86_64"
-              --@rules_python//python/config_settings:python_version="3.13.1"
+        - target: envoy_mobile_wheel
+          args: >-
+            build
+            --config=ci
+            --config=mobile-rbe
+            --config=mobile-release
+            -c opt --strip=always
+            //library/python:envoy_mobile_wheel
+            --//library/python:python_platform="manylinux2014_x86_64"
+            --@rules_python//python/config_settings:python_version="3.13.1"
   python-publish:
     needs: python-release
     if: >-
@@ -230,9 +230,9 @@ jobs:
       name: pypi
       url: https://pypi.org/p/envoy-mobile
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: python-wheel
-          path: .
-      - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: actions/download-artifact@v4
+      with:
+        name: python-wheel
+        path: .
+    - name: Publish to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -12,9 +12,9 @@ on:
         default: 'all'
         type: choice
         options:
-          - all
-          - android
-          - python
+        - all
+        - android
+        - python
   schedule:
   # Mondays at 1pm UTC (8am EST)
   - cron: "0 13 * * 1"
@@ -33,9 +33,12 @@ jobs:
       contents: read
       packages: read
     if: >-
-      ${{ github.repository == 'envoyproxy/envoy' && 
-          (github.event.schedule || !contains(github.actor, '[bot]')) &&
-          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'android' || github.event_name == 'schedule') }}
+      github.repository == 'envoyproxy/envoy'
+      && (github.event.schedule 
+             || !contains(github.actor, '[bot]'))
+      && (github.event.inputs.job_to_run == 'all' 
+             || github.event.inputs.job_to_run == 'android' 
+             || github.event_name == 'schedule')
     needs: env
     uses: ./.github/workflows/_mobile_container_ci.yml
     with:
@@ -49,22 +52,22 @@ jobs:
       request: ${{ needs.env.outputs.request }}
       steps-pre: |
         - run: |
-            mkdir /tmp/mobile
-            VERSION="0.5.0.$(date '+%Y%m%d')"
-            echo "VERSION=${VERSION}" >> $GITHUB_ENV
+              mkdir /tmp/mobile
+              VERSION="0.5.0.$(date '+%Y%m%d')"
+              echo "VERSION=${VERSION}" >> $GITHUB_ENV
           shell: bash
       steps-post: |
         - run: |
-            mkdir /tmp/output
+              mkdir /tmp/output
           shell: bash
         - name: Tar artifacts
           run: >-
-            tar
-            -czhf
-            /tmp/output/${{ matrix.output }}_android_aar_sources.tar.gz
-            -C
-            /tmp/container-output/build
-            .
+              tar
+              -czhf
+              /tmp/output/${{ matrix.output }}_android_aar_sources.tar.gz
+              -C
+              /tmp/container-output/build
+              .
           shell: bash
       target: ${{ matrix.target }}
       upload-name: ${{ matrix.output }}_android_aar_sources
@@ -87,9 +90,11 @@ jobs:
   android-deploy:
     needs: android-release
     if: >-
-      ${{ always() && 
-          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'android' || github.event_name == 'schedule') &&
-          (needs.android-release.result == 'success') }}
+      always()
+      && (github.event.inputs.job_to_run == 'all'
+             || github.event.inputs.job_to_run == 'android'
+             || github.event_name == 'schedule')
+      && (needs.android-release.result == 'success')
     permissions:
       contents: read
       packages: read
@@ -159,9 +164,10 @@ jobs:
       contents: read
       packages: read
     if: >-
-      ${{ github.repository == 'envoyproxy/envoy' && 
-          (github.event_name == 'workflow_dispatch') &&
-          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'python') }}
+      github.repository == 'envoyproxy/envoy'
+      && (github.event_name == 'workflow_dispatch')
+      && (github.event.inputs.job_to_run == 'all'
+             || github.event.inputs.job_to_run == 'python')
     needs: env      
     name: Build and Publish Python Wheel
     uses: ./.github/workflows/_mobile_container_ci.yml
@@ -174,19 +180,19 @@ jobs:
       steps-post: |
         - name: Repair wheel
           run: |
-            mkdir -p /tmp/dist
-            WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
+              mkdir -p /tmp/dist
+              WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
             
-            if [ -z "$WHEEL_PATH" ]; then
-              echo "p Error: No wheel file found in /tmp/container-output/build"
-              ls -R /tmp/container-output/
-              exit 1
-            fi
-            python3 -m venv envoy_wheel
-            source envoy_wheel/bin/activate
-            pip install patchelf auditwheel
+              if [[ -z "$WHEEL_PATH" ]]; then
+                  echo "p Error: No wheel file found in /tmp/container-output/build"
+                  ls -R /tmp/container-output/
+                  exit 1
+              fi
+              python3 -m venv envoy_wheel
+              source envoy_wheel/bin/activate
+              pip install patchelf auditwheel
             
-            auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
+              auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
           shell: bash
       target: ${{ matrix.target }}
       upload-name: python-wheel
@@ -208,9 +214,10 @@ jobs:
   python-publish:
     needs: python-release
     if: >-
-      ${{ always() && 
-          (github.event.inputs.job_to_run == 'all' || github.event.inputs.job_to_run == 'python') &&
-          (needs.python-release.result == 'success') }}
+      always()
+        && (github.event.inputs.job_to_run == 'all'
+               || github.event.inputs.job_to_run == 'python')
+        && (needs.python-release.result == 'success')
     permissions: 
       contents: read
       id-token: write
@@ -221,7 +228,7 @@ jobs:
       fail-fast: false
     environment:
       name: pypi
-      url: https://pypi.org/p/<your-package-name>
+      url: https://pypi.org/p/envoy-mobile
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -52,22 +52,22 @@ jobs:
       request: ${{ needs.env.outputs.request }}
       steps-pre: |
         - run: |
-              mkdir /tmp/mobile
-              VERSION="0.5.0.$(date '+%Y%m%d')"
-              echo "VERSION=${VERSION}" >> $GITHUB_ENV
+            mkdir /tmp/mobile
+            VERSION="0.5.0.$(date '+%Y%m%d')"
+            echo "VERSION=${VERSION}" >> $GITHUB_ENV
           shell: bash
       steps-post: |
         - run: |
-              mkdir /tmp/output
+            mkdir /tmp/output
           shell: bash
         - name: Tar artifacts
           run: >-
-              tar
-              -czhf
-              /tmp/output/${{ matrix.output }}_android_aar_sources.tar.gz
-              -C
-              /tmp/container-output/build
-              .
+            tar
+            -czhf
+            /tmp/output/${{ matrix.output }}_android_aar_sources.tar.gz
+            -C
+            /tmp/container-output/build
+            .
           shell: bash
       target: ${{ matrix.target }}
       upload-name: ${{ matrix.output }}_android_aar_sources
@@ -180,19 +180,19 @@ jobs:
       steps-post: |
         - name: Repair wheel
           run: |
-              mkdir -p /tmp/dist
-              WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
+            mkdir -p /tmp/dist
+            WHEEL_PATH=$(find /tmp/container-output/build -name "*.whl" | head -n 1)
             
-              if [[ -z "$WHEEL_PATH" ]]; then
-                  echo "p Error: No wheel file found in /tmp/container-output/build"
-                  ls -R /tmp/container-output/
-                  exit 1
-              fi
-              python3 -m venv envoy_wheel
-              source envoy_wheel/bin/activate
-              pip install patchelf auditwheel
+            if [[ -z "$WHEEL_PATH" ]]; then
+                echo "p Error: No wheel file found in /tmp/container-output/build"
+                ls -R /tmp/container-output/
+                exit 1
+            fi
+            python3 -m venv envoy_wheel
+            source envoy_wheel/bin/activate
+            pip install patchelf auditwheel
             
-              auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
+            auditwheel repair "$WHEEL_PATH" --wheel-dir /tmp/dist
           shell: bash
       target: ${{ matrix.target }}
       upload-name: python-wheel

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -27,8 +27,6 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/_load_env.yml
-    with:
-      cache-docker: false
 
   android-release:
     permissions:

--- a/mobile/library/python/BUILD
+++ b/mobile/library/python/BUILD
@@ -115,6 +115,7 @@ py_wheel(
         ":is_macos_arm64": "macosx_11_0_arm64",
         "//conditions:default": "any",
     }),
+    abi = "cp313",
     python_tag = python_tag(),
     strip_path_prefixes = [
         "mobile/library/python",

--- a/mobile/library/python/BUILD
+++ b/mobile/library/python/BUILD
@@ -115,7 +115,6 @@ py_wheel(
         ":is_macos_arm64": "macosx_11_0_arm64",
         "//conditions:default": "any",
     }),
-    abi = "cp313",
     python_tag = python_tag(),
     strip_path_prefixes = [
         "mobile/library/python",


### PR DESCRIPTION
Create a new workflow that runs on manual dispatch that builds and repairs the mobile/library/python whl and uploads to pypi

Some things that still need work:

The workflow currently only runs on manual dispatch.  We could change it to run when changes are made to the //library/python:envoy_mobile_wheel target, but the upload to pypi will fail unless the version is bumped in the BUILD configuration

~~The workflow is currently still configured for test PyPi.  We need to set up an account and credentials for an official PyPi repo and add them to the repository as a secret~~