### PR TITLE
Fix Connection header sanitization bypass on WebSocket upgrade requests

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1206,8 +1206,12 @@ Envoy::StatusOr<CallbackResult> ServerConnectionImpl::onHeadersCompleteBase() {
     auto& headers = absl::get<RequestHeaderMapPtr>(headers_or_trailers_);
     ENVOY_CONN_LOG(trace, "Server: onHeadersComplete size={}", connection_, headers->size());
 
-    if (!handling_upgrade_ && headers->Connection()) {
-      // If we fail to sanitize the request, return a 400 to the client
+    if (headers->Connection()) {
+      // Sanitize Connection-nominated headers for all requests, including
+      // upgrades. Per RFC 7230 Section 6.1, a proxy MUST remove any header
+      // listed in the Connection header before forwarding. Previously, this
+      // was skipped for upgrade requests (handling_upgrade_), allowing
+      // attacker-controlled headers to be smuggled to the upstream.
       if (!Utility::sanitizeConnectionHeader(*headers)) {
         absl::string_view header_value = headers->getConnectionValue();
         ENVOY_CONN_LOG(debug, "Invalid nominated headers in Connection: {}", connection_,


### PR DESCRIPTION
## Description

Apply `sanitizeConnectionHeader()` for all requests including WebSocket upgrades. Previously, when `handling_upgrade_` was true, the entire Connection header sanitization was skipped at `codec_impl.cc:1209`, allowing headers nominated in the Connection header to be forwarded to the upstream in violation of RFC 7230 Section 6.1.

## Root Cause

**File:** `source/common/http/http1/codec_impl.cc`, line 1209

```cpp
// BEFORE (vulnerable):
if (!handling_upgrade_ && headers->Connection()) {
    // sanitizeConnectionHeader skipped entirely for upgrades!
```

```cpp
// AFTER (fixed):
if (headers->Connection()) {
    // sanitizeConnectionHeader runs for ALL requests including upgrades
```

`handling_upgrade_` is set to `true` at line 884 in `onHeadersCompleteImpl()`, which runs BEFORE `onHeadersCompleteBase()`. So when a WebSocket upgrade request arrives, the sanitization is completely bypassed.

Additionally, at `conn_manager_utility.cc:134`, `removeConnection()` is also skipped for upgrade requests, preserving the Connection header and all nominated header names.

## Attack Scenario

An attacker sends a WebSocket upgrade request with additional headers nominated in the Connection header:

```
GET /ws HTTP/1.1
Host: target.com
Connection: Upgrade, x-internal-auth, x-forwarded-user
Upgrade: websocket
Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
Sec-WebSocket-Version: 13
x-internal-auth: admin
x-forwarded-user: superadmin
```

In a normal (non-upgrade) request, `x-internal-auth` and `x-forwarded-user` would be stripped because they are nominated as hop-by-hop in `Connection:`. During a WebSocket upgrade, the sanitization is bypassed and both headers are forwarded to the upstream.

In microservices architectures where backends trust proxy-set headers for authentication (Istio, AWS App Mesh, GKE), this enables authentication bypass — the attacker can impersonate any user or escalate privileges.

## Proof of Concept

Verified against Envoy v1.32-latest Docker image:

**Normal request — headers correctly stripped:**
```
GET /test HTTP/1.1
Connection: keep-alive, x-internal-auth
x-internal-auth: admin
→ Upstream does NOT receive x-internal-auth (correct)
```

**WebSocket upgrade — headers smuggled (BUG):**
```
GET /ws HTTP/1.1
Connection: Upgrade, x-internal-auth
Upgrade: websocket
x-internal-auth: admin
→ Upstream RECEIVES x-internal-auth: admin (BUG)
```

Full PoC with header-echo backend confirmed the smuggling.

## Precedent CVEs (same vulnerability class)

| CVE | Product | Severity | Description |
|-----|---------|----------|-------------|
| CVE-2022-31813 | Apache HTTPD | HIGH | Connection header strips X-Forwarded-* headers |
| CVE-2025-48865 | Fabio | HIGH | Connection header strips security headers |
| CVE-2026-33805 | Fastify | HIGH | Connection header strips developer-injected headers |
| CVE-2023-27487 | Envoy | HIGH (8.2) | x-envoy header smuggling from external sources |

## RFC Reference

**RFC 7230 Section 6.1:**
> "A proxy or gateway MUST parse a received Connection header field before a message is forwarded and, for each connection-option in this field, remove any header field(s) from the message with the same name as the connection-option."

This requirement applies to ALL requests, including upgrade requests.

## Fix

Removed the `!handling_upgrade_` guard. The `sanitizeConnectionHeader()` function already preserves `Upgrade` and `Connection` tokens (utility.cc:962-965) — it only removes custom nominated headers, which must be removed per RFC 7230 regardless of upgrade status.

## Verification

After the fix:
- Normal requests: Connection-nominated headers stripped (unchanged)
- Upgrade requests: Connection-nominated headers now correctly stripped
- WebSocket upgrade functionality: preserved (Upgrade and Connection tokens not removed)

Also reported to envoy-security@googlegroups.com and Google Bug Hunters (issue 504184995).