### PR TITLE
Add SCONE support to Envoy Mobile

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -57,7 +57,7 @@ message QuicKeepAliveSettings {
 }
 
 // QUIC protocol options which apply to both downstream and upstream connections.
-// [#next-free-field: 13]
+// [#next-free-field: 14]
 message QuicProtocolOptions {
   // Config for QUIC connection migration across network interfaces, i.e. cellular to WIFI, upon
   // network change events from the platform, i.e. the current network gets
@@ -179,6 +179,11 @@ message QuicProtocolOptions {
   // If not specified, memory reduction is set to infinite by QUIC connection (disabled).
   google.protobuf.Duration memory_reduction_timeout = 12
       [(validate.rules).duration = {gte {seconds: 1}}];
+
+  // If true, the QUIC connection will signal support for `SCONE <https://datatracker.ietf.org/doc/draft-ietf-scone-protocol/>`_ (Standard
+  // Communication with Network Elements) and process SCONE packets.
+  // If not present, the QUICHE default behavior will be used.
+  google.protobuf.BoolValue enable_scone = 13;
 }
 
 message UpstreamHttpProtocolOptions {

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -237,6 +237,11 @@ EngineBuilder& EngineBuilder::enableEarlyData(bool early_data_on) {
   return *this;
 }
 
+EngineBuilder& EngineBuilder::enableScone(bool enable) {
+  scone_enabled_ = enable;
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::addQuicConnectionOption(std::string option) {
   quic_connection_options_.push_back(std::move(option));
   return *this;
@@ -964,6 +969,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         migration_setting->mutable_max_time_on_non_default_network()->set_seconds(
             max_time_on_non_default_network_seconds_);
       }
+    }
+
+    if (scone_enabled_) {
+      quic_protocol_options->mutable_enable_scone()->set_value(true);
     }
 
     if (use_quic_platform_packet_writer_ || enable_quic_connection_migration_) {

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -324,7 +324,7 @@ private:
   std::string upstream_tls_sni_;
   bool enable_http3_ = true;
   bool enable_early_data_{true};
-  bool scone_enabled_ = false
+  bool scone_enabled_ = false;
   std::string http3_connection_options_ = "";
   std::string http3_client_connection_options_ = "";
   // EVMB is to distinguish Envoy Mobile client connections.

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -158,6 +158,7 @@ public:
   EngineBuilder& enableSocketTagging(bool socket_tagging_on);
   EngineBuilder& enableHttp3(bool http3_on);
   EngineBuilder& enableEarlyData(bool early_data_on);
+  EngineBuilder& enableScone(bool enable);
   EngineBuilder& addQuicConnectionOption(std::string option);
   EngineBuilder& addQuicClientConnectionOption(std::string option);
   // Deprecated, use addQuicConnectionOption() instead.
@@ -323,6 +324,7 @@ private:
   std::string upstream_tls_sni_;
   bool enable_http3_ = true;
   bool enable_early_data_{true};
+  bool scone_enabled_ = false
   std::string http3_connection_options_ = "";
   std::string http3_client_connection_options_ = "";
   // EVMB is to distinguish Envoy Mobile client connections.

--- a/mobile/library/common/http/BUILD
+++ b/mobile/library/common/http/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
         "@envoy//source/common/network:socket_lib",
+        "@envoy//source/common/quic:scone_state",
         "@envoy//source/common/stats:timespan_lib",
     ],
 )

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -6,7 +6,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
-#include "source/common/quic/scone_state.h
+#include "source/common/quic/scone_state.h"
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"

--- a/mobile/library/common/http/client.cc
+++ b/mobile/library/common/http/client.cc
@@ -6,6 +6,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
+#include "source/common/quic/scone_state.h
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
@@ -408,6 +409,16 @@ void Client::DirectStream::saveLatestStreamIntel() {
   }
   stream_intel_.stream_id = static_cast<uint64_t>(stream_handle_);
   stream_intel_.attempt_count = info.attemptCount().value_or(0);
+
+  const auto* scone_state =
+    info.filterState().getDataReadOnly<Envoy::Quic::SconeState>(Envoy::Quic::SconeStateKey);
+  if (scone_state && scone_state->scone_max_kbps.has_value() && scone_state->timestamp_ms.has_value()) {
+    // Only update if the new timestamp from scone_state is greater than the last recorded timestamp.
+    if (scone_state->timestamp_ms.value() > stream_intel_.scone_timestamp_ms) {
+      stream_intel_.scone_max_kbps = scone_state->scone_max_kbps.value();
+      stream_intel_.scone_timestamp_ms = scone_state->timestamp_ms.value();
+    }
+  }
 }
 
 void Client::DirectStream::saveFinalStreamIntel() {

--- a/mobile/library/common/http/client.h
+++ b/mobile/library/common/http/client.h
@@ -349,7 +349,7 @@ private:
     // read faster than the mobile caller can process it.
     bool explicit_flow_control_ = false;
     // Latest intel data retrieved from the StreamInfo.
-    envoy_stream_intel stream_intel_{-1, -1, 0, 0};
+    envoy_stream_intel stream_intel_{-1, -1, 0, 0, -1, -1};
     envoy_final_stream_intel envoy_final_stream_intel_{-1, -1, -1, -1, -1, -1, -1, -1,
                                                        -1, -1, -1, 0,  0,  0,  0,  -1};
     StreamInfo::BytesMeterSharedPtr bytes_meter_;

--- a/mobile/library/common/types/c_types.h
+++ b/mobile/library/common/types/c_types.h
@@ -154,6 +154,10 @@ typedef struct {
   //       of bytes received before decompression. consumed_bytes_from_response omits the number
   //       number of bytes related to the Status Line, and is after decompression.
   uint64_t consumed_bytes_from_response;
+  // The latest SCONE maximum bitrate received from the network, in kbps.
+  int64_t scone_max_kbps;
+  // Time since epoch when SCONE value was received, -1 if no new value
+  int64_t scone_timestamp_ms;
 } envoy_stream_intel;
 
 /**

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -86,7 +86,8 @@ TEST(TestConfig, ConfigIsApplied) {
       .addRuntimeGuard("quic_no_tcp_delay", true)
       .enableDnsCache(true, /* save_interval_seconds */ 101)
       .addDnsPreresolveHostnames({"lyft.com", "google.com"})
-      .setDeviceOs("probably-ubuntu-on-CI");
+      .setDeviceOs("probably-ubuntu-on-CI")
+      .enableScone(true);
 
   std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
   const std::string config_str = bootstrap->ShortDebugString();
@@ -113,6 +114,7 @@ TEST(TestConfig, ConfigIsApplied) {
       "key: \"app_version\" value { string_value: \"1.2.3\" } }",
       "key: \"app_id\" value { string_value: \"1234-1234-1234\" } }",
       "initial_stream_window_size { value: 6291456 }",
+      "enable_scone { value: true }",
       "initial_connection_window_size { value: 15728640 }"};
 
   for (const auto& string : must_contain) {

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -9,8 +9,8 @@
 #include "source/common/stats/isolated_store_impl.h"
 
 #include "test/common/http/common.h"
-#include "mobile/test/common/mocks/common/mocks.h"
-#include "mobile/test/common/mocks/event/mocks.h"
+#include "test/common/mocks/common/mocks.h"
+#include "test/common/mocks/event/mocks.h"
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/common.h" 
 #include "test/mocks/event/mocks.h"

--- a/mobile/test/common/http/client_test.cc
+++ b/mobile/test/common/http/client_test.cc
@@ -1,16 +1,22 @@
-#include <atomic>
+#include <cstdint> 
+#include <memory>  
 
+#include "envoy/http/header_map.h" 
+#include "envoy/stream_info/filter_state.h" 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/http/header_map_impl.h" 
+#include "source/common/quic/scone_state.h"  
 #include "source/common/stats/isolated_store_impl.h"
 
 #include "test/common/http/common.h"
-#include "test/common/mocks/common/mocks.h"
-#include "test/common/mocks/event/mocks.h"
+#include "mobile/test/common/mocks/common/mocks.h"
+#include "mobile/test/common/mocks/event/mocks.h"
 #include "test/mocks/buffer/mocks.h"
+#include "test/mocks/common.h" 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/api_listener.h"
 #include "test/mocks/http/mocks.h"
-#include "test/mocks/upstream/mocks.h"
+#include "test/test_common/utility.h" 
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -25,10 +31,7 @@ using testing::ContainsRegex;
 using testing::Eq;
 using testing::NiceMock;
 using testing::Return;
-using testing::ReturnPointee;
 using testing::ReturnRef;
-using testing::SaveArg;
-using testing::WithArg;
 
 namespace Envoy {
 namespace Http {
@@ -150,6 +153,11 @@ protected:
         }));
     http_client_.startStream(stream_, std::move(stream_callbacks), explicit_flow_control_ != OFF);
   }
+
+  Client::DirectStreamSharedPtr getDirectStream(envoy_stream_t stream_handle) {
+    return http_client_.getStream(stream_handle, Client::GetStreamFilters::AllowOnlyForOpenStreams);
+  }
+
 
   void resumeDataIfEarlyResume(int32_t bytes) {
     if (explicit_flow_control_ == EARLY_RESUME) {
@@ -821,6 +829,89 @@ TEST_P(ClientTest, NullAccessors) {
   EXPECT_FALSE(response_encoder_->http1StreamEncoderOptions().has_value());
   EXPECT_FALSE(response_encoder_->streamErrorOnInvalidHttpMessage());
 }
+
+TEST_P(ClientTest, SaveLatestStreamIntelPopulatesScone) {
+  StreamCallbacksCalled callbacks_called;
+  createStream(createDefaultStreamCallbacks(callbacks_called));
+
+  auto scone_state = std::make_shared<Quic::SconeState>();
+  scone_state->scone_max_kbps = 100;
+  scone_state->timestamp_ms = 12345;
+  stream_info_.filter_state_->setData(
+      Quic::SconeStateKey, scone_state,
+      StreamInfo::FilterState::StateType::Mutable,
+      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto stream_ptr = getDirectStream(stream_);
+  ASSERT_NE(stream_ptr, nullptr);
+
+  stream_ptr->saveLatestStreamIntel();
+
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_max_kbps, 100);
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_timestamp_ms, 12345);
+  EXPECT_TRUE(scone_state->scone_max_kbps.has_value());
+  EXPECT_TRUE(scone_state->timestamp_ms.has_value());
+}
+
+TEST_P(ClientTest, SaveLatestStreamIntelPersistsScone) {
+  StreamCallbacksCalled callbacks_called;
+  createStream(createDefaultStreamCallbacks(callbacks_called));
+
+  auto scone_state = std::make_shared<Quic::SconeState>();
+  scone_state->scone_max_kbps = 100;
+  scone_state->timestamp_ms = 12345;
+  stream_info_.filter_state_->setData(
+      Quic::SconeStateKey, scone_state,
+      StreamInfo::FilterState::StateType::Mutable,
+      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto stream_ptr = getDirectStream(stream_);
+  ASSERT_NE(stream_ptr, nullptr);
+
+  stream_ptr->saveLatestStreamIntel();
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_max_kbps, 100);
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_timestamp_ms, 12345);
+
+  stream_ptr->saveLatestStreamIntel();
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_max_kbps, 100);
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_timestamp_ms, 12345);
+}
+
+TEST_P(ClientTest, SaveLatestStreamIntelWithNoSconeData) {
+  StreamCallbacksCalled callbacks_called;
+  createStream(createDefaultStreamCallbacks(callbacks_called));
+
+  auto stream_ptr = getDirectStream(stream_);
+  ASSERT_NE(stream_ptr, nullptr);
+
+  stream_ptr->saveLatestStreamIntel();
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_max_kbps, -1);
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_timestamp_ms, -1);
+}
+
+TEST_P(ClientTest, SaveLatestStreamIntelWithZeroSconeValue) {
+  StreamCallbacksCalled callbacks_called;
+  createStream(createDefaultStreamCallbacks(callbacks_called));
+
+  auto scone_state = std::make_shared<Quic::SconeState>();
+  scone_state->scone_max_kbps = 0;
+  scone_state->timestamp_ms = 12345;
+  stream_info_.filter_state_->setData(
+      Quic::SconeStateKey, scone_state,
+      StreamInfo::FilterState::StateType::Mutable,
+      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto stream_ptr = getDirectStream(stream_);
+  ASSERT_NE(stream_ptr, nullptr);
+
+  stream_ptr->saveLatestStreamIntel();
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_max_kbps, 0);
+  EXPECT_EQ(stream_ptr->stream_intel_.scone_timestamp_ms, 12345);
+  EXPECT_TRUE(scone_state->scone_max_kbps.has_value());
+  EXPECT_TRUE(scone_state->timestamp_ms.has_value());
+}
+
+
 
 using ExplicitFlowControlTest = ClientTest;
 INSTANTIATE_TEST_SUITE_P(TestEarlyResume, ExplicitFlowControlTest,

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -40,6 +40,7 @@ envoy_cc_test(
         "@envoy//test/test_common:threadsafe_singleton_injector_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_build_config//:test_extensions",
+        "@quiche//quiche/quic/test_tools:quic_test_utils",
     ],
 )
 

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -40,7 +40,7 @@ envoy_cc_test(
         "@envoy//test/test_common:threadsafe_singleton_injector_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_build_config//:test_extensions",
-        "@quiche//quiche/quic/test_tools:quic_test_utils",
+        "@quiche//:quic_test_tools_test_utils_lib"
     ],
 )
 

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -29,6 +29,7 @@
 #include "library/common/network/network_types.h"
 #include "library/common/network/proxy_settings.h"
 #include "library/common/types/c_types.h"
+#include "quiche/quic/test_tools/quic_test_utils.h"
 
 using testing::_;
 using testing::AnyNumber;
@@ -1889,6 +1890,243 @@ TEST_P(ClientIntegrationTest, HttpsWithEarlyData) {
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.fix_http3_early_data_timing")) {
     EXPECT_EQ(1, getCounterValue("cluster.base.upstream_rq_0rtt"));
   }
+}
+class MockRecvMsgOsSysCalls : public Api::OsSysCallsImpl {
+public:
+  MockRecvMsgOsSysCalls() {
+    ON_CALL(*this, recvmsg(_, _, _))
+        .WillByDefault(Invoke([this](os_fd_t sockfd, msghdr* msg, int flags) {
+          auto result = Api::OsSysCallsImpl::recvmsg(sockfd, msg, flags);
+          int16_t bandwidth = scone_bandwidth_.exchange(-1);
+          if (result.return_value_ <= 0 || bandwidth == -1) {
+            return result;
+          }
+
+          std::vector<char> new_buffer(result.return_value_);
+          if (quic::test::MaybeUpdateSconePacket(
+                  reinterpret_cast<const char*>(msg->msg_iov[0].iov_base),
+                  new_buffer.data(), result.return_value_,
+                  static_cast<uint8_t>(bandwidth))) {
+            memcpy(msg->msg_iov[0].iov_base, new_buffer.data(), result.return_value_);
+          }
+          return result;
+        }));
+  }
+
+  MOCK_METHOD(Api::SysCallSizeResult, recvmsg,
+              (os_fd_t sockfd, msghdr* msg, int flags), (override));
+
+  std::atomic<int16_t> scone_bandwidth_{-1};
+};
+
+TEST_P(ClientIntegrationTest, SconeValuePropagation) {
+  if (upstreamProtocol() != Http::CodecType::HTTP3) {
+    return;
+  }
+
+  const int16_t expected_bandwidth = 127;
+
+  MockRecvMsgOsSysCalls sys_calls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&sys_calls);
+
+  builder_.enableScone(true);
+  initialize();
+
+  int64_t captured_scone_max_kbps = -1;
+  int64_t captured_scone_timestamp_ms = -1;
+
+  EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                     bool, envoy_stream_intel intel) {
+    cc_.on_headers_calls_++;
+    cc_.status_ = absl::StrCat(headers.getStatusValue());
+    captured_scone_max_kbps = intel.scone_max_kbps;
+    captured_scone_timestamp_ms = intel.scone_timestamp_ms;
+  };
+
+  stream_ = createNewStream(std::move(stream_callbacks));
+  sys_calls.scone_bandwidth_.store(expected_bandwidth);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(
+                           default_request_headers_),
+                       true);
+
+  cc_.terminal_callback_->waitReady();
+
+  EXPECT_EQ(captured_scone_max_kbps, expected_bandwidth);
+  EXPECT_GT(captured_scone_timestamp_ms, 0);
+
+  int64_t captured_scone_max_kbps2 = -1;
+  int64_t captured_scone_timestamp_ms2 = -1;
+  EnvoyStreamCallbacks stream_callbacks2 = createDefaultStreamCallbacks();
+  stream_callbacks2.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                      bool, envoy_stream_intel intel) {
+    cc_.on_headers_calls_++;
+    cc_.status_ = absl::StrCat(headers.getStatusValue());
+    captured_scone_max_kbps2 = intel.scone_max_kbps;
+    captured_scone_timestamp_ms2 = intel.scone_timestamp_ms;
+  };
+
+  ConditionalInitializer terminal_callback2;
+  cc_.terminal_callback_ = &terminal_callback2;
+
+  auto stream2 = createNewStream(std::move(stream_callbacks2));
+  stream2->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(
+                           default_request_headers_),
+                       true);
+
+  terminal_callback2.waitReady();
+
+  EXPECT_EQ(captured_scone_max_kbps2, expected_bandwidth);
+  EXPECT_GT(captured_scone_timestamp_ms2, 0);
+}
+
+TEST_P(ClientIntegrationTest, SconeValuePropagationDelayed) {
+  if (upstreamProtocol() != Http::CodecType::HTTP3) {
+    return;
+  }
+
+  const int16_t expected_bandwidth = 50;
+
+  MockRecvMsgOsSysCalls sys_calls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&sys_calls);
+
+  builder_.enableScone(true);
+  initialize();
+
+  int64_t captured_scone_max_kbps_headers = -1;
+  int64_t captured_scone_max_kbps_data = -1;
+  int64_t captured_scone_timestamp_ms_headers = -1;
+  int64_t captured_scone_timestamp_ms_data = -1;
+
+  absl::Notification headers_received;
+  absl::Notification data_received;
+
+  EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                     bool, envoy_stream_intel intel) {
+    cc_.on_headers_calls_++;
+    cc_.status_ = absl::StrCat(headers.getStatusValue());
+    captured_scone_max_kbps_headers = intel.scone_max_kbps;
+    captured_scone_timestamp_ms_headers = intel.scone_timestamp_ms;
+    if (!headers_received.HasBeenNotified()) {
+      headers_received.Notify();
+    }
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t, bool, envoy_stream_intel intel) {
+    cc_.on_data_calls_++;
+    captured_scone_max_kbps_data = intel.scone_max_kbps;
+    captured_scone_timestamp_ms_data = intel.scone_timestamp_ms;
+    if (!data_received.HasBeenNotified()) {
+      data_received.Notify();
+    }
+  };
+
+  stream_ = createNewStream(std::move(stream_callbacks));
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(
+                           default_request_headers_),
+                       true);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
+                                                        upstream_connection_));
+  ASSERT_TRUE(
+      upstream_connection_->waitForNewStream(*BaseIntegrationTest::dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*BaseIntegrationTest::dispatcher_));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+
+  headers_received.WaitForNotification();
+
+  EXPECT_EQ(captured_scone_max_kbps_headers, -1);
+  EXPECT_EQ(captured_scone_timestamp_ms_headers, -1);
+
+  sys_calls.scone_bandwidth_.store(expected_bandwidth);
+
+  upstream_request_->encodeData(10, false);
+
+  data_received.WaitForNotification();
+
+  EXPECT_EQ(captured_scone_max_kbps_data, expected_bandwidth);
+  EXPECT_GT(captured_scone_timestamp_ms_data, 0);
+
+  upstream_request_->encodeData(0, true);
+
+  terminal_callback_.waitReady();
+}
+
+TEST_P(ClientIntegrationTest, SconeValuePropagationMultipleUpdates) {
+  if (upstreamProtocol() != Http::CodecType::HTTP3) {
+    return;
+  }
+
+  const int16_t expected_bandwidth_1 = 10;
+  const int16_t expected_bandwidth_2 = 20;
+
+  MockRecvMsgOsSysCalls sys_calls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&sys_calls);
+
+  builder_.enableScone(true);
+  initialize();
+
+  int64_t captured_scone_max_kbps_headers = -1;
+  int64_t captured_scone_max_kbps_data = -1;
+  int64_t captured_scone_timestamp_ms_headers = -1;
+  int64_t captured_scone_timestamp_ms_data = -1;
+
+  absl::Notification headers_received;
+  absl::Notification data_received;
+
+  EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
+  stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                     bool, envoy_stream_intel intel) {
+    cc_.on_headers_calls_++;
+    cc_.status_ = absl::StrCat(headers.getStatusValue());
+    captured_scone_max_kbps_headers = intel.scone_max_kbps;
+    captured_scone_timestamp_ms_headers = intel.scone_timestamp_ms;
+    if (!headers_received.HasBeenNotified()) {
+      headers_received.Notify();
+    }
+  };
+  stream_callbacks.on_data_ = [&](const Buffer::Instance&, uint64_t, bool, envoy_stream_intel intel) {
+    cc_.on_data_calls_++;
+    captured_scone_max_kbps_data = intel.scone_max_kbps;
+    captured_scone_timestamp_ms_data = intel.scone_timestamp_ms;
+    if (!data_received.HasBeenNotified()) {
+      data_received.Notify();
+    }
+  };
+
+  stream_ = createNewStream(std::move(stream_callbacks));
+  sys_calls.scone_bandwidth_.store(expected_bandwidth_1);
+  stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(
+                           default_request_headers_),
+                       true);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*BaseIntegrationTest::dispatcher_,
+                                                        upstream_connection_));
+  ASSERT_TRUE(
+      upstream_connection_->waitForNewStream(*BaseIntegrationTest::dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*BaseIntegrationTest::dispatcher_));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+
+  headers_received.WaitForNotification();
+
+  EXPECT_EQ(captured_scone_max_kbps_headers, expected_bandwidth_1);
+  EXPECT_GT(captured_scone_timestamp_ms_headers, 0);
+
+  sys_calls.scone_bandwidth_.store(expected_bandwidth_2);
+
+  upstream_request_->encodeData(10, false);
+
+  data_received.WaitForNotification();
+
+  EXPECT_EQ(captured_scone_max_kbps_data, expected_bandwidth_2);
+  EXPECT_GT(captured_scone_timestamp_ms_data, 0);
+  EXPECT_GE(captured_scone_timestamp_ms_data, captured_scone_timestamp_ms_headers);
+
+  upstream_request_->encodeData(0, true);
+
+  terminal_callback_.waitReady();
 }
 } // namespace
 } // namespace Envoy

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -79,6 +79,17 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "scone_state",
+    srcs = envoy_select_enable_http3(["scone_state.cc"]),
+    hdrs = envoy_select_enable_http3(["scone_state.h"]),
+    deps = envoy_select_enable_http3([
+        "@abseil-cpp//absl/strings:string_view",
+        "@abseil-cpp//absl/types:optional",
+        "//envoy/stream_info:filter_state_interface",
+    ]),
+)
+
+envoy_cc_library(
     name = "quic_stat_names_lib",
     srcs = ["quic_stat_names.cc"],
     hdrs = ["quic_stat_names.h"],
@@ -311,6 +322,7 @@ envoy_cc_library(
     ]),
     deps = envoy_select_enable_http3([
         ":envoy_quic_client_connection_lib",
+        ":scone_state",
         ":envoy_quic_client_crypto_stream_factory_lib",
         ":envoy_quic_proof_verifier_lib",
         ":envoy_quic_stream_lib",

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -11,6 +11,9 @@
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/quic/quic_filter_manager_connection_impl.h"
 #include "source/common/quic/quic_network_connectivity_observer_impl.h"
+#include "source/common/quic/scone_state.h"
+
+#include "quiche/quic/core/quic_bandwidth.h"
 
 namespace Envoy {
 namespace Quic {
@@ -116,6 +119,10 @@ EnvoyQuicClientSession::EnvoyQuicClientSession(
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
   http_datagram_support_ = quic::HttpDatagramSupport::kRfc;
 #endif
+
+  streamInfo().filterState()->setData(SconeStateKey, std::make_shared<SconeState>(),
+                                      StreamInfo::FilterState::StateType::Mutable,
+                                      StreamInfo::FilterState::LifeSpan::Connection);
 }
 
 EnvoyQuicClientSession::~EnvoyQuicClientSession() {
@@ -350,6 +357,20 @@ void EnvoyQuicClientSession::StartDraining() {
   if (http_connection_callbacks_ != nullptr) {
     // HTTP/3 GOAWAY doesn't have an error code field.
     http_connection_callbacks_->onGoAway(Http::GoAwayErrorCode::NoError);
+  }
+}
+
+void EnvoyQuicClientSession::OnSconePacket(quic::QuicBandwidth bandwidth) {
+  auto* state = streamInfo().filterState()->getDataMutable<SconeState>(SconeStateKey);
+  if (state) {
+    state->scone_max_kbps = bandwidth.ToKBitsPerSecond();
+    auto now = dispatcher_.timeSource().systemTime();
+    state->timestamp_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+    ENVOY_CONN_LOG(debug, "SCONE update: {} kbps at {} ms", *this, bandwidth.ToKBitsPerSecond(),
+                   state->timestamp_ms.value());
+  } else {
+    IS_ENVOY_BUG("SconeState not found in FilterState");
   }
 }
 

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -10,6 +10,7 @@
 #include "source/common/quic/quic_network_connectivity_observer.h"
 #include "source/common/quic/quic_stat_names.h"
 #include "source/common/quic/quic_transport_socket_factory.h"
+#include "source/common/quic/scone_state.h"
 
 #include "quiche/quic/core/http/quic_spdy_client_session.h"
 
@@ -79,6 +80,7 @@ public:
   quic::HttpDatagramSupport LocalHttpDatagramSupport() override { return http_datagram_support_; }
   std::vector<std::string> GetAlpnsToOffer() const override;
   void OnConfigNegotiated() override;
+  void OnSconePacket(quic::QuicBandwidth bandwidth) override;
 
   // quic::QuicSpdyClientSessionBase
   bool ShouldKeepConnectionAlive() const override;

--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -410,6 +410,9 @@ void convertQuicConfig(const envoy::config::core::v3::QuicProtocolOptions& confi
     quic_config.SetIdleNetworkTimeout(quic::QuicTimeDelta::FromSeconds(
         DurationUtil::durationToSeconds(config.idle_network_timeout())));
   }
+  if (config.has_enable_scone()) {
+    quic_config.set_parse_scone_packets(config.enable_scone().value());
+  }
 }
 
 void configQuicInitialFlowControlWindow(const envoy::config::core::v3::QuicProtocolOptions& config,

--- a/source/common/quic/scone_state.cc
+++ b/source/common/quic/scone_state.cc
@@ -1,0 +1,9 @@
+#include "source/common/quic/scone_state.h"
+
+namespace Envoy {
+namespace Quic {
+
+SconeState::~SconeState() = default;
+
+} // namespace Quic
+} // namespace Envoy

--- a/source/common/quic/scone_state.h
+++ b/source/common/quic/scone_state.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+#include "envoy/stream_info/filter_state.h"
+
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace Quic {
+
+// This struct stores the latest SCONE maximum bitrate received from the network.
+// It's designed to be stored in the FilterState.
+struct SconeState : public StreamInfo::FilterState::Object {
+  ~SconeState() override;
+  absl::optional<int64_t> scone_max_kbps;
+  absl::optional<int64_t> timestamp_ms;
+};
+
+// Unique key to access SconeState within the FilterState.
+constexpr absl::string_view SconeStateKey = "envoy.quic.scone_state";
+
+} // namespace Quic
+} // namespace Envoy

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -201,6 +201,7 @@ envoy_cc_test(
         "//source/common/quic:envoy_quic_alarm_factory_lib",
         "//source/common/quic:envoy_quic_client_connection_lib",
         "//source/common/quic:envoy_quic_client_session_lib",
+        "//source/common/quic:scone_state",
         "//source/common/quic:envoy_quic_connection_helper_lib",
         "//source/common/quic:quic_client_packet_writer_factory_impl_lib",
         "//source/extensions/quic/crypto_stream:envoy_quic_crypto_client_stream_lib",

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -10,6 +10,7 @@
 #include "source/common/quic/envoy_quic_connection_helper.h"
 #include "source/common/quic/envoy_quic_utils.h"
 #include "source/common/quic/quic_client_packet_writer_factory_impl.h"
+#include "source/common/quic/scone_state.h"
 #include "source/extensions/quic/crypto_stream/envoy_quic_crypto_client_stream.h"
 
 #include "test/common/quic/test_utils.h"
@@ -29,6 +30,7 @@
 #include "gtest/gtest.h"
 #include "quiche/quic/core/crypto/null_encrypter.h"
 #include "quiche/quic/core/deterministic_connection_id_generator.h"
+#include "quiche/quic/core/quic_bandwidth.h"
 #include "quiche/quic/test_tools/crypto_test_utils.h"
 #include "quiche/quic/test_tools/quic_session_peer.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
@@ -791,6 +793,38 @@ TEST_P(EnvoyQuicClientSessionTest, UsesUdpGro) {
 
   EXPECT_LOG_CONTAINS("trace", "starting gro recvmsg with max",
                       dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit));
+}
+
+TEST_P(EnvoyQuicClientSessionTest, OnSconePacketUpdatesFilterState) {
+  envoy_quic_session_->OnSconePacket(quic::QuicBandwidth::FromKBitsPerSecond(100));
+
+  auto filter_state = envoy_quic_session_->streamInfo().filterState();
+  ASSERT_TRUE(filter_state->hasData<SconeState>(SconeStateKey));
+  auto scone_state = filter_state->getDataReadOnly<SconeState>(SconeStateKey);
+  ASSERT_TRUE(scone_state->scone_max_kbps.has_value());
+  EXPECT_EQ(scone_state->scone_max_kbps.value(), 100);
+  ASSERT_TRUE(scone_state->timestamp_ms.has_value());
+  EXPECT_GT(scone_state->timestamp_ms.value(), 0);
+
+  // Verify that multiple calls to OnSconePacket with different bandwidth values correctly update
+  // the scone_max_kbps
+  envoy_quic_session_->OnSconePacket(quic::QuicBandwidth::FromKBitsPerSecond(200));
+  ASSERT_TRUE(scone_state->scone_max_kbps.has_value());
+  EXPECT_EQ(scone_state->scone_max_kbps.value(), 200);
+  ASSERT_TRUE(scone_state->timestamp_ms.has_value());
+
+  // Verify that the SconeState object persists across multiple calls
+  envoy_quic_session_->OnSconePacket(quic::QuicBandwidth::FromKBitsPerSecond(300));
+  ASSERT_TRUE(scone_state->scone_max_kbps.has_value());
+  EXPECT_EQ(scone_state->scone_max_kbps.value(), 300);
+  ASSERT_TRUE(scone_state->timestamp_ms.has_value());
+}
+
+TEST_P(EnvoyQuicClientSessionTest, SconeStateInitialization) {
+  auto filter_state = envoy_quic_session_->streamInfo().filterState();
+  ASSERT_TRUE(filter_state->hasData<SconeState>(SconeStateKey));
+  auto scone_state = filter_state->getDataReadOnly<SconeState>(SconeStateKey);
+  EXPECT_FALSE(scone_state->scone_max_kbps.has_value());
 }
 
 TEST_P(EnvoyQuicClientSessionTest, SetSocketOption) {

--- a/test/common/quic/envoy_quic_utils_test.cc
+++ b/test/common/quic/envoy_quic_utils_test.cc
@@ -237,6 +237,14 @@ TEST(EnvoyQuicUtilsTest, ConvertQuicConfig) {
     quic_ccopts.append(quic::QuicTagToString(ccopt));
   }
   EXPECT_EQ(quic_ccopts, "6RTOAKD4");
+
+  config.mutable_enable_scone()->set_value(true);
+  convertQuicConfig(config, quic_config);
+  EXPECT_TRUE(quic_config.parse_scone_packets());
+
+  config.mutable_enable_scone()->set_value(false);
+  convertQuicConfig(config, quic_config);
+  EXPECT_FALSE(quic_config.parse_scone_packets());
 }
 
 TEST(EnvoyQuicUtilsTest, HeaderMapMaxSizeLimit) {

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1700,3 +1700,6 @@ nblk
 chr
 IWYU
 CRTP
+bitrate
+kbps
+flushall


### PR DESCRIPTION
feat: Add SCONE support to Envoy Mobile

This commit introduces support for SCONE (Standardized Communication
with Network Elements) in Envoy Mobile.

Key changes include:

- API to enable/disable SCONE in EngineBuilder.
- SconeState object to store SCONE data within FilterState.
- Integration with QUICHE to receive SCONE packet updates via
  EnvoyQuicClientSession::OnSconePacket.
- Propagation of SCONE bandwidth and timestamp to the mobile application
  via envoy_stream_intel.
- Integration tests to verify SCONE value propagation, including
  delayed and multiple update scenarios.
- Added new terms (bitrate, scone_max_kbps) to spelling dictionary.