### PR TITLE
quic/udp: fix 'occured' -> 'occurred' in capsule error log messages

### DIFF
--- a/source/common/quic/http_datagram_handler.cc
+++ b/source/common/quic/http_datagram_handler.cc
@@ -80,7 +80,7 @@ bool HttpDatagramHandler::encodeCapsuleFragment(absl::string_view capsule_fragme
   // If a CapsuleParser object fails to parse a capsule fragment, the corresponding stream should
   // be reset. Returning false in this method resets the stream.
   if (!capsule_parser_.IngestCapsuleFragment(capsule_fragment)) {
-    ENVOY_LOG(error, fmt::format("Capsule parsing error occured: capsule_fragment = {}",
+    ENVOY_LOG(error, fmt::format("Capsule parsing error occurred: capsule_fragment = {}",
                                  capsule_fragment));
     return false;
   }

--- a/source/extensions/upstreams/http/udp/upstream_request.cc
+++ b/source/extensions/upstreams/http/udp/upstream_request.cc
@@ -76,7 +76,7 @@ void UdpUpstream::encodeData(Buffer::Instance& data, bool end_stream) {
   for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     absl::string_view mem_slice(static_cast<const char*>(slice.mem_), slice.len_);
     if (!capsule_parser_.IngestCapsuleFragment(mem_slice)) {
-      ENVOY_LOG_MISC(error, "Capsule ingestion error occured: slice = {}", mem_slice);
+      ENVOY_LOG_MISC(error, "Capsule ingestion error occurred: slice = {}", mem_slice);
       break;
     }
   }


### PR DESCRIPTION
**Description:** Two ENVOY_LOG error messages contained `error occured`:
- `source/common/quic/http_datagram_handler.cc` line 83
- `source/extensions/upstreams/http/udp/upstream_request.cc` line 79

Fixed to `occurred`. String-literal-only change; no code or behavior change.

**Risk Level:** Low (log string only)
**Testing:** N/A — string-literal-only change.