### PR TITLE
dynamic_modules: replace silent get_or_init with fail-fast set_factory_once for factory registration

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
@@ -258,10 +258,21 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_config_new(
     name.length,
   ));
   let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
-  let new_config_fn = NEW_CERT_VALIDATOR_CONFIG_FUNCTION
-    .get()
-    .expect("NEW_CERT_VALIDATOR_CONFIG_FUNCTION must be set");
-  match new_config_fn(name_str, config_slice) {
+  init_cert_validator_config(
+    name_str,
+    config_slice,
+    NEW_CERT_VALIDATOR_CONFIG_FUNCTION
+      .get()
+      .expect("NEW_CERT_VALIDATOR_CONFIG_FUNCTION must be set"),
+  )
+}
+
+pub(crate) fn init_cert_validator_config(
+  name: &str,
+  config: &[u8],
+  new_config_fn: &crate::NewCertValidatorConfigFunction,
+) -> abi::envoy_dynamic_module_type_cert_validator_config_module_ptr {
+  match new_config_fn(name, config) {
     Some(config) => wrap_into_c_void_ptr!(config),
     None => std::ptr::null(),
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -99,10 +99,16 @@ macro_rules! declare_init_functions {
   ($f:ident, $new_http_filter_config_fn:expr, $new_http_filter_per_route_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_http_filter_config_fn);
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
-        .get_or_init(|| $new_http_filter_per_route_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
+        $new_http_filter_config_fn,
+        "NEW_HTTP_FILTER_CONFIG_FUNCTION"
+      );
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
+        $new_http_filter_per_route_config_fn,
+        "NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -114,8 +120,11 @@ macro_rules! declare_init_functions {
   ($f:ident, $new_http_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_http_filter_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
+        $new_http_filter_config_fn,
+        "NEW_HTTP_FILTER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -351,6 +360,42 @@ macro_rules! envoy_log {
   };
 }
 
+/// Guard macro that ensures each factory `OnceLock` is registered by exactly one module.
+///
+/// When the same module is re-initialized (e.g. static modules loaded multiple times via
+/// `newDynamicModuleByName`, or per-route config triggering a second init), the function
+/// pointer will be identical and the re-registration is silently accepted (idempotent).
+///
+/// If a *different* module (standalone `.so` or consolidated `.so`) tries to register a
+/// different factory function for the same slot, this macro logs a critical message via
+/// `envoy_log_critical!` and panics. The panic is caught at the FFI boundary by Envoy,
+/// which converts it into a null return from `envoy_dynamic_module_on_program_init`,
+/// causing Envoy to refuse to start — the correct behaviour for a data-correctness issue.
+///
+/// In contrast, the previous `get_or_init` approach silently ignored the second writer,
+/// making the second module's factories unreachable at runtime with no diagnostic.
+#[macro_export]
+macro_rules! set_factory_once {
+  ($static:expr, $fn:expr, $name:literal) => {
+    if let Err(new_val) = $static.set($fn) {
+      if *$static.get().unwrap() != new_val {
+        $crate::envoy_log_critical!(
+          "Duplicate factory registration for {}. A different module already registered this \
+           factory. Check dynamic_module_config for conflicting standalone and consolidated \
+           .so loads.",
+          $name,
+        );
+        panic!(
+          "Duplicate factory registration for {}. A different module already registered this \
+           factory. Check dynamic_module_config for conflicting standalone and consolidated \
+           .so loads.",
+          $name,
+        );
+      }
+    }
+  };
+}
+
 /// The function signature for the program init function.
 ///
 /// This is called when the dynamic module is loaded, and it must return true on success, and false
@@ -524,8 +569,11 @@ macro_rules! declare_network_filter_init_functions {
   ($f:ident, $new_network_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_network_filter_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION,
+        $new_network_filter_config_fn,
+        "NEW_NETWORK_FILTER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -661,56 +709,95 @@ macro_rules! declare_all_init_functions {
   };
 
   (@register http : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_HTTP_FILTER_CONFIG_FUNCTION"
+    );
   };
   (@register http_per_route : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
+      $fn,
+      "NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION"
+    );
   };
   (@register network : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_NETWORK_FILTER_CONFIG_FUNCTION"
+    );
   };
   (@register listener : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_LISTENER_FILTER_CONFIG_FUNCTION"
+    );
   };
   (@register udp_listener : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION"
+    );
   };
   (@register bootstrap : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION,
+      $fn,
+      "NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION"
+    );
   };
   (@register load_balancer : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_LOAD_BALANCER_CONFIG_FUNCTION"
+    );
   };
   (@register cluster : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_CLUSTER_CONFIG_FUNCTION"
+    );
   };
   (@register cert_validator : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION,
+      $fn,
+      "NEW_CERT_VALIDATOR_CONFIG_FUNCTION"
+    );
   };
   (@register upstream_http_tcp_bridge : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION,
+      $fn,
+      "NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION"
+    );
   };
   (@register tracer : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_TRACER_CONFIG_FUNCTION"
+    );
   };
   (@register dns_resolver : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_DNS_RESOLVER_CONFIG_FUNCTION"
+    );
   };
   (@register transport_socket : $fn:expr) => {
-    envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION
-      .get_or_init(|| $fn);
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION,
+      $fn,
+      "NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION"
+    );
   };
 }
 
@@ -758,8 +845,11 @@ macro_rules! declare_listener_filter_init_functions {
     pub extern "C" fn envoy_dynamic_module_on_program_init(
       server_factory_context_ptr: abi::envoy_dynamic_module_type_server_factory_context_envoy_ptr,
     ) -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_listener_filter_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION,
+        $new_listener_filter_config_fn,
+        "NEW_LISTENER_FILTER_CONFIG_FUNCTION"
+      );
       if ($f(server_factory_context_ptr)) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -813,8 +903,11 @@ macro_rules! declare_udp_listener_filter_init_functions {
   ($f:ident, $new_udp_listener_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_udp_listener_filter_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION,
+        $new_udp_listener_filter_config_fn,
+        "NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -917,8 +1010,11 @@ macro_rules! declare_bootstrap_init_functions {
   ($f:ident, $new_bootstrap_extension_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
-        .get_or_init(|| $new_bootstrap_extension_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION,
+        $new_bootstrap_extension_config_fn,
+        "NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -1026,8 +1122,11 @@ macro_rules! declare_cluster_init_functions {
   ($f:ident, $new_cluster_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION
-        .get_or_init(|| $new_cluster_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION,
+        $new_cluster_config_fn,
+        "NEW_CLUSTER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -1127,8 +1226,11 @@ macro_rules! declare_load_balancer_init_functions {
   ($f:ident, $new_lb_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION
-        .get_or_init(|| $new_lb_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION,
+        $new_lb_config_fn,
+        "NEW_LOAD_BALANCER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -1198,8 +1300,11 @@ macro_rules! declare_cert_validator_init_functions {
   ($f:ident, $new_cert_validator_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION
-        .get_or_init(|| $new_cert_validator_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION,
+        $new_cert_validator_config_fn,
+        "NEW_CERT_VALIDATOR_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -1312,8 +1417,11 @@ macro_rules! declare_dns_resolver_init_functions {
   ($f:ident, $new_dns_resolver_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION
-        .get_or_init(|| $new_dns_resolver_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION,
+        $new_dns_resolver_config_fn,
+        "NEW_DNS_RESOLVER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char
@@ -1371,8 +1479,11 @@ macro_rules! declare_transport_socket_init_functions {
   ($f:ident, $new_transport_socket_factory_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION
-        .get_or_init(|| $new_transport_socket_factory_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION,
+        $new_transport_socket_factory_config_fn,
+        "NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3080,26 +3080,12 @@ fn test_cert_validator_config_new_and_destroy() {
     }
   }
 
-  NEW_CERT_VALIDATOR_CONFIG_FUNCTION.get_or_init(|| {
+  let new_config_fn: NewCertValidatorConfigFunction =
     |_name: &str, _config: &[u8]| -> Option<Box<dyn cert_validator::CertValidatorConfig>> {
       Some(Box::new(TestCertValidatorConfig))
-    }
-  });
+    };
 
-  let name = "test";
-  let config = b"config";
-  let name_buf = abi::envoy_dynamic_module_type_envoy_buffer {
-    ptr: name.as_ptr() as *const _,
-    length: name.len(),
-  };
-  let config_buf = abi::envoy_dynamic_module_type_envoy_buffer {
-    ptr: config.as_ptr() as *const _,
-    length: config.len(),
-  };
-
-  let config_ptr = unsafe {
-    envoy_dynamic_module_on_cert_validator_config_new(std::ptr::null_mut(), name_buf, config_buf)
-  };
+  let config_ptr = cert_validator::init_cert_validator_config("test", b"config", &new_config_fn);
   assert!(!config_ptr.is_null());
 
   unsafe {

--- a/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
@@ -952,8 +952,11 @@ macro_rules! declare_tracer_init_functions {
   ($f:ident, $new_tracer_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION
-        .get_or_init(|| $new_tracer_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION,
+        $new_tracer_config_fn,
+        "NEW_TRACER_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char

--- a/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
@@ -417,8 +417,11 @@ macro_rules! declare_upstream_http_tcp_bridge_init_functions {
   ($f:ident, $new_bridge_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION
-        .get_or_init(|| $new_bridge_config_fn);
+      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+        envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION,
+        $new_bridge_config_fn,
+        "NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION"
+      );
       if ($f()) {
         envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
           as *const ::std::os::raw::c_char


### PR DESCRIPTION
## Description

This PR replaces `OnceLock::get_or_init` with `OnceLock::set` in all the factory registration macros to detect conflicting dual-load of standalone and consolidated `.so` modules at startup.

Previously, if both a standalone `.so` and a consolidated `.so` were loaded in the same process, the second `get_or_init` silently no-oped (first writer wins). The second module's factories were completely ignored with no diagnostic.

Now, a new `set_factory_once!` macro uses `OnceLock::set` and panics on duplicate registration. The panic is caught at the FFI boundary, causing `envoy_dynamic_module_on_program_init` to return `null`, which makes Envoy refuse to start. This is the correct behavior for a configuration conflict. This change is backward compatible.

---

**Commit Message:** dynamic_modules: replace silent get_or_init with fail-fast set_factory_once for factory registration
**Additional Description:** Replaces `OnceLock::get_or_init` with `OnceLock::set` in all the factory registration macros to detect conflicting dual-load of standalone and consolidated `.so` modules at startup.
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A