### PR TITLE
dynamic_modules: lock the owner before touching its dispatcher in schedulers

### DIFF
--- a/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
+++ b/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
@@ -22,8 +22,7 @@ envoy_dynamic_module_type_bootstrap_extension_config_scheduler_module_ptr
 envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
     envoy_dynamic_module_type_bootstrap_extension_config_envoy_ptr extension_config_envoy_ptr) {
   auto* config = static_cast<DynamicModuleBootstrapExtensionConfig*>(extension_config_envoy_ptr);
-  return new DynamicModuleBootstrapExtensionConfigScheduler(config->weak_from_this(),
-                                                            config->main_thread_dispatcher_);
+  return new DynamicModuleBootstrapExtensionConfigScheduler(config->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_delete(

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -476,14 +476,19 @@ using DynamicModuleBootstrapExtensionConfigSharedPtr =
  */
 class DynamicModuleBootstrapExtensionConfigScheduler {
 public:
-  DynamicModuleBootstrapExtensionConfigScheduler(
-      std::weak_ptr<DynamicModuleBootstrapExtensionConfig> config, Event::Dispatcher& dispatcher)
-      : config_(std::move(config)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleBootstrapExtensionConfigScheduler(
+      std::weak_ptr<DynamicModuleBootstrapExtensionConfig> config)
+      : config_(std::move(config)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([config = config_, event_id]() {
-      if (std::shared_ptr<DynamicModuleBootstrapExtensionConfig> config_shared = config.lock()) {
-        config_shared->onScheduled(event_id);
+    // Lock the config so its dispatcher member stays valid across `post`.
+    auto config_shared = config_.lock();
+    if (!config_shared) {
+      return;
+    }
+    config_shared->main_thread_dispatcher_.post([config = config_, event_id]() {
+      if (std::shared_ptr<DynamicModuleBootstrapExtensionConfig> cs = config.lock()) {
+        cs->onScheduled(event_id);
       }
     });
   }
@@ -492,8 +497,6 @@ private:
   // The config that this scheduler is associated with. Using a weak pointer to avoid unnecessarily
   // extending the lifetime of the config.
   std::weak_ptr<DynamicModuleBootstrapExtensionConfig> config_;
-  // The dispatcher is used to post the event to the main thread.
-  Event::Dispatcher& dispatcher_;
 };
 
 /**

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -433,25 +433,28 @@ public:
    * Creates a new scheduler for the given cluster.
    */
   static DynamicModuleClusterScheduler* create(DynamicModuleCluster* cluster) {
-    return new DynamicModuleClusterScheduler(cluster->weak_from_this(), cluster->dispatcher_);
+    return new DynamicModuleClusterScheduler(cluster->weak_from_this());
   }
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([cluster = cluster_, event_id]() {
-      if (std::shared_ptr<DynamicModuleCluster> cluster_shared = cluster.lock()) {
-        cluster_shared->onScheduled(event_id);
+    // Lock the cluster so its dispatcher member stays valid across `post`.
+    auto cluster_shared = cluster_.lock();
+    if (!cluster_shared) {
+      return;
+    }
+    cluster_shared->dispatcher_.post([cluster = cluster_, event_id]() {
+      if (std::shared_ptr<DynamicModuleCluster> cs = cluster.lock()) {
+        cs->onScheduled(event_id);
       }
     });
   }
 
 private:
-  DynamicModuleClusterScheduler(std::weak_ptr<DynamicModuleCluster> cluster,
-                                Event::Dispatcher& dispatcher)
-      : cluster_(std::move(cluster)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleClusterScheduler(std::weak_ptr<DynamicModuleCluster> cluster)
+      : cluster_(std::move(cluster)) {}
 
   // Using a weak pointer to avoid unnecessarily extending the lifetime of the cluster.
   std::weak_ptr<DynamicModuleCluster> cluster_;
-  Event::Dispatcher& dispatcher_;
 };
 
 /**

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1945,8 +1945,7 @@ envoy_dynamic_module_type_http_filter_scheduler_module_ptr
 envoy_dynamic_module_callback_http_filter_scheduler_new(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  return new DynamicModuleHttpFilterScheduler(filter->weak_from_this(),
-                                              filter->decoder_callbacks_->dispatcher());
+  return new DynamicModuleHttpFilterScheduler(filter->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_http_filter_scheduler_delete(
@@ -1966,8 +1965,7 @@ envoy_dynamic_module_type_http_filter_config_scheduler_module_ptr
 envoy_dynamic_module_callback_http_filter_config_scheduler_new(
     envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr) {
   auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
-  return new DynamicModuleHttpFilterConfigScheduler(filter_config->weak_from_this(),
-                                                    filter_config->main_thread_dispatcher_);
+  return new DynamicModuleHttpFilterConfigScheduler(filter_config->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_http_filter_config_scheduler_delete(

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -389,14 +389,20 @@ using DynamicModuleHttpFilterWeakPtr = std::weak_ptr<DynamicModuleHttpFilter>;
  */
 class DynamicModuleHttpFilterScheduler {
 public:
-  DynamicModuleHttpFilterScheduler(DynamicModuleHttpFilterWeakPtr filter,
-                                   Event::Dispatcher& dispatcher)
-      : filter_(std::move(filter)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleHttpFilterScheduler(DynamicModuleHttpFilterWeakPtr filter)
+      : filter_(std::move(filter)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([filter = filter_, event_id]() {
-      if (DynamicModuleHttpFilterSharedPtr filter_shared = filter.lock()) {
-        filter_shared->onScheduled(event_id);
+    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
+    // `post`.
+    auto filter_shared = filter_.lock();
+    if (!filter_shared || filter_shared->isDestroyed() ||
+        filter_shared->decoder_callbacks_ == nullptr) {
+      return;
+    }
+    filter_shared->decoder_callbacks_->dispatcher().post([filter = filter_, event_id]() {
+      if (DynamicModuleHttpFilterSharedPtr fs = filter.lock()) {
+        fs->onScheduled(event_id);
       }
     });
   }
@@ -405,8 +411,6 @@ private:
   // The filter that this scheduler is associated with. Using a weak pointer to avoid unnecessarily
   // extending the lifetime of the filter.
   DynamicModuleHttpFilterWeakPtr filter_;
-  // The dispatcher is used to post the event to the worker thread that filter_ is assigned to.
-  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace HttpFilters

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -439,21 +439,25 @@ private:
 
 class DynamicModuleHttpFilterConfigScheduler {
 public:
-  DynamicModuleHttpFilterConfigScheduler(std::weak_ptr<DynamicModuleHttpFilterConfig> config,
-                                         Event::Dispatcher& dispatcher)
-      : config_(std::move(config)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleHttpFilterConfigScheduler(
+      std::weak_ptr<DynamicModuleHttpFilterConfig> config)
+      : config_(std::move(config)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([config = config_, event_id]() {
-      if (std::shared_ptr<DynamicModuleHttpFilterConfig> config_shared = config.lock()) {
-        config_shared->onScheduled(event_id);
+    // Lock the config so its dispatcher member stays valid across `post`.
+    auto config_shared = config_.lock();
+    if (!config_shared) {
+      return;
+    }
+    config_shared->main_thread_dispatcher_.post([config = config_, event_id]() {
+      if (std::shared_ptr<DynamicModuleHttpFilterConfig> cs = config.lock()) {
+        cs->onScheduled(event_id);
       }
     });
   }
 
 private:
   std::weak_ptr<DynamicModuleHttpFilterConfig> config_;
-  Event::Dispatcher& dispatcher_;
 };
 
 class DynamicModuleHttpPerRouteFilterConfig : public Router::RouteSpecificFilterConfig {

--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -1124,11 +1124,7 @@ envoy_dynamic_module_type_listener_filter_scheduler_module_ptr
 envoy_dynamic_module_callback_listener_filter_scheduler_new(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr) {
   auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
-  Event::Dispatcher* dispatcher = filter->dispatcher();
-  if (dispatcher == nullptr) {
-    return nullptr;
-  }
-  return new DynamicModuleListenerFilterScheduler(filter->weak_from_this(), *dispatcher);
+  return new DynamicModuleListenerFilterScheduler(filter->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_listener_filter_scheduler_delete(
@@ -1147,8 +1143,7 @@ envoy_dynamic_module_type_listener_filter_config_scheduler_module_ptr
 envoy_dynamic_module_callback_listener_filter_config_scheduler_new(
     envoy_dynamic_module_type_listener_filter_config_envoy_ptr filter_config_envoy_ptr) {
   auto* filter_config = static_cast<DynamicModuleListenerFilterConfig*>(filter_config_envoy_ptr);
-  return new DynamicModuleListenerFilterConfigScheduler(filter_config->weak_from_this(),
-                                                        filter_config->main_thread_dispatcher_);
+  return new DynamicModuleListenerFilterConfigScheduler(filter_config->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_listener_filter_config_scheduler_delete(

--- a/source/extensions/filters/listener/dynamic_modules/filter.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter.h
@@ -152,14 +152,23 @@ private:
  */
 class DynamicModuleListenerFilterScheduler {
 public:
-  DynamicModuleListenerFilterScheduler(DynamicModuleListenerFilterWeakPtr filter,
-                                       Event::Dispatcher& dispatcher)
-      : filter_(std::move(filter)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleListenerFilterScheduler(DynamicModuleListenerFilterWeakPtr filter)
+      : filter_(std::move(filter)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([filter = filter_, event_id]() {
-      if (DynamicModuleListenerFilterSharedPtr filter_shared = filter.lock()) {
-        filter_shared->onScheduled(event_id);
+    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
+    // `post`.
+    auto filter_shared = filter_.lock();
+    if (!filter_shared) {
+      return;
+    }
+    Event::Dispatcher* dispatcher = filter_shared->dispatcher();
+    if (dispatcher == nullptr) {
+      return;
+    }
+    dispatcher->post([filter = filter_, event_id]() {
+      if (DynamicModuleListenerFilterSharedPtr fs = filter.lock()) {
+        fs->onScheduled(event_id);
       }
     });
   }
@@ -168,8 +177,6 @@ private:
   // The filter that this scheduler is associated with. Using a weak pointer to avoid unnecessarily
   // extending the lifetime of the filter.
   DynamicModuleListenerFilterWeakPtr filter_;
-  // The dispatcher is used to post the event to the worker thread that filter_ is assigned to.
-  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace ListenerFilters

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.h
@@ -216,21 +216,25 @@ private:
  */
 class DynamicModuleListenerFilterConfigScheduler {
 public:
-  DynamicModuleListenerFilterConfigScheduler(
-      std::weak_ptr<DynamicModuleListenerFilterConfig> config, Event::Dispatcher& dispatcher)
-      : config_(std::move(config)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleListenerFilterConfigScheduler(
+      std::weak_ptr<DynamicModuleListenerFilterConfig> config)
+      : config_(std::move(config)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([config = config_, event_id]() {
-      if (std::shared_ptr<DynamicModuleListenerFilterConfig> config_shared = config.lock()) {
-        config_shared->onScheduled(event_id);
+    // Lock the config so its dispatcher member stays valid across `post`.
+    auto config_shared = config_.lock();
+    if (!config_shared) {
+      return;
+    }
+    config_shared->main_thread_dispatcher_.post([config = config_, event_id]() {
+      if (std::shared_ptr<DynamicModuleListenerFilterConfig> cs = config.lock()) {
+        cs->onScheduled(event_id);
       }
     });
   }
 
 private:
   std::weak_ptr<DynamicModuleListenerFilterConfig> config_;
-  Event::Dispatcher& dispatcher_;
 };
 
 /**

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -1173,11 +1173,7 @@ envoy_dynamic_module_type_network_filter_scheduler_module_ptr
 envoy_dynamic_module_callback_network_filter_scheduler_new(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  Event::Dispatcher* dispatcher = filter->dispatcher();
-  if (dispatcher == nullptr) {
-    return nullptr;
-  }
-  return new DynamicModuleNetworkFilterScheduler(filter->weak_from_this(), *dispatcher);
+  return new DynamicModuleNetworkFilterScheduler(filter->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_network_filter_scheduler_delete(
@@ -1196,8 +1192,7 @@ envoy_dynamic_module_type_network_filter_config_scheduler_module_ptr
 envoy_dynamic_module_callback_network_filter_config_scheduler_new(
     envoy_dynamic_module_type_network_filter_config_envoy_ptr filter_config_envoy_ptr) {
   auto* filter_config = static_cast<DynamicModuleNetworkFilterConfig*>(filter_config_envoy_ptr);
-  return new DynamicModuleNetworkFilterConfigScheduler(filter_config->weak_from_this(),
-                                                       filter_config->main_thread_dispatcher_);
+  return new DynamicModuleNetworkFilterConfigScheduler(filter_config->weak_from_this());
 }
 
 void envoy_dynamic_module_callback_network_filter_config_scheduler_delete(

--- a/source/extensions/filters/network/dynamic_modules/filter.h
+++ b/source/extensions/filters/network/dynamic_modules/filter.h
@@ -241,14 +241,23 @@ private:
  */
 class DynamicModuleNetworkFilterScheduler {
 public:
-  DynamicModuleNetworkFilterScheduler(DynamicModuleNetworkFilterWeakPtr filter,
-                                      Event::Dispatcher& dispatcher)
-      : filter_(std::move(filter)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleNetworkFilterScheduler(DynamicModuleNetworkFilterWeakPtr filter)
+      : filter_(std::move(filter)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([filter = filter_, event_id]() {
-      if (DynamicModuleNetworkFilterSharedPtr filter_shared = filter.lock()) {
-        filter_shared->onScheduled(event_id);
+    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
+    // `post`.
+    auto filter_shared = filter_.lock();
+    if (!filter_shared) {
+      return;
+    }
+    Event::Dispatcher* dispatcher = filter_shared->dispatcher();
+    if (dispatcher == nullptr) {
+      return;
+    }
+    dispatcher->post([filter = filter_, event_id]() {
+      if (DynamicModuleNetworkFilterSharedPtr fs = filter.lock()) {
+        fs->onScheduled(event_id);
       }
     });
   }
@@ -257,8 +266,6 @@ private:
   // The filter that this scheduler is associated with. Using a weak pointer to avoid unnecessarily
   // extending the lifetime of the filter.
   DynamicModuleNetworkFilterWeakPtr filter_;
-  // The dispatcher is used to post the event to the worker thread that filter_ is assigned to.
-  Event::Dispatcher& dispatcher_;
 };
 
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -221,21 +221,25 @@ private:
  */
 class DynamicModuleNetworkFilterConfigScheduler {
 public:
-  DynamicModuleNetworkFilterConfigScheduler(std::weak_ptr<DynamicModuleNetworkFilterConfig> config,
-                                            Event::Dispatcher& dispatcher)
-      : config_(std::move(config)), dispatcher_(dispatcher) {}
+  explicit DynamicModuleNetworkFilterConfigScheduler(
+      std::weak_ptr<DynamicModuleNetworkFilterConfig> config)
+      : config_(std::move(config)) {}
 
   void commit(uint64_t event_id) {
-    dispatcher_.post([config = config_, event_id]() {
-      if (std::shared_ptr<DynamicModuleNetworkFilterConfig> config_shared = config.lock()) {
-        config_shared->onScheduled(event_id);
+    // Lock the config so its dispatcher member stays valid across `post`.
+    auto config_shared = config_.lock();
+    if (!config_shared) {
+      return;
+    }
+    config_shared->main_thread_dispatcher_.post([config = config_, event_id]() {
+      if (std::shared_ptr<DynamicModuleNetworkFilterConfig> cs = config.lock()) {
+        cs->onScheduled(event_id);
       }
     });
   }
 
 private:
   std::weak_ptr<DynamicModuleNetworkFilterConfig> config_;
-  Event::Dispatcher& dispatcher_;
 };
 
 /**

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -52,7 +52,7 @@ directories:
   source/extensions/filters/http/mcp_router: 82.3
   source/extensions/filters/http/oauth2: 97.6
   source/extensions/filters/listener: 96.5
-  source/extensions/filters/listener/dynamic_modules: 96.9
+  source/extensions/filters/listener/dynamic_modules: 96.7
   source/extensions/filters/listener/original_src: 92.1
   source/extensions/filters/listener/tls_inspector: 94.5
   source/extensions/filters/network/dubbo_proxy: 96.2

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -1140,6 +1140,26 @@ TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
   captured_cb();
 }
 
+// `commit` must not touch the dispatcher once the owning cluster has been destroyed.
+TEST_F(DynamicModuleClusterTest, CommitAfterClusterDestroyedDoesNotTouchDispatcher) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  auto* scheduler_ptr = envoy_dynamic_module_callback_cluster_scheduler_new(cluster.get());
+  EXPECT_NE(scheduler_ptr, nullptr);
+
+  cluster.reset();
+  result = absl::InternalError("cleanup");
+
+  EXPECT_CALL(server_context_.dispatcher_, post(_)).Times(0);
+
+  envoy_dynamic_module_callback_cluster_scheduler_commit(scheduler_ptr, 42);
+
+  envoy_dynamic_module_callback_cluster_scheduler_delete(scheduler_ptr);
+}
+
 // Test calling onScheduled directly.
 TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -156,6 +156,32 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
   captured_cb();
 }
 
+// `commit` must not touch the dispatcher once the owning config has been destroyed. Exercises
+// the validate-mode teardown race where a background thread may call `commit` after the main
+// thread dispatcher has already been released.
+TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
+  auto dynamic_module =
+      Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
+  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
+  ASSERT_TRUE(config.ok()) << config.status();
+
+  auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
+      config.value()->thisAsVoidPtr());
+  EXPECT_NE(scheduler_ptr, nullptr);
+
+  config.value().reset();
+
+  EXPECT_CALL(dispatcher_, post(testing::_)).Times(0);
+
+  envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_commit(scheduler_ptr, 42);
+
+  envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_delete(scheduler_ptr);
+}
+
 // Test calling onScheduled directly.
 TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
   auto dynamic_module =

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -118,6 +118,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/dynamic_modules:filter_lib",
         "//test/common/stats:stat_test_utility_lib",
         "//test/extensions/dynamic_modules:util",
+        "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_factory_context_mocks",

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -13,6 +13,7 @@
 
 #include "test/common/stats/stat_test_utility.h"
 #include "test/extensions/dynamic_modules/util.h"
+#include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
@@ -3396,6 +3397,138 @@ TEST(ABIImpl, ReceivedBufferedResponseBody) {
   // current_response_body_ is the same as encodingBuffer() - received buffered body.
   EXPECT_CALL(callbacks, encodingBuffer()).WillRepeatedly(testing::Return(&current_body));
   EXPECT_TRUE(envoy_dynamic_module_callback_http_received_buffered_response_body(&filter));
+}
+
+// =============================================================================
+// Tests for scheduler callbacks.
+// =============================================================================
+
+class DynamicModuleHttpFilterSchedulerTest : public testing::Test {
+public:
+  void SetUp() override {
+    ON_CALL(context_, mainThreadDispatcher())
+        .WillByDefault(testing::ReturnRef(main_thread_dispatcher_));
+    ON_CALL(decoder_callbacks_, dispatcher())
+        .WillByDefault(testing::ReturnRef(worker_thread_dispatcher_));
+
+    auto dynamic_module = Envoy::Extensions::DynamicModules::newDynamicModule(
+        testSharedObjectPath("no_op", "c"), false);
+    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+
+    auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
+        "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+        *stats_store_.rootScope(), context_);
+    ASSERT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    filter_config_ = filter_config_or_status.value();
+
+    filter_ = std::make_shared<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);
+    filter_->initializeInModuleFilter();
+  }
+
+  void TearDown() override { filter_.reset(); }
+
+  void* filterPtr() { return static_cast<void*>(filter_.get()); }
+  void* configPtr() { return static_cast<void*>(filter_config_.get()); }
+
+  Stats::SymbolTableImpl symbol_table_;
+  Stats::IsolatedStoreImpl stats_store_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  NiceMock<Event::MockDispatcher> main_thread_dispatcher_;
+  NiceMock<Event::MockDispatcher> worker_thread_dispatcher_{"worker_0"};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  DynamicModuleHttpFilterConfigSharedPtr filter_config_;
+  std::shared_ptr<DynamicModuleHttpFilter> filter_;
+};
+
+// Covers the happy path: `commit` posts to the dispatcher resolved via decoder callbacks.
+TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitPostsToWorkerDispatcher) {
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  Event::PostCb captured_cb;
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_))
+      .WillOnce(testing::Invoke([&](Event::PostCb cb) { captured_cb = std::move(cb); }));
+
+  envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 123);
+  ASSERT_TRUE(captured_cb);
+  captured_cb();
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
+}
+
+// Covers the `!filter_shared` early return.
+TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterFilterDestroyedIsNoOp) {
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_.reset();
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_)).Times(0);
+  envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 123);
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
+}
+
+// Covers the `filter_shared->isDestroyed()` early return.
+TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterOnDestroyIsNoOp) {
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_->onDestroy();
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_)).Times(0);
+  envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 123);
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
+}
+
+// Covers the `decoder_callbacks_ == nullptr` early return.
+TEST_F(DynamicModuleHttpFilterSchedulerTest,
+       HttpFilterSchedulerCommitWithoutDecoderCallbacksIsNoOp) {
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_)).Times(0);
+  envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 123);
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
+}
+
+// Covers the happy path for the config scheduler: `commit` posts to the main thread dispatcher.
+TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterConfigSchedulerCommitPostsToMainDispatcher) {
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_config_scheduler_new(configPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  Event::PostCb captured_cb;
+  EXPECT_CALL(main_thread_dispatcher_, post(testing::_))
+      .WillOnce(testing::Invoke([&](Event::PostCb cb) { captured_cb = std::move(cb); }));
+
+  envoy_dynamic_module_callback_http_filter_config_scheduler_commit(scheduler, 456);
+  ASSERT_TRUE(captured_cb);
+  captured_cb();
+
+  envoy_dynamic_module_callback_http_filter_config_scheduler_delete(scheduler);
+}
+
+// Covers the `!config_shared` early return of the config scheduler.
+TEST_F(DynamicModuleHttpFilterSchedulerTest,
+       HttpFilterConfigSchedulerCommitAfterConfigDestroyedIsNoOp) {
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_config_scheduler_new(configPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_.reset();
+  filter_config_.reset();
+
+  EXPECT_CALL(main_thread_dispatcher_, post(testing::_)).Times(0);
+  envoy_dynamic_module_callback_http_filter_config_scheduler_commit(scheduler, 456);
+
+  envoy_dynamic_module_callback_http_filter_config_scheduler_delete(scheduler);
 }
 
 } // namespace HttpFilters

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -2105,6 +2105,20 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   envoy_dynamic_module_callback_listener_filter_config_scheduler_delete(scheduler);
 }
 
+// Covers the `dispatcher == nullptr` early return of the listener filter scheduler.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
+       ListenerFilterSchedulerCommitWithoutCallbacksIsNoOp) {
+  auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_->setCallbacksForTest(nullptr);
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).Times(0);
+  envoy_dynamic_module_callback_listener_filter_scheduler_commit(scheduler, 123);
+
+  envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
+}
+
 // =============================================================================
 // Tests for socket option callbacks.
 // =============================================================================
@@ -2623,6 +2637,95 @@ TEST_F(DynamicModuleListenerFilterHttpCalloutTest, FilterDestructionCancelsPendi
   EXPECT_CALL(request, cancel());
   // Destroy the filter. This should cancel all pending callouts.
   filter_.reset();
+}
+
+// Covers the `on_listener_filter_http_callout_done_ == nullptr` branch of `onSuccess`.
+TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnSuccessWithoutCalloutDoneHook) {
+  NiceMock<Upstream::MockThreadLocalCluster> cluster;
+  NiceMock<Http::MockAsyncClient> async_client;
+  Http::MockAsyncClientRequest request(&async_client);
+  const Http::AsyncClient::Callbacks* captured_callback = nullptr;
+
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test_cluster"))
+      .WillOnce(testing::Return(&cluster));
+  EXPECT_CALL(cluster, httpAsyncClient()).WillOnce(testing::ReturnRef(async_client));
+  EXPECT_CALL(async_client, send_(testing::_, testing::_, testing::_))
+      .WillOnce(testing::DoAll(testing::WithArg<1>([&](const Http::AsyncClient::Callbacks& cb) {
+                                 captured_callback = &cb;
+                               }),
+                               testing::Return(&request)));
+
+  uint64_t callout_id = 0;
+  std::vector<envoy_dynamic_module_type_module_http_header> headers = {
+      {.key_ptr = ":method", .key_length = 7, .value_ptr = "GET", .value_length = 3},
+      {.key_ptr = ":path", .key_length = 5, .value_ptr = "/test", .value_length = 5},
+      {.key_ptr = "host", .key_length = 4, .value_ptr = "example.com", .value_length = 11},
+  };
+
+  auto result = envoy_dynamic_module_callback_listener_filter_http_callout(
+      filterPtr(), &callout_id, {"test_cluster", 12}, headers.data(), headers.size(), {nullptr, 0},
+      5000);
+  ASSERT_EQ(envoy_dynamic_module_type_http_callout_init_result_Success, result);
+  ASSERT_NE(nullptr, captured_callback);
+
+  filter_config_->on_listener_filter_http_callout_done_ = nullptr;
+
+  Http::ResponseMessagePtr response =
+      std::make_unique<Http::ResponseMessageImpl>(Http::ResponseHeaderMapImpl::create());
+  response->headers().setStatus(200);
+  const_cast<Http::AsyncClient::Callbacks*>(captured_callback)
+      ->onSuccess(request, std::move(response));
+}
+
+// Covers the `on_listener_filter_http_callout_done_ == nullptr` branch of `onFailure` along with
+// the `ExceedResponseBufferLimit` path of the reason switch.
+TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnFailureWithoutCalloutDoneHook) {
+  NiceMock<Upstream::MockThreadLocalCluster> cluster;
+  NiceMock<Http::MockAsyncClient> async_client;
+  Http::MockAsyncClientRequest request(&async_client);
+  const Http::AsyncClient::Callbacks* captured_callback = nullptr;
+
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test_cluster"))
+      .WillOnce(testing::Return(&cluster));
+  EXPECT_CALL(cluster, httpAsyncClient()).WillOnce(testing::ReturnRef(async_client));
+  EXPECT_CALL(async_client, send_(testing::_, testing::_, testing::_))
+      .WillOnce(testing::DoAll(testing::WithArg<1>([&](const Http::AsyncClient::Callbacks& cb) {
+                                 captured_callback = &cb;
+                               }),
+                               testing::Return(&request)));
+
+  uint64_t callout_id = 0;
+  std::vector<envoy_dynamic_module_type_module_http_header> headers = {
+      {.key_ptr = ":method", .key_length = 7, .value_ptr = "GET", .value_length = 3},
+      {.key_ptr = ":path", .key_length = 5, .value_ptr = "/test", .value_length = 5},
+      {.key_ptr = "host", .key_length = 4, .value_ptr = "example.com", .value_length = 11},
+  };
+
+  auto result = envoy_dynamic_module_callback_listener_filter_http_callout(
+      filterPtr(), &callout_id, {"test_cluster", 12}, headers.data(), headers.size(), {nullptr, 0},
+      5000);
+  ASSERT_EQ(envoy_dynamic_module_type_http_callout_init_result_Success, result);
+  ASSERT_NE(nullptr, captured_callback);
+
+  filter_config_->on_listener_filter_http_callout_done_ = nullptr;
+
+  const_cast<Http::AsyncClient::Callbacks*>(captured_callback)
+      ->onFailure(request, Http::AsyncClient::FailureReason::ExceedResponseBufferLimit);
+}
+
+// Covers `DynamicModuleListenerFilter::onScheduled` when `in_module_filter_` is null.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
+       ListenerFilterOnScheduledWithoutInModuleFilterIsNoOp) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  filter->onScheduled(42);
+}
+
+// Covers the `on_listener_filter_config_scheduled_ == nullptr` branch of
+// `DynamicModuleListenerFilterConfig::onScheduled`.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
+       ListenerFilterConfigOnScheduledWithoutHookIsNoOp) {
+  filter_config_->on_listener_filter_config_scheduled_ = nullptr;
+  filter_config_->onScheduled(42);
 }
 
 } // namespace ListenerFilters


### PR DESCRIPTION
## Description

Each of the eight scheduler classes under `source/extensions/**/dynamic_modules/` held a raw `Event::Dispatcher&` captured at construction and used it unconditionally from `commit`:

```
void commit(uint64_t event_id) {
  dispatcher_.post([owner = owner_weak_ptr_, event_id]() {
    if (auto s = owner.lock()) {
      s->onScheduled(event_id);
    }
  });
}
```

`commit` is invoked from background threads (for example, a tokio worker inside the shared `common/bootstrap` async-init runtime). The `weak_ptr.lock()` guard inside the lambda only protects the lambda body. The enclosing `dispatcher_.post` runs first and dereferences the captured reference even when the owning config, cluster, or filter has already been destroyed. 

Under `envoy --mode validate` the server tears the bootstrap context down synchronously after config parse, so a tokio task committing the init-success event races the main thread dispatcher's destruction and faults at a small offset inside a freed object.

The dispatcher lifetime is bounded by the owner that references it in every case we care about. The fix is to take the weak pointer first, and access the dispatcher through the locked owner:

```
void commit(uint64_t event_id) {
  auto owner = owner_.lock();
  if (!owner) {
    return;
  }
  owner->dispatcher().post([o = owner_, event_id]() {
    if (auto s = o.lock()) {
      s->onScheduled(event_id);
    }
  });
}
```

Holding the shared pointer for the duration of `post` keeps the dispatcher reference valid while the post queue is mutated. The same pattern is applied to every scheduler: bootstrap extension config, cluster, HTTP filter, HTTP filter config, network filter, network filter config, listener filter, and listener filter config.

Filter schedulers (HTTP / network / listener) obtain the worker dispatcher through the filter's callbacks at commit time instead of at construction. The `scheduler_new` ABI callbacks no longer return nullptr when callbacks are not yet set, since a commit after teardown is now a safe no-op.

---

**Commit Message:** dynamic_modules: lock the owner before touching its dispatcher in schedulers
**Additional Description:** Removes the raw `Event::Dispatcher&` members from all dynamic modules scheduler classes and routes the dispatcher access through the owner locked by its `weak_ptr`.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A