### PR TITLE
quic: Remove flaky ASSERT in `ShouldCreateOutgoingBidirectionalStream`

### DIFF
--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -123,8 +123,10 @@ protected:
   quic::QuicSpdyStream* CreateIncomingStream(quic::PendingStream* pending) override;
   std::unique_ptr<quic::QuicCryptoClientStreamBase> CreateQuicCryptoStream() override;
   bool ShouldCreateOutgoingBidirectionalStream() override {
-    // Prefer creating an "invalid" stream outside of current stream bounds to
-    // crashing when dereferencing a nullptr in QuicHttpClientConnectionImpl::newStream
+    // quic::QuicSpdyClientSession::ShouldCreateOutgoingBidirectionalStream()
+    // might return false, but we want to create the stream anyway
+    // because otherwise we crash dereferencing a nullptr, so we
+    // don't even ask it, and just return true.
     return true;
   }
   // QuicFilterManagerConnectionImpl

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -123,7 +123,6 @@ protected:
   quic::QuicSpdyStream* CreateIncomingStream(quic::PendingStream* pending) override;
   std::unique_ptr<quic::QuicCryptoClientStreamBase> CreateQuicCryptoStream() override;
   bool ShouldCreateOutgoingBidirectionalStream() override {
-    ASSERT(quic::QuicSpdyClientSession::ShouldCreateOutgoingBidirectionalStream());
     // Prefer creating an "invalid" stream outside of current stream bounds to
     // crashing when dereferencing a nullptr in QuicHttpClientConnectionImpl::newStream
     return true;


### PR DESCRIPTION
QuicSpdyClientSession::ShouldCreateOutgoingBidirectionalStream() can legitimately return false, but we return true unconditionally to avoid a nullptr deref in QuicHttpClientConnectionImpl::newStream.

The existing ASSERT on the parent's return value was therefore incorrect and triggered flakes (e.g. in buffer_accounting_integration_test on MSAN). Drop the ASSERT and update the comment.

Fixes #41526