### PR TITLE
dynamic_modules: subscribe to worker local priority set in cluster LB

### DIFF
--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -31,8 +31,8 @@ struct DynamicModuleThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBa
   struct LoadBalancerFactory : public Upstream::LoadBalancerFactory {
     LoadBalancerFactory(DynamicModuleClusterHandleSharedPtr handle) : handle_(std::move(handle)) {}
 
-    Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams) override {
-      return std::make_unique<DynamicModuleLoadBalancer>(handle_);
+    Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams params) override {
+      return std::make_unique<DynamicModuleLoadBalancer>(handle_, params.priority_set);
     }
 
     DynamicModuleClusterHandleSharedPtr handle_;
@@ -591,14 +591,15 @@ void DynamicModuleCluster::HttpCalloutCallback::onFailure(const Http::AsyncClien
 // =================================================================================================
 
 DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(
-    const DynamicModuleClusterHandleSharedPtr& handle)
-    : handle_(handle), in_module_lb_(nullptr) {
+    const DynamicModuleClusterHandleSharedPtr& handle, const Upstream::PrioritySet& priority_set)
+    : handle_(handle), priority_set_(priority_set), in_module_lb_(nullptr) {
   in_module_lb_ =
       handle_->cluster_->config()->on_cluster_lb_new_(handle_->cluster_->inModuleCluster(), this);
 
-  // Register for host membership updates if the module implements the hook.
+  // Register for host membership updates if the module implements the hook. Subscribe on the
+  // worker local priority set so the callback list is only mutated on this worker thread.
   if (handle_->cluster_->config()->on_cluster_lb_on_host_membership_update_ != nullptr) {
-    member_update_cb_ = handle_->cluster_->prioritySet().addMemberUpdateCb(
+    member_update_cb_ = priority_set_.addMemberUpdateCb(
         [this](const Upstream::HostVector& hosts_added, const Upstream::HostVector& hosts_removed) {
           hosts_added_ = &hosts_added;
           hosts_removed_ = &hosts_removed;

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -485,7 +485,11 @@ private:
  */
 class DynamicModuleLoadBalancer : public Upstream::LoadBalancer {
 public:
-  DynamicModuleLoadBalancer(const DynamicModuleClusterHandleSharedPtr& handle);
+  // ``priority_set`` must be the worker local priority set supplied via
+  // ``LoadBalancerParams::priority_set``. The membership update subscription is registered on it so
+  // that the callback list is mutated only on the thread that owns this load balancer instance.
+  DynamicModuleLoadBalancer(const DynamicModuleClusterHandleSharedPtr& handle,
+                            const Upstream::PrioritySet& priority_set);
   ~DynamicModuleLoadBalancer() override;
 
   // Upstream::LoadBalancer.
@@ -532,8 +536,13 @@ public:
   const Upstream::HostVector* hostsAdded() const { return hosts_added_; }
   const Upstream::HostVector* hostsRemoved() const { return hosts_removed_; }
 
+  // Returns the priority set that this load balancer subscribes to for host membership updates.
+  const Upstream::PrioritySet& memberUpdatePrioritySet() const { return priority_set_; }
+
 private:
   const DynamicModuleClusterHandleSharedPtr handle_;
+  // Worker local priority set that backs the membership update subscription.
+  const Upstream::PrioritySet& priority_set_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
 
   // Shared cancellation flag for the active async host selection. Set in chooseHost when the

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -2104,7 +2104,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteWithHost) {
   // Create a handle for the async completion callback.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(
       std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
@@ -2128,7 +2128,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteNullHost) {
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(
       std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
@@ -2152,7 +2152,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(
       std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
@@ -2631,7 +2631,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadataABI) {
 
   // Verify metadata through the LB host metadata ABI callbacks.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   envoy_dynamic_module_type_envoy_buffer meta_result = {nullptr, 0};
@@ -2696,7 +2696,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthABI) {
 
   // Verify via the LB health callback.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   EXPECT_EQ(envoy_dynamic_module_type_host_health_Unhealthy,
@@ -2771,7 +2771,7 @@ TEST_F(DynamicModuleClusterTest, LbHostMembershipUpdate) {
   // Create an LB. The cluster_no_op module implements on_cluster_lb_on_host_membership_update,
   // so the LB should register for membership updates.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
 
   // Add hosts - this should trigger the membership update callback on the LB.
   std::vector<Upstream::HostSharedPtr> hosts;
@@ -2793,7 +2793,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // When not in a membership update callback, the function should return false.
@@ -2830,7 +2830,7 @@ TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
 
   // Verify through the LB that locality grouping works.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // Should have 2 locality buckets (the healthy hosts per locality).
@@ -2855,7 +2855,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAffectsHealthyHosts) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002"}, {1, 1}, hosts));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // Both hosts should be healthy initially.
@@ -2883,7 +2883,7 @@ TEST_F(DynamicModuleClusterTest, LbFindHostByAddress) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002"}, {1, 2}, hosts));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // Find existing host by address via the LB callback.
@@ -2920,7 +2920,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHost) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002"}, {1, 2}, hosts));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // Get host by index from all hosts.
@@ -2956,7 +2956,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
   EXPECT_TRUE(cluster->updateHostHealth(hosts[0], envoy_dynamic_module_type_host_health_Unhealthy));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // get_host should still return both hosts.
@@ -2987,7 +2987,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsToPriority) {
       addSimpleHosts(*cluster, {"127.0.0.1:10002", "127.0.0.1:10003"}, {1, 1}, hosts_p1, 1));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // Verify hosts at each priority level.
@@ -3025,7 +3025,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithPriorityABI) {
 
   // Verify via LB.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_lb_get_hosts_count(lb_ptr, 0));
@@ -3061,7 +3061,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndPriorityABI) {
 
   // Verify via LB.
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_get_hosts_count(lb_ptr, 0));
@@ -3090,7 +3090,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
       addSimpleHosts(*cluster, {"127.0.0.1:10002", "127.0.0.1:10003"}, {1, 1}, hosts_p1, 1));
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
-  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
   auto* lb_ptr = static_cast<void*>(lb_instance.get());
 
   // All hosts should be healthy initially.
@@ -3112,6 +3112,54 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
   EXPECT_TRUE(
       cluster->updateHostHealth(hosts_p1[0], envoy_dynamic_module_type_host_health_Healthy));
   EXPECT_EQ(2, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(lb_ptr, 1));
+}
+
+// The load balancer must register its membership update callback on the priority set supplied at
+// construction, which production callers always fill with the worker local set from
+// ``LoadBalancerParams``. Reference equality against the constructor argument proves the
+// subscription target and would fail if the registration moved back to the cluster main set.
+TEST_F(DynamicModuleClusterTest, LbMemberUpdateCbRegistersOnWorkerLocalPrioritySet) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+
+  Upstream::PrioritySetImpl worker_local;
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, worker_local);
+
+  EXPECT_EQ(&lb_instance->memberUpdatePrioritySet(), &worker_local);
+  EXPECT_NE(&lb_instance->memberUpdatePrioritySet(), &cluster->prioritySet());
+}
+
+// Repeated construct, update, destroy cycle on the worker local priority set to cover the
+// subscribe and unsubscribe paths under sanitizer builds.
+TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+
+  Upstream::PrioritySetImpl worker_priority_set;
+  worker_priority_set.getOrCreateHostSet(0);
+
+  std::vector<Upstream::HostSharedPtr> hosts;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10101", "127.0.0.1:10102"}, {1, 1}, hosts));
+
+  for (int i = 0; i < 16; ++i) {
+    auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+    auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, worker_priority_set);
+
+    Upstream::HostVectorSharedPtr all_hosts(new Upstream::HostVector{hosts[0]});
+    worker_priority_set.updateHosts(
+        0,
+        Upstream::HostSetImpl::partitionHosts(all_hosts, Upstream::HostsPerLocalityImpl::empty()),
+        {}, {hosts[0]}, {}, absl::nullopt, absl::nullopt);
+
+    all_hosts = std::make_shared<Upstream::HostVector>(Upstream::HostVector{hosts[0], hosts[1]});
+    worker_priority_set.updateHosts(
+        0,
+        Upstream::HostSetImpl::partitionHosts(all_hosts, Upstream::HostsPerLocalityImpl::empty()),
+        {}, {hosts[1]}, {}, absl::nullopt, absl::nullopt);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Description

This PR moves the membership update subscription on `DynamicModuleLoadBalancer` from the cluster main priority set to the worker local priority set delivered through `LoadBalancerParams`. `LoadBalancerFactory::create` runs on each worker thread via `tls_.runOnAllThreads` posted from `postThreadLocalClusterUpdate`, so subscribing on the cluster main priority set required mutating the shared `Common::CallbackManager` callback list from worker threads while the main thread could iterate it via `PrioritySetImpl::runUpdateCallbacks`. 

The worker local priority set is updated only on the thread that owns the load balancer, via `ThreadLocalClusterManagerImpl::updateClusterMembership`, so subscribe, fire, and unsubscribe all stay on a single thread.

---

**Commit Message:** dynamic_modules: subscribe to worker local priority set in cluster LB
**Additional Description:** Moves the cluster LB membership update subscription onto the worker local priority set delivered via ``LoadBalancerParams``. 
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** Added