### PR TITLE
Adds a streamlined maglev table implementation for the single host case

### DIFF
--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -7,6 +7,7 @@
 namespace Envoy {
 namespace Upstream {
 namespace {
+
 bool shouldUseCompactTable(size_t num_hosts, uint64_t table_size) {
   // Don't use compact maglev on 32-bit platforms.
   if constexpr (!(ENVOY_BIT_ARRAY_SUPPORTED)) {
@@ -41,7 +42,14 @@ public:
                     bool use_hostname_for_hashing, MaglevLoadBalancerStats& stats) {
 
     MaglevTableSharedPtr maglev_table;
-    if (shouldUseCompactTable(normalized_host_weights.size(), table_size)) {
+    if (normalized_host_weights.size() == 1) {
+      maglev_table =
+          std::make_shared<DegenerateMaglevTable>(normalized_host_weights, max_normalized_weight,
+                                                  table_size, use_hostname_for_hashing, stats);
+      ENVOY_LOG(debug,
+                "creating single host maglev table given table size {} and number of hosts {}",
+                table_size, normalized_host_weights.size());
+    } else if (shouldUseCompactTable(normalized_host_weights.size(), table_size)) {
       maglev_table =
           std::make_shared<CompactMaglevTable>(normalized_host_weights, max_normalized_weight,
                                                table_size, use_hostname_for_hashing, stats);
@@ -189,6 +197,7 @@ void OriginalMaglevTable::constructImplementationInternals(
     }
   }
 }
+
 CompactMaglevTable::CompactMaglevTable(const NormalizedHostWeightVector& normalized_host_weights,
                                        double max_normalized_weight, uint64_t table_size,
                                        bool use_hostname_for_hashing,
@@ -254,6 +263,21 @@ void CompactMaglevTable::constructImplementationInternals(
   }
 }
 
+DegenerateMaglevTable::DegenerateMaglevTable(
+    const NormalizedHostWeightVector& normalized_host_weights, double max_normalized_weight,
+    uint64_t table_size, bool use_hostname_for_hashing, MaglevLoadBalancerStats& stats)
+    : MaglevTable(table_size, stats) {
+  constructMaglevTableInternal(normalized_host_weights, max_normalized_weight,
+                               use_hostname_for_hashing);
+}
+
+void DegenerateMaglevTable::constructImplementationInternals(
+    std::vector<TableBuildEntry>& table_build_entries, double /*max_normalized_weight*/) {
+  ASSERT(table_build_entries.size() == 1,
+         "DegenerateMaglevTable is intended for the case of a single host!");
+  single_host_ = table_build_entries[0].host_;
+}
+
 void OriginalMaglevTable::logMaglevTable(bool use_hostname_for_hashing) const {
   for (uint64_t i = 0; i < table_.size(); ++i) {
     const absl::string_view key_to_hash = hashKey(table_[i], use_hostname_for_hashing);
@@ -273,6 +297,10 @@ void CompactMaglevTable::logMaglevTable(bool use_hostname_for_hashing) const {
     ENVOY_LOG(trace, "maglev: i={} address={} host={}", i, host->address()->asString(),
               key_to_hash);
   }
+}
+
+void DegenerateMaglevTable::logMaglevTable(bool /*use_hostname_for_hashing*/) const {
+  ENVOY_LOG(trace, "maglev: single host {}", single_host_->address()->asString());
 }
 
 MaglevTable::MaglevTable(uint64_t table_size, MaglevLoadBalancerStats& stats)
@@ -308,6 +336,11 @@ HostSelectionResponse CompactMaglevTable::chooseHost(uint64_t hash, uint32_t att
   const uint32_t index = table_.get(hash % table_size_);
   ASSERT(index < host_table_.size(), "Compact MaglevTable index into host table out of range");
   return {host_table_[index]};
+}
+
+HostSelectionResponse DegenerateMaglevTable::chooseHost(uint64_t /*hash*/,
+                                                        uint32_t /*attempt*/) const {
+  return {single_host_};
 }
 
 MaglevLoadBalancer::MaglevLoadBalancer(const PrioritySet& priority_set, ClusterLbStats& stats,

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.cc
@@ -275,7 +275,9 @@ void DegenerateMaglevTable::constructImplementationInternals(
     std::vector<TableBuildEntry>& table_build_entries, double /*max_normalized_weight*/) {
   ASSERT(table_build_entries.size() == 1,
          "DegenerateMaglevTable is intended for the case of a single host!");
-  single_host_ = table_build_entries[0].host_;
+  TableBuildEntry& entry = table_build_entries[0];
+  single_host_ = entry.host_;
+  ++entry.count_;
 }
 
 void OriginalMaglevTable::logMaglevTable(bool use_hostname_for_hashing) const {

--- a/source/extensions/load_balancing_policies/maglev/maglev_lb.h
+++ b/source/extensions/load_balancing_policies/maglev/maglev_lb.h
@@ -162,6 +162,26 @@ private:
   std::vector<HostConstSharedPtr> host_table_;
 };
 
+// A simplified implementation for the case where there is only a single host.
+class DegenerateMaglevTable : public MaglevTable {
+public:
+  DegenerateMaglevTable(const NormalizedHostWeightVector& normalized_host_weights,
+                        double max_normalized_weight, uint64_t table_size,
+                        bool use_hostname_for_hashing, MaglevLoadBalancerStats& stats);
+  ~DegenerateMaglevTable() override = default;
+
+  // ThreadAwareLoadBalancerBase::HashingLoadBalancer
+  HostSelectionResponse chooseHost(uint64_t hash, uint32_t attempt) const override;
+
+  void logMaglevTable(bool use_hostname_for_hashing) const override;
+
+private:
+  void constructImplementationInternals(std::vector<TableBuildEntry>& table_build_entries,
+                                        double max_normalized_weight) override;
+
+  HostConstSharedPtr single_host_;
+};
+
 /**
  * Thread aware load balancer implementation for Maglev.
  */

--- a/test/extensions/load_balancing_policies/maglev/integration_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/integration_test.cc
@@ -10,6 +10,7 @@
 
 #include "test/integration/http_integration.h"
 
+#include "absl/strings/substitute.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -18,12 +19,16 @@ namespace LoadBalancingPolicies {
 namespace Maglev {
 namespace {
 
-class MaglevIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
-                              public HttpIntegrationTest {
+class MaglevIntegrationTest
+    : public testing::TestWithParam<std::tuple<Network::Address::IpVersion, uint32_t>>,
+      public HttpIntegrationTest {
 public:
-  MaglevIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
-    // Create 3 different upstream server for stateful session test.
-    setUpstreamCount(3);
+  static Network::Address::IpVersion getIpVersion() { return std::get<0>(GetParam()); }
+  static uint32_t getNumUpstreams() { return std::get<1>(GetParam()); }
+
+  MaglevIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, getIpVersion()) {
+    // Create the desired number of upstream servers for the stateful session test.
+    setUpstreamCount(getNumUpstreams());
 
     config_helper_.addConfigModifier(
         [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -45,28 +50,20 @@ public:
           ASSERT(cluster_0->name() == "cluster_0");
           auto* endpoint = cluster_0->mutable_load_assignment()->mutable_endpoints()->Mutable(0);
 
-          constexpr absl::string_view endpoints_yaml = R"EOF(
-          lb_endpoints:
+          std::string endpoints_yaml = "lb_endpoints:";
+          constexpr absl::string_view single_endpoint = R"EOF(
           - endpoint:
               address:
                 socket_address:
-                  address: {}
-                  port_value: 0
-          - endpoint:
-              address:
-                socket_address:
-                  address: {}
-                  port_value: 0
-          - endpoint:
-              address:
-                socket_address:
-                  address: {}
+                  address: $0
                   port_value: 0
           )EOF";
+          for (uint32_t i = 0; i < getNumUpstreams(); ++i) {
+            absl::StrAppend(&endpoints_yaml, single_endpoint);
+          }
 
-          const std::string local_address = Network::Test::getLoopbackAddressString(GetParam());
-          TestUtility::loadFromYaml(
-              fmt::format(endpoints_yaml, local_address, local_address, local_address), *endpoint);
+          const std::string local_address = Network::Test::getLoopbackAddressString(getIpVersion());
+          TestUtility::loadFromYaml(absl::Substitute(endpoints_yaml, local_address), *endpoint);
 
           // If legacy API is used, set the LB policy by the old way.
           if (legacy_api) {
@@ -95,6 +92,15 @@ public:
     HttpIntegrationTest::initialize();
   }
 
+  std::vector<uint64_t> range(uint64_t bound) {
+    std::vector<uint64_t> v;
+    v.reserve(bound);
+    for (uint64_t i = 0; i < bound; ++i) {
+      v.push_back(i);
+    }
+    return v;
+  }
+
   void runNormalLoadBalancing() {
     absl::optional<uint64_t> unique_upstream_index;
 
@@ -108,7 +114,7 @@ public:
 
       auto response = codec_client_->makeRequestWithBody(request_headers, 0);
 
-      auto upstream_index = waitForNextUpstreamRequest({0, 1, 2});
+      auto upstream_index = waitForNextUpstreamRequest(range(getNumUpstreams()));
       ASSERT(upstream_index.has_value());
 
       if (unique_upstream_index.has_value()) {
@@ -129,9 +135,14 @@ public:
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, MaglevIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, MaglevIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::Values(1, 3)),
+    [](const testing::TestParamInfo<std::tuple<Network::Address::IpVersion, uint32_t>>& params) {
+      return absl::StrCat(TestUtility::ipVersionToString(std::get<0>(params.param)),
+                          std::get<1>(params.param), "Upstreams");
+    });
 
 TEST_P(MaglevIntegrationTest, NormalLoadBalancing) {
   initializeConfig();

--- a/test/extensions/load_balancing_policies/maglev/integration_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/integration_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <cstdint>
+#include <numeric>
 
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
 
@@ -93,11 +94,8 @@ public:
   }
 
   std::vector<uint64_t> range(uint64_t bound) {
-    std::vector<uint64_t> v;
-    v.reserve(bound);
-    for (uint64_t i = 0; i < bound; ++i) {
-      v.push_back(i);
-    }
+    std::vector<uint64_t> v(bound);
+    std::iota(v.begin(), v.end(), 0);
     return v;
   }
 

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
@@ -72,6 +72,7 @@ void benchmarkMaglevLoadBalancerBuildTable(::benchmark::State& state) {
   }
 }
 BENCHMARK(benchmarkMaglevLoadBalancerBuildTable)
+    ->Arg(1)
     ->Arg(100)
     ->Arg(200)
     ->Arg(500)

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
@@ -57,12 +57,17 @@ TEST(MaglevTableLogMaglevTableTest, MaglevTableLogMaglevTableTest) {
   NormalizedHostWeightVector normalized_host_weights = {{host1, 1}};
 
   {
-    CompactMaglevTable table(normalized_host_weights, 1, 2, true, stats);
+    OriginalMaglevTable table(normalized_host_weights, 1, 2, true, stats);
     table.logMaglevTable(true);
   }
 
   {
     CompactMaglevTable table(normalized_host_weights, 1, 2, true, stats);
+    table.logMaglevTable(true);
+  }
+
+  {
+    DegenerateMaglevTable table(normalized_host_weights, 1, 2, true, stats);
     table.logMaglevTable(true);
   }
 }
@@ -146,6 +151,25 @@ TEST_F(MaglevLoadBalancerTest, DefaultMaglevTableSize) {
   createLb();
   EXPECT_EQ(defaultValue, lb_->tableSize());
 };
+
+TEST_F(MaglevLoadBalancerTest, SingleHost) {
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90")};
+  host_set_.healthy_hosts_ = host_set_.hosts_;
+  host_set_.runCallbacks({}, {});
+  init(7);
+
+  EXPECT_EQ("maglev_lb.min_entries_per_host", lb_->stats().min_entries_per_host_.name());
+  EXPECT_EQ("maglev_lb.max_entries_per_host", lb_->stats().max_entries_per_host_.name());
+  EXPECT_EQ(1, lb_->stats().min_entries_per_host_.value());
+  EXPECT_EQ(1, lb_->stats().max_entries_per_host_.value());
+
+  // Always selects the single host: 127.0.0.1:90
+  LoadBalancerPtr lb = lb_->factory()->create(lb_params_);
+  for (uint32_t i = 0; i < 5; ++i) {
+    TestLoadBalancerContext context(i);
+    EXPECT_EQ(host_set_.hosts_[0], lb->chooseHost(&context).host);
+  }
+}
 
 // Basic sanity tests.
 TEST_F(MaglevLoadBalancerTest, Basic) {
@@ -508,6 +532,21 @@ TEST_F(MaglevLoadBalancerTest, Weighted) {
     TestLoadBalancerContext context(i);
     EXPECT_EQ(host_set_.hosts_[expected_assignments[i % expected_assignments.size()]],
               lb->chooseHost(&context).host);
+  }
+}
+
+TEST_F(MaglevLoadBalancerTest, WeightedSingleHost) {
+  host_set_.hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:90", 7)};
+  host_set_.healthy_hosts_ = host_set_.hosts_;
+  host_set_.runCallbacks({}, {});
+  init(17);
+  EXPECT_EQ(1, lb_->stats().min_entries_per_host_.value());
+  EXPECT_EQ(1, lb_->stats().max_entries_per_host_.value());
+
+  LoadBalancerPtr lb = lb_->factory()->create(lb_params_);
+  for (uint32_t i = 0; i < 17; ++i) {
+    TestLoadBalancerContext context(i);
+    EXPECT_EQ(host_set_.hosts_[0], lb->chooseHost(&context).host);
   }
 }
 


### PR DESCRIPTION
It's a complete waste of CPU and RAM to build and initialize a multi-slot Maglev table if there is only a single host.

## Baseline
Benchmark  |  Time |  CPU |  Iterations | Memory | Memory per host
-- | -- | -- | -- | -- | --
benchmarkMaglevLoadBalancerBuildTable/1 |       0.772 ms |       0.772 ms |         856 | 9.96k | 9.96k                                                     
benchmarkMaglevLoadBalancerBuildTable/100  |      2.10 ms |        2.10 ms |         309 | 67.8k | 678                                                       
benchmarkMaglevLoadBalancerBuildTable/200    |   1.96 ms  |       1.95 ms |         342 | 77.656k | 388                                                     
benchmarkMaglevLoadBalancerBuildTable/500     |  2.12 ms  |       2.12 ms |         328 | 90.584k | 181

## With single host implementation
Benchmark |                                         Time |            CPU |  Iterations | Memory | Memory per host
-- | -- | -- | -- | -- | --
benchmarkMaglevLoadBalancerBuildTable/1 |       0.320 ms |       0.320 ms |        2321 | 440 | 440                                                         
benchmarkMaglevLoadBalancerBuildTable/100 |      2.06 ms |        2.06 ms  |        328  | 67.8k | 678                                                       
benchmarkMaglevLoadBalancerBuildTable/200  |     1.94 ms  |       1.94 ms   |       359 | 77.656k | 388                                                     
benchmarkMaglevLoadBalancerBuildTable/500  |     2.14 ms   |      2.14 ms    |      331 | 90.584k | 181

Commit Message: adds a streamlined maglev table implementation for the single host case
Additional Description:
Risk Level: low
Testing: ran unit and integration tests locally
Docs Changes:
Release Notes:
Platform Specific Features:
