### PR TITLE
Add Paul Ogilby and Peng Gao to OWNERS.md

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -102,6 +102,8 @@ without further review.
 * Antonio Leonti ([antoniovleonti](https://github.com/antoniovleonti)) (leonti@google.com)
 * Takeshi Yoneda ([mathetake](https://github.com/mathetake)) (tyoneda@netflix.com)
 * Reuben Tanner ([reubent-goog](https://github.com/reubent-goog)) (reubent@google.com)
+* Paul Ogilby ([paul-r-gall](https://github.com/paul-r-gall)) (pgal@google.com)
+* Peng Gao ([penguingao](https://github.com/penguingao)) (pengg@google.com)
 
 # Emeritus maintainers
 


### PR DESCRIPTION
Add Paul Ogilby and Peng Gao to the Envoy security team in OWNERS.md