### PR TITLE
Graceful handling of errors when reading SO_ORIGINAL_DST option

### DIFF
--- a/source/common/network/utility.cc
+++ b/source/common/network/utility.cc
@@ -376,7 +376,14 @@ Address::InstanceConstSharedPtr Utility::getOriginalDst(Socket& sock) {
     return nullptr;
   }
 
-  return Address::addressFromSockAddrOrDie(orig_addr, 0, -1, true /* default for v6 constructor */);
+  auto address_or_status =
+      Address::addressFromSockAddr(orig_addr, 0, true /* default for v6 constructor */);
+  if (!address_or_status.ok()) {
+    ENVOY_LOG_MISC(debug, "Failed to get address from sockaddr for getOriginalDst: {}",
+                   address_or_status.status().message());
+    return nullptr;
+  }
+  return *address_or_status;
 
 #else
   // TODO(zuercher): determine if connection redirection is possible under macOS (c.f. pfctl and

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -391,6 +391,15 @@ TEST(NetworkUtility, GetOriginalDst) {
   EXPECT_CALL(socket, getSocketOption(Eq(SOL_IP), Eq(SO_ORIGINAL_DST), _, _))
       .WillOnce(DoAll(SetArg2Sockaddr(storage), Return(Api::SysCallIntResult{0, 0})));
   EXPECT_EQ("12.34.56.78:9527", Utility::getOriginalDst(socket)->asString());
+
+  // Invalid family returned by SO_ORIGINAL_DST should cause addressFromSockAddr to fail and
+  // getOriginalDst to return nullptr
+  sin.sin_family = AF_UNSPEC;
+  EXPECT_CALL(socket, getSocketOption(Eq(SOL_IP), Eq(SO_ORIGINAL_DST), _, _))
+      .WillOnce(DoAll(SetArg2Sockaddr(storage), Return(Api::SysCallIntResult{0, 0})));
+  EXPECT_EQ(nullptr, Utility::getOriginalDst(socket));
+
+  sin.sin_family = AF_INET;
 #ifndef WIN32
   // Transparent socket gets original dst from local address while connection tracking disabled
   EXPECT_CALL(socket, getSocketOption(Eq(SOL_IP), Eq(SO_ORIGINAL_DST), _, _))


### PR DESCRIPTION
Remove possibility of hard crash when SO_ORIGINAL_DST returns an invalid address. Such errors have not been observed in production and the change is purely defensive.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: Linux only
