### PR TITLE
Reject signed inputs in unsigned parser to prevent malformed x-request-id

### DIFF
--- a/source/common/common/utility.cc
+++ b/source/common/common/utility.cc
@@ -361,6 +361,16 @@ const char* StringUtil::strtoull(const char* str, uint64_t& out, int base) {
     return nullptr;
   }
 
+  // Reject signed values for unsigned parsing to avoid normalizing malformed
+  // inputs (e.g. "-1") into large uint64_t values.
+  const char* first_non_whitespace = str;
+  while (*first_non_whitespace != '\0' && absl::ascii_isspace(*first_non_whitespace)) {
+    ++first_non_whitespace;
+  }
+  if (*first_non_whitespace == '+' || *first_non_whitespace == '-') {
+    return nullptr;
+  }
+
   char* end_ptr;
   errno = 0;
   out = std::strtoull(str, &end_ptr, base);

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -313,6 +313,7 @@ public:
 
   /**
    * Convert a string to an unsigned long, checking for error.
+   * Rejects leading '+' or '-' after optional ASCII whitespace.
    * @return pointer to the remainder of 'str' if successful, nullptr otherwise.
    */
   static const char* strtoull(const char* str, uint64_t& out, int base = 10);

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -117,6 +117,11 @@ TEST(StringUtil, strtoull) {
   EXPECT_EQ(nullptr, StringUtil::strtoull("18446744073709551616", out));
   EXPECT_NE(nullptr, StringUtil::strtoull("18446744073709551615", out));
   EXPECT_EQ(18446744073709551615U, out);
+
+  // Signed values are invalid for unsigned parsing.
+  EXPECT_EQ(nullptr, StringUtil::strtoull("-1", out));
+  EXPECT_EQ(nullptr, StringUtil::strtoull("+1", out));
+  EXPECT_EQ(nullptr, StringUtil::strtoull("\t-42", out));
 }
 
 TEST(StringUtil, atoull) {
@@ -133,6 +138,11 @@ TEST(StringUtil, atoull) {
 
   EXPECT_TRUE(StringUtil::atoull("00789", out));
   EXPECT_EQ(789U, out);
+
+  // Signed values are invalid for unsigned parsing.
+  EXPECT_FALSE(StringUtil::atoull("-1", out));
+  EXPECT_FALSE(StringUtil::atoull("+1", out));
+  EXPECT_FALSE(StringUtil::atoull("\r\n-9", out));
 
   // Verify subsequent call to atoull succeeds after the first one
   // failed due to errno ERANGE

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2495,13 +2495,13 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceOnSignedRequestId) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"x-request-id", "-1aaaaaa-6f55-44ba-ad80-413f09f48a28"}};
 
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("tracing.random_sampling",
-                             An<const envoy::type::v3::FractionalPercent&>(), _))
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("tracing.random_sampling", An<const envoy::type::v3::FractionalPercent&>(), _))
       .Times(0);
-  EXPECT_CALL(runtime_.snapshot_,
-              featureEnabled("tracing.global_enabled",
-                             An<const envoy::type::v3::FractionalPercent&>(), _))
+  EXPECT_CALL(
+      runtime_.snapshot_,
+      featureEnabled("tracing.global_enabled", An<const envoy::type::v3::FractionalPercent&>(), _))
       .Times(0);
   EXPECT_CALL(*request_id_extension_, setTraceReason(_, _)).Times(0);
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2490,6 +2490,25 @@ TEST_F(ConnectionManagerUtilityTest, NoTraceOnBrokenUuid) {
   EXPECT_EQ(Tracing::Reason::NotTraceable, request_id_extension_->getTraceReason(request_headers));
 }
 
+// Signed request IDs are malformed and must not participate in trace sampling.
+TEST_F(ConnectionManagerUtilityTest, NoTraceOnSignedRequestId) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {"x-request-id", "-1aaaaaa-6f55-44ba-ad80-413f09f48a28"}};
+
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("tracing.random_sampling",
+                             An<const envoy::type::v3::FractionalPercent&>(), _))
+      .Times(0);
+  EXPECT_CALL(runtime_.snapshot_,
+              featureEnabled("tracing.global_enabled",
+                             An<const envoy::type::v3::FractionalPercent&>(), _))
+      .Times(0);
+  EXPECT_CALL(*request_id_extension_, setTraceReason(_, _)).Times(0);
+
+  callMutateRequestHeaders(request_headers, Protocol::Http2);
+  EXPECT_EQ(Tracing::Reason::NotTraceable, request_id_extension_->getTraceReason(request_headers));
+}
+
 TEST_F(ConnectionManagerUtilityTest, RemovesProxyResponseHeaders) {
   Http::TestRequestHeaderMapImpl request_headers{{}};
   Http::TestResponseHeaderMapImpl response_headers{{"keep-alive", "timeout=60"},

--- a/test/extensions/request_id/uuid/config_test.cc
+++ b/test/extensions/request_id/uuid/config_test.cc
@@ -197,6 +197,14 @@ TEST(UUIDRequestIDExtensionTest, GetRequestIdAndModRequestIDBy) {
   EXPECT_EQ("fffffffz-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
   EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
 
+  request_headers.setRequestId("-1aaaaaa-0012-0110-00ff-0c00400600ff");
+  EXPECT_EQ("-1aaaaaa-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
+  EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
+
+  request_headers.setRequestId("+1aaaaaa-0012-0110-00ff-0c00400600ff");
+  EXPECT_EQ("+1aaaaaa-0012-0110-00ff-0c00400600ff", uuid_utils.get(request_headers).value());
+  EXPECT_FALSE(uuid_utils.getInteger(request_headers).has_value());
+
   request_headers.setRequestId("00000000-0000-0000-0000-000000000000");
   EXPECT_EQ("00000000-0000-0000-0000-000000000000", uuid_utils.get(request_headers).value());
   EXPECT_EQ(0, uuid_utils.getInteger(request_headers).value());


### PR DESCRIPTION
This change tightens unsigned integer parsing semantics in StringUtil::strtoull by rejecting signed inputs after optional ASCII whitespace.

Previously, parsing relied on std::strtoull, which accepts signed strings and normalizes them into unsigned values. This behavior can cause malformed or non-canonical inputs to be treated as valid values, which may lead to unexpected behavior in downstream logic that relies on parsing failure to detect invalid input.

This patch enforces stricter validation at the shared utility layer by:

- Rejecting leading '+' and '-' characters before conversion
- Preserving existing behavior for valid unsigned inputs
- Returning failure (nullptr / false) for non-canonical signed inputs

## Testing
- Added unit tests in utility_test.cc to verify rejection of signed inputs (including with leading whitespace)
- Extended request-id parsing tests in config_test.cc to ensure signed prefixes are treated as invalid
- Added an end-to-end test in conn_manager_utility_test.cc confirming that malformed signed request IDs do not participate in tracing decision logic

## Risk Level
Low.
This change only tightens input validation for a shared parsing utility and does not alter core logic or algorithms. Existing valid inputs continue to behave identically, while non-canonical signed inputs are now rejected instead of being implicitly normalized.

## Docs Changes
Updated inline documentation for `StringUtil::strtoull` to clarify that signed inputs are rejected.

## Release Notes
Improved validation for unsigned integer parsing to reject signed inputs and avoid normalization of malformed values.

## AI Disclosure
This change was developed with assistance from generative AI tools, and all code and logic have been reviewed and verified manually.