### PR TITLE
QUIC: Add memory_reduction_timeout configuration

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -57,7 +57,7 @@ message QuicKeepAliveSettings {
 }
 
 // QUIC protocol options which apply to both downstream and upstream connections.
-// [#next-free-field: 12]
+// [#next-free-field: 13]
 message QuicProtocolOptions {
   // Config for QUIC connection migration across network interfaces, i.e. cellular to WIFI, upon
   // network change events from the platform, i.e. the current network gets
@@ -173,6 +173,11 @@ message QuicProtocolOptions {
   // If absent, the feature will be disabled.
   // [#not-implemented-hide:]
   ConnectionMigrationSettings connection_migration = 11;
+
+  // Timeout for a QUIC connection to schedule memory reduction callback when the network has been idle for a while.
+  // This value should be smaller than the idle timeout to take effect.
+  // If not specified, memory reduction is set to infinite by QUIC connection (disabled).
+  google.protobuf.Duration memory_reduction_timeout = 12 [(validate.rules).duration = {gte {seconds: 1}}];
 }
 
 message UpstreamHttpProtocolOptions {

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -177,7 +177,8 @@ message QuicProtocolOptions {
   // Timeout for a QUIC connection to schedule memory reduction callback when the network has been idle for a while.
   // This value should be smaller than the idle timeout to take effect.
   // If not specified, memory reduction is set to infinite by QUIC connection (disabled).
-  google.protobuf.Duration memory_reduction_timeout = 12 [(validate.rules).duration = {gte {seconds: 1}}];
+  google.protobuf.Duration memory_reduction_timeout = 12
+      [(validate.rules).duration = {gte {seconds: 1}}];
 }
 
 message UpstreamHttpProtocolOptions {

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -214,6 +214,14 @@ void EnvoyQuicServerSession::setHttp3Options(
       }
     }
   }
+  if (http3_options.has_quic_protocol_options()) {
+    const uint64_t memory_reduction_timeout_ms = PROTOBUF_GET_MS_OR_DEFAULT(
+        http3_options.quic_protocol_options(), memory_reduction_timeout, 0);
+    if (memory_reduction_timeout_ms > 0) {
+      connection()->SetMemoryReductionTimeout(
+          quic::QuicTime::Delta::FromMilliseconds(memory_reduction_timeout_ms));
+    }
+  }
   set_allow_extended_connect(http3_options_->allow_extended_connect());
   if (http3_options_->disable_qpack()) {
     DisableHuffmanEncoding();

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -1346,6 +1346,32 @@ TEST_F(EnvoyQuicServerSessionTest, SessionIdleCallbacksIdempotency) {
   EXPECT_CALL(session_idle_list_, RemoveSession(_));
 }
 
+TEST_F(EnvoyQuicServerSessionTest, MemoryReductionTimeoutTest) {
+  envoy::config::core::v3::Http3ProtocolOptions http3_options;
+  auto* quic_options = http3_options.mutable_quic_protocol_options();
+  quic_options->mutable_memory_reduction_timeout()->set_seconds(300);
+
+  // Mark handshake complete and set connection idle timeout to a large duration.
+  quic::test::QuicConnectionPeer::GetIdleNetworkDetector(quic_connection_)
+      .SetTimeouts(quic::QuicTime::Delta::Infinite(), quic::QuicTime::Delta::FromSeconds(600));
+
+  envoy_quic_session_.setHttp3Options(http3_options);
+
+  // Trigger SetAlarm.
+  quic::test::QuicConnectionPeer::GetIdleNetworkDetector(quic_connection_)
+      .OnPacketReceived(connection_helper_.GetClock()->Now());
+
+  // Check the alarm deadline.
+  quic::QuicAlarmProxy idle_detector_alarm =
+      quic::test::QuicConnectionPeer::GetIdleNetworkDetectorAlarm(quic_connection_);
+
+  EXPECT_TRUE(idle_detector_alarm.IsSet());
+  EXPECT_EQ(connection_helper_.GetClock()->Now() + quic::QuicTime::Delta::FromSeconds(300),
+            idle_detector_alarm.deadline());
+
+  installReadFilter();
+}
+
 class EnvoyQuicServerSessionTestWillNotInitialize : public EnvoyQuicServerSessionTest {
   void SetUp() override {}
   void TearDown() override {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: quic: add memory_reduction_timeout configuration support
Additional Description: Added a new configuration option `memory_reduction_timeout` to `QuicProtocolOptions` to allow setting a timeout for memory reduction callbacks when the network is idle.
Risk Level: low
Testing: N/A
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
