### PR TITLE
chore: typo `enviroment` -> `environment` in maxmind test_data README

### DIFF
--- a/test/extensions/geoip_providers/maxmind/test_data/README.md
+++ b/test/extensions/geoip_providers/maxmind/test_data/README.md
@@ -1,6 +1,6 @@
 # Generating custom geoip databases
 
-For testing purposes one could generate geolocation databases with custom data by using [Maxmind test utility](https://github.com/maxmind/MaxMind-DB/blob/main/cmd/write-test-data/main.go). Assuming your enviroment has Golang installed, follow these steps:
+For testing purposes one could generate geolocation databases with custom data by using [Maxmind test utility](https://github.com/maxmind/MaxMind-DB/blob/main/cmd/write-test-data/main.go). Assuming your environment has Golang installed, follow these steps:
 * Create `source` directory on the same level as `main.go` utility and copy all geolocation db files from [source-data](https://github.com/maxmind/MaxMind-DB/tree/main/source-data) directory.
 * Update the target geolocation db file (e.g. GeoIP2-City-Test.json) in newly created `source` directory with test data.
 * Create `out-data` directory on the same level as `main.go` utility and run:


### PR DESCRIPTION
One-character typo fix inside `test/extensions/geoip_providers/maxmind/test_data/README.md:3`. No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>