### PR TITLE
test/ext_proc: Fix spinning loop (and hang) in serverReceiveBodyDuplexStreamed

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
@@ -100,7 +100,10 @@ TEST_P(ExtProcIntegrationTest, LargeBodyTestDuplexStreamed) {
   const std::string body_sent(2 * 1024 * 1024, 's');
   initializeConfigDuplexStreamed(false);
 
-  // Sends 30 consecutive request, each carrying 2MB data.
+  // Sends 30 consecutive requests, each carrying 2MB data.
+  // The processor gRPC connection is established once on the first iteration and reused across all
+  // iterations; each iteration opens a new gRPC stream on that persistent connection. This matches
+  // real ext_proc behavior and avoids the per-iteration connection-churn race.
   for (int i = 0; i < 30; i++) {
     codec_client_ = makeHttpConnection(lookupPort("http"));
     Http::TestRequestHeaderMapImpl default_headers;
@@ -111,13 +114,21 @@ TEST_P(ExtProcIntegrationTest, LargeBodyTestDuplexStreamed) {
     request_encoder_ = &encoder_decoder.first;
     IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
     codec_client_->sendData(*request_encoder_, body_sent, true);
-    // The ext_proc server receives the headers.
+
+    // On the first iteration, wait for the gRPC connection to be established.
+    if (i == 0) {
+      EXPECT_TRUE(grpc_upstreams_[0]->waitForHttpConnection(*dispatcher_, processor_connection_));
+    }
+    // Each iteration opens a new gRPC stream on the persistent processor connection.
     ProcessingRequest header_request;
-    serverReceiveHeaderReq(header_request);
+    EXPECT_TRUE(processor_connection_->waitForNewStream(*dispatcher_, processor_stream_));
+    EXPECT_TRUE(processor_stream_->waitForGrpcMessage(*dispatcher_, header_request));
+    EXPECT_TRUE(header_request.has_request_headers());
+
     // The ext_proc server receives the body.
     uint32_t total_req_body_msg = serverReceiveBodyDuplexStreamed(body_sent, processor_stream_);
     EXPECT_GT(total_req_body_msg, 0);
-    // The ext_proc server sends back the header response.
+    // The ext_proc server sends back the header response (startGrpcStream is per-stream).
     serverSendHeaderResp();
     // The ext_proc server sends back body responses, which include 50 chunks,
     // and each chunk contains 64KB data, thus totally ~3MB per request.
@@ -131,7 +142,9 @@ TEST_P(ExtProcIntegrationTest, LargeBodyTestDuplexStreamed) {
     EXPECT_THAT(upstream_request_->headers(), ContainsHeader("x-new-header", "new"));
     EXPECT_EQ(upstream_request_->body().toString(), body_upstream);
     verifyDownstreamResponse(*response, 200);
-    TearDown();
+
+    // Clean up per-iteration upstream/downstream state; processor_connection_ stays alive.
+    cleanupUpstreamAndDownstream();
   }
 }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
@@ -841,12 +841,18 @@ uint32_t ExtProcIntegrationTest::serverReceiveBodyDuplexStreamed(absl::string_vi
   uint32_t total_req_body_msg = 0;
   while (!end_stream) {
     ProcessingRequest body_request;
-    EXPECT_TRUE(processor_stream->waitForGrpcMessage(*dispatcher_, body_request));
+    if (!processor_stream->waitForGrpcMessage(*dispatcher_, body_request)) {
+      ADD_FAILURE() << "Timed out waiting for gRPC message in serverReceiveBodyDuplexStreamed";
+      return total_req_body_msg;
+    }
     if (response) {
       if (body_request.has_response_trailers()) {
         end_stream = true;
       } else {
-        EXPECT_TRUE(body_request.has_response_body());
+        if (!body_request.has_response_body()) {
+          ADD_FAILURE() << "Expected response body message but got unexpected message type";
+          return total_req_body_msg;
+        }
         body_received = absl::StrCat(body_received, body_request.response_body().body());
         end_stream = body_request.response_body().end_of_stream();
         total_req_body_msg++;
@@ -855,7 +861,10 @@ uint32_t ExtProcIntegrationTest::serverReceiveBodyDuplexStreamed(absl::string_vi
       if (body_request.has_request_trailers()) {
         end_stream = true;
       } else {
-        EXPECT_TRUE(body_request.has_request_body());
+        if (!body_request.has_request_body()) {
+          ADD_FAILURE() << "Expected request body message but got unexpected message type";
+          return total_req_body_msg;
+        }
         body_received = absl::StrCat(body_received, body_request.request_body().body());
         end_stream = body_request.request_body().end_of_stream();
         total_req_body_msg++;


### PR DESCRIPTION
by using early-return on failure

i have been increasing sharding - but it seems in reality the test is just hanging

we possibly want to decrease the shards if this works