### PR TITLE
harden JsonEscaper by removing sprintf and clarifying byte handling

### DIFF
--- a/source/common/common/json_escape_string.h
+++ b/source/common/common/json_escape_string.h
@@ -64,16 +64,15 @@ public:
         position += 2;
         break;
       default:
-        if (character == 0x00 || (character > 0x00 && character <= 0x1f)) {
-          // Print character as unicode hex.
-          sprintf(&result[position + 1], "u%04x", static_cast<int>(character));
+        const uint8_t byte = static_cast<uint8_t>(character);
+        if (byte <= 0x1f) {
+          // Print character as a Unicode escape sequence.
+          result[position + 1] = 'u';
+          result[position + 2] = '0';
+          result[position + 3] = '0';
+          result[position + 4] = hexDigit(byte >> 4);
+          result[position + 5] = hexDigit(byte);
           position += 6;
-          // Overwrite trailing null character from `sprintf`, but only if there are more characters
-          // to process. If this is the last character then we must not write past the end of the
-          // string.
-          if (position < result.size()) {
-            result[position] = '\\';
-          }
         } else {
           // All other characters are added as-is.
           result[position++] = character;
@@ -111,7 +110,7 @@ public:
       }
 
       default: {
-        if (character == 0x00 || (character > 0x00 && character <= 0x1f)) {
+        if (static_cast<uint8_t>(character) <= 0x1f) {
           // From character (1 byte) to unicode hex (6 bytes).
           result += 5;
         }
@@ -121,5 +120,8 @@ public:
     }
     return result;
   }
+
+private:
+  static constexpr char hexDigit(uint8_t value) { return "0123456789abcdef"[value & 0x0f]; }
 };
 } // namespace Envoy

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -118,6 +118,16 @@ TEST(JsonEscapeTest, Escape) {
   expect_json_escape("\x1d", "\\u001d");
   expect_json_escape("\x1e", "\\u001e");
   expect_json_escape("\x1f", "\\u001f");
+
+  const std::string high_bytes =
+      std::string(1, static_cast<char>(0x80)) + std::string(1, static_cast<char>(0xff));
+  expect_json_escape(high_bytes, high_bytes);
+
+  const std::string mixed_bytes =
+      std::string(1, static_cast<char>(0x80)) + "\x01" + std::string(1, static_cast<char>(0xff));
+  const std::string mixed_expected =
+      std::string(1, static_cast<char>(0x80)) + "\\u0001" + std::string(1, static_cast<char>(0xff));
+  expect_json_escape(mixed_bytes, mixed_expected);
 }
 
 // Regression test for off-by-one write when control characters appear at the end of input.


### PR DESCRIPTION

**Additional Description:**
- Replaces C-style sprintf writes in JSON escaping with explicit fixed-position hex encoding for control bytes.
- Uses unsigned-byte comparison for control character detection to avoid signed char ambiguity on non-ASCII input.
- Preserves existing escaping behavior while reducing error-prone string write patterns.
- Adds regression coverage for high-bit bytes (0x80, 0xFF) and mixed high-bit/control-byte input.

**Risk Level:**
Low. The change is localized to JSON escaping utility logic and test coverage was expanded for edge cases.

**Testing:**
- Added JsonEscapeTest coverage for high-bit byte pass-through.
- Added JsonEscapeTest coverage for mixed high-bit and control-byte escaping.

**Docs Changes:**
None.

**Release Notes:**
None.

**Platform Specific Features:**
None.

**[Optional Runtime guard:]**
Not needed.

**[Optional Fixes #Issue]**
N/A

**[Optional Fixes commit #PR or SHA]**
N/A

**[Optional Deprecated:]**
N/A
