### PR TITLE
repokitteh: Exclude compat/openssl patches from dependency-shepherds review

### DIFF
--- a/repokitteh.star
+++ b/repokitteh.star
@@ -41,7 +41,7 @@ use(
         },
         {
             "owner": "envoyproxy/dependency-shepherds!",
-            "path": "(bazel/.*repos.*\\.bzl)|(bazel/dependency_imports\\.bzl)|(api/bazel/.*\\.bzl)|(.*/requirements\\.txt)|(.*\\.patch)",
+            "path": "(bazel/.*repos.*\\.bzl)|(bazel/dependency_imports\\.bzl)|(api/bazel/.*\\.bzl)|(.*/requirements\\.txt)|((?!.*compat/openssl/).*\\.patch)",
             "label": "deps",
             "github_status_label": "any dependency change",
             "auto_assign": True,


### PR DESCRIPTION
The repokitteh rule for dependency-shepherds matched all .patch files, including those under compat/openssl/ which are not dependency changes. Add a negative lookahead to skip compat/openssl/ patches.
