### PR TITLE
secret_provider: atomically replace thread-local-storage value

### DIFF
--- a/source/common/secret/secret_provider_impl.cc
+++ b/source/common/secret/secret_provider_impl.cc
@@ -47,8 +47,9 @@ absl::Status ThreadLocalGenericSecretProvider::update() {
     RETURN_IF_NOT_OK_REF(value_or_error.status());
     value = std::move(value_or_error.value());
   }
-  tls_->runOnAllThreads(
-      [value = std::move(value)](OptRef<ThreadLocalSecret> tls) { tls->value_ = value; });
+  tls_->set([value = std::move(value)](Event::Dispatcher&) {
+    return std::make_shared<ThreadLocalSecret>(value);
+  });
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Commit Message: secret_provider: atomically replace thread-local-storage value
Additional Description:
Refactor the code to use the `set()` pattern that does an immutable atomic replacement of the thread-local-storage value rather than updating the pointed value contents.

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
