### PR TITLE
ci: harden CI workflows against shell injection

### DIFF
--- a/.github/workflows/_load.yml
+++ b/.github/workflows/_load.yml
@@ -87,14 +87,16 @@ jobs:
         gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/runs/${{ inputs.run-id }} \
+            "/repos/${GH_REPO}/actions/runs/${RUN_ID}" \
           | jq '.'
-        RUNID=$(gh run view ${{ inputs.run-id }} --repo ${{ github.repository }} --json databaseId | jq -r '.databaseId')
+        RUNID=$(gh run view "${RUN_ID}" --repo "${GH_REPO}" --json databaseId | jq -r '.databaseId')
         echo "value=${RUNID}" >> "$GITHUB_OUTPUT"
       id: run-id
       if: ${{ inputs.runs-after == true }}
       env:
         GH_TOKEN: ${{ github.token }}
+        RUN_ID: ${{ inputs.run-id }}
+        GH_REPO: ${{ github.repository }}
 
     # Load env data
     # Handle any failure in triggering job

--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -121,10 +121,6 @@ jobs:
         include:
         - target: publish
           name: github
-          source: |
-            export ENVOY_COMMIT=${{ fromJSON(inputs.request).request.sha }}
-            export ENVOY_REPO=${{ github.repository }}
-            export ENVOY_PUBLISH_DRY_RUN=${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}
 
   docs:
     # For normal commits to Envoy main this will trigger an update in the website repo,

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -109,9 +109,9 @@ jobs:
           cd /source
           export BAZEL_BUILD_EXTRA_OPTIONS="--config=ci --config=rbe"
           export ENVOY_CACHE_ROOT=/build/bazel_root
-          export ENVOY_CACHE_OUTPUT_BASE="${{ inputs.output-base }}"
-          export ENVOY_CACHE_TARGETS=$(echo "${{ inputs.targets }}" | sed 's/ / + /g')
-          export ENVOY_CACHE_WORKING_DIR="${{ inputs.working-dir }}"
+          export ENVOY_CACHE_OUTPUT_BASE="${INPUT_OUTPUT_BASE}"
+          export ENVOY_CACHE_TARGETS=$(echo "${INPUT_TARGETS}" | sed 's/ / + /g')
+          export ENVOY_CACHE_WORKING_DIR="${INPUT_WORKING_DIR}"
           # ironically the repository_cache is just about the only thing you dont want to cache
           export ENVOY_REPOSITORY_CACHE=/tmp/cache
           ./ci/do_ci.sh cache-create
@@ -128,3 +128,6 @@ jobs:
         run-as-sudo: false
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        INPUT_OUTPUT_BASE: ${{ inputs.output-base }}
+        INPUT_TARGETS: ${{ inputs.targets }}
+        INPUT_WORKING_DIR: ${{ inputs.working-dir }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -241,7 +241,7 @@ jobs:
           | . * {$config, $check}
 
     - run: |
-        mkdir ${{ runner.temp }}/container
+        mkdir "${RUNNER_TEMP}/container"
         MNT_AVAILABLE=false
         if mountpoint -q /mnt; then
             MNT_AVAILABLE=true
@@ -380,9 +380,11 @@ jobs:
       if: >-
         ${{ fromJSON(inputs.request).request.pr != '' }}
     - run: |
-        echo "${{ vars.ENVOY_CI_BAZELRC }}" > repo.bazelrc
+        echo "${BAZELRC_CONTENT}" > repo.bazelrc
       if: ${{ vars.ENVOY_CI_BAZELRC }}
       name: Configure repo Bazel settings
+      env:
+        BAZELRC_CONTENT: ${{ vars.ENVOY_CI_BAZELRC }}
 
     # NOTE: This is where untrusted code can be run!!!
     #  It MUST be the last step in the workflow
@@ -438,3 +440,6 @@ jobs:
         MOUNT_GPG_HOME: ${{ inputs.import-gpg && 1 || '' }}
         ENVOY_DOCKER_CPUS: ${{ inputs.docker-cpus }}
         ENVOY_DOCKER_CI: ${{ inputs.docker-ci && 'true' || '' }}
+        ENVOY_COMMIT: ${{ fromJSON(inputs.request).request.sha }}
+        ENVOY_REPO: ${{ github.repository }}
+        ENVOY_PUBLISH_DRY_RUN: ${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}

--- a/ci/envoy_build_sha.sh
+++ b/ci/envoy_build_sha.sh
@@ -36,9 +36,22 @@ case $ENVOY_BUILD_VARIANT in
         ;;
 esac
 
+# Validate extracted values contain only expected characters
+if [[ -n "$BUILD_REPO" && ! "$BUILD_REPO" =~ ^[a-zA-Z0-9._:/-]+$ ]]; then
+    echo "Error: build-image.repo contains invalid characters"
+    exit 1
+fi
+if [[ -n "$BUILD_SHA" && ! "$BUILD_SHA" =~ ^[a-fA-F0-9]+$ ]]; then
+    echo "Error: build-image.sha contains invalid characters"
+    exit 1
+fi
+if [[ -n "$BUILD_TAG" && ! "$BUILD_TAG" =~ ^[a-fA-F0-9]+$ ]]; then
+    echo "Error: build-image.tag contains invalid characters"
+    exit 1
+fi
+
 # shellcheck disable=SC2034
 BUILD_CONTAINER="${BUILD_REPO}@sha256:${BUILD_SHA}"
-
 
 if [[ -z "$BUILD_REPO" || -z "$BUILD_SHA" || -z "$BUILD_TAG" ]]; then
     echo "Error: Missing repo, sha, or tag values in .github/config.yml"


### PR DESCRIPTION
Replace all `${{ }}` expression interpolation inside `run:` blocks with environment variable references passed through `env:` blocks. This prevents attacker-controlled values (e.g. from .github/config.yml) from being interpreted as shell syntax.

Changes:
- _publish_release.yml: move ENVOY_COMMIT/ENVOY_REPO/ENVOY_PUBLISH_DRY_RUN from inline source shell code to _run.yml env block
- _run.yml: replace ${{ runner.temp }} and ${{ vars.ENVOY_CI_BAZELRC }} with env var references
- _request_cache_bazel.yml: replace ${{ inputs.* }} in command block with env var references
- _load.yml: replace ${{ inputs.run-id }} and ${{ github.repository }} with env var references
- ci/envoy_build_sha.sh: add allowlist validation for repo, sha, and tag values extracted from config.yml
