### PR TITLE
jwt: avoid unnecessary copy by returning early

### DIFF
--- a/source/extensions/filters/http/jwt_authn/authenticator.cc
+++ b/source/extensions/filters/http/jwt_authn/authenticator.cc
@@ -433,6 +433,7 @@ void AuthenticatorImpl::setPayloadMetadata(const Protobuf::Struct& jwt_payload) 
   const auto& normalize = provider.normalize_payload_in_metadata();
   if (normalize.space_delimited_claims().empty()) {
     set_extracted_jwt_data_cb_(provider.payload_in_metadata(), jwt_payload);
+    return;
   }
   // Make a temporary copy to normalize the JWT struct.
   Protobuf::Struct out_payload = jwt_payload;


### PR DESCRIPTION
Commit Message: When `normalize_payload_in_metadata` is unset, we're performing an unnecessary copy of the payload because we're not returning early.
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
