### PR TITLE
dynamic_modules: add access_logger arm and unify access logger FFI in the SDK

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -478,6 +478,12 @@ new_features:
     in dynamic modules.
 - area: dynamic_modules
   change: |
+    Rust SDK: a single dynamic module can now host multiple access loggers via the new
+    ``access_logger:`` arm of ``declare_all_init_functions!``, which registers a factory that
+    dispatches to different ``AccessLoggerConfig`` implementations by ``logger_name``. The
+    legacy ``declare_access_logger!`` macro is preserved as a single-config shim.
+- area: dynamic_modules
+  change: |
     Added upstream HTTP TCP bridge extension for dynamic modules. This enables modules to transform
     HTTP requests into raw TCP data for upstream connections and convert TCP responses back into HTTP
     responses via explicit send callbacks. See :ref:`envoy.upstreams.http.dynamic_modules

--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -1,6 +1,11 @@
 //! Access logger support for dynamic modules.
 //!
 //! This module provides traits and types for implementing access loggers as dynamic modules.
+//! The recommended entry point is the `access_logger:` arm of
+//! [`crate::declare_all_init_functions!`], which registers a factory through
+//! [`crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION`] and lets a single module dispatch by
+//! `logger_name`. The legacy [`crate::declare_access_logger!`] macro is preserved as a
+//! single-config shim over the same factory.
 
 use crate::{abi, EnvoyBuffer};
 use std::ffi::c_void;
@@ -197,12 +202,25 @@ impl MetricsContext {
 }
 
 /// Trait that the dynamic module must implement to provide the access logger configuration.
-pub trait AccessLoggerConfig: Sized + Send + Sync + 'static {
+///
+/// The trait is dyn-safe: the
+/// [`NewAccessLoggerConfigFunction`](crate::NewAccessLoggerConfigFunction) factory returns `Box<dyn
+/// AccessLoggerConfig>`, which lets a single module host multiple logger implementations and
+/// dispatch between them by `name`. Methods bounded by `Self: Sized` are excluded from the vtable,
+/// so [`AccessLoggerConfig::new`] remains callable from `impl` blocks via the legacy
+/// [`crate::declare_access_logger!`] shim.
+pub trait AccessLoggerConfig: Send + Sync {
   /// Create a new configuration from the provided name and config bytes.
   ///
   /// The `ctx` provides access to metrics definition APIs. Metrics should be defined
   /// during configuration creation and the handles stored in the config for later use.
-  fn new(ctx: &ConfigContext, name: &str, config: &[u8]) -> Result<Self, String>;
+  ///
+  /// Only invoked by the legacy [`crate::declare_access_logger!`] shim. Callers using
+  /// [`crate::declare_all_init_functions!`]'s `access_logger:` arm provide a free factory
+  /// function instead and do not need to implement this method.
+  fn new(ctx: &ConfigContext, name: &str, config: &[u8]) -> Result<Self, String>
+  where
+    Self: Sized;
 
   /// Create a logger instance. Called per-thread for thread-local loggers.
   ///
@@ -1232,10 +1250,145 @@ impl LogContext {
   }
 }
 
-/// Macro to declare access logger entry points.
+/// Wrapper that stores the trait object together with the config-scope Envoy pointer.
 ///
-/// This macro generates the required C ABI functions that Envoy calls to interact with
-/// the access logger implementation.
+/// Envoy does not re-pass the config-scope pointer to the per-worker logger callback, so the
+/// SDK captures it at config creation and reuses it to build a [`MetricsContext`] in
+/// [`envoy_dynamic_module_on_access_logger_new`].
+struct AccessLoggerConfigHandle {
+  inner: Box<dyn AccessLoggerConfig>,
+  config_envoy_ptr: *mut c_void,
+}
+
+// SAFETY: `inner` is `Send + Sync` via the `AccessLoggerConfig` bound. `config_envoy_ptr`
+// addresses Envoy's `DynamicModuleAccessLogConfig`, which is thread-safe for the operations
+// invoked through `MetricsContext`.
+unsafe impl Send for AccessLoggerConfigHandle {}
+unsafe impl Sync for AccessLoggerConfigHandle {}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_new(
+  config_envoy_ptr: *mut c_void,
+  name: abi::envoy_dynamic_module_type_envoy_buffer,
+  config: abi::envoy_dynamic_module_type_envoy_buffer,
+) -> *const c_void {
+  // The name and config originate from protobuf string/bytes fields, so they are valid
+  // UTF-8 and within bounds when received here. Mirrors the http filter FFI entry point.
+  let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+    name.ptr as *const _,
+    name.length,
+  ));
+  let config_bytes = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+  let ctx = ConfigContext::new(config_envoy_ptr);
+
+  envoy_dynamic_module_on_access_logger_config_new_impl(
+    &ctx,
+    name_str,
+    config_bytes,
+    crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION
+      .get()
+      .expect("NEW_ACCESS_LOGGER_CONFIG_FUNCTION must be set"),
+    config_envoy_ptr,
+  )
+}
+
+/// Testable wrapper for [`envoy_dynamic_module_on_access_logger_config_new`].
+///
+/// Mirrors `http::envoy_dynamic_module_on_http_filter_config_new_impl`: the FFI entry point
+/// extracts the inputs and resolves the registered factory; this function performs the
+/// `Option`-to-pointer conversion that unit tests can drive directly.
+pub fn envoy_dynamic_module_on_access_logger_config_new_impl(
+  ctx: &ConfigContext,
+  name: &str,
+  config: &[u8],
+  new_fn: &crate::NewAccessLoggerConfigFunction,
+  config_envoy_ptr: *mut c_void,
+) -> *const c_void {
+  match new_fn(ctx, name, config) {
+    Some(inner) => Box::into_raw(Box::new(AccessLoggerConfigHandle {
+      inner,
+      config_envoy_ptr,
+    })) as *const c_void,
+    None => ptr::null(),
+  }
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_destroy(
+  config_ptr: *const c_void,
+) {
+  drop(Box::from_raw(config_ptr as *mut AccessLoggerConfigHandle));
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_new(
+  config_ptr: *const c_void,
+  logger_envoy_ptr: *mut c_void,
+) -> *const c_void {
+  let handle = &*(config_ptr as *const AccessLoggerConfigHandle);
+  let metrics = MetricsContext::new(handle.config_envoy_ptr);
+  let logger: Box<dyn AccessLogger> = handle.inner.create_logger(metrics, logger_envoy_ptr);
+  crate::wrap_into_c_void_ptr!(logger)
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_log(
+  envoy_ptr: *mut c_void,
+  logger_ptr: *mut c_void,
+  log_type: abi::envoy_dynamic_module_type_access_log_type,
+) {
+  let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+  let access_log_type = AccessLogType::from_abi(log_type);
+  let ctx = LogContext::new(envoy_ptr, access_log_type);
+  logger.log(&ctx);
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_destroy(logger_ptr: *mut c_void) {
+  crate::drop_wrapped_c_void_ptr!(logger_ptr, AccessLogger);
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_flush(logger_ptr: *mut c_void) {
+  let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+  logger.flush();
+}
+
+/// Declare access-logger entry points for a single user-supplied config type.
+///
+/// This is the legacy single-config entry point. New callers should prefer
+/// [`crate::declare_all_init_functions!`]'s `access_logger:` arm, which dispatches to
+/// different config types by `logger_name` and lets a single module host multiple loggers.
+///
+/// Like every other single-type init macro in the SDK (for example
+/// [`crate::declare_bootstrap_init_functions!`] or
+/// [`crate::declare_cluster_init_functions!`]), this macro emits
+/// `envoy_dynamic_module_on_program_init` and therefore cannot be combined with another
+/// init macro in the same crate.
 ///
 /// # Example
 ///
@@ -1246,21 +1399,16 @@ impl LogContext {
 /// struct MyLoggerConfig {
 ///   format: String,
 ///   logs_counter: CounterHandle,
-///   config_envoy_ptr: *mut std::ffi::c_void,
 /// }
 ///
-/// unsafe impl Send for MyLoggerConfig {}
-/// unsafe impl Sync for MyLoggerConfig {}
-///
 /// impl AccessLoggerConfig for MyLoggerConfig {
-///   fn new(ctx: &ConfigContext, name: &str, config: &[u8]) -> Result<Self, String> {
+///   fn new(ctx: &ConfigContext, _name: &str, config: &[u8]) -> Result<Self, String> {
 ///     let logs_counter = ctx
 ///       .define_counter("logs_total")
 ///       .ok_or("Failed to define counter")?;
 ///     Ok(Self {
 ///       format: String::from_utf8_lossy(config).to_string(),
 ///       logs_counter,
-///       config_envoy_ptr: ctx.envoy_ptr(),
 ///     })
 ///   }
 ///
@@ -1297,94 +1445,25 @@ impl LogContext {
 #[macro_export]
 macro_rules! declare_access_logger {
   ($config_type:ty) => {
-    /// Wrapper that stores both the config and the envoy pointer for metrics access.
-    struct AccessLoggerConfigWrapper {
-      config: $config_type,
-      config_envoy_ptr: *mut ::std::ffi::c_void,
-    }
-
-    unsafe impl Send for AccessLoggerConfigWrapper {}
-    unsafe impl Sync for AccessLoggerConfigWrapper {}
-
     #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_config_new(
-      config_envoy_ptr: *mut ::std::ffi::c_void,
-      name: $crate::abi::envoy_dynamic_module_type_envoy_buffer,
-      config: $crate::abi::envoy_dynamic_module_type_envoy_buffer,
-    ) -> *const ::std::ffi::c_void {
-      let name_str = unsafe {
-        let slice = ::std::slice::from_raw_parts(name.ptr as *const u8, name.length);
-        ::std::str::from_utf8(slice).unwrap_or("")
-      };
-      let config_bytes =
-        unsafe { ::std::slice::from_raw_parts(config.ptr as *const u8, config.length) };
-
-      let ctx = $crate::access_log::ConfigContext::new(config_envoy_ptr);
-      match <$config_type as $crate::access_log::AccessLoggerConfig>::new(
-        &ctx,
-        name_str,
-        config_bytes,
-      ) {
-        Ok(c) => {
-          let wrapper = AccessLoggerConfigWrapper {
-            config: c,
-            config_envoy_ptr,
-          };
-          Box::into_raw(Box::new(wrapper)) as *const ::std::ffi::c_void
-        },
-        Err(_) => ::std::ptr::null(),
+    pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
+      fn __single_access_logger_factory(
+        ctx: &$crate::access_log::ConfigContext,
+        name: &str,
+        config: &[u8],
+      ) -> ::std::option::Option<::std::boxed::Box<dyn $crate::access_log::AccessLoggerConfig>> {
+        match <$config_type as $crate::access_log::AccessLoggerConfig>::new(ctx, name, config) {
+          Ok(c) => ::std::option::Option::Some(::std::boxed::Box::new(c)
+            as ::std::boxed::Box<dyn $crate::access_log::AccessLoggerConfig>),
+          Err(_) => ::std::option::Option::None,
+        }
       }
-    }
-
-    #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_config_destroy(
-      config_ptr: *const ::std::ffi::c_void,
-    ) {
-      unsafe {
-        drop(Box::from_raw(config_ptr as *mut AccessLoggerConfigWrapper));
-      }
-    }
-
-    #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_new(
-      config_ptr: *const ::std::ffi::c_void,
-      logger_envoy_ptr: *mut ::std::ffi::c_void,
-    ) -> *const ::std::ffi::c_void {
-      let wrapper = unsafe { &*(config_ptr as *const AccessLoggerConfigWrapper) };
-      let metrics = $crate::access_log::MetricsContext::new(wrapper.config_envoy_ptr);
-      let logger = wrapper.config.create_logger(metrics, logger_envoy_ptr);
-      Box::into_raw(Box::new(logger)) as *const ::std::ffi::c_void
-    }
-
-    #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_log(
-      envoy_ptr: *mut ::std::ffi::c_void,
-      logger_ptr: *mut ::std::ffi::c_void,
-      log_type: $crate::abi::envoy_dynamic_module_type_access_log_type,
-    ) {
-      let logger = unsafe { &mut *(logger_ptr as *mut Box<dyn $crate::access_log::AccessLogger>) };
-      let access_log_type = $crate::access_log::AccessLogType::from_abi(log_type);
-      let ctx = $crate::access_log::LogContext::new(envoy_ptr, access_log_type);
-      logger.log(&ctx);
-    }
-
-    #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_destroy(
-      logger_ptr: *mut ::std::ffi::c_void,
-    ) {
-      unsafe {
-        drop(Box::from_raw(
-          logger_ptr as *mut Box<dyn $crate::access_log::AccessLogger>,
-        ));
-      }
-    }
-
-    #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_access_logger_flush(
-      logger_ptr: *mut ::std::ffi::c_void,
-    ) {
-      let logger = unsafe { &mut *(logger_ptr as *mut Box<dyn $crate::access_log::AccessLogger>) };
-      logger.flush();
+      $crate::set_factory_once!(
+        $crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION,
+        __single_access_logger_factory as $crate::NewAccessLoggerConfigFunction,
+        "NEW_ACCESS_LOGGER_CONFIG_FUNCTION"
+      );
+      $crate::abi::envoy_dynamic_modules_abi_version.as_ptr() as *const ::std::os::raw::c_char
     }
   };
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -609,6 +609,7 @@ macro_rules! declare_network_filter_init_functions {
 /// - `tracer:` — [`NewTracerConfigFunction`] for tracers
 /// - `dns_resolver:` — [`NewDnsResolverConfigFunction`] for DNS resolvers
 /// - `transport_socket:` — [`NewTransportSocketFactoryConfigFunction`] for transport sockets
+/// - `access_logger:` — [`NewAccessLoggerConfigFunction`] for access loggers
 ///
 /// # Examples
 ///
@@ -797,6 +798,13 @@ macro_rules! declare_all_init_functions {
       envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION,
       $fn,
       "NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION"
+    );
+  };
+  (@register access_logger : $fn:expr) => {
+    envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+      envoy_proxy_dynamic_modules_rust_sdk::NEW_ACCESS_LOGGER_CONFIG_FUNCTION,
+      $fn,
+      "NEW_ACCESS_LOGGER_CONFIG_FUNCTION"
     );
   };
 }
@@ -1024,6 +1032,28 @@ macro_rules! declare_bootstrap_init_functions {
     }
   };
 }
+
+// =================================================================================================
+// Access Logger Dynamic Module
+// =================================================================================================
+
+/// The function signature for creating a new access logger configuration.
+///
+/// The `ctx` provides access to the metrics-defining APIs that should be invoked at
+/// configuration time. The `name` is the value of `logger_name` from the `dynamic_modules`
+/// access-log configuration, allowing a single module to dispatch to different logger
+/// implementations. Returning `None` causes Envoy to reject the access-log configuration.
+pub type NewAccessLoggerConfigFunction = fn(
+  ctx: &access_log::ConfigContext,
+  name: &str,
+  config: &[u8],
+) -> Option<Box<dyn access_log::AccessLoggerConfig>>;
+
+/// The global factory function for access logger configurations. This is set via the
+/// `access_logger:` arm of [`declare_all_init_functions!`] (or the legacy
+/// [`declare_access_logger!`] shim) and is not intended to be set directly.
+pub static NEW_ACCESS_LOGGER_CONFIG_FUNCTION: OnceLock<NewAccessLoggerConfigFunction> =
+  OnceLock::new();
 
 // =================================================================================================
 // Cluster Dynamic Module

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -5526,3 +5526,143 @@ fn test_mock_envoy_network_filter_on_read() {
     abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
   );
 }
+
+// =============================================================================
+// Access Logger unit tests
+// =============================================================================
+
+#[test]
+fn test_envoy_dynamic_module_on_access_logger_config_new_impl() {
+  struct TestAccessLoggerConfig;
+  impl access_log::AccessLoggerConfig for TestAccessLoggerConfig {
+    fn new(_ctx: &access_log::ConfigContext, _name: &str, _config: &[u8]) -> Result<Self, String> {
+      Ok(TestAccessLoggerConfig)
+    }
+    fn create_logger(
+      &self,
+      _metrics: access_log::MetricsContext,
+      _logger_envoy_ptr: *mut std::ffi::c_void,
+    ) -> Box<dyn access_log::AccessLogger> {
+      unimplemented!()
+    }
+  }
+
+  let ctx = access_log::ConfigContext::new(std::ptr::null_mut());
+  let mut new_fn: NewAccessLoggerConfigFunction = |_, _, _| Some(Box::new(TestAccessLoggerConfig));
+  let result = access_log::envoy_dynamic_module_on_access_logger_config_new_impl(
+    &ctx,
+    "test_logger",
+    b"test_config",
+    &new_fn,
+    std::ptr::null_mut(),
+  );
+  assert!(!result.is_null());
+
+  unsafe {
+    access_log::envoy_dynamic_module_on_access_logger_config_destroy(result);
+  }
+
+  // None should result in a null pointer (e.g. unknown logger name).
+  new_fn = |_, _, _| None;
+  let result = access_log::envoy_dynamic_module_on_access_logger_config_new_impl(
+    &ctx,
+    "test_logger",
+    b"test_config",
+    &new_fn,
+    std::ptr::null_mut(),
+  );
+  assert!(result.is_null());
+}
+
+#[test]
+fn test_envoy_dynamic_module_on_access_logger_config_destroy() {
+  // This test ensures the wrapped trait object is dropped exactly once on `_destroy`.
+  static DROPPED: AtomicBool = AtomicBool::new(false);
+  struct TestAccessLoggerConfig;
+  impl access_log::AccessLoggerConfig for TestAccessLoggerConfig {
+    fn new(_ctx: &access_log::ConfigContext, _name: &str, _config: &[u8]) -> Result<Self, String> {
+      Ok(TestAccessLoggerConfig)
+    }
+    fn create_logger(
+      &self,
+      _metrics: access_log::MetricsContext,
+      _logger_envoy_ptr: *mut std::ffi::c_void,
+    ) -> Box<dyn access_log::AccessLogger> {
+      unimplemented!()
+    }
+  }
+  impl Drop for TestAccessLoggerConfig {
+    fn drop(&mut self) {
+      DROPPED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+  }
+
+  let ctx = access_log::ConfigContext::new(std::ptr::null_mut());
+  let new_fn: NewAccessLoggerConfigFunction = |_, _, _| Some(Box::new(TestAccessLoggerConfig));
+  let config_ptr = access_log::envoy_dynamic_module_on_access_logger_config_new_impl(
+    &ctx,
+    "test_logger",
+    b"test_config",
+    &new_fn,
+    std::ptr::null_mut(),
+  );
+  assert!(!config_ptr.is_null());
+
+  unsafe {
+    access_log::envoy_dynamic_module_on_access_logger_config_destroy(config_ptr);
+  }
+  assert!(DROPPED.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_envoy_dynamic_module_on_access_logger_new_destroy() {
+  // Round-trip the per-worker logger to ensure both `_new` and `_destroy` correctly own and
+  // free the boxed trait object.
+  static LOGGER_DROPPED: AtomicBool = AtomicBool::new(false);
+
+  struct TestAccessLoggerConfig;
+  impl access_log::AccessLoggerConfig for TestAccessLoggerConfig {
+    fn new(_ctx: &access_log::ConfigContext, _name: &str, _config: &[u8]) -> Result<Self, String> {
+      Ok(TestAccessLoggerConfig)
+    }
+    fn create_logger(
+      &self,
+      _metrics: access_log::MetricsContext,
+      _logger_envoy_ptr: *mut std::ffi::c_void,
+    ) -> Box<dyn access_log::AccessLogger> {
+      Box::new(TestAccessLogger)
+    }
+  }
+
+  struct TestAccessLogger;
+  impl access_log::AccessLogger for TestAccessLogger {
+    fn log(&mut self, _ctx: &access_log::LogContext) {}
+  }
+  impl Drop for TestAccessLogger {
+    fn drop(&mut self) {
+      LOGGER_DROPPED.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+  }
+
+  let ctx = access_log::ConfigContext::new(std::ptr::null_mut());
+  let new_fn: NewAccessLoggerConfigFunction = |_, _, _| Some(Box::new(TestAccessLoggerConfig));
+  let config_ptr = access_log::envoy_dynamic_module_on_access_logger_config_new_impl(
+    &ctx,
+    "test_logger",
+    b"test_config",
+    &new_fn,
+    std::ptr::null_mut(),
+  );
+  assert!(!config_ptr.is_null());
+
+  let logger_ptr = unsafe {
+    access_log::envoy_dynamic_module_on_access_logger_new(config_ptr, std::ptr::null_mut())
+  };
+  assert!(!logger_ptr.is_null());
+
+  unsafe {
+    access_log::envoy_dynamic_module_on_access_logger_destroy(logger_ptr as *mut _);
+    access_log::envoy_dynamic_module_on_access_logger_config_destroy(config_ptr);
+  }
+  assert!(LOGGER_DROPPED.load(std::sync::atomic::Ordering::SeqCst));
+}

--- a/test/extensions/access_loggers/dynamic_modules/BUILD
+++ b/test/extensions/access_loggers/dynamic_modules/BUILD
@@ -18,6 +18,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:access_log_missing_logger_log",
         "//test/extensions/dynamic_modules/test_data/c:access_log_missing_logger_new",
         "//test/extensions/dynamic_modules/test_data/c:access_log_no_op",
+        "//test/extensions/dynamic_modules/test_data/rust:access_log_integration_test",
     ],
     deps = [
         "//envoy/registry",

--- a/test/extensions/access_loggers/dynamic_modules/config_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/config_test.cc
@@ -201,6 +201,49 @@ logger_name: test_logger
       EnvoyException, "Failed to resolve symbol.*logger_destroy");
 }
 
+// Verifies that the unified Rust SDK factory correctly rejects unknown logger names by
+// returning `None`, which the C++ factory translates into an `InvalidArgumentError` with the
+// standard "Failed to initialize" message. This exercises the dispatch-by-name code path
+// installed via the `access_logger:` arm of `declare_all_init_functions!`.
+class DynamicModuleAccessLogFactoryRustTest : public testing::Test {
+public:
+  DynamicModuleAccessLogFactoryRustTest() {
+    TestEnvironment::setEnvVar(
+        "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+        TestEnvironment::substitute(
+            "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/rust"),
+        1);
+  }
+
+  DynamicModuleAccessLogFactory factory_;
+};
+
+TEST_F(DynamicModuleAccessLogFactoryRustTest, UnknownLoggerNameRejectedAtConfigLoad) {
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  NiceMock<Server::MockOptions> options;
+  ON_CALL(options, concurrency()).WillByDefault(testing::Return(1));
+  ON_CALL(context.server_context_, options()).WillByDefault(testing::ReturnRef(options));
+  ScopedThreadLocalServerContextSetter setter(context.server_context_);
+
+  const std::string yaml = R"EOF(
+dynamic_module_config:
+  name: access_log_integration_test
+  do_not_close: true
+logger_name: unknown_logger
+logger_config:
+  "@type": type.googleapis.com/google.protobuf.StringValue
+  value: test_config
+)EOF";
+
+  envoy::extensions::access_loggers::dynamic_modules::v3::DynamicModuleAccessLog proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  AccessLog::FilterPtr filter;
+  EXPECT_THROW_WITH_REGEX(
+      factory_.createAccessLogInstance(proto_config, std::move(filter), context, {}),
+      EnvoyException, "Failed to initialize dynamic module access logger config");
+}
+
 } // namespace
 } // namespace DynamicModules
 } // namespace AccessLoggers

--- a/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
@@ -1,13 +1,19 @@
 //! Integration test module for access logger dynamic modules.
 //!
-//! This module implements a simple access logger that records log events and flush calls.
+//! This module exercises the unified `declare_all_init_functions!` registration: a single
+//! `.so` registers both an HTTP filter factory and an access-logger factory that dispatches
+//! to different implementations by `logger_name`. The C++ side rejects unknown logger names
+//! at config load time when the factory returns `None`.
 
 use envoy_proxy_dynamic_modules_rust_sdk::access_log::*;
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-declare_init_functions!(init, new_nop_http_filter_config_fn);
-declare_access_logger!(TestAccessLoggerConfig);
+declare_all_init_functions!(
+  init,
+  http: new_nop_http_filter_config_fn,
+  access_logger: new_access_logger_config_fn,
+);
 
 /// Global counter for log events.
 static LOG_COUNT: AtomicU32 = AtomicU32::new(0);
@@ -21,13 +27,29 @@ fn init() -> bool {
   true
 }
 
-/// Dummy HTTP filter config function (required by declare_init_functions).
+/// Dummy HTTP filter config function (required by declare_all_init_functions).
 fn new_nop_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
   _envoy_filter_config: &mut EC,
   _name: &str,
   _config: &[u8],
 ) -> Option<Box<dyn HttpFilterConfig<EHF>>> {
   None
+}
+
+/// Access logger factory function: dispatches to the correct config implementation based on
+/// `logger_name`. Returning `None` for an unknown name causes Envoy to reject the access-log
+/// configuration at config load time.
+fn new_access_logger_config_fn(
+  ctx: &ConfigContext,
+  name: &str,
+  config: &[u8],
+) -> Option<Box<dyn AccessLoggerConfig>> {
+  match name {
+    "test_logger" => TestAccessLoggerConfig::new(ctx, name, config)
+      .ok()
+      .map(|c| Box::new(c) as Box<dyn AccessLoggerConfig>),
+    _ => None,
+  }
 }
 
 /// Access logger configuration.


### PR DESCRIPTION
## Description

A single RUST dynamic module can now host multiple access loggers via the new `access_logger:` arm of `declare_all_init_functions!`, which registers a `NewAccessLoggerConfigFunction` factory that dispatches to different `AccessLoggerConfig` implementations by `logger_name`.

The C ABI is unchanged.

---

**Commit Message:** dynamic_modules: add access_logger arm and unify access logger FFI in the SDK
**Additional Description:** Added a way for a single RUST dynamic module can now host multiple access loggers.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A