### PR TITLE
cache_v2: update the scope to use server lifetime

### DIFF
--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -275,7 +275,7 @@ public:
   CacheSessionsImpl(Server::Configuration::FactoryContext& context,
                     std::unique_ptr<HttpCache> cache)
       : time_source_(context.serverFactoryContext().timeSource()), cache_(std::move(cache)),
-        stats_(generateStats(context.scope(), cache_->cacheInfo().name_)) {}
+        stats_(generateStats(context.serverFactoryContext().scope(), cache_->cacheInfo().name_)) {}
 
   void lookup(ActiveLookupRequestPtr request, ActiveLookupResultCallback&& cb) override;
   CacheFilterStats& stats() const override { return *stats_; }

--- a/source/extensions/http/cache_v2/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache_v2/file_system_http_cache/config.cc
@@ -64,7 +64,7 @@ public:
           async_file_manager_factory_->getAsyncFileManager(config.manager_config());
       std::unique_ptr<FileSystemHttpCache> fs_cache = std::make_unique<FileSystemHttpCache>(
           singleton, cache_eviction_thread_, std::move(config), std::move(async_file_manager),
-            context.serverFactoryContext().scope());
+          context.serverFactoryContext().scope());
       cache = CacheSessions::create(context, std::move(fs_cache));
       caches_[key] = cache;
     } else {

--- a/source/extensions/http/cache_v2/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache_v2/file_system_http_cache/config.cc
@@ -64,7 +64,7 @@ public:
           async_file_manager_factory_->getAsyncFileManager(config.manager_config());
       std::unique_ptr<FileSystemHttpCache> fs_cache = std::make_unique<FileSystemHttpCache>(
           singleton, cache_eviction_thread_, std::move(config), std::move(async_file_manager),
-          context.scope());
+            context.serverFactoryContext().scope());
       cache = CacheSessions::create(context, std::move(fs_cache));
       caches_[key] = cache;
     } else {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Updates the scope for cache_v2 stats to use the server lifetime for singletons
Additional Description: The current implementation uses the default filterchain lifetime for stats when creating singleton objects for cache_v2 that persist across filterchain & listener updates.  This leads to a segfault when incrementing stats after an XDS/other update causes the filterchain to be drained.
Risk Level: low
Testing: Tested manually with a minimal local setup using a golang-based XDS server which can trigger listener updates.  The issue can be replicated by leveraging cache_v2 with a consistent stream of requests (cacheability is irrelevant), followed by an update which causes the filterchain to be drained.
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:] None
[Optional Fixes #Issue] None
[Optional Fixes commit #PR or SHA] None
[Optional Deprecated:] None
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] None
