### PR TITLE
oauth2: add allowed_redirect_domains and original_request_uri

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -151,7 +151,7 @@ message OAuth2Credentials {
 
 // OAuth config
 //
-// [#next-free-field: 28]
+// [#next-free-field: 30]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -304,6 +304,44 @@ message OAuth2Config {
   // Note: If a request matches pass_through_matcher, it bypasses OAuth validation and this matcher won't be evaluated.
   // This matcher takes precedence over deny_redirect_matcher.
   repeated config.route.v3.HeaderMatcher allow_failed_matcher = 27;
+
+  // Optional base URI (scheme + host, e.g. ``https://app.example.com``) used to build the
+  // original request URI that is encoded into the OAuth2 ``state`` parameter.
+  // This URI will be used later to redirect users on a successful OAuth.
+  //
+  // This is useful when Envoy sits behind a gateway or load balancer that terminates the
+  // user-facing hostname: In that case, the post-authentication redirect derived from ``state`` would
+  // send the user to an internal host they didn't request.
+  //
+  // Supports request header formatting tokens.
+  //
+  // Example:
+  //
+  //    original_request_uri: "%REQ(x-forwarded-proto?:scheme)%://%REQ(x-forwarded-host?:authority)%"
+  //
+  // If not set, defaults to ``<:scheme>://<:authority>`` of the incoming request.
+  string original_request_uri = 28;
+
+  // Optional list of domains that are allowed as
+  // 1. redirect_uri: which is what the IdP calls after OAuth
+  // 2. original_request_uri: the one extracted from the state of an OAuth callback (where should the request go after OAuth)
+  //
+  // This mitigates:
+  // - injecting a malicious x-forwarded-host or any header that is used to template the redirect urls
+  // - open redirect attacks where an attacker crafts a ``state`` value pointing to an untrusted host.
+  //
+  // Each entry is matched against the host (with any port stripped) extracted from the
+  // formatted ``redirect_uri``, the formatted ``original_request_uri``, and the URL decoded from
+  // the ``state`` parameter on callback. Matching is case-insensitive and supports two forms:
+  //
+  // * Exact match, e.g. ``example.com`` matches only ``example.com``.
+  // * Wildcard subdomain match using a leading ``*.``, e.g. ``*.example.com`` matches
+  //   ``foo.example.com`` and ``bar.baz.example.com`` but not ``example.com`` itself.
+  //
+  // IPv6 literals must be configured without surrounding brackets (e.g. ``::1``, not ``[::1]``).
+  //
+  // If this list is empty (the default), all hosts are allowed and no validation is performed.
+  repeated string allowed_redirect_domains = 29;
 }
 
 // Per-route OAuth2 config.

--- a/changelogs/current/new_features/oauth2__make-original-request-url-configurable.rst
+++ b/changelogs/current/new_features/oauth2__make-original-request-url-configurable.rst
@@ -1,0 +1,16 @@
+Added :ref:`original_request_uri
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.original_request_uri>`
+to let the OAuth2 filter derive the post-authentication redirect URL encoded in the ``state``
+parameter from formatter tokens (e.g. ``%REQ(x-forwarded-proto)%``/``%REQ(x-forwarded-host)%``)
+instead of from the request's ``:scheme`` and ``:authority`` headers. This is useful when Envoy
+sits behind a gateway that terminates the user-facing hostname, so the post-login redirect
+targets the public host rather than Envoy's internal authority.
+Also added :ref:`allowed_redirect_domains
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.allowed_redirect_domains>`,
+a case-insensitive allow-list (exact match or ``*.`` wildcard) applied to the host of the
+formatted ``redirect_uri``, the formatted ``original_request_uri``, and the URL decoded from
+the OAuth2 ``state`` parameter on callback. Requests whose host is not in the list are rejected
+with 401, mitigating open-redirect attacks via injected ``x-forwarded-host`` headers or forged
+``state`` values. Formatter output that is not a parseable absolute URL is now also rejected
+with 401 instead of silently passing through. An empty list (the default) disables the check
+for backward compatibility.

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -311,6 +311,40 @@ std::string generateCodeChallenge(const std::string& code_verifier) {
   return Base64Url::encode(sha256_string.data(), sha256_string.size());
 }
 
+bool isHostAllowedDomain(absl::string_view host, const std::vector<std::string>& allowed_domains) {
+  if (allowed_domains.empty()) {
+    return true;
+  }
+
+  // The formatted uri must be a parseable absolute URL; otherwise a malformed template
+  Http::Utility::Url uri;
+  if (!uri.initialize(host, false)) {
+    return false;
+  }
+
+  // Strip port and any IPv6 brackets via the shared authority parser so that "example.com:8080",
+  // "[::1]:443" and bare "[::1]" all normalize consistently. For IPv6 literals that are
+  // recognized as IP addresses, parseAuthority returns the host without brackets, so allow-list
+  // entries for IPv6 must also be written without brackets (e.g. "::1", not "[::1]").
+  const absl::string_view hostname = Http::Utility::parseAuthority(uri.hostAndPort()).host_;
+
+  for (const auto& domain : allowed_domains) {
+    if (absl::StartsWith(domain, "*.")) {
+      // Wildcard match: "*.example.com" matches "foo.example.com"
+      absl::string_view suffix = absl::string_view(domain).substr(1);
+      if (absl::EndsWith(hostname, suffix) && hostname.size() > suffix.size()) {
+        return true;
+      }
+    } else {
+      // Exact match
+      if (absl::EqualsIgnoreCase(hostname, domain)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 /**
  * Encodes the state parameter for the OAuth2 flow.
  * The state parameter is a base64Url encoded JSON object containing the original request URL, a
@@ -465,6 +499,9 @@ FilterConfig::FilterConfig(
       authorization_query_params_(buildAutorizationQueryParams(proto_config)),
       client_id_(proto_config.credentials().client_id()),
       redirect_uri_(proto_config.redirect_uri()),
+      allowed_redirect_domains_(proto_config.allowed_redirect_domains().begin(),
+                                proto_config.allowed_redirect_domains().end()),
+      original_request_uri_(proto_config.original_request_uri()),
       redirect_matcher_(proto_config.redirect_path_matcher(), context),
       signout_path_(proto_config.signout_path(), context), secret_reader_(secret_reader),
       stats_(FilterConfig::generateStats(stats_prefix, proto_config.stat_prefix(), scope)),
@@ -972,7 +1009,21 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
   if (Http::Utility::schemeIsHttp(headers.getSchemeValue())) {
     scheme = Http::Headers::get().SchemeValues.Http;
   }
-  const std::string base_path = absl::StrCat(scheme, "://", host_);
+
+  auto base_path = absl::StrCat(scheme, "://", host_);
+
+  if (!config_->originalRequestUri().empty()) {
+    Formatter::FormatterPtr base_path_formatter = THROW_OR_RETURN_VALUE(
+        Formatter::FormatterImpl::create(config_->originalRequestUri()), Formatter::FormatterPtr);
+    base_path = base_path_formatter->format({&headers}, decoder_callbacks_->streamInfo());
+  }
+
+  if (!isHostAllowedDomain(base_path, config_->allowedRedirectDomains())) {
+    sendUnauthorizedResponse(fmt::format(
+        "authority or original_request_uri failed domain allow-list validation: {}", base_path));
+    return;
+  }
+
   const std::string original_url = absl::StrCat(base_path, headers.Path()->value().getStringView());
 
   const CookieNames& cookie_names = config_->cookieNames();
@@ -1006,9 +1057,17 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
   auto query_params = config_->authorizationQueryParams();
   query_params.overwrite(queryParamsState, state);
 
-  Formatter::FormatterPtr formatter = THROW_OR_RETURN_VALUE(
+  // Format redirect_uri — needed for the query param sent to the identity provider
+  Formatter::FormatterPtr redirect_uri_formatter = THROW_OR_RETURN_VALUE(
       Formatter::FormatterImpl::create(config_->redirectUri()), Formatter::FormatterPtr);
-  const auto redirect_uri = formatter->format({&headers}, decoder_callbacks_->streamInfo());
+  const auto redirect_uri =
+      redirect_uri_formatter->format({&headers}, decoder_callbacks_->streamInfo());
+  if (!isHostAllowedDomain(redirect_uri, config_->allowedRedirectDomains())) {
+    sendUnauthorizedResponse(
+        fmt::format("redirect_uri failed domain allow-list validation: {}", redirect_uri));
+    return;
+  }
+
   const std::string escaped_redirect_uri = Http::Utility::PercentEncoding::urlEncode(redirect_uri);
   query_params.overwrite(queryParamsRedirectUri, escaped_redirect_uri);
 
@@ -1618,6 +1677,13 @@ CallbackValidationResult OAuth2Filter::validateState(const Http::RequestHeaderMa
   if (!url.initialize(original_request_url, false)) {
     return {false, "", "", flow_id,
             fmt::format("State url can not be initialized: {}", original_request_url)};
+  }
+
+  // Validate the host of the original request URL against allowed redirect domains.
+  if (!isHostAllowedDomain(original_request_url, config_->allowedRedirectDomains())) {
+    return {false, "", "", flow_id,
+            fmt::format("State url host is not in the allowed redirect domains: {}",
+                        original_request_url)};
   }
 
   return {true, "", original_request_url, flow_id, ""};

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -174,6 +174,10 @@ public:
     return authorization_query_params_;
   }
   const std::string& redirectUri() const { return redirect_uri_; }
+  const std::vector<std::string>& allowedRedirectDomains() const {
+    return allowed_redirect_domains_;
+  }
+  const std::string& originalRequestUri() const { return original_request_uri_; }
   const Matchers::PathMatcher& redirectPathMatcher() const { return redirect_matcher_; }
   const Matchers::PathMatcher& signoutPath() const { return signout_path_; }
   std::string clientSecret() const { return secret_reader_->clientSecret(); }
@@ -245,6 +249,8 @@ private:
   const Http::Utility::QueryParamsMulti authorization_query_params_;
   const std::string client_id_;
   const std::string redirect_uri_;
+  const std::vector<std::string> allowed_redirect_domains_;
+  const std::string original_request_uri_;
   const Matchers::PathMatcher redirect_matcher_;
   const Matchers::PathMatcher signout_path_;
   std::shared_ptr<SecretReader> secret_reader_;

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -398,6 +398,56 @@ public:
   NiceMock<Random::MockRandomGenerator> test_random_;
 };
 
+// Fixture for tests that exercise the allowed_redirect_domains allow-list and the
+// original_request_uri override. Skips the default init() done by OAuth2Test so each
+// test can install its own config via init(getAllowedDomainsConfig(...)).
+class OAuth2AllowedDomainsTest : public OAuth2Test {
+public:
+  OAuth2AllowedDomainsTest() : OAuth2Test(false) {}
+
+  FilterConfigSharedPtr getAllowedDomainsConfig(
+      const std::vector<std::string>& allowed_domains,
+      const std::string& redirect_uri = "%REQ(:scheme)%://%REQ(:authority)%/_oauth",
+      const std::string& original_request_uri = "") {
+    envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
+
+    auto* endpoint = p.mutable_token_endpoint();
+    endpoint->set_cluster("auth.example.com");
+    endpoint->set_uri("auth.example.com/_oauth");
+    endpoint->mutable_timeout()->set_seconds(1);
+
+    p.set_redirect_uri(redirect_uri);
+    p.set_original_request_uri(original_request_uri);
+    for (const auto& domain : allowed_domains) {
+      p.add_allowed_redirect_domains(domain);
+    }
+
+    p.mutable_redirect_path_matcher()->mutable_path()->set_exact(TEST_CALLBACK);
+    p.set_authorization_endpoint("https://auth.example.com/oauth/authorize/");
+    p.mutable_signout_path()->mutable_path()->set_exact("/_signout");
+    p.set_forward_bearer_token(true);
+    p.set_stat_prefix("my_prefix");
+    p.add_auth_scopes("user");
+    p.add_auth_scopes("openid");
+    p.add_auth_scopes("email");
+    p.add_resources("oauth2-resource");
+    p.add_resources("http://example.com");
+    p.add_resources("https://example.com/some/path%2F..%2F/utf8\xc3\x83;foo=bar?var1=1&var2=2");
+
+    auto* credentials = p.mutable_credentials();
+    credentials->set_client_id(TEST_CLIENT_ID);
+    credentials->mutable_token_secret()->set_name("secret");
+    credentials->mutable_hmac_secret()->set_name("hmac");
+    p.mutable_use_refresh_token()->set_value(false);
+
+    MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
+
+    auto secret_reader = std::make_shared<MockSecretReader>();
+    return std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
+                                          secret_reader, scope_, "test.");
+  }
+};
+
 // Verifies that the OAuth SDSSecretReader correctly updates dynamic generic secret.
 TEST_F(OAuth2Test, SdsDynamicGenericSecret) {
   NiceMock<Server::MockConfigTracker> config_tracker;
@@ -1909,6 +1959,378 @@ TEST_F(OAuth2Test, RedirectToOAuthServerWithInvalidCSRFToken) {
            "&response_type=code"
            "&scope=" +
            TEST_ENCODED_AUTH_SCOPES + "&state=" + TEST_ENCODED_STATE + "&resource=oauth2-resource" +
+           "&resource=http%3A%2F%2Fexample.com"
+           "&resource=https%3A%2F%2Fexample.com%2Fsome%2Fpath%252F..%252F%2Futf8%C3%83%3Bfoo%3Dbar%"
+           "3Fvar1%3D1%26var2%3D2"},
+  };
+
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: redirect_uri is built from X-Forwarded-* headers so that Envoy can sit behind a
+ * gateway. An attacker injects X-Forwarded-Host: evil.com to try to make Envoy send the
+ * OAuth flow to a host they control. allowed_redirect_domains restricts valid hosts to the
+ * legitimate public host.
+ *
+ * Expected behavior: the formatted redirect_uri resolves to evil.com, fails the allow-list
+ * check, and the filter rejects the request with 401 before contacting the IdP.
+ */
+TEST_F(OAuth2AllowedDomainsTest, RedirectUriHostNotInAllowList) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{"app.example.com"},
+      /*redirect_uri=*/
+      "%REQ(x-forwarded-proto?:scheme)%://%REQ(x-forwarded-host?:authority)%/_oauth"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Host.get(), "internal.svc.cluster.local"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      // Attacker-injected header — formatter will substitute "evil.com" into redirect_uri.
+      {"x-forwarded-host", "evil.com"},
+      {"x-forwarded-proto", "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: original_request_uri is built from X-Forwarded-* headers so Envoy can sit behind a
+ * gateway. An attacker injects X-Forwarded-Host: evil.com to try to bake a malicious host into
+ * the OAuth `state` parameter (which is used as the post-auth redirect target). redirect_uri is
+ * a static allowed value so it passes its own check — ensuring this test specifically exercises
+ * the original_request_uri allow-list branch.
+ *
+ * Expected behavior: the formatted original_request_uri resolves to evil.com, fails the
+ * allow-list check, and the filter rejects the request with 401 before contacting the IdP.
+ */
+TEST_F(OAuth2AllowedDomainsTest, OriginalRequestUriHostNotInAllowList) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{"app.example.com"},
+      /*redirect_uri=*/"https://app.example.com/_oauth",
+      /*original_request_uri=*/
+      "%REQ(x-forwarded-proto?:scheme)%://%REQ(x-forwarded-host?:authority)%"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Host.get(), "internal.svc.cluster.local"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      // Attacker-injected header — formatter will substitute "evil.com" into the state URL.
+      {"x-forwarded-host", "evil.com"},
+      {"x-forwarded-proto", "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: the formatted redirect_uri is not a parseable absolute URL (e.g. the formatter
+ * template evaluated to garbage because an expected header was missing). When an allow-list is
+ * configured, this must be rejected to avoid producing a malformed URL in the OAuth2 authorize
+ * request. Parse-validity is only checked when allowed_redirect_domains is non-empty so that
+ * deployments that have not opted into the allow-list feature see no behavior change.
+ *
+ * Expected behavior: the filter rejects the request with 401 before contacting the IdP.
+ */
+TEST_F(OAuth2AllowedDomainsTest, RedirectUriParseFailureIsRejected) {
+  init(getAllowedDomainsConfig(
+      // Allow-list must be populated for the parse check to run.
+      /*allowed_domains=*/{"app.example.com"},
+      // Literal, non-URL value: Http::Utility::Url::initialize() returns false on this input.
+      /*redirect_uri=*/"not-a-url"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Host.get(), "app.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: redirect_uri is valid but the formatted original_request_uri is not a parseable
+ * absolute URL. Same rationale as RedirectUriParseFailureIsRejected — rejection is gated on
+ * allowed_redirect_domains being configured.
+ *
+ * Expected behavior: the filter rejects the request with 401 before contacting the IdP.
+ */
+TEST_F(OAuth2AllowedDomainsTest, OriginalRequestUriParseFailureIsRejected) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{"app.example.com"},
+      /*redirect_uri=*/"https://app.example.com/_oauth",
+      // Literal, non-URL value: Http::Utility::Url::initialize() returns false on this input.
+      /*original_request_uri=*/"not-a-url"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Host.get(), "app.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: allowed_redirect_domains covers both the formatted redirect_uri and
+ * original_request_uri.
+ *
+ * Expected behavior: the filter passes both allow-list checks and proceeds with the
+ * usual 302 redirect to the identity provider.
+ */
+TEST_F(OAuth2AllowedDomainsTest, AllowedRedirectDomainsHappyPath) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{"traffic.example.com"},
+      /*redirect_uri=*/"%REQ(:scheme)%://%REQ(:authority)%/_oauth",
+      /*original_request_uri=*/"%REQ(:scheme)%://%REQ(:authority)%"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce.00000000075bcd15=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier.00000000075bcd15=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().Location.get(),
+       "https://auth.example.com/oauth/"
+       "authorize/?client_id=" +
+           TEST_CLIENT_ID + "&code_challenge=" + TEST_CODE_CHALLENGE +
+           "&code_challenge_method=S256" +
+           "&redirect_uri=https%3A%2F%2Ftraffic.example.com%2F_oauth"
+           "&response_type=code"
+           "&scope=" +
+           TEST_ENCODED_AUTH_SCOPES + "&state=" + TEST_ENCODED_STATE + "&resource=oauth2-resource" +
+           "&resource=http%3A%2F%2Fexample.com"
+           "&resource=https%3A%2F%2Fexample.com%2Fsome%2Fpath%252F..%252F%2Futf8%C3%83%3Bfoo%3Dbar%"
+           "3Fvar1%3D1%26var2%3D2"},
+  };
+
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: allowed_redirect_domains is the empty list (feature unconfigured). redirect_uri
+ * is set to a host that any non-empty allow-list would reject. This verifies that the empty
+ * list is a genuine no-op and backward-compatible — the filter proceeds to the IdP redirect
+ * without running the allow-list check.
+ */
+TEST_F(OAuth2AllowedDomainsTest, AllowedDomainsEmptyListIsNoOp) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{},
+      /*redirect_uri=*/"https://arbitrary-host.example.net/_oauth"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce.00000000075bcd15=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier.00000000075bcd15=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().Location.get(),
+       "https://auth.example.com/oauth/"
+       "authorize/?client_id=" +
+           TEST_CLIENT_ID + "&code_challenge=" + TEST_CODE_CHALLENGE +
+           "&code_challenge_method=S256"
+           "&redirect_uri=https%3A%2F%2Farbitrary-host.example.net%2F_oauth"
+           "&response_type=code"
+           "&scope=" +
+           TEST_ENCODED_AUTH_SCOPES + "&state=" + TEST_ENCODED_STATE + "&resource=oauth2-resource" +
+           "&resource=http%3A%2F%2Fexample.com"
+           "&resource=https%3A%2F%2Fexample.com%2Fsome%2Fpath%252F..%252F%2Futf8%C3%83%3Bfoo%3Dbar%"
+           "3Fvar1%3D1%26var2%3D2"},
+  };
+
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), true));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: The OAuth filter receives a callback from the IdP. allowed_redirect_domains is set
+ * to a wildcard pattern, and the host of the URL decoded from the `state` parameter matches
+ * the wildcard.
+ *
+ * Expected behavior: the filter accepts the callback and proceeds with the token exchange
+ * (asyncGetAccessToken is called).
+ */
+TEST_F(OAuth2AllowedDomainsTest, AllowedDomainsWildcardMatchOnCallback) {
+  init(getAllowedDomainsConfig(/*allowed_domains=*/{"*.example.com"}));
+
+  // TEST_ENCODED_STATE encodes the URL "https://traffic.example.com/original_path?var1=1&var2=2"
+  // whose host "traffic.example.com" matches "*.example.com".
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
+      {Http::Headers::get().Cookie.get(), "OauthNonce.00000000075bcd15=" + TEST_CSRF_TOKEN},
+      {Http::Headers::get().Cookie.get(),
+       "CodeVerifier.00000000075bcd15=" + TEST_ENCRYPTED_CODE_VERIFIER},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  EXPECT_CALL(*oauth_client_, asyncGetAccessToken("123", TEST_CLIENT_ID, "asdf_client_secret_fdsa",
+                                                  "https://traffic.example.com" + TEST_CALLBACK,
+                                                  TEST_CODE_VERIFIER, AuthType::UrlEncodedBody));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: An attacker crafts an OAuth2 callback whose `state` parameter decodes to a URL on
+ * a host that is not in allowed_redirect_domains. Without this check, the filter would redirect
+ * the user to the attacker-controlled host after token exchange — a classic open redirect.
+ *
+ * Expected behavior: validateState() rejects the callback before the token exchange, so
+ * asyncGetAccessToken is not called and a 401 is returned.
+ */
+TEST_F(OAuth2AllowedDomainsTest, AllowedDomainsRejectsCallbackStateHost) {
+  // Allow-list that does NOT cover "traffic.example.com" (the host encoded in TEST_ENCODED_STATE).
+  init(getAllowedDomainsConfig(/*allowed_domains=*/{"other.example.com"}));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
+      {Http::Headers::get().Cookie.get(), "OauthNonce.00000000075bcd15=" + TEST_CSRF_TOKEN},
+      {Http::Headers::get().Cookie.get(),
+       "CodeVerifier.00000000075bcd15=" + TEST_ENCRYPTED_CODE_VERIFIER},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  // Token exchange must not be attempted when the state host is rejected.
+  EXPECT_CALL(*oauth_client_, asyncGetAccessToken(_, _, _, _, _, _)).Times(0);
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::Unauthorized, _, _, _, _));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+}
+
+/**
+ * Scenario: Envoy sits behind a gateway that terminates the public hostname. :authority is the
+ * internal host, X-Forwarded-Host / X-Forwarded-Proto carry the public one. Both redirect_uri
+ * and original_request_uri are formatter templates that prefer the forwarded headers.
+ *
+ * Expected behavior: the formatted redirect_uri and the URL encoded into state both use the
+ * public host (from X-Forwarded-*), not the internal :authority. allowed_redirect_domains
+ * covers the public host so the checks pass, and a normal 302 to the IdP is issued.
+ */
+TEST_F(OAuth2AllowedDomainsTest, ForwardedHeadersDriveRedirectAndState) {
+  init(getAllowedDomainsConfig(
+      /*allowed_domains=*/{"app.example.com"},
+      /*redirect_uri=*/
+      "%REQ(x-forwarded-proto?:scheme)%://%REQ(x-forwarded-host?:authority)%/_oauth",
+      /*original_request_uri=*/
+      "%REQ(x-forwarded-proto?:scheme)%://%REQ(x-forwarded-host?:authority)%"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
+      // :authority is the internal hostname Envoy sees.
+      {Http::Headers::get().Host.get(), "internal.svc.cluster.local"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      // The gateway in front of Envoy forwards the public host/proto here.
+      {"x-forwarded-host", "app.example.com"},
+      {"x-forwarded-proto", "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  // State URL decoded from this base64 is:
+  //   https://app.example.com/original_path?var1=1&var2=2
+  static const std::string TEST_ENCODED_STATE_PUBLIC_HOST =
+      "eyJ1cmwiOiJodHRwczovL2FwcC5leGFtcGxlLmNvbS9vcmlnaW5hbF9wYXRoP3ZhcjE9MSZ2YXIyPTIiLCJjc3JmX3"
+      "Rva2VuIjoiMDAwMDAwMDAwNzViY2QxNS5uYTZrcnU0eDFwSGdvY1NJZVUvbWR0SFluNThHaDFicXdlUzRYWG9pcVZn"
+      "PSIsImZsb3dfaWQiOiIwMDAwMDAwMDA3NWJjZDE1In0";
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {Http::Headers::get().Status.get(), "302"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce.00000000075bcd15=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier.00000000075bcd15=" + TEST_ENCRYPTED_CODE_VERIFIER +
+           ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().SetCookie.get(),
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().Location.get(),
+       "https://auth.example.com/oauth/"
+       "authorize/?client_id=" +
+           TEST_CLIENT_ID + "&code_challenge=" + TEST_CODE_CHALLENGE +
+           "&code_challenge_method=S256"
+           "&redirect_uri=https%3A%2F%2Fapp.example.com%2F_oauth"
+           "&response_type=code"
+           "&scope=" +
+           TEST_ENCODED_AUTH_SCOPES + "&state=" + TEST_ENCODED_STATE_PUBLIC_HOST +
+           "&resource=oauth2-resource"
            "&resource=http%3A%2F%2Fexample.com"
            "&resource=https%3A%2F%2Fexample.com%2Fsome%2Fpath%252F..%252F%2Futf8%C3%83%3Bfoo%3Dbar%"
            "3Fvar1%3D1%26var2%3D2"},


### PR DESCRIPTION
When Envoy sits behind an external load balancer, the internal :authority and :scheme headers don't match the externally-visible hostname. The redirect_uri can already be templated with formatters to handle this, but the URL encoded in the OAuth2 state parameter is always derived from the request's :authority/:scheme — causing a mismatch that breaks the post-login redirect.

This PR adds two new config fields:

- `original_request_uri`: an optional formatter-supported base URI (scheme + host)
  used to build the original request URL encoded into the OAuth2 state parameter.
  Operators can template it from `x-forwarded-host`/`x-forwarded-proto` so the
  post-auth redirect uses the public host rather than Envoy's internal `:authority`.
- `allowed_redirect_domains`: a case-insensitive allowlist (exact or `*.` wildcard)
  applied to the host of the formatted `redirect_uri`, the formatted
  `original_request_uri`, and the URL decoded from the `state` parameter on callback.
  Mitigates open-redirect attacks via injected `x-forwarded-host` headers or forged
  `state` values. Empty list (default) disables the check for backward compatibility.

Risk Level: Low
Testing: Unit tests added for the allowlist (exact, wildcard, empty-list no-op), forwarded-header-driven redirect and state, and rejection on mismatch and on unparseable URLs.
Docs Changes: Proto field documentation added inline.
Release Notes: Added `original_request_uri` and `allowed_redirect_domains` options to the OAuth2 filter to support deployments behind external load balancers and prevent open redirects via the state parameter.
Platform Specific Features: N/A
[Optional Fixes #41034]
[Optional API Considerations: Two new fields added to OAuth2Config (field numbers 28 and 29). No breaking changes to existing configs.]