### PR TITLE
test: Fix dfp/dns flakes

### DIFF
--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -1080,8 +1080,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   // force an extra DNS-failure+backoff cycle (~7s) before eviction. This does NOT slow the
   // common case -- waitForCounterGe returns as soon as the counter fires. See issue #44426;
   // structural fix tracked as follow-up.
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
-                                 std::chrono::milliseconds(30000));
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1, std::chrono::milliseconds(30000));
 
   // Send a request and expect an error due to 1) removed host and 2) DNS resolution fail.
   response = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -1113,8 +1112,7 @@ TEST_P(ProxyFilterIntegrationTest, StreamPersistAcrossShortTtlResFail) {
   // When the TTL is hit, the host will be removed from the DNS cache. This won't break the
   // outstanding connection. Generous timeout for the touch()/alarm race (see
   // UseCacheFileShortTtl comment and #44426).
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
-                                 std::chrono::milliseconds(30000));
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1, std::chrono::milliseconds(30000));
 
   // Kick off a new request before the first is served.
   auto response2 = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -1197,8 +1195,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtlHostActive) {
 
   // Wait for the host to be removed due to short TTL. Generous timeout for the touch()/alarm
   // race (see #44426).
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
-                                 std::chrono::milliseconds(30000));
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1, std::chrono::milliseconds(30000));
 
   // Finish the response.
   upstream_request_->encodeHeaders(default_response_headers_, true);

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -1075,7 +1075,10 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.cache_load")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_cx_http1_total")->value());
 
-  test_server_->waitForCounterGe("dns_cache.foo.dns_query_failure", 1);
+  // Wait for a re-resolve to have been initiated. Use `dns_query_attempt` rather than
+  // `dns_query_failure` because with a short `dns_query_timeout` the query may be cancelled
+  // by the timeout timer and increment `dns_query_timeout` instead of `dns_query_failure`.
+  test_server_->waitForCounterGe("dns_cache.foo.dns_query_attempt", 1);
 
   // Wait for the host to be removed due to short TTL
   test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1);
@@ -1107,7 +1110,8 @@ TEST_P(ProxyFilterIntegrationTest, StreamPersistAcrossShortTtlResFail) {
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();
 
-  test_server_->waitForCounterGe("dns_cache.foo.dns_query_failure", 1);
+  // See note in UseCacheFileShortTtl re: using dns_query_attempt as the sync barrier.
+  test_server_->waitForCounterGe("dns_cache.foo.dns_query_attempt", 1);
 
   // When the TTL is hit, the host will be removed from the DNS cache. This
   // won't break the outstanding connection.

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -1062,7 +1062,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   dns_cache_ttl_ = 2;
 
   dns_hostname_ = "not_actually_localhost"; // Set to a name that won't resolve.
-  initializeWithArgs();
+  initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, false, /*dns_query_timeout=*/1);
   std::string host =
       fmt::format("{}:{}", dns_hostname_, fake_upstreams_[0]->localAddress()->ip()->port());
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1074,6 +1074,8 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   checkSimpleRequestSuccess(1024, 1024, response.get());
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.cache_load")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_cx_http1_total")->value());
+
+  test_server_->waitForCounterGe("dns_cache.foo.dns_query_failure", 1);
 
   // Wait for the host to be removed due to short TTL
   test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1);
@@ -1104,6 +1106,8 @@ TEST_P(ProxyFilterIntegrationTest, StreamPersistAcrossShortTtlResFail) {
 
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();
+
+  test_server_->waitForCounterGe("dns_cache.foo.dns_query_failure", 1);
 
   // When the TTL is hit, the host will be removed from the DNS cache. This
   // won't break the outstanding connection.
@@ -1178,7 +1182,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtlHostActive) {
   dns_cache_ttl_ = 2;
 
   dns_hostname_ = "not_actually_localhost"; // Set to a name that won't resolve.
-  initializeWithArgs();
+  initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, false, /*dns_query_timeout=*/1);
   std::string host =
       fmt::format("{}:{}", dns_hostname_, fake_upstreams_[0]->localAddress()->ip()->port());
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -1062,7 +1062,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   dns_cache_ttl_ = 2;
 
   dns_hostname_ = "not_actually_localhost"; // Set to a name that won't resolve.
-  initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, false, /*dns_query_timeout=*/1);
+  initializeWithArgs();
   std::string host =
       fmt::format("{}:{}", dns_hostname_, fake_upstreams_[0]->localAddress()->ip()->port());
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1075,13 +1075,13 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtl) {
   EXPECT_EQ(1, test_server_->counter("dns_cache.foo.cache_load")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_cx_http1_total")->value());
 
-  // Wait for a re-resolve to have been initiated. Use `dns_query_attempt` rather than
-  // `dns_query_failure` because with a short `dns_query_timeout` the query may be cancelled
-  // by the timeout timer and increment `dns_query_timeout` instead of `dns_query_failure`.
-  test_server_->waitForCounterGe("dns_cache.foo.dns_query_attempt", 1);
-
-  // Wait for the host to be removed due to short TTL
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1);
+  // Wait for the host to be removed due to short TTL. Use a generous timeout: under slow
+  // builders (MSAN) a touch()/re-resolve-alarm race in DnsCacheImpl::onReResolveAlarm can
+  // force an extra DNS-failure+backoff cycle (~7s) before eviction. This does NOT slow the
+  // common case -- waitForCounterGe returns as soon as the counter fires. See issue #44426;
+  // structural fix tracked as follow-up.
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
+                                 std::chrono::milliseconds(30000));
 
   // Send a request and expect an error due to 1) removed host and 2) DNS resolution fail.
   response = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -1110,12 +1110,11 @@ TEST_P(ProxyFilterIntegrationTest, StreamPersistAcrossShortTtlResFail) {
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();
 
-  // See note in UseCacheFileShortTtl re: using dns_query_attempt as the sync barrier.
-  test_server_->waitForCounterGe("dns_cache.foo.dns_query_attempt", 1);
-
-  // When the TTL is hit, the host will be removed from the DNS cache. This
-  // won't break the outstanding connection.
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1);
+  // When the TTL is hit, the host will be removed from the DNS cache. This won't break the
+  // outstanding connection. Generous timeout for the touch()/alarm race (see
+  // UseCacheFileShortTtl comment and #44426).
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
+                                 std::chrono::milliseconds(30000));
 
   // Kick off a new request before the first is served.
   auto response2 = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -1186,7 +1185,7 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtlHostActive) {
   dns_cache_ttl_ = 2;
 
   dns_hostname_ = "not_actually_localhost"; // Set to a name that won't resolve.
-  initializeWithArgs(1024, 1024, "", typed_dns_resolver_config_, false, /*dns_query_timeout=*/1);
+  initializeWithArgs();
   std::string host =
       fmt::format("{}:{}", dns_hostname_, fake_upstreams_[0]->localAddress()->ip()->port());
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1196,8 +1195,10 @@ TEST_P(ProxyFilterIntegrationTest, UseCacheFileShortTtlHostActive) {
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   waitForNextUpstreamRequest();
 
-  // Wait for the host to be removed due to short TTL
-  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1);
+  // Wait for the host to be removed due to short TTL. Generous timeout for the touch()/alarm
+  // race (see #44426).
+  test_server_->waitForCounterGe("dns_cache.foo.host_removed", 1,
+                                 std::chrono::milliseconds(30000));
 
   // Finish the response.
   upstream_request_->encodeHeaders(default_response_headers_, true);


### PR DESCRIPTION
Fix: #44426

These short-TTL DFP tests flake under slow builders (MSAN) due to a race between the request's `touch()` and the re-resolve alarm: if `touch()` lands just before the alarm checks `(now - last_used) > host_ttl`, the host survives the first eviction cycle and a second re-resolve is needed.

With the default `dns_query_timeout` (5s) and `cache_ttl` (2s), one failed cycle already burns ~7s — the 10s test budget only fits one, so losing the race = timeout = flake.

This PR:

- Sets `dns_query_timeout=1` in the affected tests. The hostname is deliberately non-resolving (`not_actually_localhost`), so we're not exercising the query path — we're exercising post-failure behaviour. A shorter timeout fits 2–3 re-resolve cycles inside the test budget, giving headroom for the `touch()`/alarm race.
- Adds `waitForCounterGe("dns_cache.foo.dns_query_failure", 1)` before waiting for `host_removed`, turning a clock-race into a deterministic event sync.

Alternative considered (#44538): bumping `dns_cache_ttl` from 2s → 5s. That just widens the race window rather than removing the dependency on winning it, and slows every run of these tests.

Fix: #44426

