### PR TITLE
Scone release note

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -1106,5 +1106,12 @@ new_features:
   change: |
     Added ``connection.peer_certificate`` and ``upstream.peer_certificate`` attributes that provide the
     PEM-encoded peer certificate for downstream and upstream TLS connections respectively.
+- area: quic
+  change: |
+    Added SCONE (Standardized Communication with Network Elements) support for QUIC. This includes
+    a new :ref:`enable_scone <envoy_v3_api_field_config.core.v3.QuicProtocolOptions.enable_scone>`
+    field in ``QuicProtocolOptions``, and support in Envoy Mobile via a new ``enableScone()`` API in
+    ``EngineBuilder``. SCONE bandwidth and timestamp data are now propagated to the application via
+    new ``scone_max_kbps`` and ``scone_timestamp_ms`` fields in the ``envoy_stream_intel`` struct.
 
 deprecated:

--- a/mobile/docs/root/intro/version_history.rst
+++ b/mobile/docs/root/intro/version_history.rst
@@ -54,6 +54,7 @@ Features:
 - build: Add a build feature ``exclude_certificates`` to disable inclusion of the Envoy Mobile certificate list, for use when using platform certificate validation.
 - build: Add a build feature ``envoy_http_datagrams`` to allow disabling HTTP Datagram support. (:issue:`#23564 <23564>`)
 - android: log cleared JNI exceptions to platform layer as `jni_cleared_pending_exception` events (:issue:`#26133 <26133>`).
+- api: Add support for SCONE (Standardized Communication with Network Elements) via ``enableScone()`` in ``EngineBuilder``. SCONE data is propagated via new fields in ``envoy_stream_intel``. (#44543)
 
 0.5.0 (September 2, 2022)
 ===========================


### PR DESCRIPTION
Commit Message: docs: add release notes for SCONE support
Additional Description: This PR adds the missing release notes for the SCONE (Standardized Communication with Network Elements) support feature. 
The implementation was recently merged in #44543. This follow-up documents:
   1. The new enable_scone field in QuicProtocolOptions.
   2. The enableScone() API addition to the Envoy Mobile EngineBuilder.
   3. The new scone_max_kbps and scone_timestamp_ms fields in the envoy_stream_intel struct used by the mobile library.
Addressing feedback from @adi-envoy.

Risk Level: Low (documentation-only change)
Testing: N/A
Docs Changes: Yes
Release Notes: Yes (this PR adds them)
Platform Specific Features: Envoy Mobile
Fixes commit: #44543 (7a86d60b03917a9b0eba92a6941b3ba0499aea61)
