### PR TITLE
Replaces a shared_ptr with a unique_ptr in a data structure

### DIFF
--- a/source/common/http/matching/data_impl.h
+++ b/source/common/http/matching/data_impl.h
@@ -70,8 +70,6 @@ private:
   const ResponseTrailerMap* response_trailers_{};
 };
 
-using HttpMatchingDataImplSharedPtr = std::shared_ptr<HttpMatchingDataImpl>;
-
 struct HttpFilterActionContext {
   // Identify whether the filter is in downstream filter chain or upstream filter chain.
   const bool is_downstream_ = true;

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -33,7 +33,7 @@ public:
     bool skipFilter() const { return skip_filter_; }
     void onStreamInfo(const StreamInfo::StreamInfo& stream_info) {
       if (matching_data_ == nullptr) {
-        matching_data_ = std::make_shared<Envoy::Http::Matching::HttpMatchingDataImpl>(stream_info);
+        matching_data_ = std::make_unique<Envoy::Http::Matching::HttpMatchingDataImpl>(stream_info);
       }
     }
 
@@ -49,7 +49,7 @@ public:
     Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
     Envoy::Http::StreamFilterBase* base_filter_{};
 
-    Envoy::Http::Matching::HttpMatchingDataImplSharedPtr matching_data_;
+    std::unique_ptr<Envoy::Http::Matching::HttpMatchingDataImpl> matching_data_;
     bool match_tree_evaluated_{};
     bool skip_filter_{};
   };


### PR DESCRIPTION
The `std::shared_ptr` is not necessary for a private member of `FilterMatchState` that is initialized by the data structure itself, and never shared via an accessor or copy operation.

This is just a small attempt to push back against the shared pointer incontinence that appears to be prevalent in the Envoy codebase.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
