### PR TITLE
Ext Proc: Fix unintended conversion from unit32 to int32 in ext_proc.h

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -151,8 +151,8 @@ public:
   const std::string& httpResponseCodeDetails() const { return http_response_code_details_; }
   void incrementRequestBodySentCount() { request_body_sent_++; }
   void incrementResponseBodySentCount() { response_body_sent_++; }
-  int32_t requestBodySentCount() const { return request_body_sent_; }
-  int32_t responseBodySentCount() const { return response_body_sent_; }
+  uint32_t requestBodySentCount() const { return request_body_sent_; }
+  uint32_t responseBodySentCount() const { return response_body_sent_; }
 
   ProtobufTypes::MessagePtr serializeAsProto() const override;
 


### PR DESCRIPTION
Commit Message: Fix unintentional conversion from uinst32 to int32. `request_body_sent_` and `response_body_sent_` are type unint32_t
Risk Level: None
Testing: Ran integration test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

/assign @adisuissa 
/assign @yanjunxiang-google 