### PR TITLE
coverage: adjust the LCOV numbers to reflect current state

### DIFF
--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -6,85 +6,85 @@ directories:
   source/common: 96.4
   source/common/api: 95.3  # some syscalls require sandboxing
   source/common/api/posix: 94.9  # setns requires Linux CAP_NET_ADMIN privileges
-  source/common/crypto: 91.0  # Static singleton initialization and OpenSSL internal error paths not testable
-  source/common/filesystem/posix: 96.4  # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
+  source/common/crypto: 91.2  # Static singleton initialization and OpenSSL internal error paths not testable
+  source/common/filesystem/posix: 96.5  # FileReadToEndNotReadable fails in some env; createPath can't test all failure branches.
   source/common/http: 96.5
-  source/common/http/http1: 93.4  # To be removed when http_inspector_use_balsa_parser is retired.
+  source/common/http/http1: 93.6  # To be removed when http_inspector_use_balsa_parser is retired.
   source/common/http/http2: 96.6
-  source/common/json: 95.2
+  source/common/json: 95.8
   source/common/jwt: 86.2
-  source/common/matcher: 94.8
+  source/common/matcher: 95.2
   source/common/memory: 98.1  # tcmalloc code path is not enabled in coverage build, only gperf tcmalloc, see PR#32589
   source/common/network: 94.3  # Flaky, `activateFileEvents`, `startSecureTransport` and `ioctl`, listener_socket do not always report LCOV
   source/common/network/dns_resolver: 91.4   # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
-  source/common/quic: 93.3
+  source/common/quic: 93.5
   source/common/signal: 87.4  # Death tests don't report LCOV
   source/common/thread: 0.0  # Death tests don't report LCOV
-  source/common/tls: 94.1  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
-  source/common/tls/cert_validator: 95.0
+  source/common/tls: 94.3  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
+  source/common/tls/cert_validator: 95.1
   source/common/tls/private_key: 88.9
   source/common/watchdog: 60.0  # Death tests don't report LCOV
   source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures
   source/extensions/api_listeners: 55.0  # Many IS_ENVOY_BUG are not covered.
-  source/extensions/api_listeners/default_api_listener: 67.8  # Many IS_ENVOY_BUG are not covered.
+  source/extensions/api_listeners/default_api_listener: 68.9  # Many IS_ENVOY_BUG are not covered.
   source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface: 96.3
   source/extensions/common/aws: 97.5
   source/extensions/common/aws/credential_providers: 100.0
-  source/extensions/common/proxy_protocol: 94.6  # Adjusted for security patch
-  source/extensions/common/tap: 95.1
-  source/extensions/common/wasm: 95.3  # flaky: be careful adjusting
+  source/extensions/common/proxy_protocol: 95.1  # Adjusted for security patch
+  source/extensions/common/tap: 95.2
+  source/extensions/common/wasm: 95.6  # flaky: be careful adjusting
   source/extensions/common/wasm/ext: 100.0
-  source/extensions/clusters/dynamic_modules: 95.5
+  source/extensions/clusters/dynamic_modules: 97.7
   source/extensions/filters/common: 97.1
   source/extensions/filters/common/fault: 94.5
   source/extensions/filters/common/lua: 95.6
-  source/extensions/filters/http/a2a: 93  # TODO(tyxia) Under active development
+  source/extensions/filters/http/a2a: 98.4
   source/extensions/filters/http/cache: 95.9
   source/extensions/filters/http/dynamic_forward_proxy: 94.8
-  source/extensions/filters/http/dynamic_modules: 95.2
+  source/extensions/filters/http/dynamic_modules: 95.5
   source/extensions/filters/http/decompressor: 95.9
-  source/extensions/filters/http/ext_proc: 96.4
-  source/extensions/filters/http/grpc_json_reverse_transcoder: 94.8
-  source/extensions/filters/http/grpc_json_transcoder: 94.0  # TODO(#28232)
+  source/extensions/filters/http/ext_proc: 96.5
+  source/extensions/filters/http/grpc_json_reverse_transcoder: 94.9
+  source/extensions/filters/http/grpc_json_transcoder: 94.1  # TODO(#28232)
   source/extensions/filters/http/ip_tagging: 95.9
   source/extensions/filters/http/kill_request: 91.7  # Death tests don't report LCOV
-  source/extensions/filters/http/mcp_json_rest_bridge: 80  # TODO(guoyilin42): adjust up. Overriden to check-in boilerplate.
-  source/extensions/filters/http/mcp_router: 80  # TODO(yanavlasov): adjust up. Overriden to just scheck-in boilerplate.
+  source/extensions/filters/http/mcp_json_rest_bridge: 94.0
+  source/extensions/filters/http/mcp_router: 82.3
   source/extensions/filters/http/oauth2: 97.6
   source/extensions/filters/listener: 96.5
-  source/extensions/filters/listener/dynamic_modules: 95.5
+  source/extensions/filters/listener/dynamic_modules: 96.9
   source/extensions/filters/listener/original_src: 92.1
-  source/extensions/filters/listener/tls_inspector: 94.4
+  source/extensions/filters/listener/tls_inspector: 94.5
   source/extensions/filters/network/dubbo_proxy: 96.2
   source/extensions/filters/network/mongo_proxy: 96.1
-  source/extensions/filters/network/reverse_tunnel: 92.0
+  source/extensions/filters/network/reverse_tunnel: 95.9
   source/extensions/filters/network/sni_cluster: 88.9
   source/extensions/formatter/cel: 100.0
-  source/extensions/formatter/file_content: 96.2
+  source/extensions/formatter/file_content: 96.3
   source/extensions/internal_redirect: 86.2
   source/extensions/internal_redirect/safe_cross_scheme: 81.3
   source/extensions/internal_redirect/allow_listed_routes: 85.7
   source/extensions/internal_redirect/previous_routes: 89.3
-  source/extensions/load_balancing_policies/common: 96.3
-  source/extensions/load_balancing_policies/maglev: 94.9
+  source/extensions/load_balancing_policies/common: 96.4
+  source/extensions/load_balancing_policies/maglev: 95.2
   source/extensions/load_balancing_policies/round_robin: 96.4
   source/extensions/load_balancing_policies/ring_hash: 96.9
   source/extensions/rate_limit_descriptors: 95.0
   source/extensions/rate_limit_descriptors/expr: 96.1
   source/extensions/stat_sinks/graphite_statsd: 82.8  # Death tests don't report LCOV
   source/extensions/stat_sinks/statsd: 85.2  # Death tests don't report LCOV
-  source/extensions/tracers/zipkin: 95.6
-  source/extensions/transport_sockets/proxy_protocol: 96.2
-  source/extensions/transport_sockets/tls/cert_mappers/filter_state_override: 96.2
-  source/extensions/transport_sockets/tls/cert_validator/spiffe: 96.2
+  source/extensions/tracers/zipkin: 96.2
+  source/extensions/transport_sockets/proxy_protocol: 96.6
+  source/extensions/transport_sockets/tls/cert_mappers/filter_state_override: 96.4
+  source/extensions/transport_sockets/tls/cert_validator/spiffe: 96.7
   source/extensions/wasm_runtime/wamr: 0.0  # Not enabled in coverage build
   source/extensions/wasm_runtime/wasmtime: 0.0  # Not enabled in coverage build
   source/extensions/watchdog: 83.3  # Death tests within extensions
-  source/extensions/listener_managers: 77.3
-  source/extensions/listener_managers/validation_listener_manager: 77.3
+  source/extensions/listener_managers: 77.8
+  source/extensions/listener_managers/validation_listener_manager: 77.8
   source/extensions/watchdog/profile_action: 86.1
-  source/server: 91.0  # flaky: be careful adjusting. See https://github.com/envoyproxy/envoy/issues/15239
-  source/server/config_validation: 93.1
+  source/server: 93.3  # flaky: be careful adjusting. See https://github.com/envoyproxy/envoy/issues/15239
+  source/server/config_validation: 93.4
   source/extensions/health_checkers: 96.1
   source/extensions/health_checkers/http: 94.6
   source/extensions/health_checkers/grpc: 92.3


### PR DESCRIPTION
## Description

This PR adjusts the LCOV numbers to reflect the current state as both these extensions now have good coverage and could be removed from the exception list:
```
source/common/http/http2: 96.6
source/common/memory: 98.1
source/extensions/common/aws: 97.5
source/extensions/common/aws/credential_providers: 100.0
source/extensions/common/wasm/ext: 100.0
source/extensions/clusters/dynamic_modules: 97.7
source/extensions/filters/common: 97.1
source/extensions/filters/http/a2a: 98.4
source/extensions/filters/http/oauth2: 97.6
source/extensions/filters/listener/dynamic_modules: 96.9
source/extensions/formatter/cel: 100.0
source/extensions/load_balancing_policies/ring_hash: 96.9
source/extensions/transport_sockets/proxy_protocol: 96.6
source/extensions/transport_sockets/tls/cert_validator/spiffe: 96.7
source/extensions/matching/input_matchers/cel_matcher: 100.0
```

---

**Commit Message:** coverage: adjust the LCOV numbers to reflect current state
**Additional Description:** Adjusts the LCOV numbers to reflect the current state
**Risk Level:** N/A
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A