### PR TITLE
contrib/kafka: fix 'succesfully' typo in log message

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
@@ -65,7 +65,7 @@ RichKafkaConsumer::~RichKafkaConsumer() {
   consumer_->unassign();
   consumer_->close();
 
-  ENVOY_LOG(debug, "Kafka consumer [{}] closed succesfully", topic_);
+  ENVOY_LOG(debug, "Kafka consumer [{}] closed successfully", topic_);
 }
 
 // Read timeout constants.


### PR DESCRIPTION
Trivial typo fix in a debug log message: `succesfully` -> `successfully`.

Commit Message: contrib/kafka: fix 'succesfully' typo in log message
Additional Description: Log-only change, no behavior impact.
Risk Level: Low
Testing: N/A (log message only)
Docs Changes: N/A
Release Notes: None
Platform Specific Features: N/A