### PR TITLE
ci: Add deflake target

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -368,6 +368,25 @@ case $CI_TARGET in
         echo "Generated cache: ${TOTAL_SIZE}"
         ;;
 
+    deflake)
+        ENVOY_DEFLAKE_RUNS=${ENVOY_DEFLAKE_RUNS:-1000}
+        if [[ -z "$ENVOY_DEFLAKE_TARGET" || -z "$ENVOY_DEFLAKE_TEST" ]]; then
+            echo "Both ENVOY_DEFLAKE_TARGET and ENVOY_DEFLAKE_TEST must be set to use deflake" >&2
+            exit 1
+        fi
+        _BAZEL_ARGS=(
+            "$ENVOY_DEFLAKE_TARGET"
+            "${BAZEL_BUILD_OPTIONS[@]}"
+            --test_arg=--gtest_filter="$ENVOY_DEFLAKE_TEST"
+            --runs_per_test="${ENVOY_DEFLAKE_RUNS}"
+            --test_arg="-l trace"
+            --cache_test_results=no)
+        if [[ -n "$ENVOY_DEFLAKE_JOBS" ]]; then
+            _BAZEL_ARGS+=(--jobs="$ENVOY_DEFLAKE_JOBS")
+        fi
+        bazel test "${_BAZEL_ARGS[@]}"
+        ;;
+
     format-api|check_and_fix_proto_format)
         setup_clang_toolchain
         echo "Check and fix proto format ..."

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -166,6 +166,18 @@ bazel test //test/integration:http2_upstream_integration_test \
 --jobs 60 --local_test_jobs=60 --runs_per_test=1000 --test_arg="-l trace"
 ```
 
+You can also run the above command via `do_ci.sh`, eg:
+
+```console
+
+$ export ENVOY_DEFLAKE_JOBS="60"
+$ export BAZEL_BUILD_EXTRA_OPTIONS="--config=clang --config=tsan"
+$ export ENVOY_DEFLAKE_TARGET=//test/integration:load_stats_integration_test
+$ export ENVOY_DEFLAKE_TEST=IpVersionsClientType/LoadStatsIntegrationTest.SuccessWithCustomMetrics/IPv4_GoogleGrpc
+$ ./ci/do_ci.sh deflake
+
+```
+
 For hard to reproduce flakes, a sometimes useful tool is `stress`, available via
 `apt install stress`. Running stress alongsize `bazel test` (in another window,
 starting it after the build completes) can be a great help in reproducing issues,
@@ -183,5 +195,3 @@ Once you've managed to reproduce your test flake, you get to figure out what's
 going on. If your failure mode isn't documented below, ideally some combination
 of cerr << logging and trace logs will help you sort out what is going on (and
 please add to this document as you figure it out!)
-
-

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -170,10 +170,11 @@ You can also run the above command via `do_ci.sh`, eg:
 
 ```console
 
-$ export ENVOY_DEFLAKE_JOBS="60"
-$ export BAZEL_BUILD_EXTRA_OPTIONS="--config=clang --config=tsan"
-$ export ENVOY_DEFLAKE_TARGET=//test/integration:load_stats_integration_test
-$ export ENVOY_DEFLAKE_TEST=IpVersionsClientType/LoadStatsIntegrationTest.SuccessWithCustomMetrics/IPv4_GoogleGrpc
+$ export ENVOY_DEFLAKE_JOBS="60"  # optional
+$ export ENVOY_DEFLAKE_RUNS="10"  # optional, defaults to 1000
+$ export BAZEL_BUILD_EXTRA_OPTIONS="--config=clang --config=tsan"  # set the type of test/toolchain
+$ export ENVOY_DEFLAKE_TARGET=//test/integration:load_stats_integration_test  # required
+$ export ENVOY_DEFLAKE_TEST=IpVersionsClientType/LoadStatsIntegrationTest.SuccessWithCustomMetrics/IPv4_GoogleGrpc  # required
 $ ./ci/do_ci.sh deflake
 
 ```


### PR DESCRIPTION
this provides a standardized way to run deflaking tests

this should be backported to allow for repairing release branches

in a follow up i will add this as a ci workflow