### PR TITLE
io_uring: thread cqe->flags through CompletionCb

### DIFF
--- a/envoy/common/io/io_uring.h
+++ b/envoy/common/io/io_uring.h
@@ -53,8 +53,13 @@ private:
  * queue.
  * @param result is a return code of submitted system call.
  * @param injected indicates whether the completion is injected or not.
+ * @param flags is the raw ``cqe->flags`` value from the io_uring completion. For multishot
+ * completions, callers inspect ``IORING_CQE_F_BUFFER`` (the buffer ID is encoded in the upper
+ * bits) and ``IORING_CQE_F_MORE`` (whether the SQE will produce further completions). For
+ * injected completions the value is always ``0``.
  */
-using CompletionCb = std::function<void(Request* user_data, int32_t result, bool injected)>;
+using CompletionCb =
+    std::function<void(Request* user_data, int32_t result, bool injected, uint32_t flags)>;
 
 /**
  * Callback for releasing the user data.

--- a/source/common/io/io_uring_impl.cc
+++ b/source/common/io/io_uring_impl.cc
@@ -69,7 +69,7 @@ void IoUringImpl::forEveryCompletion(const CompletionCb& completion_cb) {
 
   for (unsigned i = 0; i < count; ++i) {
     struct io_uring_cqe* cqe = cqes_[i];
-    completion_cb(reinterpret_cast<Request*>(cqe->user_data), cqe->res, false);
+    completion_cb(reinterpret_cast<Request*>(cqe->user_data), cqe->res, false, cqe->flags);
   }
 
   io_uring_cq_advance(&ring_, count);
@@ -80,7 +80,9 @@ void IoUringImpl::forEveryCompletion(const CompletionCb& completion_cb) {
   // Iterate the injected completion.
   while (!injected_completions_.empty()) {
     auto& completion = injected_completions_.front();
-    completion_cb(completion.user_data_, completion.result_, true);
+    // Injected completions always carry ``flags == 0``; they do not originate from the kernel
+    // and have no associated CQE.
+    completion_cb(completion.user_data_, completion.result_, true, 0);
     // The socket may closed in the completion_cb and all the related completions are
     // removed.
     if (injected_completions_.empty()) {

--- a/source/common/io/io_uring_worker_impl.cc
+++ b/source/common/io/io_uring_worker_impl.cc
@@ -251,7 +251,11 @@ void IoUringWorkerImpl::injectCompletion(IoUringSocket& socket, Request::Request
 void IoUringWorkerImpl::onFileEvent() {
   ENVOY_LOG(trace, "io uring worker, on file event");
   delay_submit_ = true;
-  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected) {
+  // ``flags`` carries the raw ``cqe->flags`` value. The worker does not yet branch on it; this
+  // is wired through so a follow-up change can observe ``IORING_CQE_F_BUFFER`` and
+  // ``IORING_CQE_F_MORE`` for multishot recv.
+  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected,
+                                   uint32_t /*flags*/) {
     ENVOY_LOG(trace, "receive request completion, type = {}, req = {}",
               static_cast<uint8_t>(req->type()), fmt::ptr(req));
     ASSERT(req != nullptr);

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -102,7 +102,7 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool, uint32_t) {
           EXPECT_TRUE(res < 0);
           completions_nr++;
         });
@@ -139,7 +139,7 @@ TEST_F(IoUringImplTest, InjectCompletion) {
       event_fd,
       [this, &completions_nr](uint32_t) {
         io_uring_->forEveryCompletion(
-            [&completions_nr](Request* user_data, int32_t res, bool injected) {
+            [&completions_nr](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
               EXPECT_EQ(-11, res);
@@ -173,7 +173,7 @@ TEST_F(IoUringImplTest, NestInjectCompletion) {
       event_fd,
       [this, &fd2, &completions_nr, &request2](uint32_t) {
         io_uring_->forEveryCompletion([this, &fd2, &completions_nr,
-                                       &request2](Request* user_data, int32_t res, bool injected) {
+                                       &request2](Request* user_data, int32_t res, bool injected, uint32_t) {
           EXPECT_TRUE(injected);
           if (completions_nr == 0) {
             EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
@@ -214,7 +214,7 @@ TEST_F(IoUringImplTest, RemoveInjectCompletion) {
       event_fd,
       [this, &completions_nr](uint32_t) {
         io_uring_->forEveryCompletion(
-            [&completions_nr](Request* user_data, int32_t res, bool injected) {
+            [&completions_nr](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
               EXPECT_EQ(-11, res);
@@ -250,7 +250,7 @@ TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
       event_fd,
       [this, &fd2, &completions_nr, &data2](uint32_t) {
         io_uring_->forEveryCompletion(
-            [this, &fd2, &completions_nr, &data2](Request* user_data, int32_t res, bool injected) {
+            [this, &fd2, &completions_nr, &data2](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               if (completions_nr == 0) {
                 EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
@@ -302,7 +302,7 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr, d = dispatcher.get()](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool, uint32_t) {
           completions_nr++;
           EXPECT_EQ(res, strlen("test text"));
         });
@@ -348,7 +348,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request* user_data, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request* user_data, int32_t res, bool, uint32_t) {
           EXPECT_TRUE(user_data != nullptr);
           EXPECT_EQ(res, 2);
           completions_nr++;

--- a/test/common/io/io_uring_worker_impl_test.cc
+++ b/test/common/io/io_uring_worker_impl_test.cc
@@ -218,7 +218,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&io_uring_socket](const CompletionCb& cb) {
         auto* req = new Request(Request::RequestType::Write, io_uring_socket);
-        cb(req, -EAGAIN, true);
+        cb(req, -EAGAIN, true, 0);
       }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
@@ -244,9 +244,9 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
   // Finish the read, cancel and write request, then expect the close request submitted.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&read_req, &cancel_req, &write_req](const CompletionCb& cb) {
-        cb(read_req, -EAGAIN, false);
-        cb(cancel_req, 0, false);
-        cb(write_req, -EAGAIN, false);
+        cb(read_req, -EAGAIN, false, 0);
+        cb(cancel_req, 0, false, 0);
+        cb(write_req, -EAGAIN, false, 0);
       }));
   Request* close_req = nullptr;
   EXPECT_CALL(mock_io_uring, prepareClose(_, _))
@@ -257,7 +257,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
@@ -296,7 +296,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&io_uring_socket](const CompletionCb& cb) {
         auto* req = new Request(Request::RequestType::Write, io_uring_socket);
-        cb(req, -EAGAIN, true);
+        cb(req, -EAGAIN, true, 0);
       }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
@@ -313,8 +313,8 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
   // Finish the read and cancel request, then expect the close request submitted.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&read_req, &cancel_req](const CompletionCb& cb) {
-        cb(read_req, -EAGAIN, false);
-        cb(cancel_req, 0, false);
+        cb(read_req, -EAGAIN, false, 0);
+        cb(cancel_req, 0, false, 0);
       }));
   Request* close_req = nullptr;
   EXPECT_CALL(mock_io_uring, prepareClose(_, _))
@@ -325,7 +325,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
@@ -380,13 +380,13 @@ TEST(IoUringWorkerImplTest, CloseAllSocketsWhenDestruction) {
         EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
 
         // Fake the read request cancel completion.
-        cb(read_req, -ECANCELED, false);
+        cb(read_req, -ECANCELED, false, 0);
 
         // Fake the cancel request is done.
-        cb(cancel_req, 0, false);
+        cb(cancel_req, 0, false, 0);
 
         // Fake the close request is done.
-        cb(close_req, 0, false);
+        cb(close_req, 0, false, 0);
       }));
 
   EXPECT_CALL(dispatcher, deferredDelete_);
@@ -422,7 +422,8 @@ TEST(IoUringWorkerImplTest, ServerCloseWithWriteRequestOnly) {
   io_uring_socket.disableRead();
   // Fake the read request finish.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false); }));
+      .WillOnce(
+          Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false, 0); }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -448,13 +449,13 @@ TEST(IoUringWorkerImplTest, ServerCloseWithWriteRequestOnly) {
             .RetiresOnSaturation();
         EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
 
-        cb(write_req, -EAGAIN, false);
+        cb(write_req, -EAGAIN, false, 0);
       }));
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());


### PR DESCRIPTION
Commit Message:
io_uring: thread cqe->flags through CompletionCb

No-behavior-change refactor in preparation for multishot recv. `CompletionCb`
gains a `uint32_t flags` argument carrying the raw `cqe->flags` value from the
kernel. Kernel completions forward `cqe->flags`; injected completions pass `0`.
The worker callback ignores it for now. A follow-up will introduce a buf-ring
plus `prepareRecvMultishot` and start observing `IORING_CQE_F_BUFFER` and
`IORING_CQE_F_MORE`.

Additional Description:
The full multishot-recv change touches the buf-ring lifecycle in `IoUringImpl`,
the read path in `IoUringServerSocket`, and the proto config. Threading `flags`
through the existing callback is mechanical and easy to review on its own;
landing it first lets the rest of the stack be a behavioral change rather than
a behavioral + signature change.

Files touched:
- `envoy/common/io/io_uring.h` — `CompletionCb` typedef + doc.
- `source/common/io/io_uring_impl.cc` — pass `cqe->flags` for kernel
  completions, `0` for injected.
- `source/common/io/io_uring_worker_impl.cc` — accept the new arg in the
  worker lambda (unused for now).
- `test/common/io/io_uring_impl_test.cc`,
  `test/common/io/io_uring_worker_impl_test.cc` — update test lambdas.

`IoUringSocket::on*` virtual methods are intentionally unchanged here; only
`onRead` will need flags, in the multishot recv change.

AI usage disclosure: Portions of the code and/or PR description were drafted
with the assistance of Claude (Anthropic). I reviewed and understand all
submitted code.

Risk Level: Low
(No behavior change; mechanical signature change to an internal callback.
Worker still discards the new argument.)

Testing: Existing `io_uring` unit and integration tests on Linux CI.

Docs Changes: N/A

Release Notes: N/A (internal refactor, no user-visible or extension-developer-
visible change.)

Platform Specific Features: N/A. io_uring is Linux-only and the affected code
already lives behind the existing io_uring build gating; this PR does not
change platform support or introduce new platform-specific surface.

Runtime guard: N/A (no behavioral change).
