### PR TITLE
dynamic_modules: promote HTTP filter dynamic modules to GA

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -969,7 +969,6 @@ new_features:
 - area: ratelimit
   change: |
     Support populating rate limit descriptors from cluster metadata.
-
 - area: contrib
   change: |
     Added a new :ref:`Kafka stats sink <config_stat_sinks_kafka>` contrib extension
@@ -981,7 +980,6 @@ new_features:
     tag-as-label emission, and full librdkafka producer tuning (including TLS and SASL
     authentication) are supported via
     :ref:`KafkaStatsSinkConfig <envoy_v3_api_msg_extensions.stat_sinks.kafka.v3.KafkaStatsSinkConfig>`.
-
 - area: tls
   change: |
     Added support for building Envoy with OpenSSL as an alternative to the default BoringSSL.
@@ -990,5 +988,9 @@ new_features:
     ``--config=openssl``. HTTP/3 (QUIC) is disabled for OpenSSL builds. Note that OpenSSL builds are
     not currently covered by the `Envoy security policy <https://github.com/envoyproxy/envoy/blob/main/SECURITY.md>`_.
     See :repo:`bazel/SSL.md <bazel/SSL.md>` for details.
+- area: dynamic_modules
+  change: |
+    Promoted the dynamic modules HTTP filter (``envoy.filters.http.dynamic_modules``) from alpha
+    to stable.
 
 deprecated:

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -2324,9 +2324,9 @@ envoy.filters.http.dynamic_modules:
   categories:
   - envoy.filters.http
   - envoy.filters.http.upstream
-  security_posture: unknown
-  status: alpha
-  status_upstream: alpha
+  security_posture: requires_trusted_downstream_and_upstream
+  status: stable
+  status_upstream: stable
   type_urls:
   - envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilter
 envoy.tls.certificate_selectors.on_demand_secret:


### PR DESCRIPTION
## Description

We are now promoting `envoy.filters.http.dynamic_modules` from alpha to stable (GA). The HTTP filter has had substantial production burn time and a stable ABI. 

Security posture updated from `unknown` to `requires_trusted_downstream_and_upstream`, consistent with all other dynamic modules extensions. All other dynamic modules extensions remain `alpha` for now.

---

**Commit Message:** dynamic_modules: promote HTTP filter dynamic modules to GA
**Additional Description:** Promoted `envoy.filters.http.dynamic_modules` from alpha to stable (GA).
**Risk Level:** N/A
**Testing:** N/A
**Docs Changes:** Added
**Release Notes:** Added