### PR TITLE
fix: stats: make the HDS's cluster to honor alt_stat_name

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -77,6 +77,11 @@ minor_behavior_changes:
     making per-host comparison O(1). In rare cases where two semantically equivalent metadata messages
     have different serializations, this may cause a spurious metadata update (false positive) but will
     never miss an actual change.
+- area: upstream
+  change: |
+    ``ProdClusterInfoFactory`` now honors ``alt_stat_name`` when creating cluster stats scopes, so
+    stats emitted through that path use the alternate cluster name consistently with other upstream
+    cluster implementations.
 - area: histograms
   change: |
     Updated libcircllhist to 0.3.2, which changes how bucket bounds are interpreted. This should not impact
@@ -300,6 +305,11 @@ bug_fixes:
   change: |
     Fixed an out-of-bounds issue in ThreadAwareLoadBalancerBase that could occur during mid-batch EDS host updates
     due to eagerly calling refresh() before the deferred priority state resize.
+- area: upstream
+  change: |
+    Fixed ``ProdClusterInfoFactory`` of HDS to honor ``alt_stat_name`` when creating cluster stats scopes, so
+    stats emitted through that path now use the alternate cluster name consistently with other upstream
+    cluster implementations.
 - area: access_log
   change: |
     Fixed a crash on listener removal with a process-level access log rate limiter

--- a/source/common/upstream/prod_cluster_info_factory.cc
+++ b/source/common/upstream/prod_cluster_info_factory.cc
@@ -12,8 +12,7 @@ namespace Upstream {
 
 ClusterInfoConstSharedPtr
 ProdClusterInfoFactory::createClusterInfo(const CreateClusterInfoParams& params) {
-  Envoy::Stats::ScopeSharedPtr scope =
-      generateStatsScope(params.cluster_, params.server_context_, false);
+  Envoy::Stats::ScopeSharedPtr scope = generateStatsScope(params.cluster_, params.server_context_);
 
   Envoy::Server::Configuration::TransportSocketFactoryContextImpl factory_context(
       params.server_context_, *scope, params.server_context_.messageValidationVisitor());

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -420,8 +420,7 @@ constexpr absl::string_view StatsMatcherMetadataKey = "envoy.stats_matcher";
 
 Stats::ScopeSharedPtr
 generateStatsScope(const envoy::config::cluster::v3::Cluster& config,
-                   Server::Configuration::ServerFactoryContext& server_context,
-                   bool use_alt_stat_name) {
+                   Server::Configuration::ServerFactoryContext& server_context) {
   auto& stats = server_context.serverScope().store();
   Stats::StatsMatcherSharedPtr scope_matcher;
 
@@ -442,11 +441,10 @@ generateStatsScope(const envoy::config::cluster::v3::Cluster& config,
     }
   }
 
-  return stats.createScope(
-      fmt::format("cluster.{}.", (!config.alt_stat_name().empty() && use_alt_stat_name)
-                                     ? config.alt_stat_name()
-                                     : config.name()),
-      false, {}, std::move(scope_matcher));
+  return stats.createScope(fmt::format("cluster.{}.", (!config.alt_stat_name().empty())
+                                                          ? config.alt_stat_name()
+                                                          : config.name()),
+                           false, {}, std::move(scope_matcher));
 }
 
 // TODO(pianiststickman): this implementation takes a lock on the hot path and puts a copy of the

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -85,8 +85,7 @@ using UpstreamNetworkFilterConfigProviderManager =
 
 Stats::ScopeSharedPtr
 generateStatsScope(const envoy::config::cluster::v3::Cluster& config,
-                   Server::Configuration::ServerFactoryContext& server_context,
-                   bool use_alt_stat_name = true);
+                   Server::Configuration::ServerFactoryContext& server_context);
 
 class LegacyLbPolicyConfigHelper {
 public:

--- a/test/common/upstream/prod_cluster_info_factory_test.cc
+++ b/test/common/upstream/prod_cluster_info_factory_test.cc
@@ -36,6 +36,33 @@ protected:
   ProdClusterInfoFactory factory_;
 };
 
+// alt_stat_name is preferred over name for stats scope generation.
+TEST_F(ProdClusterInfoFactoryTest, AltStatNamePreferred) {
+  const std::string yaml = R"EOF(
+    name: my_cluster
+    alt_stat_name: my_alt_cluster
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: 127.0.0.1
+                  port_value: 11001
+  )EOF";
+
+  auto info = createClusterInfo(parseClusterFromV3Yaml(yaml));
+  ASSERT_NE(nullptr, info);
+  info->trafficStats();
+
+  // Stats scope should be generated with alt_stat_name, not name.
+  EXPECT_EQ(info->statsScope().symbolTable().toString(info->statsScope().prefix()),
+            "cluster.my_alt_cluster");
+}
+
 // Verify that a cluster without a stats matcher in metadata creates all stats normally.
 TEST_F(ProdClusterInfoFactoryTest, NoMetadataStatsMatcher) {
   const std::string yaml = R"EOF(
@@ -56,6 +83,9 @@ TEST_F(ProdClusterInfoFactoryTest, NoMetadataStatsMatcher) {
   auto info = createClusterInfo(parseClusterFromV3Yaml(yaml));
   ASSERT_NE(nullptr, info);
   info->trafficStats();
+
+  EXPECT_EQ(info->statsScope().symbolTable().toString(info->statsScope().prefix()),
+            "cluster.my_cluster");
 
   // Without a scope matcher, stats of any name are accepted.
   EXPECT_NE("", info->statsScope().counterFromString("upstream_cx_total").name());


### PR DESCRIPTION
Commit Message: fix: stats: make the HDS's cluster to honor alt_stat_name
Additional Description:

In the previous implementation, the cluster of HDS update will not use the alt_stat_name even it's set. This PR fixed related behavior.

Risk Level: low
Testing: unit.
Docs Changes: n/a.
Release Notes: added.