### PR TITLE
dynamic_modules: add is_validation_mode ABI callback for module optimizaion

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -350,6 +350,10 @@ removed_config_or_runtime:
     and legacy code path.
 
 new_features:
+- area: dynamic_modules
+  change: |
+    Added ``envoy_dynamic_module_callback_is_validation_mode`` ABI callback that allows dynamic
+    modules to check if the server is running in config validation mode.
 - area: ratelimit
   change: |
     Added ``is_negative_hits`` boolean to the ``hits_addend``

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -495,6 +495,19 @@ bool envoy_dynamic_module_callback_log_enabled(envoy_dynamic_module_type_log_lev
  */
 uint32_t envoy_dynamic_module_callback_get_concurrency();
 
+// ----------------------------- Server Mode -----------------------------------
+
+/**
+ * envoy_dynamic_module_callback_is_validation_mode may be called by the dynamic
+ * module to check if the server is running in config validation mode (--mode validate).
+ * This allows modules to optimize by only parsing and validating their config without
+ * performing expensive operations such as provider lookups or loading external resources.
+ * NOTE: This function must be called on the main thread.
+ *
+ * @return true if the server is in validation mode, false otherwise.
+ */
+bool envoy_dynamic_module_callback_is_validation_mode();
+
 // ----------------------------- Function Registry -----------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -74,6 +74,13 @@ uint32_t envoy_dynamic_module_callback_get_concurrency() {
   return context->options().concurrency();
 }
 
+bool envoy_dynamic_module_callback_is_validation_mode() {
+  using namespace Envoy;
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  auto context = Server::Configuration::ServerFactoryContextInstance::getExisting();
+  return context->options().mode() == Server::Mode::Validate;
+}
+
 // ---------------------- Function registry callbacks --------------------------------
 
 bool envoy_dynamic_module_callback_register_function(envoy_dynamic_module_type_module_buffer key,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -134,6 +134,18 @@ pub unsafe fn get_server_concurrency() -> u32 {
   unsafe { abi::envoy_dynamic_module_callback_get_concurrency() }
 }
 
+/// Check if the server is running in config validation mode (`--mode validate`).
+///
+/// This allows modules to optimize by only parsing and validating their config without
+/// performing expensive operations such as provider lookups or loading external resources.
+///
+/// # Safety
+///
+/// This function must be called on the main thread.
+pub unsafe fn is_validation_mode() -> bool {
+  unsafe { abi::envoy_dynamic_module_callback_is_validation_mode() }
+}
+
 /// Register a function pointer under a name in the process-wide function registry.
 ///
 /// This allows modules loaded in the same process to expose functions that other modules can

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -48,6 +48,7 @@ envoy_cc_test(
     srcs = ["abi_impl_test.cc"],
     deps = [
         "//source/extensions/dynamic_modules:abi_impl",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1,13 +1,48 @@
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
+
+using testing::Return;
 
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 namespace {
+
+// =============================================================================
+// Validation Mode Tests
+// =============================================================================
+
+TEST(CommonAbiImplTest, IsValidationModeReturnsTrueInValidateMode) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, mode()).WillByDefault(Return(Server::Mode::Validate));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_TRUE(envoy_dynamic_module_callback_is_validation_mode());
+}
+
+TEST(CommonAbiImplTest, IsValidationModeReturnsFalseInServeMode) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, mode()).WillByDefault(Return(Server::Mode::Serve));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_FALSE(envoy_dynamic_module_callback_is_validation_mode());
+}
+
+TEST(CommonAbiImplTest, IsValidationModeReturnsFalseInInitOnlyMode) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, mode()).WillByDefault(Return(Server::Mode::InitOnly));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_FALSE(envoy_dynamic_module_callback_is_validation_mode());
+}
+
+// =============================================================================
+// Function Registry Tests
+// =============================================================================
 
 // Test registering and retrieving a function.
 TEST(CommonAbiImplTest, FunctionRegistryRegisterAndGet) {


### PR DESCRIPTION
## Description

This PR adds a new `envoy_dynamic_module_callback_is_validation_mode()` to the dynamic modules common ABI so that any module like Bootstrap, HTTP filter, network filter, etc. could detect when Envoy is running in the `--mode validate`. 

This lets modules optimize by only parsing/validating their config without performing expensive operations like provider lookups or loading external resources when we are in the non-production mode.

---

**Commit Message**: dynamic_modules: add is_validation_mode ABI callback for module optimizaion
**Additional Description:** Added a new `envoy_dynamic_module_callback_is_validation_mode()` to the dynamic modules common ABI.
**Risk Level**: Low
**Testing**: Added Tests
**Docs Changes**: Added
**Release Notes:** Added