### PR TITLE
repokitteh: Add path_exclude support to fix compat/openssl exclusion

### DIFF
--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -59,7 +59,11 @@ def _get_relevant_specs(specs, changed_files):
     for spec in specs:
         path_match = spec["path"]
 
+        path_exclude = spec.get("path_exclude", "")
+
         files = [f for f in changed_files if match(path_match, f["filename"])]
+        if path_exclude and files:
+            files = [f for f in files if not match(path_exclude, f["filename"])]
         allow_global_approval = spec.get("allow_global_approval", True)
         status_label = spec.get("github_status_label", "")
         if files:

--- a/repokitteh.star
+++ b/repokitteh.star
@@ -41,7 +41,8 @@ use(
         },
         {
             "owner": "envoyproxy/dependency-shepherds!",
-            "path": "(bazel/.*repos.*\\.bzl)|(bazel/dependency_imports\\.bzl)|(api/bazel/.*\\.bzl)|(.*/requirements\\.txt)|((?!.*compat/openssl/).*\\.patch)",
+            "path": "(bazel/.*repos.*\\.bzl)|(bazel/dependency_imports\\.bzl)|(api/bazel/.*\\.bzl)|(.*/requirements\\.txt)|(.*\\.patch)",
+            "path_exclude": "compat/openssl/.*\\.patch",
             "label": "deps",
             "github_status_label": "any dependency change",
             "auto_assign": True,


### PR DESCRIPTION
The previous commit used a Perl-style negative lookahead (?!) to exclude compat/openssl patches from dependency-shepherds review, but RepokitteH uses Go's regexp (RE2) which doesn't support lookaheads.

Add a `path_exclude` option to the ownerscheck module and use it to exclude compat/openssl .patch files from dependency-shepherds review.
