### PR TITLE
Support repeated string extraction in Proto Message Extraction filter

### DIFF
--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
@@ -335,12 +335,20 @@ absl::StatusOr<std::string> ExtractStringFieldValue(
                          CodedInputStream* input_stream) -> absl::StatusOr<std::string> {
     if (field->kind() != Field::TYPE_STRING) {
       return absl::InvalidArgumentError(
-          absl::Substitute("Field '$0' is not a singular string field.", field->name()));
+          absl::Substitute("Field '$0' is not a string field.", field->name()));
     } else if (field->cardinality() == Field::CARDINALITY_REPEATED) {
-      return absl::InvalidArgumentError(
-          absl::Substitute("Field '$0' is a repeated string field, only singular "
-                           "string field is accepted.",
-                           field->name()));
+      std::string result;
+      uint32_t tag = 0;
+      while ((tag = input_stream->ReadTag()) != 0) {
+        if (field->number() == WireFormatLite::GetTagFieldNumber(tag)) {
+          uint32_t length;
+          input_stream->ReadVarint32(&length);
+          input_stream->ReadString(&result, length);
+        } else {
+          WireFormatLite::SkipField(input_stream, tag);
+        }
+      }
+      return result;
     } else { // singular string field
       std::string result;
       if (FieldExtractor::SearchField(*field, input_stream)) {

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
@@ -82,7 +82,7 @@ ExtractedMessageDirective typeMapping(const MethodExtraction::ExtractDirective& 
 absl::Status ExtractorImpl::init() {
   FieldValueExtractorFactory extractor_factory(type_finder_);
   for (const auto& it : method_extraction_.request_extraction_by_field()) {
-    // TODO(adh-goog): Allow repeated field extraction in field_value_extractor.
+    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is constrained to supported types in the proto field extraction library: https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
     if (it.second != MethodExtraction::EXTRACT_REPEATED_CARDINALITY) {
       auto extractor = extractor_factory.Create(request_type_url_, it.first);
       if (!extractor.ok()) {
@@ -95,7 +95,7 @@ absl::Status ExtractorImpl::init() {
   }
 
   for (const auto& it : method_extraction_.response_extraction_by_field()) {
-    // TODO(adh-goog): Allow repeated field extraction in field_value_extractor.
+    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is constrained to supported types in the proto field extraction library: https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
     if (it.second != MethodExtraction::EXTRACT_REPEATED_CARDINALITY) {
       auto extractor = extractor_factory.Create(response_type_url_, it.first);
       if (!extractor.ok()) {

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
@@ -82,7 +82,9 @@ ExtractedMessageDirective typeMapping(const MethodExtraction::ExtractDirective& 
 absl::Status ExtractorImpl::init() {
   FieldValueExtractorFactory extractor_factory(type_finder_);
   for (const auto& it : method_extraction_.request_extraction_by_field()) {
-    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is constrained to supported types in the proto field extraction library: https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
+    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is
+    // constrained to supported types in the proto field extraction library:
+    // https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
     if (it.second != MethodExtraction::EXTRACT_REPEATED_CARDINALITY) {
       auto extractor = extractor_factory.Create(request_type_url_, it.first);
       if (!extractor.ok()) {
@@ -95,7 +97,9 @@ absl::Status ExtractorImpl::init() {
   }
 
   for (const auto& it : method_extraction_.response_extraction_by_field()) {
-    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is constrained to supported types in the proto field extraction library: https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
+    // Allow arbitrary types only for cardinality extraction. Otherwise, the extractor is
+    // constrained to supported types in the proto field extraction library:
+    // https://github.com/grpc-ecosystem/proto-field-extraction/blob/main/proto_field_extraction/field_value_extractor/field_value_extractor_factory.cc#L42-L61
     if (it.second != MethodExtraction::EXTRACT_REPEATED_CARDINALITY) {
       auto extractor = extractor_factory.Create(response_type_url_, it.first);
       if (!extractor.ok()) {

--- a/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
@@ -672,9 +672,9 @@ TEST_F(ExtractionUtilTest, ExtractStringFieldValue_OK_DefaultValue) {
 }
 
 TEST_F(ExtractionUtilTest, ExtractStringFieldValue_OK_RepeatedStringLeafNode) {
-  EXPECT_THAT(
-      ExtractStringFieldValue(*request_type_, type_finder_, "repeated_strings", test_request_raw_proto_),
-      IsOkAndHolds("repeated-string-0"));
+  EXPECT_THAT(ExtractStringFieldValue(*request_type_, type_finder_, "repeated_strings",
+                                      test_request_raw_proto_),
+              IsOkAndHolds("repeated-string-0"));
 }
 
 TEST_F(ExtractionUtilTest, ExtractStringFieldValue_Error_EmptyPath) {

--- a/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util_test.cc
@@ -671,6 +671,12 @@ TEST_F(ExtractionUtilTest, ExtractStringFieldValue_OK_DefaultValue) {
       IsOkAndHolds(""));
 }
 
+TEST_F(ExtractionUtilTest, ExtractStringFieldValue_OK_RepeatedStringLeafNode) {
+  EXPECT_THAT(
+      ExtractStringFieldValue(*request_type_, type_finder_, "repeated_strings", test_request_raw_proto_),
+      IsOkAndHolds("repeated-string-0"));
+}
+
 TEST_F(ExtractionUtilTest, ExtractStringFieldValue_Error_EmptyPath) {
   EXPECT_THAT(ExtractStringFieldValue(*request_type_, type_finder_, "", test_request_raw_proto_),
               StatusIs(absl::StatusCode::kInvalidArgument));
@@ -686,12 +692,6 @@ TEST_F(ExtractionUtilTest, ExtractStringFieldValue_Error_UnknownField) {
       StatusIs(absl::StatusCode::kInvalidArgument));
 
   EXPECT_THAT(ExtractStringFieldValue(*request_type_, type_finder_, "unknown1.unknown2",
-                                      test_request_raw_proto_),
-              StatusIs(absl::StatusCode::kInvalidArgument));
-}
-
-TEST_F(ExtractionUtilTest, ExtractStringFieldValue_Error_RepeatedStringLeafNode) {
-  EXPECT_THAT(ExtractStringFieldValue(*request_type_, type_finder_, "repeated_strings",
                                       test_request_raw_proto_),
               StatusIs(absl::StatusCode::kInvalidArgument));
 }

--- a/test/extensions/filters/http/proto_message_extraction/filter_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/filter_test.cc
@@ -1094,6 +1094,86 @@ TEST_F(FilterTestExtractOk, ExtractCardinalityRepeatedComplexField) {
   EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->encodeData(*response_data, true));
 }
 
+TEST_F(FilterTestExtractOk, ExtractRepeatedStringField) {
+  setUp(R"pb(
+    mode: FIRST_AND_LAST
+    extraction_by_method: {
+      key: "apikeys.ApiKeys.CreateApiKey"
+      value: {
+        response_extraction_by_field: { key: "repeated_string_field" value: EXTRACT }
+      }
+    })pb");
+
+  TestRequestHeaderMapImpl req_headers =
+      TestRequestHeaderMapImpl{{":method", "POST"},
+                               {":path", "/apikeys.ApiKeys/CreateApiKey"},
+                               {"content-type", "application/grpc"}};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(req_headers, true));
+
+  CreateApiKeyRequest request = makeCreateApiKeyRequest();
+  Envoy::Buffer::InstancePtr request_data = Envoy::Grpc::Common::serializeToGrpcFrame(request);
+  EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(*request_data, true));
+
+  Envoy::Http::TestResponseHeaderMapImpl resp_headers = TestResponseHeaderMapImpl{
+      {":status", "200"},
+      {"grpc-status", "1"},
+      {"content-type", "application/grpc"},
+  };
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter_->encodeHeaders(resp_headers, false));
+
+  apikeys::ApiKey response = makeCreateApiKeyResponse(R"pb(
+    repeated_string_field: "one"
+    repeated_string_field: "two"
+    repeated_string_field: "three"
+  )pb");
+  Envoy::Buffer::InstancePtr response_data = Envoy::Grpc::Common::serializeToGrpcFrame(response);
+
+  EXPECT_CALL(mock_encoder_callbacks_.stream_info_, setDynamicMetadata(_, _))
+      .WillOnce([](const std::string& ns, const Envoy::Protobuf::Struct& new_dynamic_metadata) {
+        EXPECT_EQ(ns, kFilterName);
+        checkProtoStruct(new_dynamic_metadata, R"pb(
+            fields {
+              key: "responses"
+              value {
+                struct_value {
+                  fields {
+                    key: "first"
+                    value {
+                      struct_value {
+                        fields {
+                          key: "@type"
+                          value {
+                            string_value: "type.googleapis.com/apikeys.ApiKey"
+                          }
+                        }
+                        fields {
+                          key: "repeatedStringField"
+                          value {
+                            list_value {
+                              values {
+                                string_value: "one"
+                              }
+                              values {
+                                string_value: "two"
+                              }
+                              values {
+                                string_value: "three"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          )pb");
+      });
+  EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->encodeData(*response_data, true));
+}
+
 TEST_F(FilterTestExtractOk, ExtractCardinalityRepeatedStringField) {
   setUp(R"pb(
     mode: FIRST_AND_LAST

--- a/test/extensions/filters/http/proto_message_extraction/integration_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/integration_test.cc
@@ -73,6 +73,7 @@ typed_config:
         parent: EXTRACT
       response_extraction_by_field:
         name: EXTRACT
+        repeated_string_field: EXTRACT
     apikeys.ApiKeys.CreateApiKeyInStream:
       request_extraction_by_field:
         parent: EXTRACT
@@ -308,6 +309,58 @@ TEST_P(IntegrationTest, ExtractRepeatedCardinality) {
     "first": {
       "@type": "type.googleapis.com/apikeys.ListApiKeysResponse",
       "numResponseItems": "2"
+    }
+  }
+})");
+}
+
+TEST_P(IntegrationTest, ExtractRepeatedStringField) {
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto request = makeCreateApiKeyRequest();
+  Envoy::Buffer::InstancePtr request_data = Envoy::Grpc::Common::serializeToGrpcFrame(request);
+  auto request_headers = Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                        {":path", "/apikeys.ApiKeys/CreateApiKey"},
+                                                        {"content-type", "application/grpc"},
+                                                        {":authority", "host"},
+                                                        {":scheme", "http"}};
+
+  auto response = codec_client_->makeRequestWithBody(request_headers, request_data->toString());
+  waitForNextUpstreamRequest();
+
+  // Make sure that the body was properly propagated (with no modification).
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(upstream_request_->receivedData());
+  EXPECT_EQ(upstream_request_->body().toString(), request_data->toString());
+
+  // Send response.
+  ApiKey apikey_response = makeCreateApiKeyResponse(R"pb(
+    name: "apikey-name"
+    repeated_string_field: "one"
+    repeated_string_field: "two"
+    repeated_string_field: "three"
+  )pb");
+  Envoy::Buffer::InstancePtr response_data =
+      Envoy::Grpc::Common::serializeToGrpcFrame(apikey_response);
+  sendResponse(response.get(), response_data.get());
+
+  compareJson(waitForAccessLog(access_log_name_),
+              R"(
+{
+  "requests": {
+    "first": {
+      "@type": "type.googleapis.com/apikeys.CreateApiKeyRequest",
+      "parent": "project-id"
+    }
+  },
+  "responses": {
+    "first": {
+      "@type": "type.googleapis.com/apikeys.ApiKey",
+      "name": "apikey-name",
+      "repeatedStringField": [
+        "one",
+        "two",
+        "three"
+      ]
     }
   }
 })");


### PR DESCRIPTION
## Summary

Expands the functionality of the extraction library to support repeated string values, which currently is explicitly an error. The resulting dynamic metadata contains the extracted fields in a ListValue.

___

Commit Message: Support repeated string extraction in PME filter
Additional Description: N/A
Risk Level: low
Testing: unit & integration filter tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
