### PR TITLE
original_dst filter is robust to untrusted upstream

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -797,7 +797,7 @@ envoy.filters.listener.local_ratelimit:
 envoy.filters.listener.original_dst:
   categories:
   - envoy.filters.listener
-  security_posture: robust_to_untrusted_downstream
+  security_posture: robust_to_untrusted_downstream_and_upstream
   status: stable
   type_urls:
   - envoy.extensions.filters.listener.original_dst.v3.OriginalDst


### PR DESCRIPTION
original_dst listener filter is robust to untrusted upstream by default because it does not observe or act on untrusted inputs from upstream servers.

This change is only to make an internal robot happy that verifies the match between extension security posture with product's threat model. 

Risk Level: none
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
