### PR TITLE
aws/signing: Fix new/free mismatch

### DIFF
--- a/source/extensions/common/aws/signers/sigv4a_key_derivation.cc
+++ b/source/extensions/common/aws/signers/sigv4a_key_derivation.cc
@@ -72,7 +72,7 @@ absl::StatusOr<EC_KEY*> SigV4AKeyDerivation::derivePrivateKey(absl::string_view 
       // And set the private key we calculated above
       if (!EC_KEY_set_private_key(ec_key, priv_key_num)) {
         BN_free(priv_key_num);
-        OPENSSL_free(ec_key);
+        EC_KEY_free(ec_key);
         return absl::InvalidArgumentError("SigV4a private key could not be set");
       }
       BN_free(priv_key_num);


### PR DESCRIPTION
`OPENSSL_free(ec_key)` is incorrect for an `EC_KEY*` allocated by `EC_KEY_new_by_curve_name()`.

This is a raw free that skips cleanup of internal resources (group, point, `BIGNUM`, etc.), causing memory leaks and undefined behavior.

Use `EC_KEY_free()` instead, consistent with all other call sites in the codebase.

Fixes CodeQL alert cpp/new-free-mismatch (CWE-762).

