### PR TITLE
cache_v2: guard against nullptr dereference on upstream reset

### DIFF
--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -29,7 +29,7 @@ public:
         [entry = std::move(entry_), cb = std::move(cb),
          cacheable_response_checker = std::move(cacheable_response_checker_)](
             Http::ResponseHeaderMapPtr headers, EndStream end_stream) mutable {
-          if (cacheable_response_checker->isCacheableResponse(*headers)) {
+          if (headers != nullptr && cacheable_response_checker->isCacheableResponse(*headers)) {
             entry->clearUncacheableState();
           }
           cb(std::move(headers), end_stream);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: cache_v2: guard against nullptr dereference on upstream reset
Additional Description: There is a potential issue when an upstream connection resets when using cache_v2.  The code https://github.com/envoyproxy/envoy/blob/ac8ea19f77a183dac1ee31dcc4b6f2f345765377/source/extensions/filters/http/cache_v2/upstream_request_impl.cc#L197 calls with a nullptr which causes a segfault.
Risk Level: Low
Testing: Manually verified that the issue no longer occurs by simulating upstream disconnects, as well as simulating the load-test scenario that had produced the crash in the past.
Docs Changes: None
Release Notes: None
Platform Specific Features: None
[Optional Runtime guard:] None
[Optional Fixes #Issue] None
[Optional Fixes commit #PR or SHA] None
[Optional Deprecated:] None
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] None
