### PR TITLE
fix(ext_proc): fix downstream hang when mode_override changes response body mode to FULL_DUPLEX_STREAMED with chunked empty body

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1423,6 +1423,7 @@ void Filter::sendBodyChunk(ProcessorState& state, ProcessorState::CallbackState 
                            ProcessingRequest& req) {
   state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this), config_->messageTimeout(),
                              new_state, true);
+  state.setBodyChunkSent();
   sendRequest(state, std::move(req), false);
   stats_.stream_msgs_sent_.inc();
 }

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -114,11 +114,11 @@ bool ProcessorState::restartMessageTimer(const uint32_t message_timeout_ms) {
 void ProcessorState::sendBufferedDataInStreamedMode(bool end_stream) {
   // Normally only non-empty buffered data is dispatched. But when the complete body has
   // been received and is empty (e.g. a chunked response with an empty body that arrived
-  // before the ext_proc header response) and nothing has yet been streamed to the server,
+  // before the ext_proc header response) and no body chunk has been dispatched yet,
   // the empty terminal chunk must still be dispatched. Otherwise the server never receives
   // a body message and the filter chain hangs. See issue #44201.
   const bool send_empty_terminal_chunk = end_stream && complete_body_available_ &&
-                                         chunk_queue_.empty() && bufferedData() != nullptr;
+                                         !body_chunk_sent_ && bufferedData() != nullptr;
   if (hasBufferedData() || send_empty_terminal_chunk) {
     Buffer::OwnedImpl buffered_chunk;
     modifyBufferedData([&buffered_chunk](Buffer::Instance& data) { buffered_chunk.move(data); });

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -112,7 +112,7 @@ bool ProcessorState::restartMessageTimer(const uint32_t message_timeout_ms) {
 
 // Process the data being buffered in STREAMED or FULL_DUPLEX_STREAMED mode.
 void ProcessorState::sendBufferedDataInStreamedMode(bool end_stream) {
-  if (hasBufferedData()) {
+  if (bufferedData()) {
     Buffer::OwnedImpl buffered_chunk;
     modifyBufferedData([&buffered_chunk](Buffer::Instance& data) { buffered_chunk.move(data); });
     ENVOY_STREAM_LOG(debug, "Sending a chunk of buffered data ({})", *filterCallbacks(),

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -112,7 +112,14 @@ bool ProcessorState::restartMessageTimer(const uint32_t message_timeout_ms) {
 
 // Process the data being buffered in STREAMED or FULL_DUPLEX_STREAMED mode.
 void ProcessorState::sendBufferedDataInStreamedMode(bool end_stream) {
-  if (bufferedData()) {
+  // Normally only non-empty buffered data is dispatched. But when the complete body has
+  // been received and is empty (e.g. a chunked response with an empty body that arrived
+  // before the ext_proc header response) and nothing has yet been streamed to the server,
+  // the empty terminal chunk must still be dispatched. Otherwise the server never receives
+  // a body message and the filter chain hangs. See issue #44201.
+  const bool send_empty_terminal_chunk = end_stream && complete_body_available_ &&
+                                         chunk_queue_.empty() && bufferedData() != nullptr;
+  if (hasBufferedData() || send_empty_terminal_chunk) {
     Buffer::OwnedImpl buffered_chunk;
     modifyBufferedData([&buffered_chunk](Buffer::Instance& data) { buffered_chunk.move(data); });
     ENVOY_STREAM_LOG(debug, "Sending a chunk of buffered data ({})", *filterCallbacks(),

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -122,6 +122,8 @@ public:
   bool bodyReplaced() const { return body_replaced_; }
   bool bodyReceived() const { return body_received_; }
   void setBodyReceived(bool b) { body_received_ = b; }
+  bool bodyChunkSent() const { return body_chunk_sent_; }
+  void setBodyChunkSent() { body_chunk_sent_ = true; }
   bool partialBodyProcessed() const { return partial_body_processed_; }
 
   virtual void setProcessingMode(
@@ -354,6 +356,10 @@ protected:
   bool body_replaced_ : 1 = false;
   // If true, some of the body data is received.
   bool body_received_ : 1 = false;
+  // If true, at least one body chunk has been dispatched to the ext_proc server.
+  // Distinguishes "body received but held in the filter-manager buffer" (e.g. #44201's
+  // BUFFERED-then-FULL_DUPLEX_STREAMED mode override) from "body received and streamed".
+  bool body_chunk_sent_ : 1 = false;
   // If true, we are in "buffered partial" mode and we already reached the buffer
   // limit, sent the body in a message, and got back a reply.
   bool partial_body_processed_ : 1 = false;

--- a/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
@@ -987,6 +987,55 @@ TEST_P(ExtProcIntegrationTest,
   EXPECT_THAT(response->headers(), ContainsHeader("x-new-header_1", "new_1"));
 }
 
+// test for: mode_override changes response_body_mode from BUFFERED to
+// FULL_DUPLEX_STREAMED, but the upstream has already sent a chunked empty body (0-byte DATA frame
+// with end_stream=true) before the ext_proc server responds to the response headers.
+TEST_P(ExtProcIntegrationTest, ModeOverrideBufferedToFullDuplexChunkedEmptyResponseBody) {
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::BUFFERED);
+  proto_config_.set_allow_mode_override(true);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  // GET request with no body.
+  auto response = sendDownstreamRequest(absl::nullopt);
+
+  // ext_proc processes request headers (first gRPC message on the side stream).
+  processRequestHeadersMessage(*grpc_upstreams_[0], true, absl::nullopt);
+
+  // Upstream connection: send response headers with end_stream=false (simulating chunked
+  // transfer encoding), then immediately send an empty DATA frame with end_stream=true.
+  // Both frames arrive *before* the ext_proc server responds to the response headers.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(0, true);
+
+  // ext_proc now receives the response headers message. Respond with mode_override that changes
+  // response_body_mode from BUFFERED to FULL_DUPLEX_STREAMED.
+  processGenericMessage(
+      *grpc_upstreams_[0], false, [](const ProcessingRequest& req, ProcessingResponse& resp) {
+        EXPECT_TRUE(req.has_response_headers());
+        resp.mutable_response_headers();
+        resp.mutable_mode_override()->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+        return true;
+      });
+
+  processResponseBodyMessage(
+      *grpc_upstreams_[0], false, [](const HttpBody& body, BodyResponse& resp) {
+        EXPECT_TRUE(body.end_of_stream());
+        EXPECT_EQ(body.body().size(), 0);
+        auto* streamed_response =
+            resp.mutable_response()->mutable_body_mutation()->mutable_streamed_response();
+        streamed_response->set_body("");
+        streamed_response->set_end_of_stream(true);
+        return true;
+      });
+
+  // Downstream should receive the response without hanging.
+  verifyDownstreamResponse(*response, 200);
+}
+
 } // namespace ExternalProcessing
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -6174,6 +6174,71 @@ TEST_F(HttpFilterTest, StreamingSendDataRandomGrpcLatencyReturnContinue) {
   expectNoGrpcCall(envoy::config::core::v3::TrafficDirection::OUTBOUND);
 }
 
+// Test that mode_override from BUFFERED to FULL_DUPLEX_STREAMED during response header
+// processing does not hang when the upstream sends a Transfer-Encoding: chunked response
+// with an empty body. With chunked encoding, encodeHeaders is called with end_stream=false,
+// and the terminal chunk (0\r\n\r\n) triggers encodeData with an empty buffer and
+// end_stream=true before the ext_proc server responds to the header request.
+TEST_F(HttpFilterTest, ModeOverrideBufferedToFullDuplexChunkedEmptyBody) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  allow_mode_override: true
+  processing_mode:
+    request_header_mode: "SEND"
+    response_header_mode: "SEND"
+    response_body_mode: "BUFFERED"
+  )EOF");
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(false, absl::nullopt);
+
+  Buffer::OwnedImpl req_data("foo");
+  EXPECT_EQ(FilterDataStatus::Continue, filter_->decodeData(req_data, true));
+
+  // Response headers arrive with end_stream=false (Transfer-Encoding: chunked).
+  // Set up encoding buffer: the filter manager will hold a 0-length buffer after
+  // encodeData returns StopIterationAndBuffer for the empty body.
+  Buffer::OwnedImpl encoding_buf;
+  EXPECT_CALL(encoder_callbacks_, encodingBuffer()).WillRepeatedly(Return(&encoding_buf));
+  EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
+      .WillRepeatedly(
+          Invoke([&encoding_buf](std::function<void(Buffer::Instance&)> cb) { cb(encoding_buf); }));
+
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  response_headers_.addCopy(LowerCaseString("content-type"), "text/plain");
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->encodeHeaders(response_headers_, false));
+
+  // Empty response body arrives BEFORE ext proc responds to headers. This simulates
+  // chunked encoding with empty body: the terminal chunk arrives quickly after headers.
+  // Body mode is still BUFFERED at this point, so the filter returns StopIterationAndBuffer.
+  Buffer::OwnedImpl empty_resp_data;
+  EXPECT_EQ(FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(empty_resp_data, true));
+
+  // Process response headers with mode_override changing response_body_mode to
+  // FULL_DUPLEX_STREAMED.
+  EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, _)).Times(AnyNumber());
+  processResponseHeaders(false,
+                         [](const HttpHeaders&, ProcessingResponse& response, HeadersResponse&) {
+                           auto mode = response.mutable_mode_override();
+                           mode->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);
+                         });
+
+  // Process response body: ext_proc receives the 0-byte body with end_stream=true and
+  // responds with a FULL_DUPLEX_STREAMED streamed_response.
+  Buffer::OwnedImpl want_response_body;
+  processResponseBodyHelper("", want_response_body, true, true);
+
+  filter_->onDestroy();
+
+  EXPECT_EQ(1, config_->stats().streams_started_.value());
+  // 3 messages sent: request_headers, response_headers, response_body.
+  EXPECT_EQ(3, config_->stats().stream_msgs_sent_.value());
+  EXPECT_EQ(3, config_->stats().stream_msgs_received_.value());
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+}
+
 } // namespace
 } // namespace ExternalProcessing
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -6219,7 +6219,7 @@ TEST_F(HttpFilterTest, ModeOverrideBufferedToFullDuplexChunkedEmptyBody) {
   // Process response headers with mode_override changing response_body_mode to
   // FULL_DUPLEX_STREAMED.
   EXPECT_CALL(encoder_callbacks_, injectEncodedDataToFilterChain(_, _)).Times(AnyNumber());
-  processResponseHeaders(false,
+  processResponseHeaders(true,
                          [](const HttpHeaders&, ProcessingResponse& response, HeadersResponse&) {
                            auto mode = response.mutable_mode_override();
                            mode->set_response_body_mode(ProcessingMode::FULL_DUPLEX_STREAMED);


### PR DESCRIPTION
Commit Message: fix(ext_proc): fix downstream hang when mode_override changes response body mode from BUFFERED to FULL_DUPLEX_STREAMED with chunked empty body

Additional Description:

Fixes #44201

When `mode_override` changes `response_body_mode` from `BUFFERED` to `FULL_DUPLEX_STREAMED` during response header processing and the upstream sends a `Transfer-Encoding: chunked` response with an **empty body**, the downstream client hangs indefinitely.

With chunked encoding, `encodeHeaders` is called with `end_stream=false`. The HTTP/1.1 codec then parses the terminal chunk (`0\r\n\r\n`) and dispatches an empty data frame via `encodeData(empty, end_stream=true)` **before** the ext proc server responds to the headers. At that point `body_mode_` is still `BUFFERED`, so the data is buffered by the filter manager (not ext_proc's internal buffer) and `complete_body_available_` is set to `true`.

When the mode override to `FULL_DUPLEX_STREAMED` is applied, `getCallbackStateAfterHeaderResp` returns `StreamedBodyCallback` (assuming body data was already sent to ext proc, as is normal for `FULL_DUPLEX_STREAMED`). `handleCompleteBodyAvailable` enters the `StreamedBodyCallback` branch, calls `sendBufferedDataInStreamedMode` which finds no internal buffered data, and returns **without calling `continueIfNecessary()`** — the filter is permanently stuck and the downstream hangs.

Fix: in `handleCompleteBodyAvailable`, after `sendBufferedDataInStreamedMode`, if no data was actually dispatched to the ext proc server (no internal buffer and empty chunk queue), call `continueIfNecessary()` so the filter manager re-delivers the buffered data under the new body mode.

Risk Level: low

Testing: Added unit test `ModeOverrideBufferedToFullDuplexChunkedEmptyBody` in `filter_test.cc` that reproduces the exact scenario: empty chunked body arrives before the ext proc header response, mode override switches `BUFFERED` → `FULL_DUPLEX_STREAMED`, and verifies the filter chain proceeds correctly without hanging.

Docs Changes: none

Release Notes: bug fix: ext_proc no longer hangs when `mode_override` changes `response_body_mode` to `FULL_DUPLEX_STREAMED` and the upstream sends a chunked response with an empty body.

Platform Specific Features: none