### PR TITLE
golang: replace per-cgo-call destroy mutex with std::atomic<bool>

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -12,15 +12,15 @@ minor_behavior_changes:
     Filter-owned or runs on the worker thread (``setHeader``, ``removeHeader``, ``setTrailer``,
     ``removeTrailer``, ``addData``, ``injectData``, ``continueStatus``, ``sendLocalReply``,
     ``setBufferHelper``, ``copyBuffer``, ``drainBuffer``, ``setUpstreamOverrideHost``,
-    ``clearRouteCache``, ``setDynamicMetadata``, ``setStringFilterState``,
-    ``setDrainConnectionUponCompletion``) no longer take the mutex, eliminating an uncontended
-    atomic compare-and-swap pair on every such call. The mutex is retained on the four CAPI
-    methods that inline-dereference Envoy-stream-owned objects from off-thread
-    (``getHeader``, ``copyHeaders``, ``copyTrailers``, ``getIntegerValue``) where it serialises
-    against ``onDestroy`` to prevent the worker thread from freeing the underlying header map or
-    ``StreamInfo`` mid-read, and on the five methods that write to the per-request ``strValue``
-    scratch buffer (``getStringValue``, ``getDynamicMetadata``, ``getStringFilterState``,
-    ``getStringProperty``, ``getSecret``).
+    ``clearRouteCache``, ``setDynamicMetadata``, ``setStringFilterState``) no longer take the
+    mutex, eliminating an uncontended atomic compare-and-swap pair on every such call. The
+    mutex is retained on the CAPI methods that inline-dereference Envoy-stream-owned objects
+    from off-thread (``getHeader``, ``copyHeaders``, ``copyTrailers``, ``getIntegerValue``,
+    ``setDrainConnectionUponCompletion``) where it serialises against ``onDestroy`` to prevent
+    the worker thread from freeing the underlying header map or ``StreamInfo`` mid-access, and
+    on the five methods that write to the per-request ``strValue`` scratch buffer
+    (``getStringValue``, ``getDynamicMetadata``, ``getStringFilterState``, ``getStringProperty``,
+    ``getSecret``).
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -5,6 +5,15 @@ behavior_changes:
 
 minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
+- area: golang
+  change: |
+    Removed the per-cgo-call mutex on the Golang HTTP filter's destroy check by making the
+    ``has_destroyed_`` flag a ``std::atomic<bool>``. The lock-free destroy check eliminates an
+    atomic compare-and-swap on every CAPI call from Go (``getHeader``, ``copyHeaders``,
+    ``setHeader``, ``addData``, ``continueStatus``, etc.), reducing per-call overhead and removing
+    a source of contention between off-thread Go callers. The mutex is retained only on the few
+    CAPI methods that write to the per-request ``strValue`` scratch buffer (``getStringValue``,
+    ``getDynamicMetadata``, ``getStringFilterState``, ``getStringProperty``, ``getSecret``).
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -7,13 +7,20 @@ minor_behavior_changes:
 # *Changes that may cause incompatibilities for some users, but should not for most*
 - area: golang
   change: |
-    Removed the per-cgo-call mutex on the Golang HTTP filter's destroy check by making the
-    ``has_destroyed_`` flag a ``std::atomic<bool>``. The lock-free destroy check eliminates an
-    atomic compare-and-swap on every CAPI call from Go (``getHeader``, ``copyHeaders``,
-    ``setHeader``, ``addData``, ``continueStatus``, etc.), reducing per-call overhead and removing
-    a source of contention between off-thread Go callers. The mutex is retained only on the few
-    CAPI methods that write to the per-request ``strValue`` scratch buffer (``getStringValue``,
-    ``getDynamicMetadata``, ``getStringFilterState``, ``getStringProperty``, ``getSecret``).
+    Reduced the per-cgo-call mutex acquisition on the Golang HTTP filter by making the
+    ``has_destroyed_`` flag a ``std::atomic<bool>``. CAPI methods whose only Envoy-side work is
+    Filter-owned or runs on the worker thread (``setHeader``, ``removeHeader``, ``setTrailer``,
+    ``removeTrailer``, ``addData``, ``injectData``, ``continueStatus``, ``sendLocalReply``,
+    ``setBufferHelper``, ``copyBuffer``, ``drainBuffer``, ``setUpstreamOverrideHost``,
+    ``clearRouteCache``, ``setDynamicMetadata``, ``setStringFilterState``,
+    ``setDrainConnectionUponCompletion``) no longer take the mutex, eliminating an uncontended
+    atomic compare-and-swap pair on every such call. The mutex is retained on the four CAPI
+    methods that inline-dereference Envoy-stream-owned objects from off-thread
+    (``getHeader``, ``copyHeaders``, ``copyTrailers``, ``getIntegerValue``) where it serialises
+    against ``onDestroy`` to prevent the worker thread from freeing the underlying header map or
+    ``StreamInfo`` mid-read, and on the five methods that write to the per-request ``strValue``
+    scratch buffer (``getStringValue``, ``getDynamicMetadata``, ``getStringFilterState``,
+    ``getStringProperty``, ``getSecret``).
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1183,7 +1183,12 @@ CAPIStatus Filter::getIntegerValue(int id, uint64_t* value) {
 }
 
 CAPIStatus Filter::getStringValue(int id, uint64_t* value_data, int* value_len) {
-  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
+  // mutex_ has two roles here:
+  //   1) it serialises writes to req_->strValue across off-thread Go callers, and
+  //   2) it is held across the inline streamInfo() / SSL / upstream-info dereferences below,
+  //      stalling onDestroy() so the worker thread cannot tear down the parent stream (and
+  //      free StreamInfo) while this off-thread Go caller is mid-read.
+  // See has_destroyed_ comment in the header for the full lifetime invariant.
   Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
@@ -1763,6 +1768,11 @@ CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data,
 }
 
 CAPIStatus Filter::setDrainConnectionUponCompletion() {
+  // mutex_ is held across the inline streamInfo() dereference below: it serialises against
+  // onDestroy() so the worker thread cannot tear down the parent stream (and free StreamInfo)
+  // while this off-thread Go caller is mid-write. See has_destroyed_ comment in the header for
+  // the full lifetime invariant.
+  Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -151,13 +151,10 @@ void Filter::onDestroy() {
     return;
   }
 
-  {
-    Thread::LockGuard lock(mutex_);
-    if (has_destroyed_) {
-      ENVOY_LOG(debug, "golang filter has been destroyed");
-      return;
-    }
-    has_destroyed_ = true;
+  bool already_destroyed = has_destroyed_.exchange(true, std::memory_order_acq_rel);
+  if (already_destroyed) {
+    ENVOY_LOG(debug, "golang filter has been destroyed");
+    return;
   }
 
   auto reason = (decoding_state_.isProcessingInGo() || encoding_state_.isProcessingInGo())
@@ -473,20 +470,16 @@ Filter::sendLocalReply(ProcessorState& state, Http::Code response_code, std::str
                        std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                        Grpc::Status::GrpcStatus grpc_status, std::string details) {
   bool on_worker_thread = state.isThreadSafe();
-  {
-    Thread::LockGuard lock(mutex_);
-    if (has_destroyed_) {
-      ENVOY_LOG(debug, "golang filter has been destroyed");
-      return CAPIStatus::CAPIFilterIsDestroy;
-    }
-    if (!state.isProcessingInGo()) {
-      ENVOY_LOG(debug, "golang filter is not processing Go");
-      return CAPIStatus::CAPINotInGo;
-    }
-    ENVOY_LOG(debug, "sendLocalReply, response code: {}", int(response_code));
+  if (hasDestroyed()) {
+    ENVOY_LOG(debug, "golang filter has been destroyed");
+    return CAPIStatus::CAPIFilterIsDestroy;
   }
+  if (!state.isProcessingInGo()) {
+    ENVOY_LOG(debug, "golang filter is not processing Go");
+    return CAPIStatus::CAPINotInGo;
+  }
+  ENVOY_LOG(debug, "sendLocalReply, response code: {}", int(response_code));
 
-  // See continueStatus() for the reentrancy/deadlock rationale.
   if (on_worker_thread) {
     sendLocalReplyInternal(state, response_code, body_text, modify_headers, grpc_status, details);
     return CAPIStatus::CAPIOK;
@@ -517,30 +510,22 @@ CAPIStatus Filter::sendPanicReply(ProcessorState& state, absl::string_view detai
 }
 
 CAPIStatus Filter::continueStatus(ProcessorState& state, GolangStatus status) {
-  // isThreadSafe() is a pure thread-id comparison, safe to read without the mutex.
   bool on_worker_thread = state.isThreadSafe();
-  {
-    Thread::LockGuard lock(mutex_);
-    if (has_destroyed_) {
-      ENVOY_LOG(debug, "golang filter has been destroyed");
-      return CAPIStatus::CAPIFilterIsDestroy;
-    }
-    if (!state.isProcessingInGo()) {
-      ENVOY_LOG(debug, "golang filter is not processing Go");
-      return CAPIStatus::CAPINotInGo;
-    }
-    ENVOY_LOG(debug, "golang filter continue from Go, status: {}, state: {}", int(status),
-              state.stateStr());
+  if (hasDestroyed()) {
+    ENVOY_LOG(debug, "golang filter has been destroyed");
+    return CAPIStatus::CAPIFilterIsDestroy;
   }
-  // Lock released before calling into the filter chain to avoid deadlocking:
-  // continueStatusInternal() calls hasDestroyed() which re-acquires the non-reentrant mutex_.
-  //
-  // NB: inline execution means continueStatusInternal re-enters the filter chain
-  // (continueProcessing / continueDoData / sendLocalReply) while the cgo call is still on the
-  // stack. This is the same reentrancy model as the existing addData inline path. The unit tests
-  // verify the branch selection but do not reproduce the full cgo-on-stack scenario; the existing
-  // Go integration tests (golang_filter_integration_test) exercise that path end-to-end.
+  if (!state.isProcessingInGo()) {
+    ENVOY_LOG(debug, "golang filter is not processing Go");
+    return CAPIStatus::CAPINotInGo;
+  }
+  ENVOY_LOG(debug, "golang filter continue from Go, status: {}, state: {}", int(status),
+            state.stateStr());
 
+  // When on the worker thread, continueStatusInternal re-enters the filter chain
+  // (continueProcessing / continueDoData / sendLocalReply) while the cgo call is still on the
+  // stack. This synchronous reentrancy is intentional and is the same model used by the addData
+  // inline path below; callers must not hold any state-mutating locks across this call.
   if (on_worker_thread) {
     continueStatusInternal(state, status);
     return CAPIStatus::CAPIOK;
@@ -566,8 +551,7 @@ CAPIStatus Filter::addData(ProcessorState& state, absl::string_view data, bool i
     return CAPIStatus::CAPIInvalidPhase;
   }
 
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -576,9 +560,12 @@ CAPIStatus Filter::addData(ProcessorState& state, absl::string_view data, bool i
     return CAPIStatus::CAPINotInGo;
   }
 
+  // On the worker thread we add data synchronously: state.addData() re-enters the filter chain
+  // while the cgo call is still on the stack (same reentrancy model as continueStatus above).
+  // Off the worker thread, we cannot touch the filter-chain buffer directly, so post a copy of
+  // the data to the dispatcher; the lambda re-checks hasDestroyed() under acquire ordering since
+  // onDestroy may have run between post and dispatch.
   if (state.isThreadSafe()) {
-    // NB: unlike continueStatus/sendLocalReply, we can hold mutex_ here because
-    // state.addData() does not call hasDestroyed() or re-acquire the mutex.
     Buffer::OwnedImpl buffer;
     buffer.add(data);
     state.addData(buffer, is_streaming);
@@ -600,9 +587,13 @@ CAPIStatus Filter::addData(ProcessorState& state, absl::string_view data, bool i
 }
 
 CAPIStatus Filter::injectData(ProcessorState& state, absl::string_view data) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  // Unlike addData, injectData is the *off-thread-only* path: it injects directly into the filter
+  // chain via state.injectDataToFilterChain(), which must run on the worker thread but must not
+  // run synchronously from within a cgo callback on that thread (it would re-enter the filter
+  // chain while the data path is still mid-flight). Callers from inside a synchronous Go callback
+  // are therefore rejected with CAPIInvalidScene below; the only legal caller is an off-thread
+  // goroutine, whose work we forward to the worker via a dispatcher post.
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -638,8 +629,7 @@ CAPIStatus Filter::injectData(ProcessorState& state, absl::string_view data) {
 
 CAPIStatus Filter::getHeader(ProcessorState& state, absl::string_view key, uint64_t* value_data,
                              int* value_len) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -694,8 +684,7 @@ void copyHeaderMapToGo(Http::HeaderMap& m, GoString* go_strs, char* go_buf) {
 }
 
 CAPIStatus Filter::copyHeaders(ProcessorState& state, GoString* go_strs, char* go_buf) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -716,8 +705,7 @@ CAPIStatus Filter::copyHeaders(ProcessorState& state, GoString* go_strs, char* g
 // callback to run in the envoy worker thread.
 CAPIStatus Filter::setHeader(ProcessorState& state, absl::string_view key, absl::string_view value,
                              headerAction act) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -780,8 +768,7 @@ CAPIStatus Filter::setHeader(ProcessorState& state, absl::string_view key, absl:
 // It won't take affect immediately while it's invoked from a Go thread, instead, it will post a
 // callback to run in the envoy worker thread.
 CAPIStatus Filter::removeHeader(ProcessorState& state, absl::string_view key) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -817,9 +804,7 @@ CAPIStatus Filter::removeHeader(ProcessorState& state, absl::string_view key) {
 }
 
 CAPIStatus Filter::copyBuffer(ProcessorState& state, Buffer::Instance* buffer, char* data) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -841,9 +826,7 @@ CAPIStatus Filter::copyBuffer(ProcessorState& state, Buffer::Instance* buffer, c
 }
 
 CAPIStatus Filter::drainBuffer(ProcessorState& state, Buffer::Instance* buffer, uint64_t length) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -862,9 +845,7 @@ CAPIStatus Filter::drainBuffer(ProcessorState& state, Buffer::Instance* buffer, 
 
 CAPIStatus Filter::setBufferHelper(ProcessorState& state, Buffer::Instance* buffer,
                                    absl::string_view& value, bufferAction action) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -888,8 +869,7 @@ CAPIStatus Filter::setBufferHelper(ProcessorState& state, Buffer::Instance* buff
 }
 
 CAPIStatus Filter::copyTrailers(ProcessorState& state, GoString* go_strs, char* go_buf) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -908,8 +888,7 @@ CAPIStatus Filter::copyTrailers(ProcessorState& state, GoString* go_strs, char* 
 
 CAPIStatus Filter::setTrailer(ProcessorState& state, absl::string_view key, absl::string_view value,
                               headerAction act) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -967,8 +946,7 @@ CAPIStatus Filter::setTrailer(ProcessorState& state, absl::string_view key, absl
 }
 
 CAPIStatus Filter::removeTrailer(ProcessorState& state, absl::string_view key) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1004,8 +982,7 @@ CAPIStatus Filter::removeTrailer(ProcessorState& state, absl::string_view key) {
 
 CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_view host,
                                            bool strict) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1054,8 +1031,7 @@ CAPIStatus Filter::setUpstreamOverrideHost(ProcessorState& state, absl::string_v
 }
 
 CAPIStatus Filter::clearRouteCache(bool refresh) {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1086,9 +1062,7 @@ void Filter::clearRouteCacheInternal(bool refresh) {
 }
 
 CAPIStatus Filter::getIntegerValue(int id, uint64_t* value) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1179,9 +1153,9 @@ CAPIStatus Filter::getIntegerValue(int id, uint64_t* value) {
 }
 
 CAPIStatus Filter::getStringValue(int id, uint64_t* value_data, int* value_len) {
-  // lock until this function return since it may running in a Go thread.
+  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
   Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1369,8 +1343,9 @@ CAPIStatus Filter::getStringValue(int id, uint64_t* value_data, int* value_len) 
 
 CAPIStatus Filter::getDynamicMetadata(const std::string& filter_name, uint64_t* buf_data,
                                       int* buf_len) {
+  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
   Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1409,9 +1384,7 @@ void Filter::populateSliceWithMetadata(const std::string& filter_name, uint64_t*
 
 CAPIStatus Filter::setDynamicMetadata(std::string filter_name, std::string key,
                                       absl::string_view buf) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1450,9 +1423,7 @@ void Filter::setDynamicMetadataInternal(std::string filter_name, std::string key
 
 CAPIStatus Filter::setStringFilterState(absl::string_view key, absl::string_view value,
                                         int state_type, int life_span, int stream_sharing) {
-  // lock until this function return since it may running in a Go thread.
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1484,9 +1455,9 @@ CAPIStatus Filter::setStringFilterState(absl::string_view key, absl::string_view
 
 CAPIStatus Filter::getStringFilterState(absl::string_view key, uint64_t* value_data,
                                         int* value_len) {
-  // lock until this function return since it may running in a Go thread.
+  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
   Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1522,9 +1493,9 @@ CAPIStatus Filter::getStringFilterState(absl::string_view key, uint64_t* value_d
 
 CAPIStatus Filter::getStringProperty(absl::string_view path, uint64_t* value_data, int* value_len,
                                      int* rc) {
-  // lock until this function return since it may running in a Go thread.
+  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
   Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1721,9 +1692,9 @@ void Filter::deferredDeleteRequest(HttpRequestInternal* req) {
 }
 
 CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data, int* value_len) {
-  // lock until this function return since it may running in a Go thread.
+  // mutex_ serializes writes to req_->strValue across off-thread Go callers.
   Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }
@@ -1762,8 +1733,7 @@ CAPIStatus Filter::getSecret(const absl::string_view name, uint64_t* value_data,
 }
 
 CAPIStatus Filter::setDrainConnectionUponCompletion() {
-  Thread::LockGuard lock(mutex_);
-  if (has_destroyed_) {
+  if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
   }

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -151,7 +151,17 @@ void Filter::onDestroy() {
     return;
   }
 
-  bool already_destroyed = has_destroyed_.exchange(true, std::memory_order_acq_rel);
+  // Acquire mutex_ so any off-thread CAPI caller currently dereferencing an Envoy-stream-owned
+  // object (HeaderMap / TrailerMap / StreamInfo via getHeader, copyHeaders, copyTrailers,
+  // getIntegerValue) finishes before this worker thread can return into destroyFilters() and let
+  // the event loop process the deferred-delete that frees the underlying stream. The flag itself
+  // is std::atomic so unrelated CAPI methods can observe destruction lock-free; this lock only
+  // exists to provide the worker-stall fence. See has_destroyed_ comment in golang_filter.h.
+  bool already_destroyed;
+  {
+    Thread::LockGuard lock(mutex_);
+    already_destroyed = has_destroyed_.exchange(true, std::memory_order_acq_rel);
+  }
   if (already_destroyed) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return;

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -629,6 +629,11 @@ CAPIStatus Filter::injectData(ProcessorState& state, absl::string_view data) {
 
 CAPIStatus Filter::getHeader(ProcessorState& state, absl::string_view key, uint64_t* value_data,
                              int* value_len) {
+  // mutex_ is held across the inline read of the Envoy-owned header map below: it serialises
+  // against onDestroy() so the worker thread cannot tear down the parent stream (and free the
+  // header map) while this off-thread Go caller is mid-dereference. See has_destroyed_ comment
+  // in the header for the full lifetime invariant.
+  Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -684,6 +689,11 @@ void copyHeaderMapToGo(Http::HeaderMap& m, GoString* go_strs, char* go_buf) {
 }
 
 CAPIStatus Filter::copyHeaders(ProcessorState& state, GoString* go_strs, char* go_buf) {
+  // mutex_ is held across the inline iteration of the Envoy-owned header map below: it
+  // serialises against onDestroy() so the worker thread cannot tear down the parent stream
+  // (and free the header map) while this off-thread Go caller is mid-iteration. See
+  // has_destroyed_ comment in the header for the full lifetime invariant.
+  Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -869,6 +879,11 @@ CAPIStatus Filter::setBufferHelper(ProcessorState& state, Buffer::Instance* buff
 }
 
 CAPIStatus Filter::copyTrailers(ProcessorState& state, GoString* go_strs, char* go_buf) {
+  // mutex_ is held across the inline iteration of the Envoy-owned trailer map below: it
+  // serialises against onDestroy() so the worker thread cannot tear down the parent stream
+  // (and free the trailer map) while this off-thread Go caller is mid-iteration. See
+  // has_destroyed_ comment in the header for the full lifetime invariant.
+  Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -1062,6 +1077,11 @@ void Filter::clearRouteCacheInternal(bool refresh) {
 }
 
 CAPIStatus Filter::getIntegerValue(int id, uint64_t* value) {
+  // mutex_ is held across the inline reads of streamInfo() and its SSL/upstream sub-objects
+  // below: it serialises against onDestroy() so the worker thread cannot tear down the parent
+  // stream (and free StreamInfo) while this off-thread Go caller is mid-dereference. See
+  // has_destroyed_ comment in the header for the full lifetime invariant.
+  Thread::LockGuard lock(mutex_);
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -410,15 +410,32 @@ private:
 
   Event::Dispatcher* dispatcher_;
 
-  // Serializes off-thread Go callers that write to req_->strValue (e.g. getStringValue,
-  // getDynamicMetadata, getStringFilterState, getStringProperty, getSecret). The destroy flag
-  // itself no longer requires this mutex; see has_destroyed_.
+  // mutex_ has two distinct roles:
+  //
+  // 1. Serialises off-thread Go callers that write to req_->strValue (getStringValue,
+  //    getDynamicMetadata, getStringFilterState, getStringProperty, getSecret) so that
+  //    concurrent goroutines do not corrupt the per-request scratch buffer.
+  //
+  // 2. Stalls onDestroy() against off-thread CAPI methods that inline-dereference
+  //    Envoy-owned objects whose lifetime is tied to the parent stream rather than to the
+  //    Filter (getHeader, copyHeaders, copyTrailers, getIntegerValue). The Filter itself is
+  //    kept alive across any cgo call by the shared_ptr taken at the cgo wrapper layer
+  //    (see cgo.cc), but the stream's HeaderMap / TrailerMap / StreamInfo are not. By
+  //    holding mutex_ across the off-thread dereference, onDestroy() blocks on the same
+  //    mutex and cannot return; this prevents the worker thread from progressing into
+  //    deferredDelete(stream) until every in-flight off-thread reader has unwound.
+  //
+  // The bare destroy-flag check (`if (hasDestroyed()) return CAPIFilterIsDestroy;`) does
+  // NOT require this mutex; see has_destroyed_ below. CAPI methods whose only Envoy-side
+  // work is either Filter-owned (e.g. doDataList buffers) or runs on the worker thread
+  // (via dispatcher.post or under isThreadSafe()) do not need to take mutex_ at all.
   Thread::MutexBasicLockable mutex_{};
   // Set exactly once by onDestroy() (write with release), read lock-free by hasDestroyed()
   // (acquire load) from any thread. Concurrent cgo callers from Go bail out with
-  // CAPIFilterIsDestroy as soon as they observe the store. The Filter itself is kept alive across
-  // any cgo call by the shared_ptr taken at the cgo wrapper layer (see cgo.cc), so observing a
-  // false-then-true transition during a call is benign.
+  // CAPIFilterIsDestroy as soon as they observe the store. The Filter itself is kept alive
+  // across any cgo call by the shared_ptr taken at the cgo wrapper layer (see cgo.cc), so
+  // observing a false-then-true transition during a call is benign for Filter-owned state.
+  // For Envoy-stream-owned state see the role-2 explanation on mutex_ above.
   std::atomic<bool> has_destroyed_{false};
 };
 

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -420,22 +420,31 @@ private:
   //    Envoy-owned objects whose lifetime is tied to the parent stream rather than to the
   //    Filter (getHeader, copyHeaders, copyTrailers, getIntegerValue). The Filter itself is
   //    kept alive across any cgo call by the shared_ptr taken at the cgo wrapper layer
-  //    (see cgo.cc), but the stream's HeaderMap / TrailerMap / StreamInfo are not. By
-  //    holding mutex_ across the off-thread dereference, onDestroy() blocks on the same
-  //    mutex and cannot return; this prevents the worker thread from progressing into
-  //    deferredDelete(stream) until every in-flight off-thread reader has unwound.
+  //    (see cgo.cc), but the stream's HeaderMap / TrailerMap / StreamInfo are not. The
+  //    fence is two-sided: those off-thread CAPI methods hold mutex_ across their
+  //    dereference, and onDestroy() re-acquires mutex_ once before letting the worker
+  //    thread return. The worker therefore blocks on mutex_ until every in-flight
+  //    off-thread reader has unwound, which prevents it from progressing into
+  //    deferredDelete(stream) (and the eventual stream / header-map free) while a Go
+  //    goroutine is still mid-deref. The atomic flag alone is not sufficient for this:
+  //    once onDestroy has set it the off-thread caller can already be past its own check
+  //    and committed to the deref, so the lock acquisition in onDestroy is what actually
+  //    serialises the two sides.
   //
   // The bare destroy-flag check (`if (hasDestroyed()) return CAPIFilterIsDestroy;`) does
   // NOT require this mutex; see has_destroyed_ below. CAPI methods whose only Envoy-side
   // work is either Filter-owned (e.g. doDataList buffers) or runs on the worker thread
   // (via dispatcher.post or under isThreadSafe()) do not need to take mutex_ at all.
   Thread::MutexBasicLockable mutex_{};
-  // Set exactly once by onDestroy() (write with release), read lock-free by hasDestroyed()
-  // (acquire load) from any thread. Concurrent cgo callers from Go bail out with
-  // CAPIFilterIsDestroy as soon as they observe the store. The Filter itself is kept alive
-  // across any cgo call by the shared_ptr taken at the cgo wrapper layer (see cgo.cc), so
-  // observing a false-then-true transition during a call is benign for Filter-owned state.
-  // For Envoy-stream-owned state see the role-2 explanation on mutex_ above.
+  // Set exactly once by onDestroy() while holding mutex_ (acq_rel exchange), read lock-free
+  // by hasDestroyed() (acquire load) from any thread. Concurrent cgo callers from Go bail
+  // out with CAPIFilterIsDestroy as soon as they observe the store. The Filter itself is
+  // kept alive across any cgo call by the shared_ptr taken at the cgo wrapper layer (see
+  // cgo.cc), so observing a false-then-true transition during a call is benign for
+  // Filter-owned state. For Envoy-stream-owned state, the lock-free observation is not
+  // sufficient on its own: see the role-2 explanation on mutex_ above for how the
+  // worker-stall fence (mutex_ acquired in onDestroy() and across the off-thread deref)
+  // closes the lifetime gap.
   std::atomic<bool> has_destroyed_{false};
 };
 

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -350,10 +350,10 @@ public:
 private:
   friend class TestFilter;
 
-  bool hasDestroyed() {
-    Thread::LockGuard lock(mutex_);
-    return has_destroyed_;
-  };
+  // Lock-free destroy check. The flag is set once, with release ordering, by onDestroy() on the
+  // worker thread; concurrent off-thread cgo callers do an acquire load to detect destruction
+  // without taking mutex_. See header note on has_destroyed_ below.
+  bool hasDestroyed() { return has_destroyed_.load(std::memory_order_acquire); };
   const StreamInfo::StreamInfo& streamInfo() const { return decoding_state_.streamInfo(); }
   StreamInfo::StreamInfo& streamInfo() { return decoding_state_.streamInfo(); }
   bool isThreadSafe() { return decoding_state_.isThreadSafe(); };
@@ -410,10 +410,16 @@ private:
 
   Event::Dispatcher* dispatcher_;
 
-  // lock for has_destroyed_/etc, to avoid race between envoy c thread and go thread (when calling
-  // back from go).
+  // Serializes off-thread Go callers that write to req_->strValue (e.g. getStringValue,
+  // getDynamicMetadata, getStringFilterState, getStringProperty, getSecret). The destroy flag
+  // itself no longer requires this mutex; see has_destroyed_.
   Thread::MutexBasicLockable mutex_{};
-  bool has_destroyed_ ABSL_GUARDED_BY(mutex_){false};
+  // Set exactly once by onDestroy() (write with release), read lock-free by hasDestroyed()
+  // (acquire load) from any thread. Concurrent cgo callers from Go bail out with
+  // CAPIFilterIsDestroy as soon as they observe the store. The Filter itself is kept alive across
+  // any cgo call by the shared_ptr taken at the cgo wrapper layer (see cgo.cc), so observing a
+  // false-then-true transition during a call is benign.
+  std::atomic<bool> has_destroyed_{false};
 };
 
 struct httpConfigInternal : httpConfig {


### PR DESCRIPTION
Commit Message:
Every CAPI call from Go into the C++ filter (getHeader, copyHeaders, setHeader, addData, continueStatus, ...) was acquiring Filter::mutex_ purely to read the has_destroyed_ flag. Off-thread Go callers paid the cost twice: once at the entry point and again inside the dispatcher-post lambda's hasDestroyed() check. On uncontended fast paths this is two atomic compare-and-swap operations and a memory fence per call, on top of the cgo boundary cost that's already paid for every API call.

Make has_destroyed_ a std::atomic<bool> with release-store on the single onDestroy() write and acquire-load on the read path. This turns the destroy check into a plain atomic load (free on x86, an ldar on ARM) and removes the mutex acquisition from 18 CAPI entry points and ~12 dispatcher-post lambdas. The Filter is kept alive across cgo calls by the shared_ptr taken at the cgo wrapper layer (cgo.cc), so seeing a false-then-true transition mid-call is benign; the lambdas all also check weak_from_this() expiration.

Filter::mutex_ is retained on the five CAPI methods that write to req_->strValue (getStringValue, getDynamicMetadata, getStringFilterState, getStringProperty, getSecret) to keep the existing serialization between off-thread Go callers writing to the shared scratch buffer.

No behaviour change for unit/integration tests; existing onDestroy() ordering and the post-destroy CAPIFilterIsDestroy semantics are preserved.

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
