### PR TITLE
docs, http_capsule: fix 'occured' -> 'occurred' in geoip docs and UDP capsule log

### DIFF
--- a/docs/root/configuration/http/http_filters/geoip_filter.rst
+++ b/docs/root/configuration/http/http_filters/geoip_filter.rst
@@ -61,7 +61,7 @@ per geolocation database type (rooted at ``<stat_prefix>.maxmind.``). Database t
 
    ``<db_type>.total``, Counter, Total number of lookups performed for a given geolocation database file.
    ``<db_type>.hit``, Counter, Total number of successful lookups (with non empty lookup result) performed for a given geolocation database file.
-   ``<db_type>.lookup_error``, Counter, Total number of errors that occured during lookups for a given geolocation database file.
+   ``<db_type>.lookup_error``, Counter, Total number of errors that occurred during lookups for a given geolocation database file.
    ``<db_type>.db_reload_success``, Counter, Total number of times when the geolocation database file was reloaded successfully.
    ``<db_type>.db_reload_error``, Counter, Total number of times when the geolocation database file failed to reload.
    ``<db_type>.db_build_epoch``, Gauge, The build timestamp of the geolocation database file represented as a Unix epoch value.

--- a/docs/root/configuration/listeners/network_filters/geoip_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/geoip_filter.rst
@@ -144,7 +144,7 @@ Database type can be one of `city_db <https://www.maxmind.com/en/geoip2-city>`_,
 
    ``<db_type>.total``, Counter, Total number of lookups performed for a given geolocation database file.
    ``<db_type>.hit``, Counter, Total number of successful lookups (with non empty lookup result) performed for a given geolocation database file.
-   ``<db_type>.lookup_error``, Counter, Total number of errors that occured during lookups for a given geolocation database file.
+   ``<db_type>.lookup_error``, Counter, Total number of errors that occurred during lookups for a given geolocation database file.
    ``<db_type>.db_reload_success``, Counter, Total number of times when the geolocation database file was reloaded successfully.
    ``<db_type>.db_reload_error``, Counter, Total number of times when the geolocation database file failed to reload.
    ``<db_type>.db_build_epoch``, Gauge, The build timestamp of the geolocation database file represented as a Unix epoch value.

--- a/source/extensions/filters/udp/udp_proxy/session_filters/http_capsule/http_capsule.cc
+++ b/source/extensions/filters/udp/udp_proxy/session_filters/http_capsule/http_capsule.cc
@@ -33,7 +33,7 @@ WriteFilterStatus HttpCapsuleFilter::onWrite(Network::UdpRecvData& data) {
   for (const Buffer::RawSlice& slice : data.buffer_->getRawSlices()) {
     absl::string_view mem_slice(reinterpret_cast<const char*>(slice.mem_), slice.len_);
     if (!capsule_parser_.IngestCapsuleFragment(mem_slice)) {
-      ENVOY_LOG(error, "Capsule ingestion error occured: slice length = {}", slice.len_);
+      ENVOY_LOG(error, "Capsule ingestion error occurred: slice length = {}", slice.len_);
       break;
     }
   }


### PR DESCRIPTION
Fix remaining 3 occurrences of \`occured\` → \`occurred\` after #44485:

| File | Kind |
|------|------|
| \`docs/root/configuration/http/http_filters/geoip_filter.rst\` line 64 | Docs (HTTP geoip filter) |
| \`docs/root/configuration/listeners/network_filters/geoip_filter.rst\` line 147 | Docs (listener geoip filter) |
| \`source/extensions/filters/udp/udp_proxy/session_filters/http_capsule/http_capsule.cc\` line 36 | \`ENVOY_LOG(error, ...)\` log format string |

All user-visible in docs / log output. No behavior change.

Risk Level: Low (docs + log string)
Testing: N/A — string-literal-only change.