### PR TITLE
Use a different file descriptor for fake sockets

### DIFF
--- a/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.h
+++ b/test/extensions/filters/listener/common/fuzz/listener_filter_fakes.h
@@ -11,7 +11,7 @@ namespace Envoy {
 namespace Extensions {
 namespace ListenerFilters {
 
-static constexpr int kFakeSocketFd = 42;
+static constexpr int kFakeSocketFd = 65534;
 
 class FakeConnectionSocket : public Network::MockConnectionSocket {
 public:


### PR DESCRIPTION
Using file descriptor 42 caused tests that use FakeConnectionSocket to be flaky internally. File descriptor with value 42 could be used by internal runtime and closing the descriptor caused tests errors due to infra. Pick a descriptor number that is much less likely to be in use.

The other fix is to actually open a new socket and let OS pick descriptor, but it has a negative impact on fuzzing perf.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
