### PR TITLE
Update buildkit to 0.29

### DIFF
--- a/ci/Dockerfile-buildkit
+++ b/ci/Dockerfile-buildkit
@@ -1,3 +1,3 @@
 # We dont build from this dockerfile - we just parse the version, but storing
 # here means we get the dependabot updates
-FROM moby/buildkit:v0.23.2
+FROM moby/buildkit:v0.29.0


### PR DESCRIPTION
Update moby/buildkit to 0.29.
Fixes CVE-2026-33747 and CVE-2026-33748  (buildkit >= 0.28.1).