### PR TITLE
[bp/1.37] ProcessRateLimiter: fix use after free (#43325)

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -21,6 +21,12 @@ bug_fixes:
   change: |
     Fixed a bug where the internal redirect logic may hang up a request when the request buffer is
     overflowed.
+- area: access_log
+  change: |
+    Fixed a crash on listener removal with a process-level access log rate limiter
+    :ref:`ProcessRateLimitFilter <envoy_v3_api_msg_extensions.access_loggers.filters.process_ratelimit.v3.ProcessRateLimitFilter>`.
+
+    Note: Release notes show this to be fixed on 1.37.1 branch, but it was not backported in that release.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/access_loggers/filters/process_ratelimit/filter.h
+++ b/source/extensions/access_loggers/filters/process_ratelimit/filter.h
@@ -37,7 +37,7 @@ public:
 private:
   const intptr_t setter_key_;
   std::shared_ptr<std::atomic<bool>> cancel_cb_;
-  Server::Configuration::GenericFactoryContext& context_;
+  Event::Dispatcher& main_thread_dispatcher_;
   ProcessRateLimitFilterStats stats_;
   mutable Envoy::Extensions::Filters::Common::LocalRateLimit::RateLimiterProviderSingleton::
       RateLimiterWrapperPtr rate_limiter_;


### PR DESCRIPTION
Commit Message: [listener_factory_context and
access_logs](https://github.com/envoyproxy/envoy/blob/29a553cd459786eb6bece9b5dd2e0602e9b4b921/source/common/listener_manager/listener_impl.h#L468-L483) are both owned by ListenerImpl while listener_factory_context get destructed first so this PR just replace listener_factory_context with main_thread_dispatcher which is used in destructor Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:

