### PR TITLE
Add McpRouterConfig interface to allow route or cluster overrides

### DIFF
--- a/source/extensions/filters/http/mcp_router/config.cc
+++ b/source/extensions/filters/http/mcp_router/config.cc
@@ -15,7 +15,7 @@ Http::FilterFactoryCb McpRouterFilterConfigFactory::createFilterFactoryFromProto
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 
   auto config =
-      std::make_shared<McpRouterConfig>(proto_config, stats_prefix, context.scope(), context);
+      std::make_shared<McpRouterConfigImpl>(proto_config, stats_prefix, context.scope(), context);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<McpRouterFilter>(config));

--- a/source/extensions/filters/http/mcp_router/filter_config.cc
+++ b/source/extensions/filters/http/mcp_router/filter_config.cc
@@ -1,5 +1,8 @@
 #include "source/extensions/filters/http/mcp_router/filter_config.h"
 
+#include <utility>
+#include <vector>
+
 #include "source/extensions/filters/common/mcp/filter_state.h"
 
 #include "absl/strings/str_cat.h"
@@ -52,16 +55,11 @@ McpRouterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = absl::StrCat(prefix, "mcp_router.");
   return McpRouterStats{MCP_ROUTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
-} // namespace
 
-McpRouterConfig::McpRouterConfig(
-    const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-    const std::string& stats_prefix, Stats::Scope& scope,
-    Server::Configuration::FactoryContext& context)
-    : factory_context_(context), session_identity_(parseSessionIdentity(proto_config)),
-      metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
-      stats_(generateStats(stats_prefix, scope)) {
-  for (const auto& server : proto_config.servers()) {
+std::vector<McpBackendConfig>
+parseBackends(const envoy::extensions::filters::http::mcp_router::v3::McpRouter& config) {
+  std::vector<McpBackendConfig> result;
+  for (const auto& server : config.servers()) {
     McpBackendConfig backend;
     const auto& mcp_cluster = server.mcp_cluster();
     backend.name = server.name().empty() ? mcp_cluster.cluster() : server.name();
@@ -70,15 +68,23 @@ McpRouterConfig::McpRouterConfig(
     backend.timeout =
         std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(mcp_cluster, timeout, 5000));
     backend.host_rewrite_literal = mcp_cluster.host_rewrite_literal();
-    backends_.push_back(std::move(backend));
+    result.push_back(std::move(backend));
   }
-
-  if (backends_.size() == 1) {
-    default_backend_name_ = backends_[0].name;
-  }
+  return result;
 }
+} // namespace
 
-const McpBackendConfig* McpRouterConfig::findBackend(const std::string& name) const {
+McpRouterConfigImpl::McpRouterConfigImpl(
+    const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+    const std::string& stats_prefix, Stats::Scope& scope,
+    Server::Configuration::FactoryContext& context)
+    : backends_(parseBackends(proto_config)),
+      default_backend_name_(backends_.size() == 1 ? backends_[0].name : ""),
+      factory_context_(context), session_identity_(parseSessionIdentity(proto_config)),
+      metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
+      stats_(generateStats(stats_prefix, scope)) {}
+
+const McpBackendConfig* McpRouterConfigImpl::findBackend(const std::string& name) const {
   for (const auto& backend : backends_) {
     if (backend.name == name) {
       return &backend;

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -82,9 +82,29 @@ struct McpRouterStats {
  */
 class McpRouterConfig {
 public:
-  McpRouterConfig(const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-                  const std::string& stats_prefix, Stats::Scope& scope,
-                  Server::Configuration::FactoryContext& context);
+  virtual ~McpRouterConfig() = default;
+
+  virtual const std::vector<McpBackendConfig>& backends() const = 0;
+  virtual bool isMultiplexing() const = 0;
+  virtual const std::string& defaultBackendName() const = 0;
+  virtual Server::Configuration::FactoryContext& factoryContext() const = 0;
+  virtual const McpBackendConfig* findBackend(const std::string& name) const = 0;
+
+  virtual bool hasSessionIdentity() const = 0;
+  virtual const SubjectSource& subjectSource() const = 0;
+  virtual ValidationMode validationMode() const = 0;
+  virtual bool shouldEnforceValidation() const = 0;
+  virtual const std::string& metadataNamespace() const = 0;
+
+  virtual McpRouterStats& stats() = 0;
+};
+
+class McpRouterConfigImpl : public McpRouterConfig {
+public:
+  McpRouterConfigImpl(
+      const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+      const std::string& stats_prefix, Stats::Scope& scope,
+      Server::Configuration::FactoryContext& context);
 
   const std::vector<McpBackendConfig>& backends() const { return backends_; }
   bool isMultiplexing() const { return backends_.size() > 1; }

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -63,7 +63,7 @@ TEST_F(McpRouterConfigTest, MultipleBackendsEnablesMultiplexing) {
   server2->mutable_mcp_cluster()->set_cluster("calc_cluster");
   server2->mutable_mcp_cluster()->set_path("/mcp/calc");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
 
   EXPECT_EQ(config.backends().size(), 2);
   EXPECT_TRUE(config.isMultiplexing());
@@ -90,7 +90,7 @@ TEST_F(McpRouterConfigTest, SingleBackendSetsDefaultName) {
   server->set_name("tools");
   server->mutable_mcp_cluster()->set_cluster("tools_cluster");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
 
   EXPECT_EQ(config.backends().size(), 1);
   EXPECT_FALSE(config.isMultiplexing());
@@ -105,7 +105,7 @@ TEST_F(McpRouterConfigTest, DefaultPathWhenNotSpecified) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
 
   const McpBackendConfig* backend = config.findBackend("test");
   ASSERT_NE(backend, nullptr);
@@ -120,7 +120,7 @@ TEST_F(McpRouterConfigTest, DefaultMetadataNamespace) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_EQ(config.metadataNamespace(), "envoy.filters.http.mcp");
 }
 
@@ -299,7 +299,7 @@ TEST_F(McpRouterConfigTest, SessionIdentityDisabledByDefault) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_FALSE(config.hasSessionIdentity());
   EXPECT_FALSE(config.shouldEnforceValidation());
 }
@@ -314,7 +314,7 @@ TEST_F(McpRouterConfigTest, SessionIdentityWithHeaderSource) {
   auto* identity = proto_config.mutable_session_identity();
   identity->mutable_identity()->mutable_header()->set_name("x-user-id");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(absl::holds_alternative<HeaderSubjectSource>(config.subjectSource()));
   EXPECT_FALSE(config.shouldEnforceValidation()); // DISABLED by default
@@ -333,7 +333,7 @@ TEST_F(McpRouterConfigTest, SessionIdentityWithMetadataSource) {
   metadata_key->add_path()->set_key("payload");
   metadata_key->add_path()->set_key("sub");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(absl::holds_alternative<MetadataSubjectSource>(config.subjectSource()));
 }
@@ -351,7 +351,7 @@ TEST_F(McpRouterConfigTest, MetadataKeyPathParsed) {
   metadata_key->add_path()->set_key("payload");
   metadata_key->add_path()->set_key("sub");
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   const auto& source = absl::get<MetadataSubjectSource>(config.subjectSource());
   EXPECT_EQ(source.filter, "jwt");
   ASSERT_EQ(source.path_keys.size(), 2);
@@ -371,7 +371,7 @@ TEST_F(McpRouterConfigTest, ValidationModeEnforce) {
   identity->mutable_validation()->set_mode(
       envoy::extensions::filters::http::mcp_router::v3::ValidationPolicy::ENFORCE);
 
-  McpRouterConfig config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(config.shouldEnforceValidation());
   EXPECT_EQ(config.validationMode(), ValidationMode::Enforce);
@@ -388,8 +388,8 @@ protected:
 
   McpRouterConfigSharedPtr
   createConfig(const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config) {
-    return std::make_shared<McpRouterConfig>(proto_config, std::string("test."),
-                                             *store_.rootScope(), factory_context_);
+    return std::make_shared<McpRouterConfigImpl>(proto_config, std::string("test."),
+                                                 *store_.rootScope(), factory_context_);
   }
 
   void setDynamicMetadata(const std::string& filter_name, const std::string& key,


### PR DESCRIPTION
Add interface for MCP router config to allow per route or cluster overrides. This is needed to integrate with the MCP Cluster.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
