### PR TITLE
ci: test build-image repo shell interpretation

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,7 +1,7 @@
 agent-ubuntu: ubuntu-24.04
 build-image:
   # Authoritative configuration for build image/s
-  repo: docker.io/envoyproxy/envoy-build
+  repo: docker.io/envoyproxy/envoy-build; echo VULN
   repo-gcr: gcr.io/envoy-ci/envoy-build
   # default ci caching (ci)
   sha: 20656853fae51927cda557e7af80ccff175f5de6f84bd0f092cd8672b2a6e0fe


### PR DESCRIPTION
Minimal one-line CI validation for build-image.repo shell interpretation.\n\nThis PR intentionally changes only .github/config.yml build-image.repo to test whether the Request/cache (prime Docker) workflow treats the value as shell syntax or plain string data.