### PR TITLE
Update QUICHE from bbe3dde94 to f4cb73412

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-04-09"
+  release_date: "2026-04-14"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "bbe3dde941efd8cc9297face96b6305bbfd880e1",
-        sha256 = "4e1c184c1f4c9e350c718127754c7d369f9fcc11dc7557cce48a9fe47970a0ed",
+        version = "f4cb73412317e1ec397f37ec8e218396dad18186",
+        sha256 = "5798004d460932ef454f38a341773eba614097e581cbaa50513a8a0a446921a8",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/bbe3dde94..f4cb73412

```
$ git log bbe3dde94..f4cb73412 --date=short --no-merges --format="%ad %al %s"

2026-04-14 martinduke Limit Joining FETCH to largest_object at time of SUBSCRIBE.
2026-04-13 dmcardle Deprecate MASQUE PerRequestConfig::SetExpectedEncapsulatedResponseBody()
2026-04-10 dmcardle Add encapsulated response body callback to MASQUE client's PerRequestConfig
2026-04-10 ripere Add `num_ohttp_chunks` flag and remove `chunked` flag.
2026-04-10 ripere Add `num_bhttp_chunks` flag and remove `indeterminate_length` flag.
2026-04-10 ianswett Reject NEW_CONNECTION_ID frames with empty connection IDs and close the connection, per RFC9000.  Based on cr/896368856
2026-04-10 wub No public description
2026-04-09 reubent Enforce a limit on the amount of total, uncompressed header bytes
2026-04-09 dschinazi Improve connection logging in OHTTP toy client
2026-04-09 dmcardle No public description
2026-04-09 martinduke Joining FETCH is allowed for any subscribe with forward = 1, without regard for filter type.
2026-04-08 asedeno Fis OSS QUICHE build.
```
