### PR TITLE
contrib: fix ambiguous select for aws-lc on aarch64

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -8,6 +8,11 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: build
+  change: |
+    Fixed ``Illegal ambiguous match`` error when building contrib targets with ``--config=aws-lc-fips``
+    on aarch64 by restricting the ``using_aws_lc`` branch of ``SELECTED_CONTRIB_EXTENSIONS`` to
+    ``linux_x86_64``. Mirrors the approach taken by #32382 for ``boringssl_fips``.
 - area: dynamic_modules
   change: |
     Fixed a crashing bug in the HTTP filter when a stream was already above the downstream write-buffer

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@envoy_toolshed//:macros.bzl", "json_data")
 load("//bazel:envoy_build_system.bzl", "envoy_cc_test_library", "envoy_contrib_package")
 load(":all_contrib_extensions.bzl", "SELECTED_CONTRIB_EXTENSIONS")
@@ -6,6 +7,21 @@ load(":contrib_build_config.bzl", "CONTRIB_EXTENSIONS")
 licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
+
+# Disambiguation for SELECTED_CONTRIB_EXTENSIONS' select, where both
+# "//bazel:linux_aarch64" and "//bazel:using_aws_lc" otherwise match for an
+# arm64 aws-lc build. Restricting the aws-lc branch to x86_64 lets the
+# aarch64 branch win on arm64; arm64 + ppc64le aws-lc builds then fall through
+# to their platform skip lists, which already exclude the Intel-specific
+# contribs that AWS-LC cannot build.
+selects.config_setting_group(
+    name = "using_aws_lc_on_linux_x86_64",
+    match_all = [
+        "//bazel:using_aws_lc",
+        "//bazel:linux_x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
 
 exports_files([
     "extensions_metadata.yaml",

--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -55,7 +55,7 @@ def envoy_all_contrib_extensions(denylist = []):
 SELECTED_CONTRIB_EXTENSIONS = select({
     "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
     "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
-    "//bazel:using_aws_lc": envoy_all_contrib_extensions(AWS_LC_SKIP_CONTRIB_TARGETS),
+    "//contrib:using_aws_lc_on_linux_x86_64": envoy_all_contrib_extensions(AWS_LC_SKIP_CONTRIB_TARGETS),
     "//bazel:using_boringssl_fips": envoy_all_contrib_extensions(BORINGSSL_FIPS_SKIP_CONTRIB_TARGETS),
     "//conditions:default": envoy_all_contrib_extensions(X86_SKIP_CONTRIB_TARGETS),
 })


### PR DESCRIPTION
Commit Message:
Building contrib targets with ``--config=aws-lc-fips`` on aarch64 fails with:

    ERROR: contrib/exe/BUILD:25:16: Illegal ambiguous match on configurable
    attribute "deps" in //contrib/exe:envoy-static:
    //bazel:linux_aarch64
    //bazel:using_aws_lc
    Multiple matches are not allowed unless one is unambiguously more
    specialized or they resolve to the same value.

Both ``//bazel:linux_aarch64`` and ``//bazel:using_aws_lc`` match in ``SELECTED_CONTRIB_EXTENSIONS``, and Bazel does not specialize between a ``config_setting_group`` and a sibling ``config_setting`` (bazelbuild/bazel#16139), so the keys must be made disjoint.

The ``AWS_LC_SKIP_CONTRIB_TARGETS`` list is in fact the x86-only delta over the platform skip lists: the Intel-specific contribs ``cryptomb``, ``qat``, ``qatzip`` and ``qatzstd`` are already in ``ARM64_SKIP_CONTRIB_TARGETS`` and ``PPC_SKIP_CONTRIB_TARGETS``, and ``kae`` is in ``X86_SKIP_CONTRIB_TARGETS``. The ``using_aws_lc`` branch only does real work for ``x86_64 + aws-lc``; on ``arm64 + aws-lc`` and ``ppc + aws-lc`` the platform branches already exclude the same set. The ambiguous-match was therefore Bazel correctly flagging that the key was under-specified for what it actually meant.

Mirroring the approach taken by #32382 (which fixed the analogous ambiguity for ``boringssl_fips``), this restricts the aws-lc branch of the select to ``linux_x86_64`` via a new ``using_aws_lc_on_linux_x86_64`` config setting group. The aarch64 aws-lc build then falls through to the ``linux_aarch64`` branch and uses ``ARM64_SKIP_CONTRIB_TARGETS``, matching the behaviour for non-fips aarch64 builds.

The new setting group is defined in ``contrib/BUILD`` (next to its only consumer, ``SELECTED_CONTRIB_EXTENSIONS``) rather than in ``bazel/BUILD``, to keep the disambiguation tightly scoped to contrib.

The base ``//bazel:using_aws_lc`` config_setting is left unchanged; it is still used by ``source/common/version/BUILD`` to pick the FIPS version string for any-arch aws-lc builds.

Risk Level: low (build configuration only).
Testing: ``bazel build --config=aws-lc-fips //contrib/exe:envoy-static`` on linux/aarch64 (previously failed with the ambiguous-match error, now configures through to compilation).
Docs Changes: none.
Release Notes: added ``bug_fixes`` entry.
Platform Specific Features: