### PR TITLE
Add defensive nullptr check

### DIFF
--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -90,7 +90,7 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
     } else {
       const auto* local_object = cb.filterState().getDataReadOnly<Network::AddressObject>(
           FilterNames::get().LocalFilterStateKey);
-      if (local_object) {
+      if (local_object && local_object->address()) {
         ENVOY_LOG_MISC(debug, "original_dst: set destination from filter state to {}",
                        local_object->address()->asString());
         socket.connectionInfoProvider().restoreLocalAddress(local_object->address());
@@ -98,7 +98,7 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
     }
     const auto* remote_object = cb.filterState().getDataReadOnly<Network::AddressObject>(
         FilterNames::get().RemoteFilterStateKey);
-    if (remote_object) {
+    if (remote_object && remote_object->address()) {
       ENVOY_LOG_MISC(debug, "original_dst: set source from filter state to {}",
                      remote_object->address()->asString());
       socket.connectionInfoProvider().setRemoteAddress(remote_object->address());

--- a/test/extensions/filters/listener/original_dst/original_dst_test.cc
+++ b/test/extensions/filters/listener/original_dst/original_dst_test.cc
@@ -98,6 +98,20 @@ TEST_F(OriginalDstTest, InternalFilterState) {
   EXPECT_EQ(remote->asString(), socket_.connectionInfoProvider().remoteAddress()->asString());
 }
 
+TEST_F(OriginalDstTest, InternalFilterStateNullAddress) {
+  expectInternalAddress();
+  cb_.filter_state_.setData("envoy.filters.listener.original_dst.local_ip",
+                            std::make_shared<Network::AddressObject>(nullptr),
+                            StreamInfo::FilterState::StateType::Mutable,
+                            StreamInfo::FilterState::LifeSpan::Connection);
+  cb_.filter_state_.setData("envoy.filters.listener.original_dst.remote_ip",
+                            std::make_shared<Network::AddressObject>(nullptr),
+                            StreamInfo::FilterState::StateType::Mutable,
+                            StreamInfo::FilterState::LifeSpan::Connection);
+  filter_.onAccept(cb_);
+  EXPECT_FALSE(socket_.connectionInfoProvider().localAddressRestored());
+}
+
 } // namespace
 } // namespace OriginalDst
 } // namespace ListenerFilters


### PR DESCRIPTION
The pointer can not be nullptr at this point, but add a defensive check to cover future changes.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
