### PR TITLE
dfp: cap DNS failure backoff to bound eviction delay after a race condition

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -562,11 +562,25 @@ void DnsCacheImpl::finishResolve(const std::string& host,
               dns_ttl.count() * 1000);
   } else {
     if (!config_.disable_dns_refresh_on_failure()) {
-      const uint64_t refresh_interval =
-          primary_host_info->failure_backoff_strategy_->nextBackOffMs();
-      primary_host_info->refresh_timer_->enableTimer(std::chrono::milliseconds(refresh_interval));
+      // Cap the failure backoff so the next re-resolve alarm fires no later than when the host
+      // becomes eligible for eviction. Without this cap, a touch() that lands just before
+      // onReResolveAlarm leaves the host active and schedules the next check at the full backoff,
+      // which can exceed host_ttl by a large margin.
+      const auto now = main_thread_dispatcher_.timeSource().monotonicTime().time_since_epoch();
+      const auto elapsed = now - primary_host_info->host_info_->lastUsedTime();
+      std::chrono::milliseconds refresh_interval(
+          primary_host_info->failure_backoff_strategy_->nextBackOffMs());
+      if (elapsed >= host_ttl_) {
+        refresh_interval = std::chrono::milliseconds(1);
+      } else {
+        const auto until_eviction =
+            std::chrono::duration_cast<std::chrono::milliseconds>(host_ttl_ - elapsed) +
+            std::chrono::milliseconds(1);
+        refresh_interval = std::min(refresh_interval, until_eviction);
+      }
+      primary_host_info->refresh_timer_->enableTimer(refresh_interval);
       ENVOY_LOG(debug, "DNS refresh rate reset for host '{}', (failure) refresh rate {} ms", host,
-                refresh_interval);
+                refresh_interval.count());
     }
   }
 }

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -867,6 +867,66 @@ TEST_F(DnsCacheImplTest, ResolveFailureAfterResolveSuccess) {
              1 /* added */, 1 /* removed */, 0 /* num hosts */);
 }
 
+TEST_F(DnsCacheImplTest, ResolveFailureBackoffCappedByHostTtl) {
+  *config_.mutable_host_ttl() = Protobuf::util::TimeUtil::SecondsToDuration(1);
+  *config_.mutable_dns_refresh_rate() = Protobuf::util::TimeUtil::SecondsToDuration(60);
+  *config_.mutable_dns_min_refresh_rate() = Protobuf::util::TimeUtil::SecondsToDuration(1);
+  initialize();
+  InSequence s;
+
+  MockLoadDnsCacheEntryCallbacks callbacks;
+  Network::DnsResolver::ResolveCb resolve_cb;
+  Event::MockTimer* resolve_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  auto result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::Loading, result.status_);
+
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(
+      update_callbacks_,
+      onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
+  EXPECT_CALL(callbacks,
+              onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("10.0.0.1:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
+
+  // touch() at T+900ms, then the alarm fires at T+1000ms: now-last_used=100ms < host_ttl=1000ms,
+  // so startResolve runs.
+  simTime().advanceTimeWait(std::chrono::milliseconds(900));
+  dns_cache_->getHost("foo.com:80").value()->touch();
+  simTime().advanceTimeWait(std::chrono::milliseconds(100));
+
+  EXPECT_CALL(*timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  resolve_timer->invokeCallback();
+
+  // DNS fails. The raw failure backoff is 60s (dns_refresh_rate). Without the cap the next alarm
+  // would fire at T+61s. With the cap, it fires at host_ttl-elapsed+1ms = 1000-100+1 = 901ms.
+  EXPECT_CALL(*timeout_timer, disableTimer());
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("10.0.0.1:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Failure));
+  EXPECT_CALL(*resolve_timer, enableTimer(std::chrono::milliseconds(901), _));
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Failure, "", TestUtility::makeDnsResponse({}));
+
+  // After the capped backoff now-last_used = 1001ms > host_ttl: the host is evicted.
+  simTime().advanceTimeWait(std::chrono::milliseconds(901));
+  EXPECT_CALL(update_callbacks_, onDnsHostRemove("foo.com:80"));
+  resolve_timer->invokeCallback();
+  checkStats(2 /* attempt */, 1 /* success */, 1 /* failure */, 1 /* address changed */,
+             1 /* added */, 1 /* removed */, 0 /* num hosts */);
+}
+
 TEST_F(DnsCacheImplTest, DisableRefreshOnFailureContainsFailedHost) {
   config_.set_disable_dns_refresh_on_failure(true);
 


### PR DESCRIPTION
## Description

Today, when `touch()` lands just before `onReResolveAlarm` fires, the eviction check is `false` by a narrow margin, so `startResolve` runs instead of removing the host. If DNS then fails, the next re-resolve alarm gets armed at the full failure backoff which can exceed the Host TTL by a large margin and leaves a stale host alive for a full backoff cycle past its TTL.

This change caps the failure-path refresh interval such that the next alarm fires when the host is eligible for eviction. If the host is already past its TTL, the next alarm is scheduled one millisecond out so `onReResolveAlarm` can evict without further delay. The success path is unchanged where a successful resolve already reset the backoff and the normal DNS TTL cadence is used.

Fix: https://github.com/envoyproxy/envoy/issues/44426

---

**Commit Message:** dfp: cap DNS failure backoff to bound eviction delay after a race condition
**Additional Description:** After a DNS failure the refresh timer is now clamped.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A