### PR TITLE
xds: log per-resource rejection details for LDS/CDS/RDS/EDS/SDS/SRDS

### DIFF
--- a/source/common/listener_manager/lds_api.cc
+++ b/source/common/listener_manager/lds_api.cc
@@ -84,6 +84,7 @@ LdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_
       state.mutable_failed_configuration()->PackFrom(resource.get().resource());
 #endif
       absl::StrAppend(&message, listener_name, ": ", error_message, "\n");
+      ENVOY_LOG(warn, "lds: listener '{}' config rejected: {}", listener_name, error_message);
     };
 
     TRY_ASSERT_MAIN_THREAD {

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -567,6 +567,8 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
                                           *(it->second->mutable_last_update_attempt()));
     it->second->set_details(add_or_update_status.status().message());
     it->second->mutable_failed_configuration()->PackFrom(config);
+    ENVOY_LOG(warn, "listener '{}' config rejected: {}", name,
+              add_or_update_status.status().message());
   }
   return add_or_update_status;
 }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -567,8 +567,6 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
                                           *(it->second->mutable_last_update_attempt()));
     it->second->set_details(add_or_update_status.status().message());
     it->second->mutable_failed_configuration()->PackFrom(config);
-    ENVOY_LOG(warn, "listener '{}' config rejected: {}", name,
-              add_or_update_status.status().message());
   }
   return add_or_update_status;
 }

--- a/source/common/rds/rds_route_config_subscription.cc
+++ b/source/common/rds/rds_route_config_subscription.cc
@@ -84,24 +84,29 @@ absl::Status RdsRouteConfigSubscription::onConfigUpdate(
     return absl::OkStatus();
   }
   if (resources.size() != 1) {
-    return absl::InvalidArgumentError(
-        fmt::format("Unexpected {} resource length: {}", rds_type_, resources.size()));
+    const auto msg = fmt::format("Unexpected {} resource length: {}", rds_type_, resources.size());
+    ENVOY_LOG(warn, "rds: route config '{}' rejected: {}", route_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
 
   const auto& route_config = resources[0].get().resource();
   Protobuf::ReflectableMessage reflectable_config = createReflectableMessage(route_config);
   if (reflectable_config->GetDescriptor()->full_name() !=
       route_config_provider_manager_.protoTraits().resourceType()) {
-    return absl::InvalidArgumentError(
+    const auto msg =
         fmt::format("Unexpected {} configuration type (expecting {}): {}", rds_type_,
                     route_config_provider_manager_.protoTraits().resourceType(),
-                    reflectable_config->GetDescriptor()->full_name()));
+                    reflectable_config->GetDescriptor()->full_name());
+    ENVOY_LOG(warn, "rds: route config '{}' rejected: {}", route_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
   if (resourceName(route_config_provider_manager_.protoTraits(), route_config) !=
       route_config_name_) {
-    return absl::InvalidArgumentError(
+    const auto msg =
         fmt::format("Unexpected {} configuration (expecting {}): {}", rds_type_, route_config_name_,
-                    resourceName(route_config_provider_manager_.protoTraits(), route_config)));
+                    resourceName(route_config_provider_manager_.protoTraits(), route_config));
+    ENVOY_LOG(warn, "rds: route config '{}' rejected: {}", route_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
   std::unique_ptr<Init::ManagerImpl> noop_init_manager;
   std::unique_ptr<Cleanup> resume_rds;

--- a/source/common/rds/rds_route_config_subscription.cc
+++ b/source/common/rds/rds_route_config_subscription.cc
@@ -93,10 +93,9 @@ absl::Status RdsRouteConfigSubscription::onConfigUpdate(
   Protobuf::ReflectableMessage reflectable_config = createReflectableMessage(route_config);
   if (reflectable_config->GetDescriptor()->full_name() !=
       route_config_provider_manager_.protoTraits().resourceType()) {
-    const auto msg =
-        fmt::format("Unexpected {} configuration type (expecting {}): {}", rds_type_,
-                    route_config_provider_manager_.protoTraits().resourceType(),
-                    reflectable_config->GetDescriptor()->full_name());
+    const auto msg = fmt::format("Unexpected {} configuration type (expecting {}): {}", rds_type_,
+                                 route_config_provider_manager_.protoTraits().resourceType(),
+                                 reflectable_config->GetDescriptor()->full_name());
     ENVOY_LOG(warn, "rds: route config '{}' rejected: {}", route_config_name_, msg);
     return absl::InvalidArgumentError(msg);
   }

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -434,6 +434,7 @@ absl::Status ScopedRdsConfigSubscription::onConfigUpdate(
   Protobuf::RepeatedPtrField<std::string> clean_removed_resources =
       detectUpdateConflictAndCleanupRemoved(added_resources, removed_resources, exception_msg);
   if (!exception_msg.empty()) {
+    ENVOY_LOG(warn, "srds: scoped route config '{}' rejected: {}", name_, exception_msg);
     return absl::InvalidArgumentError(
         fmt::format("Error adding/updating scoped route(s): {}", exception_msg));
   }
@@ -447,6 +448,8 @@ absl::Status ScopedRdsConfigSubscription::onConfigUpdate(
       added_resources, (srds_init_mgr == nullptr ? localInitManager() : *srds_init_mgr),
       version_info);
   if (!status_or_applied.status().ok()) {
+    ENVOY_LOG(warn, "srds: scoped route config '{}' rejected: {}", name_,
+              status_or_applied.status().message());
     return status_or_applied.status();
   }
   const bool any_applied = status_or_applied.value();

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -195,10 +195,9 @@ absl::Status SdsApi::validateUpdateSize(uint32_t added_resources_num,
   // It is, however, preferred to ignore these nonsensical responses rather
   // than NACK them, so it is allowed here.
   if (added_resources_num > 1 || removed_resources_num > 1) {
-    const auto msg =
-        fmt::format("Unexpected SDS secrets length for {}, number of added resources "
-                    "{}, number of removed resources {}. Expected sum is 1",
-                    sds_config_name_, added_resources_num, removed_resources_num);
+    const auto msg = fmt::format("Unexpected SDS secrets length for {}, number of added resources "
+                                 "{}, number of removed resources {}. Expected sum is 1",
+                                 sds_config_name_, added_resources_num, removed_resources_num);
     ENVOY_LOG_MISC(warn, "sds: secret '{}' config rejected: {}", sds_config_name_, msg);
     return absl::InvalidArgumentError(msg);
   }

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -96,8 +96,10 @@ absl::Status SdsApi::onConfigUpdate(const std::vector<Config::DecodedResourceRef
       resources[0].get().resource());
 
   if (secret.name() != sds_config_name_) {
-    return absl::InvalidArgumentError(
-        fmt::format("Unexpected SDS secret (expecting {}): {}", sds_config_name_, secret.name()));
+    const auto msg =
+        fmt::format("Unexpected SDS secret (expecting {}): {}", sds_config_name_, secret.name());
+    ENVOY_LOG_MISC(warn, "sds: secret '{}' config rejected: {}", sds_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
 
   const uint64_t new_hash = MessageUtil::hash(secret);
@@ -182,8 +184,10 @@ void SdsApi::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason reaso
 absl::Status SdsApi::validateUpdateSize(uint32_t added_resources_num,
                                         uint32_t removed_resources_num) const {
   if (added_resources_num == 0 && removed_resources_num == 0) {
-    return absl::InvalidArgumentError(
-        fmt::format("Missing SDS resources for {} in onConfigUpdate()", sds_config_name_));
+    const auto msg =
+        fmt::format("Missing SDS resources for {} in onConfigUpdate()", sds_config_name_);
+    ENVOY_LOG_MISC(warn, "sds: secret '{}' config rejected: {}", sds_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
 
   // This conditional technically allows a response with added=1 removed=1
@@ -191,10 +195,12 @@ absl::Status SdsApi::validateUpdateSize(uint32_t added_resources_num,
   // It is, however, preferred to ignore these nonsensical responses rather
   // than NACK them, so it is allowed here.
   if (added_resources_num > 1 || removed_resources_num > 1) {
-    return absl::InvalidArgumentError(
+    const auto msg =
         fmt::format("Unexpected SDS secrets length for {}, number of added resources "
                     "{}, number of removed resources {}. Expected sum is 1",
-                    sds_config_name_, added_resources_num, removed_resources_num));
+                    sds_config_name_, added_resources_num, removed_resources_num);
+    ENVOY_LOG_MISC(warn, "sds: secret '{}' config rejected: {}", sds_config_name_, msg);
+    return absl::InvalidArgumentError(msg);
   }
   return absl::OkStatus();
 }

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -45,12 +45,16 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
       cluster_name = cluster.name();
       if (!cluster_names.insert(cluster.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully applied.
-        exception_msgs.push_back(
-            fmt::format("{}: duplicate cluster {} found", cluster_name, cluster_name));
+        const std::string msg =
+            fmt::format("{}: duplicate cluster {} found", cluster_name, cluster_name);
+        ENVOY_LOG(warn, "cds: cluster '{}' config rejected: {}", cluster_name, msg);
+        exception_msgs.push_back(msg);
         continue;
       }
       auto update_or_error = cm_.addOrUpdateCluster(cluster, resource.get().version());
       if (!update_or_error.status().ok()) {
+        ENVOY_LOG(warn, "cds: cluster '{}' config rejected: {}", cluster_name,
+                  update_or_error.status().message());
         exception_msgs.push_back(
             fmt::format("{}: {}", cluster_name, update_or_error.status().message()));
         continue;
@@ -65,8 +69,10 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
       }
     }
     END_TRY
-    CATCH(const EnvoyException& e,
-          { exception_msgs.push_back(fmt::format("{}: {}", cluster_name, e.what())); });
+    CATCH(const EnvoyException& e, {
+      ENVOY_LOG(warn, "cds: cluster '{}' config rejected: {}", cluster_name, e.what());
+      exception_msgs.push_back(fmt::format("{}: {}", cluster_name, e.what()));
+    });
   }
 
   uint32_t removed = 0;

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -204,27 +204,31 @@ EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& re
     return absl::OkStatus();
   }
   if (resources.size() != 1) {
-    return absl::InvalidArgumentError(
-        fmt::format("Unexpected EDS resource length: {}", resources.size()));
+    const auto msg = fmt::format("Unexpected EDS resource length: {}", resources.size());
+    ENVOY_LOG(warn, "eds: cluster '{}' config rejected: {}", edsServiceName(), msg);
+    return absl::InvalidArgumentError(msg);
   }
 
   envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment =
       dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
           resources[0].get().resource());
   if (cluster_load_assignment.cluster_name() != edsServiceName()) {
-    return absl::InvalidArgumentError(fmt::format("Unexpected EDS cluster (expecting {}): {}",
-                                                  edsServiceName(),
-                                                  cluster_load_assignment.cluster_name()));
+    const auto msg = fmt::format("Unexpected EDS cluster (expecting {}): {}", edsServiceName(),
+                                 cluster_load_assignment.cluster_name());
+    ENVOY_LOG(warn, "eds: cluster '{}' config rejected: {}", edsServiceName(), msg);
+    return absl::InvalidArgumentError(msg);
   }
   // Validate that each locality doesn't have both LEDS and endpoints defined.
   // TODO(adisuissa): This is only needed for the API v3 support. In future major versions
   // the oneof definition will take care of it.
   for (const auto& locality : cluster_load_assignment.endpoints()) {
     if (locality.has_leds_cluster_locality_config() && locality.lb_endpoints_size() > 0) {
-      return absl::InvalidArgumentError(fmt::format(
+      const auto msg = fmt::format(
           "A ClusterLoadAssignment for cluster {} cannot include both LEDS (resource: {}) and a "
           "list of endpoints.",
-          edsServiceName(), locality.leds_cluster_locality_config().leds_collection_name()));
+          edsServiceName(), locality.leds_cluster_locality_config().leds_collection_name());
+      ENVOY_LOG(warn, "eds: cluster '{}' config rejected: {}", edsServiceName(), msg);
+      return absl::InvalidArgumentError(msg);
     }
   }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: xds: log per-resource rejection details for LDS/CDS/RDS/EDS/SDS/SRDS

Additional Description: When an xDS update is rejected, the error detail (e.g. "route: unknown cluster '...'") was only visible via the admin `/config_dump` API or buried in an aggregated subscription-layer NACK log using an opaque proto type URL.
This made diagnosing readiness failures like "lds updates: 0 successful, N rejected" require manual config dump inspection. This PR adds a per-resource `warn` log at the point of rejection in each xDS resource handler, naming the specific resource and the exact reason:

  [warn] lds: listener 'foo' config rejected: route: unknown cluster 'bar'
  [warn] cds: cluster 'foo' config rejected: <detail>
  [warn] rds: route config 'foo' rejected: <detail>
  [warn] eds: cluster 'foo' config rejected: <detail>
  [warn] sds: secret 'foo' config rejected: <detail>
  [warn] srds: scoped route config 'foo' rejected: <detail>

The log level matches the three existing rejection log sites in the subscription layer (subscription_state.h, delta_subscription_state.cc, grpc_subscription_impl.cc) which all use `warn` for the same class of event. 

Risk Level: Low, additive logging only, no behavioral changes.
Testing: Existing unit tests for each xDS handler cover the error paths that now emit the new log lines. No new behavior was introduced that requires additional test coverage. Manual testing performed using a filesystem-based LDS subscription with a listener referencing a non-existent cluster (validate_clusters: true) to confirm the new log line appears.
Docs Changes: None
Release Notes: Added per-resource warn-level log lines when xDS config updates are rejected for LDS, CDS, RDS, EDS, SDS, and SRDS. Previously these errors were only surfaced via the admin config_dump API or as an aggregated
message in the subscription-layer NACK log.
Platform Specific Features: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
