### PR TITLE
Update QUICHE from f4cb73412 to ba02ee8fc

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-04-14"
+  release_date: "2026-04-16"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -3986,7 +3986,6 @@ envoy_quic_cc_library(
         ":quic_core_server_id_lib",
         ":quic_core_session_notifier_interface_lib",
         ":quic_core_stream_frame_data_producer_lib",
-        ":quic_core_stream_send_buffer_base_lib",
         ":quic_core_stream_send_buffer_inlining_lib",
         ":quic_core_stream_sequencer_buffer_lib",
         ":quic_core_types_lib",
@@ -4065,22 +4064,6 @@ envoy_quic_cc_library(
 )
 
 envoy_quic_cc_library(
-    name = "quic_core_stream_send_buffer_base_lib",
-    srcs = ["quiche/quic/core/quic_stream_send_buffer_base.cc"],
-    hdrs = ["quiche/quic/core/quic_stream_send_buffer_base.h"],
-    deps = [
-        ":quic_core_interval_lib",
-        ":quic_core_interval_set_lib",
-        ":quic_core_types_lib",
-        ":quic_platform_base",
-        ":quic_platform_bug_tracker",
-        ":quiche_common_mem_slice",
-        "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/types:span",
-    ],
-)
-
-envoy_quic_cc_library(
     name = "quic_core_inlined_string_view_lib",
     hdrs = ["quiche/quic/core/quic_inlined_string_view.h"],
     deps = [
@@ -4100,7 +4083,6 @@ envoy_quic_cc_library(
         ":quic_core_interval_deque_lib",
         ":quic_core_interval_lib",
         ":quic_core_interval_set_lib",
-        ":quic_core_stream_send_buffer_base_lib",
         ":quic_core_types_lib",
         ":quic_platform_base",
         ":quic_platform_bug_tracker",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "f4cb73412317e1ec397f37ec8e218396dad18186",
-        sha256 = "5798004d460932ef454f38a341773eba614097e581cbaa50513a8a0a446921a8",
+        version = "ba02ee8fc1c0ab27d55f6bbb9e1ac7c9705c3e69",
+        sha256 = "670791b54c8f73eafbb25226b27132bad5d336b70f8543be9d39bbfd9dc7222c",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/f4cb73412..ba02ee8fc

```
$ git log f4cb73412..ba02ee8fc --date=short --no-merges --format="%ad %al %s"

2026-04-16 martinduke Permanently cancel subgroups if the stream has STOP_SENDING.
2026-04-16 haoyuewang QUIC_BUG on the size of connection_state_map_.
2026-04-16 ianswett Move Bbr2ProbeBwMode::CyclePhase to bbr2_misc.h and rename it to ProbePhase.
2026-04-15 reubent Reset streams which surpass MAX_HEADER_LIST_SIZE
2026-04-15 ianswett Deprecate --gfe2_reloadable_flag_quic_send_connection_close_on_max_age.
2026-04-14 birenroy Enabling rolled out flags.
2026-04-14 martinduke Deprecate gfe2_reloadable_flag_quic_disconnect_early_exit.
2026-04-14 vasilvv Merge QuicStreamSendBufferBase into QuicStreamSendBufferInlining.
```

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
