### PR TITLE
quic: fix 'occured' -> 'occurred' typo in http_datagram_handler log

### DIFF
--- a/source/common/quic/http_datagram_handler.cc
+++ b/source/common/quic/http_datagram_handler.cc
@@ -80,7 +80,7 @@ bool HttpDatagramHandler::encodeCapsuleFragment(absl::string_view capsule_fragme
   // If a CapsuleParser object fails to parse a capsule fragment, the corresponding stream should
   // be reset. Returning false in this method resets the stream.
   if (!capsule_parser_.IngestCapsuleFragment(capsule_fragment)) {
-    ENVOY_LOG(error, fmt::format("Capsule parsing error occured: capsule_fragment = {}",
+    ENVOY_LOG(error, fmt::format("Capsule parsing error occurred: capsule_fragment = {}",
                                  capsule_fragment));
     return false;
   }


### PR DESCRIPTION
`ENVOY_LOG` error message in `source/common/quic/http_datagram_handler.cc:83` read `Capsule parsing error occured: capsule_fragment = {}`. Surfaced in envoy-admin logs during capsule parse failures. String-literal-only change.