### PR TITLE
stats: consolidate iteration via IterationCriteria

### DIFF
--- a/envoy/stats/stats.h
+++ b/envoy/stats/stats.h
@@ -316,5 +316,9 @@ private:
   const StatType& metric_;
 };
 
+struct IterationCriteria {
+  bool sinked_only{false};
+};
+
 } // namespace Stats
 } // namespace Envoy

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -105,16 +105,23 @@ public:
    * after forEach* is not supported, as scope/stat deletions can occur in any
    * thread. Implementation locks ensures the stat/scope is valid until the
    * f_stat returns.
+   * Additional filtering is passed via a struct reference.
    *
    * @param f_size functor that is provided the current number of all
    * stats. Note that this is called only once, prior to any calls to f_stat.
    * @param f_stat functor that is provided one stat at a time from the stats
    * container.
+   * @param criteria contains filters for the iteration through stats (e.g.
+   * whether to only iterate over stats that need to be flushed to sinks)
    */
-  virtual void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat) const PURE;
-  virtual void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat) const PURE;
-  virtual void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const PURE;
-  virtual void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const PURE;
+  virtual void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat,
+                              const IterationCriteria& criteria) const PURE;
+  virtual void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat,
+                            const IterationCriteria& criteria) const PURE;
+  virtual void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat,
+                                  const IterationCriteria& criteria) const PURE;
+  virtual void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat,
+                                const IterationCriteria& criteria) const PURE;
   virtual void forEachScope(SizeFn f_size, StatFn<const Scope> f_stat) const PURE;
 
   /**
@@ -131,19 +138,6 @@ public:
    * @return a null gauge that will ignore set() calls and always return 0.
    */
   virtual Gauge& nullGauge() PURE;
-
-  /**
-   * Iterate over all stats that need to be flushed to sinks. Note, that implementations can
-   * potentially hold on to a mutex that will deadlock if the passed in functors try to create
-   * or delete a stat.
-   * @param f_size functor that is provided the number of all stats that will be flushed to sinks.
-   * Note that this is called only once, prior to any calls to f_stat.
-   * @param f_stat functor that is provided one stat that will be flushed to sinks, at a time.
-   */
-  virtual void forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const PURE;
-  virtual void forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const PURE;
-  virtual void forEachSinkedTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const PURE;
-  virtual void forEachSinkedHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const PURE;
 
   /**
    * Calls 'fn' for every stat. Note that in the case of overlapping scopes, the

--- a/source/common/stats/allocator.cc
+++ b/source/common/stats/allocator.cc
@@ -371,73 +371,78 @@ Counter* Allocator::makeCounterInternal(StatName name, StatName tag_extracted_na
   return new CounterImpl(name, *this, tag_extracted_name, stat_name_tags);
 }
 
-void Allocator::forEachCounter(SizeFn f_size, StatFn<Counter> f_stat) const {
-  Thread::LockGuard lock(mutex_);
-  if (f_size != nullptr) {
-    f_size(counters_.size());
-  }
-  for (auto& counter : counters_) {
-    f_stat(*counter);
-  }
-}
-
-void Allocator::forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat) const {
-  Thread::LockGuard lock(mutex_);
-  if (f_size != nullptr) {
-    f_size(gauges_.size());
-  }
-  for (auto& gauge : gauges_) {
-    f_stat(*gauge);
-  }
-}
-
-void Allocator::forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const {
-  Thread::LockGuard lock(mutex_);
-  if (f_size != nullptr) {
-    f_size(text_readouts_.size());
-  }
-  for (auto& text_readout : text_readouts_) {
-    f_stat(*text_readout);
-  }
-}
-
-void Allocator::forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const {
-  if (sink_predicates_ != nullptr) {
+void Allocator::forEachCounter(SizeFn f_size, StatFn<Counter> f_stat,
+                               const IterationCriteria& criteria) const {
+  if (criteria.sinked_only && sink_predicates_ != nullptr) {
     Thread::LockGuard lock(mutex_);
-    f_size(sinked_counters_.size());
+    if (f_size != nullptr) {
+      f_size(sinked_counters_.size());
+    }
     for (auto counter : sinked_counters_) {
       f_stat(*counter);
     }
   } else {
-    forEachCounter(f_size, f_stat);
+    Thread::LockGuard lock(mutex_);
+    if (f_size != nullptr) {
+      f_size(counters_.size());
+    }
+    for (auto& counter : counters_) {
+      f_stat(*counter);
+    }
   }
 }
 
-void Allocator::forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const {
-  if (sink_predicates_ != nullptr) {
-    Thread::LockGuard lock(mutex_);
-    f_size(sinked_gauges_.size());
-    for (auto gauge : sinked_gauges_) {
-      f_stat(*gauge);
+void Allocator::forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat,
+                             const IterationCriteria& criteria) const {
+
+  if (criteria.sinked_only) {
+    if (sink_predicates_ != nullptr) {
+      Thread::LockGuard lock(mutex_);
+      if (f_size != nullptr) {
+        f_size(sinked_gauges_.size());
+      }
+      for (auto gauge : sinked_gauges_) {
+        f_stat(*gauge);
+      }
+    } else {
+      Thread::LockGuard lock(mutex_);
+      if (f_size != nullptr) {
+        f_size(gauges_.size());
+      }
+      for (auto& gauge : gauges_) {
+        if (!gauge->hidden())
+          f_stat(*gauge);
+      }
     }
   } else {
-    forEachGauge(f_size, [&f_stat](Gauge& gauge) {
-      if (!gauge.hidden()) {
-        f_stat(gauge);
-      }
-    });
+    Thread::LockGuard lock(mutex_);
+    if (f_size != nullptr) {
+      f_size(gauges_.size());
+    }
+    for (auto& gauge : gauges_) {
+      f_stat(*gauge);
+    }
   }
 }
 
-void Allocator::forEachSinkedTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const {
-  if (sink_predicates_ != nullptr) {
+void Allocator::forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat,
+                                   const IterationCriteria& criteria) const {
+  if (criteria.sinked_only && sink_predicates_ != nullptr) {
     Thread::LockGuard lock(mutex_);
-    f_size(sinked_text_readouts_.size());
+    if (f_size != nullptr) {
+      f_size(sinked_text_readouts_.size());
+    }
     for (auto text_readout : sinked_text_readouts_) {
       f_stat(*text_readout);
     }
   } else {
-    forEachTextReadout(f_size, f_stat);
+    Thread::LockGuard lock(mutex_);
+    if (f_size != nullptr) {
+      f_size(text_readouts_.size());
+    }
+    for (auto& text_readout : text_readouts_) {
+      f_stat(*text_readout);
+    }
   }
 }
 

--- a/source/common/stats/allocator.h
+++ b/source/common/stats/allocator.h
@@ -60,21 +60,9 @@ public:
    * called only once, prior to any calls to f_stat.
    * @param f_stat functor that is provided one stat at a time from the stats container.
    */
-  void forEachCounter(SizeFn, StatFn<Counter>) const;
-  void forEachGauge(SizeFn, StatFn<Gauge>) const;
-  void forEachTextReadout(SizeFn, StatFn<TextReadout>) const;
-
-  /**
-   * Iterate over all stats that need to be flushed to sinks. Note, that implementations can
-   * potentially hold on to a mutex that will deadlock if the passed in functors try to create
-   * or delete a stat.
-   * @param f_size functor that is provided the number of all stats that will be flushed to sinks.
-   * Note that this is called only once, prior to any calls to f_stat.
-   * @param f_stat functor that is provided one stat that will be flushed to sinks, at a time.
-   */
-  void forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const;
-  void forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const;
-  void forEachSinkedTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const;
+  void forEachCounter(SizeFn, StatFn<Counter>, const IterationCriteria& criteria) const;
+  void forEachGauge(SizeFn, StatFn<Gauge>, const IterationCriteria& criteria) const;
+  void forEachTextReadout(SizeFn, StatFn<TextReadout>, const IterationCriteria& criteria) const;
 
   /**
    * Set the predicates to filter stats for sink.

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -56,19 +56,23 @@ public:
     return text_readouts_.toVector();
   }
 
-  void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat) const override {
+  void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat,
+                      const IterationCriteria& /*criteria*/) const override {
     counters_.forEachStat(f_size, f_stat);
   }
 
-  void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat) const override {
+  void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat,
+                    const IterationCriteria& /*criteria*/) const override {
     gauges_.forEachStat(f_size, f_stat);
   }
 
-  void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const override {
+  void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat,
+                          const IterationCriteria& /*criteria*/) const override {
     text_readouts_.forEachStat(f_size, f_stat);
   }
 
-  void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const override {
+  void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat,
+                        const IterationCriteria& /*criteria*/) const override {
     UNREFERENCED_PARAMETER(f_size);
     UNREFERENCED_PARAMETER(f_stat);
   }
@@ -85,23 +89,6 @@ public:
 
   void evictUnused() override {
     // Do nothing. Eviction is only supported on the thread local stores.
-  }
-
-  void forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const override {
-    forEachCounter(f_size, f_stat);
-  }
-
-  void forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const override {
-    forEachGauge(f_size, f_stat);
-  }
-
-  void forEachSinkedTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const override {
-    forEachTextReadout(f_size, f_stat);
-  }
-
-  void forEachSinkedHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const override {
-    UNREFERENCED_PARAMETER(f_size);
-    UNREFERENCED_PARAMETER(f_stat);
   }
 
   NullCounterImpl& nullCounter() override { return null_counter_; }

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -154,7 +154,7 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
   // Handle de-dup due to overlapping scopes.
   std::vector<CounterSharedPtr> ret;
   forEachCounter([&ret](std::size_t size) { ret.reserve(size); },
-                 [&ret](Counter& counter) { ret.emplace_back(CounterSharedPtr(&counter)); });
+                 [&ret](Counter& counter) { ret.emplace_back(CounterSharedPtr(&counter)); }, {});
   return ret;
 }
 
@@ -188,7 +188,7 @@ std::vector<GaugeSharedPtr> ThreadLocalStoreImpl::gauges() const {
   // Handle de-dup due to overlapping scopes.
   std::vector<GaugeSharedPtr> ret;
   forEachGauge([&ret](std::size_t size) { ret.reserve(size); },
-               [&ret](Gauge& gauge) { ret.emplace_back(GaugeSharedPtr(&gauge)); });
+               [&ret](Gauge& gauge) { ret.emplace_back(GaugeSharedPtr(&gauge)); }, {});
   return ret;
 }
 
@@ -197,7 +197,8 @@ std::vector<TextReadoutSharedPtr> ThreadLocalStoreImpl::textReadouts() const {
   std::vector<TextReadoutSharedPtr> ret;
   forEachTextReadout(
       [&ret](std::size_t size) { ret.reserve(size); },
-      [&ret](TextReadout& text_readout) { ret.emplace_back(TextReadoutSharedPtr(&text_readout)); });
+      [&ret](TextReadout& text_readout) { ret.emplace_back(TextReadoutSharedPtr(&text_readout)); },
+      {});
   return ret;
 }
 
@@ -206,7 +207,8 @@ std::vector<ParentHistogramSharedPtr> ThreadLocalStoreImpl::histograms() const {
   forEachHistogram([&ret](std::size_t size) mutable { ret.reserve(size); },
                    [&ret](ParentHistogram& histogram) mutable {
                      ret.emplace_back(ParentHistogramSharedPtr(&histogram));
-                   });
+                   },
+                   {});
   return ret;
 }
 
@@ -262,7 +264,7 @@ void ThreadLocalStoreImpl::mergeHistograms(PostMergeCb merge_complete_cb) {
 
 void ThreadLocalStoreImpl::mergeInternal(PostMergeCb merge_complete_cb) {
   if (!shutting_down_) {
-    forEachHistogram(nullptr, [](ParentHistogram& histogram) { histogram.merge(); });
+    forEachHistogram(nullptr, [](ParentHistogram& histogram) { histogram.merge(); }, {});
     merge_complete_cb();
     merge_in_progress_ = false;
   }
@@ -1060,25 +1062,40 @@ bool ParentHistogramImpl::usedLockHeld() const {
   return false;
 }
 
-void ThreadLocalStoreImpl::forEachCounter(SizeFn f_size, StatFn<Counter> f_stat) const {
-  alloc_.forEachCounter(f_size, f_stat);
+void ThreadLocalStoreImpl::forEachCounter(SizeFn f_size, StatFn<Counter> f_stat,
+                                          const IterationCriteria& criteria) const {
+  alloc_.forEachCounter(f_size, f_stat, criteria);
 }
 
-void ThreadLocalStoreImpl::forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat) const {
-  alloc_.forEachGauge(f_size, f_stat);
+void ThreadLocalStoreImpl::forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat,
+                                        const IterationCriteria& criteria) const {
+  alloc_.forEachGauge(f_size, f_stat, criteria);
 }
 
-void ThreadLocalStoreImpl::forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const {
-  alloc_.forEachTextReadout(f_size, f_stat);
+void ThreadLocalStoreImpl::forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat,
+                                              const IterationCriteria& criteria) const {
+  alloc_.forEachTextReadout(f_size, f_stat, criteria);
 }
 
-void ThreadLocalStoreImpl::forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const {
+void ThreadLocalStoreImpl::forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat,
+                                            const IterationCriteria& criteria) const {
   Thread::LockGuard lock(hist_mutex_);
-  if (f_size != nullptr) {
-    f_size(histogram_set_.size());
-  }
-  for (ParentHistogramImpl* histogram : histogram_set_) {
-    f_stat(*histogram);
+
+  if (criteria.sinked_only && sink_predicates_.has_value()) {
+
+    if (f_size != nullptr) {
+      f_size(sinked_histograms_.size());
+    }
+    for (auto histogram : sinked_histograms_) {
+      f_stat(*histogram);
+    }
+  } else {
+    if (f_size != nullptr) {
+      f_size(histogram_set_.size());
+    }
+    for (ParentHistogramImpl* histogram : histogram_set_) {
+      f_stat(*histogram);
+    }
   }
 }
 
@@ -1225,35 +1242,6 @@ bool ThreadLocalStoreImpl::iterateScopesLockHeld(
     }
   }
   return true;
-}
-
-void ThreadLocalStoreImpl::forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const {
-  alloc_.forEachSinkedCounter(f_size, f_stat);
-}
-
-void ThreadLocalStoreImpl::forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const {
-  alloc_.forEachSinkedGauge(f_size, f_stat);
-}
-
-void ThreadLocalStoreImpl::forEachSinkedTextReadout(SizeFn f_size,
-                                                    StatFn<TextReadout> f_stat) const {
-  alloc_.forEachSinkedTextReadout(f_size, f_stat);
-}
-
-void ThreadLocalStoreImpl::forEachSinkedHistogram(SizeFn f_size,
-                                                  StatFn<ParentHistogram> f_stat) const {
-  if (sink_predicates_.has_value()) {
-    Thread::LockGuard lock(hist_mutex_);
-
-    if (f_size != nullptr) {
-      f_size(sinked_histograms_.size());
-    }
-    for (auto histogram : sinked_histograms_) {
-      f_stat(*histogram);
-    }
-  } else {
-    forEachHistogram(f_size, f_stat);
-  }
 }
 
 void ThreadLocalStoreImpl::setSinkPredicates(std::unique_ptr<SinkPredicates>&& sink_predicates) {

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -186,10 +186,14 @@ public:
   std::vector<TextReadoutSharedPtr> textReadouts() const override;
   std::vector<ParentHistogramSharedPtr> histograms() const override;
 
-  void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat) const override;
-  void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat) const override;
-  void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const override;
-  void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const override;
+  void forEachCounter(SizeFn f_size, StatFn<Counter> f_stat,
+                      const IterationCriteria& criteria) const override;
+  void forEachGauge(SizeFn f_size, StatFn<Gauge> f_stat,
+                    const IterationCriteria& criteria) const override;
+  void forEachTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat,
+                          const IterationCriteria& criteria) const override;
+  void forEachHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat,
+                        const IterationCriteria& criteria) const override;
   void forEachScope(SizeFn f_size, StatFn<const Scope> f_stat) const override;
 
   void evictUnused() override;
@@ -208,11 +212,6 @@ public:
   void deliverHistogramToSinks(const Histogram& histogram, uint64_t value) override;
 
   Histogram& tlsHistogram(ParentHistogramImpl& parent, uint64_t id);
-
-  void forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const override;
-  void forEachSinkedGauge(SizeFn f_size, StatFn<Gauge> f_stat) const override;
-  void forEachSinkedTextReadout(SizeFn f_size, StatFn<TextReadout> f_stat) const override;
-  void forEachSinkedHistogram(SizeFn f_size, StatFn<ParentHistogram> f_stat) const override;
 
   void setSinkPredicates(std::unique_ptr<SinkPredicates>&& sink_predicates) override;
   OptRef<SinkPredicates> sinkPredicates() override { return sink_predicates_; }

--- a/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
+++ b/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
@@ -148,7 +148,8 @@ bool envoy_dynamic_module_callback_bootstrap_extension_get_histogram_summary(
           *sample_sum_ptr = stats.sampleSum();
           found = true;
         }
-      });
+      },
+      {});
   return found;
 }
 
@@ -168,7 +169,8 @@ void envoy_dynamic_module_callback_bootstrap_extension_iterate_counters(
                                // action. The module should handle this by setting a flag in
                                // user_data.
                                (void)action;
-                             });
+                             },
+                             {});
 }
 
 void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
@@ -187,7 +189,8 @@ void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
                              // action. The module should handle this by setting a flag in
                              // user_data.
                              (void)action;
-                           });
+                           },
+                           {});
 }
 
 // -------------------- Stats Definition and Update Callbacks --------------------

--- a/source/server/hot_restarting_parent.cc
+++ b/source/server/hot_restarting_parent.cc
@@ -177,26 +177,31 @@ HotRestartingParent::Internal::getListenSocketsForChild(const HotRestartMessage:
 // magnitude of memory usage that they are meant to avoid, since this map holds full-string
 // names. The problem can be solved by splitting the export up over many chunks.
 void HotRestartingParent::Internal::exportStatsToChild(HotRestartMessage::Reply::Stats* stats) {
-  server_->stats().forEachSinkedGauge(nullptr, [this, stats](Stats::Gauge& gauge) mutable {
-    if (gauge.used()) {
-      const std::string name = gauge.name();
-      (*stats->mutable_gauges())[name] = gauge.value();
-      recordDynamics(stats, name, gauge.statName());
-    }
-  });
+  server_->stats().forEachGauge(nullptr,
+                                [this, stats](Stats::Gauge& gauge) mutable {
+                                  if (gauge.used()) {
+                                    const std::string name = gauge.name();
+                                    (*stats->mutable_gauges())[name] = gauge.value();
+                                    recordDynamics(stats, name, gauge.statName());
+                                  }
+                                },
+                                {.sinked_only = true});
 
-  server_->stats().forEachSinkedCounter(nullptr, [this, stats](Stats::Counter& counter) mutable {
-    if (counter.used()) {
-      // The hot restart parent is expected to have stopped its normal stat exporting (and so
-      // latching) by the time it begins exporting to the hot restart child.
-      uint64_t latched_value = counter.latch();
-      if (latched_value > 0) {
-        const std::string name = counter.name();
-        (*stats->mutable_counter_deltas())[name] = latched_value;
-        recordDynamics(stats, name, counter.statName());
-      }
-    }
-  });
+  server_->stats().forEachCounter(nullptr,
+                                  [this, stats](Stats::Counter& counter) mutable {
+                                    if (counter.used()) {
+                                      // The hot restart parent is expected to have stopped its
+                                      // normal stat exporting (and so latching) by the time it
+                                      // begins exporting to the hot restart child.
+                                      uint64_t latched_value = counter.latch();
+                                      if (latched_value > 0) {
+                                        const std::string name = counter.name();
+                                        (*stats->mutable_counter_deltas())[name] = latched_value;
+                                        recordDynamics(stats, name, counter.statName());
+                                      }
+                                    }
+                                  },
+                                  {.sinked_only = true});
   stats->set_memory_allocated(Memory::Stats::totalCurrentlyAllocated());
   stats->set_num_connections(server_->listenerManager().numConnections());
 }

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -171,7 +171,7 @@ void InstanceBase::failHealthcheck(bool fail) {
 MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store,
                                        Upstream::ClusterManager& cluster_manager,
                                        TimeSource& time_source) {
-  store.forEachSinkedCounter(
+  store.forEachCounter(
       [this](std::size_t size) {
         snapped_counters_.reserve(size);
         counters_.reserve(size);
@@ -179,9 +179,10 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store,
       [this](Stats::Counter& counter) {
         snapped_counters_.push_back(Stats::CounterSharedPtr(&counter));
         counters_.push_back({counter.latch(), counter});
-      });
+      },
+      {.sinked_only = true});
 
-  store.forEachSinkedGauge(
+  store.forEachGauge(
       [this](std::size_t size) {
         snapped_gauges_.reserve(size);
         gauges_.reserve(size);
@@ -189,9 +190,10 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store,
       [this](Stats::Gauge& gauge) {
         snapped_gauges_.push_back(Stats::GaugeSharedPtr(&gauge));
         gauges_.push_back(gauge);
-      });
+      },
+      {.sinked_only = true});
 
-  store.forEachSinkedHistogram(
+  store.forEachHistogram(
       [this](std::size_t size) {
         snapped_histograms_.reserve(size);
         histograms_.reserve(size);
@@ -199,9 +201,10 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store,
       [this](Stats::ParentHistogram& histogram) {
         snapped_histograms_.push_back(Stats::ParentHistogramSharedPtr(&histogram));
         histograms_.push_back(histogram);
-      });
+      },
+      {.sinked_only = true});
 
-  store.forEachSinkedTextReadout(
+  store.forEachTextReadout(
       [this](std::size_t size) {
         snapped_text_readouts_.reserve(size);
         text_readouts_.reserve(size);
@@ -209,7 +212,8 @@ MetricSnapshotImpl::MetricSnapshotImpl(Stats::Store& store,
       [this](Stats::TextReadout& text_readout) {
         snapped_text_readouts_.push_back(Stats::TextReadoutSharedPtr(&text_readout));
         text_readouts_.push_back(text_readout);
-      });
+      },
+      {.sinked_only = true});
 
   Upstream::HostUtility::forEachHostMetric(
       cluster_manager,

--- a/test/common/stats/allocator_test.cc
+++ b/test/common/stats/allocator_test.cc
@@ -172,7 +172,8 @@ TEST_F(AllocatorTest, ForEachCounter) {
                         [&num_iterations, &stat_names](Counter& counter) {
                           EXPECT_EQ(stat_names.count(counter.statName()), 1);
                           ++num_iterations;
-                        });
+                        },
+                        {});
   EXPECT_EQ(num_counters, 11);
   EXPECT_EQ(num_iterations, 11);
 
@@ -191,7 +192,8 @@ TEST_F(AllocatorTest, ForEachCounter) {
                         [&num_iterations, &rejected_stat_name](Counter& counter) {
                           EXPECT_THAT(counter.statName(), ::testing::Ne(rejected_stat_name));
                           ++num_iterations;
-                        });
+                        },
+                        {});
   EXPECT_EQ(num_iterations, 10);
   EXPECT_EQ(num_counters, 10);
 
@@ -202,7 +204,7 @@ TEST_F(AllocatorTest, ForEachCounter) {
   counters.clear();
   num_iterations = 0;
   alloc_.forEachCounter([&num_counters](std::size_t size) { num_counters = size; },
-                        [&num_iterations](Counter&) { ++num_iterations; });
+                        [&num_iterations](Counter&) { ++num_iterations; }, {});
   EXPECT_EQ(num_counters, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -225,7 +227,8 @@ TEST_F(AllocatorTest, ForEachGauge) {
                       [&num_iterations, &stat_names](Gauge& gauge) {
                         EXPECT_EQ(stat_names.count(gauge.statName()), 1);
                         ++num_iterations;
-                      });
+                      },
+                      {});
   EXPECT_EQ(num_gauges, 11);
   EXPECT_EQ(num_iterations, 11);
 
@@ -244,7 +247,8 @@ TEST_F(AllocatorTest, ForEachGauge) {
                       [&num_iterations, &rejected_stat_name](Gauge& gauge) {
                         EXPECT_THAT(gauge.statName(), ::testing::Ne(rejected_stat_name));
                         ++num_iterations;
-                      });
+                      },
+                      {});
   EXPECT_EQ(num_iterations, 10);
   EXPECT_EQ(num_gauges, 10);
 
@@ -255,7 +259,7 @@ TEST_F(AllocatorTest, ForEachGauge) {
   gauges.clear();
   num_iterations = 0;
   alloc_.forEachGauge([&num_gauges](std::size_t size) { num_gauges = size; },
-                      [&num_iterations](Gauge&) { ++num_iterations; });
+                      [&num_iterations](Gauge&) { ++num_iterations; }, {});
   EXPECT_EQ(num_gauges, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -278,7 +282,8 @@ TEST_F(AllocatorTest, ForEachTextReadout) {
                             [&num_iterations, &stat_names](TextReadout& text_readout) {
                               EXPECT_EQ(stat_names.count(text_readout.statName()), 1);
                               ++num_iterations;
-                            });
+                            },
+                            {});
   EXPECT_EQ(num_text_readouts, 11);
   EXPECT_EQ(num_iterations, 11);
 
@@ -298,7 +303,8 @@ TEST_F(AllocatorTest, ForEachTextReadout) {
                               EXPECT_THAT(text_readout.statName(),
                                           ::testing::Ne(rejected_stat_name));
                               ++num_iterations;
-                            });
+                            },
+                            {});
   EXPECT_EQ(num_iterations, 10);
   EXPECT_EQ(num_text_readouts, 10);
 
@@ -309,7 +315,7 @@ TEST_F(AllocatorTest, ForEachTextReadout) {
   text_readouts.clear();
   num_iterations = 0;
   alloc_.forEachTextReadout([&num_text_readouts](std::size_t size) { num_text_readouts = size; },
-                            [&num_iterations](TextReadout&) { ++num_iterations; });
+                            [&num_iterations](TextReadout&) { ++num_iterations; }, {});
   EXPECT_EQ(num_text_readouts, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -329,10 +335,12 @@ TEST_F(AllocatorTest, ForEachWithNullSizeLambda) {
     counters.emplace_back(alloc_.makeCounter(stat_name, StatName(), {}));
   }
   size_t num_iterations = 0;
-  alloc_.forEachCounter(nullptr, [&num_iterations](Counter& counter) {
-    UNREFERENCED_PARAMETER(counter);
-    ++num_iterations;
-  });
+  alloc_.forEachCounter(nullptr,
+                        [&num_iterations](Counter& counter) {
+                          UNREFERENCED_PARAMETER(counter);
+                          ++num_iterations;
+                        },
+                        {});
   EXPECT_EQ(num_iterations, num_stats);
 
   // For each gauge.
@@ -341,10 +349,12 @@ TEST_F(AllocatorTest, ForEachWithNullSizeLambda) {
     gauges.emplace_back(alloc_.makeGauge(stat_name, StatName(), {}, Gauge::ImportMode::Accumulate));
   }
   num_iterations = 0;
-  alloc_.forEachGauge(nullptr, [&num_iterations](Gauge& gauge) {
-    UNREFERENCED_PARAMETER(gauge);
-    ++num_iterations;
-  });
+  alloc_.forEachGauge(nullptr,
+                      [&num_iterations](Gauge& gauge) {
+                        UNREFERENCED_PARAMETER(gauge);
+                        ++num_iterations;
+                      },
+                      {});
   EXPECT_EQ(num_iterations, num_stats);
 
   // For each text readout.
@@ -353,10 +363,12 @@ TEST_F(AllocatorTest, ForEachWithNullSizeLambda) {
     text_readouts.emplace_back(alloc_.makeTextReadout(stat_name, StatName(), {}));
   }
   num_iterations = 0;
-  alloc_.forEachTextReadout(nullptr, [&num_iterations](TextReadout& text_readout) {
-    UNREFERENCED_PARAMETER(text_readout);
-    ++num_iterations;
-  });
+  alloc_.forEachTextReadout(nullptr,
+                            [&num_iterations](TextReadout& text_readout) {
+                              UNREFERENCED_PARAMETER(text_readout);
+                              ++num_iterations;
+                            },
+                            {});
   EXPECT_EQ(num_iterations, num_stats);
 }
 
@@ -458,21 +470,20 @@ TEST_F(AllocatorTest, ForEachSinkedCounter) {
 
   size_t num_sinked_counters = 0;
   size_t num_iterations = 0;
-  alloc_.forEachSinkedCounter(
-      [&num_sinked_counters](std::size_t size) { num_sinked_counters = size; },
-      [&num_iterations, sink_predicates](Counter& counter) {
-        EXPECT_TRUE(sink_predicates->has(counter.statName()));
-        ++num_iterations;
-      });
+  alloc_.forEachCounter([&num_sinked_counters](std::size_t size) { num_sinked_counters = size; },
+                        [&num_iterations, sink_predicates](Counter& counter) {
+                          EXPECT_TRUE(sink_predicates->has(counter.statName()));
+                          ++num_iterations;
+                        },
+                        {.sinked_only = true});
   EXPECT_EQ(num_sinked_counters, 3);
   EXPECT_EQ(num_iterations, 3);
 
   // Erase all sinked stats.
   sinked_counters.clear();
   num_iterations = 0;
-  alloc_.forEachSinkedCounter(
-      [&num_sinked_counters](std::size_t size) { num_sinked_counters = size; },
-      [&num_iterations](Counter&) { ++num_iterations; });
+  alloc_.forEachCounter([&num_sinked_counters](std::size_t size) { num_sinked_counters = size; },
+                        [&num_iterations](Counter&) { ++num_iterations; }, {.sinked_only = true});
   EXPECT_EQ(num_sinked_counters, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -505,19 +516,20 @@ TEST_F(AllocatorTest, ForEachSinkedGauge) {
 
   size_t num_sinked_gauges = 0;
   size_t num_iterations = 0;
-  alloc_.forEachSinkedGauge([&num_sinked_gauges](std::size_t size) { num_sinked_gauges = size; },
-                            [&num_iterations, sink_predicates](Gauge& gauge) {
-                              EXPECT_TRUE(sink_predicates->has(gauge.statName()));
-                              ++num_iterations;
-                            });
+  alloc_.forEachGauge([&num_sinked_gauges](std::size_t size) { num_sinked_gauges = size; },
+                      [&num_iterations, sink_predicates](Gauge& gauge) {
+                        EXPECT_TRUE(sink_predicates->has(gauge.statName()));
+                        ++num_iterations;
+                      },
+                      {.sinked_only = true});
   EXPECT_EQ(num_sinked_gauges, 2);
   EXPECT_EQ(num_iterations, 2);
 
   // Erase all sinked stats.
   sinked_gauges.clear();
   num_iterations = 0;
-  alloc_.forEachSinkedGauge([&num_sinked_gauges](std::size_t size) { num_sinked_gauges = size; },
-                            [&num_iterations](Gauge&) { ++num_iterations; });
+  alloc_.forEachGauge([&num_sinked_gauges](std::size_t size) { num_sinked_gauges = size; },
+                      [&num_iterations](Gauge&) { ++num_iterations; }, {.sinked_only = true});
   EXPECT_EQ(num_sinked_gauges, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -538,11 +550,12 @@ TEST_F(AllocatorTest, ForEachSinkedGaugeHidden) {
   hidden_gauge =
       alloc_.makeGauge(hidden_stat_name, StatName(), {}, Gauge::ImportMode::HiddenAccumulate);
 
-  alloc_.forEachSinkedGauge([&num_gauges](std::size_t size) { num_gauges = size; },
-                            [&num_iterations, unhidden_stat_name](Gauge& gauge) {
-                              EXPECT_EQ(unhidden_stat_name, gauge.statName());
-                              num_iterations++;
-                            });
+  alloc_.forEachGauge([&num_gauges](std::size_t size) { num_gauges = size; },
+                      [&num_iterations, unhidden_stat_name](Gauge& gauge) {
+                        EXPECT_EQ(unhidden_stat_name, gauge.statName());
+                        num_iterations++;
+                      },
+                      {.sinked_only = true});
   EXPECT_EQ(num_gauges, 2);
   EXPECT_EQ(num_iterations, 1);
 }
@@ -571,11 +584,12 @@ TEST_F(AllocatorTest, ForEachSinkedGaugeHiddenPredicate) {
   hidden_gauge =
       alloc_.makeGauge(hidden_stat_name, StatName(), {}, Gauge::ImportMode::HiddenAccumulate);
 
-  alloc_.forEachSinkedGauge([&num_gauges](std::size_t size) { num_gauges = size; },
-                            [&num_iterations, &sink_predicates](Gauge& gauge) {
-                              ++num_iterations;
-                              EXPECT_TRUE(sink_predicates->has(gauge.statName()));
-                            });
+  alloc_.forEachGauge([&num_gauges](std::size_t size) { num_gauges = size; },
+                      [&num_iterations, &sink_predicates](Gauge& gauge) {
+                        ++num_iterations;
+                        EXPECT_TRUE(sink_predicates->has(gauge.statName()));
+                      },
+                      {.sinked_only = true});
 
   EXPECT_EQ(num_gauges, 2);
   EXPECT_EQ(num_iterations, 2);
@@ -607,21 +621,22 @@ TEST_F(AllocatorTest, ForEachSinkedTextReadout) {
 
   size_t num_sinked_text_readouts = 0;
   size_t num_iterations = 0;
-  alloc_.forEachSinkedTextReadout(
+  alloc_.forEachTextReadout(
       [&num_sinked_text_readouts](std::size_t size) { num_sinked_text_readouts = size; },
       [&num_iterations, sink_predicates](TextReadout& text_readout) {
         EXPECT_TRUE(sink_predicates->has(text_readout.statName()));
         ++num_iterations;
-      });
+      },
+      {.sinked_only = true});
   EXPECT_EQ(num_sinked_text_readouts, 5);
   EXPECT_EQ(num_iterations, 5);
 
   // Erase all sinked stats.
   sinked_text_readouts.clear();
   num_iterations = 0;
-  alloc_.forEachSinkedTextReadout(
+  alloc_.forEachTextReadout(
       [&num_sinked_text_readouts](std::size_t size) { num_sinked_text_readouts = size; },
-      [&num_iterations](TextReadout&) { ++num_iterations; });
+      [&num_iterations](TextReadout&) { ++num_iterations; }, {.sinked_only = true});
   EXPECT_EQ(num_sinked_text_readouts, 0);
   EXPECT_EQ(num_iterations, 0);
 }

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -586,19 +586,20 @@ TEST_F(StatsThreadLocalStoreTest, ForEach) {
   auto collect_counters = [this]() -> std::vector<std::string> {
     std::vector<std::string> names;
     store_->forEachCounter([](size_t) {},
-                           [&names](Counter& counter) { names.push_back(counter.name()); });
+                           [&names](Counter& counter) { names.push_back(counter.name()); }, {});
     return names;
   };
   auto collect_gauges = [this]() -> std::vector<std::string> {
     std::vector<std::string> names;
-    store_->forEachGauge([](size_t) {}, [&names](Gauge& gauge) { names.push_back(gauge.name()); });
+    store_->forEachGauge([](size_t) {}, [&names](Gauge& gauge) { names.push_back(gauge.name()); },
+                         {});
     return names;
   };
   auto collect_text_readouts = [this]() -> std::vector<std::string> {
     std::vector<std::string> names;
     store_->forEachTextReadout(
         [](size_t) {},
-        [&names](TextReadout& text_readout) { names.push_back(text_readout.name()); });
+        [&names](TextReadout& text_readout) { names.push_back(text_readout.name()); }, {});
     return names;
   };
 
@@ -2242,7 +2243,7 @@ TEST_F(HistogramTest, ForEachHistogram) {
   size_t num_histograms = 0;
   size_t num_iterations = 0;
   store_->forEachHistogram([&num_histograms](std::size_t size) { num_histograms = size; },
-                           [&num_iterations](ParentHistogram&) { ++num_iterations; });
+                           [&num_iterations](ParentHistogram&) { ++num_iterations; }, {});
   EXPECT_EQ(num_histograms, 11);
   EXPECT_EQ(num_iterations, 11);
 
@@ -2256,7 +2257,7 @@ TEST_F(HistogramTest, ForEachHistogram) {
   num_histograms = 0;
   num_iterations = 0;
   store_->forEachHistogram([&num_histograms](std::size_t size) { num_histograms = size; },
-                           [&num_iterations](ParentHistogram&) { ++num_iterations; });
+                           [&num_iterations](ParentHistogram&) { ++num_iterations; }, {});
   EXPECT_EQ(num_histograms, 0);
   EXPECT_EQ(num_iterations, 0);
 
@@ -2310,12 +2311,13 @@ TEST_F(HistogramTest, ForEachSinkedHistogram) {
 
   size_t num_sinked_histograms = 0;
   size_t num_iterations = 0;
-  store_->forEachSinkedHistogram(
+  store_->forEachHistogram(
       [&num_sinked_histograms](std::size_t size) { num_sinked_histograms = size; },
       [&num_iterations, &sink_predicates](ParentHistogram& histogram) {
         EXPECT_TRUE(sink_predicates.has(histogram.statName()));
         ++num_iterations;
-      });
+      },
+      {.sinked_only = true});
   EXPECT_EQ(num_sinked_histograms, 3);
   EXPECT_EQ(num_iterations, 3);
   // Verify that rejecting histograms removes them from the sink set.
@@ -2325,9 +2327,9 @@ TEST_F(HistogramTest, ForEachSinkedHistogram) {
       std::make_unique<StatsMatcherImpl>(stats_config_, symbol_table_, context_));
   num_sinked_histograms = 0;
   num_iterations = 0;
-  store_->forEachSinkedHistogram(
+  store_->forEachHistogram(
       [&num_sinked_histograms](std::size_t size) { num_sinked_histograms = size; },
-      [&num_iterations](ParentHistogram&) { ++num_iterations; });
+      [&num_iterations](ParentHistogram&) { ++num_iterations; }, {.sinked_only = true});
   EXPECT_EQ(num_sinked_histograms, 0);
   EXPECT_EQ(num_iterations, 0);
 }
@@ -2365,12 +2367,13 @@ TEST_F(HistogramTest, UnsinkedHistogramsAreMerged) {
   store_->mergeHistograms([this, &sink_predicates]() -> void {
     size_t num_iterations = 0;
     size_t num_sinked_histograms = 0;
-    store_->forEachSinkedHistogram(
+    store_->forEachHistogram(
         [&num_sinked_histograms](std::size_t size) { num_sinked_histograms = size; },
         [&num_iterations, &sink_predicates](ParentHistogram& histogram) {
           EXPECT_TRUE(sink_predicates.has(histogram.statName()));
           ++num_iterations;
-        });
+        },
+        {.sinked_only = true});
     EXPECT_EQ(num_sinked_histograms, 1);
     EXPECT_EQ(num_iterations, 1);
   });
@@ -2669,17 +2672,19 @@ TEST_F(StatsThreadLocalStoreTest, SetSinkPredicates) {
   uint32_t num_sinked_counters = 0, num_sinked_gauges = 0, num_sinked_text_readouts = 0;
   auto check_expected_size = [](size_t size) { EXPECT_EQ(expected_sinked_stats, size); };
 
-  store_->forEachSinkedCounter(check_expected_size,
-                               [&num_sinked_counters](Counter&) { ++num_sinked_counters; });
+  store_->forEachCounter(check_expected_size,
+                         [&num_sinked_counters](Counter&) { ++num_sinked_counters; },
+                         {.sinked_only = true});
   EXPECT_EQ(expected_sinked_stats, num_sinked_counters);
 
-  store_->forEachSinkedGauge(check_expected_size,
-                             [&num_sinked_gauges](Gauge&) { ++num_sinked_gauges; });
+  store_->forEachGauge(check_expected_size, [&num_sinked_gauges](Gauge&) { ++num_sinked_gauges; },
+                       {.sinked_only = true});
   EXPECT_EQ(expected_sinked_stats, num_sinked_gauges);
 
-  store_->forEachSinkedTextReadout(check_expected_size, [&num_sinked_text_readouts](TextReadout&) {
-    ++num_sinked_text_readouts;
-  });
+  store_->forEachTextReadout(
+      check_expected_size,
+      [&num_sinked_text_readouts](TextReadout&) { ++num_sinked_text_readouts; },
+      {.sinked_only = true});
   EXPECT_EQ(expected_sinked_stats, num_sinked_text_readouts);
 }
 } // namespace Stats

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -875,9 +875,9 @@ void BaseIntegrationTest::checkForMissingTagExtractionRules() {
           << "' and stat_prefix '" << stat_prefix << "'";
     }
   };
-  test_server_->statStore().forEachCounter(nullptr, check_metric);
-  test_server_->statStore().forEachGauge(nullptr, check_metric);
-  test_server_->statStore().forEachHistogram(nullptr, check_metric);
+  test_server_->statStore().forEachCounter(nullptr, check_metric, {});
+  test_server_->statStore().forEachGauge(nullptr, check_metric, {});
+  test_server_->statStore().forEachHistogram(nullptr, check_metric, {});
 }
 
 envoy::config::bootstrap::v3::Bootstrap

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -284,42 +284,30 @@ private:
 class TestIsolatedStoreImpl : public StoreRoot {
 public:
   // Stats::Store
-  void forEachCounter(Stats::SizeFn f_size, StatFn<Counter> f_stat) const override {
+  void forEachCounter(Stats::SizeFn f_size, StatFn<Counter> f_stat,
+                      const IterationCriteria& criteria) const override {
     Thread::LockGuard lock(lock_);
-    store_.forEachCounter(f_size, f_stat);
+    store_.forEachCounter(f_size, f_stat, criteria);
   }
-  void forEachGauge(Stats::SizeFn f_size, StatFn<Gauge> f_stat) const override {
+  void forEachGauge(Stats::SizeFn f_size, StatFn<Gauge> f_stat,
+                    const IterationCriteria& criteria) const override {
     Thread::LockGuard lock(lock_);
-    store_.forEachGauge(f_size, f_stat);
+    store_.forEachGauge(f_size, f_stat, criteria);
   }
-  void forEachTextReadout(Stats::SizeFn f_size, StatFn<TextReadout> f_stat) const override {
+  void forEachTextReadout(Stats::SizeFn f_size, StatFn<TextReadout> f_stat,
+                          const IterationCriteria& criteria) const override {
     Thread::LockGuard lock(lock_);
-    store_.forEachTextReadout(f_size, f_stat);
+    store_.forEachTextReadout(f_size, f_stat, criteria);
   }
-  void forEachHistogram(Stats::SizeFn f_size, StatFn<ParentHistogram> f_stat) const override {
+  void forEachHistogram(Stats::SizeFn f_size, StatFn<ParentHistogram> f_stat,
+                        const IterationCriteria& criteria) const override {
     Thread::LockGuard lock(lock_);
-    store_.forEachHistogram(f_size, f_stat);
+    store_.forEachHistogram(f_size, f_stat, criteria);
   }
   void forEachScope(std::function<void(std::size_t)> f_size,
                     StatFn<const Scope> f_scope) const override {
     Thread::LockGuard lock(lock_);
     store_.forEachScope(f_size, f_scope);
-  }
-  void forEachSinkedCounter(Stats::SizeFn f_size, StatFn<Counter> f_stat) const override {
-    Thread::LockGuard lock(lock_);
-    store_.forEachSinkedCounter(f_size, f_stat);
-  }
-  void forEachSinkedGauge(Stats::SizeFn f_size, StatFn<Gauge> f_stat) const override {
-    Thread::LockGuard lock(lock_);
-    store_.forEachSinkedGauge(f_size, f_stat);
-  }
-  void forEachSinkedTextReadout(Stats::SizeFn f_size, StatFn<TextReadout> f_stat) const override {
-    Thread::LockGuard lock(lock_);
-    store_.forEachSinkedTextReadout(f_size, f_stat);
-  }
-  void forEachSinkedHistogram(Stats::SizeFn f_size, StatFn<ParentHistogram> f_stat) const override {
-    Thread::LockGuard lock(lock_);
-    store_.forEachSinkedHistogram(f_size, f_stat);
   }
   void setSinkPredicates(std::unique_ptr<SinkPredicates>&& sink_predicates) override {
     UNREFERENCED_PARAMETER(sink_predicates);

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -335,11 +335,12 @@ public:
   ~MockStore() override;
 
   // Store
-  MOCK_METHOD(void, forEachCounter, (SizeFn, StatFn<Counter>), (const));
-  MOCK_METHOD(void, forEachGauge, (SizeFn, StatFn<Gauge>), (const));
-  MOCK_METHOD(void, forEachTextReadout, (SizeFn, StatFn<TextReadout>), (const));
-  MOCK_METHOD(void, forEachHistogram, (SizeFn, StatFn<ParentHistogram>), (const));
-  MOCK_METHOD(void, forEachSinkedHistogram, (SizeFn, StatFn<ParentHistogram>), (const));
+  MOCK_METHOD(void, forEachCounter, (SizeFn, StatFn<Counter>, const IterationCriteria&), (const));
+  MOCK_METHOD(void, forEachGauge, (SizeFn, StatFn<Gauge>, const IterationCriteria&), (const));
+  MOCK_METHOD(void, forEachTextReadout, (SizeFn, StatFn<TextReadout>, const IterationCriteria&),
+              (const));
+  MOCK_METHOD(void, forEachHistogram, (SizeFn, StatFn<ParentHistogram>, const IterationCriteria&),
+              (const));
   MOCK_METHOD(Counter&, counter, (const std::string&));
   MOCK_METHOD(Gauge&, gauge, (const std::string&, Gauge::ImportMode));
   MOCK_METHOD(Histogram&, histogram, (const std::string&, Histogram::Unit));

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -99,9 +99,10 @@ TEST(ServerInstanceUtil, flushHelper) {
   NiceMock<Stats::MockStore> mock_store;
   Stats::ParentHistogramSharedPtr parent_histogram(new Stats::MockParentHistogram());
   std::vector<Stats::ParentHistogramSharedPtr> parent_histograms = {parent_histogram};
-  ON_CALL(mock_store, forEachSinkedHistogram)
+  ON_CALL(mock_store, forEachHistogram)
       .WillByDefault([&](std::function<void(std::size_t)> f_size,
-                         std::function<void(Stats::ParentHistogram&)> f_stat) {
+                         std::function<void(Stats::ParentHistogram&)> f_stat,
+                         const Stats::IterationCriteria&) {
         if (f_size != nullptr) {
           f_size(parent_histograms.size());
         }


### PR DESCRIPTION
Ref: https://github.com/envoyproxy/envoy/issues/44156

Store previously had 8 virtual forEach methods: `forEachCounter`, `forEachGauge`, `forEachTextReadout`, `forEachHistogram`, and a parallel `forEachSinked*` family for each.
The sinked variants were functionally identical to the non-sinked variants except for a filter.
This PR collapses them into 4 methods by introducing an `IterationCriteria` struct.

A struct over a naked bool since it reads clearly (with the help of designated initializers) and allows for more filter fields in the future. #44156 mentions one for `used_only`, I've not added that one since I felt like a smaller change would be best to start with.

There were three differences between the sinked and non-sinked variants in `Allocator` that I preserved in the merged implementation:
  1. Missing `f_size` nullptr checks in the sinked variants; the merged implementation adds them in both cases
  2. Gauges have a `hidden()` filter applied when iterating sinked stats with no sink predicates
  3. Sinked iteration falls back to all stats when `sink_predicates_` is not set


Risk Level: Low
Testing: adapted existing tests only
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

Claude Code was used to help navigate the codebase and understand the existing implementation prior to making changes.