### PR TITLE
tcp_proxy: support formatter extensions in tunneling config headers

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -6,6 +6,7 @@ import "envoy/config/accesslog/v3/accesslog.proto";
 import "envoy/config/core/v3/backoff.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/core/v3/proxy_protocol.proto";
 import "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto";
 import "envoy/type/v3/hash_policy.proto";
@@ -119,7 +120,7 @@ message TcpProxy {
   // Configuration for tunneling TCP over other transports or application layers.
   // Tunneling is supported over HTTP/1.1 and HTTP/2. The upstream protocol is
   // determined by the cluster configuration.
-  // [#next-free-field: 10]
+  // [#next-free-field: 11]
   message TunnelingConfig {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.tcp_proxy.v2.TcpProxy.TunnelingConfig";
@@ -200,6 +201,12 @@ message TcpProxy {
     // This enables customizing the key used by access log formatters such as
     // ``%DYNAMIC_METADATA(envoy.filters.network.tcp_proxy:<key>)%``.
     string request_id_metadata_key = 9;
+
+    // Specifies a collection of Formatter plugins that can be used in substitution formatters
+    // in ``headers_to_add``.
+    // See the formatters extensions documentation for details.
+    // [#extension-category: envoy.formatter]
+    repeated config.core.v3.TypedExtensionConfig formatters = 10;
   }
 
   message OnDemand {

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -94,10 +94,16 @@ HeadersToAddEntry::HeadersToAddEntry(const HeaderValue& header_value,
 
 absl::StatusOr<HeaderParserPtr>
 HeaderParser::configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add) {
+  return configure(headers_to_add, Formatter::CommandParserPtrVector{});
+}
+
+absl::StatusOr<HeaderParserPtr>
+HeaderParser::configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
+                        const Formatter::CommandParserPtrVector& command_parsers) {
   HeaderParserPtr header_parser(new HeaderParser());
   header_parser->headers_to_add_.reserve(headers_to_add.size());
   for (const auto& header_value_option : headers_to_add) {
-    auto entry_or_error = HeadersToAddEntry::create(header_value_option);
+    auto entry_or_error = HeadersToAddEntry::create(header_value_option, command_parsers);
     RETURN_IF_NOT_OK_REF(entry_or_error.status());
     header_parser->headers_to_add_.emplace_back(
         Http::LowerCaseString(header_value_option.header().key()),

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -72,6 +72,15 @@ public:
   configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add);
 
   /*
+   * @param headers_to_add defines the headers to add during calls to evaluateHeaders.
+   * @param command_parsers custom formatter command parsers (e.g. for %SECRET()% substitution).
+   * @return HeaderParserPtr a configured HeaderParserPtr.
+   */
+  static absl::StatusOr<HeaderParserPtr>
+  configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
+            const Formatter::CommandParserPtrVector& command_parsers);
+
+  /*
    * @param headers_to_add defines headers to add during calls to evaluateHeaders.
    * @param append_action defines action taken to append/overwrite the given value for an existing
    * header or to only add this header if it's absent.

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -27,6 +27,7 @@
 #include "source/common/config/metadata.h"
 #include "source/common/config/utility.h"
 #include "source/common/config/well_known_names.h"
+#include "source/common/formatter/substitution_format_string.h"
 #include "source/common/http/request_id_extension_impl.h"
 #include "source/common/network/application_protocol.h"
 #include "source/common/network/proxy_protocol_filter_state.h"
@@ -39,6 +40,7 @@
 #include "source/common/stream_info/stream_id_provider_impl.h"
 #include "source/common/stream_info/uint64_accessor_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
+#include "source/server/generic_factory_context.h"
 
 #include "absl/container/flat_hash_set.h"
 
@@ -941,13 +943,31 @@ const std::string& TunnelResponseTrailers::key() {
   CONSTRUCT_ON_FIRST_USE(std::string, "envoy.tcp_proxy.propagate_response_trailers");
 }
 
+Router::HeaderParserPtr buildTunnelingHeaderParser(
+    const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy::TunnelingConfig&
+        tunneling_config,
+    Server::Configuration::FactoryContext& context) {
+  if (tunneling_config.formatters().empty()) {
+    return THROW_OR_RETURN_VALUE(
+        Envoy::Router::HeaderParser::configure(tunneling_config.headers_to_add()),
+        Router::HeaderParserPtr);
+  }
+
+  Server::GenericFactoryContextImpl generic_context(context);
+  auto command_parsers =
+      THROW_OR_RETURN_VALUE(Formatter::SubstitutionFormatStringUtils::parseFormatters(
+                                tunneling_config.formatters(), generic_context),
+                            Formatter::CommandParserPtrVector);
+  return THROW_OR_RETURN_VALUE(
+      Envoy::Router::HeaderParser::configure(tunneling_config.headers_to_add(), command_parsers),
+      Router::HeaderParserPtr);
+}
+
 TunnelingConfigHelperImpl::TunnelingConfigHelperImpl(
     Stats::Scope& stats_scope,
     const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config_message,
     Server::Configuration::FactoryContext& context)
-    : header_parser_(THROW_OR_RETURN_VALUE(Envoy::Router::HeaderParser::configure(
-                                               config_message.tunneling_config().headers_to_add()),
-                                           Router::HeaderParserPtr)),
+    : header_parser_(buildTunnelingHeaderParser(config_message.tunneling_config(), context)),
       propagate_response_headers_(config_message.tunneling_config().propagate_response_headers()),
       propagate_response_trailers_(config_message.tunneling_config().propagate_response_trailers()),
       post_path_(config_message.tunneling_config().post_path()),

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -520,6 +520,7 @@ envoy_cc_test(
         "//source/common/router:header_parser_lib",
         "//source/common/router:string_accessor_lib",
         "//source/common/stream_info:filter_state_lib",
+        "//test/common/formatter:command_extension_lib",
         "//test/common/stream_info:test_int_accessor_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/http:http_mocks",

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -14,6 +14,7 @@
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
 
+#include "test/common/formatter/command_extension.h"
 #include "test/common/stream_info/test_int_accessor.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
@@ -1202,6 +1203,25 @@ response_headers_to_remove: ["x-baz-header"]
 
     EXPECT_THAT(transforms.headers_to_remove, ElementsAre(Http::LowerCaseString("x-baz-header")));
   }
+}
+
+TEST(HeaderParserTest, ConfigureWithCommandParsers) {
+  Formatter::CommandParserPtrVector command_parsers;
+  command_parsers.push_back(std::make_unique<Envoy::Formatter::TestCommandParser>());
+
+  Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValueOption> to_add;
+  auto* header = to_add.Add();
+  header->mutable_header()->set_key("x-secret");
+  header->mutable_header()->set_value("Bearer %COMMAND_EXTENSION()%");
+
+  HeaderParserPtr parser = HeaderParser::configure(to_add, command_parsers).value();
+
+  Http::TestRequestHeaderMapImpl header_map{{":method", "POST"}};
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  parser->evaluateHeaders(header_map, stream_info);
+
+  EXPECT_TRUE(header_map.has("x-secret"));
+  EXPECT_EQ("Bearer TestFormatter", header_map.get_("x-secret"));
 }
 
 } // namespace

--- a/test/common/tcp_proxy/BUILD
+++ b/test/common/tcp_proxy/BUILD
@@ -85,6 +85,7 @@ envoy_cc_test(
     deps = [
         "//source/common/formatter:formatter_extension_lib",
         "//source/common/tcp_proxy",
+        "//test/common/formatter:command_extension_lib",
         "//test/common/memory:memory_test_utility_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/router:router_filter_interface",
@@ -94,6 +95,7 @@ envoy_cc_test(
         "//test/mocks/tcp:tcp_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/mocks/upstream:load_balancer_context_mock",
+        "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/request_id/uuid/v3:pkg_cc_proto",

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -6,6 +6,7 @@
 #include "source/common/tcp_proxy/tcp_proxy.h"
 #include "source/common/tcp_proxy/upstream.h"
 
+#include "test/common/formatter/command_extension.h"
 #include "test/common/memory/memory_test_utility.h"
 #include "test/mocks/buffer/mocks.h"
 #include "test/mocks/http/mocks.h"
@@ -17,6 +18,7 @@
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
@@ -571,6 +573,32 @@ TEST_P(HttpUpstreamRequestEncoderTest, RequestEncoderHeadersWithDownstreamInfo) 
       .WillRepeatedly(testing::ReturnRef(connection_info));
   EXPECT_CALL(this->encoder_, encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
   this->upstream_->setRequestEncoder(this->encoder_, false);
+}
+
+TEST(TunnelingConfigHelperImplTest, FormatterExtensionRendersInHeader) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<Stats::MockStore> store;
+  Stats::MockScope& scope = store.mockScope();
+
+  TcpProxy config;
+  auto* tunneling = config.mutable_tunneling_config();
+  tunneling->set_hostname("host.example.com:443");
+  auto* formatter = tunneling->add_formatters();
+  formatter->set_name("envoy.formatter.TestFormatter");
+  formatter->mutable_typed_config()->PackFrom(Protobuf::StringValue());
+  auto* header = tunneling->add_headers_to_add();
+  header->mutable_header()->set_key("x-custom");
+  header->mutable_header()->set_value("%COMMAND_EXTENSION()%");
+
+  TunnelingConfigHelperImpl helper(scope, config, context);
+
+  Http::TestRequestHeaderMapImpl headers;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  helper.headerEvaluator().evaluateHeaders(headers, {&headers, nullptr}, stream_info);
+  EXPECT_EQ(headers.get_("x-custom"), "TestFormatter");
 }
 
 TEST_P(HttpUpstreamRequestEncoderTest,

--- a/test/extensions/filters/network/tcp_proxy/BUILD
+++ b/test/extensions/filters/network/tcp_proxy/BUILD
@@ -18,7 +18,9 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//test/common/formatter:command_extension_lib",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -5,7 +5,9 @@
 
 #include "source/extensions/filters/network/tcp_proxy/config.h"
 
+#include "test/common/formatter/command_extension.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -71,6 +73,55 @@ TEST(ConfigTest, ConfigTest) {
         filter->initializeReadFilterCallbacks(readFilterCallback);
       }));
   cb(connection);
+}
+
+// Test that TunnelingConfig with a populated formatters field wires the extension through. Uses
+// the shared TestCommandFactory fake (see test/common/formatter/command_extension.h) so this test
+// does not depend on any real formatter extension's availability.
+TEST(ConfigTest, TunnelingConfigWithFormatters) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  ConfigFactory factory;
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
+      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+          factory.createEmptyConfigProto().get());
+  config.set_stat_prefix("prefix");
+  config.set_cluster("cluster");
+  auto* tunneling = config.mutable_tunneling_config();
+  tunneling->set_hostname("example.com:80");
+
+  auto* header = tunneling->add_headers_to_add();
+  auto* hdr = header->mutable_header();
+  hdr->set_key("x-custom");
+  hdr->set_value("%COMMAND_EXTENSION()%");
+
+  auto* formatter = tunneling->add_formatters();
+  formatter->set_name("envoy.formatter.TestFormatter");
+  formatter->mutable_typed_config()->PackFrom(Protobuf::StringValue());
+
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
+}
+
+// Test that a TunnelingConfig referencing an unknown formatter extension fails at config time.
+TEST(ConfigTest, TunnelingConfigWithUnknownFormatter) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  ConfigFactory factory;
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
+      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+          factory.createEmptyConfigProto().get());
+  config.set_stat_prefix("prefix");
+  config.set_cluster("cluster");
+  auto* tunneling = config.mutable_tunneling_config();
+  tunneling->set_hostname("example.com:80");
+
+  auto* formatter = tunneling->add_formatters();
+  formatter->set_name("envoy.formatter.does_not_exist");
+  formatter->mutable_typed_config()->PackFrom(Protobuf::StringValue());
+
+  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, context).IgnoreError(),
+                          EnvoyException, "envoy.formatter.does_not_exist");
 }
 
 } // namespace TcpProxy

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -75,9 +75,6 @@ TEST(ConfigTest, ConfigTest) {
   cb(connection);
 }
 
-// Test that TunnelingConfig with a populated formatters field wires the extension through. Uses
-// the shared TestCommandFactory fake (see test/common/formatter/command_extension.h) so this test
-// does not depend on any real formatter extension's availability.
 TEST(ConfigTest, TunnelingConfigWithFormatters) {
   Envoy::Formatter::TestCommandFactory test_factory;
   Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
@@ -104,7 +101,6 @@ TEST(ConfigTest, TunnelingConfigWithFormatters) {
   EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
 }
 
-// Test that a TunnelingConfig referencing an unknown formatter extension fails at config time.
 TEST(ConfigTest, TunnelingConfigWithUnknownFormatter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/envoy/issues/44532

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
