### PR TITLE
perf: Improve memory footprint on router, part 2

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -73,28 +73,28 @@ public:
     RouteEntryImplBaseConstSharedPtr route;
     switch (route_config.match().path_specifier_case()) {
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kPrefix:
-      route.reset(new PrefixRouteEntryImpl(vhost, route_config, factory_context, validator,
-                                           creation_status));
+      route = std::make_shared<PrefixRouteEntryImpl>(vhost, route_config, factory_context,
+                                                     validator, creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kPath:
-      route.reset(
-          new PathRouteEntryImpl(vhost, route_config, factory_context, validator, creation_status));
+      route = std::make_shared<PathRouteEntryImpl>(vhost, route_config, factory_context, validator,
+                                                   creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kSafeRegex:
-      route.reset(new RegexRouteEntryImpl(vhost, route_config, factory_context, validator,
-                                          creation_status));
+      route = std::make_shared<RegexRouteEntryImpl>(vhost, route_config, factory_context, validator,
+                                                    creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kConnectMatcher:
-      route.reset(new ConnectRouteEntryImpl(vhost, route_config, factory_context, validator,
-                                            creation_status));
+      route = std::make_shared<ConnectRouteEntryImpl>(vhost, route_config, factory_context,
+                                                      validator, creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kPathSeparatedPrefix:
-      route.reset(new PathSeparatedPrefixRouteEntryImpl(vhost, route_config, factory_context,
-                                                        validator, creation_status));
+      route = std::make_shared<PathSeparatedPrefixRouteEntryImpl>(
+          vhost, route_config, factory_context, validator, creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::kPathMatchPolicy:
-      route.reset(new UriTemplateMatcherRouteEntryImpl(vhost, route_config, factory_context,
-                                                       validator, creation_status));
+      route = std::make_shared<UriTemplateMatcherRouteEntryImpl>(
+          vhost, route_config, factory_context, validator, creation_status);
       break;
     case envoy::config::route::v3::RouteMatch::PathSpecifierCase::PATH_SPECIFIER_NOT_SET:
       break; // return the error below.

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -951,7 +951,6 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-public:
   friend class RouteCreator;
 
   UriTemplateMatcherRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
@@ -987,7 +986,6 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-public:
   friend class RouteCreator;
 
   PrefixRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
@@ -1023,7 +1021,6 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-public:
   friend class RouteCreator;
 
   PathRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
@@ -1058,7 +1055,6 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-public:
   friend class RouteCreator;
 
   RegexRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
@@ -1126,7 +1122,6 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-public:
   friend class RouteCreator;
 
   PathSeparatedPrefixRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -951,7 +951,7 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-private:
+public:
   friend class RouteCreator;
 
   UriTemplateMatcherRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
@@ -960,6 +960,7 @@ private:
                                    ProtobufMessage::ValidationVisitor& validator,
                                    absl::Status& creation_status);
 
+private:
   const std::string uri_template_;
 };
 
@@ -986,14 +987,16 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-private:
+public:
   friend class RouteCreator;
+
   PrefixRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
                        const envoy::config::route::v3::Route& route,
                        Server::Configuration::ServerFactoryContext& factory_context,
                        ProtobufMessage::ValidationVisitor& validator,
                        absl::Status& creation_status);
 
+private:
   const Matchers::PathMatcherConstSharedPtr path_matcher_;
 };
 
@@ -1020,13 +1023,15 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-private:
+public:
   friend class RouteCreator;
+
   PathRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
                      const envoy::config::route::v3::Route& route,
                      Server::Configuration::ServerFactoryContext& factory_context,
                      ProtobufMessage::ValidationVisitor& validator, absl::Status& creation_status);
 
+private:
   const Matchers::PathMatcherConstSharedPtr path_matcher_;
 };
 
@@ -1053,13 +1058,15 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-private:
+public:
   friend class RouteCreator;
+
   RegexRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
                       const envoy::config::route::v3::Route& route,
                       Server::Configuration::ServerFactoryContext& factory_context,
                       ProtobufMessage::ValidationVisitor& validator, absl::Status& creation_status);
 
+private:
   const Matchers::PathMatcherConstSharedPtr path_matcher_;
 };
 
@@ -1087,8 +1094,8 @@ public:
 
   bool supportsPathlessHeaders() const override { return true; }
 
-private:
   friend class RouteCreator;
+
   ConnectRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
                         const envoy::config::route::v3::Route& route,
                         Server::Configuration::ServerFactoryContext& factory_context,
@@ -1119,14 +1126,16 @@ public:
                                          const Formatter::Context& context,
                                          const StreamInfo::StreamInfo& stream_info) const override;
 
-private:
+public:
   friend class RouteCreator;
+
   PathSeparatedPrefixRouteEntryImpl(const CommonVirtualHostSharedPtr& vhost,
                                     const envoy::config::route::v3::Route& route,
                                     Server::Configuration::ServerFactoryContext& factory_context,
                                     ProtobufMessage::ValidationVisitor& validator,
                                     absl::Status& creation_status);
 
+private:
   const Matchers::PathMatcherConstSharedPtr path_matcher_;
 };
 


### PR DESCRIPTION
Credit: Optimization from @penguingao 

make_shared does one single heap allocation of the shared_ptr and the object, resulting in more compact memory usage compared to two separate allocations when reset(new) is used.

Save ~6% of memory (0.1G out of 1.6G) on router creation


Before:
<img width="1973" height="779" alt="image" src="https://github.com/user-attachments/assets/29cf9239-bed5-492f-b107-d7039de33426" />

After
<img width="1275" height="460" alt="image" src="https://github.com/user-attachments/assets/d2554f00-3e84-4498-8287-f9565784c640" />


