### PR TITLE
Make CELFormatterCommandParser function without a thread-singleton

### DIFF
--- a/source/extensions/formatter/cel/cel.cc
+++ b/source/extensions/formatter/cel/cel.cc
@@ -85,10 +85,9 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
     if (!parse_status.ok()) {
       throw EnvoyException("Not able to parse expression: " + parse_status.status().ToString());
     }
-    Server::Configuration::ServerFactoryContext& context =
-        Server::Configuration::ServerFactoryContextInstance::get();
     return std::make_unique<CELFormatter>(
-        context.localInfo(), Extensions::Filters::Common::Expr::getBuilder(context),
+        server_factory_context_.localInfo(),
+        Extensions::Filters::Common::Expr::getBuilder(server_factory_context_),
         parse_status.value().expr(), max_length, command == "TYPED_CEL");
   }
 

--- a/source/extensions/formatter/cel/cel.h
+++ b/source/extensions/formatter/cel/cel.h
@@ -32,10 +32,15 @@ private:
 
 class CELFormatterCommandParser : public ::Envoy::Formatter::CommandParser {
 public:
-  CELFormatterCommandParser() = default;
+  explicit CELFormatterCommandParser(
+      Server::Configuration::ServerFactoryContext& server_factory_context)
+      : server_factory_context_(server_factory_context) {}
   ::Envoy::Formatter::FormatterProviderPtr parse(absl::string_view command,
                                                  absl::string_view subcommand,
                                                  absl::optional<size_t> max_length) const override;
+
+private:
+  Server::Configuration::ServerFactoryContext& server_factory_context_;
 };
 
 } // namespace Formatter

--- a/source/extensions/formatter/cel/config.cc
+++ b/source/extensions/formatter/cel/config.cc
@@ -8,14 +8,13 @@ namespace Envoy {
 namespace Extensions {
 namespace Formatter {
 
-::Envoy::Formatter::CommandParserPtr
-CELFormatterFactory::createCommandParserFromProto(const Protobuf::Message&,
-                                                  Server::Configuration::GenericFactoryContext&) {
+::Envoy::Formatter::CommandParserPtr CELFormatterFactory::createCommandParserFromProto(
+    const Protobuf::Message&, Server::Configuration::GenericFactoryContext& context) {
 #if defined(USE_CEL_PARSER)
   ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), warn,
                       "'CEL' formatter is treated as a built-in formatter and does not "
                       "require configuration.");
-  return std::make_unique<CELFormatterCommandParser>();
+  return std::make_unique<CELFormatterCommandParser>(context.serverFactoryContext());
 #else
   UNREFERENCED_PARAMETER(context);
   throw EnvoyException("CEL is not available for use in this environment.");
@@ -35,7 +34,9 @@ public:
   std::string name() const override { return "envoy.built_in_formatters.cel"; }
 
   ::Envoy::Formatter::CommandParserPtr createCommandParser() const override {
-    return std::make_unique<CELFormatterCommandParser>();
+    Server::Configuration::ServerFactoryContext& context =
+        Server::Configuration::ServerFactoryContextInstance::get();
+    return std::make_unique<CELFormatterCommandParser>(context);
   }
 };
 

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -87,7 +87,7 @@ public:
 
 #ifdef USE_CEL_PARSER
 TEST_F(CELFormatterTest, TestNodeId) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "xds.node.id", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -99,7 +99,7 @@ TEST_F(CELFormatterTest, TestNodeId) {
 }
 
 TEST_F(CELFormatterTest, Testformat) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "xds.node.id", max_length);
   EXPECT_THAT(formatter->format(formatter_context_, stream_info_), "node_name");
@@ -109,7 +109,7 @@ TEST_F(CELFormatterTest, Testformat) {
 }
 
 TEST_F(CELFormatterTest, TestFormatStringValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "request.headers[':method']", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -121,7 +121,7 @@ TEST_F(CELFormatterTest, TestFormatStringValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatNumberValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "request.headers[':method'].size()", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -134,7 +134,7 @@ TEST_F(CELFormatterTest, TestFormatNumberValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatNullValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "request.headers.nope", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -148,7 +148,7 @@ TEST_F(CELFormatterTest, TestFormatNullValue) {
 TEST_F(CELFormatterTest, TestFormatNoHeaders) {
   Envoy::Formatter::Context formatter_context;
 
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
 
   {
@@ -183,7 +183,7 @@ TEST_F(CELFormatterTest, TestFormatNoHeaders) {
 }
 
 TEST_F(CELFormatterTest, TestFormatBoolValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "request.headers[':method'] == 'GET'", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -196,7 +196,7 @@ TEST_F(CELFormatterTest, TestFormatBoolValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatDurationValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "duration(\"1h30m\")", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -208,7 +208,7 @@ TEST_F(CELFormatterTest, TestFormatDurationValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatTimestampValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "timestamp(\"2023-08-26T12:39:00-07:00\")", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -221,7 +221,7 @@ TEST_F(CELFormatterTest, TestFormatTimestampValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatBytesValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "bytes(\"hello\")", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -233,7 +233,7 @@ TEST_F(CELFormatterTest, TestFormatBytesValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatListValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "[\"foo\", 42, true]", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -247,7 +247,7 @@ TEST_F(CELFormatterTest, TestFormatListValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatMapValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "{\"foo\": \"42\"}", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -265,7 +265,7 @@ TEST_F(CELFormatterTest, TestFormatMapValue) {
 }
 
 TEST_F(CELFormatterTest, TestTruncation) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = 2;
   auto formatter = cel_parser->parse("CEL", "request.headers[':method']", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -277,14 +277,14 @@ TEST_F(CELFormatterTest, TestTruncation) {
 }
 
 TEST_F(CELFormatterTest, TestParseFail) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   EXPECT_EQ(nullptr,
             cel_parser->parse("INVALID_CMD", "requests.headers['missing_headers']", max_length));
 }
 
 TEST_F(CELFormatterTest, TestNullFormatValue) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
   auto formatter = cel_parser->parse("CEL", "requests.headers['missing_headers']", max_length);
   EXPECT_THAT(formatter->formatValue(formatter_context_, stream_info_),
@@ -292,7 +292,7 @@ TEST_F(CELFormatterTest, TestNullFormatValue) {
 }
 
 TEST_F(CELFormatterTest, TestFormatConversionV1AlphaToDevCel) {
-  auto cel_parser = std::make_unique<CELFormatterCommandParser>();
+  auto cel_parser = std::make_unique<CELFormatterCommandParser>(context_.server_factory_context_);
   absl::optional<size_t> max_length = absl::nullopt;
 
   // Test with a basic path expression


### PR DESCRIPTION
Commit Message: Make CELFormatterCommandParser function without a thread-singleton
Additional Description: Previously, initializing a `CELFormatterCommandParser` (e.g. from yaml instantiating a `SubstitutionFormatString`) uses the `ServerConfigurationFactoryContext` singleton, which only works after server initialization. This means that in tests an ASSERT fails: `ThreadLocalInjectableSingleton used prior to initialization`. In unit tests this can be mitigated by initializing a `ScopedThreadLocalServerContextSetter`, but this issue also occurs in the config validator used by CI. Rather than making that test also work around this issue, we can use the GenericFactoryContext that's available in this code path to initialize a reference with the required context via proper dependency injection.

There's a second initialization path that doesn't have a FactoryContext available, so that one still uses the singleton, to initialize the injected reference - the path that checks configs doesn't use that path, so this solves the immediate problem.
Risk Level: Negative, it fixes an issue and changes no behavior except making for fewer touches of a singleton-instance.
Testing: Updated tests to use the modified constructor.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
