### PR TITLE
Remove ScopeStatsLimitSettings: no longer needed since stats dropped …

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <functional>
 #include <memory>
 
@@ -28,17 +27,6 @@ using HistogramOptConstRef = absl::optional<std::reference_wrapper<const Histogr
 using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextReadout>>;
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
-
-// Settings for limiting the number of counters, gauges and histograms allowed
-// in a scope. This currently only supports thread local stats.
-struct ScopeStatsLimitSettings {
-  // Max number of counters allowed in this scope. 0 means no limit.
-  uint32_t max_counters = 0;
-  // Max number of gauges allowed in this scope. 0 means no limit.
-  uint32_t max_gauges = 0;
-  // Max number of histograms allowed in this scope. 0 means no limit.
-  uint32_t max_histograms = 0;
-};
 
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 
@@ -85,13 +73,11 @@ public:
    * @param name supplies the scope's namespace prefix.
    * @param evictable whether unused metrics can be deleted from the scope caches. This requires
    * that the metrics are not stored by reference.
-   * @param limits metric limits for counters, gauges and histograms allowed in this scope.
    * @param matcher optional per-scope stats matcher; replaces the store-level matcher when set.
    * NOTE: If the scope specific matcher is set, then the sub scope will inherit the same matcher
    * unless another matcher is explicitly set.
    */
   virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                                     const ScopeStatsLimitSettings& limits = {},
                                      StatsMatcherSharedPtr matcher = nullptr) PURE;
 
   /**
@@ -102,13 +88,11 @@ public:
    * @param name supplies the scope's namespace prefix.
    * @param evictable whether unused metrics can be deleted from the scope caches. This requires
    * that the metrics are not stored by reference.
-   * @param limits metric limits for counters, gauges and histograms allowed in this scope.
    * @param matcher optional per-scope stats matcher; replaces the store-level matcher when set.
    * NOTE: If the scope specific matcher is set, then the sub scope will inherit the same matcher
    * unless another matcher is explicitly set.
    */
   virtual ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                           const ScopeStatsLimitSettings& limits = {},
                                            StatsMatcherSharedPtr matcher = nullptr) PURE;
 
   /**

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -178,9 +178,8 @@ public:
    * @return a scope of the given name.
    */
   ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                             const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) {
-    return rootScope()->createScope(name, evictable, limits, std::move(matcher));
+    return rootScope()->createScope(name, evictable, std::move(matcher));
   }
 
   /**

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -64,14 +64,12 @@ ConstScopeSharedPtr IsolatedStoreImpl::constRootScope() const {
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
 ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool,
-                                              const ScopeStatsLimitSettings& limits,
                                               StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), false, limits, std::move(matcher));
+  return scopeFromStatName(stat_name_storage.statName(), false, std::move(matcher));
 }
 
 ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name, bool,
-                                                    const ScopeStatsLimitSettings&,
                                                     StatsMatcherSharedPtr matcher) {
   SymbolTable::StoragePtr prefix_name_storage = symbolTable().join({prefix(), name});
   // Use explicit matcher if provided; otherwise inherit scope_matcher_.

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -337,10 +337,8 @@ public:
         .value_or(store_.null_counter_);
   }
   ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                             const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) override;
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                   const ScopeStatsLimitSettings& limits = {},
                                    StatsMatcherSharedPtr matcher = nullptr) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -159,21 +159,19 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
 }
 
 ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name, bool evictable,
-                                                            const ScopeStatsLimitSettings& limits,
                                                             StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), evictable, limits, std::move(matcher));
+  return scopeFromStatName(stat_name_storage.statName(), evictable, std::move(matcher));
 }
 
 ScopeSharedPtr
 ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable,
-                                                   const ScopeStatsLimitSettings& limits,
                                                    StatsMatcherSharedPtr matcher) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
   // Use explicit matcher if provided; otherwise inherit scope_matcher_ (which may be null,
   // meaning the store-level matcher is used).
   StatsMatcherSharedPtr child_matcher = matcher ? std::move(matcher) : scope_matcher_;
-  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable, limits,
+  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable,
                                                std::move(child_matcher));
   parent_.addScope(new_scope);
   return new_scope;
@@ -408,12 +406,11 @@ void ThreadLocalStoreImpl::clearHistogramsFromCaches() {
 }
 
 ThreadLocalStoreImpl::ScopeImpl::ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix,
-                                           bool evictable, const ScopeStatsLimitSettings& limits,
+                                           bool evictable,
                                            StatsMatcherSharedPtr scope_matcher)
-    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable), limits_(limits),
+    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable),
       scope_matcher_(std::move(scope_matcher)), prefix_(prefix, parent.alloc_.symbolTable()),
       central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {
-  parent_.ensureOverflowStats(limits_);
 }
 
 ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() {
@@ -531,24 +528,6 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
                                                effectiveMatcher())) {
     return null_stat;
   } else {
-    // Stat creation here. Check limits.
-    if constexpr (std::is_same_v<StatType, Counter>) {
-      if (limits_.max_counters != 0 && central_cache_map.size() >= limits_.max_counters) {
-        parent_.counters_overflow_->inc();
-        return null_stat;
-      }
-    } else if constexpr (std::is_same_v<StatType, Gauge>) {
-      if (limits_.max_gauges != 0 && central_cache_map.size() >= limits_.max_gauges) {
-        parent_.gauges_overflow_->inc();
-        return null_stat;
-      }
-    } else {
-      // TextReadouts are currently not limited, but we must ensure they are the only
-      // other type being handled. This static_assert will trigger a compilation error
-      // if a new StatType is introduced in the future, forcing the developer to
-      // explicitly decide how to handle its limits.
-      static_assert(std::is_same_v<StatType, TextReadout>, "Unexpected StatType");
-    }
     StatNameTagHelper tag_helper(parent_, name_no_tags, stat_name_tags);
 
     RefcountPtr<StatType> stat = make_stat(
@@ -721,11 +700,6 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatNameWithTags(
       if (iter != parent_.histogram_set_.end()) {
         stat = RefcountPtr<ParentHistogramImpl>(*iter);
       } else {
-        if (limits_.max_histograms != 0 &&
-            central_cache->histograms_.size() >= limits_.max_histograms) {
-          parent_.histograms_overflow_->inc();
-          return parent_.null_histogram_;
-        }
         stat = new ParentHistogramImpl(final_stat_name, unit, parent_,
                                        tag_helper.tagExtractedName(), tag_helper.statNameTags(),
                                        *buckets, bins, parent_.next_histogram_id_++);
@@ -1276,33 +1250,6 @@ void ThreadLocalStoreImpl::extractAndAppendTags(absl::string_view name, StatName
   tagProducer().produceTags(name, tags);
   for (const auto& tag : tags) {
     stat_tags.emplace_back(pool.add(tag.name_), pool.add(tag.value_));
-  }
-}
-
-void ThreadLocalStoreImpl::ensureOverflowStats(const ScopeStatsLimitSettings& limits) {
-  const bool need_counter_overflow_stat = limits.max_counters != 0;
-  const bool need_gauge_overflow_stat = limits.max_gauges != 0;
-  const bool need_histogram_overflow_stat = limits.max_histograms != 0;
-
-  if (!need_counter_overflow_stat && !need_gauge_overflow_stat && !need_histogram_overflow_stat) {
-    return;
-  }
-
-  Thread::LockGuard lock(lock_);
-  if (need_counter_overflow_stat && counters_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.counter");
-    counters_overflow_ = alloc_.makeCounter(name, name, {});
-  }
-  if (need_gauge_overflow_stat && gauges_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.gauge");
-    gauges_overflow_ = alloc_.makeCounter(name, name, {});
-  }
-  if (need_histogram_overflow_stat && histograms_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.histogram");
-    histograms_overflow_ = alloc_.makeCounter(name, name, {});
   }
 }
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -236,7 +236,7 @@ public:
                             StatNameTagVector& tags) override;
   const TagVector& fixedTags() override { return tag_producer_->fixedTags(); };
 
-  void ensureOverflowStats(const ScopeStatsLimitSettings& limits);
+  void ensureOverflowStats();
 
 private:
   friend class ThreadLocalStoreTestingPeer;
@@ -290,7 +290,6 @@ private:
 
   struct ScopeImpl : public Scope {
     ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix, bool evictable,
-              const ScopeStatsLimitSettings& limits = {},
               StatsMatcherSharedPtr scope_matcher = nullptr);
     ~ScopeImpl() override;
 
@@ -305,10 +304,8 @@ private:
     TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
                                                  StatNameTagVectorOptConstRef tags) override;
     ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                               const ScopeStatsLimitSettings& limits = {},
                                StatsMatcherSharedPtr matcher = nullptr) override;
     ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                     const ScopeStatsLimitSettings& limits = {},
                                      StatsMatcherSharedPtr matcher = nullptr) override;
     const SymbolTable& constSymbolTable() const final { return parent_.constSymbolTable(); }
     SymbolTable& symbolTable() final { return parent_.symbolTable(); }
@@ -474,8 +471,6 @@ private:
     const uint64_t scope_id_;
     ThreadLocalStoreImpl& parent_;
     const bool evictable_{};
-
-    const ScopeStatsLimitSettings limits_;
     StatsMatcherSharedPtr scope_matcher_;
 
   private:
@@ -615,10 +610,6 @@ private:
   // (e.g. when a scope is deleted), it is likely more efficient to batch their
   // cleanup, which would otherwise entail a post() per histogram per thread.
   std::vector<uint64_t> histograms_to_cleanup_ ABSL_GUARDED_BY(hist_mutex_);
-
-  CounterSharedPtr counters_overflow_;
-  CounterSharedPtr gauges_overflow_;
-  CounterSharedPtr histograms_overflow_;
 };
 
 using ThreadLocalStoreImplPtr = std::unique_ptr<ThreadLocalStoreImpl>;

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -78,19 +78,17 @@ public:
       : lock_(lock), wrapped_scope_(wrapped_scope), store_(store) {}
 
   ScopeSharedPtr createScope(const std::string& name, bool evictable,
-                             const ScopeStatsLimitSettings& limits,
                              StatsMatcherSharedPtr matcher = nullptr) override {
     Thread::LockGuard lock(lock_);
     return std::make_shared<TestScopeWrapper>(
-        lock_, wrapped_scope_->createScope(name, evictable, limits, std::move(matcher)), store_);
+        lock_, wrapped_scope_->createScope(name, evictable, std::move(matcher)), store_);
   }
 
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable,
-                                   const ScopeStatsLimitSettings& limits,
                                    StatsMatcherSharedPtr matcher = nullptr) override {
     Thread::LockGuard lock(lock_);
     return std::make_shared<TestScopeWrapper>(
-        lock_, wrapped_scope_->scopeFromStatName(name, evictable, limits, std::move(matcher)),
+        lock_, wrapped_scope_->scopeFromStatName(name, evictable, std::move(matcher)),
         store_);
   }
 

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -297,11 +297,11 @@ class MockScope : public TestUtil::TestScope {
 public:
   MockScope(StatName prefix, MockStore& store);
 
-  ScopeSharedPtr createScope(const std::string& name, bool, const ScopeStatsLimitSettings&,
+  ScopeSharedPtr createScope(const std::string& name, bool,
                              StatsMatcherSharedPtr = nullptr) override {
     return ScopeSharedPtr(createScope_(name));
   }
-  ScopeSharedPtr scopeFromStatName(StatName name, bool, const ScopeStatsLimitSettings&,
+  ScopeSharedPtr scopeFromStatName(StatName name, bool,
                                    StatsMatcherSharedPtr = nullptr) override {
     return createScope_(symbolTable().toString(name));
   }


### PR DESCRIPTION
Fixes #44162


stats: remove ScopeStatsLimitSettings and per-scope stat overflow counters

Additional Description : ScopeStatsLimitSettings was previously used to limit the number of
counters, gauges, and histograms in a shared memory block per scope.
Since stats no longer use shared memory, these limits have no effect
and there is no way to set them. The command-line options were
deprecated in #5910 (2019) and removed shortly after.

This removes the dead code entirely.

Note: This PR was developed with the assistance of generative AI 
The changes have been reviewed and understood by the author.


Risk Level: Low

Testing: No new tests needed. Existing tests continue to pass — the removed parameters had default values of {} (no limit) everywhere, so no behavior changes.

Docs Changes: None

Release Notes: None

Platform Specific Features: None

Deprecated: Removes ScopeStatsLimitSettings struct and the limits parameter from Scope::createScope and Scope::scopeFromStatName.
