### PR TITLE
dynamic_modules: add http_per_route, load_balancer, and cluster arms to declare_all_init_functions!

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -555,6 +555,9 @@ macro_rules! declare_network_filter_init_functions {
 /// - `cert_validator:` — [`NewCertValidatorConfigFunction`] for TLS certificate validators
 /// - `upstream_http_tcp_bridge:` — [`NewUpstreamHttpTcpBridgeConfigFunction`] for upstream HTTP TCP
 ///   bridges
+/// - `http_per_route:` — [`NewHttpFilterPerRouteConfigFunction`] for HTTP per-route configs
+/// - `load_balancer:` — [`NewLoadBalancerConfigFunction`] for load balancer policies
+/// - `cluster:` — [`NewClusterConfigFunction`] for custom clusters
 /// - `tracer:` — [`NewTracerConfigFunction`] for tracers
 /// - `dns_resolver:` — [`NewDnsResolverConfigFunction`] for DNS resolvers
 /// - `transport_socket:` — [`NewTransportSocketFactoryConfigFunction`] for transport sockets
@@ -661,6 +664,10 @@ macro_rules! declare_all_init_functions {
     envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION
       .get_or_init(|| $fn);
   };
+  (@register http_per_route : $fn:expr) => {
+    envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
+      .get_or_init(|| $fn);
+  };
   (@register network : $fn:expr) => {
     envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION
       .get_or_init(|| $fn);
@@ -675,6 +682,14 @@ macro_rules! declare_all_init_functions {
   };
   (@register bootstrap : $fn:expr) => {
     envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
+      .get_or_init(|| $fn);
+  };
+  (@register load_balancer : $fn:expr) => {
+    envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION
+      .get_or_init(|| $fn);
+  };
+  (@register cluster : $fn:expr) => {
+    envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION
       .get_or_init(|| $fn);
   };
   (@register cert_validator : $fn:expr) => {


### PR DESCRIPTION
## Description

The `declare_all_init_functions!` macro supports registering multiple filter types in a single module, but was missing arms for a couple of extension types. With this change, they can use the macro directly:
```
  declare_all_init_functions!(init,
      bootstrap: new_bootstrap_config,
      http: new_http_filter_config,
      http_per_route: new_per_route_config,
      cluster: new_cluster_config,
  );
```

---

**Commit Message:** dynamic_modules: add http_per_route, load_balancer, and cluster arms to declare_all_init_functions!
**Additional Description:**
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A