### PR TITLE
dynamic_modules: harden cluster handle teardown and async host selection lifetime

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -1078,7 +1078,9 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
     envoy_dynamic_module_type_cluster_host_envoy_ptr host,
     envoy_dynamic_module_type_module_buffer details) {
-  auto* lb = getLb(lb_envoy_ptr);
+  using Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterHandleSharedPtr;
+  using Envoy::Extensions::Clusters::DynamicModules::DynamicModuleLoadBalancer;
+  auto* lb_raw = static_cast<DynamicModuleLoadBalancer*>(lb_envoy_ptr);
 
   // Copy the details string on the calling thread. The pointer is not valid after we return.
   std::string details_str;
@@ -1086,14 +1088,24 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
     details_str.assign(details.ptr, details.length);
   }
 
-  auto cancelled = lb->activeAsyncCancelled();
-  auto* dispatcher = lb->activeAsyncDispatcher();
+  // The module may invoke this callback on any thread and race the load balancer destructor.
+  // Validate the raw pointer against the live registry and snapshot the state we need under the
+  // registry lock.
+  std::shared_ptr<std::atomic<bool>> cancelled;
+  Envoy::Event::Dispatcher* dispatcher = nullptr;
+  DynamicModuleClusterHandleSharedPtr handle;
+  const bool found = DynamicModuleLoadBalancer::withActiveInstance(
+      lb_raw, [&](const DynamicModuleLoadBalancer& lb) {
+        cancelled = lb.activeAsyncCancelled();
+        dispatcher = lb.activeAsyncDispatcher();
+        handle = lb.handle();
+      });
+  if (!found) {
+    return;
+  }
 
   if (dispatcher != nullptr) {
-    // Post all work to the worker thread. The host lookup and context access must happen
-    // on the worker thread because the module may call this from a background thread.
-    // Keep the cluster alive via the handle's shared_ptr until the callback fires.
-    auto handle = lb->handle();
+    // Post to the worker thread. The handle keeps the cluster alive until the callback runs.
     dispatcher->post([context_envoy_ptr, host, details_str = std::move(details_str),
                       cancelled = std::move(cancelled), handle = std::move(handle)]() {
       if (cancelled != nullptr && cancelled->load(std::memory_order_acquire)) {
@@ -1111,7 +1123,7 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
     auto* context = getContext(context_envoy_ptr);
     Envoy::Upstream::HostConstSharedPtr host_shared;
     if (host != nullptr) {
-      host_shared = lb->handle()->cluster()->findHost(host);
+      host_shared = handle->cluster()->findHost(host);
     }
     context->onAsyncHostSelection(std::move(host_shared), std::move(details_str));
   }

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -7,6 +7,7 @@
 #include "envoy/upstream/locality.h"
 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/thread.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/protobuf.h"
@@ -157,13 +158,24 @@ DynamicModuleClusterConfig::~DynamicModuleClusterConfig() {
 DynamicModuleClusterHandle::~DynamicModuleClusterHandle() {
   std::shared_ptr<DynamicModuleCluster> cluster = std::move(cluster_);
   cluster_.reset();
-  // Release lifecycle handles eagerly while the lifecycle notifier is still valid. When the
-  // dispatcher destructor clears pending callbacks, the cluster destructor would otherwise try to
-  // unregister from already-destroyed lifecycle notifier lists.
+  if (cluster == nullptr) {
+    return;
+  }
+  Event::Dispatcher& dispatcher = cluster->dispatcher_;
+  // The lifecycle handle resets unregister from main-thread-owned notifiers. When the handle is
+  // destroyed on a worker thread, post the full teardown onto the main dispatcher.
+  if (!Thread::MainThread::isMainThread() && !Thread::TestThread::isTestThread()) {
+    dispatcher.post([cluster = std::move(cluster)]() mutable {
+      cluster->server_initialized_handle_.reset();
+      cluster->shutdown_handle_.reset();
+      cluster->drain_handle_.reset();
+      cluster.reset();
+    });
+    return;
+  }
   cluster->server_initialized_handle_.reset();
   cluster->shutdown_handle_.reset();
   cluster->drain_handle_.reset();
-  Event::Dispatcher& dispatcher = cluster->dispatcher_;
   dispatcher.post([cluster = std::move(cluster)]() mutable { cluster.reset(); });
 }
 
@@ -590,9 +602,48 @@ void DynamicModuleCluster::HttpCalloutCallback::onFailure(const Http::AsyncClien
 // DynamicModuleLoadBalancer
 // =================================================================================================
 
+namespace {
+// Process-wide registry of live `DynamicModuleLoadBalancer` instances, consulted by the async
+// host selection completion ABI callback to validate the raw pointer it receives from the module.
+absl::Mutex& activeDynamicModuleLoadBalancersMutex() {
+  static auto* m = new absl::Mutex();
+  return *m;
+}
+
+absl::flat_hash_set<const DynamicModuleLoadBalancer*>& activeDynamicModuleLoadBalancers()
+    ABSL_EXCLUSIVE_LOCKS_REQUIRED(activeDynamicModuleLoadBalancersMutex()) {
+  static auto* s = new absl::flat_hash_set<const DynamicModuleLoadBalancer*>();
+  return *s;
+}
+
+void registerActiveDynamicModuleLoadBalancer(const DynamicModuleLoadBalancer* lb) {
+  absl::MutexLock lock(&activeDynamicModuleLoadBalancersMutex());
+  activeDynamicModuleLoadBalancers().insert(lb);
+}
+
+void unregisterActiveDynamicModuleLoadBalancer(const DynamicModuleLoadBalancer* lb) {
+  absl::MutexLock lock(&activeDynamicModuleLoadBalancersMutex());
+  activeDynamicModuleLoadBalancers().erase(lb);
+}
+} // namespace
+
+bool DynamicModuleLoadBalancer::withActiveInstance(
+    const DynamicModuleLoadBalancer* lb,
+    absl::FunctionRef<void(const DynamicModuleLoadBalancer&)> f) {
+  absl::MutexLock lock(&activeDynamicModuleLoadBalancersMutex());
+  if (!activeDynamicModuleLoadBalancers().contains(lb)) {
+    return false;
+  }
+  f(*lb);
+  return true;
+}
+
 DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(
     const DynamicModuleClusterHandleSharedPtr& handle, const Upstream::PrioritySet& priority_set)
     : handle_(handle), priority_set_(priority_set), in_module_lb_(nullptr) {
+  // Register before invoking any module hook so a concurrent async host selection completion can
+  // validate its raw pointer against a live instance.
+  registerActiveDynamicModuleLoadBalancer(this);
   in_module_lb_ =
       handle_->cluster_->config()->on_cluster_lb_new_(handle_->cluster_->inModuleCluster(), this);
 
@@ -612,6 +663,9 @@ DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(
 }
 
 DynamicModuleLoadBalancer::~DynamicModuleLoadBalancer() {
+  // Unregister before tearing down module-side state so any concurrent async host selection
+  // completion observes the instance as gone and drops the event.
+  unregisterActiveDynamicModuleLoadBalancer(this);
   if (in_module_lb_ != nullptr && handle_->cluster_->config()->on_cluster_lb_destroy_ != nullptr) {
     handle_->cluster_->config()->on_cluster_lb_destroy_(in_module_lb_);
   }

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -26,6 +26,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/functional/function_ref.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -541,6 +542,15 @@ public:
 
   // Returns the priority set that this load balancer subscribes to for host membership updates.
   const Upstream::PrioritySet& memberUpdatePrioritySet() const { return priority_set_; }
+
+  /**
+   * Looks up `lb` in the process-wide registry of live instances. Returns true and invokes `f`
+   * with the instance under the registry lock when found, false otherwise. Used by the async
+   * host selection completion ABI callback, which receives a raw pointer from the module that
+   * may outlive the load balancer.
+   */
+  static bool withActiveInstance(const DynamicModuleLoadBalancer* lb,
+                                 absl::FunctionRef<void(const DynamicModuleLoadBalancer&)> f);
 
 private:
   const DynamicModuleClusterHandleSharedPtr handle_;

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -36,6 +36,7 @@ envoy_cc_test(
         "//test/mocks/upstream:priority_set_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:thread_factory_for_test_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_modules/v3:pkg_cc_proto",

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -16,6 +16,7 @@
 #include "test/mocks/upstream/priority_set.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/thread_factory_for_test.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -1187,6 +1188,36 @@ TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
   handle.reset();
 }
 
+// Covers that a worker-thread handle destruction posts the full teardown to the main dispatcher.
+TEST_F(DynamicModuleClusterTest, HandleDestructorFromWorkerThreadDefersAllTeardownToMainThread) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // The internal handle held by the thread-aware load balancer also posts on its main-thread
+  // destruction when `result` is torn down, so allow repeated posts and capture the first one
+  // from the worker-thread handle destruction.
+  Event::PostCb captured_cb;
+  EXPECT_CALL(server_context_.dispatcher_, post(_))
+      .WillRepeatedly(testing::Invoke([&](Event::PostCb cb) {
+        if (!captured_cb) {
+          captured_cb = std::move(cb);
+        }
+      }));
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+  auto& thread_factory = Thread::threadFactoryForTest();
+  auto thread = thread_factory.createThread([&]() { handle.reset(); });
+  thread->join();
+
+  ASSERT_TRUE(captured_cb);
+  EXPECT_NE(cluster.use_count(), 1);
+  captured_cb();
+  cluster.reset();
+  result = absl::InternalError("cleanup");
+}
+
 // Test that the server_initialized lifecycle callback is invoked.
 TEST_F(DynamicModuleClusterTest, ServerInitializedCallback) {
   // Capture the PostInit callback registered during cluster construction.
@@ -2179,6 +2210,46 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(lb_envoy_ptr, context_ptr,
                                                                          nullptr, {nullptr, 0});
+}
+
+// Covers that `async_host_selection_complete` drops the event when the owning load balancer has
+// already been destroyed.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteAfterLbDestroyedDropsEvent) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+  void* raw_lb_ptr = lb_instance.get();
+
+  lb_instance.reset();
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  EXPECT_CALL(context, onAsyncHostSelection(_, _)).Times(0);
+
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      raw_lb_ptr, static_cast<void*>(&context), nullptr, {"dropped", 7});
+}
+
+// Covers pointer reuse: a new load balancer allocated at the same address as a freed one must
+// still be found by the registry.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteRegistersFreshInstancePerLb) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+
+  auto first = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+  first.reset();
+  auto second = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  bool found = DynamicModuleLoadBalancer::withActiveInstance(
+      second.get(), [](const DynamicModuleLoadBalancer&) {});
+  EXPECT_TRUE(found);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

Today, `DynamicModuleClusterHandle::~DynamicModuleClusterHandle` synchronously resets the cluster's lifecycle notifier handles before posting the final cluster destruction onto the main thread. When the last shared pointer to the handle is held by a per-worker load balancer, the destructor runs on a worker thread and those synchronous resets mutate main-thread-owned `ServerLifecycleNotifier` and drain manager state from off the main thread.

Also, `envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete` dereferences the raw `envoy_lb` pointer that the module stored at `on_cluster_lb_new` time: `lb->activeAsyncCancelled()`, `lb->activeAsyncDispatcher()` and `lb->handle()`. A cluster removed mid selection destroys the per-worker `DynamicModuleLoadBalancer` before the module's background task invokes the completion callback, so any of those three accesses can read freed memory.

This PR fixes both the issues.

---

**Commit Message:** dynamic_modules: harden cluster handle teardown and async host selection lifetime
**Additional Description:** Moves cluster handle teardown onto the main dispatcher when running on a worker thread, and adds a process-wide registry of live `DynamicModuleLoadBalancer` instances so the async host selection completion ABI callback never dereferences a raw pointer to a destroyed instance.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A