### PR TITLE
ci: remove ENVOY_RBE env var, auto-detect RBE from bazel config

### DIFF
--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -423,7 +423,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ inputs.trusted && steps.appauth.outputs.token || github.token }}
         ENVOY_DOCKER_BUILD_DIR: ${{ runner.temp }}/container
-        ENVOY_RBE: ${{ inputs.rbe == true && 1 || '' }}
         BAZEL_BUILD_EXTRA_OPTIONS: >-
           ${{ env.BAZEL_BUILD_EXTRA_OPTIONS }}
           --config=remote-ci

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -423,6 +423,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ inputs.trusted && steps.appauth.outputs.token || github.token }}
         ENVOY_DOCKER_BUILD_DIR: ${{ runner.temp }}/container
+        ENVOY_RBE: ${{ inputs.rbe == true && 1 || '' }}
         BAZEL_BUILD_EXTRA_OPTIONS: >-
           ${{ env.BAZEL_BUILD_EXTRA_OPTIONS }}
           --config=remote-ci

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -118,7 +118,13 @@ BAZEL_BUILD_OPTIONS=(
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
   "--test_env=HEAPCHECK=")
 
-if bazel "${BAZEL_STARTUP_OPTIONS[@]}" info --announce_rc "${BAZEL_BUILD_OPTIONS[@]}" 2>&1 | grep -q "remote_executor"; then
+rc_output=$(bazel "${BAZEL_STARTUP_OPTIONS[@]}" info --announce_rc "${BAZEL_BUILD_OPTIONS[@]}" 2>&1) || {
+    echo "bazel info failed:" >&2
+    echo "$rc_output" >&2
+    exit 1
+}
+if grep -q "remote_executor" <<<"$rc_output"; then
+
     echo "Remote execution detected, not setting test_tmpdir."
 else
     BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -115,11 +115,10 @@ BAZEL_BUILD_OPTIONS=(
   "${BAZEL_BUILD_EXTRA_OPTIONS[@]}"
   "${BAZEL_EXTRA_TEST_OPTIONS[@]}")
 
-
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
   "--test_env=HEAPCHECK=")
 
-if [[ -z "${ENVOY_RBE}" ]]; then
+if [[ "${BAZEL_BUILD_EXTRA_OPTIONS[*]}" != *"--config=rbe"* ]]; then
     BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
     echo "Setting test_tmpdir to ${ENVOY_TEST_TMPDIR}."
 fi

--- a/ci/build_setup.sh
+++ b/ci/build_setup.sh
@@ -118,7 +118,9 @@ BAZEL_BUILD_OPTIONS=(
 [[ "${ENVOY_BUILD_ARCH}" == "aarch64" ]] && BAZEL_BUILD_OPTIONS+=(
   "--test_env=HEAPCHECK=")
 
-if [[ "${BAZEL_BUILD_EXTRA_OPTIONS[*]}" != *"--config=rbe"* ]]; then
+if bazel "${BAZEL_STARTUP_OPTIONS[@]}" info --announce_rc "${BAZEL_BUILD_OPTIONS[@]}" 2>&1 | grep -q "remote_executor"; then
+    echo "Remote execution detected, not setting test_tmpdir."
+else
     BAZEL_BUILD_OPTIONS+=("--test_tmpdir=${ENVOY_TEST_TMPDIR}")
     echo "Setting test_tmpdir to ${ENVOY_TEST_TMPDIR}."
 fi

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -49,7 +49,6 @@ x-envoy-build-base: &envoy-build-base
   # Build configuration
   - NUM_CPUS
   - ENVOY_BRANCH
-  - ENVOY_RBE
   - ENVOY_BUILD_IMAGE
   - ENVOY_DOCS_PATH
   - ENVOY_SRCDIR


### PR DESCRIPTION
Instead of requiring users to set ENVOY_RBE=1 when using remote execution, detect it automatically by checking if `--config=rbe` is present in BAZEL_BUILD_EXTRA_OPTIONS. This avoids an issue where forgetting to set ENVOY_RBE causes --test_tmpdir to point to a local path that doesn't exist on remote executors.
