### PR TITLE
ci/workflows: Remove repo constraint on _load_env

### DIFF
--- a/.github/workflows/_load_env.yml
+++ b/.github/workflows/_load_env.yml
@@ -55,7 +55,6 @@ env:
 
 jobs:
   request:
-    if: ${{ github.repository == 'envoyproxy/envoy' || vars.ENVOY_CI }}
     runs-on: ubuntu-24.04
     outputs:
       build-image: ${{ toJSON(fromJSON(steps.env.outputs.data).request.build-image) }}


### PR DESCRIPTION
as this is only intended to be called from dispatch wfs its better to always allow

