### PR TITLE
contrib/golang: address race condition in Go HTTP filter

### DIFF
--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -157,6 +157,9 @@ func getRequest(r *C.httpRequest) *httpRequest {
 func getState(s *C.processState) *processState {
 	r := s.req
 	req := getRequest(r)
+	if req == nil {
+		return nil
+	}
 	if s.is_encoding == 0 {
 		return &req.decodingState.processState
 	}
@@ -237,6 +240,9 @@ func envoyGoFilterOnHttpHeader(s *C.processState, endStream, headerNum, headerBy
 //export envoyGoFilterOnHttpData
 func envoyGoFilterOnHttpData(s *C.processState, endStream, buffer, length uint64) uint64 {
 	state := getState(s)
+	if state == nil {
+		return uint64(api.Continue)
+	}
 
 	req := state.request
 	if req.pInfo.paniced {
@@ -389,6 +395,9 @@ func envoyGoFilterOnHttpDestroy(r *C.httpRequest, reason uint64) {
 //export envoyGoRequestSemaDec
 func envoyGoRequestSemaDec(r *C.httpRequest) {
 	req := getRequest(r)
+	if req == nil {
+		return
+	}
 	defer req.recoverPanic()
 	req.resumeWaitCallback()
 }

--- a/contrib/golang/filters/http/source/go/pkg/http/shim.go
+++ b/contrib/golang/filters/http/source/go/pkg/http/shim.go
@@ -241,6 +241,7 @@ func envoyGoFilterOnHttpHeader(s *C.processState, endStream, headerNum, headerBy
 func envoyGoFilterOnHttpData(s *C.processState, endStream, buffer, length uint64) uint64 {
 	state := getState(s)
 	if state == nil {
+		// safe to do as the C++ side hasDestroyed() check prevents acting on the returned value
 		return uint64(api.Continue)
 	}
 

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -404,11 +404,18 @@ void Filter::continueStatusInternal(ProcessorState& state, GolangStatus status) 
 
     case FilterState::ProcessingTrailer:
       state.continueDoData();
+      if (hasDestroyed()) {
+        return;
+      }
       state.continueProcessing();
       break;
 
     default:
       ASSERT(0, "unexpected state");
+    }
+
+    if (hasDestroyed()) {
+      return;
     }
   }
 
@@ -426,6 +433,9 @@ void Filter::continueStatusInternal(ProcessorState& state, GolangStatus status) 
     auto done = doDataGo(state, state.getBufferData(), state.getEndStream());
     if (done) {
       state.continueDoData();
+      if (hasDestroyed()) {
+        return;
+      }
     } else {
       // do not process trailers when data is not finished
       return;

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -348,6 +348,8 @@ public:
   void deferredDeleteRequest(HttpRequestInternal* req);
 
 private:
+  friend class TestFilter;
+
   bool hasDestroyed() {
     Thread::LockGuard lock(mutex_);
     return has_destroyed_;

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -33,7 +33,9 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        "//contrib/golang/common/dso/test:dso_mocks",
         "//contrib/golang/filters/http/source:golang_filter_lib",
+        "//source/common/network:address_lib",
         "//source/common/stream_info:stream_info_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -5,6 +5,7 @@
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/http/message_impl.h"
+#include "source/common/network/address_impl.h"
 #include "source/common/stream_info/stream_info_impl.h"
 
 #include "test/common/stats/stat_test_utility.h"
@@ -21,6 +22,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_format.h"
+#include "contrib/golang/common/dso/test/mocks.h"
 #include "contrib/golang/filters/http/source/golang_filter.h"
 #include "gmock/gmock.h"
 
@@ -28,17 +30,23 @@ using testing::_;
 using testing::AtLeast;
 using testing::InSequence;
 using testing::Invoke;
+using testing::Return;
+using testing::SaveArg;
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Golang {
-namespace {
 
 class TestFilter : public Filter {
 public:
+  using Filter::continueStatusInternal;
   using Filter::Filter;
+  DecodingProcessorState& testDecodingState() { return decoding_state_; }
+  HttpRequestInternal* testReq() { return req_; }
 };
+
+namespace {
 
 class GolangHttpFilterTest : public testing::Test {
 public:
@@ -189,6 +197,73 @@ TEST_F(GolangHttpFilterTest, InvalidConfigForRouteConfigFilter) {
   InSequence s;
   EXPECT_THROW_WITH_REGEX(setup(ROUTECONFIG, genSoPath(), ROUTECONFIG), EnvoyException,
                           "golang filter failed to parse plugin config");
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/44320.
+TEST_F(GolangHttpFilterTest, BufferedDataAfterDestroyDuringContinue) {
+  auto dso_lib = std::make_shared<NiceMock<Dso::MockHttpFilterDsoImpl>>();
+  ON_CALL(*dso_lib, envoyGoFilterNewHttpPluginConfig(_)).WillByDefault(Return(1));
+  ON_CALL(*dso_lib, envoyGoFilterOnHttpHeader(_, _, _, _))
+      .WillByDefault(Return(static_cast<uint64_t>(GolangStatus::Running)));
+
+  bool destroyed = false;
+  bool data_called_after_destroy = false;
+  ON_CALL(*dso_lib, envoyGoFilterOnHttpData(_, _, _, _))
+      .WillByDefault(Invoke(
+          [&destroyed, &data_called_after_destroy](processState*, GoUint64, GoUint64, GoUint64) {
+            if (destroyed) {
+              data_called_after_destroy = true;
+            }
+            return static_cast<uint64_t>(GolangStatus::Continue);
+          }));
+  ON_CALL(*dso_lib, envoyGoFilterOnHttpDestroy(_, _))
+      .WillByDefault(Invoke([&destroyed](httpRequest*, int) { destroyed = true; }));
+
+  const auto yaml = R"EOF(
+    library_id: test
+    library_path: test
+    plugin_name: test
+    )EOF";
+  envoy::extensions::filters::http::golang::v3alpha::Config proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> mock_context;
+  auto config = std::make_shared<FilterConfig>(proto_config, dso_lib, "", mock_context);
+  config->newGoPluginConfig();
+
+  Network::Address::InstanceConstSharedPtr addr(
+      (*Network::Address::PipeInstance::create("/test/test.sock")).release());
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> mock_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> mock_enc_callbacks;
+  NiceMock<Envoy::Network::MockConnection> mock_connection;
+  ON_CALL(mock_callbacks, connection())
+      .WillByDefault(Return(OptRef<const Network::Connection>{mock_connection}));
+  mock_connection.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr);
+  mock_connection.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr);
+  EXPECT_CALL(mock_callbacks.dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
+
+  auto filter = std::make_shared<TestFilter>(config, dso_lib, 0);
+  filter->setDecoderFilterCallbacks(mock_callbacks);
+  filter->setEncoderFilterCallbacks(mock_enc_callbacks);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl body("request body");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter->decodeData(body, false));
+
+  EXPECT_CALL(mock_callbacks, continueDecoding()).WillOnce(Invoke([&filter]() {
+    filter->onDestroy();
+  }));
+
+  filter->continueStatusInternal(filter->testDecodingState(), GolangStatus::Continue);
+
+  EXPECT_FALSE(data_called_after_destroy)
+      << "envoyGoFilterOnHttpData must not be called after onDestroy";
+
+  // The mock onDestroy intentionally didn't delete req_ (to keep state valid
+  // for the doDataGo path). Clean it up now to avoid leaking under ASAN.
+  delete filter->testReq();
 }
 
 } // namespace

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -261,8 +261,7 @@ TEST_F(GolangHttpFilterTest, BufferedDataAfterDestroyDuringContinue) {
   EXPECT_FALSE(data_called_after_destroy)
       << "envoyGoFilterOnHttpData must not be called after onDestroy";
 
-  // The mock onDestroy intentionally didn't delete req_ (to keep state valid
-  // for the doDataGo path). Clean it up now to avoid leaking under ASAN.
+  ASSERT_NE(nullptr, filter->testReq());
   delete filter->testReq();
 }
 

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -2128,31 +2128,4 @@ TEST_P(GolangIntegrationTest, DrainConnectionUponCompletion) {
   cleanupUpstreamAndDownstream();
 }
 
-// Regression test for https://github.com/envoyproxy/envoy/issues/44320.
-TEST_P(GolangIntegrationTest, AsyncContinueWithNoHealthyUpstream) {
-  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-    auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
-    cluster->mutable_load_assignment()->mutable_endpoints(0)->clear_lb_endpoints();
-  });
-
-  initializeBasicFilter(BASIC, "test.com");
-
-  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-
-  Http::TestRequestHeaderMapImpl request_headers{
-      {":method", "POST"},        {":path", "/test?async=1&sleep=1"}, {":scheme", "http"},
-      {":authority", "test.com"}, {"x-test-header-0", "foo"},
-  };
-
-  auto encoder_decoder = codec_client_->startRequest(request_headers);
-  Http::RequestEncoder& request_encoder = encoder_decoder.first;
-  auto response = std::move(encoder_decoder.second);
-  codec_client_->sendData(request_encoder, "request body", true);
-
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_EQ("503", response->headers().getStatusValue());
-
-  cleanup();
-}
-
 } // namespace Envoy

--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -2128,4 +2128,31 @@ TEST_P(GolangIntegrationTest, DrainConnectionUponCompletion) {
   cleanupUpstreamAndDownstream();
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/44320.
+TEST_P(GolangIntegrationTest, AsyncContinueWithNoHealthyUpstream) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster->mutable_load_assignment()->mutable_endpoints(0)->clear_lb_endpoints();
+  });
+
+  initializeBasicFilter(BASIC, "test.com");
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "POST"},        {":path", "/test?async=1&sleep=1"}, {":scheme", "http"},
+      {":authority", "test.com"}, {"x-test-header-0", "foo"},
+  };
+
+  auto encoder_decoder = codec_client_->startRequest(request_headers);
+  Http::RequestEncoder& request_encoder = encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  codec_client_->sendData(request_encoder, "request body", true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("503", response->headers().getStatusValue());
+
+  cleanup();
+}
+
 } // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:

addresses https://github.com/envoyproxy/envoy/issues/44320

the issue here arises when the client sends data and the data is pending to be dispatched. Previously, the stream could have been destroyed already by the time `continueStatusInternal` was invoked. This PR adds safety-checks in the Go shim, and on the C++ filter side to avoid it

Additional Description: n/a
Risk Level: n/a
Testing:

this was tested by building Envoy + a test client that sends HTTP/1.1 + POST with a body, and verifying the crash happens before consistently, and no longer crashes with the patch

also added a test to confirm the behavior - the test fails on main but passes with the patch

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
