### PR TITLE
stats: perf: optimize StatName hot paths in symbol table

### DIFF
--- a/source/common/stats/metric_impl.cc
+++ b/source/common/stats/metric_impl.cc
@@ -32,26 +32,9 @@ MetricHelper::MetricHelper(StatName name, StatName tag_extracted_name,
   symbol_table.populateList(names.begin(), num_names, stat_names_);
 }
 
-StatName MetricHelper::statName() const { return stat_names_.front(); }
+StatName MetricHelper::statName() const { return stat_names_.at(0); }
 
-StatName MetricHelper::tagExtractedStatName() const {
-  // The name is the first element in stat_names_. The second is the
-  // tag-extracted-name. We don't have random access in that format,
-  // so we iterate through them, skipping the first element (name),
-  // and terminating the iteration after capturing the tag-extracted
-  // name by returning false from the lambda.
-  StatName tag_extracted_stat_name;
-  bool skip = true;
-  stat_names_.iterate([&tag_extracted_stat_name, &skip](StatName s) -> bool {
-    if (skip) {
-      skip = false;
-      return true;
-    }
-    tag_extracted_stat_name = s;
-    return false; // Returning 'false' stops the iteration.
-  });
-  return tag_extracted_stat_name;
-}
+StatName MetricHelper::tagExtractedStatName() const { return stat_names_.at(1); }
 
 void MetricHelper::iterateTagStatNames(const Metric::TagStatNameIterFn& fn) const {
   enum { Name, TagExtractedName, TagName, TagValue } state = Name;

--- a/source/common/stats/metric_impl.cc
+++ b/source/common/stats/metric_impl.cc
@@ -32,14 +32,7 @@ MetricHelper::MetricHelper(StatName name, StatName tag_extracted_name,
   symbol_table.populateList(names.begin(), num_names, stat_names_);
 }
 
-StatName MetricHelper::statName() const {
-  StatName stat_name;
-  stat_names_.iterate([&stat_name](StatName s) -> bool {
-    stat_name = s;
-    return false; // Returning 'false' stops the iteration.
-  });
-  return stat_name;
-}
+StatName MetricHelper::statName() const { return stat_names_.front(); }
 
 StatName MetricHelper::tagExtractedStatName() const {
   // The name is the first element in stat_names_. The second is the

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -24,13 +24,6 @@ namespace Stats {
 static constexpr Symbol FirstValidSymbol = 1;
 static constexpr uint8_t LiteralStringIndicator = 0;
 
-size_t StatName::dataSize() const {
-  if (size_and_data_ == nullptr) {
-    return 0;
-  }
-  return SymbolTable::Encoding::decodeNumber(size_and_data_).first;
-}
-
 #ifndef ENVOY_CONFIG_COVERAGE
 void StatName::debugPrint() {
   // TODO(jmarantz): capture this functionality (always prints regardless of

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -14,13 +14,6 @@
 namespace Envoy {
 namespace Stats {
 
-// Masks used for variable-length encoding of arbitrary-sized integers into a
-// uint8-array. The integers are typically small, so we try to store them in as
-// few bytes as possible. The bottom 7 bits hold values, and the top bit is used
-// to determine whether another byte is needed for more data.
-static constexpr uint32_t SpilloverMask = 0x80;
-static constexpr uint32_t Low7Bits = 0x7f;
-
 // When storing Symbol arrays, we disallow Symbol 0, which is the only Symbol
 // that will decode into uint8_t array starting (and ending) with {0}. Thus we
 // can use a leading 0 in the first byte to indicate that what follows is
@@ -30,13 +23,6 @@ static constexpr uint32_t Low7Bits = 0x7f;
 // tokens as fully elaborated strings.
 static constexpr Symbol FirstValidSymbol = 1;
 static constexpr uint8_t LiteralStringIndicator = 0;
-
-size_t StatName::dataSize() const {
-  if (size_and_data_ == nullptr) {
-    return 0;
-  }
-  return SymbolTable::Encoding::decodeNumber(size_and_data_).first;
-}
 
 #ifndef ENVOY_CONFIG_COVERAGE
 void StatName::debugPrint() {
@@ -67,15 +53,6 @@ SymbolTable::Encoding::~Encoding() {
   ASSERT(mem_block_.capacity() == 0);
 }
 
-size_t SymbolTable::Encoding::encodingSizeBytes(uint64_t number) {
-  size_t num_bytes = 0;
-  do {
-    ++num_bytes;
-    number >>= 7;
-  } while (number != 0);
-  return num_bytes;
-}
-
 void SymbolTable::Encoding::appendEncoding(uint64_t number, MemBlockBuilder<uint8_t>& mem_block) {
   // UTF-8-like encoding where a value 127 or less gets written as a single
   // byte. For higher values we write the low-order 7 bits with a 1 in
@@ -88,7 +65,7 @@ void SymbolTable::Encoding::appendEncoding(uint64_t number, MemBlockBuilder<uint
     if (number < (1 << 7)) {
       mem_block.appendOne(number); // number <= 127 gets encoded in one byte.
     } else {
-      mem_block.appendOne((number & Low7Bits) | SpilloverMask); // >= 128 need spillover bytes.
+      mem_block.appendOne((number & kLow7Bits) | kSpilloverMask); // >= 128 need spillover bytes.
     }
     number >>= 7;
   } while (number != 0);
@@ -103,17 +80,6 @@ void SymbolTable::Encoding::addSymbols(const std::vector<Symbol>& symbols) {
   for (Symbol symbol : symbols) {
     appendEncoding(symbol, mem_block_);
   }
-}
-
-std::pair<uint64_t, size_t> SymbolTable::Encoding::decodeNumber(const uint8_t* encoding) {
-  uint64_t number = 0;
-  uint64_t uc = SpilloverMask;
-  const uint8_t* start = encoding;
-  for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
-    uc = static_cast<uint32_t>(*encoding);
-    number |= (uc & Low7Bits) << shift;
-  }
-  return std::make_pair(number, encoding - start);
 }
 
 SymbolVec SymbolTable::Encoding::decodeSymbols(StatName stat_name) {

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -24,6 +24,13 @@ namespace Stats {
 static constexpr Symbol FirstValidSymbol = 1;
 static constexpr uint8_t LiteralStringIndicator = 0;
 
+size_t StatName::dataSize() const {
+  if (size_and_data_ == nullptr) {
+    return 0;
+  }
+  return SymbolTable::Encoding::decodeNumber(size_and_data_).first;
+}
+
 #ifndef ENVOY_CONFIG_COVERAGE
 void StatName::debugPrint() {
   // TODO(jmarantz): capture this functionality (always prints regardless of
@@ -51,6 +58,15 @@ SymbolTable::Encoding::~Encoding() {
   // Verifies that moveToMemBlock() was called on this encoding. Failure
   // to call moveToMemBlock() will result in leaks symbols.
   ASSERT(mem_block_.capacity() == 0);
+}
+
+size_t SymbolTable::Encoding::encodingSizeBytes(uint64_t number) {
+  size_t num_bytes = 0;
+  do {
+    ++num_bytes;
+    number >>= 7;
+  } while (number != 0);
+  return num_bytes;
 }
 
 void SymbolTable::Encoding::appendEncoding(uint64_t number, MemBlockBuilder<uint8_t>& mem_block) {

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -81,7 +81,7 @@ void SymbolTable::Encoding::appendEncoding(uint64_t number, MemBlockBuilder<uint
     if (number < (1 << 7)) {
       mem_block.appendOne(number); // number <= 127 gets encoded in one byte.
     } else {
-      mem_block.appendOne((number & kLow7Bits) | kSpilloverMask); // >= 128 need spillover bytes.
+      mem_block.appendOne((number & Low7Bits) | SpilloverMask); // >= 128 need spillover bytes.
     }
     number >>= 7;
   } while (number != 0);

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -618,7 +618,18 @@ public:
   uint64_t hash() const { return absl::Hash<StatName>()(*this); }
 
   bool operator==(const StatName& rhs) const {
-    return dataAsStringView() == rhs.dataAsStringView();
+    if (size_and_data_ == rhs.size_and_data_) {
+      return true;
+    }
+
+    if (size_and_data_ == nullptr || rhs.size_and_data_ == nullptr) {
+      return empty() && rhs.empty();
+    }
+
+    const auto [lhs_sz, lhs_prefix] = SymbolTable::Encoding::decodeNumber(size_and_data_);
+    const auto [rhs_sz, rhs_prefix] = SymbolTable::Encoding::decodeNumber(rhs.size_and_data_);
+    return lhs_sz == rhs_sz &&
+           memcmp(size_and_data_ + lhs_prefix, rhs.size_and_data_ + rhs_prefix, lhs_sz) == 0;
   }
   bool operator!=(const StatName& rhs) const { return !(*this == rhs); }
 
@@ -682,7 +693,11 @@ public:
   /**
    * @return whether this is empty.
    */
-  bool empty() const { return size_and_data_ == nullptr || dataSize() == 0; }
+  bool empty() const {
+    // Avoid a full varint decode: it is sufficient to know the first byte,
+    // since 0x00 uniquely encodes zero
+    return size_and_data_ == nullptr || size_and_data_[0] == 0;
+  }
 
   /**
    * Determines whether this starts with the prefix. Note: dynamic segments

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -900,13 +900,24 @@ public:
   void clear(SymbolTable& symbol_table);
 
   /**
-   * @return the first StatName in the list. List must be populated and non-empty.
+   * @return the number of StatNames in the list, or 0 if not populated.
    */
-  StatName front() const {
-    // storage_[0] holds the element count, so if we are populated and non-empty
-    // the first byte will be greater than 0.
-    ASSERT(populated() && storage_[0] > 0);
-    return StatName(&storage_[1]);
+  uint32_t size() const { return populated() ? storage_[0] : 0; }
+
+  /**
+   * @return the StatName at the given index. This is O(index): each element
+   *         has a variable-length encoding, so callers that need to visit
+   *         many elements should prefer iterate().
+   *
+   * Requires: populated() && index < size().
+   */
+  StatName at(uint32_t index) const {
+    ASSERT(populated() && index < storage_[0]);
+    const uint8_t* p = &storage_[1];
+    for (uint32_t i = 0; i < index; ++i) {
+      p += StatName(p).size();
+    }
+    return StatName(p);
   }
 
 private:

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -159,6 +159,10 @@ public:
      * Defined inline in the header to allow the compiler to inline on hot paths.
      */
     static size_t encodingSizeBytes(uint64_t number) {
+      // fast-path for the case 127 or less
+      if (number < kSpilloverMask) {
+        return 1;
+      }
       size_t num_bytes = 0;
       do {
         ++num_bytes;
@@ -205,6 +209,11 @@ public:
      * Defined inline in the header to allow the compiler to inline on hot paths.
      */
     static std::pair<uint64_t, size_t> decodeNumber(const uint8_t* encoding) {
+      // fast-path for the case 127 or less
+      if (encoding[0] < kSpilloverMask) {
+        return {encoding[0], 1};
+      }
+
       uint64_t number = 0;
       uint64_t uc = kSpilloverMask;
       const uint8_t* start = encoding;

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <bit>
 #include <memory>
 #include <stack>
 #include <string>
@@ -159,16 +160,10 @@ public:
      * Defined inline in the header to allow the compiler to inline on hot paths.
      */
     static size_t encodingSizeBytes(uint64_t number) {
-      // fast-path for the case 127 or less
-      if (number < kSpilloverMask) {
-        return 1;
-      }
-      size_t num_bytes = 0;
-      do {
-        ++num_bytes;
-        number >>= 7;
-      } while (number != 0);
-      return num_bytes;
+      // Branch-free: compute number of 7-bit groups needed via leading-zero count.
+      // appendEncoding() always emits at least one byte (i.e. a 0 length), so the
+      // value 0 requires 1 byte. number|1 ensures we have a floor of 1 byte.
+      return (64 - std::countl_zero(number | 1) + 6) / 7;
     }
 
     /**

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -671,7 +671,11 @@ public:
    * @param mem_block_builder the builder to receive the storage.
    */
   void appendDataToMemBlock(MemBlockBuilder<uint8_t>& storage) {
-    storage.appendData(absl::MakeSpan(data(), dataSize()));
+    if (size_and_data_ == nullptr) {
+      return;
+    }
+    const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);
+    storage.appendData(absl::MakeSpan(size_and_data_ + prefix_size, data_size));
   }
 
 #ifndef ENVOY_CONFIG_COVERAGE
@@ -685,7 +689,7 @@ public:
     if (size_and_data_ == nullptr) {
       return nullptr;
     }
-    return size_and_data_ + SymbolTable::Encoding::encodingSizeBytes(dataSize());
+    return size_and_data_ + SymbolTable::Encoding::decodeNumber(size_and_data_).second;
   }
 
   const uint8_t* dataIncludingSize() const { return size_and_data_; }
@@ -716,8 +720,12 @@ private:
    * hasher and comparator.
    */
   absl::string_view dataAsStringView() const {
-    return {reinterpret_cast<const char*>(data()),
-            static_cast<absl::string_view::size_type>(dataSize())};
+    if (size_and_data_ == nullptr) {
+      return {};
+    }
+    const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);
+    return {reinterpret_cast<const char*>(size_and_data_ + prefix_size),
+            static_cast<absl::string_view::size_type>(data_size)};
   }
 
   const uint8_t* size_and_data_{nullptr};

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -197,16 +197,16 @@ public:
      */
     static std::pair<uint64_t, size_t> decodeNumber(const uint8_t* encoding) {
       // fast-path for the case 127 or less
-      if (encoding[0] < kSpilloverMask) {
+      if (encoding[0] < SpilloverMask) {
         return {encoding[0], 1};
       }
 
       uint64_t number = 0;
-      uint64_t uc = kSpilloverMask;
+      uint64_t uc = SpilloverMask;
       const uint8_t* start = encoding;
-      for (uint32_t shift = 0; (uc & kSpilloverMask) != 0; ++encoding, shift += 7) {
+      for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
         uc = static_cast<uint32_t>(*encoding);
-        number |= (uc & kLow7Bits) << shift;
+        number |= (uc & Low7Bits) << shift;
       }
       return std::make_pair(number, encoding - start);
     }
@@ -220,8 +220,8 @@ public:
     // uint8-array. The integers are typically small, so we try to store them in as
     // few bytes as possible. The bottom 7 bits hold values, and the top bit is used
     // to determine whether another byte is needed for more data.
-    static constexpr uint32_t kSpilloverMask = 0x80;
-    static constexpr uint32_t kLow7Bits = 0x7f;
+    static constexpr uint32_t SpilloverMask = 0x80;
+    static constexpr uint32_t Low7Bits = 0x7f;
 
     size_t data_bytes_required_{0};
     MemBlockBuilder<uint8_t> mem_block_;

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <bit>
 #include <memory>
 #include <stack>
 #include <string>
@@ -156,15 +155,8 @@ public:
     /**
      * @param number A number to encode in a variable length byte-array.
      * @return The number of bytes it would take to encode the number.
-     *
-     * Defined inline in the header to allow the compiler to inline on hot paths.
      */
-    static size_t encodingSizeBytes(uint64_t number) {
-      // Branch-free: compute number of 7-bit groups needed via leading-zero count.
-      // appendEncoding() always emits at least one byte (i.e. a 0 length), so the
-      // value 0 requires 1 byte. number|1 ensures we have a floor of 1 byte.
-      return (64 - std::countl_zero(number | 1) + 6) / 7;
-    }
+    static size_t encodingSizeBytes(uint64_t number);
 
     /**
      * @param num_data_bytes The number of bytes in a data-block.
@@ -637,12 +629,7 @@ public:
    * @return size_t the number of bytes in the symbol array, excluding the
    *                overhead for the size itself.
    */
-  size_t dataSize() const {
-    if (size_and_data_ == nullptr) {
-      return 0;
-    }
-    return SymbolTable::Encoding::decodeNumber(size_and_data_).first;
-  }
+  size_t dataSize() const;
 
   /**
    * @return size_t the number of bytes in the symbol array, including the

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -211,17 +211,17 @@ public:
       return std::make_pair(number, encoding - start);
     }
 
-  private:
-    friend class StatName;
-    friend class SymbolTable;
-    class TokenIter;
-
     // Masks used for variable-length encoding of arbitrary-sized integers into a
     // uint8-array. The integers are typically small, so we try to store them in as
     // few bytes as possible. The bottom 7 bits hold values, and the top bit is used
     // to determine whether another byte is needed for more data.
     static constexpr uint32_t SpilloverMask = 0x80;
     static constexpr uint32_t Low7Bits = 0x7f;
+
+  private:
+    friend class StatName;
+    friend class SymbolTable;
+    class TokenIter;
 
     size_t data_bytes_required_{0};
     MemBlockBuilder<uint8_t> mem_block_;

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -910,7 +910,7 @@ public:
   void clear(SymbolTable& symbol_table);
 
   /**
-   * @return the first StatName in the list. List must be populated.
+   * @return the first StatName in the list. List must be populated and non-empty.
    */
   StatName front() const {
     ASSERT(populated());

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -899,6 +899,14 @@ public:
    */
   void clear(SymbolTable& symbol_table);
 
+  /**
+   * @return the first StatName in the list. List must be populated.
+   */
+  StatName front() const {
+    ASSERT(populated());
+    return StatName(&storage_[1]);
+  }
+
 private:
   friend class SymbolTable;
 

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -618,10 +618,7 @@ public:
       return empty() && rhs.empty();
     }
 
-    const auto [lhs_sz, lhs_prefix] = SymbolTable::Encoding::decodeNumber(size_and_data_);
-    const auto [rhs_sz, rhs_prefix] = SymbolTable::Encoding::decodeNumber(rhs.size_and_data_);
-    return lhs_sz == rhs_sz &&
-           memcmp(size_and_data_ + lhs_prefix, rhs.size_and_data_ + rhs_prefix, lhs_sz) == 0;
+    return dataAsStringView() == rhs.dataAsStringView();
   }
   bool operator!=(const StatName& rhs) const { return !(*this == rhs); }
 
@@ -629,7 +626,7 @@ public:
    * @return size_t the number of bytes in the symbol array, excluding the
    *                overhead for the size itself.
    */
-  size_t dataSize() const;
+  size_t dataSize() const { return dataAsStringView().size(); }
 
   /**
    * @return size_t the number of bytes in the symbol array, including the
@@ -658,11 +655,8 @@ public:
    * @param mem_block_builder the builder to receive the storage.
    */
   void appendDataToMemBlock(MemBlockBuilder<uint8_t>& storage) {
-    if (size_and_data_ == nullptr) {
-      return;
-    }
-    const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);
-    storage.appendData(absl::MakeSpan(size_and_data_ + prefix_size, data_size));
+    auto sv = dataAsStringView();
+    storage.appendData(absl::MakeSpan(reinterpret_cast<const uint8_t*>(sv.data()), sv.size()));
   }
 
 #ifndef ENVOY_CONFIG_COVERAGE
@@ -673,10 +667,7 @@ public:
    * @return A pointer to the first byte of data (skipping over size bytes).
    */
   const uint8_t* data() const {
-    if (size_and_data_ == nullptr) {
-      return nullptr;
-    }
-    return size_and_data_ + SymbolTable::Encoding::decodeNumber(size_and_data_).second;
+    return reinterpret_cast<const uint8_t*>(dataAsStringView().data());
   }
 
   const uint8_t* dataIncludingSize() const { return size_and_data_; }
@@ -702,17 +693,16 @@ public:
 
 private:
   /**
-   * Casts the raw data as a string_view. Note that this string_view will not
-   * be in human-readable form, but it will be compatible with a string-view
-   * hasher and comparator.
+   * Casts the raw data as a string_view, decoding the varint length prefix.
+   * All accessors that need the data pointer and/or size should delegate to
+   * this method so the decode happens in exactly one place.
    */
   absl::string_view dataAsStringView() const {
     if (size_and_data_ == nullptr) {
       return {};
     }
     const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);
-    return {reinterpret_cast<const char*>(size_and_data_ + prefix_size),
-            static_cast<absl::string_view::size_type>(data_size)};
+    return {reinterpret_cast<const char*>(size_and_data_ + prefix_size), data_size};
   }
 
   const uint8_t* size_and_data_{nullptr};

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -155,8 +155,17 @@ public:
     /**
      * @param number A number to encode in a variable length byte-array.
      * @return The number of bytes it would take to encode the number.
+     *
+     * Defined inline in the header to allow the compiler to inline on hot paths.
      */
-    static size_t encodingSizeBytes(uint64_t number);
+    static size_t encodingSizeBytes(uint64_t number) {
+      size_t num_bytes = 0;
+      do {
+        ++num_bytes;
+        number >>= 7;
+      } while (number != 0);
+      return num_bytes;
+    }
 
     /**
      * @param num_data_bytes The number of bytes in a data-block.
@@ -192,13 +201,31 @@ public:
      *
      * @param The encoded byte array, written previously by appendEncoding.
      * @return A pair containing the decoded number, and the number of bytes consumed from encoding.
+     *
+     * Defined inline in the header to allow the compiler to inline on hot paths.
      */
-    static std::pair<uint64_t, size_t> decodeNumber(const uint8_t* encoding);
+    static std::pair<uint64_t, size_t> decodeNumber(const uint8_t* encoding) {
+      uint64_t number = 0;
+      uint64_t uc = kSpilloverMask;
+      const uint8_t* start = encoding;
+      for (uint32_t shift = 0; (uc & kSpilloverMask) != 0; ++encoding, shift += 7) {
+        uc = static_cast<uint32_t>(*encoding);
+        number |= (uc & kLow7Bits) << shift;
+      }
+      return std::make_pair(number, encoding - start);
+    }
 
   private:
     friend class StatName;
     friend class SymbolTable;
     class TokenIter;
+
+    // Masks used for variable-length encoding of arbitrary-sized integers into a
+    // uint8-array. The integers are typically small, so we try to store them in as
+    // few bytes as possible. The bottom 7 bits hold values, and the top bit is used
+    // to determine whether another byte is needed for more data.
+    static constexpr uint32_t kSpilloverMask = 0x80;
+    static constexpr uint32_t kLow7Bits = 0x7f;
 
     size_t data_bytes_required_{0};
     MemBlockBuilder<uint8_t> mem_block_;
@@ -595,7 +622,12 @@ public:
    * @return size_t the number of bytes in the symbol array, excluding the
    *                overhead for the size itself.
    */
-  size_t dataSize() const;
+  size_t dataSize() const {
+    if (size_and_data_ == nullptr) {
+      return 0;
+    }
+    return SymbolTable::Encoding::decodeNumber(size_and_data_).first;
+  }
 
   /**
    * @return size_t the number of bytes in the symbol array, including the

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -913,7 +913,9 @@ public:
    * @return the first StatName in the list. List must be populated and non-empty.
    */
   StatName front() const {
-    ASSERT(populated());
+    // storage_[0] holds the element count, so if we are populated and non-empty
+    // the first byte will be greater than 0.
+    ASSERT(populated() && storage_[0] > 0);
     return StatName(&storage_[1]);
   }
 

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -743,6 +743,96 @@ TEST_F(StatNameTest, StatNameEqualityFastPaths) {
   EXPECT_NE(a, null_name);
 }
 
+TEST_F(StatNameTest, EqualityWithMultiByteVarint) {
+  // Build a name with 130 unique segments so encoded data > 127 bytes,
+  // exercising the multi-byte varint slow-path in decodeNumber when
+  // operator== and AbslHashValue decode the length prefix.
+  std::string long_name = "s0";
+  for (int i = 1; i < 130; ++i) {
+    absl::StrAppend(&long_name, ".s", i);
+  }
+  // Two pool entries for the same name: distinct backing storage, identical content.
+  StatName x = makeStat(long_name);
+  StatName y = makeStat(long_name);
+  // different pointers: ensure not fast-path
+  EXPECT_NE(x.dataIncludingSize(), y.dataIncludingSize());
+  // check equality and hash with slow path decode and memcmp
+  EXPECT_EQ(x, y);
+  EXPECT_EQ(x.hash(), y.hash());
+
+  // Same segment count (same encoded size) but shifted names — memcmp mismatch.
+  std::string long_name_alt = "s1";
+  for (int i = 2; i < 131; ++i) {
+    absl::StrAppend(&long_name_alt, ".s", i);
+  }
+  StatName z = makeStat(long_name_alt);
+  // slow-path: sizes match, memcmp fails
+  EXPECT_NE(x, z);
+}
+
+TEST_F(StatNameTest, EqualitySizeMismatch) {
+  // Two non-null, different-pointer names with different encoded sizes:
+  // exercises the early lhs_sz != rhs_sz exit in operator==.
+  StatName short_name = makeStat("foo.bar");
+  StatName long_name = makeStat("foo.bar.baz");
+  EXPECT_NE(short_name, long_name);
+  EXPECT_NE(long_name, short_name);
+}
+
+TEST_F(StatNameTest, EncodingSizeBytesAtBoundaries) {
+  // Verify the branch-free encodingSizeBytes formula at every varint boundary.
+  auto esb = SymbolTable::Encoding::encodingSizeBytes;
+  EXPECT_EQ(1, esb(0));
+  EXPECT_EQ(1, esb(1));
+  EXPECT_EQ(1, esb(126));
+  EXPECT_EQ(1, esb(127)); // last 1-byte value
+  EXPECT_EQ(2, esb(128)); // first 2-byte value
+  EXPECT_EQ(2, esb(129));
+  EXPECT_EQ(2, esb(16383)); // last 2-byte value (2^14 - 1)
+  EXPECT_EQ(3, esb(16384)); // first 3-byte value (2^14)
+  EXPECT_EQ(3, esb(16385));
+  EXPECT_EQ(3, esb((1 << 21) - 1)); // last 3-byte
+  EXPECT_EQ(4, esb(1 << 21));       // first 4-byte
+  EXPECT_EQ(4, esb((1 << 28) - 1)); // last 4-byte
+  EXPECT_EQ(5, esb(1 << 28));       // first 5-byte
+}
+
+TEST_F(StatNameTest, EqualityAtVarintBoundary) {
+  // Dynamic names give precise control over dataSize():
+  //   dataSize = 1 (LiteralStringIndicator) + varint_size(name.size()) + name.size()
+  // So name length 125 → dataSize 127 (1-byte varint, decodeNumber fast-path)
+  //    name length 126 → dataSize 128 (2-byte varint, decodeNumber slow-path)
+  StatNameDynamicPool dynamic(table_);
+  const std::string fast_str(125, 'a'); // dataSize = 127, fast-path
+  const std::string slow_str(126, 'a'); // dataSize = 128, slow-path
+
+  StatName fast1 = dynamic.add(fast_str);
+  StatName fast2 = dynamic.add(fast_str); // separate storage, same content
+  StatName slow1 = dynamic.add(slow_str);
+  StatName slow2 = dynamic.add(slow_str);
+
+  // Verify data sizes land where we expect (127 = last fast-path, 128 = first slow-path).
+  EXPECT_EQ(127, fast1.dataSize());
+  EXPECT_EQ(128, slow1.dataSize());
+
+  // Same-path equality and hash.
+  EXPECT_NE(fast1.dataIncludingSize(), fast2.dataIncludingSize()); // distinct storage
+  EXPECT_EQ(fast1, fast2);
+  EXPECT_EQ(fast1.hash(), fast2.hash());
+  EXPECT_NE(slow1.dataIncludingSize(), slow2.dataIncludingSize());
+  EXPECT_EQ(slow1, slow2);
+  EXPECT_EQ(slow1.hash(), slow2.hash());
+
+  // Cross-boundary: fast-path name != slow-path name.
+  EXPECT_NE(fast1, slow1);
+  EXPECT_NE(slow1, fast1);
+  EXPECT_NE(fast1.hash(), slow1.hash());
+
+  // Neither is empty.
+  EXPECT_FALSE(fast1.empty());
+  EXPECT_FALSE(slow1.empty());
+}
+
 TEST_F(StatNameTest, StartsWith) {
   StatName prefix = makeStat("prefix");
   EXPECT_TRUE(prefix.startsWith(prefix));

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -756,8 +756,10 @@ TEST_F(StatNameTest, EqualityWithMultiByteVarint) {
 
   // Sweep a few potential padding numbers just to make sure we cover. This
   // is over-testing but that's ok.
+  constexpr int lower_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) - 5;
+  constexpr int upper_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) + 5;
   for (int padding = 0; padding <= 10; ++padding) {
-    for (int num_segments = 125; num_segments <= 135; ++num_segments) {
+    for (int num_segments = lower_bound; num_segments <= upper_bound; ++num_segments) {
       clearStorage();
 
       // Pre-allocate throwaway symbols to shift symbol numbering.
@@ -790,8 +792,8 @@ TEST_F(StatNameTest, EqualityWithMultiByteVarint) {
       EXPECT_NE(x, z) << "padding=" << padding << " segments=" << num_segments;
     }
   }
-  // Confirm every dataSize from 125 through 135 was exercised.
-  for (size_t i = 125; i <= 135; ++i) {
+  // Confirm every dataSize across the varint boundary was exercised.
+  for (int i = lower_bound; i <= upper_bound; ++i) {
     EXPECT_TRUE(seen[i]) << "dataSize " << i << " was never hit";
   }
 }
@@ -826,37 +828,23 @@ TEST_F(StatNameTest, EncodingSizeBytesAtBoundaries) {
 TEST_F(StatNameTest, EqualityAtVarintBoundary) {
   // Dynamic names give precise control over dataSize():
   //   dataSize = 1 (LiteralStringIndicator) + varint_size(name.size()) + name.size()
-  // So name length 125 → dataSize 127 (1-byte varint, decodeNumber fast-path)
-  //    name length 126 → dataSize 128 (2-byte varint, decodeNumber slow-path)
+  // Sweep base_len across the outer-varint boundary (dataSize 127/128) so we
+  // hit both the decodeNumber fast-path and slow-path for operator==/hash.
   StatNameDynamicPool dynamic(table_);
-  const std::string fast_str(125, 'a'); // dataSize = 127, fast-path
-  const std::string slow_str(126, 'a'); // dataSize = 128, slow-path
+  constexpr int lower_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) - 5;
+  constexpr int upper_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) + 5;
 
-  StatName fast1 = dynamic.add(fast_str);
-  StatName fast2 = dynamic.add(fast_str); // separate storage, same content
-  StatName slow1 = dynamic.add(slow_str);
-  StatName slow2 = dynamic.add(slow_str);
+  for (int base_len = lower_bound; base_len <= upper_bound; ++base_len) {
+    const std::string s(base_len, 'a');
+    StatName a = dynamic.add(s);
+    StatName b = dynamic.add(s);
 
-  // Verify data sizes land where we expect (127 = last fast-path, 128 = first slow-path).
-  EXPECT_EQ(127, fast1.dataSize());
-  EXPECT_EQ(128, slow1.dataSize());
-
-  // Same-path equality and hash.
-  EXPECT_NE(fast1.dataIncludingSize(), fast2.dataIncludingSize()); // distinct storage
-  EXPECT_EQ(fast1, fast2);
-  EXPECT_EQ(fast1.hash(), fast2.hash());
-  EXPECT_NE(slow1.dataIncludingSize(), slow2.dataIncludingSize());
-  EXPECT_EQ(slow1, slow2);
-  EXPECT_EQ(slow1.hash(), slow2.hash());
-
-  // Cross-boundary: fast-path name != slow-path name.
-  EXPECT_NE(fast1, slow1);
-  EXPECT_NE(slow1, fast1);
-  EXPECT_NE(fast1.hash(), slow1.hash());
-
-  // Neither is empty.
-  EXPECT_FALSE(fast1.empty());
-  EXPECT_FALSE(slow1.empty());
+    // Distinct backing storage, identical content.
+    EXPECT_NE(a.dataIncludingSize(), b.dataIncludingSize()) << "base_len=" << base_len;
+    ASSERT_TRUE(a == b) << "base_len=" << base_len;
+    EXPECT_EQ(a.hash(), b.hash()) << "base_len=" << base_len;
+    EXPECT_FALSE(a.empty()) << "base_len=" << base_len;
+  }
 }
 
 TEST_F(StatNameTest, StartsWith) {

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -390,8 +390,14 @@ TEST_F(StatNameTest, List) {
   StatName names[] = {makeStat("hello.world"), makeStat("goodbye.world")};
   StatNameList name_list;
   EXPECT_FALSE(name_list.populated());
+  EXPECT_EQ(0, name_list.size());
   table_.populateList(names, ARRAY_SIZE(names), name_list);
   EXPECT_TRUE(name_list.populated());
+  EXPECT_EQ(2, name_list.size());
+
+  // Random-access via at().
+  EXPECT_EQ("hello.world", table_.toString(name_list.at(0)));
+  EXPECT_EQ("goodbye.world", table_.toString(name_list.at(1)));
 
   // First, decode only the first name.
   name_list.iterate([this](StatName stat_name) -> bool {
@@ -410,6 +416,36 @@ TEST_F(StatNameTest, List) {
   EXPECT_EQ("goodbye.world", decoded_strings[1]);
   name_list.clear(table_);
   EXPECT_FALSE(name_list.populated());
+  EXPECT_EQ(0, name_list.size());
+}
+
+// Exercises StatNameList::at() walking across entries whose encoded sizes
+// straddle the single-byte varint boundary (dataSize 127/128). This catches
+// any mistake in advancing the pointer with StatName::size() across a
+// 1-byte-vs-2-byte length prefix.
+TEST_F(StatNameTest, ListAtVarintBoundary) {
+  // Build names with controlled dataSize via the dynamic-storage path:
+  //   dataSize = 1 (LiteralStringIndicator) + varint_size(len) + len.
+  StatNameDynamicPool dynamic(table_);
+  constexpr int lower_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) - 3;
+  constexpr int upper_bound = static_cast<int>(SymbolTable::Encoding::SpilloverMask) + 3;
+
+  std::vector<StatName> names;
+  std::vector<std::string> expected;
+  for (int len = lower_bound; len <= upper_bound; ++len) {
+    std::string s(len, 'a' + ((len - lower_bound) % 26));
+    expected.push_back(s);
+    names.push_back(dynamic.add(s));
+  }
+
+  StatNameList name_list;
+  table_.populateList(names.data(), names.size(), name_list);
+  EXPECT_EQ(expected.size(), name_list.size());
+
+  for (uint32_t i = 0; i < expected.size(); ++i) {
+    EXPECT_EQ(expected[i], table_.toString(name_list.at(i))) << "index=" << i;
+  }
+  name_list.clear(table_);
 }
 
 TEST_F(StatNameTest, HashTable) {

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -744,30 +744,56 @@ TEST_F(StatNameTest, StatNameEqualityFastPaths) {
 }
 
 TEST_F(StatNameTest, EqualityWithMultiByteVarint) {
-  // Build a name with 130 unique segments so encoded data > 127 bytes,
-  // exercising the multi-byte varint slow-path in decodeNumber when
-  // operator== and AbslHashValue decode the length prefix.
-  std::string long_name = "s0";
-  for (int i = 1; i < 130; ++i) {
-    absl::StrAppend(&long_name, ".s", i);
-  }
-  // Two pool entries for the same name: distinct backing storage, identical content.
-  StatName x = makeStat(long_name);
-  StatName y = makeStat(long_name);
-  // different pointers: ensure not fast-path
-  EXPECT_NE(x.dataIncludingSize(), y.dataIncludingSize());
-  // check equality and hash with slow path decode and memcmp
-  EXPECT_EQ(x, y);
-  EXPECT_EQ(x.hash(), y.hash());
+  // Sweep segment counts around the varint boundary to catch off-by-one
+  // errors in decodeNumber's fast-path vs slow-path. Each segment gets a
+  // unique symbol assigned sequentially. Symbols 1-127 encode as 1 byte
+  // each; symbol 128+ encodes as 2 bytes. Pre-allocating throwaway symbols
+  // shifts the numbering so that different padding values produce different
+  // dataSizes for the same segment count. We verify that the sweep covers
+  // both sides of the 128 boundary (the fast-path/slow-path transition in
+  // the length-prefix varint).
+  bool seen[150] = {};
 
-  // Same segment count (same encoded size) but shifted names — memcmp mismatch.
-  std::string long_name_alt = "s1";
-  for (int i = 2; i < 131; ++i) {
-    absl::StrAppend(&long_name_alt, ".s", i);
+  // Sweep a few potential padding numbers just to make sure we cover. This
+  // is over-testing but that's ok.
+  for (int padding = 0; padding <= 10; ++padding) {
+    for (int num_segments = 125; num_segments <= 135; ++num_segments) {
+      clearStorage();
+
+      // Pre-allocate throwaway symbols to shift symbol numbering.
+      for (int p = 0; p < padding; ++p) {
+        makeStat(absl::StrCat("pad", p));
+      }
+
+      std::string long_name = "s0";
+      for (int i = 1; i < num_segments; ++i) {
+        absl::StrAppend(&long_name, ".s", i);
+      }
+
+      // Two pool entries for the same name: distinct backing storage, identical content.
+      StatName x = makeStat(long_name);
+      StatName y = makeStat(long_name);
+      size_t ds = x.dataSize();
+      ASSERT_LT(ds, 150);
+      seen[ds] = true;
+      EXPECT_NE(x.dataIncludingSize(), y.dataIncludingSize())
+          << "padding=" << padding << " segments=" << num_segments;
+      EXPECT_EQ(x, y) << "padding=" << padding << " segments=" << num_segments;
+      EXPECT_EQ(x.hash(), y.hash()) << "padding=" << padding << " segments=" << num_segments;
+
+      // Same segment count but shifted names — memcmp mismatch.
+      std::string long_name_alt = "s1";
+      for (int i = 2; i < num_segments + 1; ++i) {
+        absl::StrAppend(&long_name_alt, ".s", i);
+      }
+      StatName z = makeStat(long_name_alt);
+      EXPECT_NE(x, z) << "padding=" << padding << " segments=" << num_segments;
+    }
   }
-  StatName z = makeStat(long_name_alt);
-  // slow-path: sizes match, memcmp fails
-  EXPECT_NE(x, z);
+  // Confirm every dataSize from 125 through 135 was exercised.
+  for (size_t i = 125; i <= 135; ++i) {
+    EXPECT_TRUE(seen[i]) << "dataSize " << i << " was never hit";
+  }
 }
 
 TEST_F(StatNameTest, EqualitySizeMismatch) {

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -726,6 +726,23 @@ TEST_F(StatNameTest, StatNameEmptyEquivalent) {
   EXPECT_NE(empty2.hash(), non_empty.hash());
 }
 
+TEST_F(StatNameTest, StatNameEqualityFastPaths) {
+  // Pointer-identity: same backing storage compares equal without memcmp.
+  StatName a = makeStat("foo.bar");
+  StatName alias(a.dataIncludingSize());
+  EXPECT_EQ(a, alias);
+
+  // Null vs zero-length: both are empty() and must compare equal in both directions.
+  StatName null_name;
+  StatName zero_length = makeStat("");
+  EXPECT_EQ(null_name, zero_length);
+  EXPECT_EQ(zero_length, null_name);
+
+  // Null vs non-empty: must not compare equal.
+  EXPECT_NE(null_name, a);
+  EXPECT_NE(a, null_name);
+}
+
 TEST_F(StatNameTest, StartsWith) {
   StatName prefix = makeStat("prefix");
   EXPECT_TRUE(prefix.startsWith(prefix));

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -3,6 +3,9 @@
 //
 // NOLINT(namespace-envoy)
 
+#include <array>
+#include <bit>
+
 #include "source/common/common/hash.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
@@ -285,3 +288,392 @@ static void bmSetStrings(benchmark::State& state) {
   }
 }
 BENCHMARK(bmSetStrings);
+
+// ---------------------------------------------------------------------------
+// decodeNumber micro-benchmarks
+//
+// These benchmarks isolate the varint decode function with different
+// implementations so we can measure the cost of the fast-path branch,
+// loop overhead, etc. Values are parameterized across varint-size
+// boundaries: 1-byte (<=127), 2-byte (128-16383), 3-byte (16384-2097151).
+// ---------------------------------------------------------------------------
+
+static constexpr uint32_t SpilloverMask = 0x80;
+static constexpr uint32_t Low7Bits = 0x7f;
+static constexpr size_t MaxVarintBytes = 10;
+
+// Encode a varint into buf[]. Returns the number of bytes written.
+static size_t encodeNumberToBuffer(uint64_t number, uint8_t* buf) {
+  size_t len = 0;
+  do {
+    if (number < SpilloverMask) {
+      buf[len++] = static_cast<uint8_t>(number);
+    } else {
+      buf[len++] = static_cast<uint8_t>((number & Low7Bits) | SpilloverMask);
+    }
+    number >>= 7;
+  } while (number != 0);
+  return len;
+}
+
+// Implementation A: fast-path + loop (matches the current header).
+static std::pair<uint64_t, size_t> decodeNumberFastPath(const uint8_t* encoding) {
+  if (encoding[0] < SpilloverMask) {
+    return {encoding[0], 1};
+  }
+  uint64_t number = 0;
+  uint64_t uc = SpilloverMask;
+  const uint8_t* start = encoding;
+  for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
+    uc = static_cast<uint32_t>(*encoding);
+    number |= (uc & Low7Bits) << shift;
+  }
+  return {number, static_cast<size_t>(encoding - start)};
+}
+
+// Implementation B: loop-only (the original, no fast-path check).
+static std::pair<uint64_t, size_t> decodeNumberLoopOnly(const uint8_t* encoding) {
+  uint64_t number = 0;
+  uint64_t uc = SpilloverMask;
+  const uint8_t* start = encoding;
+  for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
+    uc = static_cast<uint32_t>(*encoding);
+    number |= (uc & Low7Bits) << shift;
+  }
+  return {number, static_cast<size_t>(encoding - start)};
+}
+
+// Implementation C: do-while with index instead of pointer arithmetic.
+static std::pair<uint64_t, size_t> decodeNumberDoWhile(const uint8_t* encoding) {
+  uint64_t res = 0;
+  uint64_t byte;
+  size_t i = 0;
+  do {
+    byte = encoding[i];
+    res |= (byte & Low7Bits) << (7 * i);
+    i++;
+  } while ((byte & SpilloverMask) && i < MaxVarintBytes);
+  return {res, i};
+}
+
+// Implementation D: unrolled with early returns per byte.
+static std::pair<uint64_t, size_t> decodeNumberUnrolled(const uint8_t* p) {
+  if (p[0] < SpilloverMask) {
+    return {p[0], 1};
+  }
+  uint64_t res = p[0] & Low7Bits;
+  if (p[1] < SpilloverMask) {
+    return {res | static_cast<uint64_t>(p[1]) << 7, 2};
+  }
+  res |= static_cast<uint64_t>(p[1] & Low7Bits) << 7;
+  if (p[2] < SpilloverMask) {
+    return {res | static_cast<uint64_t>(p[2]) << 14, 3};
+  }
+  // Fall back to loop for 4+ byte varints (values >= 2^21).
+  res |= static_cast<uint64_t>(p[2] & Low7Bits) << 14;
+  for (size_t i = 3; i < MaxVarintBytes; ++i) {
+    if (p[i] < SpilloverMask) {
+      return {res | static_cast<uint64_t>(p[i]) << (7 * i), i + 1};
+    }
+    res |= static_cast<uint64_t>(p[i] & Low7Bits) << (7 * i);
+  }
+  return {res, MaxVarintBytes};
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_FastPath(benchmark::State& state) {
+  uint8_t buf[MaxVarintBytes];
+  encodeNumberToBuffer(static_cast<uint64_t>(state.range(0)), buf);
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberFastPath(buf);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_FastPath)
+    ->Arg(10)
+    ->Arg(127)
+    ->Arg(128)
+    ->Arg(16383)
+    ->Arg(16384)
+    ->Arg(100000)
+    ->Arg(2097151)
+    ->Arg(2097152);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_LoopOnly(benchmark::State& state) {
+  uint8_t buf[MaxVarintBytes];
+  encodeNumberToBuffer(static_cast<uint64_t>(state.range(0)), buf);
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberLoopOnly(buf);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_LoopOnly)
+    ->Arg(10)
+    ->Arg(127)
+    ->Arg(128)
+    ->Arg(16383)
+    ->Arg(16384)
+    ->Arg(100000)
+    ->Arg(2097151)
+    ->Arg(2097152);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_DoWhile(benchmark::State& state) {
+  uint8_t buf[MaxVarintBytes];
+  encodeNumberToBuffer(static_cast<uint64_t>(state.range(0)), buf);
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberDoWhile(buf);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_DoWhile)
+    ->Arg(10)
+    ->Arg(127)
+    ->Arg(128)
+    ->Arg(16383)
+    ->Arg(16384)
+    ->Arg(100000)
+    ->Arg(2097151)
+    ->Arg(2097152);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_Unrolled(benchmark::State& state) {
+  uint8_t buf[MaxVarintBytes];
+  encodeNumberToBuffer(static_cast<uint64_t>(state.range(0)), buf);
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberUnrolled(buf);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_Unrolled)
+    ->Arg(10)
+    ->Arg(127)
+    ->Arg(128)
+    ->Arg(16383)
+    ->Arg(16384)
+    ->Arg(100000)
+    ->Arg(2097151)
+    ->Arg(2097152);
+
+// Pre-encoded varint buffers for mixed-distribution benchmarks.
+// ~80% values <= 127 (1-byte fast-path), ~20% values > 127 (multi-byte).
+static std::vector<std::array<uint8_t, MaxVarintBytes>> prepareDecodeNumberMixedBuffers() {
+  const uint64_t values[] = {1, 42, 5, 100, 200, 77, 13, 63, 500, 120, 50000};
+  constexpr size_t num_entries = 1024;
+  std::vector<std::array<uint8_t, MaxVarintBytes>> buffers(num_entries);
+  for (size_t i = 0; i < num_entries; ++i) {
+    buffers[i].fill(0);
+    encodeNumberToBuffer(values[i % 11], buffers[i].data());
+  }
+  return buffers;
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_FastPathMixed(benchmark::State& state) {
+  const auto buffers = prepareDecodeNumberMixedBuffers();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    const auto& buf = buffers[idx++ % buffers.size()];
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberFastPath(buf.data());
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_FastPathMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_LoopOnlyMixed(benchmark::State& state) {
+  const auto buffers = prepareDecodeNumberMixedBuffers();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    const auto& buf = buffers[idx++ % buffers.size()];
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberLoopOnly(buf.data());
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_LoopOnlyMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_DoWhileMixed(benchmark::State& state) {
+  const auto buffers = prepareDecodeNumberMixedBuffers();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    const auto& buf = buffers[idx++ % buffers.size()];
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberDoWhile(buf.data());
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_DoWhileMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmDecodeNumber_UnrolledMixed(benchmark::State& state) {
+  const auto buffers = prepareDecodeNumberMixedBuffers();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    const auto& buf = buffers[idx++ % buffers.size()];
+    benchmark::DoNotOptimize(buf);
+    auto result = decodeNumberUnrolled(buf.data());
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(bmDecodeNumber_UnrolledMixed);
+
+// ---------------------------------------------------------------------------
+// encodingSizeBytes micro-benchmarks
+//
+// Compare implementations of the varint *size* calculation: loop, hybrid
+// (branch + clz), loop-with-early-exit, and pure clz (branch-free).
+// Two value distributions: short (1-byte varints) and mixed (1-5 byte).
+// ---------------------------------------------------------------------------
+
+static size_t encodingSizeBytesLoop(uint64_t number) {
+  size_t num_bytes = 0;
+  do {
+    ++num_bytes;
+    number >>= 7;
+  } while (number != 0);
+  return num_bytes;
+}
+
+static size_t encodingSizeBytesHybrid(uint64_t number) {
+  if (number < SpilloverMask) {
+    return 1;
+  }
+  return (64 - std::countl_zero(number) + 6) / 7;
+}
+
+static size_t encodingSizeBytesLoopEarly(uint64_t number) {
+  if (number < SpilloverMask) {
+    return 1;
+  }
+  size_t num_bytes = 0;
+  do {
+    ++num_bytes;
+    number >>= 7;
+  } while (number != 0);
+  return num_bytes;
+}
+
+static size_t encodingSizeBytesClz(uint64_t number) {
+  return (64 - std::countl_zero(number | 1) + 6) / 7;
+}
+
+static std::vector<uint64_t> prepareShortValues() {
+  std::vector<uint64_t> values(1024);
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = (i * 7 + 13) % 127 + 1;
+  }
+  return values;
+}
+
+static std::vector<uint64_t> prepareMixedValues() {
+  std::vector<uint64_t> values(1024);
+  const uint64_t representatives[] = {42, 200, 100000, 0x1000000, 0x100000000ULL};
+  for (size_t i = 0; i < values.size(); ++i) {
+    values[i] = representatives[i % 5];
+  }
+  return values;
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_HybridShort(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareShortValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesHybrid(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_HybridShort);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_HybridMixed(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareMixedValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesHybrid(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_HybridMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_LoopShort(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareShortValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesLoop(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_LoopShort);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_LoopMixed(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareMixedValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesLoop(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_LoopMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_LoopEarlyShort(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareShortValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesLoopEarly(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_LoopEarlyShort);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_LoopEarlyMixed(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareMixedValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesLoopEarly(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_LoopEarlyMixed);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_ClzShort(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareShortValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesClz(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_ClzShort);
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmEncodingSizeBytes_ClzMixed(benchmark::State& state) {
+  const std::vector<uint64_t> vals = prepareMixedValues();
+  uint32_t idx = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(encodingSizeBytesClz(vals[idx++ % vals.size()]));
+  }
+}
+BENCHMARK(bmEncodingSizeBytes_ClzMixed);

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -369,7 +369,7 @@ static std::pair<uint64_t, size_t> decodeNumberUnrolled(const uint8_t* p) {
   if (p[2] < SpilloverMask) {
     return {res | static_cast<uint64_t>(p[2]) << 14, 3};
   }
-  // Fall back to loop for 4+ byte varints (values >= 2^21).
+  // Fall back to loop for 4+ byte varint (values >= 2^21).
   res |= static_cast<uint64_t>(p[2] & Low7Bits) << 14;
   for (size_t i = 3; i < MaxVarintBytes; ++i) {
     if (p[i] < SpilloverMask) {
@@ -536,9 +536,10 @@ BENCHMARK(bmDecodeNumber_UnrolledMixed);
 // ---------------------------------------------------------------------------
 // encodingSizeBytes micro-benchmarks
 //
-// Compare implementations of the varint *size* calculation: loop, hybrid
-// (branch + clz), loop-with-early-exit, and pure clz (branch-free).
-// Two value distributions: short (1-byte varints) and mixed (1-5 byte).
+// Compare implementations of the varint size calculation: loop, hybrid
+// (branch + count-leading-zero), loop-with-early-exit, and pure count-
+// leading-zero (branch-free). Two value distributions: short (1-byte varint)
+// and mixed (1-5 byte).
 // ---------------------------------------------------------------------------
 
 static size_t encodingSizeBytesLoop(uint64_t number) {

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -99,7 +99,8 @@ static void bmJoinElements(benchmark::State& state) {
 BENCHMARK(bmJoinElements);
 
 static std::vector<Envoy::Stats::StatName> prepareNames(Envoy::Stats::StatNamePool& pool,
-                                                        uint32_t num_words) {
+                                                        uint32_t num_words,
+                                                        uint32_t num_tokens_per_word = 4) {
   const std::vector<absl::string_view> all_tokens = {
       "alpha", "beta",  "gamma",  "delta",   "epsilon", "zeta", "eta",     "theta",
       "iota",  "kappa", "lambda", "mu",      "nu",      "xi",   "omicron", "pi",
@@ -107,8 +108,7 @@ static std::vector<Envoy::Stats::StatName> prepareNames(Envoy::Stats::StatNamePo
   };
   std::vector<Envoy::Stats::StatName> names;
 
-  // Form 64 4-token names selecting pseudo-randomly from the above set.
-  const uint32_t num_tokens_per_word = 4;
+  // Form token combinations selecting psuedo-randomly from the above set.
   for (uint32_t i = 0; i < num_words; ++i) {
     std::vector<absl::string_view> tokens;
     for (uint32_t j = 0; j < num_tokens_per_word; ++j) {
@@ -173,6 +173,78 @@ static void bmStdSort(benchmark::State& state) {
   }
 }
 BENCHMARK(bmStdSort);
+
+// Benchmarks StatName as a map key, exercising hash() + operator== on lookup.
+// This covers the hot path in thread_local_store where counters/gauges are
+// stored in StatNameHashMap and looked up via MetricHelper::statName().
+// Uses 1000 entries with 20-token names to reflect production-scale stat names.
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmStatNameMapLookup(benchmark::State& state) {
+  Envoy::Stats::SymbolTableImpl symbol_table;
+  Envoy::Stats::StatNamePool pool(symbol_table);
+  const std::vector<Envoy::Stats::StatName> names = prepareNames(pool, 2000, 24);
+
+  Envoy::Stats::StatNameHashMap<uint64_t> map;
+  for (uint64_t i = 0; i < names.size(); ++i) {
+    map[names[i]] = i;
+  }
+
+  // Lookup each name -- the key is the same StatName pointer that was inserted,
+  // so operator== hits the pointer-equal fast path.
+  uint32_t index = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(map.find(names[index++ % names.size()]));
+  }
+}
+BENCHMARK(bmStatNameMapLookup);
+
+// Same as above but the lookup key is a different StatName with identical
+// encoding, forcing operator== through the memcmp path.
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmStatNameMapLookupDifferentPointer(benchmark::State& state) {
+  Envoy::Stats::SymbolTableImpl symbol_table;
+  Envoy::Stats::StatNamePool pool_a(symbol_table);
+  Envoy::Stats::StatNamePool pool_b(symbol_table);
+  const std::vector<Envoy::Stats::StatName> names_a = prepareNames(pool_a, 2000, 24);
+  const std::vector<Envoy::Stats::StatName> names_b = prepareNames(pool_b, 2000, 24);
+
+  Envoy::Stats::StatNameHashMap<uint64_t> map;
+  for (uint64_t i = 0; i < names_a.size(); ++i) {
+    map[names_a[i]] = i;
+  }
+
+  // Lookup using names from pool_b -- same encoding but different pointers.
+  uint32_t index = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(map.find(names_b[index++ % names_b.size()]));
+  }
+}
+BENCHMARK(bmStatNameMapLookupDifferentPointer);
+
+// Measures the hash+miss path where the key is not in the map.
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void bmStatNameMapLookupMiss(benchmark::State& state) {
+  Envoy::Stats::SymbolTableImpl symbol_table;
+  Envoy::Stats::StatNamePool pool_map(symbol_table);
+  Envoy::Stats::StatNamePool pool_miss(symbol_table);
+  const std::vector<Envoy::Stats::StatName> map_names = prepareNames(pool_map, 2000, 24);
+  // Different token count produces names that won't be in the map.
+  const std::vector<Envoy::Stats::StatName> miss_names = prepareNames(pool_miss, 2000, 25);
+
+  Envoy::Stats::StatNameHashMap<uint64_t> map;
+  for (uint64_t i = 0; i < map_names.size(); ++i) {
+    map[map_names[i]] = i;
+  }
+
+  uint32_t index = 0;
+  for (auto _ : state) {
+    UNREFERENCED_PARAMETER(_);
+    benchmark::DoNotOptimize(map.find(miss_names[index++ % miss_names.size()]));
+  }
+}
+BENCHMARK(bmStatNameMapLookupMiss);
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void bmSortStrings(benchmark::State& state) {

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -108,7 +108,7 @@ static std::vector<Envoy::Stats::StatName> prepareNames(Envoy::Stats::StatNamePo
   };
   std::vector<Envoy::Stats::StatName> names;
 
-  // Form token combinations selecting psuedo-randomly from the above set.
+  // Form token combinations selecting pseudo-randomly from the above set.
   for (uint32_t i = 0; i < num_words; ++i) {
     std::vector<absl::string_view> tokens;
     for (uint32_t j = 0; j < num_tokens_per_word; ++j) {

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -298,18 +298,17 @@ BENCHMARK(bmSetStrings);
 // boundaries: 1-byte (<=127), 2-byte (128-16383), 3-byte (16384-2097151).
 // ---------------------------------------------------------------------------
 
-static constexpr uint32_t SpilloverMask = 0x80;
-static constexpr uint32_t Low7Bits = 0x7f;
+using Encoding = Envoy::Stats::SymbolTable::Encoding;
 static constexpr size_t MaxVarintBytes = 10;
 
 // Encode a varint into buf[]. Returns the number of bytes written.
 static size_t encodeNumberToBuffer(uint64_t number, uint8_t* buf) {
   size_t len = 0;
   do {
-    if (number < SpilloverMask) {
+    if (number < Encoding::SpilloverMask) {
       buf[len++] = static_cast<uint8_t>(number);
     } else {
-      buf[len++] = static_cast<uint8_t>((number & Low7Bits) | SpilloverMask);
+      buf[len++] = static_cast<uint8_t>((number & Encoding::Low7Bits) | Encoding::SpilloverMask);
     }
     number >>= 7;
   } while (number != 0);
@@ -318,15 +317,15 @@ static size_t encodeNumberToBuffer(uint64_t number, uint8_t* buf) {
 
 // Implementation A: fast-path + loop (matches the current header).
 static std::pair<uint64_t, size_t> decodeNumberFastPath(const uint8_t* encoding) {
-  if (encoding[0] < SpilloverMask) {
+  if (encoding[0] < Encoding::SpilloverMask) {
     return {encoding[0], 1};
   }
   uint64_t number = 0;
-  uint64_t uc = SpilloverMask;
+  uint64_t uc = Encoding::SpilloverMask;
   const uint8_t* start = encoding;
-  for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
+  for (uint32_t shift = 0; (uc & Encoding::SpilloverMask) != 0; ++encoding, shift += 7) {
     uc = static_cast<uint32_t>(*encoding);
-    number |= (uc & Low7Bits) << shift;
+    number |= (uc & Encoding::Low7Bits) << shift;
   }
   return {number, static_cast<size_t>(encoding - start)};
 }
@@ -334,11 +333,11 @@ static std::pair<uint64_t, size_t> decodeNumberFastPath(const uint8_t* encoding)
 // Implementation B: loop-only (the original, no fast-path check).
 static std::pair<uint64_t, size_t> decodeNumberLoopOnly(const uint8_t* encoding) {
   uint64_t number = 0;
-  uint64_t uc = SpilloverMask;
+  uint64_t uc = Encoding::SpilloverMask;
   const uint8_t* start = encoding;
-  for (uint32_t shift = 0; (uc & SpilloverMask) != 0; ++encoding, shift += 7) {
+  for (uint32_t shift = 0; (uc & Encoding::SpilloverMask) != 0; ++encoding, shift += 7) {
     uc = static_cast<uint32_t>(*encoding);
-    number |= (uc & Low7Bits) << shift;
+    number |= (uc & Encoding::Low7Bits) << shift;
   }
   return {number, static_cast<size_t>(encoding - start)};
 }
@@ -350,32 +349,32 @@ static std::pair<uint64_t, size_t> decodeNumberDoWhile(const uint8_t* encoding) 
   size_t i = 0;
   do {
     byte = encoding[i];
-    res |= (byte & Low7Bits) << (7 * i);
+    res |= (byte & Encoding::Low7Bits) << (7 * i);
     i++;
-  } while ((byte & SpilloverMask) && i < MaxVarintBytes);
+  } while ((byte & Encoding::SpilloverMask) && i < MaxVarintBytes);
   return {res, i};
 }
 
 // Implementation D: unrolled with early returns per byte.
 static std::pair<uint64_t, size_t> decodeNumberUnrolled(const uint8_t* p) {
-  if (p[0] < SpilloverMask) {
+  if (p[0] < Encoding::SpilloverMask) {
     return {p[0], 1};
   }
-  uint64_t res = p[0] & Low7Bits;
-  if (p[1] < SpilloverMask) {
+  uint64_t res = p[0] & Encoding::Low7Bits;
+  if (p[1] < Encoding::SpilloverMask) {
     return {res | static_cast<uint64_t>(p[1]) << 7, 2};
   }
-  res |= static_cast<uint64_t>(p[1] & Low7Bits) << 7;
-  if (p[2] < SpilloverMask) {
+  res |= static_cast<uint64_t>(p[1] & Encoding::Low7Bits) << 7;
+  if (p[2] < Encoding::SpilloverMask) {
     return {res | static_cast<uint64_t>(p[2]) << 14, 3};
   }
   // Fall back to loop for 4+ byte varint (values >= 2^21).
-  res |= static_cast<uint64_t>(p[2] & Low7Bits) << 14;
+  res |= static_cast<uint64_t>(p[2] & Encoding::Low7Bits) << 14;
   for (size_t i = 3; i < MaxVarintBytes; ++i) {
-    if (p[i] < SpilloverMask) {
+    if (p[i] < Encoding::SpilloverMask) {
       return {res | static_cast<uint64_t>(p[i]) << (7 * i), i + 1};
     }
-    res |= static_cast<uint64_t>(p[i] & Low7Bits) << (7 * i);
+    res |= static_cast<uint64_t>(p[i] & Encoding::Low7Bits) << (7 * i);
   }
   return {res, MaxVarintBytes};
 }
@@ -552,14 +551,14 @@ static size_t encodingSizeBytesLoop(uint64_t number) {
 }
 
 static size_t encodingSizeBytesHybrid(uint64_t number) {
-  if (number < SpilloverMask) {
+  if (number < Encoding::SpilloverMask) {
     return 1;
   }
   return (64 - std::countl_zero(number) + 6) / 7;
 }
 
 static size_t encodingSizeBytesLoopEarly(uint64_t number) {
-  if (number < SpilloverMask) {
+  if (number < Encoding::SpilloverMask) {
     return 1;
   }
   size_t num_bytes = 0;


### PR DESCRIPTION
Optimizations to StatName to make it more friendly for use as a key in a map. Specifically we improve `operator==` and similar calls and clean up some duplicate unnecessary work across the file.

(nb: if preferred i can resubmit the commits as separated PRs, do let me know)

Key changes:
- Inline `dataSize()`, `decodeNumber()`, `encodingSizeBytes()` into the header to make inlining easier
- Fast-path `decodeNumber()` for values <= 127 - skip loop for values with length less than 127
- Branch-free `encodingSizeBytes()` via `std::countl_zero`
- `StatNameList::front()` + `MetricHelper::statName()` bypass - avoid `std::function` allocation and iterator setup for the common "get first element"
- `operator==` fast-path pointer-identity check and early size comparison before `memcmp`; `AbslHashValue` also avoids redundant varint decode
- `empty()` checks first byte instead of full varint decode - `0x00` uniquely encodes zero length (`d040567`)

Cumulative benchmark results (`--benchmark_min_time=5s`):

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| `BM_StatsNoTls` | 5697 us | 5077 us | **-10.9%** |
| `BM_StatsWithTls` | 6023 us | 5453 us | **-9.5%** |
| `BM_StatsWithTlsAndRejectionsWithDot` | 2889 us | 2715 us | **-6.1%** |
| `BM_StatsWithTlsAndRejectionsWithoutDot` | 5486 us | 4866 us | **-11.3%** |
| `bmCreateRace` | 49.2 ms | 49.7 ms | ~flat |
| `bmJoinStatNames` | 101 ns | 87.6 ns | **-13.3%** |
| `bmJoinElements` | 233 ns | 208 ns | **-10.7%** |
| `bmCompareElements` | 34.3 ns | 33.5 ns | **-2.3%** |
| `bmSortByStatNames` | 49976 us | 50547 us | ~flat |
| `bmStdSort` | 60993 us | 56058 us | **-8.1%** |
| `bmStatNameMapLookup` | 22.4 ns | 8.52 ns | **-62.0%** |
| `bmStatNameMapLookupDifferentPointer` | 22.4 ns | 11.8 ns | **-47.3%** |
| `bmStatNameMapLookupMiss` | 12.1 ns | 6.70 ns | **-44.6%** |
| `bmSortStrings` | 20443 us | 20488 us | ~flat |
| `bmSetStrings` | 38079 us | 38100 us | ~flat |

Optimizations were developed and benchmarked incrementally (see individual commit messages). The map-lookup benchmarks were added in the first commit to establish a baseline.

Generative AI (Claude) was used as a development aid for this change. I understand all code in the PR.

Risk Level: Medium - all changes are to internal implementation details with no API or behavioral changes. The varint encoding format is unchanged. But, it is a core component.

Testing:
- Existing `bazel test //test/common/stats/...` passes incl config=asan.
- New `StatNameEqualityFastPaths` test covers pointer-identity, null-vs-zero-length, and null-vs-non-empty cases
- Benchmarked with `symbol_table_benchmark` and `thread_local_store_speed_test`

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
