### PR TITLE
[bp/1.35] Disable excessively flaky test (#42599)

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -448,6 +448,9 @@ TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
 }
 
 TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) {
+  // TODO(yanavlasov): fix the test
+  GTEST_SKIP() << "Test is too flaky for CI. "
+                  "https://github.com/envoyproxy/envoy/issues/39856#issuecomment-3637976574";
   config_helper_.addRuntimeOverride("envoy.reloadable_features.reject_early_connect_data", "true");
   initialize();
 


### PR DESCRIPTION
With a TODO to fix. We can't roll back the PR
that introduced the flakiness (#42370) because it was a security patch. Relevant flakiness described in
https://github.com/envoyproxy/envoy/issues/39856#issuecomment-3637997415 Risk Level: test-only
Testing: it is
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

