### PR TITLE
Promote http geoip filter to alpha

### DIFF
--- a/api/envoy/extensions/filters/http/geoip/v3/BUILD
+++ b/api/envoy/extensions/filters/http/geoip/v3/BUILD
@@ -8,6 +8,5 @@ api_proto_package(
     deps = [
         "//envoy/config/core/v3:pkg",
         "@xds//udpa/annotations:pkg",
-        "@xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/geoip/v3/geoip.proto
+++ b/api/envoy/extensions/filters/http/geoip/v3/geoip.proto
@@ -14,7 +14,6 @@ option java_outer_classname = "GeoipProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/geoip/v3;geoipv3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: Geoip]
 // Geoip :ref:`configuration overview <config_http_filters_geoip>`.

--- a/api/envoy/extensions/filters/http/geoip/v3/geoip.proto
+++ b/api/envoy/extensions/filters/http/geoip/v3/geoip.proto
@@ -4,8 +4,6 @@ package envoy.extensions.filters.http.geoip.v3;
 
 import "envoy/config/core/v3/extension.proto";
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -390,7 +390,7 @@ envoy.filters.http.geoip:
   categories:
   - envoy.filters.http
   security_posture: unknown
-  status: wip
+  status: alpha
   type_urls:
   - envoy.extensions.filters.http.geoip.v3.Geoip
 envoy.filters.network.geoip:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Http geoip filter has sufficient production burn time and has been used by many companies. Tagging @barroca to confirm that filter has been used for long time at Spotify prod. 

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
