### PR TITLE
http2: add keepalive observer hook

### DIFF
--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -25,11 +25,20 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "keepalive_observer_lib",
+    hdrs = ["keepalive_observer.h"],
+    deps = [
+        "//envoy/stream_info:stream_info_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "codec_lib",
     srcs = ["codec_impl.cc"],
     hdrs = ["codec_impl.h"],
     deps = [
         ":codec_stats_lib",
+        ":keepalive_observer_lib",
         ":metadata_decoder_lib",
         ":metadata_encoder_lib",
         ":protocol_constraints_lib",

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1036,6 +1036,9 @@ void ConnectionImpl::sendKeepalive() {
     // Intended to check through coverage that this error case is tested
     return;
   }
+  if (const auto* observer = keepaliveObserver(); observer != nullptr) {
+    observer->onKeepalivePingSent(connection_.streamInfo(), ms_since_epoch);
+  }
   keepalive_timeout_timer_->enableTimer(keepalive_timeout_);
 }
 
@@ -1060,6 +1063,14 @@ void ConnectionImpl::onKeepaliveResponseTimeout() {
   stats_.keepalive_timeout_.inc();
   connection_.close(Network::ConnectionCloseType::NoFlush,
                     StreamInfo::LocalCloseReasons::get().Http2PingTimeout);
+}
+
+const KeepaliveObserver* ConnectionImpl::keepaliveObserver() const {
+  if (const auto& filter_state = connection_.streamInfo().filterState(); filter_state != nullptr) {
+    return filter_state->getDataReadOnly<KeepaliveObserver>(kKeepaliveObserverFilterStateKey);
+  }
+
+  return nullptr;
 }
 
 bool ConnectionImpl::slowContainsStreamId(int32_t stream_id) const {
@@ -1228,6 +1239,9 @@ Status ConnectionImpl::onPing(uint64_t opaque_data, bool is_ack) {
 
   if (is_ack) {
     ENVOY_CONN_LOG(trace, "recv PING ACK {}", connection_, opaque_data);
+    if (const auto* observer = keepaliveObserver(); observer != nullptr) {
+      observer->onKeepalivePingAck(connection_.streamInfo(), opaque_data);
+    }
 
     onKeepaliveResponse();
   }

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -24,6 +24,7 @@
 #include "source/common/http/codec_helper.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/http2/codec_stats.h"
+#include "source/common/http/http2/keepalive_observer.h"
 #include "source/common/http/http2/metadata_decoder.h"
 #include "source/common/http/http2/metadata_encoder.h"
 #include "source/common/http/http2/protocol_constraints.h"
@@ -798,6 +799,7 @@ private:
                             uint32_t padding_length);
   void onKeepaliveResponse();
   void onKeepaliveResponseTimeout();
+  const KeepaliveObserver* keepaliveObserver() const;
   bool slowContainsStreamId(int32_t stream_id) const;
   virtual StreamResetReason getMessagingErrorResetReason() const PURE;
 

--- a/source/common/http/http2/keepalive_observer.h
+++ b/source/common/http/http2/keepalive_observer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/common/pure.h"
+#include "envoy/stream_info/filter_state.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Http {
+namespace Http2 {
+
+inline constexpr absl::string_view kKeepaliveObserverFilterStateKey =
+    "envoy.http2.keepalive_observer";
+
+class KeepaliveObserver : public StreamInfo::FilterState::Object {
+public:
+  ~KeepaliveObserver() override = default;
+
+  virtual void onKeepalivePingSent(StreamInfo::StreamInfo& stream_info,
+                                   uint64_t opaque_data) const PURE;
+  virtual void onKeepalivePingAck(StreamInfo::StreamInfo& stream_info,
+                                  uint64_t opaque_data) const PURE;
+  virtual absl::optional<uint64_t> pendingKeepalivePingId() const PURE;
+};
+
+} // namespace Http2
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -111,6 +111,13 @@ private:
   Http::ServerHeaderValidator* header_validator_{nullptr};
   Http::ResponseEncoder* response_encoder_{nullptr};
 };
+
+class MockKeepaliveObserver : public KeepaliveObserver {
+public:
+  MOCK_METHOD(void, onKeepalivePingSent, (StreamInfo::StreamInfo&, uint64_t), (const, override));
+  MOCK_METHOD(void, onKeepalivePingAck, (StreamInfo::StreamInfo&, uint64_t), (const, override));
+  MOCK_METHOD(absl::optional<uint64_t>, pendingKeepalivePingId, (), (const, override));
+};
 } // namespace
 
 enum class Http2Impl {
@@ -1374,6 +1381,37 @@ TEST_P(Http2CodecImplTest, ConnectionKeepalive) {
   driveClient();
   EXPECT_CALL(client_connection_, close(Network::ConnectionCloseType::NoFlush, _));
   timeout_timer->invokeCallback();
+}
+
+TEST_P(Http2CodecImplTest, ConnectionKeepaliveObserver) {
+  constexpr uint32_t interval_ms = 100;
+  constexpr uint32_t timeout_ms = 200;
+  client_http2_options_.mutable_connection_keepalive()->mutable_interval()->set_nanos(interval_ms *
+                                                                                      1000 * 1000);
+  client_http2_options_.mutable_connection_keepalive()->mutable_timeout()->set_nanos(timeout_ms *
+                                                                                     1000 * 1000);
+  client_http2_options_.mutable_connection_keepalive()->mutable_interval_jitter()->set_value(0);
+
+  auto observer = std::make_shared<NiceMock<MockKeepaliveObserver>>();
+  ON_CALL(*observer, pendingKeepalivePingId()).WillByDefault(Return(absl::nullopt));
+  client_connection_.streamInfo().filterState()->setData(
+      kKeepaliveObserverFilterStateKey, observer, StreamInfo::FilterState::StateType::ReadOnly,
+      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto timeout_timer = new NiceMock<Event::MockTimer>(&client_connection_.dispatcher_);
+  auto send_timer = new NiceMock<Event::MockTimer>(&client_connection_.dispatcher_);
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(*send_timer, enableTimer(std::chrono::milliseconds(interval_ms), _));
+  initialize();
+
+  testing::InSequence sequence;
+  EXPECT_CALL(*observer, onKeepalivePingSent(_, _));
+  EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(timeout_ms), _));
+  EXPECT_CALL(*observer, onKeepalivePingAck(_, _));
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(*send_timer, enableTimer(std::chrono::milliseconds(interval_ms), _));
+  send_timer->invokeCallback();
+  driveToCompletion();
 }
 
 // Verify that extending the timeout is performed when a frame is received.


### PR DESCRIPTION
Expose HTTP/2 keepalive send and ack events through a small observer interface so higher layers can react to codec keepalives without coupling reverse-tunnel logic into the core codec.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

  Commit Message: http2: add keepalive observer hook
  Additional Description:

  Today, higher-level extensions (e.g. reverse tunnel lifecycle logging) that
  need to react to HTTP/2 keepalive events must either parse raw HTTP/2 frames
  from network filter buffers or embed extension-specific logic directly in the
  codec. Both approaches are undesirable — the first is fragile and works against
  Envoy's layered architecture, and the second couples domain logic into core
  protocol code.

  This PR introduces a lightweight `KeepaliveObserver` interface that the HTTP/2
  codec queries via connection FilterState on keepalive ping send and ack events.
  If no observer is registered, the codec does nothing (null-check only). If an
  observer is present, it receives callbacks with the connection's `StreamInfo`
  and the PING opaque data.

  **New interface (`keepalive_observer.h`)**

  `KeepaliveObserver` extends `StreamInfo::FilterState::Object` and defines:

  - `onKeepalivePingSent(StreamInfo::StreamInfo&, uint64_t opaque_data)` — called
    immediately after the codec submits an HTTP/2 PING frame via the adapter.
  - `onKeepalivePingAck(StreamInfo::StreamInfo&, uint64_t opaque_data)` — called
    when the codec receives a PING ACK frame from the peer.
  - `pendingKeepalivePingId()` — returns the opaque data of the outstanding PING,
    if any, allowing the observer to correlate send/ack pairs.

  The observer is looked up from FilterState under the key
  `envoy.http2.keepalive_observer`.

  **Codec changes (`codec_impl.cc`)**

  - `sendKeepalive()`: after `adapter_->SubmitPing()`, checks for an observer
    and calls `onKeepalivePingSent()` (~3 lines added).
  - `onPing()` (ACK path): after logging the PING ACK, checks for an observer
    and calls `onKeepalivePingAck()` (~3 lines added).
  - New private helper `keepaliveObserver()` retrieves the observer from
    `connection_.streamInfo().filterState()` (~6 lines).

  **Usage pattern**

  An upstream network filter sets a `KeepaliveObserver` implementation in
  the connection's FilterState during `onNewConnection()`. The codec picks it
  up automatically on the next keepalive cycle. Example:

  ```cpp
  filter_state.setData(
      kKeepaliveObserverFilterStateKey,
      std::make_shared<MyObserverImpl>(),
      StreamInfo::FilterState::StateType::ReadOnly,
      StreamInfo::FilterState::LifeSpan::Connection);

  No observer registered → zero overhead beyond a null-check per ping event.

  Risk Level: Low — opt-in via FilterState; no behavioral change when no observer
    is registered. The null-check in the keepalive hot path is negligible.
  Testing: New ConnectionKeepaliveObserver test in codec_impl_test.cc
    validates that onKeepalivePingSent and onKeepalivePingAck are called in
    correct sequence with proper timer interactions using a MockKeepaliveObserver.
  Docs Changes: N/A
  Release Notes: N/A
  Platform Specific Features: N/A
