### PR TITLE
Integrate MCP router with MCP cluster

### DIFF
--- a/source/extensions/filters/http/mcp_router/BUILD
+++ b/source/extensions/filters/http/mcp_router/BUILD
@@ -33,6 +33,7 @@ envoy_cc_library(
         "//source/extensions/filters/common/mcp:filter_state_lib",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/types:variant",
+        "@envoy_api//envoy/extensions/clusters/mcp_multicluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/mcp_router/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/mcp_router/filter_config.cc
+++ b/source/extensions/filters/http/mcp_router/filter_config.cc
@@ -56,8 +56,7 @@ McpRouterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   return McpRouterStats{MCP_ROUTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
 
-std::vector<McpBackendConfig>
-parseBackends(const envoy::extensions::filters::http::mcp_router::v3::McpRouter& config) {
+template <typename Config> std::vector<McpBackendConfig> parseBackends(const Config& config) {
   std::vector<McpBackendConfig> result;
   for (const auto& server : config.servers()) {
     McpBackendConfig backend;
@@ -91,6 +90,21 @@ const McpBackendConfig* McpRouterConfigImpl::findBackend(const std::string& name
     }
   }
   return nullptr;
+}
+
+McpRouterClusterConfigImpl::McpRouterClusterConfigImpl(
+    const envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig& proto_config,
+    McpRouterConfigSharedPtr base_config)
+    : base_config_(std::move(base_config)), backends_(parseBackends(proto_config)),
+      default_backend_name_(backends_.size() == 1 ? backends_[0].name : "") {}
+
+const McpBackendConfig* McpRouterClusterConfigImpl::findBackend(const std::string& name) const {
+  for (const auto& backend : backends_) {
+    if (backend.name == name) {
+      return &backend;
+    }
+  }
+  return base_config_->findBackend(name);
 }
 
 } // namespace McpRouter

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/extensions/clusters/mcp_multicluster/v3/cluster.pb.h"
 #include "envoy/extensions/filters/http/mcp_router/v3/mcp_router.pb.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/stats/scope.h"
@@ -99,6 +100,8 @@ public:
   virtual McpRouterStats& stats() = 0;
 };
 
+using McpRouterConfigSharedPtr = std::shared_ptr<McpRouterConfig>;
+
 class McpRouterConfigImpl : public McpRouterConfig {
 public:
   McpRouterConfigImpl(
@@ -133,7 +136,39 @@ private:
   McpRouterStats stats_;
 };
 
-using McpRouterConfigSharedPtr = std::shared_ptr<McpRouterConfig>;
+// This class overrides configuration of the MCP filter with the list of MCP servers based on
+// cluster configuration.
+// TODO(yanavlasov): use only cluster config for MCP servers once list of servers is removed from
+// the filter config.
+class McpRouterClusterConfigImpl : public McpRouterConfig {
+public:
+  McpRouterClusterConfigImpl(
+      const envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig& proto_config,
+      McpRouterConfigSharedPtr base_config);
+
+  const std::vector<McpBackendConfig>& backends() const override { return backends_; }
+  bool isMultiplexing() const override { return backends_.size() > 1; }
+  const std::string& defaultBackendName() const override { return default_backend_name_; }
+  Server::Configuration::FactoryContext& factoryContext() const override {
+    return base_config_->factoryContext();
+  }
+  const McpBackendConfig* findBackend(const std::string& name) const override;
+
+  bool hasSessionIdentity() const override { return base_config_->hasSessionIdentity(); }
+  const SubjectSource& subjectSource() const override { return base_config_->subjectSource(); }
+  ValidationMode validationMode() const override { return base_config_->validationMode(); }
+  bool shouldEnforceValidation() const override { return base_config_->shouldEnforceValidation(); }
+  const std::string& metadataNamespace() const override {
+    return base_config_->metadataNamespace();
+  }
+
+  McpRouterStats& stats() override { return base_config_->stats(); }
+
+private:
+  const McpRouterConfigSharedPtr base_config_;
+  const std::vector<McpBackendConfig> backends_;
+  const std::string default_backend_name_;
+};
 
 } // namespace McpRouter
 } // namespace HttpFilters

--- a/source/extensions/filters/http/mcp_router/mcp_router.cc
+++ b/source/extensions/filters/http/mcp_router/mcp_router.cc
@@ -95,6 +95,29 @@ void McpRouterFilter::onDestroy() {
   single_backend_callback_ = nullptr;
 }
 
+absl::StatusOr<envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig>
+McpRouterFilter::getClusterConfig() {
+  OptRef<const Upstream::ClusterInfo> cluster_info = decoder_callbacks_->clusterInfo();
+  if (!cluster_info.has_value()) {
+    return absl::NotFoundError("No cluster info");
+  }
+
+  const auto& typed_filter_metadata = cluster_info.ref().metadata().typed_filter_metadata();
+  auto it = typed_filter_metadata.find("envoy.clusters.mcp_multicluster");
+  if (it == typed_filter_metadata.end()) {
+    return absl::NotFoundError(
+        fmt::format("Metadata for 'envoy.clusters.mcp_multicluster' not found in cluster '{}'",
+                    cluster_info.ref().name()));
+  }
+
+  envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig cluster_config;
+  if (!it->second.UnpackTo(&cluster_config)) {
+    return absl::InvalidArgumentError("Failed to parse ClusterConfig metadata: {}");
+  }
+
+  return cluster_config;
+}
+
 Http::FilterHeadersStatus McpRouterFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                          bool end_stream) {
   // TODO(botengyao): also supports /GET endpoints.
@@ -105,6 +128,12 @@ Http::FilterHeadersStatus McpRouterFilter::decodeHeaders(Http::RequestHeaderMap&
   }
 
   request_headers_ = &headers;
+
+  auto cluster_config_or = getClusterConfig();
+  if (cluster_config_or.ok()) {
+    config_ =
+        std::make_shared<McpRouterClusterConfigImpl>(cluster_config_or.value(), std::move(config_));
+  }
 
   // Extract session ID from header
   auto session_header = headers.get(Http::LowerCaseString(std::string(kSessionIdHeader)));

--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -153,6 +153,8 @@ private:
   void sendHttpError(uint64_t status_code, const std::string& message);
   Http::RequestHeaderMapPtr createUpstreamHeaders(const McpBackendConfig& backend,
                                                   const std::string& backend_session_id = "");
+  absl::StatusOr<envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig>
+  getClusterConfig();
 
   McpRouterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};

--- a/test/extensions/filters/http/mcp_router/BUILD
+++ b/test/extensions/filters/http/mcp_router/BUILD
@@ -26,6 +26,7 @@ envoy_extension_cc_test(
     srcs = ["mcp_router_test.cc"],
     extension_names = ["envoy.filters.http.mcp_router"],
     deps = [
+        "//envoy/http:async_client_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/http:message_lib",
         "//source/extensions/filters/http/mcp_router:mcp_router_lib",
@@ -35,6 +36,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/clusters/mcp_multicluster/v3:pkg_cc_proto",
     ],
 )
 
@@ -57,9 +59,11 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.mcp_router"],
     rbe_pool = "6gig",
     deps = [
+        "//source/extensions/clusters/mcp_multicluster:cluster",
         "//source/extensions/filters/http/mcp:config",
         "//source/extensions/filters/http/mcp_router:config",
         "//test/integration:http_integration_lib",
+        "@envoy_api//envoy/extensions/clusters/mcp_multicluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/mcp/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/mcp_router/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_integration_test.cc
@@ -1,3 +1,6 @@
+#include <tuple>
+
+#include "envoy/extensions/clusters/mcp_multicluster/v3/cluster.pb.h"
 #include "envoy/extensions/filters/http/mcp/v3/mcp.pb.h"
 #include "envoy/extensions/filters/http/mcp_router/v3/mcp_router.pb.h"
 
@@ -11,10 +14,18 @@ namespace HttpFilters {
 namespace McpRouter {
 namespace {
 
-class McpRouterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+// Make this test suite run with server config in either filter or cluster.
+// TODO(yanavlasov): remove this parameterization once server config is removed from the filter.
+enum class ConfigSource { Filter, Cluster };
+using TestParams = std::tuple<Network::Address::IpVersion, ConfigSource>;
+
+class McpRouterIntegrationTest : public testing::TestWithParam<TestParams>,
                                  public HttpIntegrationTest {
 public:
-  McpRouterIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+  McpRouterIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, ipVersion()) {}
+
+  Network::Address::IpVersion ipVersion() const { return std::get<0>(GetParam()); }
+  ConfigSource configSource() const { return std::get<1>(GetParam()); }
 
   void createUpstreams() override {
     // Create two fake upstreams for MCP backends (time and tools)
@@ -40,7 +51,7 @@ public:
       auto* time_locality = time_endpoint->add_endpoints();
       auto* time_lb = time_locality->add_lb_endpoints();
       time_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_address(
-          Network::Test::getLoopbackAddressString(GetParam()));
+          Network::Test::getLoopbackAddressString(ipVersion()));
       time_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_port_value(
           fake_upstreams_[0]->localAddress()->ip()->port());
 
@@ -56,30 +67,61 @@ public:
       auto* tools_locality = tools_endpoint->add_endpoints();
       auto* tools_lb = tools_locality->add_lb_endpoints();
       tools_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_address(
-          Network::Test::getLoopbackAddressString(GetParam()));
+          Network::Test::getLoopbackAddressString(ipVersion()));
       tools_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_port_value(
           fake_upstreams_[1]->localAddress()->ip()->port());
+
+      // Add MCP multicluster.
+      auto* multicluster = bootstrap.mutable_static_resources()->add_clusters();
+      multicluster->set_name("multicluster");
+      multicluster->mutable_connect_timeout()->set_seconds(5);
+      multicluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+      multicluster->mutable_cluster_type()->set_name("envoy.clusters.mcp_multicluster");
+
+      // Configure the MCP multicluster.
+      envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig multicluster_config;
+      auto* server = multicluster_config.add_servers();
+      server->set_name("time");
+      auto* mcp_cluster = server->mutable_mcp_cluster();
+      mcp_cluster->set_cluster("mcp_time_backend");
+      mcp_cluster->set_host_rewrite_literal("time.mcp.example.com");
+
+      server = multicluster_config.add_servers();
+      server->set_name("tools");
+      mcp_cluster = server->mutable_mcp_cluster();
+      mcp_cluster->set_cluster("mcp_tools_backend");
+      mcp_cluster->set_host_rewrite_literal("tools.mcp.example.com");
+
+      multicluster->mutable_cluster_type()->mutable_typed_config()->PackFrom(multicluster_config);
     });
 
     // MCP router as terminal filter
-    config_helper_.prependFilter(R"EOF(
-      name: envoy.filters.http.mcp_router
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
-        servers:
-          - name: time
-            mcp_cluster:
-              cluster: mcp_time_backend
-              path: /mcp
-              timeout: 5s
-              host_rewrite_literal: time.mcp.example.com
-          - name: tools
-            mcp_cluster:
-              cluster: mcp_tools_backend
-              path: /mcp
-              timeout: 5s
-              host_rewrite_literal: tools.mcp.example.com
-    )EOF");
+    if (configSource() == ConfigSource::Cluster) {
+      config_helper_.prependFilter(R"EOF(
+        name: envoy.filters.http.mcp_router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
+      )EOF");
+    } else {
+      config_helper_.prependFilter(R"EOF(
+        name: envoy.filters.http.mcp_router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
+          servers:
+            - name: time
+              mcp_cluster:
+                cluster: mcp_time_backend
+                path: /mcp
+                timeout: 5s
+                host_rewrite_literal: time.mcp.example.com
+            - name: tools
+              mcp_cluster:
+                cluster: mcp_tools_backend
+                path: /mcp
+                timeout: 5s
+                host_rewrite_literal: tools.mcp.example.com
+      )EOF");
+    }
 
     // MCP filter (validates JSON-RPC, sets metadata)
     config_helper_.prependFilter(R"EOF(
@@ -91,8 +133,9 @@ public:
 
     // Remove the default router filter.
     config_helper_.addConfigModifier(
-        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-               hcm) {
+        [this](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
           auto* filters = hcm.mutable_http_filters();
           for (auto it = filters->begin(); it != filters->end();) {
             if (it->name() == "envoy.filters.http.router") {
@@ -100,6 +143,13 @@ public:
             } else {
               ++it;
             }
+          }
+          if (configSource() == ConfigSource::Cluster) {
+            hcm.mutable_route_config()
+                ->mutable_virtual_hosts(0)
+                ->mutable_routes(0)
+                ->mutable_route()
+                ->set_cluster("multicluster");
           }
         });
 
@@ -114,8 +164,10 @@ public:
   FakeStreamPtr tools_backend_request_;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, McpRouterIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, McpRouterIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::Values(ConfigSource::Filter, ConfigSource::Cluster)));
 
 // Test that ping request returns JSON-RPC response with empty result
 TEST_P(McpRouterIntegrationTest, PingReturnsEmptyResult) {
@@ -2145,29 +2197,60 @@ public:
       auto* time_locality = time_endpoint->add_endpoints();
       auto* time_lb = time_locality->add_lb_endpoints();
       time_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_address(
-          Network::Test::getLoopbackAddressString(GetParam()));
+          Network::Test::getLoopbackAddressString(ipVersion()));
       time_lb->mutable_endpoint()->mutable_address()->mutable_socket_address()->set_port_value(
           fake_upstreams_[0]->localAddress()->ip()->port());
+
+      // Add MCP multicluster.
+      auto* multicluster = bootstrap.mutable_static_resources()->add_clusters();
+      multicluster->set_name("multicluster");
+      multicluster->mutable_connect_timeout()->set_seconds(5);
+      multicluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+      multicluster->mutable_cluster_type()->set_name("envoy.clusters.mcp_multicluster");
+
+      // Configure the MCP multicluster.
+      envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig multicluster_config;
+      auto* server = multicluster_config.add_servers();
+      server->set_name("time");
+      auto* mcp_cluster = server->mutable_mcp_cluster();
+      mcp_cluster->set_cluster("mcp_time_backend");
+      mcp_cluster->set_host_rewrite_literal("time.mcp.example.com");
+
+      multicluster->mutable_cluster_type()->mutable_typed_config()->PackFrom(multicluster_config);
     });
 
     // MCP router with session identity and ENFORCE validation
-    config_helper_.prependFilter(R"EOF(
-      name: envoy.filters.http.mcp_router
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
-        servers:
-          - name: time
-            mcp_cluster:
-              cluster: mcp_time_backend
-              path: /mcp
-              timeout: 5s
-        session_identity:
-          identity:
-            header:
-              name: x-user-id
-          validation:
-            mode: ENFORCE
-    )EOF");
+    if (configSource() == ConfigSource::Cluster) {
+      config_helper_.prependFilter(R"EOF(
+        name: envoy.filters.http.mcp_router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
+          session_identity:
+            identity:
+              header:
+                name: x-user-id
+            validation:
+              mode: ENFORCE
+      )EOF");
+    } else {
+      config_helper_.prependFilter(R"EOF(
+        name: envoy.filters.http.mcp_router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
+          servers:
+            - name: time
+              mcp_cluster:
+                cluster: mcp_time_backend
+                path: /mcp
+                timeout: 5s
+          session_identity:
+            identity:
+              header:
+                name: x-user-id
+            validation:
+              mode: ENFORCE
+      )EOF");
+    }
 
     config_helper_.prependFilter(R"EOF(
       name: envoy.filters.http.mcp
@@ -2177,8 +2260,9 @@ public:
     )EOF");
 
     config_helper_.addConfigModifier(
-        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
-               hcm) {
+        [this](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
           auto* filters = hcm.mutable_http_filters();
           for (auto it = filters->begin(); it != filters->end();) {
             if (it->name() == "envoy.filters.http.router") {
@@ -2186,6 +2270,13 @@ public:
             } else {
               ++it;
             }
+          }
+          if (configSource() == ConfigSource::Cluster) {
+            hcm.mutable_route_config()
+                ->mutable_virtual_hosts(0)
+                ->mutable_routes(0)
+                ->mutable_route()
+                ->set_cluster("multicluster");
           }
         });
 
@@ -2200,9 +2291,10 @@ public:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, McpRouterSubjectValidationIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, McpRouterSubjectValidationIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::Values(ConfigSource::Filter, ConfigSource::Cluster)));
 
 // Subject mismatch returns 403
 TEST_P(McpRouterSubjectValidationIntegrationTest, SubjectMismatchReturns403) {

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -1,3 +1,6 @@
+#include "envoy/extensions/clusters/mcp_multicluster/v3/cluster.pb.h"
+#include "envoy/http/async_client.h"
+
 #include "source/common/http/message_impl.h"
 #include "source/extensions/filters/http/mcp_router/mcp_router.h"
 
@@ -5,6 +8,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/upstream/cluster.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -16,6 +20,7 @@ namespace HttpFilters {
 namespace McpRouter {
 namespace {
 
+using testing::_;
 using testing::AnyNumber;
 using testing::NiceMock;
 using testing::ReturnRef;
@@ -122,6 +127,32 @@ TEST_F(McpRouterConfigTest, DefaultMetadataNamespace) {
 
   McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
   EXPECT_EQ(config.metadataNamespace(), "envoy.filters.http.mcp");
+}
+
+// Verifies McpRouterClusterConfigImpl parses ClusterConfig proto correctly.
+TEST_F(McpRouterConfigTest, McpRouterClusterConfigImplParsesProto) {
+  envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("cluster_backend");
+  server->mutable_mcp_cluster()->set_cluster("target_cluster");
+  server->mutable_mcp_cluster()->set_path("/custom_mcp");
+  server->mutable_mcp_cluster()->mutable_timeout()->set_seconds(10);
+
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter base_proto;
+  auto base_config = std::make_shared<McpRouterConfigImpl>(base_proto, "test.", *store_.rootScope(),
+                                                           factory_context_);
+
+  McpRouterClusterConfigImpl cluster_config(proto_config, base_config);
+
+  EXPECT_EQ(cluster_config.backends().size(), 1);
+  EXPECT_FALSE(cluster_config.isMultiplexing());
+
+  const McpBackendConfig* backend = cluster_config.findBackend("cluster_backend");
+  ASSERT_NE(backend, nullptr);
+  EXPECT_EQ(backend->name, "cluster_backend");
+  EXPECT_EQ(backend->cluster_name, "target_cluster");
+  EXPECT_EQ(backend->path, "/custom_mcp");
+  EXPECT_EQ(backend->timeout, std::chrono::milliseconds(10000));
 }
 
 class BackendStreamCallbacksTest : public testing::Test {};
@@ -434,6 +465,67 @@ protected:
   envoy::config::core::v3::Metadata dynamic_metadata_;
   Stats::TestUtil::TestStore store_;
 };
+
+TEST_F(McpRouterFilterTest, UsingClusterConfigForListOfServers) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("initialize");
+
+  auto config = createConfig(proto_config);
+
+  // These vectors have to outlive the filter object
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  McpRouterFilter filter(config);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig cluster_config;
+  auto* backend = cluster_config.add_servers();
+  backend->set_name("backend");
+  backend->mutable_mcp_cluster()->set_cluster("backend_cluster");
+
+  (*decoder_callbacks_.cluster_info_->metadata_
+        .mutable_typed_filter_metadata())["envoy.clusters.mcp_multicluster"]
+      .PackFrom(cluster_config);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .Times(AnyNumber())
+      .WillRepeatedly(testing::Invoke([](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_NE("403", headers.getStatusValue());
+      }));
+
+  filter.decodeHeaders(headers, false);
+
+  // Add "backend_cluster" to the list of cluster manager.
+  factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
+      {"backend_cluster"});
+  // MCP router is expected to use list of servers from the cluster metadata, which contains
+  // "backend_cluster". If it does use cluster metadata, the cluster lookup will succeed and
+  // a new HTTP stream will be opened. Otherwise this expectation will fail.
+  EXPECT_CALL(
+      factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.async_client_,
+      start(_, _))
+      .WillRepeatedly(
+          [&http_callbacks, &http_streams](Http::AsyncClient::StreamCallbacks& callbacks,
+                                           const Http::AsyncClient::StreamOptions&) {
+            http_callbacks.push_back(&callbacks);
+            http_streams.emplace_back(std::make_unique<NiceMock<Http::MockAsyncClientStream>>());
+            return http_streams.back().get();
+          });
+
+  // This test only validates that correct cluster is selected.
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter.decodeData(buffer, true);
+}
 
 // Verifies subject extraction from dynamic metadata succeeds.
 TEST_F(McpRouterFilterTest, MetadataSubjectExtractionSuccess) {


### PR DESCRIPTION
Make MCP router use MCP cluster as the source the list of servers. If the cluster is not an MCP cluster MCP router falls back to the filter config. This is a temporary state to avoid disruption to the existing operators that use MCP router.

The server configuration will be removed from the filter in a follow up PR.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
