### PR TITLE
[RFC] Add the ability to give HTTP filters names, and a utility to get them.

### DIFF
--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -889,6 +889,11 @@ public:
   virtual ~StreamFilterBase() = default;
 
   /**
+   * A name for the filter. Used for monitoring and disagnostics.
+   */
+  virtual absl::string_view name() { return {}; }
+
+  /**
    * This routine is called before the access log handlers' final log() is called. Filters can use
    * this callback to enrich the data passed in to the log handlers.
    */

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1641,6 +1641,14 @@ std::string Utility::newUri(::Envoy::OptRef<const Utility::RedirectConfig> redir
   return fmt::format("{}://{}{}{}", final_scheme, final_host, final_port, final_path);
 }
 
+absl::string_view Utility::nameWithFallback(StreamFilterBase& stream_filter) {
+  absl::string_view name = stream_filter.name();
+  if (!name.empty()) {
+    return name;
+  }
+  return typeid(stream_filter).name();
+}
+
 bool Utility::isValidRefererValue(absl::string_view value) {
 
   // First, we try to parse it as an absolute URL and

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -728,6 +728,11 @@ bool schemeIsHttps(const absl::string_view scheme);
 std::string newUri(::Envoy::OptRef<const RedirectConfig> redirect_config,
                    const Http::RequestHeaderMap& headers);
 
+/*
+ * Returns the filter's name, if empty, resolves it using RTTI.
+ */
+absl::string_view nameWithFallback(StreamFilterBase& stream_filter);
+
 } // namespace Utility
 } // namespace Http
 } // namespace Envoy

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -2055,5 +2055,29 @@ TEST(HeaderIsValidTest, SchemeIsHttps) {
   EXPECT_FALSE(Utility::schemeIsHttps("http"));
 }
 
+class ExampleFilterWithName : public PassThroughDecoderFilter {
+public:
+  virtual ~ExampleFilterWithName() = default;
+
+  static constexpr absl::string_view filter_name{"example_filter"};
+  absl::string_view name() override { return ExampleFilterWithName::filter_name; }
+};
+
+class ExampleFilterWithoutName : public PassThroughDecoderFilter {
+public:
+  virtual ~ExampleFilterWithoutName() = default;
+};
+
+TEST(TestNameWithFallback, ProvidesName) {
+  ExampleFilterWithName filter_with_name;
+  EXPECT_EQ(Utility::nameWithFallback(filter_with_name), "example_filter");
+
+  // Check that there is *some* name returned,  for the fallback case.
+  // Different compilers handle this differently --
+  // some return mangled names directly, others return human readable names.
+  ExampleFilterWithoutName filter_without_name;
+  EXPECT_FALSE(Utility::nameWithFallback(filter_without_name).empty());
+}
+
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: Add the ability to give HTTP filters names, and a utility to get them (or fall back to RTTI if not overwritten).

Additional Description: 

At Uber, we have added logging in filter_manager.h/cc for filter operations (ctors, dtors, OnDestroy, encodeHeaders, decodeHeaders) to debug slow p99.9 forward latencies in our filter chains.

To do so, we need a way to identify filters, and this is my proposal for how to do so. It allows gradual onboarding with a reasonable fallback.

Additionally, we would like some guidance on whether or not you would be open to adding logging similar to what we have upstream. 

Currently, we have a configurable "slowness" level in runtime configuration, and filter_manager emits logs if specific functions cross that threshold. On top of this, we could emit stats about these latencies in the filter_manager.

Let me know what you folks think, and if the direction is agreeable, I can put up a pull request. Thanks!

Risk Level: Low

Testing: Unit tests.

Docs Changes: None

Release Notes: None

Platform Specific Features: None
