### PR TITLE
bazel: add additional_libs support to envoy_directory_genrule

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -92,11 +92,14 @@ def envoy_contrib_package():
 def _envoy_directory_genrule_impl(ctx):
     tree = ctx.actions.declare_directory(ctx.attr.name + ".outputs")
     ctx.actions.run_shell(
-        inputs = ctx.files.srcs,
+        inputs = ctx.files.srcs + ctx.files.additional_libs,
         tools = ctx.files.tools,
         outputs = [tree],
         command = "mkdir -p " + tree.path + " && " + ctx.expand_location(ctx.attr.cmd),
-        env = {"GENRULE_OUTPUT_DIR": tree.path},
+        env = {
+            "GENRULE_OUTPUT_DIR": tree.path,
+            "LD_LIBRARY_PATH": ":".join([f.dirname for f in ctx.files.additional_libs]),
+        },
         use_default_shell_env = True,
         toolchain = None,
     )
@@ -108,6 +111,9 @@ envoy_directory_genrule = rule(
         "srcs": attr.label_list(),
         "cmd": attr.string(),
         "tools": attr.label_list(),
+        "additional_libs": attr.label(
+            allow_files = True,
+        ),
     },
 )
 


### PR DESCRIPTION
Add an `additional_libs` attribute to the `envoy_directory_genrule` rule, allowing callers to specify shared libraries that should be included as inputs and made available via LD_LIBRARY_PATH.
