### PR TITLE
Use plain atomic<uint64_t> for last HC status

### DIFF
--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -390,9 +390,12 @@ public:
   uint32_t healthFlagsGetAll() const override { return health_flags_; }
   void healthFlagsSetAll(uint32_t bits) override { health_flags_ |= bits; }
 
-  void setLastHealthCheckHttpStatus(uint64_t status) override { last_hc_http_status_ = status; }
+  void setLastHealthCheckHttpStatus(uint64_t status) override {
+    last_hc_http_status_.store(status, std::memory_order_relaxed);
+  }
   absl::optional<uint64_t> lastHealthCheckHttpStatus() const override {
-    return last_hc_http_status_;
+    const uint64_t status = last_hc_http_status_.load(std::memory_order_relaxed);
+    return status == 0 ? absl::nullopt : absl::make_optional(status);
   }
 
   Host::HealthStatus healthStatus() const override {
@@ -483,7 +486,8 @@ private:
   // flag access? May be we could refactor HealthFlag to contain all these statuses and flags in the
   // future.
   std::atomic<Host::HealthStatus> eds_health_status_{};
-  absl::optional<std::atomic<uint64_t>> last_hc_http_status_ = absl::nullopt;
+  // 0 indicates no status has been set.
+  std::atomic<uint64_t> last_hc_http_status_{0};
 
   struct HostHandleImpl : HostHandle {
     HostHandleImpl(const std::shared_ptr<const HostImplBase>& parent) : parent_(parent) {


### PR DESCRIPTION
Commit Message: Use plain atomic<uint64_t> for last HC status
optional<atomic> is not thread-safe. Use plain atomic and use 0 as the sentinel value (as noted in the upsteram.h comment)

Risk Level: low
Testing: unit tests: //test/common/upstream:hds_test, //test/common/upstream:health_checker_impl_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a