### PR TITLE
Removes unnecessary pointer indirection from a member of DelegatingStreamFilter

### DIFF
--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -82,7 +82,7 @@ void DelegatingStreamFilter::FilterMatchState::evaluateMatchTree(
     return;
   }
 
-  ASSERT(matching_data_ != nullptr);
+  ASSERT(matching_data_.has_value());
   data_update_func(*matching_data_);
 
   const Matcher::ActionMatchResult match_result =

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -11,7 +11,7 @@
 #include "source/common/matcher/matcher.h"
 #include "source/extensions/filters/http/common/factory_base.h"
 
-#include "third_party/absl/types/optional.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Common {

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "envoy/extensions/common/matching/v3/extension_matcher.pb.validate.h"
 #include "envoy/extensions/filters/common/matcher/action/v3/skip_action.pb.h"
@@ -32,8 +33,8 @@ public:
     void evaluateMatchTree(MatchDataUpdateFunc data_update_func);
     bool skipFilter() const { return skip_filter_; }
     void onStreamInfo(const StreamInfo::StreamInfo& stream_info) {
-      if (matching_data_ == nullptr) {
-        matching_data_ = std::make_unique<Envoy::Http::Matching::HttpMatchingDataImpl>(stream_info);
+      if (!matching_data_.has_value()) {
+        matching_data_.emplace(stream_info);
       }
     }
 
@@ -49,7 +50,7 @@ public:
     Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
     Envoy::Http::StreamFilterBase* base_filter_{};
 
-    std::unique_ptr<Envoy::Http::Matching::HttpMatchingDataImpl> matching_data_;
+    std::optional<Envoy::Http::Matching::HttpMatchingDataImpl> matching_data_;
     bool match_tree_evaluated_{};
     bool skip_filter_{};
   };

--- a/source/extensions/filters/http/match_delegate/config.h
+++ b/source/extensions/filters/http/match_delegate/config.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 
 #include "envoy/extensions/common/matching/v3/extension_matcher.pb.validate.h"
 #include "envoy/extensions/filters/common/matcher/action/v3/skip_action.pb.h"
@@ -11,6 +10,8 @@
 #include "source/common/http/matching/data_impl.h"
 #include "source/common/matcher/matcher.h"
 #include "source/extensions/filters/http/common/factory_base.h"
+
+#include "third_party/absl/types/optional.h"
 
 namespace Envoy {
 namespace Common {
@@ -50,7 +51,7 @@ public:
     Matcher::MatchTreeSharedPtr<Envoy::Http::HttpMatchingData> match_tree_;
     Envoy::Http::StreamFilterBase* base_filter_{};
 
-    std::optional<Envoy::Http::Matching::HttpMatchingDataImpl> matching_data_;
+    absl::optional<Envoy::Http::Matching::HttpMatchingDataImpl> matching_data_;
     bool match_tree_evaluated_{};
     bool skip_filter_{};
   };


### PR DESCRIPTION
We have noticed that these filters are using more memory than expected. This is one attempt to slightly reduce the cost.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
