### PR TITLE
Add singleton initialization to config tests

### DIFF
--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test_library(
         "//source/extensions/config_subscription/rest:http_subscription_lib",
         "//source/extensions/filters/http/match_delegate:config",
         "//test/config:v2_link_hacks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -16,6 +16,7 @@
 #include "source/server/options_impl.h"
 
 #include "test/integration/server.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_component_factory.h"
 #include "test/mocks/server/worker.h"

--- a/test/config_test/config_test.cc
+++ b/test/config_test/config_test.cc
@@ -16,7 +16,6 @@
 #include "source/server/options_impl.h"
 
 #include "test/integration/server.h"
-#include "test/mocks/server/factory_context.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/listener_component_factory.h"
 #include "test/mocks/server/worker.h"

--- a/test/config_test/configs_test.cc
+++ b/test/config_test/configs_test.cc
@@ -2,6 +2,7 @@
 
 #include "test/config/v2_link_hacks.h"
 #include "test/config_test/config_test.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
@@ -10,6 +11,12 @@
 namespace Envoy {
 
 TEST(ExampleConfigsTest, All) {
+  // If an example config yaml in docs uses a CELFormatterCommandParser, the
+  // ServerFactoryContext singleton must be initialized, as that parser gets
+  // its context from the singleton.
+  NiceMock<Server::Configuration::MockFactoryContext> mock_factory_context_;
+  ScopedThreadLocalServerContextSetter server_context_singleton_setter_{
+      mock_factory_context_.server_factory_context_};
   TestEnvironment::exec({TestEnvironment::runfilesPath("test/config_test/configs_test_setup.sh")});
   Filesystem::InstanceImpl file_system;
   const auto config_file_count = std::stoi(


### PR DESCRIPTION
Commit Message: Add singleton initialization to config tests
Additional Description: If a doc config under test features a `CELFormatterCommandParser` (via `type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel` in a `SubstitutionFormatString`), config validation fails due to server singletons it uses not having been initialized. This fixes that.
Risk Level: Test-only.
Testing:  Tested against #44275 which was failing config validation without this change, and no longer fails after the change.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
