### PR TITLE
perf: Improve memory footprint on router

### DIFF
--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -38,9 +38,9 @@
 #include "source/common/router/tls_context_match_criteria_impl.h"
 #include "source/common/stats/symbol_table.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
-#include "absl/container/node_hash_map.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -1212,7 +1212,7 @@ private:
                absl::Status& creation_status);
 
   using WildcardVirtualHosts =
-      std::map<int64_t, absl::node_hash_map<std::string, VirtualHostImplSharedPtr>, std::greater<>>;
+      std::map<int64_t, absl::flat_hash_map<std::string, VirtualHostImplSharedPtr>, std::greater<>>;
   using SubstringFunction = std::function<absl::string_view(absl::string_view, int)>;
   const VirtualHostImpl* findWildcardVirtualHost(absl::string_view host,
                                                  const WildcardVirtualHosts& wildcard_virtual_hosts,
@@ -1220,7 +1220,7 @@ private:
   bool ignorePortInHostMatching() const { return ignore_port_in_host_matching_; }
 
   Stats::ScopeSharedPtr vhost_scope_;
-  absl::node_hash_map<std::string, VirtualHostImplSharedPtr> virtual_hosts_;
+  absl::flat_hash_map<std::string, VirtualHostImplSharedPtr> virtual_hosts_;
   // std::greater as a minor optimization to iterate from more to less specific
   //
   // A note on using an unordered_map versus a vector of (string, VirtualHostImplSharedPtr) pairs:

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -420,6 +420,60 @@ void Filter::chargeUpstreamCode(Http::Code code, Upstream::HostDescriptionOptCon
   chargeUpstreamCode(response_status_code, *fake_response_headers, upstream_host, dropped);
 }
 
+Http::FilterHeadersStatus Filter::checkStrictHeaders(const Http::RequestHeaderMap& headers) {
+  auto handle_invalid_header =
+      [this](const FilterUtility::StrictHeaderChecker::HeaderCheckResult& res) {
+        callbacks_->streamInfo().setResponseFlag(
+            StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders);
+        const std::string body = fmt::format("invalid header '{}' with value '{}'",
+                                             std::string(res.entry_->key().getStringView()),
+                                             std::string(res.entry_->value().getStringView()));
+        const std::string details =
+            absl::StrCat(StreamInfo::ResponseCodeDetails::get().InvalidEnvoyRequestHeaders, "{",
+                         StringUtil::replaceAllEmptySpace(res.entry_->key().getStringView()), "}");
+        callbacks_->sendLocalReply(Http::Code::BadRequest, body, modify_headers_, absl::nullopt,
+                                   details);
+        return Http::FilterHeadersStatus::StopIteration;
+      };
+
+  if (config_->envoy_upstream_rq_timeout_ms_) {
+    const auto res =
+        FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyUpstreamRequestTimeoutMs());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->envoy_upstream_rq_per_try_timeout_ms_) {
+    const auto res = FilterUtility::StrictHeaderChecker::isInteger(
+        headers.EnvoyUpstreamRequestPerTryTimeoutMs());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->envoy_max_retries_) {
+    const auto res = FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyMaxRetries());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->envoy_retry_on_) {
+    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+        headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn);
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->envoy_retry_grpc_on_) {
+    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+        headers.EnvoyRetryGrpcOn(), &Router::RetryStateImpl::parseRetryGrpcOn);
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
   downstream_headers_ = &headers;
 
@@ -531,54 +585,9 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   ENVOY_STREAM_LOG(debug, "cluster '{}' match for URL '{}'", *callbacks_,
                    route_entry_->clusterName(), headers.getPathValue());
 
-  auto handle_invalid_header =
-      [this](const FilterUtility::StrictHeaderChecker::HeaderCheckResult& res) {
-        callbacks_->streamInfo().setResponseFlag(
-            StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders);
-        const std::string body = fmt::format("invalid header '{}' with value '{}'",
-                                             std::string(res.entry_->key().getStringView()),
-                                             std::string(res.entry_->value().getStringView()));
-        const std::string details =
-            absl::StrCat(StreamInfo::ResponseCodeDetails::get().InvalidEnvoyRequestHeaders, "{",
-                         StringUtil::replaceAllEmptySpace(res.entry_->key().getStringView()), "}");
-        callbacks_->sendLocalReply(Http::Code::BadRequest, body, modify_headers_, absl::nullopt,
-                                   details);
-        return Http::FilterHeadersStatus::StopIteration;
-      };
-
-  if (config_->strict_check_headers_.envoy_upstream_rq_timeout_ms_) {
-    const auto res =
-        FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyUpstreamRequestTimeoutMs());
-    if (!res.valid_) {
-      return handle_invalid_header(res);
-    }
-  }
-  if (config_->strict_check_headers_.envoy_upstream_rq_per_try_timeout_ms_) {
-    const auto res = FilterUtility::StrictHeaderChecker::isInteger(
-        headers.EnvoyUpstreamRequestPerTryTimeoutMs());
-    if (!res.valid_) {
-      return handle_invalid_header(res);
-    }
-  }
-  if (config_->strict_check_headers_.envoy_max_retries_) {
-    const auto res = FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyMaxRetries());
-    if (!res.valid_) {
-      return handle_invalid_header(res);
-    }
-  }
-  if (config_->strict_check_headers_.envoy_retry_on_) {
-    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
-        headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn);
-    if (!res.valid_) {
-      return handle_invalid_header(res);
-    }
-  }
-  if (config_->strict_check_headers_.envoy_retry_grpc_on_) {
-    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
-        headers.EnvoyRetryGrpcOn(), &Router::RetryStateImpl::parseRetryGrpcOn);
-    if (!res.valid_) {
-      return handle_invalid_header(res);
-    }
+  const Http::FilterHeadersStatus status = checkStrictHeaders(headers);
+  if (status != Http::FilterHeadersStatus::Continue) {
+    return status;
   }
 
   const Http::HeaderEntry* request_alt_name = headers.EnvoyUpstreamAltStatName();

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -354,25 +354,6 @@ Filter::~Filter() {
   ASSERT(!retry_state_);
 }
 
-const FilterUtility::StrictHeaderChecker::HeaderCheckResult
-FilterUtility::StrictHeaderChecker::checkHeader(Http::RequestHeaderMap& headers,
-                                                const Http::LowerCaseString& target_header) {
-  if (target_header == Http::Headers::get().EnvoyUpstreamRequestTimeoutMs) {
-    return isInteger(headers.EnvoyUpstreamRequestTimeoutMs());
-  } else if (target_header == Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs) {
-    return isInteger(headers.EnvoyUpstreamRequestPerTryTimeoutMs());
-  } else if (target_header == Http::Headers::get().EnvoyMaxRetries) {
-    return isInteger(headers.EnvoyMaxRetries());
-  } else if (target_header == Http::Headers::get().EnvoyRetryOn) {
-    return hasValidRetryFields(headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn);
-  } else if (target_header == Http::Headers::get().EnvoyRetryGrpcOn) {
-    return hasValidRetryFields(headers.EnvoyRetryGrpcOn(),
-                               &Router::RetryStateImpl::parseRetryGrpcOn);
-  }
-  // Should only validate headers for which we have implemented a validator.
-  PANIC("unexpectedly reached");
-}
-
 Stats::StatName Filter::upstreamZone(Upstream::HostDescriptionOptConstRef upstream_host) {
   return upstream_host ? upstream_host->localityZoneStatName() : config_->empty_stat_name_;
 }
@@ -550,10 +531,8 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   ENVOY_STREAM_LOG(debug, "cluster '{}' match for URL '{}'", *callbacks_,
                    route_entry_->clusterName(), headers.getPathValue());
 
-  if (config_->strict_check_headers_ != nullptr) {
-    for (const auto& header : *config_->strict_check_headers_) {
-      const auto res = FilterUtility::StrictHeaderChecker::checkHeader(headers, header);
-      if (!res.valid_) {
+  auto handle_invalid_header =
+      [this](const FilterUtility::StrictHeaderChecker::HeaderCheckResult& res) {
         callbacks_->streamInfo().setResponseFlag(
             StreamInfo::CoreResponseFlag::InvalidEnvoyRequestHeaders);
         const std::string body = fmt::format("invalid header '{}' with value '{}'",
@@ -565,7 +544,40 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         callbacks_->sendLocalReply(Http::Code::BadRequest, body, modify_headers_, absl::nullopt,
                                    details);
         return Http::FilterHeadersStatus::StopIteration;
-      }
+      };
+
+  if (config_->strict_check_headers_.envoy_upstream_rq_timeout_ms_) {
+    const auto res =
+        FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyUpstreamRequestTimeoutMs());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->strict_check_headers_.envoy_upstream_rq_per_try_timeout_ms_) {
+    const auto res = FilterUtility::StrictHeaderChecker::isInteger(
+        headers.EnvoyUpstreamRequestPerTryTimeoutMs());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->strict_check_headers_.envoy_max_retries_) {
+    const auto res = FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyMaxRetries());
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->strict_check_headers_.envoy_retry_on_) {
+    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+        headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn);
+    if (!res.valid_) {
+      return handle_invalid_header(res);
+    }
+  }
+  if (config_->strict_check_headers_.envoy_retry_grpc_on_) {
+    const auto res = FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+        headers.EnvoyRetryGrpcOn(), &Router::RetryStateImpl::parseRetryGrpcOn);
+    if (!res.valid_) {
+      return handle_invalid_header(res);
     }
   }
 

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -203,16 +203,17 @@ public:
         http_context_(http_context), zone_name_(factory_context.localInfo().zoneStatName()),
         shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
     for (const auto& header : strict_check_headers) {
-      const std::string lower_header = absl::AsciiStrToLower(header);
-      if (lower_header == Http::Headers::get().EnvoyUpstreamRequestTimeoutMs.get()) {
+      if (absl::EqualsIgnoreCase(header,
+                                 Http::Headers::get().EnvoyUpstreamRequestTimeoutMs.get())) {
         envoy_upstream_rq_timeout_ms_ = true;
-      } else if (lower_header == Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs.get()) {
+      } else if (absl::EqualsIgnoreCase(
+                     header, Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs.get())) {
         envoy_upstream_rq_per_try_timeout_ms_ = true;
-      } else if (lower_header == Http::Headers::get().EnvoyMaxRetries.get()) {
+      } else if (absl::EqualsIgnoreCase(header, Http::Headers::get().EnvoyMaxRetries.get())) {
         envoy_max_retries_ = true;
-      } else if (lower_header == Http::Headers::get().EnvoyRetryOn.get()) {
+      } else if (absl::EqualsIgnoreCase(header, Http::Headers::get().EnvoyRetryOn.get())) {
         envoy_retry_on_ = true;
-      } else if (lower_header == Http::Headers::get().EnvoyRetryGrpcOn.get()) {
+      } else if (absl::EqualsIgnoreCase(header, Http::Headers::get().EnvoyRetryGrpcOn.get())) {
         envoy_retry_grpc_on_ = true;
       }
     }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -36,6 +36,8 @@
 #include "source/common/upstream/load_balancer_context_base.h"
 #include "source/common/upstream/upstream_factory_context_impl.h"
 
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/ascii.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -62,22 +64,8 @@ public:
       const Http::HeaderEntry* entry_;
     };
 
-    /**
-     * Determine whether a given header's value passes the strict validation
-     * defined for that header.
-     * @param headers supplies the headers from which to get the target header.
-     * @param target_header is the header to be validated.
-     * @return HeaderCheckResult containing the entry for @param target_header
-     *         and valid_ set to FALSE if @param target_header is set to an
-     *         invalid value. If @param target_header doesn't appear in
-     *         @param headers, return a result with valid_ set to TRUE.
-     */
-    static const HeaderCheckResult checkHeader(Http::RequestHeaderMap& headers,
-                                               const Http::LowerCaseString& target_header);
-
     using ParseRetryFlagsFunc = std::function<std::pair<uint32_t, bool>(absl::string_view)>;
 
-  private:
     static HeaderCheckResult hasValidRetryFields(const Http::HeaderEntry* header_entry,
                                                  const ParseRetryFlagsFunc& parse_fn) {
       HeaderCheckResult r;
@@ -214,10 +202,18 @@ public:
         reject_connect_request_early_data_(reject_connect_request_early_data),
         http_context_(http_context), zone_name_(factory_context.localInfo().zoneStatName()),
         shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
-    if (!strict_check_headers.empty()) {
-      strict_check_headers_ = std::make_unique<HeaderVector>();
-      for (const auto& header : strict_check_headers) {
-        strict_check_headers_->emplace_back(Http::LowerCaseString(header));
+    for (const auto& header : strict_check_headers) {
+      const std::string lower_header = absl::AsciiStrToLower(header);
+      if (lower_header == "x-envoy-upstream-rq-timeout-ms") {
+        strict_check_headers_.envoy_upstream_rq_timeout_ms_ = true;
+      } else if (lower_header == "x-envoy-upstream-rq-per-try-timeout-ms") {
+        strict_check_headers_.envoy_upstream_rq_per_try_timeout_ms_ = true;
+      } else if (lower_header == "x-envoy-max-retries") {
+        strict_check_headers_.envoy_max_retries_ = true;
+      } else if (lower_header == "x-envoy-retry-on") {
+        strict_check_headers_.envoy_retry_on_ = true;
+      } else if (lower_header == "x-envoy-retry-grpc-on") {
+        strict_check_headers_.envoy_retry_grpc_on_ = true;
       }
     }
   }
@@ -265,13 +261,19 @@ public:
   FilterStats default_stats_;
   FilterStats async_stats_;
   Random::RandomGenerator& random_;
-  const bool emit_dynamic_stats_;
-  const bool start_child_span_;
-  const bool suppress_envoy_headers_;
-  const bool respect_expected_rq_timeout_;
-  const bool suppress_grpc_request_failure_code_stats_;
-  // TODO(xyu-stripe): Make this a bitset to keep cluster memory footprint down.
-  HeaderVectorPtr strict_check_headers_;
+  const bool emit_dynamic_stats_ : 1;
+  const bool start_child_span_ : 1;
+  const bool suppress_envoy_headers_ : 1;
+  const bool respect_expected_rq_timeout_ : 1;
+  const bool suppress_grpc_request_failure_code_stats_ : 1;
+  struct StrictCheckHeaders {
+    bool envoy_upstream_rq_timeout_ms_ : 1;
+    bool envoy_upstream_rq_per_try_timeout_ms_ : 1;
+    bool envoy_max_retries_ : 1;
+    bool envoy_retry_on_ : 1;
+    bool envoy_retry_grpc_on_ : 1;
+  };
+  StrictCheckHeaders strict_check_headers_{};
   const bool flush_upstream_log_on_upstream_stream_;
   const bool reject_connect_request_early_data_;
   absl::optional<std::chrono::milliseconds> upstream_log_flush_interval_;
@@ -659,7 +661,7 @@ private:
   MetadataMatchCriteriaConstPtr metadata_match_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_from_upstream_lb_;
-  std::vector<std::reference_wrapper<const ShadowPolicy>> active_shadow_policies_;
+  absl::InlinedVector<std::reference_wrapper<const ShadowPolicy>, 2> active_shadow_policies_;
   std::unique_ptr<Http::RequestHeaderMap> shadow_headers_;
   std::unique_ptr<Http::RequestTrailerMap> shadow_trailers_;
   // The stream lifetime configured by request header.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -27,6 +27,7 @@
 #include "source/common/common/logger.h"
 #include "source/common/config/well_known_names.h"
 #include "source/common/http/filter_chain_helper.h"
+#include "source/common/http/headers.h"
 #include "source/common/http/sidestream_watermark.h"
 #include "source/common/http/utility.h"
 #include "source/common/router/context_impl.h"
@@ -204,15 +205,15 @@ public:
         shadow_writer_(std::move(shadow_writer)), time_source_(time_source) {
     for (const auto& header : strict_check_headers) {
       const std::string lower_header = absl::AsciiStrToLower(header);
-      if (lower_header == "x-envoy-upstream-rq-timeout-ms") {
+      if (lower_header == Http::Headers::get().EnvoyUpstreamRequestTimeoutMs.get()) {
         strict_check_headers_.envoy_upstream_rq_timeout_ms_ = true;
-      } else if (lower_header == "x-envoy-upstream-rq-per-try-timeout-ms") {
+      } else if (lower_header == Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs.get()) {
         strict_check_headers_.envoy_upstream_rq_per_try_timeout_ms_ = true;
-      } else if (lower_header == "x-envoy-max-retries") {
+      } else if (lower_header == Http::Headers::get().EnvoyMaxRetries.get()) {
         strict_check_headers_.envoy_max_retries_ = true;
-      } else if (lower_header == "x-envoy-retry-on") {
+      } else if (lower_header == Http::Headers::get().EnvoyRetryOn.get()) {
         strict_check_headers_.envoy_retry_on_ = true;
-      } else if (lower_header == "x-envoy-retry-grpc-on") {
+      } else if (lower_header == Http::Headers::get().EnvoyRetryGrpcOn.get()) {
         strict_check_headers_.envoy_retry_grpc_on_ = true;
       }
     }

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -37,7 +37,6 @@
 #include "source/common/upstream/load_balancer_context_base.h"
 #include "source/common/upstream/upstream_factory_context_impl.h"
 
-#include "absl/container/inlined_vector.h"
 #include "absl/strings/ascii.h"
 #include "absl/types/optional.h"
 
@@ -206,15 +205,15 @@ public:
     for (const auto& header : strict_check_headers) {
       const std::string lower_header = absl::AsciiStrToLower(header);
       if (lower_header == Http::Headers::get().EnvoyUpstreamRequestTimeoutMs.get()) {
-        strict_check_headers_.envoy_upstream_rq_timeout_ms_ = true;
+        envoy_upstream_rq_timeout_ms_ = true;
       } else if (lower_header == Http::Headers::get().EnvoyUpstreamRequestPerTryTimeoutMs.get()) {
-        strict_check_headers_.envoy_upstream_rq_per_try_timeout_ms_ = true;
+        envoy_upstream_rq_per_try_timeout_ms_ = true;
       } else if (lower_header == Http::Headers::get().EnvoyMaxRetries.get()) {
-        strict_check_headers_.envoy_max_retries_ = true;
+        envoy_max_retries_ = true;
       } else if (lower_header == Http::Headers::get().EnvoyRetryOn.get()) {
-        strict_check_headers_.envoy_retry_on_ = true;
+        envoy_retry_on_ = true;
       } else if (lower_header == Http::Headers::get().EnvoyRetryGrpcOn.get()) {
-        strict_check_headers_.envoy_retry_grpc_on_ = true;
+        envoy_retry_grpc_on_ = true;
       }
     }
   }
@@ -267,14 +266,11 @@ public:
   const bool suppress_envoy_headers_ : 1;
   const bool respect_expected_rq_timeout_ : 1;
   const bool suppress_grpc_request_failure_code_stats_ : 1;
-  struct StrictCheckHeaders {
-    bool envoy_upstream_rq_timeout_ms_ : 1;
-    bool envoy_upstream_rq_per_try_timeout_ms_ : 1;
-    bool envoy_max_retries_ : 1;
-    bool envoy_retry_on_ : 1;
-    bool envoy_retry_grpc_on_ : 1;
-  };
-  StrictCheckHeaders strict_check_headers_{};
+  bool envoy_upstream_rq_timeout_ms_ : 1 = false;
+  bool envoy_upstream_rq_per_try_timeout_ms_ : 1 = false;
+  bool envoy_max_retries_ : 1 = false;
+  bool envoy_retry_on_ : 1 = false;
+  bool envoy_retry_grpc_on_ : 1 = false;
   const bool flush_upstream_log_on_upstream_stream_;
   const bool reject_connect_request_early_data_;
   absl::optional<std::chrono::milliseconds> upstream_log_flush_interval_;
@@ -566,6 +562,7 @@ private:
                           Upstream::HostDescriptionOptConstRef upstream_host, bool dropped);
   void chargeUpstreamCode(Http::Code code, Upstream::HostDescriptionOptConstRef upstream_host,
                           bool dropped);
+  Http::FilterHeadersStatus checkStrictHeaders(const Http::RequestHeaderMap& headers);
   void chargeUpstreamAbort(Http::Code code, bool dropped, UpstreamRequest& upstream_request);
   void cleanup();
   virtual RetryStatePtr createRetryState(const RetryPolicy& policy,
@@ -662,7 +659,7 @@ private:
   MetadataMatchCriteriaConstPtr metadata_match_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_;
   std::function<void(Http::ResponseHeaderMap&)> modify_headers_from_upstream_lb_;
-  absl::InlinedVector<std::reference_wrapper<const ShadowPolicy>, 2> active_shadow_policies_;
+  std::vector<std::reference_wrapper<const ShadowPolicy>> active_shadow_policies_;
   std::unique_ptr<Http::RequestHeaderMap> shadow_headers_;
   std::unique_ptr<Http::RequestTrailerMap> shadow_trailers_;
   // The stream lifetime configured by request header.

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -37,7 +37,7 @@
 #include "source/common/upstream/load_balancer_context_base.h"
 #include "source/common/upstream/upstream_factory_context_impl.h"
 
-#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -1,3 +1,4 @@
+#include "source/common/router/retry_state_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
 
 #include "test/common/router/router_test_base.h"
@@ -955,12 +956,18 @@ TEST(RouterFilterUtilityTest, StrictCheckValidHeaders) {
        "cancelled,internal,deadline-exceeded,resource-exhausted , unavailable"}, // space is allowed
   };
 
-  for (const auto& target : SUPPORTED_STRICT_CHECKED_HEADERS) {
-    EXPECT_TRUE(
-        FilterUtility::StrictHeaderChecker::checkHeader(headers, Http::LowerCaseString(target))
-            .valid_)
-        << fmt::format("'{}' should have passed strict validation", target);
-  }
+  EXPECT_TRUE(FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyUpstreamRequestTimeoutMs())
+                  .valid_);
+  EXPECT_TRUE(
+      FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyUpstreamRequestPerTryTimeoutMs())
+          .valid_);
+  EXPECT_TRUE(FilterUtility::StrictHeaderChecker::isInteger(headers.EnvoyMaxRetries()).valid_);
+  EXPECT_TRUE(FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+                  headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn)
+                  .valid_);
+  EXPECT_TRUE(FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+                  headers.EnvoyRetryGrpcOn(), &Router::RetryStateImpl::parseRetryGrpcOn)
+                  .valid_);
 
   Http::TestRequestHeaderMapImpl failing_headers{
       {"X-envoy-Upstream-rq-timeout-ms", "10.0"},
@@ -970,12 +977,20 @@ TEST(RouterFilterUtilityTest, StrictCheckValidHeaders) {
       {"x-envoy-retry-grpc-on", "5xx,cancelled, internal"}, // '5xx' is an invalid entry
   };
 
-  for (const auto& target : SUPPORTED_STRICT_CHECKED_HEADERS) {
-    EXPECT_FALSE(FilterUtility::StrictHeaderChecker::checkHeader(failing_headers,
-                                                                 Http::LowerCaseString(target))
-                     .valid_)
-        << fmt::format("'{}' should have failed strict validation", target);
-  }
+  EXPECT_FALSE(
+      FilterUtility::StrictHeaderChecker::isInteger(failing_headers.EnvoyUpstreamRequestTimeoutMs())
+          .valid_);
+  EXPECT_FALSE(FilterUtility::StrictHeaderChecker::isInteger(
+                   failing_headers.EnvoyUpstreamRequestPerTryTimeoutMs())
+                   .valid_);
+  EXPECT_FALSE(
+      FilterUtility::StrictHeaderChecker::isInteger(failing_headers.EnvoyMaxRetries()).valid_);
+  EXPECT_FALSE(FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+                   failing_headers.EnvoyRetryOn(), &Router::RetryStateImpl::parseRetryOn)
+                   .valid_);
+  EXPECT_FALSE(FilterUtility::StrictHeaderChecker::hasValidRetryFields(
+                   failing_headers.EnvoyRetryGrpcOn(), &Router::RetryStateImpl::parseRetryGrpcOn)
+                   .valid_);
 }
 
 class RouterTestSupressGRPCStatsEnabled : public RouterTestBase {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

- replace vector with struct of bitfields bools
- use flat_hash_map with shared_ptr value, for better cache locality. Pointer/iterator stability is not required for shared ptr
- use inline vector for shadow policy

Save ~6% of memory (0.1G out of 1.6G) on router creation 

Before: 
<img width="1961" height="794" alt="image" src="https://github.com/user-attachments/assets/4ec6d668-b635-42e6-9d2a-284855da4a7f" />

After Opt:
<img width="1284" height="665" alt="image" src="https://github.com/user-attachments/assets/47fa4ae3-d07d-4dd6-9dea-07c486f33210" />

