### PR TITLE
router: give VHDS virtual hosts precedence over RDS in route config merge

### DIFF
--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -191,6 +191,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/rds:rds_lib",
+        "@abseil-cpp//absl/container:flat_hash_set",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
     ],

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -13,22 +13,48 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/router/config_impl.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace Router {
 
 namespace {
 
 // Resets 'route_config::virtual_hosts' by merging VirtualHost contained in
-// 'rds_vhosts' and 'vhds_vhosts'.
+// 'rds_vhosts' and 'vhds_vhosts'. Per the RouteConfiguration proto spec, VHDS-supplied
+// virtual hosts take precedence: any RDS vhost whose name or domains collide with a
+// VHDS vhost is skipped.
 void rebuildRouteConfigVirtualHosts(
     const RouteConfigUpdateReceiverImpl::VirtualHostMap& rds_vhosts,
     const RouteConfigUpdateReceiverImpl::VirtualHostMap& vhds_vhosts,
     envoy::config::route::v3::RouteConfiguration& route_config) {
   route_config.clear_virtual_hosts();
-  for (const auto& vhost : rds_vhosts) {
-    route_config.mutable_virtual_hosts()->Add()->CheckTypeAndMergeFrom(vhost.second);
-  }
+
+  absl::flat_hash_set<std::string> vhds_domains;
   for (const auto& vhost : vhds_vhosts) {
+    route_config.mutable_virtual_hosts()->Add()->CheckTypeAndMergeFrom(vhost.second);
+    for (const auto& domain : vhost.second.domains()) {
+      vhds_domains.insert(domain);
+    }
+  }
+
+  for (const auto& vhost : rds_vhosts) {
+    if (vhds_vhosts.find(vhost.first) != vhds_vhosts.end()) {
+      ENVOY_LOG_MISC(debug, "rds: skipping vhost '{}' - superseded by VHDS", vhost.first);
+      continue;
+    }
+    bool domain_collision = false;
+    for (const auto& domain : vhost.second.domains()) {
+      if (vhds_domains.contains(domain)) {
+        domain_collision = true;
+        ENVOY_LOG_MISC(warn, "rds: skipping vhost '{}' - domain '{}' already provided by VHDS",
+                       vhost.first, domain);
+        break;
+      }
+    }
+    if (domain_collision) {
+      continue;
+    }
     route_config.mutable_virtual_hosts()->Add()->CheckTypeAndMergeFrom(vhost.second);
   }
 }

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -316,6 +316,157 @@ vhds:
               "vhost_vhds1" == actual_vhost_2.name());
 }
 
+// Verify that when VHDS provides a vhost and RDS later sends a vhost with the same name,
+// the VHDS vhost takes precedence (per the RouteConfiguration proto spec).
+TEST_F(VhdsTest, VhdsVhostTakesPrecedenceOverRdsSameName) {
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(default_vhds_config_);
+  RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
+
+  VhdsSubscriptionPtr subscription = VhdsSubscription::createVhdsSubscription(
+                                         config_update_info, factory_context_, context_, provider_)
+                                         .value();
+  EXPECT_EQ(0UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+
+  // VHDS delivers a vhost named "shared_vhost" with domain "example.com"
+  auto vhds_vhost = buildVirtualHost("shared_vhost", "example.com");
+  const auto& added_resources = buildAddedResources({vhds_vhost});
+  const auto decoded_resources =
+      TestUtility::decodeResources<envoy::config::route::v3::VirtualHost>(added_resources);
+  const Protobuf::RepeatedPtrField<std::string> removed_resources;
+  EXPECT_TRUE(factory_context_.cluster_manager_.subscription_factory_.callbacks_
+                  ->onConfigUpdate(decoded_resources.refvec_, removed_resources, "1")
+                  .ok());
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+  EXPECT_EQ("shared_vhost",
+            config_update_info->protobufConfigurationCast().virtual_hosts(0).name());
+
+  // RDS update arrives with a vhost of the same name but different route config.
+  const auto updated_route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
+name: my_route
+virtual_hosts:
+- name: shared_vhost
+  domains: ["example.com"]
+  routes:
+  - match: { prefix: "/rds-route" }
+    route: { cluster: rds_cluster }
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  )EOF");
+  config_update_info->onRdsUpdate(updated_route_config, "2");
+
+  // Only one vhost should remain (no duplicate) and it should be the VHDS version.
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+  EXPECT_EQ("shared_vhost",
+            config_update_info->protobufConfigurationCast().virtual_hosts(0).name());
+  // Verify it's the VHDS version (routes to my_service, not rds_cluster).
+  EXPECT_EQ(
+      "my_service",
+      config_update_info->protobufConfigurationCast().virtual_hosts(0).routes(0).route().cluster());
+}
+
+// Verify that a VHDS vhost whose domain collides with an RDS vhost (but has a different name)
+// takes precedence and the RDS vhost is skipped.
+TEST_F(VhdsTest, VhdsVhostTakesPrecedenceOverRdsSameDomain) {
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
+name: my_route
+virtual_hosts:
+- name: rds_vhost
+  domains: ["example.com"]
+  routes:
+  - match: { prefix: "/" }
+    route: { cluster: rds_cluster }
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  )EOF");
+  RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
+
+  VhdsSubscriptionPtr subscription = VhdsSubscription::createVhdsSubscription(
+                                         config_update_info, factory_context_, context_, provider_)
+                                         .value();
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+
+  // VHDS delivers a vhost with a *different* name but the *same* domain "example.com".
+  auto vhds_vhost = buildVirtualHost("vhds_vhost", "example.com");
+  const auto& added_resources = buildAddedResources({vhds_vhost});
+  const auto decoded_resources =
+      TestUtility::decodeResources<envoy::config::route::v3::VirtualHost>(added_resources);
+  const Protobuf::RepeatedPtrField<std::string> removed_resources;
+  EXPECT_TRUE(factory_context_.cluster_manager_.subscription_factory_.callbacks_
+                  ->onConfigUpdate(decoded_resources.refvec_, removed_resources, "1")
+                  .ok());
+
+  // The VHDS vhost takes precedence; the RDS vhost with domain "example.com" is skipped.
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+  EXPECT_EQ("vhds_vhost", config_update_info->protobufConfigurationCast().virtual_hosts(0).name());
+}
+
+// Verify that when VHDS removes a vhost that was shadowing an RDS vhost,
+// the RDS vhost reappears in the merged config.
+TEST_F(VhdsTest, RdsVhostReappearsWhenVhdsRemovesOverlap) {
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
+name: my_route
+virtual_hosts:
+- name: rds_vhost
+  domains: ["example.com"]
+  routes:
+  - match: { prefix: "/" }
+    route: { cluster: rds_cluster }
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  )EOF");
+  RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
+
+  VhdsSubscriptionPtr subscription = VhdsSubscription::createVhdsSubscription(
+                                         config_update_info, factory_context_, context_, provider_)
+                                         .value();
+
+  // VHDS delivers a vhost with the same domain — it supersedes the RDS vhost.
+  auto vhds_vhost = buildVirtualHost("vhds_vhost", "example.com");
+  const auto& added_resources = buildAddedResources({vhds_vhost});
+  const auto decoded_resources =
+      TestUtility::decodeResources<envoy::config::route::v3::VirtualHost>(added_resources);
+  const Protobuf::RepeatedPtrField<std::string> removed_resources_empty;
+  EXPECT_TRUE(factory_context_.cluster_manager_.subscription_factory_.callbacks_
+                  ->onConfigUpdate(decoded_resources.refvec_, removed_resources_empty, "1")
+                  .ok());
+
+  // Only VHDS vhost visible (RDS filtered due to domain overlap).
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+  EXPECT_EQ("vhds_vhost", config_update_info->protobufConfigurationCast().virtual_hosts(0).name());
+
+  // VHDS removes the overlapping vhost.
+  const auto removed_resources = buildRemovedResources({"vhds_vhost"});
+  const Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource> no_added;
+  const auto empty_decoded =
+      TestUtility::decodeResources<envoy::config::route::v3::VirtualHost>(no_added);
+  EXPECT_TRUE(factory_context_.cluster_manager_.subscription_factory_.callbacks_
+                  ->onConfigUpdate(empty_decoded.refvec_, removed_resources, "2")
+                  .ok());
+
+  // Now the RDS vhost should reappear since the VHDS shadow is gone.
+  EXPECT_EQ(1UL, config_update_info->protobufConfigurationCast().virtual_hosts_size());
+  EXPECT_EQ("rds_vhost", config_update_info->protobufConfigurationCast().virtual_hosts(0).name());
+}
+
 } // namespace
 } // namespace Router
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
When both RDS and VHDS supply virtual hosts covering the same name or domains, the merge in rebuildRouteConfigVirtualHosts() blindly concatenated them, producing duplicate domains that RouteMatcher rejects, causing the envoy node to NACK the config update.

Per the [RouteConfiguration proto spec](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto#config-route-v3-routeconfiguration), "the contents of these two fields will be merged to generate a routing table for a given RouteConfiguration, with vhds derived configuration taking precedence."

Skip RDS virtual hosts whose name or domains collide with VHDS-supplied virtual hosts so that VHDS always wins. RDS vhosts are still retained in the rds_virtual_hosts_ map and will reappear if VHDS later removes the overlap.
Additional Description:
Risk Level: Medium
Testing: Added 3 new unit tests covering name-based precedence, domain-based precedence, and RDS vhost reappearance when VHDS removes the overlap.
Docs Changes: N/A (aligns implementation with existing docs)
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]