### PR TITLE
ci: fix verify_distro Docker Hub rate limit by adding read-only login

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   workflow_call:
     secrets:
+      dockerhub-token:
       slack-bot-token:
     inputs:
       request:
@@ -23,6 +24,7 @@ concurrency:
 jobs:
   build:
     secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
       slack-bot-token: ${{ secrets.slack-bot-token }}
     permissions:
       actions: read

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   workflow_call:
     secrets:
+      dockerhub-token:
       gcp-key:
         required: true
 
@@ -24,6 +25,8 @@ concurrency:
 
 jobs:
   coverage:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       request:
         type: string
@@ -20,6 +22,8 @@ concurrency:
 
 jobs:
   runtime:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       request:
         type: string
@@ -20,6 +22,8 @@ concurrency:
 
 jobs:
   san:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -8,6 +8,7 @@ on:
     secrets:
       app-id:
       app-key:
+      dockerhub-token:
       rbe-key:
       ssh-key-extra:
     inputs:
@@ -132,14 +133,15 @@ on:
 
 jobs:
   ci:
-    uses: ./.github/workflows/_run.yml
-    name: ${{ inputs.target }}
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
+      ssh-key-extra: ${{ secrets.ssh-key-extra }}
     permissions:
       actions: read
       contents: read
       packages: read
-    secrets:
-      ssh-key-extra: ${{ secrets.ssh-key-extra }}
+    uses: ./.github/workflows/_run.yml
+    name: ${{ inputs.target }}
     with:
       args: ${{ inputs.args }}
       rbe: ${{ inputs.rbe }}

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       dependency-review:
         type: boolean
@@ -23,6 +25,8 @@ concurrency:
 
 jobs:
   deps:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       request:
         type: string
@@ -20,6 +22,8 @@ concurrency:
 
 jobs:
   external:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       request:
         type: string
@@ -21,6 +23,8 @@ concurrency:
 
 jobs:
   format:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   workflow_call:
     secrets:
+      dockerhub-token:
       gcp-key:
         required: true
     inputs:
@@ -23,6 +24,8 @@ concurrency:
 
 jobs:
   publish:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -6,6 +6,7 @@ permissions:
 on:
   workflow_call:
     secrets:
+      dockerhub-token:
       gpg-key:
         required: true
       gpg-key-password:
@@ -33,6 +34,8 @@ concurrency:
 
 jobs:
   binary:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read
@@ -58,6 +61,8 @@ jobs:
       upload-path: container/envoy/${{ inputs.arch }}/bin/
 
   docker:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read
@@ -87,13 +92,14 @@ jobs:
       runs-on: ${{ inputs.arch == 'arm64' && (vars.ENVOY_ARM_VM || 'ubuntu-24.04-arm') || null }}
 
   distribution:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
+      gpg-key: ${{ secrets.gpg-key }}
+      gpg-key-password: ${{ secrets.gpg-key-password }}
     permissions:
       actions: read
       contents: read
       packages: read
-    secrets:
-      gpg-key: ${{ secrets.gpg-key }}
-      gpg-key-password: ${{ secrets.gpg-key-password }}
     name: Packages
     needs:
     - binary

--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -6,7 +6,8 @@ permissions:
 on:
   workflow_call:
     secrets:
-      dockerhub-password:
+      dockerhub-token:
+      dockerhub-write-token:
       ENVOY_CI_SYNC_APP_ID:
       ENVOY_CI_SYNC_APP_KEY:
       ENVOY_CI_PUBLISH_APP_ID:
@@ -37,13 +38,14 @@ concurrency:
 
 jobs:
   sign:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
+      gpg-key: ${{ secrets.gpg-key }}
+      gpg-key-password: ${{ secrets.gpg-key-password }}
     permissions:
       actions: read
       contents: read
       packages: read
-    secrets:
-      gpg-key: ${{ secrets.gpg-key }}
-      gpg-key-password: ${{ secrets.gpg-key-password }}
     if: ${{ vars.ENVOY_CI_RELEASE || github.repository == 'envoyproxy/envoy' }}
     name: Sign packages
     uses: ./.github/workflows/_run.yml
@@ -77,7 +79,7 @@ jobs:
 
   container:
     secrets:
-      dockerhub-password: ${{ secrets.dockerhub-password }}
+      dockerhub-write-token: ${{ secrets.dockerhub-write-token }}
     permissions:
       actions: read
       contents: read
@@ -99,6 +101,7 @@ jobs:
     secrets:
       app-id: ${{ inputs.trusted && secrets.ENVOY_CI_PUBLISH_APP_ID || '' }}
       app-key: ${{ inputs.trusted && secrets.ENVOY_CI_PUBLISH_APP_KEY || '' }}
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_publish_release_container.yml
+++ b/.github/workflows/_publish_release_container.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_call:
     secrets:
-      dockerhub-password:
+      dockerhub-write-token:
     inputs:
       dev:
         required: true
@@ -233,4 +233,4 @@ jobs:
         manifest-config: ${{ steps.dev-config.outputs.value || steps.release-config.outputs.value }}
         dry-run: ${{ ! inputs.trusted || (inputs.target-branch != 'main' && inputs.dev) }}
         dockerhub-username: ${{ inputs.trusted && inputs.dockerhub-username || '' }}
-        dockerhub-password: ${{ inputs.trusted && secrets.dockerhub-password || '' }}
+        dockerhub-password: ${{ inputs.trusted && secrets.dockerhub-write-token || '' }}

--- a/.github/workflows/_publish_verify.yml
+++ b/.github/workflows/_publish_verify.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      dockerhub-token:
     inputs:
       request:
         type: string
@@ -24,6 +26,8 @@ concurrency:
 
 jobs:
   examples:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read
@@ -76,6 +80,8 @@ jobs:
               shell: bash
 
   distroless:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read
@@ -134,6 +140,8 @@ jobs:
               shell: bash
 
   distro:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -8,6 +8,7 @@ on:
     secrets:
       app-id:
       app-key:
+      dockerhub-token:
       gpg-key:
       gpg-key-password:
       slack-bot-token:
@@ -387,6 +388,20 @@ jobs:
       name: Configure repo Bazel settings
       env:
         BAZELRC_CONTENT: ${{ vars.ENVOY_CI_BAZELRC }}
+
+    - id: dockerhub
+      run: |
+        if [[ -n "$DOCKERHUB_TOKEN" ]]; then
+          echo "login=true" >> "$GITHUB_OUTPUT"
+        fi
+      env:
+        DOCKERHUB_TOKEN: ${{ secrets.dockerhub-token }}
+    - name: Login to Docker Hub (read-only)
+      if: steps.dockerhub.outputs.login == 'true'
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ secrets.dockerhub-token }}
 
     # NOTE: This is where untrusted code can be run!!!
     #  Only post-failure notification steps (which don't use any repo code) should follow this step.

--- a/.github/workflows/envoy-checks.yml
+++ b/.github/workflows/envoy-checks.yml
@@ -47,6 +47,7 @@ jobs:
 
   build:
     secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
     permissions:
       actions: read
@@ -64,6 +65,7 @@ jobs:
 
   coverage:
     secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       gcp-key: ${{ fromJSON(needs.load.outputs.trusted) && secrets.GCP_SERVICE_ACCOUNT_KEY_TRUSTED || secrets.GCP_SERVICE_ACCOUNT_KEY }}
     permissions:
       actions: read
@@ -80,6 +82,8 @@ jobs:
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 
   runtime:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -95,6 +99,8 @@ jobs:
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 
   san:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/envoy-deflake.yml
+++ b/.github/workflows/envoy-deflake.yml
@@ -35,6 +35,8 @@ jobs:
     uses: ./.github/workflows/_load_env.yml
 
   deflake:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/envoy-macos.yml
+++ b/.github/workflows/envoy-macos.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: macos
 
   macos:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/envoy-prechecks.yml
+++ b/.github/workflows/envoy-prechecks.yml
@@ -42,6 +42,8 @@ jobs:
       check-name: prechecks
 
   format:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -57,6 +59,8 @@ jobs:
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 
   deps:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -74,6 +78,7 @@ jobs:
 
   publish:
     secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       gcp-key: >-
         ${{ needs.load.outputs.trusted
             && fromJSON(needs.load.outputs.trusted)
@@ -94,6 +99,8 @@ jobs:
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 
   external:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -49,11 +49,8 @@ jobs:
       # head-sha: ${{ github.sha }}
 
   build:
-    permissions:
-      actions: read
-      contents: read
-      packages: read
     secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       gpg-key: >-
         ${{ needs.load.outputs.trusted
             && fromJSON(needs.load.outputs.trusted)
@@ -64,6 +61,10 @@ jobs:
             && fromJSON(needs.load.outputs.trusted)
             && secrets.ENVOY_GPG_MAINTAINER_KEY_PASSWORD
             || secrets.ENVOY_GPG_SNAKEOIL_KEY_PASSWORD }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
     if: ${{ fromJSON(needs.load.outputs.request).run.release || fromJSON(needs.load.outputs.request).run.verify }}
     needs:
     - load
@@ -82,7 +83,8 @@ jobs:
 
   release:
     secrets:
-      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+      dockerhub-write-token: ${{ secrets.DOCKERHUB_WRITE_TOKEN }}
       ENVOY_CI_SYNC_APP_ID: >-
         ${{ needs.load.outputs.trusted
             && fromJSON(needs.load.outputs.trusted)
@@ -129,6 +131,8 @@ jobs:
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 
   verify:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-android
 
   build:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -63,6 +65,8 @@ jobs:
       target: build
 
   kotlin-hello-world:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -115,6 +119,8 @@ jobs:
       working-directory: mobile
 
   apps:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-android_tests.yml
+++ b/.github/workflows/mobile-android_tests.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-android-tests
 
   linux:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-asan.yml
+++ b/.github/workflows/mobile-asan.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-asan
 
   asan:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-cc_tests.yml
+++ b/.github/workflows/mobile-cc_tests.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-cc
 
   cc-tests:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -59,6 +61,8 @@ jobs:
       target: cc-tests
 
   cc-xds-integration-tests:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-coverage
 
   coverage:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-docs.yml
+++ b/.github/workflows/mobile-docs.yml
@@ -40,6 +40,7 @@ jobs:
 
   docs:
     secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       ssh-key-extra: ${{ needs.load.outputs.trusted  && secrets.ENVOY_MOBILE_WEBSITE_DEPLOY_KEY || '' }}
     permissions:
       actions: read

--- a/.github/workflows/mobile-format.yml
+++ b/.github/workflows/mobile-format.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-format
 
   container:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-ios
 
   build:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-ios-tests
 
   tests:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-perf.yml
+++ b/.github/workflows/mobile-perf.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-perf
 
   build:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -85,6 +87,8 @@ jobs:
           target: size-main
 
   compare:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-python.yml
+++ b/.github/workflows/mobile-python.yml
@@ -39,6 +39,8 @@ jobs:
       check-name: mobile-python
 
   python-tests:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -29,6 +29,8 @@ jobs:
     uses: ./.github/workflows/_load_env.yml
 
   android-release:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read
@@ -161,6 +163,8 @@ jobs:
             ${{ matrix.output }}-javadoc.jar.asc
 
   python-release:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/mobile-tsan.yml
+++ b/.github/workflows/mobile-tsan.yml
@@ -40,6 +40,8 @@ jobs:
       run-id: ${{ github.event.workflow_run.id }}
 
   tsan:
+    secrets:
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
    Docker Hub imposes rate limits on unauthenticated pulls, which causes
    the verify_distro job (and potentially others) to fail when pulling base
    images like debian:bullseye-slim and ubuntu:20.04.

    Changes:
    - Add a conditional `docker login` step in _run.yml using a read-only
      DOCKERHUB_TOKEN, so all CI jobs pull with authentication.
    - Thread the `dockerhub-token` secret through every workflow that calls
      _run.yml (directly or via intermediate reusable workflows).
    - Rename the existing write-capable DOCKERHUB_PASSWORD to
      DOCKERHUB_WRITE_TOKEN to clearly distinguish it from the read-only
      token. The write token is only used for publishing container images.

    Required GitHub repo secret changes:
    - Rename DOCKERHUB_PASSWORD -> DOCKERHUB_WRITE_TOKEN
    - Create DOCKERHUB_TOKEN with a read-only Docker Hub access token