### PR TITLE
deps: update wasm proxy host to f0310e1

### DIFF
--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -1,9 +1,9 @@
 diff --git a/BUILD b/BUILD
-index 91792a8..872131c 100644
+index e531ce1..cc4562c 100644
 --- a/BUILD
 +++ b/BUILD
-@@ -91,7 +91,7 @@ cc_library(
-         ":headers",
+@@ -92,7 +92,7 @@ cc_library(
+         "@com_google_absl//absl/cleanup",
      ] + select({
          "//bazel:crypto_system": [],
 -        "//conditions:default": ["@boringssl//:crypto"],
@@ -11,7 +11,7 @@ index 91792a8..872131c 100644
      }),
      alwayslink = 1,
  )
-@@ -155,7 +155,7 @@ cc_library(
+@@ -156,6 +156,6 @@ cc_library(
      }),
      deps = [
          ":wasm_vm_headers",
@@ -19,8 +19,7 @@ index 91792a8..872131c 100644
 +        "@envoy//bazel/foreign_cc:wamr",
      ],
  )
- 
-@@ -221,7 +221,7 @@ cc_library(
+@@ -241,6 +241,6 @@ cc_library(
      }),
      deps = [
          ":wasm_vm_headers",
@@ -28,13 +27,3 @@ index 91792a8..872131c 100644
 +        "@wasmtime//:wasmtime_lib",
      ],
  )
- 
-@@ -280,7 +280,7 @@ cc_library(
-     }),
-     deps = [
-         ":wasm_vm_headers",
--        "@com_github_bytecodealliance_wasmtime//:prefixed_wasmtime_lib",
-+        "@wasmtime//:prefixed_wasmtime_lib",
-     ],
- )
- 

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -607,8 +607,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/{version}.tar.gz"],
     ),
     proxy_wasm_cpp_host = dict(
-        version = "beb8a4ece9eede4ab21d89d723359607600296d4",
-        sha256 = "dbd2d449fca10c1cd655efe21eee34fe880f4ff5fe7f01562f7829ca8dd4b2bf",
+        version = "f0310e1322bef51ca99a2be05a4e3d8cbb15bac2",
+        sha256 = "f9de3892ecb674abd94603dee362fcd0e887fcdd0becdcee4b70bcf56951b2f2",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
         urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
     ),


### PR DESCRIPTION
Updated proxy-wasm-cpp-host to [f0310e1](https://github.com/proxy-wasm/proxy-wasm-cpp-host/commit/f0310e1322bef51ca99a2be05a4e3d8cbb15bac2)

Commit Message:  
Updated proxy-wasm-cpp-host to f0310e1

Additional Description:  
Updated proxy-wasm-cpp-host to [f0310e1](https://github.com/proxy-wasm/proxy-wasm-cpp-host/commit/f0310e1322bef51ca99a2be05a4e3d8cbb15bac2), which provides an updated WASM host, which allocated all WASI hostcalls for Go SDK, along with upgrading wasmtime from 24.0.6 to 42.0.1.  
Full changelog from proxy-wasm-cpp-host: [here](https://github.com/proxy-wasm/proxy-wasm-cpp-host/compare/beb8a4ece9eede4ab21d89d723359607600296d4...f0310e1322bef51ca99a2be05a4e3d8cbb15bac2)
Additionally updated proxy_wasm_cpp_host.patch to align with the updated version of proxy-wasm-cpp-host.

Risk Level:  
Low

Testing:  
No additional tests were implemented.  
Tests were run, with the `//test/extensions/common/wasm:wasm_vm` test failing. Further understanding of what have failed is missing - Without tests, an Envoy binary were able to be build and runs correctly in a limited scenario.


Docs Changes:  
None

Release Notes:  


Platform Specific Features:  
None

Fixes #44526