### PR TITLE
perf: populate route match context once across entries

### DIFF
--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -66,6 +66,7 @@ envoy_cc_library(
         "//source/common/config:utility_lib",
         "//source/common/config:well_known_names",
         "//source/common/formatter:substitution_format_string_lib",
+        "//source/common/grpc:common_lib",
         "//source/common/http:hash_policy_lib",
         "//source/common/http:header_mutation_lib",
         "//source/common/http:header_utility_lib",

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -852,7 +852,7 @@ bool RouteEntryImplBase::isRedirect() const {
          redirect_config_->regex_rewrite_redirect_ != nullptr;
 }
 
-bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
+bool RouteEntryImplBase::matchRoute(const RouteMatchContext& route_match_context,
                                     const StreamInfo::StreamInfo& stream_info,
                                     uint64_t random_value) const {
   bool matches = true;
@@ -864,31 +864,26 @@ bool RouteEntryImplBase::matchRoute(const Http::RequestHeaderMap& headers,
   }
 
   if (match_grpc_) {
-    matches &= Grpc::Common::isGrpcRequestHeaders(headers);
-    if (!matches) {
+    if (!route_match_context.isGrpc()) {
       return false;
     }
   }
 
+  const Http::RequestHeaderMap& headers = route_match_context.headers();
   matches &= Http::HeaderUtility::matchHeaders(headers, config_headers_);
   if (!matches) {
     return false;
   }
   if (!config_query_parameters_.empty()) {
-    auto query_parameters =
-        Http::Utility::QueryParamsMulti::parseQueryString(headers.getPathValue());
-    matches &= ConfigUtility::matchQueryParams(query_parameters, config_query_parameters_);
+    matches &= ConfigUtility::matchQueryParams(route_match_context.queryParams(),
+                                               config_query_parameters_);
     if (!matches) {
       return false;
     }
   }
 
   if (!config_cookies_.empty()) {
-    const auto cookies =
-        Http::Utility::parseCookies(headers, [this](absl::string_view key) -> bool {
-          return config_cookie_names_.find(key) != config_cookie_names_.end();
-        });
-    if (!ConfigUtility::matchCookies(cookies, config_cookies_)) {
+    if (!ConfigUtility::matchCookies(route_match_context.cookies(), config_cookies_)) {
       return false;
     }
   }
@@ -1397,12 +1392,12 @@ std::string UriTemplateMatcherRouteEntryImpl::currentUrlPathAfterRewrite(
 }
 
 RouteConstSharedPtr
-UriTemplateMatcherRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+UriTemplateMatcherRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                           const StreamInfo::StreamInfo& stream_info,
                                           uint64_t random_value) const {
-  if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
-      path_matcher_->match(headers.getPathValue())) {
-    return clusterEntry(headers, stream_info, random_value);
+  if (RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value) &&
+      path_matcher_->match(route_match_context.path())) {
+    return clusterEntry(route_match_context.headers(), stream_info, random_value);
   }
   return nullptr;
 }
@@ -1430,12 +1425,12 @@ PrefixRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& h
   return currentUrlPathAfterRewriteWithMatchedPath(headers, context, stream_info, matcher());
 }
 
-RouteConstSharedPtr PrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+RouteConstSharedPtr PrefixRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                                   const StreamInfo::StreamInfo& stream_info,
                                                   uint64_t random_value) const {
-  if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
-      path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-    return clusterEntry(headers, stream_info, random_value);
+  if (RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value) &&
+      path_matcher_->match(route_match_context.sanitizedPath())) {
+    return clusterEntry(route_match_context.headers(), stream_info, random_value);
   }
   return nullptr;
 }
@@ -1464,12 +1459,12 @@ PathRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& hea
   return currentUrlPathAfterRewriteWithMatchedPath(headers, context, stream_info, matcher());
 }
 
-RouteConstSharedPtr PathRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+RouteConstSharedPtr PathRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                                 const StreamInfo::StreamInfo& stream_info,
                                                 uint64_t random_value) const {
-  if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value) &&
-      path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-    return clusterEntry(headers, stream_info, random_value);
+  if (RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value) &&
+      path_matcher_->match(route_match_context.sanitizedPath())) {
+    return clusterEntry(route_match_context.headers(), stream_info, random_value);
   }
 
   return nullptr;
@@ -1505,12 +1500,12 @@ RegexRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& he
   return currentUrlPathAfterRewriteWithMatchedPath(headers, context, stream_info, path);
 }
 
-RouteConstSharedPtr RegexRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+RouteConstSharedPtr RegexRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                                  const StreamInfo::StreamInfo& stream_info,
                                                  uint64_t random_value) const {
-  if (RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
-    if (path_matcher_->match(sanitizePathBeforePathMatching(headers.getPathValue()))) {
-      return clusterEntry(headers, stream_info, random_value);
+  if (RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value)) {
+    if (path_matcher_->match(route_match_context.sanitizedPathWithoutQuery())) {
+      return clusterEntry(route_match_context.headers(), stream_info, random_value);
     }
   }
   return nullptr;
@@ -1536,12 +1531,13 @@ ConnectRouteEntryImpl::currentUrlPathAfterRewrite(const Http::RequestHeaderMap& 
   return currentUrlPathAfterRewriteWithMatchedPath(headers, context, stream_info, path);
 }
 
-RouteConstSharedPtr ConnectRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+RouteConstSharedPtr ConnectRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                                    const StreamInfo::StreamInfo& stream_info,
                                                    uint64_t random_value) const {
+  const Http::RequestHeaderMap& headers = route_match_context.headers();
   if ((Http::HeaderUtility::isConnect(headers) ||
        Http::HeaderUtility::isConnectUdpRequest(headers)) &&
-      RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
+      RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value)) {
     return clusterEntry(headers, stream_info, random_value);
   }
   return nullptr;
@@ -1570,19 +1566,18 @@ std::string PathSeparatedPrefixRouteEntryImpl::currentUrlPathAfterRewrite(
 }
 
 RouteConstSharedPtr
-PathSeparatedPrefixRouteEntryImpl::matches(const Http::RequestHeaderMap& headers,
+PathSeparatedPrefixRouteEntryImpl::matches(const RouteMatchContext& route_match_context,
                                            const StreamInfo::StreamInfo& stream_info,
                                            uint64_t random_value) const {
-  if (!RouteEntryImplBase::matchRoute(headers, stream_info, random_value)) {
+  if (!RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value)) {
     return nullptr;
   }
-  absl::string_view sanitized_path = sanitizePathBeforePathMatching(
-      Http::PathUtil::removeQueryAndFragment(headers.getPathValue()));
+  const absl::string_view sanitized_path = route_match_context.sanitizedPathWithoutQuery();
   const size_t sanitized_size = sanitized_path.size();
   const size_t matcher_size = matcher().size();
   if (sanitized_size >= matcher_size && path_matcher_->match(sanitized_path) &&
       (sanitized_size == matcher_size || sanitized_path[matcher_size] == '/')) {
-    return clusterEntry(headers, stream_info, random_value);
+    return clusterEntry(route_match_context.headers(), stream_info, random_value);
   }
   return nullptr;
 }
@@ -1800,15 +1795,16 @@ VirtualHostImpl::VirtualHostImpl(const envoy::config::route::v3::VirtualHost& vi
 }
 
 RouteConstSharedPtr VirtualHostImpl::getRouteFromRoutes(
-    const RouteCallback& cb, const Http::RequestHeaderMap& headers,
+    const RouteCallback& cb, const RouteMatchContext& route_match_context,
     const StreamInfo::StreamInfo& stream_info, uint64_t random_value,
     absl::Span<const RouteEntryImplBaseConstSharedPtr> routes) const {
   for (auto route = routes.begin(); route != routes.end(); ++route) {
-    if (!headers.Path() && !(*route)->supportsPathlessHeaders()) {
+    if (!route_match_context.headers().Path() && !(*route)->supportsPathlessHeaders()) {
       continue;
     }
 
-    RouteConstSharedPtr route_entry = (*route)->matches(headers, stream_info, random_value);
+    RouteConstSharedPtr route_entry =
+        (*route)->matches(route_match_context, stream_info, random_value);
     if (route_entry == nullptr) {
       continue;
     }
@@ -1859,6 +1855,11 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
     return ssl_redirect_route_;
   }
 
+  // Constructed once per request; derived values (query params, cookies, etc.) are computed
+  // lazily on first access and reused across all route entries evaluated for this request.
+  const RouteMatchContext route_match_context(
+      headers, shared_virtual_host_->globalRouteConfig().ignorePathParametersInPathMatching());
+
   if (matcher_) {
     Http::Matching::HttpMatchingDataImpl data(stream_info);
     data.onRequestHeaders(headers);
@@ -1870,11 +1871,12 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
       const auto result = match_result.actionByMove();
       if (result->typeUrl() == RouteMatchAction::staticTypeUrl()) {
         return getRouteFromRoutes(
-            cb, headers, stream_info, random_value,
+            cb, route_match_context, stream_info, random_value,
             {std::dynamic_pointer_cast<const RouteEntryImplBase>(std::move(result))});
       } else if (result->typeUrl() == RouteListMatchAction::staticTypeUrl()) {
         const RouteListMatchAction& action = result->getTyped<RouteListMatchAction>();
-        return getRouteFromRoutes(cb, headers, stream_info, random_value, action.routes());
+        return getRouteFromRoutes(cb, route_match_context, stream_info, random_value,
+                                  action.routes());
       }
       PANIC("Action in router matcher should be Route or RouteList");
     }
@@ -1886,7 +1888,7 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
   }
 
   // Check for a route that matches the request.
-  return getRouteFromRoutes(cb, headers, stream_info, random_value, routes_);
+  return getRouteFromRoutes(cb, route_match_context, stream_info, random_value, routes_);
 }
 
 const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -646,12 +646,6 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
     config_cookies_.push_back(
         std::make_unique<ConfigUtility::CookieMatcher>(cookie_matcher, factory_context));
   }
-  if (!config_cookies_.empty()) {
-    config_cookie_names_.reserve(config_cookies_.size());
-    for (const auto& matcher : config_cookies_) {
-      config_cookie_names_.insert(matcher->name());
-    }
-  }
 
   if (!route.route().hash_policy().empty()) {
     hash_policy_ = THROW_OR_RETURN_VALUE(
@@ -883,8 +877,7 @@ bool RouteEntryImplBase::matchRoute(const RouteMatchContext& route_match_context
   }
 
   if (!config_cookies_.empty()) {
-    if (!ConfigUtility::matchCookies(route_match_context.cookies(config_cookie_names_),
-                                     config_cookies_)) {
+    if (!ConfigUtility::matchCookies(route_match_context.cookies(), config_cookies_)) {
       return false;
     }
   }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -883,7 +883,8 @@ bool RouteEntryImplBase::matchRoute(const RouteMatchContext& route_match_context
   }
 
   if (!config_cookies_.empty()) {
-    if (!ConfigUtility::matchCookies(route_match_context.cookies(), config_cookies_)) {
+    if (!ConfigUtility::matchCookies(route_match_context.cookies(config_cookie_names_),
+                                     config_cookies_)) {
       return false;
     }
   }
@@ -1504,7 +1505,7 @@ RouteConstSharedPtr RegexRouteEntryImpl::matches(const RouteMatchContext& route_
                                                  const StreamInfo::StreamInfo& stream_info,
                                                  uint64_t random_value) const {
   if (RouteEntryImplBase::matchRoute(route_match_context, stream_info, random_value)) {
-    if (path_matcher_->match(route_match_context.sanitizedPathWithoutQuery())) {
+    if (path_matcher_->match(route_match_context.sanitizedPath())) {
       return clusterEntry(route_match_context.headers(), stream_info, random_value);
     }
   }

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -81,46 +81,54 @@ public:
   absl::string_view path() const { return headers_.getPathValue(); }
 
   absl::string_view pathWithoutQuery() const {
-    if (!path_without_query_.has_value()) {
+    if (!path_without_query_computed_) {
       path_without_query_ = Http::PathUtil::removeQueryAndFragment(path());
+      path_without_query_computed_ = true;
     }
-    return *path_without_query_;
+    return path_without_query_;
   }
 
   absl::string_view sanitizedPath() const {
-    if (!sanitized_path_.has_value()) {
+    if (!sanitized_path_computed_) {
       sanitized_path_ = ignore_path_params_ ? stripPathParams(path()) : path();
+      sanitized_path_computed_ = true;
     }
-    return *sanitized_path_;
+    return sanitized_path_;
   }
 
   absl::string_view sanitizedPathWithoutQuery() const {
-    if (!sanitized_path_without_query_.has_value()) {
+    if (!sanitized_path_without_query_computed_) {
       sanitized_path_without_query_ =
           ignore_path_params_ ? stripPathParams(pathWithoutQuery()) : pathWithoutQuery();
+      sanitized_path_without_query_computed_ = true;
     }
-    return *sanitized_path_without_query_;
+    return sanitized_path_without_query_;
   }
 
   const Http::Utility::QueryParamsMulti& queryParams() const {
-    if (!query_params_.has_value()) {
+    if (!query_params_computed_) {
       query_params_ = Http::Utility::QueryParamsMulti::parseQueryString(path());
+      query_params_computed_ = true;
     }
-    return *query_params_;
+    return query_params_;
   }
 
   bool isGrpc() const {
-    if (!is_grpc_.has_value()) {
+    if (!is_grpc_computed_) {
       is_grpc_ = Grpc::Common::isGrpcRequestHeaders(headers_);
+      is_grpc_computed_ = true;
     }
-    return *is_grpc_;
+    return is_grpc_;
   }
 
-  const absl::flat_hash_map<std::string, std::string>& cookies() const {
-    if (!cookies_.has_value()) {
-      cookies_ = Http::Utility::parseCookies(headers_);
+  const absl::flat_hash_map<std::string, std::string>&
+  cookies(const absl::flat_hash_set<absl::string_view>& names) const {
+    if (!cookies_computed_) {
+      cookies_ = Http::Utility::parseCookies(
+          headers_, [&names](absl::string_view key) { return names.contains(key); });
+      cookies_computed_ = true;
     }
-    return *cookies_;
+    return cookies_;
   }
 
 private:
@@ -130,13 +138,20 @@ private:
   }
 
   const Http::RequestHeaderMap& headers_;
-  const bool ignore_path_params_;
-  mutable absl::optional<absl::string_view> path_without_query_;
-  mutable absl::optional<absl::string_view> sanitized_path_;
-  mutable absl::optional<absl::string_view> sanitized_path_without_query_;
-  mutable absl::optional<Http::Utility::QueryParamsMulti> query_params_;
-  mutable absl::optional<bool> is_grpc_;
-  mutable absl::optional<absl::flat_hash_map<std::string, std::string>> cookies_;
+  mutable absl::string_view path_without_query_;
+  mutable absl::string_view sanitized_path_;
+  mutable absl::string_view sanitized_path_without_query_;
+  mutable Http::Utility::QueryParamsMulti query_params_;
+  mutable absl::flat_hash_map<std::string, std::string> cookies_;
+  // Keep bools at the end to reduce alignment overhead
+  const bool ignore_path_params_{};
+  mutable bool path_without_query_computed_ : 1 {};
+  mutable bool sanitized_path_computed_ : 1 {};
+  mutable bool sanitized_path_without_query_computed_ : 1 {};
+  mutable bool query_params_computed_ : 1 {};
+  mutable bool is_grpc_ : 1 {};
+  mutable bool is_grpc_computed_ : 1 {};
+  mutable bool cookies_computed_ : 1 {};
 };
 
 /**

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -121,11 +121,9 @@ public:
     return is_grpc_;
   }
 
-  const absl::flat_hash_map<std::string, std::string>&
-  cookies(const absl::flat_hash_set<absl::string_view>& names) const {
+  const absl::flat_hash_map<std::string, std::string>& cookies() const {
     if (!cookies_computed_) {
-      cookies_ = Http::Utility::parseCookies(
-          headers_, [&names](absl::string_view key) { return names.contains(key); });
+      cookies_ = Http::Utility::parseCookies(headers_);
       cookies_computed_ = true;
     }
     return cookies_;
@@ -983,7 +981,6 @@ private:
   std::vector<Http::HeaderUtility::HeaderDataPtr> config_headers_;
   std::vector<ConfigUtility::QueryParameterMatcherPtr> config_query_parameters_;
   std::vector<ConfigUtility::CookieMatcherPtr> config_cookies_;
-  absl::flat_hash_set<absl::string_view> config_cookie_names_;
 
   UpgradeMap upgrade_map_;
   std::unique_ptr<const Http::HashPolicyImpl> hash_policy_;

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -25,9 +25,12 @@
 #include "source/common/common/packed_struct.h"
 #include "source/common/config/datasource.h"
 #include "source/common/config/metadata.h"
+#include "source/common/grpc/common.h"
 #include "source/common/http/hash_policy.h"
 #include "source/common/http/header_mutation.h"
 #include "source/common/http/header_utility.h"
+#include "source/common/http/path_utility.h"
+#include "source/common/http/utility.h"
 #include "source/common/matcher/matcher.h"
 #include "source/common/router/config_utility.h"
 #include "source/common/router/header_parser.h"
@@ -64,6 +67,79 @@ private:
 };
 
 /**
+ * Lazily derives and caches per-request values used during route matching
+ * (path, query params, cookies, gRPC flag, etc.) so each is computed at most
+ * once across all route entries evaluated for a single request.
+ */
+class RouteMatchContext {
+public:
+  RouteMatchContext(const Http::RequestHeaderMap& headers, bool ignore_path_params)
+      : headers_(headers), ignore_path_params_(ignore_path_params) {}
+
+  const Http::RequestHeaderMap& headers() const { return headers_; }
+
+  absl::string_view path() const { return headers_.getPathValue(); }
+
+  absl::string_view pathWithoutQuery() const {
+    if (!path_without_query_.has_value()) {
+      path_without_query_ = Http::PathUtil::removeQueryAndFragment(path());
+    }
+    return *path_without_query_;
+  }
+
+  absl::string_view sanitizedPath() const {
+    if (!sanitized_path_.has_value()) {
+      sanitized_path_ = ignore_path_params_ ? stripPathParams(path()) : path();
+    }
+    return *sanitized_path_;
+  }
+
+  absl::string_view sanitizedPathWithoutQuery() const {
+    if (!sanitized_path_without_query_.has_value()) {
+      sanitized_path_without_query_ =
+          ignore_path_params_ ? stripPathParams(pathWithoutQuery()) : pathWithoutQuery();
+    }
+    return *sanitized_path_without_query_;
+  }
+
+  const Http::Utility::QueryParamsMulti& queryParams() const {
+    if (!query_params_.has_value()) {
+      query_params_ = Http::Utility::QueryParamsMulti::parseQueryString(path());
+    }
+    return *query_params_;
+  }
+
+  bool isGrpc() const {
+    if (!is_grpc_.has_value()) {
+      is_grpc_ = Grpc::Common::isGrpcRequestHeaders(headers_);
+    }
+    return *is_grpc_;
+  }
+
+  const absl::flat_hash_map<std::string, std::string>& cookies() const {
+    if (!cookies_.has_value()) {
+      cookies_ = Http::Utility::parseCookies(headers_);
+    }
+    return *cookies_;
+  }
+
+private:
+  static absl::string_view stripPathParams(absl::string_view path) {
+    const auto pos = path.find(';');
+    return pos != absl::string_view::npos ? path.substr(0, pos) : path;
+  }
+
+  const Http::RequestHeaderMap& headers_;
+  const bool ignore_path_params_;
+  mutable absl::optional<absl::string_view> path_without_query_;
+  mutable absl::optional<absl::string_view> sanitized_path_;
+  mutable absl::optional<absl::string_view> sanitized_path_without_query_;
+  mutable absl::optional<Http::Utility::QueryParamsMulti> query_params_;
+  mutable absl::optional<bool> is_grpc_;
+  mutable absl::optional<absl::flat_hash_map<std::string, std::string>> cookies_;
+};
+
+/**
  * Base interface for something that matches a header.
  */
 class Matchable {
@@ -71,13 +147,15 @@ public:
   virtual ~Matchable() = default;
 
   /**
-   * See if this object matches the incoming headers.
-   * @param headers supplies the headers to match.
+   * See if this object matches the incoming request.
+   * @param route_match_context supplies pre-computed context for the request like path/query
+   * values.
+   * @param stream_info supplies the stream info for the request.
    * @param random_value supplies the random seed to use if a runtime choice is required. This
    *        allows stable choices between calls if desired.
-   * @return true if input headers match this object.
+   * @return RouteConstSharedPtr if input matches this object, nullptr otherwise.
    */
-  virtual RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  virtual RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                                       const StreamInfo::StreamInfo& stream_info,
                                       uint64_t random_value) const PURE;
 
@@ -379,7 +457,7 @@ public:
                                           uint64_t random_value) const;
 
   RouteConstSharedPtr
-  getRouteFromRoutes(const RouteCallback& cb, const Http::RequestHeaderMap& headers,
+  getRouteFromRoutes(const RouteCallback& cb, const RouteMatchContext& route_match_context,
                      const StreamInfo::StreamInfo& stream_info, uint64_t random_value,
                      absl::Span<const RouteEntryImplBaseConstSharedPtr> routes) const;
 
@@ -584,8 +662,8 @@ public:
 
   bool isRedirect() const;
 
-  bool matchRoute(const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
-                  uint64_t random_value) const;
+  bool matchRoute(const RouteMatchContext& route_match_context,
+                  const StreamInfo::StreamInfo& stream_info, uint64_t random_value) const;
   absl::Status validateClusters(const Upstream::ClusterManager& cluster_manager) const;
 
   // Router::RouteEntry
@@ -938,7 +1016,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Template; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
@@ -973,7 +1051,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Prefix; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
@@ -1008,7 +1086,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Exact; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
@@ -1042,7 +1120,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::Regex; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
@@ -1076,7 +1154,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::None; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 
@@ -1109,7 +1187,7 @@ public:
   PathMatchType matchType() const override { return PathMatchType::PathSeparatedPrefix; }
 
   // Router::Matchable
-  RouteConstSharedPtr matches(const Http::RequestHeaderMap& headers,
+  RouteConstSharedPtr matches(const RouteMatchContext& route_match_context,
                               const StreamInfo::StreamInfo& stream_info,
                               uint64_t random_value) const override;
 

--- a/test/common/router/config_impl_speed_test.cc
+++ b/test/common/router/config_impl_speed_test.cc
@@ -318,6 +318,86 @@ BENCHMARK(bmRouteTableSizeWithRegexMatch)->RangeMultiplier(2)->Ranges({{1, 2 << 
 BENCHMARK(bmRouteTableSizeWithExactMatcherTree)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
 BENCHMARK(bmRouteTableSizeWithPrefixMatcherTree)->RangeMultiplier(2)->Ranges({{1, 2 << 13}});
 
+// N plain prefix routes. Route i matches only /api/v{i}/. Last route matches.
+static RouteConfiguration genPlainRouteConfig(int n) {
+  RouteConfiguration route_config;
+  VirtualHost* v_host = route_config.add_virtual_hosts();
+  v_host->set_name("default");
+  v_host->add_domains("*");
+  for (int i = 0; i < n; ++i) {
+    Route* route = v_host->add_routes();
+    route->mutable_direct_response()->set_status(200);
+    route->mutable_match()->set_prefix(absl::StrCat("/api/v", i, "/"));
+  }
+  return route_config;
+}
+
+// N routes: first n/2 share prefix "/api/" with a non-matching query param;
+// last route is a plain prefix match.
+static RouteConfiguration genMixedRouteConfig(int n) {
+  RouteConfiguration route_config;
+  VirtualHost* v_host = route_config.add_virtual_hosts();
+  v_host->set_name("default");
+  v_host->add_domains("*");
+  const int n_query = n / 2;
+  for (int i = 0; i < n; ++i) {
+    Route* route = v_host->add_routes();
+    route->mutable_direct_response()->set_status(200);
+    RouteMatch* match = route->mutable_match();
+    if (i < n_query) {
+      match->set_prefix("/api/");
+      auto* qp = match->add_query_parameters();
+      qp->set_name("id");
+      qp->mutable_string_match()->set_exact(absl::StrCat("nomatch_", i));
+    } else if (i < n - 1) {
+      match->set_prefix(absl::StrCat("/other/v", i, "/"));
+    } else {
+      match->set_prefix("/api/");
+    }
+  }
+  return route_config;
+}
+
+// N plain prefix routes, no query/cookie matching. Request matches the last route.
+static void bmPlainRoutes(benchmark::State& state) {
+  const int n = state.range(0);
+  Api::ApiPtr api = Api::createApiForTest();
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(factory_context, api()).WillByDefault(ReturnRef(*api));
+  std::shared_ptr<ConfigImpl> config = *ConfigImpl::create(
+      genPlainRouteConfig(n), factory_context, ProtobufMessage::getNullValidationVisitor(), true);
+  const std::string path = absl::StrCat("/api/v", n - 1, "/foo");
+  Http::TestRequestHeaderMapImpl headers{{":authority", "www.example.com"},
+                                         {":method", "GET"},
+                                         {":path", path},
+                                         {"x-forwarded-proto", "http"}};
+  for (auto _ : state) { // NOLINT
+    config->route(headers, stream_info, 0);
+  }
+}
+
+// N routes, first half with non-matching query params. Request matches the last route.
+static void bmMixedRoutes(benchmark::State& state) {
+  const int n = state.range(0);
+  Api::ApiPtr api = Api::createApiForTest();
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(factory_context, api()).WillByDefault(ReturnRef(*api));
+  std::shared_ptr<ConfigImpl> config = *ConfigImpl::create(
+      genMixedRouteConfig(n), factory_context, ProtobufMessage::getNullValidationVisitor(), true);
+  Http::TestRequestHeaderMapImpl headers{{":authority", "www.example.com"},
+                                         {":method", "GET"},
+                                         {":path", "/api/foo?id=target"},
+                                         {"x-forwarded-proto", "http"}};
+  for (auto _ : state) { // NOLINT
+    config->route(headers, stream_info, 0);
+  }
+}
+
+BENCHMARK(bmPlainRoutes)->RangeMultiplier(2)->Ranges({{64, 2 << 10}});
+BENCHMARK(bmMixedRoutes)->RangeMultiplier(2)->Ranges({{64, 2 << 10}});
+
 } // namespace
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -426,8 +426,7 @@ TEST(RouteMatchContextTest, Cookies) {
   Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}, {"cookie", "session=abc; user=xyz"}};
   RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
 
-  const absl::flat_hash_set<absl::string_view> names = {"session", "user"};
-  const auto& cookies = ctx.cookies(names);
+  const auto& cookies = ctx.cookies();
   EXPECT_EQ(cookies.at("session"), "abc");
   EXPECT_EQ(cookies.at("user"), "xyz");
   EXPECT_EQ(cookies.size(), 2);
@@ -437,8 +436,46 @@ TEST(RouteMatchContextTest, NoCookies) {
   Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}};
   RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
 
-  const absl::flat_hash_set<absl::string_view> names;
-  EXPECT_TRUE(ctx.cookies(names).empty());
+  EXPECT_TRUE(ctx.cookies().empty());
+}
+
+// Regression test: route 1 checks cookie "session" (no match), route 2 checks
+// cookie "user" (match). With the old filtered-cache bug, route 1's evaluation
+// would cache only {"session": ...}, causing route 2 to miss "user" and fail.
+TEST_F(RouteMatcherTest, CookiesCachedAcrossDifferentNameSets) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+  - name: cookie
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+          cookies:
+            - name: session
+              string_match:
+                exact: expected
+        route: { cluster: session-cluster }
+      - match:
+          prefix: "/"
+          cookies:
+            - name: user
+              string_match:
+                exact: xyz
+        route: { cluster: user-cluster }
+      - match:
+          prefix: "/"
+        route: { cluster: default }
+  )EOF";
+
+  factory_context_.cluster_manager_.initializeClusters(
+      {"session-cluster", "user-cluster", "default"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  // session=other → route 1 misses; user=xyz → route 2 matches.
+  auto headers = genHeaders("www.example.com", "/foo", "GET");
+  headers.addCopy("cookie", "session=other; user=xyz");
+  EXPECT_EQ("user-cluster", config.route(headers, 0)->routeEntry()->clusterName());
 }
 
 TEST_F(RouteMatcherTest, TestConnectRoutes) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -426,7 +426,8 @@ TEST(RouteMatchContextTest, Cookies) {
   Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}, {"cookie", "session=abc; user=xyz"}};
   RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
 
-  const auto& cookies = ctx.cookies();
+  const absl::flat_hash_set<absl::string_view> names = {"session", "user"};
+  const auto& cookies = ctx.cookies(names);
   EXPECT_EQ(cookies.at("session"), "abc");
   EXPECT_EQ(cookies.at("user"), "xyz");
   EXPECT_EQ(cookies.size(), 2);
@@ -436,7 +437,8 @@ TEST(RouteMatchContextTest, NoCookies) {
   Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}};
   RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
 
-  EXPECT_TRUE(ctx.cookies().empty());
+  const absl::flat_hash_set<absl::string_view> names;
+  EXPECT_TRUE(ctx.cookies(names).empty());
 }
 
 TEST_F(RouteMatcherTest, TestConnectRoutes) {

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -360,6 +360,85 @@ class RouteMatcherTest : public testing::Test,
                          public ConfigImplTestBase,
                          public TestScopedRuntime {};
 
+TEST(RouteMatchContextTest, BasicPathAndQuery) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo?a=1&b=2"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  EXPECT_EQ(ctx.path(), "/foo?a=1&b=2");
+  EXPECT_EQ(ctx.pathWithoutQuery(), "/foo");
+  EXPECT_EQ(ctx.sanitizedPath(), "/foo?a=1&b=2");
+  EXPECT_EQ(ctx.sanitizedPathWithoutQuery(), "/foo");
+  EXPECT_EQ(ctx.queryParams().getFirstValue("a").value(), "1");
+  EXPECT_EQ(ctx.queryParams().getFirstValue("b").value(), "2");
+}
+
+TEST(RouteMatchContextTest, PathWithFragment) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo?x=1#section"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  EXPECT_EQ(ctx.pathWithoutQuery(), "/foo");
+  EXPECT_EQ(ctx.sanitizedPathWithoutQuery(), "/foo");
+}
+
+TEST(RouteMatchContextTest, NoQueryString) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo/bar"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  EXPECT_EQ(ctx.path(), "/foo/bar");
+  EXPECT_EQ(ctx.pathWithoutQuery(), "/foo/bar");
+  EXPECT_FALSE(ctx.queryParams().getFirstValue("any").has_value());
+}
+
+TEST(RouteMatchContextTest, SanitizedPathStripsPathParams) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo;env=prod;ver=2?a=1"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/true);
+
+  EXPECT_EQ(ctx.sanitizedPath(), "/foo");
+  EXPECT_EQ(ctx.sanitizedPathWithoutQuery(), "/foo");
+  // Raw accessors are unaffected.
+  EXPECT_EQ(ctx.path(), "/foo;env=prod;ver=2?a=1");
+  EXPECT_EQ(ctx.pathWithoutQuery(), "/foo;env=prod;ver=2");
+}
+
+TEST(RouteMatchContextTest, SanitizedPathNoOpWhenNotConfigured) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo;env=prod?a=1"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  EXPECT_EQ(ctx.sanitizedPath(), "/foo;env=prod?a=1");
+  EXPECT_EQ(ctx.sanitizedPathWithoutQuery(), "/foo;env=prod");
+}
+
+TEST(RouteMatchContextTest, IsGrpc) {
+  {
+    Http::TestRequestHeaderMapImpl headers{{":path", "/pkg.Svc/Method"},
+                                           {"content-type", "application/grpc"}};
+    RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+    EXPECT_TRUE(ctx.isGrpc());
+  }
+  {
+    Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}, {"content-type", "application/json"}};
+    RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+    EXPECT_FALSE(ctx.isGrpc());
+  }
+}
+
+TEST(RouteMatchContextTest, Cookies) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}, {"cookie", "session=abc; user=xyz"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  const auto& cookies = ctx.cookies();
+  EXPECT_EQ(cookies.at("session"), "abc");
+  EXPECT_EQ(cookies.at("user"), "xyz");
+  EXPECT_EQ(cookies.size(), 2);
+}
+
+TEST(RouteMatchContextTest, NoCookies) {
+  Http::TestRequestHeaderMapImpl headers{{":path", "/foo"}};
+  RouteMatchContext ctx(headers, /*ignore_path_params=*/false);
+
+  EXPECT_TRUE(ctx.cookies().empty());
+}
+
 TEST_F(RouteMatcherTest, TestConnectRoutes) {
   const std::string yaml = R"EOF(
 virtual_hosts:


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: `perf: populate route match context once across entries`
Additional Description: In case of multiple route entries these values are evaluated per route today which can be done only once to save compute.
Risk Level: Low
Testing: Existing tests + unit tests
Docs Changes: N/A
Release Notes: No
Platform Specific Features: N/A
Fixes #20609 

## Benchmarks

Two benchmarks added to `test/common/router/config_impl_speed_test.cc`, each
run against `main` and this branch (`-c opt`, `--benchmark_min_time=3s`).

**`bmPlainRoutes`** — N prefix-only routes, no query/cookie matching. Request
matches the last route. Measures overhead of `RouteMatchContext` when cached
values are never accessed.

**`bmMixedRoutes`** — N routes where the first half share a common prefix with
a non-matching query parameter, and the last route is a plain prefix match.
Exercises the query-string caching benefit.

### Results

#### bmPlainRoutes (ns/iter)

| N | main | this PR | speedup |
|-------|--------|---------|---------|
| 64 | 1,141 | 961 | 1.19x |
| 128 | 2,340 | 1,941 | 1.21x |
| 256 | 4,613 | 3,883 | 1.19x |
| 512 | 9,184 | 7,705 | 1.19x |
| 1,024 | 18,647 | 15,811 | 1.18x |
| 2,048 | 37,336 | 32,002 | 1.17x |

#### bmMixedRoutes (ns/iter)

| N | main | this PR | speedup |
|-------|--------|---------|---------|
| 64 | 3,112 | 1,421 | 2.19x |
| 128 | 6,173 | 2,786 | 2.21x |
| 256 | 12,109 | 5,558 | 2.18x |
| 512 | 24,656 | 10,916 | 2.26x |
| 1,024 | 48,172 | 21,793 | 2.21x |
| 2,048 | 95,990 | 43,077 | 2.23x |

No regression on plain routes (~1.2x improvement from single `sanitizePathBeforePathMatching()` instead of per-route). Consistent **~2.2x speedup** on mixed routes where query-string
parsing previously ran once per route.