### PR TITLE
reverse_tunnels: Add EventReporter for reverse tunnel connection reporting

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -496,5 +496,6 @@ extensions/upstreams/tcp @ggreenway @mattklein123
 /contrib/peak_ewma/load_balancing_policies/ @rroblak @UNOWNED
 /contrib/kae/ @Misakokoro @UNOWNED
 /contrib/istio @kyessenov @wbpcode @keithmattix @krinkinmu @zirain
+/contrib/reverse_tunnel_reporter @agrawroh @aakugan @basundhara-c
 
 /compat/openssl/ @tedjpoole @envoyproxy/envoy-openssl-sync

--- a/contrib/contrib_build_config.bzl
+++ b/contrib/contrib_build_config.bzl
@@ -118,4 +118,10 @@ CONTRIB_EXTENSIONS = {
     #
 
     "envoy.upstreams.http.tcp.golang":                          "//contrib/golang/upstreams/http/tcp/source:config",
+
+    #
+    # Reverse tunnel reporters
+    #
+
+    "envoy.bootstrap.reverse_tunnel.reverse_tunnel_reporting_service": "//contrib/reverse_tunnel_reporter/source:config",
 }

--- a/contrib/extensions_metadata.yaml
+++ b/contrib/extensions_metadata.yaml
@@ -205,3 +205,11 @@ envoy.load_balancing_policies.peak_ewma:
   status: alpha
   type_urls:
   - envoy.extensions.load_balancing_policies.peak_ewma.v3alpha.PeakEwma
+envoy.bootstrap.reverse_tunnel.reverse_tunnel_reporting_service:
+  categories:
+  - envoy.bootstrap
+  security_posture: requires_trusted_downstream_and_upstream
+  status: alpha
+  type_urls:
+  - envoy.extensions.reverse_tunnel_reporters.v3alpha.reporters.EventReporterConfig
+  - envoy.extensions.reverse_tunnel_reporters.v3alpha.clients.grpc_client.GrpcClientConfig

--- a/contrib/reverse_tunnel_reporter/source/BUILD
+++ b/contrib/reverse_tunnel_reporter/source/BUILD
@@ -1,0 +1,35 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_contrib_extension",
+    "envoy_cc_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_library(
+    name = "reverse_tunnel_event_types",
+    hdrs = [
+        "reverse_tunnel_event_types.h",
+    ],
+    deps = [
+        "//envoy/common:pure_lib",
+        "//envoy/common:time_interface",
+        "//envoy/config:typed_config_interface",
+        "//envoy/extensions/bootstrap/reverse_tunnel:reverse_tunnel_reporter_lib",
+        "//envoy/server:factory_context_interface",
+        "//source/common/common:fmt_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/protobuf",
+        "//source/common/protobuf:message_validator_lib",
+    ],
+)
+
+envoy_cc_contrib_extension(
+    name = "config",
+    deps = [
+        "//contrib/reverse_tunnel_reporter/source/reporters:reporters_lib",
+    ],
+)

--- a/contrib/reverse_tunnel_reporter/source/reporters/BUILD
+++ b/contrib/reverse_tunnel_reporter/source/reporters/BUILD
@@ -1,0 +1,16 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_library(
+    name = "reporters_lib",
+    deps = [
+        "//contrib/reverse_tunnel_reporter/source/reporters/event_reporter:event_reporter_lib",
+    ],
+)

--- a/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/BUILD
+++ b/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/BUILD
@@ -1,0 +1,30 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_library(
+    name = "event_reporter_lib",
+    srcs = [
+        "factory.cc",
+        "reporter.cc",
+    ],
+    hdrs = [
+        "factory.h",
+        "reporter.h",
+    ],
+    deps = [
+        "//contrib/reverse_tunnel_reporter/source:reverse_tunnel_event_types",
+        "//envoy/extensions/bootstrap/reverse_tunnel:reverse_tunnel_reporter_lib",
+        "//envoy/registry",
+        "//source/common/common:logger_lib",
+        "//source/common/config:utility_lib",
+        "//source/common/protobuf:utility_lib",
+        "@envoy_api//contrib/envoy/extensions/reverse_tunnel_reporters/v3alpha/reporters:pkg_cc_proto",
+    ],
+)

--- a/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.cc
+++ b/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.cc
@@ -1,0 +1,58 @@
+#include "contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.h"
+
+#include "envoy/registry/registry.h"
+
+#include "source/common/config/utility.h"
+#include "source/common/protobuf/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+ReverseTunnelReporterPtr
+EventReporterFactory::createReporter(Server::Configuration::ServerFactoryContext& context,
+                                     ProtobufTypes::MessagePtr config) {
+  const auto& reporter_config = MessageUtil::downcastAndValidate<const ConfigProto&>(
+      *config, context.messageValidationVisitor());
+
+  std::vector<ReverseTunnelReporterClientPtr> clients;
+  clients.reserve(reporter_config.clients().size());
+  for (const auto& client_config : reporter_config.clients()) {
+    clients.push_back(createClient(context, client_config));
+  }
+  return std::make_unique<EventReporter>(context, reporter_config, std::move(clients));
+}
+
+std::string EventReporterFactory::name() const {
+  return "envoy.extensions.reverse_tunnel.reverse_tunnel_reporting_service.reporters.event_"
+         "reporter";
+}
+
+ProtobufTypes::MessagePtr EventReporterFactory::createEmptyConfigProto() {
+  return std::make_unique<ConfigProto>();
+}
+
+ReverseTunnelReporterClientPtr
+EventReporterFactory::createClient(Server::Configuration::ServerFactoryContext& context,
+                                   const ClientConfigProto& client_config) {
+  auto* factory =
+      Config::Utility::getFactoryByName<ReverseTunnelReporterClientFactory>(client_config.name());
+  if (!factory) {
+    throw EnvoyException(
+        fmt::format("Unknown Reporter Client Factory: '{}'. "
+                    "Make sure it is registered as a ReverseTunnelReporterClientFactory.",
+                    client_config.name()));
+  }
+
+  auto typed_config = Config::Utility::translateAnyToFactoryConfig(
+      client_config.typed_config(), context.messageValidationVisitor(), *factory);
+  return factory->createClient(context, *typed_config);
+}
+
+REGISTER_FACTORY(EventReporterFactory, ReverseTunnelReporterFactory);
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.h
+++ b/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "envoy/extensions/bootstrap/reverse_tunnel/reverse_tunnel_reporter.h"
+
+#include "contrib/envoy/extensions/reverse_tunnel_reporters/v3alpha/reporters/event_reporter.pb.h"
+#include "contrib/envoy/extensions/reverse_tunnel_reporters/v3alpha/reporters/event_reporter.pb.validate.h"
+#include "contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.h"
+#include "contrib/reverse_tunnel_reporter/source/reverse_tunnel_event_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+/// Factory that builds an EventReporter from its proto config, dynamically
+/// resolving each child ReverseTunnelReporterClient by name.
+class EventReporterFactory : public ReverseTunnelReporterFactory {
+public:
+  ReverseTunnelReporterPtr createReporter(Server::Configuration::ServerFactoryContext& context,
+                                          ProtobufTypes::MessagePtr config) override;
+  std::string name() const override;
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+private:
+  using ConfigProto =
+      envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::EventReporterConfig;
+  using ClientConfigProto = envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::
+      ReverseConnectionReporterClient;
+
+  ReverseTunnelReporterClientPtr createClient(Server::Configuration::ServerFactoryContext& context,
+                                              const ClientConfigProto& client_config);
+};
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.cc
+++ b/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.cc
@@ -1,0 +1,126 @@
+#include "contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.h"
+
+#include "source/common/protobuf/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+EventReporter::EventReporter(Server::Configuration::ServerFactoryContext& context,
+                             const ConfigProto& config,
+                             std::vector<ReverseTunnelReporterClientPtr>&& clients)
+    : context_{context}, clients_{std::move(clients)},
+      stats_(generateStats(
+          PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_reporter"),
+          context.scope())) {
+  ENVOY_LOG(info, "Constructed with {} clients", clients_.size());
+}
+
+void EventReporter::onServerInitialized() {
+  ENVOY_LOG(info, "Initialized");
+  for (auto& client : clients_) {
+    client->onServerInitialized(this);
+  }
+}
+
+void EventReporter::reportConnectionEvent(absl::string_view node_id, absl::string_view cluster_id,
+                                          absl::string_view tenant_id) {
+  auto ptr = std::make_shared<ReverseTunnelEvent::Connected>(
+      ReverseTunnelEvent::Connected{std::string(node_id), std::string(cluster_id),
+                                    std::string(tenant_id), Envoy::SystemTime::clock::now()});
+
+  context_.mainThreadDispatcher().post(
+      [this, ptr = std::move(ptr)]() mutable { this->addConnection(std::move(ptr)); });
+}
+
+void EventReporter::reportDisconnectionEvent(absl::string_view node_id, absl::string_view) {
+  std::string name = ReverseTunnelEvent::getName(node_id);
+  auto ptr = std::make_shared<ReverseTunnelEvent::Disconnected>(name);
+
+  context_.mainThreadDispatcher().post(
+      [this, ptr = std::move(ptr)]() mutable { this->removeConnection(std::move(ptr)); });
+}
+
+// This is only served on the main thread so no locks needed.
+ReverseTunnelEvent::ConnectionsList EventReporter::getAllConnections() {
+  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
+  stats_.reverse_tunnel_full_pulls_total_.inc();
+
+  ReverseTunnelEvent::ConnectionsList all_connections;
+  all_connections.reserve(connections_.size());
+
+  for (auto& [key, val] : connections_) {
+    all_connections.push_back(val.connection);
+  }
+  return all_connections;
+}
+
+EventReporterStats EventReporter::generateStats(const std::string& prefix, Stats::Scope& scope) {
+  return EventReporterStats{ALL_EVENT_REPORTER_STATS(POOL_COUNTER_PREFIX(scope, prefix),
+                                                     POOL_GAUGE_PREFIX(scope, prefix))};
+}
+
+void EventReporter::notifyClients(ReverseTunnelEvent::TunnelUpdates&& updates) {
+  ASSERT(clients_.size() > 0, "Need atleast one client. Enforced via the protos.");
+
+  for (size_t i = 0; i < clients_.size() - 1; i++) {
+    clients_[i]->receiveEvents(updates);
+  }
+
+  clients_.back()->receiveEvents(std::move(updates));
+}
+
+void EventReporter::addConnection(std::shared_ptr<ReverseTunnelEvent::Connected>&& connection) {
+  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
+
+  ENVOY_LOG(info, "Accepted a new connection. Node: {}, Cluster: {}, Tenant: {}",
+            connection->node_id, connection->cluster_id, connection->tenant_id);
+
+  std::string name = ReverseTunnelEvent::getName(connection->node_id);
+  auto [it, inserted] = connections_.try_emplace(std::move(name), std::move(connection), 1);
+
+  if (inserted) {
+    stats_.reverse_tunnel_unique_active_.inc();
+    notifyClients(ReverseTunnelEvent::TunnelUpdates{{it->second.connection}, {}});
+  } else {
+    // Multiple reverse tunnels can share the same name (same node).
+    // We ref-count them and only notify clients of removal when the last one disconnects.
+    it->second.count++;
+  }
+
+  stats_.reverse_tunnel_established_total_.inc();
+  stats_.reverse_tunnel_active_.inc();
+}
+
+void EventReporter::removeConnection(
+    std::shared_ptr<ReverseTunnelEvent::Disconnected>&& disconnection) {
+  ASSERT(context_.mainThreadDispatcher().isThreadSafe());
+
+  const auto& name = disconnection->name;
+  auto it = connections_.find(name);
+
+  ENVOY_LOG(info, "Removed connection. Name: {}", name);
+
+  if (it == connections_.end()) {
+    ENVOY_LOG(warn, "Tried to remove a connection which doesnt exist");
+    return;
+  }
+
+  // Only notify removal on the last ref — see addConnection for the ref-count rationale.
+  if (it->second.count == 1) {
+    connections_.erase(it);
+    stats_.reverse_tunnel_unique_active_.dec();
+    notifyClients(ReverseTunnelEvent::TunnelUpdates{{}, {disconnection}});
+  } else {
+    it->second.count--;
+  }
+
+  stats_.reverse_tunnel_closed_total_.inc();
+  stats_.reverse_tunnel_active_.dec();
+}
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.h
+++ b/contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <vector>
+
+#include "envoy/stats/stats_macros.h"
+
+#include "source/common/common/logger.h"
+
+#include "contrib/envoy/extensions/reverse_tunnel_reporters/v3alpha/reporters/event_reporter.pb.h"
+#include "contrib/reverse_tunnel_reporter/source/reverse_tunnel_event_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+#define ALL_EVENT_REPORTER_STATS(COUNTER, GAUGE)                                                   \
+  COUNTER(reverse_tunnel_established_total)                                                        \
+  COUNTER(reverse_tunnel_closed_total)                                                             \
+  COUNTER(reverse_tunnel_full_pulls_total)                                                         \
+  GAUGE(reverse_tunnel_active, Accumulate)                                                         \
+  GAUGE(reverse_tunnel_unique_active, Accumulate)
+
+struct EventReporterStats {
+  ALL_EVENT_REPORTER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+};
+
+struct ConnectionEntry {
+  std::shared_ptr<ReverseTunnelEvent::Connected> connection;
+  std::size_t count;
+};
+
+/// Aggregates reverse-tunnel connection/disconnection events, de-duplicates by
+/// name, maintains stats, and fans out batched diffs as shared ptrs to registered clients.
+class EventReporter : public ReverseTunnelReporterWithState,
+                      public Logger::Loggable<Logger::Id::connection> {
+public:
+  using ConfigProto =
+      envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::EventReporterConfig;
+
+  EventReporter(Server::Configuration::ServerFactoryContext& context, const ConfigProto& config,
+                std::vector<ReverseTunnelReporterClientPtr>&& clients);
+
+  void onServerInitialized() override;
+  void reportConnectionEvent(absl::string_view node_id, absl::string_view cluster_id,
+                             absl::string_view tenant_id) override;
+  void reportDisconnectionEvent(absl::string_view node_id, absl::string_view cluster_id) override;
+  ReverseTunnelEvent::ConnectionsList getAllConnections() override;
+
+private:
+  static EventReporterStats generateStats(const std::string& prefix, Stats::Scope& scope);
+  void notifyClients(ReverseTunnelEvent::TunnelUpdates&& updates);
+  void addConnection(std::shared_ptr<ReverseTunnelEvent::Connected>&& connection);
+  void removeConnection(std::shared_ptr<ReverseTunnelEvent::Disconnected>&& disconnection);
+
+  Server::Configuration::ServerFactoryContext& context_;
+  std::vector<ReverseTunnelReporterClientPtr> clients_;
+  EventReporterStats stats_;
+  // Keyed by getName(node_id).
+  absl::flat_hash_map<std::string, ConnectionEntry> connections_;
+};
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/reverse_tunnel_reporter/source/reverse_tunnel_event_types.h
+++ b/contrib/reverse_tunnel_reporter/source/reverse_tunnel_event_types.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/common/pure.h"
+#include "envoy/common/time.h"
+#include "envoy/config/typed_config.h"
+#include "envoy/extensions/bootstrap/reverse_tunnel/reverse_tunnel_reporter.h"
+#include "envoy/server/factory_context.h"
+
+#include "source/common/common/fmt.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+// The namespace holding the structs for the reverse tunnel events
+namespace ReverseTunnelEvent {
+// getName builds the canonical connection name used as the de-duplication key in the reporter.
+// Assumption: node_id is unique.
+// When tenant isolation is enabled we get the node_id here as
+// ReverseConnectionUtility::buildTenantScopedIdentifier(node_id) from the reverse_tunnel code which
+// invokes this.
+inline std::string getName(absl::string_view node_id) { return std::string(node_id); }
+
+struct Connected {
+  std::string node_id;
+  std::string cluster_id;
+  std::string tenant_id;
+  Envoy::SystemTime created_at;
+};
+
+struct Disconnected {
+  std::string name;
+
+  explicit Disconnected(absl::string_view n) : name(n) {}
+};
+
+// Most of the events are just single connections and disconnections.
+// The clients may need to buffer them up -> some extra stack space for the same.
+using ConnectionsList = absl::InlinedVector<std::shared_ptr<const Connected>, 4>;
+using DisconnectionsList = absl::InlinedVector<std::shared_ptr<const Disconnected>, 4>;
+
+struct TunnelUpdates {
+  ConnectionsList connections;
+  DisconnectionsList disconnections;
+
+  std::size_t size() const { return connections.size() + disconnections.size(); }
+
+  void operator+=(TunnelUpdates&& events) {
+    connections.insert(connections.end(), std::make_move_iterator(events.connections.begin()),
+                       std::make_move_iterator(events.connections.end()));
+
+    disconnections.insert(disconnections.end(),
+                          std::make_move_iterator(events.disconnections.begin()),
+                          std::make_move_iterator(events.disconnections.end()));
+
+    events.connections.clear();
+    events.disconnections.clear();
+  }
+
+  void clear() {
+    connections.clear();
+    disconnections.clear();
+  }
+};
+} // namespace ReverseTunnelEvent
+
+// ReverseTunnelReporterWithState will own the clients and expose an api for them to get the full
+// state. ReverseTunnelReporterWithState allows multiple clients to share data -> clients can focus
+// on sending the data alone.
+class ReverseTunnelReporterWithState : public ReverseTunnelReporter {
+public:
+  virtual ~ReverseTunnelReporterWithState() = default;
+
+  virtual ReverseTunnelEvent::ConnectionsList getAllConnections() PURE;
+};
+
+using ReverseTunnelReporterWithStatePtr = std::unique_ptr<ReverseTunnelReporterWithState>;
+
+// ReverseTunnelReporterClient gets the ptr to the reporter for polling all the active connections.
+// ReverseTunnelReporterClient also has receiveEvents to get the diff events from the reporter.
+class ReverseTunnelReporterClient {
+public:
+  virtual ~ReverseTunnelReporterClient() = default;
+
+  virtual void onServerInitialized(ReverseTunnelReporterWithState* reporter) PURE;
+
+  virtual void receiveEvents(ReverseTunnelEvent::TunnelUpdates events) PURE;
+};
+
+using ReverseTunnelReporterClientPtr = std::unique_ptr<ReverseTunnelReporterClient>;
+
+class ReverseTunnelReporterClientFactory : public Config::TypedFactory {
+public:
+  virtual ReverseTunnelReporterClientPtr
+  createClient(Server::Configuration::ServerFactoryContext& context,
+               const Protobuf::Message& config) PURE;
+
+  std::string category() const override {
+    return "envoy.extensions.reverse_tunnel.reverse_tunnel_reporting_service.clients";
+  }
+};
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/reverse_tunnel_reporter/test/reporters/BUILD
+++ b/contrib/reverse_tunnel_reporter/test/reporters/BUILD
@@ -1,0 +1,24 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_contrib_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_contrib_package()
+
+envoy_cc_test(
+    name = "event_reporter_test",
+    srcs = ["event_reporter_test.cc"],
+    deps = [
+        "//contrib/reverse_tunnel_reporter/source/reporters/event_reporter:event_reporter_lib",
+        "//source/common/api:api_lib",
+        "//source/common/config:utility_lib",
+        "//test/mocks:common_lib",
+        "//test/mocks/server:server_mocks",
+        "//test/test_common:registry_lib",
+        "//test/test_common:test_time_lib",
+        "//test/test_common:utility_lib",
+    ],
+)

--- a/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
+++ b/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
@@ -1,0 +1,567 @@
+#include "source/common/api/api_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
+
+#include "contrib/reverse_tunnel_reporter/source/reporters/event_reporter/factory.h"
+#include "contrib/reverse_tunnel_reporter/source/reporters/event_reporter/reporter.h"
+#include "contrib/reverse_tunnel_reporter/source/reverse_tunnel_event_types.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
+
+namespace Envoy {
+namespace Extensions {
+namespace Bootstrap {
+namespace ReverseConnection {
+
+class MockReverseTunnelReporterClient : public ReverseTunnelReporterClient {
+public:
+  MockReverseTunnelReporterClient() = default;
+  ~MockReverseTunnelReporterClient() override = default;
+
+  MOCK_METHOD(void, onServerInitialized, (ReverseTunnelReporterWithState*), (override));
+  MOCK_METHOD(void, receiveEvents, (ReverseTunnelEvent::TunnelUpdates), (override));
+};
+
+class EventReporterTest : public testing::Test {
+protected:
+  void SetUp() override {
+    api_ = Api::createApiForTest();
+    dispatcher_ = api_->allocateDispatcher("test_thread");
+
+    ON_CALL(context_, mainThreadDispatcher()).WillByDefault(ReturnRef(*dispatcher_));
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(*stats_store_.rootScope()));
+    ON_CALL(context_, messageValidationVisitor())
+        .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
+
+    auto mock_client1 = std::make_unique<NiceMock<MockReverseTunnelReporterClient>>();
+    auto mock_client2 = std::make_unique<NiceMock<MockReverseTunnelReporterClient>>();
+    mock_client1_ = mock_client1.get();
+    mock_client2_ = mock_client2.get();
+
+    std::vector<ReverseTunnelReporterClientPtr> clients;
+    clients.push_back(std::move(mock_client1));
+    clients.push_back(std::move(mock_client2));
+
+    EventReporter::ConfigProto config;
+    config.set_stat_prefix("test_prefix");
+
+    reporter_ = std::make_unique<EventReporter>(context_, config, std::move(clients));
+  }
+
+  void createTestConnection(const std::string& node_id, const std::string& cluster_id,
+                            const std::string& tenant_id = "tenant1") {
+    reporter_->reportConnectionEvent(node_id, cluster_id, tenant_id);
+  }
+
+  void createTestDisconnection(const std::string& node_id, const std::string& cluster_id) {
+    reporter_->reportDisconnectionEvent(node_id, cluster_id);
+  }
+
+  void runDispatcher() { dispatcher_->run(Event::Dispatcher::RunType::NonBlock); }
+
+  uint64_t getCounterValue(const std::string& name) {
+    return stats_store_.counterFromString("test_prefix." + name).value();
+  }
+
+  uint64_t getGaugeValue(const std::string& name) {
+    return stats_store_.gaugeFromString("test_prefix." + name, Stats::Gauge::ImportMode::Accumulate)
+        .value();
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  Stats::TestUtil::TestStore stats_store_;
+  NiceMock<MockReverseTunnelReporterClient>* mock_client1_;
+  NiceMock<MockReverseTunnelReporterClient>* mock_client2_;
+  std::unique_ptr<EventReporter> reporter_;
+};
+
+TEST_F(EventReporterTest, AddRemoveConnections) {
+  EXPECT_CALL(*mock_client1_, receiveEvents(_))
+      .Times(4)
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node1", updates.connections[0]->node_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node2", updates.connections[0]->node_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(0, updates.connections.size());
+        EXPECT_EQ(1, updates.disconnections.size());
+        EXPECT_EQ(ReverseTunnelEvent::getName("node1"), updates.disconnections[0]->name);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(0, updates.connections.size());
+        EXPECT_EQ(1, updates.disconnections.size());
+        EXPECT_EQ(ReverseTunnelEvent::getName("node2"), updates.disconnections[0]->name);
+      }));
+
+  EXPECT_CALL(*mock_client2_, receiveEvents(_)).Times(4);
+
+  createTestConnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestConnection("node2", "cluster2");
+  runDispatcher();
+
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(2, connections.size());
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(2, connections.size());
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestDisconnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestDisconnection("node2", "cluster2");
+  runDispatcher();
+
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_full_pulls_total"));
+}
+
+TEST_F(EventReporterTest, DuplicateConnectionHandling) {
+  EXPECT_CALL(*mock_client1_, receiveEvents(_))
+      .Times(2)
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node1", updates.connections[0]->node_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(0, updates.connections.size());
+        EXPECT_EQ(1, updates.disconnections.size());
+        EXPECT_EQ(ReverseTunnelEvent::getName("node1"), updates.disconnections[0]->name);
+      }));
+
+  EXPECT_CALL(*mock_client2_, receiveEvents(_)).Times(2);
+
+  createTestConnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestConnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(1, connections.size());
+  EXPECT_EQ("node1", connections[0]->node_id);
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestDisconnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(1, connections.size());
+  EXPECT_EQ("node1", connections[0]->node_id);
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestDisconnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_full_pulls_total"));
+}
+
+TEST_F(EventReporterTest, PullsBeforeConnectionEvents) {
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_full_pulls_total"));
+}
+
+TEST_F(EventReporterTest, RemoveNonExistentConnection) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::warn);
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](absl::string_view, const spdlog::details::log_msg& msg) {
+        EXPECT_EQ(spdlog::level::warn, msg.level);
+      }));
+
+  EXPECT_CALL(*mock_client1_, receiveEvents(_)).Times(0);
+  EXPECT_CALL(*mock_client2_, receiveEvents(_)).Times(0);
+
+  createTestDisconnection("nonexistent", "connection");
+  runDispatcher();
+
+  EXPECT_EQ(0, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_unique_active"));
+
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  EXPECT_CALL(*mock_client1_, receiveEvents(_))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node1", updates.connections[0]->node_id);
+      }));
+  EXPECT_CALL(*mock_client2_, receiveEvents(_));
+
+  createTestConnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+}
+
+TEST_F(EventReporterTest, OnServerInitialized) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  MockLogSink sink(Envoy::Logger::Registry::getSink());
+
+  EXPECT_CALL(sink, log(_, _))
+      .WillOnce(Invoke([](absl::string_view, const spdlog::details::log_msg& msg) {
+        EXPECT_EQ(spdlog::level::info, msg.level);
+      }));
+
+  EXPECT_CALL(*mock_client1_, onServerInitialized(_));
+  EXPECT_CALL(*mock_client2_, onServerInitialized(_));
+
+  reporter_->onServerInitialized();
+
+  EXPECT_EQ(0, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(0, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(0, getCounterValue("reverse_tunnel_full_pulls_total"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_unique_active"));
+}
+
+TEST_F(EventReporterTest, DefaultStatPrefix) {
+  EventReporter::ConfigProto config;
+
+  std::vector<ReverseTunnelReporterClientPtr> clients;
+  auto mock_client1 = std::make_unique<NiceMock<MockReverseTunnelReporterClient>>();
+  auto mock_client2 = std::make_unique<NiceMock<MockReverseTunnelReporterClient>>();
+  mock_client1_ = mock_client1.get();
+  mock_client2_ = mock_client2.get();
+  clients.push_back(std::move(mock_client1));
+  clients.push_back(std::move(mock_client2));
+
+  auto default_reporter = std::make_unique<EventReporter>(context_, config, std::move(clients));
+
+  EXPECT_CALL(*mock_client1_, receiveEvents(_));
+  EXPECT_CALL(*mock_client2_, receiveEvents(_));
+
+  default_reporter->reportConnectionEvent("node1", "cluster1", "tenant1");
+  runDispatcher();
+
+  EXPECT_EQ(
+      1, stats_store_.counterFromString("reverse_tunnel_reporter.reverse_tunnel_established_total")
+             .value());
+  EXPECT_EQ(1, stats_store_
+                   .gaugeFromString("reverse_tunnel_reporter.reverse_tunnel_active",
+                                    Stats::Gauge::ImportMode::Accumulate)
+                   .value());
+  EXPECT_EQ(1, stats_store_
+                   .gaugeFromString("reverse_tunnel_reporter.reverse_tunnel_unique_active",
+                                    Stats::Gauge::ImportMode::Accumulate)
+                   .value());
+
+  auto connections = default_reporter->getAllConnections();
+  EXPECT_EQ(1, connections.size());
+  EXPECT_EQ(
+      1, stats_store_.counterFromString("reverse_tunnel_reporter.reverse_tunnel_full_pulls_total")
+             .value());
+}
+
+TEST_F(EventReporterTest, MixedScenario) {
+  EXPECT_CALL(*mock_client1_, receiveEvents(_))
+      .Times(4)
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node1", updates.connections[0]->node_id);
+        EXPECT_EQ("tenant_A", updates.connections[0]->tenant_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node2", updates.connections[0]->node_id);
+        EXPECT_EQ("tenant_B", updates.connections[0]->tenant_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(0, updates.connections.size());
+        EXPECT_EQ(1, updates.disconnections.size());
+        EXPECT_EQ(ReverseTunnelEvent::getName("node2"), updates.disconnections[0]->name);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node3", updates.connections[0]->node_id);
+        EXPECT_EQ("tenant_C", updates.connections[0]->tenant_id);
+      }));
+
+  EXPECT_CALL(*mock_client2_, receiveEvents(_)).Times(4);
+
+  createTestConnection("node1", "cluster1", "tenant_A");
+  runDispatcher();
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestConnection("node2", "cluster2", "tenant_B");
+  runDispatcher();
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(2, connections.size());
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestConnection("node1", "cluster1", "tenant_A");
+  runDispatcher();
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(3, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestConnection("node2", "cluster2", "tenant_B");
+  runDispatcher();
+  EXPECT_EQ(4, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(4, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestDisconnection("node1", "cluster1");
+  runDispatcher();
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(3, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(2, connections.size());
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestDisconnection("node2", "cluster2");
+  runDispatcher();
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestDisconnection("node2", "cluster2");
+  runDispatcher();
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  createTestConnection("node3", "cluster3", "tenant_C");
+  runDispatcher();
+  EXPECT_EQ(5, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(2, connections.size());
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  EXPECT_EQ(5, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(2, getGaugeValue("reverse_tunnel_unique_active"));
+}
+
+TEST_F(EventReporterTest, LargeDuplicateCount) {
+  EXPECT_CALL(*mock_client1_, receiveEvents(_))
+      .Times(2)
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(1, updates.connections.size());
+        EXPECT_EQ(0, updates.disconnections.size());
+        EXPECT_EQ("node1", updates.connections[0]->node_id);
+        EXPECT_EQ("tenant_A", updates.connections[0]->tenant_id);
+      }))
+      .WillOnce(Invoke([](const ReverseTunnelEvent::TunnelUpdates& updates) {
+        EXPECT_EQ(0, updates.connections.size());
+        EXPECT_EQ(1, updates.disconnections.size());
+        EXPECT_EQ(ReverseTunnelEvent::getName("node1"), updates.disconnections[0]->name);
+      }));
+
+  EXPECT_CALL(*mock_client2_, receiveEvents(_)).Times(2);
+
+  const int DUPLICATE_COUNT = 50;
+
+  for (int i = 0; i < DUPLICATE_COUNT; i++) {
+    createTestConnection("node1", "cluster1", "tenant_A");
+    runDispatcher();
+  }
+
+  EXPECT_EQ(DUPLICATE_COUNT, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(DUPLICATE_COUNT, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  auto connections = reporter_->getAllConnections();
+  EXPECT_EQ(1, connections.size());
+  EXPECT_EQ(1, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  for (int i = 0; i < DUPLICATE_COUNT - 1; i++) {
+    createTestDisconnection("node1", "cluster1");
+    runDispatcher();
+  }
+
+  EXPECT_EQ(DUPLICATE_COUNT - 1, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(1, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(1, connections.size());
+  EXPECT_EQ(2, getCounterValue("reverse_tunnel_full_pulls_total"));
+
+  createTestDisconnection("node1", "cluster1");
+  runDispatcher();
+
+  EXPECT_EQ(DUPLICATE_COUNT, getCounterValue("reverse_tunnel_established_total"));
+  EXPECT_EQ(DUPLICATE_COUNT, getCounterValue("reverse_tunnel_closed_total"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_active"));
+  EXPECT_EQ(0, getGaugeValue("reverse_tunnel_unique_active"));
+
+  connections = reporter_->getAllConnections();
+  EXPECT_EQ(0, connections.size());
+  EXPECT_EQ(3, getCounterValue("reverse_tunnel_full_pulls_total"));
+}
+
+// --- Factory tests ---
+
+class MockReverseTunnelReporterClientFactory : public ReverseTunnelReporterClientFactory {
+public:
+  MOCK_METHOD(ReverseTunnelReporterClientPtr, createClient,
+              (Server::Configuration::ServerFactoryContext&, const Protobuf::Message&), (override));
+
+  std::string name() const override { return "mock_client_factory"; }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+};
+
+class EventReporterFactoryTest : public testing::Test {
+protected:
+  void SetUp() override {
+    ON_CALL(context_, messageValidationVisitor())
+        .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(*stats_store_.rootScope()));
+
+    api_ = Api::createApiForTest();
+    dispatcher_ = api_->allocateDispatcher("test_thread");
+    ON_CALL(context_, mainThreadDispatcher()).WillByDefault(ReturnRef(*dispatcher_));
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  Stats::TestUtil::TestStore stats_store_;
+  EventReporterFactory factory_;
+};
+
+TEST_F(EventReporterFactoryTest, Name) {
+  EXPECT_EQ(
+      "envoy.extensions.reverse_tunnel.reverse_tunnel_reporting_service.reporters.event_reporter",
+      factory_.name());
+}
+
+TEST_F(EventReporterFactoryTest, CreateEmptyConfigProto) {
+  auto config = factory_.createEmptyConfigProto();
+  EXPECT_NE(nullptr, config);
+  EXPECT_NE(
+      nullptr,
+      dynamic_cast<
+          envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::EventReporterConfig*>(
+          config.get()));
+}
+
+TEST_F(EventReporterFactoryTest, CreateReporterWithRegisteredClient) {
+  MockReverseTunnelReporterClientFactory mock_client_factory;
+  Registry::InjectFactory<ReverseTunnelReporterClientFactory> registered(mock_client_factory);
+
+  EXPECT_CALL(mock_client_factory, createClient(_, _))
+      .WillOnce(Invoke([](Server::Configuration::ServerFactoryContext&,
+                          const Protobuf::Message&) -> ReverseTunnelReporterClientPtr {
+        return std::make_unique<NiceMock<MockReverseTunnelReporterClient>>();
+      }));
+
+  auto config = factory_.createEmptyConfigProto();
+  auto& reporter_config = dynamic_cast<
+      envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::EventReporterConfig&>(
+      *config);
+  reporter_config.set_stat_prefix("test");
+
+  auto* client_entry = reporter_config.add_clients();
+  client_entry->set_name("mock_client_factory");
+  client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
+
+  auto reporter = factory_.createReporter(context_, std::move(config));
+  EXPECT_NE(nullptr, reporter);
+}
+
+TEST_F(EventReporterFactoryTest, CreateClientWithUnknownFactoryThrows) {
+  auto config = factory_.createEmptyConfigProto();
+  auto& reporter_config = dynamic_cast<
+      envoy::extensions::reverse_tunnel_reporters::v3alpha::reporters::EventReporterConfig&>(
+      *config);
+  reporter_config.set_stat_prefix("test");
+
+  auto* client_entry = reporter_config.add_clients();
+  client_entry->set_name("nonexistent_client_factory");
+  client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
+
+  EXPECT_THROW_WITH_REGEX(factory_.createReporter(context_, std::move(config)), EnvoyException,
+                          "Unknown Reporter Client Factory: 'nonexistent_client_factory'");
+}
+
+} // namespace ReverseConnection
+} // namespace Bootstrap
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
BUILDS ON #44327, depends on the protos introduced there.
[Incremental DIFFS](https://github.com/envoyproxy/envoy/pull/44342/changes/0f8c02a02b6f25c01112f513ae4f22c72484994a)

## Commit Message 
Add EventReporter for reverse tunnel connection reporting
## Additional Description:
Adds the EventReporter contrib extension, which aggregates reverse tunnel connection/disconnection events and fans them out to pluggable clients. 

Key components:
- `ReverseTunnelReporterWithState` / `ReverseTunnelReporterClient`: interfaces allowing multiple transport clients to share connection state from a single reporter. Clients receive incremental diffs and can request a full state snapshot so they dont have to be "stateful" other than the protocol they manage.
- `EventReporter`: A basic implementation which does refcounting of connections by the name and stores in a map for interfacing with the clients.

Risk Level: Low, opt in extension.
## Testing
Unit tests.