### PR TITLE
stats: remove deprecated ScopeStatsLimitSettings

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -29,16 +29,6 @@ using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextR
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
-// Settings for limiting the number of counters, gauges and histograms allowed
-// in a scope. This currently only supports thread local stats.
-struct ScopeStatsLimitSettings {
-  // Max number of counters allowed in this scope. 0 means no limit.
-  uint32_t max_counters = 0;
-  // Max number of gauges allowed in this scope. 0 means no limit.
-  uint32_t max_gauges = 0;
-  // Max number of histograms allowed in this scope. 0 means no limit.
-  uint32_t max_histograms = 0;
-};
 
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 
@@ -91,7 +81,6 @@ public:
    * unless another matcher is explicitly set.
    */
   virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                                     const ScopeStatsLimitSettings& limits = {},
                                      StatsMatcherSharedPtr matcher = nullptr) PURE;
 
   /**
@@ -108,7 +97,6 @@ public:
    * unless another matcher is explicitly set.
    */
   virtual ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                           const ScopeStatsLimitSettings& limits = {},
                                            StatsMatcherSharedPtr matcher = nullptr) PURE;
 
   /**

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -178,9 +178,8 @@ public:
    * @return a scope of the given name.
    */
   ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                             const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) {
-    return rootScope()->createScope(name, evictable, limits, std::move(matcher));
+    return rootScope()->createScope(name, evictable, std::move(matcher));
   }
 
   /**

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -64,14 +64,12 @@ ConstScopeSharedPtr IsolatedStoreImpl::constRootScope() const {
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
 ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool,
-                                              const ScopeStatsLimitSettings& limits,
                                               StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), false, limits, std::move(matcher));
+  return scopeFromStatName(stat_name_storage.statName(), false, std::move(matcher));
 }
 
 ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name, bool,
-                                                    const ScopeStatsLimitSettings&,
                                                     StatsMatcherSharedPtr matcher) {
   SymbolTable::StoragePtr prefix_name_storage = symbolTable().join({prefix(), name});
   // Use explicit matcher if provided; otherwise inherit scope_matcher_.

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -337,10 +337,8 @@ public:
         .value_or(store_.null_counter_);
   }
   ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                             const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) override;
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                   const ScopeStatsLimitSettings& limits = {},
                                    StatsMatcherSharedPtr matcher = nullptr) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -159,21 +159,19 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
 }
 
 ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name, bool evictable,
-                                                            const ScopeStatsLimitSettings& limits,
                                                             StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), evictable, limits, std::move(matcher));
+  return scopeFromStatName(stat_name_storage.statName(), evictable, std::move(matcher));
 }
 
 ScopeSharedPtr
 ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable,
-                                                   const ScopeStatsLimitSettings& limits,
                                                    StatsMatcherSharedPtr matcher) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
   // Use explicit matcher if provided; otherwise inherit scope_matcher_ (which may be null,
   // meaning the store-level matcher is used).
   StatsMatcherSharedPtr child_matcher = matcher ? std::move(matcher) : scope_matcher_;
-  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable, limits,
+  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable,
                                                std::move(child_matcher));
   parent_.addScope(new_scope);
   return new_scope;
@@ -408,13 +406,11 @@ void ThreadLocalStoreImpl::clearHistogramsFromCaches() {
 }
 
 ThreadLocalStoreImpl::ScopeImpl::ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix,
-                                           bool evictable, const ScopeStatsLimitSettings& limits,
+                                           bool evictable,
                                            StatsMatcherSharedPtr scope_matcher)
-    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable), limits_(limits),
+    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable),
       scope_matcher_(std::move(scope_matcher)), prefix_(prefix, parent.alloc_.symbolTable()),
-      central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {
-  parent_.ensureOverflowStats(limits_);
-}
+      central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {}
 
 ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() {
   // Helps reproduce a previous race condition by pausing here in tests while we
@@ -531,24 +527,9 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
                                                effectiveMatcher())) {
     return null_stat;
   } else {
-    // Stat creation here. Check limits.
-    if constexpr (std::is_same_v<StatType, Counter>) {
-      if (limits_.max_counters != 0 && central_cache_map.size() >= limits_.max_counters) {
-        parent_.counters_overflow_->inc();
-        return null_stat;
-      }
-    } else if constexpr (std::is_same_v<StatType, Gauge>) {
-      if (limits_.max_gauges != 0 && central_cache_map.size() >= limits_.max_gauges) {
-        parent_.gauges_overflow_->inc();
-        return null_stat;
-      }
-    } else {
-      // TextReadouts are currently not limited, but we must ensure they are the only
-      // other type being handled. This static_assert will trigger a compilation error
-      // if a new StatType is introduced in the future, forcing the developer to
-      // explicitly decide how to handle its limits.
-      static_assert(std::is_same_v<StatType, TextReadout>, "Unexpected StatType");
-    }
+    // Limits don't need to be checked when creating stats because each scope's stats do not
+    // live in shared memory.
+
     StatNameTagHelper tag_helper(parent_, name_no_tags, stat_name_tags);
 
     RefcountPtr<StatType> stat = make_stat(
@@ -721,11 +702,6 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatNameWithTags(
       if (iter != parent_.histogram_set_.end()) {
         stat = RefcountPtr<ParentHistogramImpl>(*iter);
       } else {
-        if (limits_.max_histograms != 0 &&
-            central_cache->histograms_.size() >= limits_.max_histograms) {
-          parent_.histograms_overflow_->inc();
-          return parent_.null_histogram_;
-        }
         stat = new ParentHistogramImpl(final_stat_name, unit, parent_,
                                        tag_helper.tagExtractedName(), tag_helper.statNameTags(),
                                        *buckets, bins, parent_.next_histogram_id_++);
@@ -1276,33 +1252,6 @@ void ThreadLocalStoreImpl::extractAndAppendTags(absl::string_view name, StatName
   tagProducer().produceTags(name, tags);
   for (const auto& tag : tags) {
     stat_tags.emplace_back(pool.add(tag.name_), pool.add(tag.value_));
-  }
-}
-
-void ThreadLocalStoreImpl::ensureOverflowStats(const ScopeStatsLimitSettings& limits) {
-  const bool need_counter_overflow_stat = limits.max_counters != 0;
-  const bool need_gauge_overflow_stat = limits.max_gauges != 0;
-  const bool need_histogram_overflow_stat = limits.max_histograms != 0;
-
-  if (!need_counter_overflow_stat && !need_gauge_overflow_stat && !need_histogram_overflow_stat) {
-    return;
-  }
-
-  Thread::LockGuard lock(lock_);
-  if (need_counter_overflow_stat && counters_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.counter");
-    counters_overflow_ = alloc_.makeCounter(name, name, {});
-  }
-  if (need_gauge_overflow_stat && gauges_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.gauge");
-    gauges_overflow_ = alloc_.makeCounter(name, name, {});
-  }
-  if (need_histogram_overflow_stat && histograms_overflow_ == nullptr) {
-    StatNamePool pool(symbolTable());
-    StatName name = pool.add("server.stats_overflow.histogram");
-    histograms_overflow_ = alloc_.makeCounter(name, name, {});
   }
 }
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -236,7 +236,6 @@ public:
                             StatNameTagVector& tags) override;
   const TagVector& fixedTags() override { return tag_producer_->fixedTags(); };
 
-  void ensureOverflowStats(const ScopeStatsLimitSettings& limits);
 
 private:
   friend class ThreadLocalStoreTestingPeer;
@@ -290,7 +289,6 @@ private:
 
   struct ScopeImpl : public Scope {
     ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix, bool evictable,
-              const ScopeStatsLimitSettings& limits = {},
               StatsMatcherSharedPtr scope_matcher = nullptr);
     ~ScopeImpl() override;
 
@@ -305,10 +303,8 @@ private:
     TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
                                                  StatNameTagVectorOptConstRef tags) override;
     ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
-                               const ScopeStatsLimitSettings& limits = {},
                                StatsMatcherSharedPtr matcher = nullptr) override;
     ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
-                                     const ScopeStatsLimitSettings& limits = {},
                                      StatsMatcherSharedPtr matcher = nullptr) override;
     const SymbolTable& constSymbolTable() const final { return parent_.constSymbolTable(); }
     SymbolTable& symbolTable() final { return parent_.symbolTable(); }
@@ -475,7 +471,6 @@ private:
     ThreadLocalStoreImpl& parent_;
     const bool evictable_{};
 
-    const ScopeStatsLimitSettings limits_;
     StatsMatcherSharedPtr scope_matcher_;
 
   private:

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -446,7 +446,7 @@ generateStatsScope(const envoy::config::cluster::v3::Cluster& config,
       fmt::format("cluster.{}.", (!config.alt_stat_name().empty() && use_alt_stat_name)
                                      ? config.alt_stat_name()
                                      : config.name()),
-      false, {}, std::move(scope_matcher));
+      false, std::move(scope_matcher));
 }
 
 // TODO(pianiststickman): this implementation takes a lock on the hot path and puts a copy of the

--- a/test/common/stats/isolated_store_impl_test.cc
+++ b/test/common/stats/isolated_store_impl_test.cc
@@ -399,7 +399,7 @@ protected:
 TEST_F(IsolatedStoreScopeMatcherTest, ScopeMatcherRejectsAllStatTypes) {
   // Create a scope whose matcher rejects everything prefixed "scope.rejected.".
   ScopeSharedPtr my_scope =
-      scope_->createScope("scope", false, {}, makePrefixMatcher("scope.rejected."));
+      scope_->createScope("scope", false, makePrefixMatcher("scope.rejected."));
 
   // Rejected counter returns null counter (empty name, value always 0).
   Counter& rejected_counter = my_scope->counterFromString("rejected.foo");
@@ -466,7 +466,7 @@ TEST_F(IsolatedStoreScopeMatcherTest, ScopeWithNoMatcherAcceptsAll) {
 TEST_F(IsolatedStoreScopeMatcherTest, ChildScopeInheritsMatcher) {
   // Parent matcher rejects full names starting with "parent.child.".
   ScopeSharedPtr parent_scope =
-      scope_->createScope("parent", false, {}, makePrefixMatcher("parent.child."));
+      scope_->createScope("parent", false, makePrefixMatcher("parent.child."));
 
   // Stats directly in parent are not rejected.
   Counter& parent_counter = parent_scope->counterFromString("direct");
@@ -494,11 +494,11 @@ TEST_F(IsolatedStoreScopeMatcherTest, ChildScopeInheritsMatcher) {
 TEST_F(IsolatedStoreScopeMatcherTest, ChildScopeOverridesMatcher) {
   // Parent rejects "parent.child.rejected_by_parent.".
   ScopeSharedPtr parent_scope = scope_->createScope(
-      "parent", false, {}, makePrefixMatcher("parent.child.rejected_by_parent."));
+      "parent", false, makePrefixMatcher("parent.child.rejected_by_parent."));
 
   // Child gets its own matcher that rejects "parent.child.rejected_by_child." instead.
   ScopeSharedPtr child_scope = parent_scope->createScope(
-      "child", false, {}, makePrefixMatcher("parent.child.rejected_by_child."));
+      "child", false, makePrefixMatcher("parent.child.rejected_by_child."));
 
   // "rejected_by_parent" prefix is NOT rejected — child's matcher replaced parent's.
   Counter& not_rejected = child_scope->counterFromString("rejected_by_parent.foo");

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -500,79 +500,6 @@ TEST_F(StatsThreadLocalStoreTest, HistogramScopeOverlap) {
   tls_.shutdownThread();
 }
 
-TEST_F(StatsThreadLocalStoreTest, StatsNumLimitsWithEviction) {
-  InSequence s;
-  store_->initializeThreading(main_thread_dispatcher_, tls_);
-
-  ScopeSharedPtr scope = store_->createScope("scope.", true, {1, 1, 1});
-  EXPECT_EQ(0, TestUtility::findCounter(*store_, "server.stats_overflow.counter")->value());
-  EXPECT_EQ(0, TestUtility::findCounter(*store_, "server.stats_overflow.gauge")->value());
-  EXPECT_EQ(0, TestUtility::findCounter(*store_, "server.stats_overflow.histogram")->value());
-
-  {
-    Counter& c1 = scope->counterFromString("c1");
-    EXPECT_EQ("scope.c1", c1.name());
-    Counter& c2 = scope->counterFromString("c2");
-    EXPECT_EQ(&c2, &store_->nullCounter());
-    EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.counter")->value());
-
-    Gauge& g1 = scope->gaugeFromString("g1", Gauge::ImportMode::Accumulate);
-    EXPECT_EQ("scope.g1", g1.name());
-    Gauge& g2 = scope->gaugeFromString("g2", Gauge::ImportMode::Accumulate);
-    EXPECT_EQ(&g2, &store_->nullGauge());
-    EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.gauge")->value());
-
-    Histogram& h1 = scope->histogramFromString("h1", Histogram::Unit::Unspecified);
-    EXPECT_EQ("scope.h1", h1.name());
-    Histogram& h2 = scope->histogramFromString("h2", Histogram::Unit::Unspecified);
-    EXPECT_EQ("", h2.name());
-    EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.histogram")->value());
-
-    // c1, g1, h1 are used.
-    c1.inc();
-    g1.set(1);
-    EXPECT_CALL(sink_, onHistogramComplete(Ref(h1), 1));
-    h1.recordValue(1);
-    store_->mergeHistograms([]() -> void {});
-
-    // First eviction marks stats as unused.
-    store_->evictUnused();
-    EXPECT_FALSE(c1.used());
-    EXPECT_FALSE(g1.used());
-    EXPECT_FALSE(h1.used());
-  }
-
-  // Second eviction removes stats.
-  EXPECT_CALL(tls_, runOnAllThreads(_, _)).Times(testing::AtLeast(1));
-  store_->evictUnused();
-
-  // After eviction, we should be able to create new stats.
-  Counter& c3 = scope->counterFromString("c3");
-  EXPECT_EQ("scope.c3", c3.name());
-  EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.counter")->value());
-  Counter& c4 = scope->counterFromString("c4");
-  EXPECT_EQ(&c4, &store_->nullCounter());
-  EXPECT_EQ(2, TestUtility::findCounter(*store_, "server.stats_overflow.counter")->value());
-
-  Gauge& g3 = scope->gaugeFromString("g3", Gauge::ImportMode::Accumulate);
-  EXPECT_EQ("scope.g3", g3.name());
-  EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.gauge")->value());
-  Gauge& g4 = scope->gaugeFromString("g4", Gauge::ImportMode::Accumulate);
-  EXPECT_EQ(&g4, &store_->nullGauge());
-  EXPECT_EQ(2, TestUtility::findCounter(*store_, "server.stats_overflow.gauge")->value());
-
-  Histogram& h3 = scope->histogramFromString("h3", Histogram::Unit::Unspecified);
-  EXPECT_EQ("scope.h3", h3.name());
-  EXPECT_EQ(1, TestUtility::findCounter(*store_, "server.stats_overflow.histogram")->value());
-  Histogram& h4 = scope->histogramFromString("h4", Histogram::Unit::Unspecified);
-  EXPECT_EQ("", h4.name());
-  EXPECT_EQ(2, TestUtility::findCounter(*store_, "server.stats_overflow.histogram")->value());
-
-  tls_.shutdownGlobalThreading();
-  store_->shutdownThreading();
-  tls_.shutdownThread();
-}
-
 TEST_F(StatsThreadLocalStoreTest, ForEach) {
   auto collect_scopes = [this]() -> std::vector<std::string> {
     std::vector<std::string> names;
@@ -1472,7 +1399,7 @@ TEST_F(StatsMatcherTLSTest, ScopeMatcherReplacesGlobal) {
   // "scope.scope_rejected." (i.e. stat "scope_rejected.foo" inside "scope").
   StatsMatcherSharedPtr scope_matcher =
       makePrefixMatcher("scope.scope_rejected.", symbol_table_, context_);
-  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, {}, scope_matcher);
+  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, scope_matcher);
 
   // Within the scope, "scope_rejected.foo" has full name "scope.scope_rejected.foo" → rejected.
   Counter& scope_rejected = my_scope->counterFromString("scope_rejected.foo");
@@ -1494,7 +1421,7 @@ TEST_F(StatsMatcherTLSTest, SetStatsMatcherDoesNotAffectScopeWithOwnMatcher) {
   // Create a scope with its own matcher (rejects "scope.rejected").
   StatsMatcherSharedPtr scope_matcher =
       makePrefixMatcher("scope.rejected", symbol_table_, context_);
-  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, {}, scope_matcher);
+  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, scope_matcher);
 
   // Create a counter that is accepted by the scope matcher.
   Counter& c = my_scope->counterFromString("accepted.foo");
@@ -1519,7 +1446,7 @@ TEST_F(StatsMatcherTLSTest, SetStatsMatcherDoesNotAffectScopeWithOwnMatcher) {
 TEST_F(StatsMatcherTLSTest, ScopeMatcherRejectsAllStatTypesAndInheritsToChildren) {
   StatsMatcherSharedPtr scope_matcher =
       makePrefixMatcher("scope.rejected.", symbol_table_, context_);
-  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, {}, scope_matcher);
+  ScopeSharedPtr my_scope = store_->rootScope()->createScope("scope", false, scope_matcher);
 
   // Gauge: rejected stat returns null gauge (empty name, NeverImport).
   Gauge& rejected_gauge = my_scope->gaugeFromString("rejected.g", Gauge::ImportMode::Accumulate);

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -78,19 +78,17 @@ public:
       : lock_(lock), wrapped_scope_(wrapped_scope), store_(store) {}
 
   ScopeSharedPtr createScope(const std::string& name, bool evictable,
-                             const ScopeStatsLimitSettings& limits,
                              StatsMatcherSharedPtr matcher = nullptr) override {
     Thread::LockGuard lock(lock_);
     return std::make_shared<TestScopeWrapper>(
-        lock_, wrapped_scope_->createScope(name, evictable, limits, std::move(matcher)), store_);
+        lock_, wrapped_scope_->createScope(name, evictable, std::move(matcher)), store_);
   }
 
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable,
-                                   const ScopeStatsLimitSettings& limits,
                                    StatsMatcherSharedPtr matcher = nullptr) override {
     Thread::LockGuard lock(lock_);
     return std::make_shared<TestScopeWrapper>(
-        lock_, wrapped_scope_->scopeFromStatName(name, evictable, limits, std::move(matcher)),
+        lock_, wrapped_scope_->scopeFromStatName(name, evictable, std::move(matcher)),
         store_);
   }
 

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -297,11 +297,11 @@ class MockScope : public TestUtil::TestScope {
 public:
   MockScope(StatName prefix, MockStore& store);
 
-  ScopeSharedPtr createScope(const std::string& name, bool, const ScopeStatsLimitSettings&,
+  ScopeSharedPtr createScope(const std::string& name, bool,
                              StatsMatcherSharedPtr = nullptr) override {
     return ScopeSharedPtr(createScope_(name));
   }
-  ScopeSharedPtr scopeFromStatName(StatName name, bool, const ScopeStatsLimitSettings&,
+  ScopeSharedPtr scopeFromStatName(StatName name, bool,
                                    StatsMatcherSharedPtr = nullptr) override {
     return createScope_(symbolTable().toString(name));
   }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: stats: remove deprecated ScopeStatsLimitSettings

Additional Description: ScopeStatsLimitSettings limited the number of stats each scope could create. This was necessary when stats lived in shared memory, to prevent one scope from hogging the shared space. Stats now allocate from the heap, so these limits are unnecessary. ScopeStatsLimitSettings has been deprecated since then, leaving the struct as dead code.

Risk Level: Low

Testing: Removed tests that validated limit stats behavior. Changed tests that referenced ScopeStatsLimitSettings. All existing tests pass.

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
