### PR TITLE
io_uring: switch server-socket read path to multishot recv

### DIFF
--- a/envoy/common/io/io_uring.h
+++ b/envoy/common/io/io_uring.h
@@ -53,8 +53,13 @@ private:
  * queue.
  * @param result is a return code of submitted system call.
  * @param injected indicates whether the completion is injected or not.
+ * @param flags is the raw ``cqe->flags`` value from the io_uring completion. For multishot
+ * completions, callers inspect ``IORING_CQE_F_BUFFER`` (the buffer ID is encoded in the upper
+ * bits) and ``IORING_CQE_F_MORE`` (whether the SQE will produce further completions). For
+ * injected completions the value is always ``0``.
  */
-using CompletionCb = std::function<void(Request* user_data, int32_t result, bool injected)>;
+using CompletionCb =
+    std::function<void(Request* user_data, int32_t result, bool injected, uint32_t flags)>;
 
 /**
  * Callback for releasing the user data.

--- a/envoy/common/io/io_uring.h
+++ b/envoy/common/io/io_uring.h
@@ -27,6 +27,10 @@ public:
     Close = 0x10,
     Cancel = 0x20,
     Shutdown = 0x40,
+    // A multishot recv SQE. Distinguished from ``Read`` because the kernel reuses the same
+    // ``Request*`` across multiple completions (until ``IORING_CQE_F_MORE`` is clear), so the
+    // worker must not free the request after each completion.
+    RecvMultishot = 0x80,
   };
 
   Request(RequestType type, IoUringSocket& socket) : type_(type), socket_(socket) {}
@@ -354,8 +358,12 @@ public:
    * @param req the ReadRequest object which is as request user data.
    * @param result the result of operation in the request.
    * @param injected indicates the completion is injected or not.
+   * @param flags the raw ``cqe->flags`` value. For a multishot recv completion, the buffer ID
+   *              is encoded in the upper bits (``flags >> IORING_CQE_BUFFER_SHIFT``), and
+   *              ``IORING_CQE_F_MORE`` indicates the SQE remains armed for further completions.
+   *              For all other (non-multishot) completions the value is ``0``.
    */
-  virtual void onRead(Request* req, int32_t result, bool injected) PURE;
+  virtual void onRead(Request* req, int32_t result, bool injected, uint32_t flags) PURE;
 
   /**
    * On write request completed.

--- a/envoy/common/io/io_uring.h
+++ b/envoy/common/io/io_uring.h
@@ -153,6 +153,48 @@ public:
   virtual IoUringResult prepareShutdown(os_fd_t fd, int how, Request* user_data) PURE;
 
   /**
+   * Set up a kernel-managed buffer ring of ``count`` buffers each of ``buf_size`` bytes. The
+   * kernel selects a buffer from this ring on each multishot recv completion, eliminating the
+   * per-read allocation that ``prepareReadv`` requires. Only one buf-ring may be set up per
+   * ``IoUring`` instance for now; subsequent calls return ``IoUringResult::Failed``.
+   *
+   * @param group_id buffer group identifier; subsequent ``prepareRecvMultishot`` and
+   *                 ``recycleBuffer`` calls reference this id.
+   * @param count    number of buffers; must be a power of two.
+   * @param buf_size size of each buffer in bytes.
+   * @return ``Ok`` on success; ``Failed`` if buf-rings are unsupported by the kernel or if a
+   *         buf-ring has already been set up on this instance.
+   */
+  virtual IoUringResult setupBufRing(uint16_t group_id, uint32_t count, uint32_t buf_size) PURE;
+
+  /**
+   * Prepare a multishot recv. The same SQE may produce multiple completions, each carrying
+   * ``IORING_CQE_F_BUFFER`` (the buffer ID is in the upper bits of ``flags``) and
+   * ``IORING_CQE_F_MORE`` (set while the SQE remains armed). When ``F_MORE`` is clear the
+   * caller must re-arm by issuing another ``prepareRecvMultishot``.
+   *
+   * @param fd        the socket fd.
+   * @param group_id  the buffer group set up via ``setupBufRing``.
+   * @param user_data attached to the SQE; surfaced on every completion of this SQE.
+   */
+  virtual IoUringResult prepareRecvMultishot(os_fd_t fd, uint16_t group_id,
+                                             Request* user_data) PURE;
+
+  /**
+   * Return the storage backing buffer ID ``bid`` in group ``group_id``. The caller is expected
+   * to consume up to ``cqe->res`` bytes (the value passed as ``result`` to the completion
+   * callback) and then recycle the buffer via ``recycleBuffer``.
+   */
+  virtual uint8_t* getBufferForBid(uint16_t group_id, uint16_t bid) PURE;
+
+  /**
+   * Return a buffer to the buf-ring after the user has finished consuming it. Until the buffer
+   * is recycled the kernel cannot reuse it for new completions; failing to recycle promptly
+   * may cause the kernel to terminate the multishot recv with ``-ENOBUFS``.
+   */
+  virtual void recycleBuffer(uint16_t group_id, uint16_t bid) PURE;
+
+  /**
    * Submits the entries in the submission queue to the kernel using the
    * `io_uring_enter()` system call.
    * Returns IoUringResult::Ok in case of success and may return

--- a/source/common/io/io_uring_impl.cc
+++ b/source/common/io/io_uring_impl.cc
@@ -69,7 +69,7 @@ void IoUringImpl::forEveryCompletion(const CompletionCb& completion_cb) {
 
   for (unsigned i = 0; i < count; ++i) {
     struct io_uring_cqe* cqe = cqes_[i];
-    completion_cb(reinterpret_cast<Request*>(cqe->user_data), cqe->res, false);
+    completion_cb(reinterpret_cast<Request*>(cqe->user_data), cqe->res, false, cqe->flags);
   }
 
   io_uring_cq_advance(&ring_, count);
@@ -80,7 +80,9 @@ void IoUringImpl::forEveryCompletion(const CompletionCb& completion_cb) {
   // Iterate the injected completion.
   while (!injected_completions_.empty()) {
     auto& completion = injected_completions_.front();
-    completion_cb(completion.user_data_, completion.result_, true);
+    // Injected completions always carry ``flags == 0``; they do not originate from the kernel
+    // and have no associated CQE.
+    completion_cb(completion.user_data_, completion.result_, true, 0);
     // The socket may closed in the completion_cb and all the related completions are
     // removed.
     if (injected_completions_.empty()) {

--- a/source/common/io/io_uring_impl.cc
+++ b/source/common/io/io_uring_impl.cc
@@ -30,7 +30,14 @@ IoUringImpl::IoUringImpl(uint32_t io_uring_size, bool use_submission_queue_polli
   RELEASE_ASSERT(ret == 0, fmt::format("unable to initialize io_uring: {}", errorDetails(-ret)));
 }
 
-IoUringImpl::~IoUringImpl() { io_uring_queue_exit(&ring_); }
+IoUringImpl::~IoUringImpl() {
+  if (buf_ring_ != nullptr) {
+    // Ignore the return value; we are tearing down regardless.
+    io_uring_free_buf_ring(&ring_, buf_ring_, buf_count_, buf_group_id_);
+    buf_ring_ = nullptr;
+  }
+  io_uring_queue_exit(&ring_);
+}
 
 os_fd_t IoUringImpl::registerEventfd() {
   ASSERT(!isEventfdRegistered());
@@ -195,6 +202,83 @@ IoUringResult IoUringImpl::prepareShutdown(os_fd_t fd, int how, Request* user_da
   io_uring_prep_shutdown(sqe, fd, how);
   io_uring_sqe_set_data(sqe, user_data);
   return IoUringResult::Ok;
+}
+
+IoUringResult IoUringImpl::setupBufRing(uint16_t group_id, uint32_t count, uint32_t buf_size) {
+  if (buf_ring_ != nullptr) {
+    ENVOY_LOG(warn, "buf ring already set up for group {}, refusing to set up group {}",
+              buf_group_id_, group_id);
+    return IoUringResult::Failed;
+  }
+  if (count == 0 || (count & (count - 1)) != 0) {
+    ENVOY_LOG(warn, "buf ring count must be a non-zero power of two, got {}", count);
+    return IoUringResult::Failed;
+  }
+  if (buf_size == 0) {
+    ENVOY_LOG(warn, "buf ring buf_size must be > 0");
+    return IoUringResult::Failed;
+  }
+
+  int ret = 0;
+  struct io_uring_buf_ring* br =
+      io_uring_setup_buf_ring(&ring_, count, group_id, /*flags=*/0, &ret);
+  if (br == nullptr) {
+    ENVOY_LOG(warn, "io_uring_setup_buf_ring failed: {}", errorDetails(-ret));
+    return IoUringResult::Failed;
+  }
+
+  buf_storage_ = std::make_unique<uint8_t[]>(static_cast<size_t>(count) * buf_size);
+  const int mask = io_uring_buf_ring_mask(count);
+  for (uint32_t i = 0; i < count; i++) {
+    io_uring_buf_ring_add(br, buf_storage_.get() + static_cast<size_t>(i) * buf_size, buf_size,
+                          /*bid=*/static_cast<uint16_t>(i), mask, /*buf_offset=*/static_cast<int>(i));
+  }
+  io_uring_buf_ring_advance(br, count);
+
+  buf_ring_ = br;
+  buf_group_id_ = group_id;
+  buf_count_ = count;
+  buf_size_ = buf_size;
+  ENVOY_LOG(debug, "set up buf ring: group_id = {}, count = {}, buf_size = {}", group_id, count,
+            buf_size);
+  return IoUringResult::Ok;
+}
+
+IoUringResult IoUringImpl::prepareRecvMultishot(os_fd_t fd, uint16_t group_id,
+                                                Request* user_data) {
+  ENVOY_LOG(trace, "prepare recv multishot for fd = {}, group_id = {}", fd, group_id);
+  ASSERT(!(*(ring_.sq.kflags) & IORING_SQ_CQ_OVERFLOW));
+  if (buf_ring_ == nullptr || group_id != buf_group_id_) {
+    ENVOY_LOG(warn, "prepareRecvMultishot called for unknown buf ring group {}", group_id);
+    return IoUringResult::Failed;
+  }
+  struct io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+  if (sqe == nullptr) {
+    return IoUringResult::Failed;
+  }
+
+  io_uring_prep_recv_multishot(sqe, fd, /*buf=*/nullptr, /*len=*/0, /*flags=*/0);
+  sqe->buf_group = group_id;
+  sqe->flags |= IOSQE_BUFFER_SELECT;
+  io_uring_sqe_set_data(sqe, user_data);
+  return IoUringResult::Ok;
+}
+
+uint8_t* IoUringImpl::getBufferForBid(uint16_t group_id, uint16_t bid) {
+  ASSERT(buf_ring_ != nullptr);
+  ASSERT(group_id == buf_group_id_);
+  ASSERT(bid < buf_count_);
+  return buf_storage_.get() + static_cast<size_t>(bid) * buf_size_;
+}
+
+void IoUringImpl::recycleBuffer(uint16_t group_id, uint16_t bid) {
+  ASSERT(buf_ring_ != nullptr);
+  ASSERT(group_id == buf_group_id_);
+  ASSERT(bid < buf_count_);
+  const int mask = io_uring_buf_ring_mask(buf_count_);
+  io_uring_buf_ring_add(buf_ring_, buf_storage_.get() + static_cast<size_t>(bid) * buf_size_,
+                        buf_size_, bid, mask, /*buf_offset=*/0);
+  io_uring_buf_ring_advance(buf_ring_, 1);
 }
 
 IoUringResult IoUringImpl::submit() {

--- a/source/common/io/io_uring_impl.h
+++ b/source/common/io/io_uring_impl.h
@@ -43,6 +43,10 @@ public:
   IoUringResult prepareClose(os_fd_t fd, Request* user_data) override;
   IoUringResult prepareCancel(Request* cancelling_user_data, Request* user_data) override;
   IoUringResult prepareShutdown(os_fd_t fd, int how, Request* user_data) override;
+  IoUringResult setupBufRing(uint16_t group_id, uint32_t count, uint32_t buf_size) override;
+  IoUringResult prepareRecvMultishot(os_fd_t fd, uint16_t group_id, Request* user_data) override;
+  uint8_t* getBufferForBid(uint16_t group_id, uint16_t bid) override;
+  void recycleBuffer(uint16_t group_id, uint16_t bid) override;
   IoUringResult submit() override;
   void injectCompletion(os_fd_t fd, Request* user_data, int32_t result) override;
   void removeInjectedCompletion(os_fd_t fd) override;
@@ -52,6 +56,16 @@ private:
   std::vector<struct io_uring_cqe*> cqes_;
   os_fd_t event_fd_{INVALID_SOCKET};
   std::list<InjectedCompletion> injected_completions_;
+
+  // Buf-ring state. ``buf_ring_`` is set when ``setupBufRing`` succeeds; only one buf-ring is
+  // supported per ring for now.
+  struct io_uring_buf_ring* buf_ring_{nullptr};
+  uint16_t buf_group_id_{0};
+  uint32_t buf_count_{0};
+  uint32_t buf_size_{0};
+  // Backing storage for the buf-ring. ``buf_count_ * buf_size_`` bytes carved into ``buf_count_``
+  // contiguous slots; slot ``i`` lives at ``buf_storage_.get() + i * buf_size_``.
+  std::unique_ptr<uint8_t[]> buf_storage_;
 };
 
 } // namespace Io

--- a/source/common/io/io_uring_worker_impl.cc
+++ b/source/common/io/io_uring_worker_impl.cc
@@ -3,6 +3,14 @@
 namespace Envoy {
 namespace Io {
 
+namespace {
+
+bool isUnsupportedMultishotRecvResult(int32_t result) {
+  return result == -EINVAL || result == -EOPNOTSUPP || result == -ENOSYS;
+}
+
+} // namespace
+
 ReadRequest::ReadRequest(IoUringSocket& socket, uint32_t size)
     : Request(RequestType::Read, socket), buf_(std::make_unique<uint8_t[]>(size)),
       iov_(std::make_unique<struct iovec>()) {
@@ -291,9 +299,7 @@ Buffer::BufferFragmentImpl* IoUringWorkerImpl::makeMultishotBufferFragment(uint1
   // Capture ``this`` and ``bid`` by value; the worker is guaranteed to outlive any in-flight
   // BufferFragment because dispatcher / sockets / buffers are torn down before the worker.
   return new Buffer::BufferFragmentImpl(
-      data, len,
-      [this, bid](const void*, size_t,
-                  const Buffer::BufferFragmentImpl* this_fragment) {
+      data, len, [this, bid](const void*, size_t, const Buffer::BufferFragmentImpl* this_fragment) {
         io_uring_->recycleBuffer(kMultishotBufGroupId, bid);
         delete this_fragment;
       });
@@ -310,8 +316,8 @@ void IoUringWorkerImpl::onFileEvent() {
     // For a multishot recv, the kernel reuses the same ``Request*`` across multiple completions
     // until ``IORING_CQE_F_MORE`` is clear. Detect that here so we know whether to free ``req``
     // at the end of the dispatch.
-    const bool keep_req_alive = req->type() == Request::RequestType::RecvMultishot &&
-                                (flags & IORING_CQE_F_MORE) != 0;
+    const bool keep_req_alive =
+        req->type() == Request::RequestType::RecvMultishot && (flags & IORING_CQE_F_MORE) != 0;
 
     switch (req->type()) {
     case Request::RequestType::Accept:
@@ -499,6 +505,24 @@ void IoUringServerSocket::moveReadDataToBuffer(Request* req, size_t data_length)
   read_buf_.addBufferFragment(*fragment);
 }
 
+void IoUringServerSocket::moveMultishotReadDataToBuffer(uint16_t bid, size_t data_length) {
+  read_buf_contains_multishot_fragment_ = true;
+  read_buf_.addBufferFragment(*parent_.makeMultishotBufferFragment(bid, data_length));
+}
+
+void IoUringServerSocket::copyMultishotReadBufferForMigration() {
+  if (!read_buf_contains_multishot_fragment_ || read_buf_.length() == 0) {
+    return;
+  }
+
+  Buffer::OwnedImpl copied_read_buf;
+  const uint64_t bytes_to_copy = read_buf_.length();
+  copied_read_buf.add(read_buf_);
+  read_buf_.drain(bytes_to_copy);
+  read_buf_.move(copied_read_buf);
+  read_buf_contains_multishot_fragment_ = false;
+}
+
 void IoUringServerSocket::onReadCompleted(int32_t result) {
   ENVOY_LOG(trace, "read from socket, fd = {}, result = {}", fd_, result);
   ReadParam param{read_buf_, result};
@@ -513,17 +537,16 @@ void IoUringServerSocket::onReadCompleted(int32_t result) {
 void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected, uint32_t flags) {
   IoUringSocketEntry::onRead(req, result, injected, flags);
 
-  ENVOY_LOG(
-      trace,
-      "onRead with result {}, fd = {}, injected = {}, status_ = {}, enable_close_event = {}, "
-      "flags = {:#x}",
-      result, fd_, injected, static_cast<int>(status_), enable_close_event_, flags);
+  ENVOY_LOG(trace,
+            "onRead with result {}, fd = {}, injected = {}, status_ = {}, enable_close_event = {}, "
+            "flags = {:#x}",
+            result, fd_, injected, static_cast<int>(status_), enable_close_event_, flags);
 
   // For a multishot completion, ``read_req_`` is only cleared when the SQE has terminated
   // (``IORING_CQE_F_MORE`` clear). While the SQE is still armed the same ``Request*`` is reused
-  // by the kernel for further completions, so leaving ``read_req_`` set causes ``submitReadRequest``
-  // below to short-circuit.
-  const bool is_multishot = req->type() == Request::RequestType::RecvMultishot;
+  // by the kernel for further completions, so leaving ``read_req_`` set causes
+  // ``submitReadRequest`` below to short-circuit.
+  const bool is_multishot = req != nullptr && req->type() == Request::RequestType::RecvMultishot;
   const bool sqe_terminated = !is_multishot || (flags & IORING_CQE_F_MORE) == 0;
   if (!injected && sqe_terminated) {
     read_req_ = nullptr;
@@ -533,7 +556,7 @@ void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected, ui
       if (result > 0 && keep_fd_open_) {
         if (is_multishot && (flags & IORING_CQE_F_BUFFER)) {
           const uint16_t bid = static_cast<uint16_t>(flags >> IORING_CQE_BUFFER_SHIFT);
-          read_buf_.addBufferFragment(*parent_.makeMultishotBufferFragment(bid, result));
+          moveMultishotReadDataToBuffer(bid, result);
         } else {
           moveReadDataToBuffer(req, result);
         }
@@ -543,13 +566,24 @@ void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected, ui
     }
   }
 
+  if (is_multishot && sqe_terminated && isUnsupportedMultishotRecvResult(result)) {
+    ENVOY_LOG(warn,
+              "io_uring recv multishot unsupported for fd = {}, result = {}; falling back to readv",
+              fd_, result);
+    parent_.disableMultishotRecv();
+    if (status_ == ReadEnabled || status_ == ReadDisabled) {
+      submitReadRequest();
+    }
+    return;
+  }
+
   // Move read data from request to buffer or store the error.
   if (result > 0) {
     if (is_multishot) {
       ASSERT(flags & IORING_CQE_F_BUFFER, "multishot recv completed with data but no buffer flag");
       const uint16_t bid = static_cast<uint16_t>(flags >> IORING_CQE_BUFFER_SHIFT);
       ENVOY_LOG(trace, "multishot recv: bid = {}, bytes = {}, fd = {}", bid, result, fd_);
-      read_buf_.addBufferFragment(*parent_.makeMultishotBufferFragment(bid, result));
+      moveMultishotReadDataToBuffer(bid, result);
     } else {
       moveReadDataToBuffer(req, result);
     }
@@ -690,6 +724,7 @@ void IoUringServerSocket::onShutdown(Request* req, int32_t result, bool injected
 
 void IoUringServerSocket::closeInternal() {
   if (keep_fd_open_) {
+    copyMultishotReadBufferForMigration();
     if (on_closed_cb_) {
       on_closed_cb_(read_buf_);
     }

--- a/source/common/io/io_uring_worker_impl.cc
+++ b/source/common/io/io_uring_worker_impl.cc
@@ -60,14 +60,35 @@ void IoUringSocketEntry::onRemoteClose() {
 
 IoUringWorkerImpl::IoUringWorkerImpl(uint32_t io_uring_size, bool use_submission_queue_polling,
                                      uint32_t read_buffer_size, uint32_t write_timeout_ms,
-                                     Event::Dispatcher& dispatcher)
+                                     Event::Dispatcher& dispatcher, bool enable_multishot_recv,
+                                     uint32_t multishot_recv_buffer_count)
     : IoUringWorkerImpl(std::make_unique<IoUringImpl>(io_uring_size, use_submission_queue_polling),
-                        read_buffer_size, write_timeout_ms, dispatcher) {}
+                        read_buffer_size, write_timeout_ms, dispatcher, enable_multishot_recv,
+                        multishot_recv_buffer_count) {}
 
 IoUringWorkerImpl::IoUringWorkerImpl(IoUringPtr&& io_uring, uint32_t read_buffer_size,
-                                     uint32_t write_timeout_ms, Event::Dispatcher& dispatcher)
+                                     uint32_t write_timeout_ms, Event::Dispatcher& dispatcher,
+                                     bool enable_multishot_recv,
+                                     uint32_t multishot_recv_buffer_count)
     : io_uring_(std::move(io_uring)), read_buffer_size_(read_buffer_size),
       write_timeout_ms_(write_timeout_ms), dispatcher_(dispatcher) {
+  if (enable_multishot_recv) {
+    // Buffer size matches the per-read chunk size used by ``readv``, so the upper layer sees
+    // similarly-sized fragments either way.
+    const auto res = io_uring_->setupBufRing(kMultishotBufGroupId, multishot_recv_buffer_count,
+                                             read_buffer_size_);
+    if (res == IoUringResult::Ok) {
+      multishot_recv_enabled_ = true;
+      ENVOY_LOG(debug, "io_uring multishot recv enabled: count = {}, buf_size = {}",
+                multishot_recv_buffer_count, read_buffer_size_);
+    } else {
+      // ``setupBufRing`` returns Failed on kernels older than 5.19. Fall back to ``readv`` so the
+      // worker remains functional.
+      ENVOY_LOG(warn, "io_uring multishot recv requested but buf-ring setup failed; falling back "
+                      "to readv");
+    }
+  }
+
   const os_fd_t event_fd = io_uring_->registerEventfd();
   // We only care about the read event of Eventfd, since we only receive the
   // event here.
@@ -153,6 +174,21 @@ IoUringWorkerImpl::submitConnectRequest(IoUringSocket& socket,
 }
 
 Request* IoUringWorkerImpl::submitReadRequest(IoUringSocket& socket) {
+  if (multishot_recv_enabled_) {
+    // The multishot SQE pulls buffers from the buf-ring; no per-request allocation is needed.
+    Request* req = new Request(Request::RequestType::RecvMultishot, socket);
+    ENVOY_LOG(trace, "submit recv multishot request, fd = {}, req = {}", socket.fd(),
+              fmt::ptr(req));
+    auto res = io_uring_->prepareRecvMultishot(socket.fd(), kMultishotBufGroupId, req);
+    if (res == IoUringResult::Failed) {
+      submit();
+      res = io_uring_->prepareRecvMultishot(socket.fd(), kMultishotBufGroupId, req);
+      RELEASE_ASSERT(res == IoUringResult::Ok, "unable to prepare recv multishot");
+    }
+    submit();
+    return req;
+  }
+
   ReadRequest* req = new ReadRequest(socket, read_buffer_size_);
 
   ENVOY_LOG(trace, "submit read request, fd = {}, read req = {}", socket.fd(), fmt::ptr(req));
@@ -248,17 +284,34 @@ void IoUringWorkerImpl::injectCompletion(IoUringSocket& socket, Request::Request
   file_event_->activate(Event::FileReadyType::Read);
 }
 
+Buffer::BufferFragmentImpl* IoUringWorkerImpl::makeMultishotBufferFragment(uint16_t bid,
+                                                                           size_t len) {
+  ASSERT(multishot_recv_enabled_);
+  uint8_t* data = io_uring_->getBufferForBid(kMultishotBufGroupId, bid);
+  // Capture ``this`` and ``bid`` by value; the worker is guaranteed to outlive any in-flight
+  // BufferFragment because dispatcher / sockets / buffers are torn down before the worker.
+  return new Buffer::BufferFragmentImpl(
+      data, len,
+      [this, bid](const void*, size_t,
+                  const Buffer::BufferFragmentImpl* this_fragment) {
+        io_uring_->recycleBuffer(kMultishotBufGroupId, bid);
+        delete this_fragment;
+      });
+}
+
 void IoUringWorkerImpl::onFileEvent() {
   ENVOY_LOG(trace, "io uring worker, on file event");
   delay_submit_ = true;
-  // ``flags`` carries the raw ``cqe->flags`` value. The worker does not yet branch on it; this
-  // is wired through so a follow-up change can observe ``IORING_CQE_F_BUFFER`` and
-  // ``IORING_CQE_F_MORE`` for multishot recv.
-  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected,
-                                   uint32_t /*flags*/) {
-    ENVOY_LOG(trace, "receive request completion, type = {}, req = {}",
-              static_cast<uint8_t>(req->type()), fmt::ptr(req));
+  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected, uint32_t flags) {
+    ENVOY_LOG(trace, "receive request completion, type = {}, req = {}, flags = {:#x}",
+              static_cast<uint8_t>(req->type()), fmt::ptr(req), flags);
     ASSERT(req != nullptr);
+
+    // For a multishot recv, the kernel reuses the same ``Request*`` across multiple completions
+    // until ``IORING_CQE_F_MORE`` is clear. Detect that here so we know whether to free ``req``
+    // at the end of the dispatch.
+    const bool keep_req_alive = req->type() == Request::RequestType::RecvMultishot &&
+                                (flags & IORING_CQE_F_MORE) != 0;
 
     switch (req->type()) {
     case Request::RequestType::Accept:
@@ -272,9 +325,10 @@ void IoUringWorkerImpl::onFileEvent() {
       req->socket().onConnect(req, result, injected);
       break;
     case Request::RequestType::Read:
+    case Request::RequestType::RecvMultishot:
       ENVOY_LOG(trace, "receive Read request completion, fd = {}, req = {}", req->socket().fd(),
                 fmt::ptr(req));
-      req->socket().onRead(req, result, injected);
+      req->socket().onRead(req, result, injected, flags);
       break;
     case Request::RequestType::Write:
       ENVOY_LOG(trace, "receive write request completion, fd = {}, req = {}", req->socket().fd(),
@@ -298,7 +352,9 @@ void IoUringWorkerImpl::onFileEvent() {
       break;
     }
 
-    delete req;
+    if (!keep_req_alive) {
+      delete req;
+    }
   });
   delay_submit_ = false;
   submit();
@@ -454,19 +510,33 @@ void IoUringServerSocket::onReadCompleted(int32_t result) {
 
 // TODO(zhxie): concern submit multiple read requests or submit read request in advance to improve
 // performance in the next iteration.
-void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected) {
-  IoUringSocketEntry::onRead(req, result, injected);
+void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected, uint32_t flags) {
+  IoUringSocketEntry::onRead(req, result, injected, flags);
 
-  ENVOY_LOG(trace,
-            "onRead with result {}, fd = {}, injected = {}, status_ = {}, enable_close_event = {}",
-            result, fd_, injected, static_cast<int>(status_), enable_close_event_);
-  if (!injected) {
+  ENVOY_LOG(
+      trace,
+      "onRead with result {}, fd = {}, injected = {}, status_ = {}, enable_close_event = {}, "
+      "flags = {:#x}",
+      result, fd_, injected, static_cast<int>(status_), enable_close_event_, flags);
+
+  // For a multishot completion, ``read_req_`` is only cleared when the SQE has terminated
+  // (``IORING_CQE_F_MORE`` clear). While the SQE is still armed the same ``Request*`` is reused
+  // by the kernel for further completions, so leaving ``read_req_`` set causes ``submitReadRequest``
+  // below to short-circuit.
+  const bool is_multishot = req->type() == Request::RequestType::RecvMultishot;
+  const bool sqe_terminated = !is_multishot || (flags & IORING_CQE_F_MORE) == 0;
+  if (!injected && sqe_terminated) {
     read_req_ = nullptr;
     // If the socket is going to close, discard all results.
     if (status_ == Closed && write_or_shutdown_req_ == nullptr && read_cancel_req_ == nullptr &&
         write_or_shutdown_cancel_req_ == nullptr) {
       if (result > 0 && keep_fd_open_) {
-        moveReadDataToBuffer(req, result);
+        if (is_multishot && (flags & IORING_CQE_F_BUFFER)) {
+          const uint16_t bid = static_cast<uint16_t>(flags >> IORING_CQE_BUFFER_SHIFT);
+          read_buf_.addBufferFragment(*parent_.makeMultishotBufferFragment(bid, result));
+        } else {
+          moveReadDataToBuffer(req, result);
+        }
       }
       closeInternal();
       return;
@@ -475,7 +545,14 @@ void IoUringServerSocket::onRead(Request* req, int32_t result, bool injected) {
 
   // Move read data from request to buffer or store the error.
   if (result > 0) {
-    moveReadDataToBuffer(req, result);
+    if (is_multishot) {
+      ASSERT(flags & IORING_CQE_F_BUFFER, "multishot recv completed with data but no buffer flag");
+      const uint16_t bid = static_cast<uint16_t>(flags >> IORING_CQE_BUFFER_SHIFT);
+      ENVOY_LOG(trace, "multishot recv: bid = {}, bytes = {}, fd = {}", bid, result, fd_);
+      read_buf_.addBufferFragment(*parent_.makeMultishotBufferFragment(bid, result));
+    } else {
+      moveReadDataToBuffer(req, result);
+    }
   } else {
     if (result != -ECANCELED) {
       read_error_ = result;

--- a/source/common/io/io_uring_worker_impl.cc
+++ b/source/common/io/io_uring_worker_impl.cc
@@ -251,7 +251,11 @@ void IoUringWorkerImpl::injectCompletion(IoUringSocket& socket, Request::Request
 void IoUringWorkerImpl::onFileEvent() {
   ENVOY_LOG(trace, "io uring worker, on file event");
   delay_submit_ = true;
-  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected) {
+  // ``flags`` carries the raw ``cqe->flags`` value. The worker does not yet branch on it; this
+  // is wired through so a follow-up change can observe ``IORING_CQE_F_BUFFER`` and
+  // ``IORING_CQE_F_MORE`` for multishot recv.
+  io_uring_->forEveryCompletion([](Request* req, int32_t result, bool injected,
+                                   uint32_t /*flags*/) {
     ENVOY_LOG(trace, "receive request completion, type = {}, req = {}",
               static_cast<uint8_t>(req->type()), fmt::ptr(req));
     ASSERT(req != nullptr);

--- a/source/common/io/io_uring_worker_impl.h
+++ b/source/common/io/io_uring_worker_impl.h
@@ -32,10 +32,26 @@ class IoUringWorkerImpl : public IoUringWorker, private Logger::Loggable<Logger:
 public:
   IoUringWorkerImpl(uint32_t io_uring_size, bool use_submission_queue_polling,
                     uint32_t read_buffer_size, uint32_t write_timeout_ms,
-                    Event::Dispatcher& dispatcher);
+                    Event::Dispatcher& dispatcher,
+                    bool enable_multishot_recv = false,
+                    uint32_t multishot_recv_buffer_count = 256);
   IoUringWorkerImpl(IoUringPtr&& io_uring, uint32_t read_buffer_size, uint32_t write_timeout_ms,
-                    Event::Dispatcher& dispatcher);
+                    Event::Dispatcher& dispatcher,
+                    bool enable_multishot_recv = false,
+                    uint32_t multishot_recv_buffer_count = 256);
   ~IoUringWorkerImpl() override;
+
+  // True when multishot recv was requested AND the kernel set up the buf-ring successfully.
+  // Sockets created by this worker consult this to choose between the readv path and
+  // ``prepareRecvMultishot``.
+  bool multishotRecvEnabled() const { return multishot_recv_enabled_; }
+  uint16_t multishotRecvBufGroupId() const { return kMultishotBufGroupId; }
+
+  // Wrap a kernel-selected buf-ring buffer in a ``BufferFragmentImpl`` whose release callback
+  // recycles the buffer back to the buf-ring. The fragment owns its own deletion. Caller must
+  // ensure ``len <= read_buffer_size_``; in practice this comes from ``cqe->res`` which the
+  // kernel caps at the buffer size.
+  Buffer::BufferFragmentImpl* makeMultishotBufferFragment(uint16_t bid, size_t len);
 
   // IoUringWorker
   IoUringSocket& addServerSocket(os_fd_t fd, Event::FileReadyCb cb,
@@ -74,6 +90,12 @@ protected:
   IoUringPtr io_uring_;
   const uint32_t read_buffer_size_;
   const uint32_t write_timeout_ms_;
+  // Group ID used for the per-worker multishot recv buf-ring. Only one buf-ring is supported
+  // per ``IoUring`` instance today, so this is a constant.
+  static constexpr uint16_t kMultishotBufGroupId = 0;
+  // Set to true only when the worker requested multishot recv AND ``setupBufRing`` succeeded.
+  // On older kernels we silently fall back to ``readv``.
+  bool multishot_recv_enabled_{false};
   // The dispatcher of this worker is running on.
   Event::Dispatcher& dispatcher_;
   // The file event of iouring's eventfd.
@@ -117,7 +139,7 @@ public:
       injected_completions_ &= ~static_cast<uint8_t>(Request::RequestType::Connect);
     }
   }
-  void onRead(Request*, int32_t, bool injected) override {
+  void onRead(Request*, int32_t, bool injected, uint32_t) override {
     if (injected && (injected_completions_ & static_cast<uint8_t>(Request::RequestType::Read))) {
       injected_completions_ &= ~static_cast<uint8_t>(Request::RequestType::Read);
     }
@@ -196,7 +218,7 @@ public:
   uint64_t write(const Buffer::RawSlice* slices, uint64_t num_slice) override;
   void shutdown(int how) override;
   void onClose(Request* req, int32_t result, bool injected) override;
-  void onRead(Request* req, int32_t result, bool injected) override;
+  void onRead(Request* req, int32_t result, bool injected, uint32_t flags) override;
   void onWrite(Request* req, int32_t result, bool injected) override;
   void onShutdown(Request* req, int32_t result, bool injected) override;
   void onCancel(Request* req, int32_t result, bool injected) override;

--- a/source/common/io/io_uring_worker_impl.h
+++ b/source/common/io/io_uring_worker_impl.h
@@ -32,12 +32,10 @@ class IoUringWorkerImpl : public IoUringWorker, private Logger::Loggable<Logger:
 public:
   IoUringWorkerImpl(uint32_t io_uring_size, bool use_submission_queue_polling,
                     uint32_t read_buffer_size, uint32_t write_timeout_ms,
-                    Event::Dispatcher& dispatcher,
-                    bool enable_multishot_recv = false,
+                    Event::Dispatcher& dispatcher, bool enable_multishot_recv = false,
                     uint32_t multishot_recv_buffer_count = 256);
   IoUringWorkerImpl(IoUringPtr&& io_uring, uint32_t read_buffer_size, uint32_t write_timeout_ms,
-                    Event::Dispatcher& dispatcher,
-                    bool enable_multishot_recv = false,
+                    Event::Dispatcher& dispatcher, bool enable_multishot_recv = false,
                     uint32_t multishot_recv_buffer_count = 256);
   ~IoUringWorkerImpl() override;
 
@@ -45,6 +43,7 @@ public:
   // Sockets created by this worker consult this to choose between the readv path and
   // ``prepareRecvMultishot``.
   bool multishotRecvEnabled() const { return multishot_recv_enabled_; }
+  void disableMultishotRecv() { multishot_recv_enabled_ = false; }
   uint16_t multishotRecvBufGroupId() const { return kMultishotBufGroupId; }
 
   // Wrap a kernel-selected buf-ring buffer in a ``BufferFragmentImpl`` whose release callback
@@ -226,6 +225,9 @@ public:
   Buffer::OwnedImpl& getReadBuffer() { return read_buf_; }
 
 protected:
+  void moveMultishotReadDataToBuffer(uint16_t bid, size_t data_length);
+  void copyMultishotReadBufferForMigration();
+
   // Since the write of IoUringSocket is async, there may have write request is on the fly when
   // close the socket. This timeout is setting for a time to wait the write request done.
   const uint32_t write_timeout_ms_;
@@ -237,6 +239,7 @@ protected:
   // TODO (soulxu): Add water mark here.
   Buffer::OwnedImpl read_buf_;
   absl::optional<int32_t> read_error_;
+  bool read_buf_contains_multishot_fragment_{false};
 
   // TODO (soulxu): We need water mark for write buffer.
   // The upper layer will think the buffer released when the data copy into this write buffer.

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -102,7 +102,7 @@ TEST_P(IoUringImplParamTest, InvalidParams) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool, uint32_t) {
           EXPECT_TRUE(res < 0);
           completions_nr++;
         });
@@ -139,7 +139,7 @@ TEST_F(IoUringImplTest, InjectCompletion) {
       event_fd,
       [this, &completions_nr](uint32_t) {
         io_uring_->forEveryCompletion(
-            [&completions_nr](Request* user_data, int32_t res, bool injected) {
+            [&completions_nr](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
               EXPECT_EQ(-11, res);
@@ -173,7 +173,7 @@ TEST_F(IoUringImplTest, NestInjectCompletion) {
       event_fd,
       [this, &fd2, &completions_nr, &request2](uint32_t) {
         io_uring_->forEveryCompletion([this, &fd2, &completions_nr,
-                                       &request2](Request* user_data, int32_t res, bool injected) {
+                                       &request2](Request* user_data, int32_t res, bool injected, uint32_t) {
           EXPECT_TRUE(injected);
           if (completions_nr == 0) {
             EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
@@ -214,7 +214,7 @@ TEST_F(IoUringImplTest, RemoveInjectCompletion) {
       event_fd,
       [this, &completions_nr](uint32_t) {
         io_uring_->forEveryCompletion(
-            [&completions_nr](Request* user_data, int32_t res, bool injected) {
+            [&completions_nr](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
               EXPECT_EQ(-11, res);
@@ -250,7 +250,7 @@ TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
       event_fd,
       [this, &fd2, &completions_nr, &data2](uint32_t) {
         io_uring_->forEveryCompletion(
-            [this, &fd2, &completions_nr, &data2](Request* user_data, int32_t res, bool injected) {
+            [this, &fd2, &completions_nr, &data2](Request* user_data, int32_t res, bool injected, uint32_t) {
               EXPECT_TRUE(injected);
               if (completions_nr == 0) {
                 EXPECT_EQ(1, dynamic_cast<TestRequest*>(user_data)->data_);
@@ -302,7 +302,7 @@ TEST_F(IoUringImplTest, PrepareReadvAllDataFitsOneChunk) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr, d = dispatcher.get()](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request*, int32_t res, bool, uint32_t) {
           completions_nr++;
           EXPECT_EQ(res, strlen("test text"));
         });
@@ -348,7 +348,7 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
   auto file_event = dispatcher->createFileEvent(
       event_fd,
       [this, &completions_nr](uint32_t) {
-        io_uring_->forEveryCompletion([&completions_nr](Request* user_data, int32_t res, bool) {
+        io_uring_->forEveryCompletion([&completions_nr](Request* user_data, int32_t res, bool, uint32_t) {
           EXPECT_TRUE(user_data != nullptr);
           EXPECT_EQ(res, 2);
           completions_nr++;

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -1,3 +1,7 @@
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cstring>
 #include <functional>
 
 #include "source/common/io/io_uring_impl.h"
@@ -399,6 +403,102 @@ TEST_F(IoUringImplTest, PrepareReadvQueueOverflow) {
 
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[0], 'e');
   EXPECT_EQ(static_cast<char*>(iov3.iov_base)[1], 'f');
+}
+
+// Validates ``setupBufRing`` rejects invalid configuration without leaving the ring in a half-set
+// state.
+TEST_F(IoUringImplTest, SetupBufRingValidatesInputs) {
+  // Count must be > 0 and a power of two.
+  EXPECT_EQ(IoUringResult::Failed, io_uring_->setupBufRing(/*group_id=*/0, /*count=*/0,
+                                                          /*buf_size=*/1024));
+  EXPECT_EQ(IoUringResult::Failed, io_uring_->setupBufRing(/*group_id=*/0, /*count=*/3,
+                                                          /*buf_size=*/1024));
+  // buf_size must be > 0.
+  EXPECT_EQ(IoUringResult::Failed, io_uring_->setupBufRing(/*group_id=*/0, /*count=*/4,
+                                                          /*buf_size=*/0));
+
+  // First valid call succeeds; a second is rejected because we only support one ring per
+  // ``IoUring`` instance.
+  ASSERT_EQ(IoUringResult::Ok, io_uring_->setupBufRing(/*group_id=*/0, /*count=*/4,
+                                                      /*buf_size=*/1024));
+  EXPECT_EQ(IoUringResult::Failed, io_uring_->setupBufRing(/*group_id=*/1, /*count=*/4,
+                                                          /*buf_size=*/1024));
+}
+
+// End-to-end: arm a multishot recv against one end of a socketpair, write from the other end,
+// and verify the kernel hands us a buffer plus the ``F_MORE`` flag indicating the SQE is still
+// armed. Recycling the buffer and writing again yields a second completion from the same SQE.
+TEST_F(IoUringImplTest, MultishotRecvDeliversBuffersAndStaysArmed) {
+  // Multishot recv requires kernel >= 5.19. ``isIoUringSupported`` only checks that
+  // ``io_uring_queue_init_params`` works, so probe the multishot path here and skip if buf-rings
+  // are unsupported on this kernel.
+  if (io_uring_->setupBufRing(/*group_id=*/0, /*count=*/4, /*buf_size=*/1024) !=
+      IoUringResult::Ok) {
+    GTEST_SKIP() << "buf-ring unsupported on this kernel";
+  }
+
+  int sv[2];
+  ASSERT_EQ(0, ::socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+  const os_fd_t recv_fd = sv[0];
+  const os_fd_t send_fd = sv[1];
+
+  auto dispatcher = api_->allocateDispatcher("test_thread");
+  os_fd_t event_fd = io_uring_->registerEventfd();
+
+  int data = 1;
+  TestRequest request(data);
+  std::vector<std::string> received;
+  std::vector<uint16_t> bids;
+  bool more_clear = false;
+
+  auto file_event = dispatcher->createFileEvent(
+      event_fd,
+      [this, &received, &bids, &more_clear](uint32_t) {
+        io_uring_->forEveryCompletion(
+            [this, &received, &bids, &more_clear](Request*, int32_t res, bool, uint32_t flags) {
+              ASSERT_GT(res, 0);
+              ASSERT_TRUE(flags & IORING_CQE_F_BUFFER);
+              const uint16_t bid = static_cast<uint16_t>(flags >> IORING_CQE_BUFFER_SHIFT);
+              bids.push_back(bid);
+              uint8_t* buf = io_uring_->getBufferForBid(/*group_id=*/0, bid);
+              received.emplace_back(reinterpret_cast<const char*>(buf),
+                                    static_cast<size_t>(res));
+              if (!(flags & IORING_CQE_F_MORE)) {
+                more_clear = true;
+              }
+              io_uring_->recycleBuffer(/*group_id=*/0, bid);
+            });
+        return absl::OkStatus();
+      },
+      Event::PlatformDefaultTriggerType, Event::FileReadyType::Read);
+
+  ASSERT_EQ(IoUringResult::Ok,
+            io_uring_->prepareRecvMultishot(recv_fd, /*group_id=*/0, &request));
+  ASSERT_EQ(IoUringResult::Ok, io_uring_->submit());
+
+  const std::string msg1 = "hello";
+  ASSERT_EQ(static_cast<ssize_t>(msg1.size()),
+            ::write(send_fd, msg1.data(), msg1.size()));
+  waitForCondition(*dispatcher, [&received]() { return received.size() == 1; });
+  EXPECT_EQ(msg1, received[0]);
+  EXPECT_FALSE(more_clear) << "first completion should leave SQE armed (F_MORE set)";
+
+  // Second write reuses the same multishot SQE — proves recycling worked and the SQE is still
+  // armed.
+  const std::string msg2 = "world";
+  ASSERT_EQ(static_cast<ssize_t>(msg2.size()),
+            ::write(send_fd, msg2.data(), msg2.size()));
+  waitForCondition(*dispatcher, [&received]() { return received.size() == 2; });
+  EXPECT_EQ(msg2, received[1]);
+
+  // The kernel may pick the same bid both times after our recycle, but each completion must
+  // carry a valid bid in [0, count).
+  for (uint16_t bid : bids) {
+    EXPECT_LT(bid, 4);
+  }
+
+  ::close(send_fd);
+  ::close(recv_fd);
 }
 
 } // namespace

--- a/test/common/io/io_uring_worker_impl_integration_test.cc
+++ b/test/common/io/io_uring_worker_impl_integration_test.cc
@@ -32,8 +32,8 @@ public:
     is_connect_injected_completion_ = injected;
     nr_completion_++;
   }
-  void onRead(Request* req, int32_t result, bool injected) override {
-    IoUringSocketEntry::onRead(req, result, injected);
+  void onRead(Request* req, int32_t result, bool injected, uint32_t flags) override {
+    IoUringSocketEntry::onRead(req, result, injected, flags);
     read_result_ = result;
     is_read_injected_completion_ = injected;
     nr_completion_++;

--- a/test/common/io/io_uring_worker_impl_test.cc
+++ b/test/common/io/io_uring_worker_impl_test.cc
@@ -494,8 +494,8 @@ TEST(IoUringWorkerImplTest, CloseDetected) {
   EXPECT_CALL(mock_io_uring, prepareReadv(_, _, _, _, _))
       .WillOnce(DoAll(SaveArg<4>(&read_req2), Return<IoUringResult>(IoUringResult::Ok)));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
-  socket.onRead(read_req, 1, false);
-  socket.onRead(nullptr, 0, false);
+  socket.onRead(read_req, 1, false, 0);
+  socket.onRead(nullptr, 0, false, 0);
 
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
   delete read_req;
@@ -625,7 +625,7 @@ TEST(IoUringWorkerImplTest, CloseKeepFdOpenAndSaveData) {
   // Consumes the read request.
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(0));
   EXPECT_CALL(dispatcher, deferredDelete_);
-  socket.onRead(read_req, 1, false);
+  socket.onRead(read_req, 1, false, 0);
   EXPECT_TRUE(is_closed);
 
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
@@ -692,6 +692,175 @@ TEST(IoUringWorkerImplTest, NoEnableReadOnConnectError) {
 
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
   delete static_cast<Request*>(connect_req);
+}
+
+// A worker constructed with multishot recv enabled sets up the buf-ring once at startup and then
+// uses ``prepareRecvMultishot`` for each new server socket's read.
+class IoUringWorkerMultishotTestImpl : public IoUringWorkerImpl {
+public:
+  IoUringWorkerMultishotTestImpl(IoUringPtr io_uring_instance, Event::Dispatcher& dispatcher)
+      : IoUringWorkerImpl(std::move(io_uring_instance), 8192, 1000, dispatcher,
+                          /*enable_multishot_recv=*/true,
+                          /*multishot_recv_buffer_count=*/256) {}
+};
+
+TEST(IoUringWorkerImplTest, MultishotRecvSetupAndSubmit) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  // The worker calls ``setupBufRing`` exactly once at construction.
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Ok));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+  EXPECT_TRUE(worker.multishotRecvEnabled());
+
+  // Server socket's ``enableRead`` triggers ``submitReadRequest`` which routes to the multishot
+  // path.
+  Request* recv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+  IoUringServerSocket socket(42, worker, [](uint32_t) { return absl::OkStatus(); }, 0, false);
+  socket.enableRead();
+  ASSERT_NE(nullptr, recv_req);
+  EXPECT_EQ(Request::RequestType::RecvMultishot, recv_req->type());
+
+  // The socket is constructed directly (not via ``addServerSocket``), so it is not in the
+  // worker's tracked sockets list and the worker destructor will not try to close it. We just
+  // need to release the in-flight request.
+  delete recv_req;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
+// Falls back to the readv path when ``setupBufRing`` fails (older kernel).
+TEST(IoUringWorkerImplTest, MultishotRecvFallbackOnUnsupportedKernel) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Failed));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+  EXPECT_FALSE(worker.multishotRecvEnabled());
+
+  // ``submitReadRequest`` now picks the readv path.
+  Request* readv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareReadv(42, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&readv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+  IoUringServerSocket socket(42, worker, [](uint32_t) { return absl::OkStatus(); }, 0, false);
+  socket.enableRead();
+  ASSERT_NE(nullptr, readv_req);
+  EXPECT_EQ(Request::RequestType::Read, readv_req->type());
+
+  delete readv_req;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
+// A multishot completion with ``F_BUFFER | F_MORE`` delivers the buffer to the upper layer and
+// keeps the SQE armed (no re-arm via ``prepareRecvMultishot``).
+TEST(IoUringWorkerImplTest, MultishotRecvDeliversBufferAndStaysArmed) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Ok));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+
+  Request* recv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+
+  bool read_event_fired = false;
+  IoUringServerSocket socket(
+      42, worker,
+      [&read_event_fired, &socket](uint32_t event) {
+        if (event & Event::FileReadyType::Read) {
+          read_event_fired = true;
+          // Drain so the buffer fragment's release callback fires and the buf is recycled.
+          socket.getReadBuffer().drain(socket.getReadBuffer().length());
+        }
+        return absl::OkStatus();
+      },
+      0, false);
+  socket.enableRead();
+  ASSERT_NE(nullptr, recv_req);
+
+  // Kernel-side: arrange for ``getBufferForBid`` to return a known buffer; ``recycleBuffer`` will
+  // be called when the upper layer drains.
+  uint8_t kernel_buffer[16] = {'h', 'e', 'l', 'l', 'o', 0};
+  EXPECT_CALL(mock_io_uring, getBufferForBid(0, 7)).WillOnce(Return(kernel_buffer));
+  EXPECT_CALL(mock_io_uring, recycleBuffer(0, 7));
+
+  // Build the flags: F_BUFFER + F_MORE, with bid 7 in the upper bits.
+  const uint32_t flags = IORING_CQE_F_BUFFER | IORING_CQE_F_MORE | (7u << IORING_CQE_BUFFER_SHIFT);
+  socket.onRead(recv_req, /*result=*/5, /*injected=*/false, flags);
+  EXPECT_TRUE(read_event_fired);
+
+  delete recv_req;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
+// A multishot completion with ``F_BUFFER`` but ``F_MORE`` clear means the SQE has terminated; the
+// worker must re-arm by submitting another ``prepareRecvMultishot``.
+TEST(IoUringWorkerImplTest, MultishotRecvReArmOnFMoreClear) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Ok));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+
+  Request* recv_req1 = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req1), Return<IoUringResult>(IoUringResult::Ok)))
+      .RetiresOnSaturation();
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+
+  IoUringServerSocket socket(42, worker, [](uint32_t) { return absl::OkStatus(); }, 0, false);
+  socket.enableRead();
+  ASSERT_NE(nullptr, recv_req1);
+
+  // Completion with F_BUFFER but no F_MORE: SQE has terminated, expect a fresh
+  // ``prepareRecvMultishot`` to re-arm.
+  uint8_t kernel_buffer[16] = {0};
+  EXPECT_CALL(mock_io_uring, getBufferForBid(0, 3)).WillOnce(Return(kernel_buffer));
+  EXPECT_CALL(mock_io_uring, recycleBuffer(0, 3));
+  Request* recv_req2 = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req2), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+
+  const uint32_t flags = IORING_CQE_F_BUFFER | (3u << IORING_CQE_BUFFER_SHIFT); // F_MORE clear
+  socket.onRead(recv_req1, /*result=*/4, /*injected=*/false, flags);
+  EXPECT_NE(nullptr, recv_req2);
+  EXPECT_NE(recv_req1, recv_req2);
+  // Drain so the recycle callback fires.
+  socket.getReadBuffer().drain(socket.getReadBuffer().length());
+
+  delete recv_req1;
+  delete recv_req2;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
 }
 
 } // namespace

--- a/test/common/io/io_uring_worker_impl_test.cc
+++ b/test/common/io/io_uring_worker_impl_test.cc
@@ -422,8 +422,7 @@ TEST(IoUringWorkerImplTest, ServerCloseWithWriteRequestOnly) {
   io_uring_socket.disableRead();
   // Fake the read request finish.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(
-          Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false, 0); }));
+      .WillOnce(Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false, 0); }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -766,6 +765,55 @@ TEST(IoUringWorkerImplTest, MultishotRecvFallbackOnUnsupportedKernel) {
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
 }
 
+// Falls back to the readv path when the kernel accepts buf-ring setup but rejects recv multishot.
+TEST(IoUringWorkerImplTest, MultishotRecvFallbackOnUnsupportedCompletion) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Ok));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+  EXPECT_TRUE(worker.multishotRecvEnabled());
+
+  Request* recv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+
+  bool read_event_fired = false;
+  IoUringServerSocket socket(
+      42, worker,
+      [&read_event_fired](uint32_t event) {
+        if (event & Event::FileReadyType::Read) {
+          read_event_fired = true;
+        }
+        return absl::OkStatus();
+      },
+      0, false);
+  socket.enableRead();
+  ASSERT_NE(nullptr, recv_req);
+
+  Request* readv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareReadv(42, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<4>(&readv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+
+  socket.onRead(recv_req, -EINVAL, /*injected=*/false, /*flags=*/0);
+  EXPECT_FALSE(worker.multishotRecvEnabled());
+  EXPECT_FALSE(read_event_fired);
+  ASSERT_NE(nullptr, readv_req);
+  EXPECT_EQ(Request::RequestType::Read, readv_req->type());
+
+  delete recv_req;
+  delete readv_req;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
 // A multishot completion with ``F_BUFFER | F_MORE`` delivers the buffer to the upper layer and
 // keeps the SQE armed (no re-arm via ``prepareRecvMultishot``).
 TEST(IoUringWorkerImplTest, MultishotRecvDeliversBufferAndStaysArmed) {
@@ -860,6 +908,57 @@ TEST(IoUringWorkerImplTest, MultishotRecvReArmOnFMoreClear) {
 
   delete recv_req1;
   delete recv_req2;
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
+// During keep-fd-open close (used by cross-thread migration), any unread multishot fragments are
+// copied out before the buffer is handed to the next socket so the old worker's buf-ring is not
+// referenced from the new worker.
+TEST(IoUringWorkerImplTest, MultishotRecvCopiesUnreadDataBeforeKeepFdOpenClose) {
+  Event::MockDispatcher dispatcher;
+  IoUringPtr io_uring_instance = std::make_unique<MockIoUring>();
+  MockIoUring& mock_io_uring = *dynamic_cast<MockIoUring*>(io_uring_instance.get());
+
+  EXPECT_CALL(mock_io_uring, setupBufRing(0, 256, 8192))
+      .WillOnce(Return<IoUringResult>(IoUringResult::Ok));
+  EXPECT_CALL(mock_io_uring, registerEventfd());
+  EXPECT_CALL(dispatcher,
+              createFileEvent_(_, _, Event::PlatformDefaultTriggerType, Event::FileReadyType::Read))
+      .WillOnce(ReturnNew<NiceMock<Event::MockFileEvent>>());
+  IoUringWorkerMultishotTestImpl worker(std::move(io_uring_instance), dispatcher);
+
+  Request* recv_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareRecvMultishot(42, 0, _))
+      .WillOnce(DoAll(SaveArg<2>(&recv_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+  auto& socket = worker.addServerSocket(42, [](uint32_t) { return absl::OkStatus(); }, false);
+  ASSERT_NE(nullptr, recv_req);
+
+  Request* cancel_req = nullptr;
+  EXPECT_CALL(mock_io_uring, prepareCancel(recv_req, _))
+      .WillOnce(DoAll(SaveArg<1>(&cancel_req), Return<IoUringResult>(IoUringResult::Ok)));
+  EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
+  bool is_closed = false;
+  socket.close(true, [&is_closed](Buffer::Instance& read_buffer) {
+    EXPECT_EQ(5, read_buffer.length());
+    EXPECT_EQ("hello", read_buffer.toString());
+    is_closed = true;
+  });
+
+  socket.onCancel(cancel_req, 0, false);
+
+  uint8_t kernel_buffer[16] = {'h', 'e', 'l', 'l', 'o'};
+  EXPECT_CALL(mock_io_uring, getBufferForBid(0, 9)).WillOnce(Return(kernel_buffer));
+  EXPECT_CALL(mock_io_uring, recycleBuffer(0, 9));
+  EXPECT_CALL(mock_io_uring, removeInjectedCompletion(42));
+  EXPECT_CALL(dispatcher, deferredDelete_);
+
+  const uint32_t flags = IORING_CQE_F_BUFFER | (9u << IORING_CQE_BUFFER_SHIFT); // F_MORE clear
+  socket.onRead(recv_req, /*result=*/5, /*injected=*/false, flags);
+  EXPECT_TRUE(is_closed);
+
+  delete recv_req;
+  delete cancel_req;
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
 }
 

--- a/test/common/io/io_uring_worker_impl_test.cc
+++ b/test/common/io/io_uring_worker_impl_test.cc
@@ -218,7 +218,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&io_uring_socket](const CompletionCb& cb) {
         auto* req = new Request(Request::RequestType::Write, io_uring_socket);
-        cb(req, -EAGAIN, true);
+        cb(req, -EAGAIN, true, 0);
       }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
@@ -244,9 +244,9 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
   // Finish the read, cancel and write request, then expect the close request submitted.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&read_req, &cancel_req, &write_req](const CompletionCb& cb) {
-        cb(read_req, -EAGAIN, false);
-        cb(cancel_req, 0, false);
-        cb(write_req, -EAGAIN, false);
+        cb(read_req, -EAGAIN, false, 0);
+        cb(cancel_req, 0, false, 0);
+        cb(write_req, -EAGAIN, false, 0);
       }));
   Request* close_req = nullptr;
   EXPECT_CALL(mock_io_uring, prepareClose(_, _))
@@ -257,7 +257,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterWrite) {
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
@@ -296,7 +296,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&io_uring_socket](const CompletionCb& cb) {
         auto* req = new Request(Request::RequestType::Write, io_uring_socket);
-        cb(req, -EAGAIN, true);
+        cb(req, -EAGAIN, true, 0);
       }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
@@ -313,8 +313,8 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
   // Finish the read and cancel request, then expect the close request submitted.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
       .WillOnce(Invoke([&read_req, &cancel_req](const CompletionCb& cb) {
-        cb(read_req, -EAGAIN, false);
-        cb(cancel_req, 0, false);
+        cb(read_req, -EAGAIN, false, 0);
+        cb(cancel_req, 0, false, 0);
       }));
   Request* close_req = nullptr;
   EXPECT_CALL(mock_io_uring, prepareClose(_, _))
@@ -325,7 +325,7 @@ TEST(IoUringWorkerImplTest, ServerSocketInjectAfterRead) {
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());
@@ -380,13 +380,13 @@ TEST(IoUringWorkerImplTest, CloseAllSocketsWhenDestruction) {
         EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
 
         // Fake the read request cancel completion.
-        cb(read_req, -ECANCELED, false);
+        cb(read_req, -ECANCELED, false, 0);
 
         // Fake the cancel request is done.
-        cb(cancel_req, 0, false);
+        cb(cancel_req, 0, false, 0);
 
         // Fake the close request is done.
-        cb(close_req, 0, false);
+        cb(close_req, 0, false, 0);
       }));
 
   EXPECT_CALL(dispatcher, deferredDelete_);
@@ -422,7 +422,8 @@ TEST(IoUringWorkerImplTest, ServerCloseWithWriteRequestOnly) {
   io_uring_socket.disableRead();
   // Fake the read request finish.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false); }));
+      .WillOnce(
+          Invoke([&read_req](const CompletionCb& cb) { cb(read_req, -EAGAIN, false, 0); }));
   EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
@@ -448,13 +449,13 @@ TEST(IoUringWorkerImplTest, ServerCloseWithWriteRequestOnly) {
             .RetiresOnSaturation();
         EXPECT_CALL(mock_io_uring, submit()).Times(1).RetiresOnSaturation();
 
-        cb(write_req, -EAGAIN, false);
+        cb(write_req, -EAGAIN, false, 0);
       }));
   ASSERT_TRUE(file_event_callback(Event::FileReadyType::Read).ok());
 
   // After the close request finished, the socket will be cleanup.
   EXPECT_CALL(mock_io_uring, forEveryCompletion(_))
-      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false); }));
+      .WillOnce(Invoke([&close_req](const CompletionCb& cb) { cb(close_req, 0, false, 0); }));
   EXPECT_CALL(mock_io_uring, removeInjectedCompletion(fd));
   EXPECT_CALL(dispatcher, deferredDelete_);
   EXPECT_CALL(dispatcher, clearDeferredDeleteList());

--- a/test/mocks/io/mocks.h
+++ b/test/mocks/io/mocks.h
@@ -28,6 +28,11 @@ public:
   MOCK_METHOD(IoUringResult, prepareClose, (os_fd_t fd, Request* user_data));
   MOCK_METHOD(IoUringResult, prepareCancel, (Request * cancelling_user_data, Request* user_data));
   MOCK_METHOD(IoUringResult, prepareShutdown, (os_fd_t fd, int how, Request* user_data));
+  MOCK_METHOD(IoUringResult, setupBufRing, (uint16_t group_id, uint32_t count, uint32_t buf_size));
+  MOCK_METHOD(IoUringResult, prepareRecvMultishot,
+              (os_fd_t fd, uint16_t group_id, Request* user_data));
+  MOCK_METHOD(uint8_t*, getBufferForBid, (uint16_t group_id, uint16_t bid));
+  MOCK_METHOD(void, recycleBuffer, (uint16_t group_id, uint16_t bid));
   MOCK_METHOD(IoUringResult, submit, ());
   MOCK_METHOD(void, injectCompletion, (os_fd_t fd, Request* user_data, int32_t result));
   MOCK_METHOD(void, removeInjectedCompletion, (os_fd_t fd));

--- a/test/mocks/io/mocks.h
+++ b/test/mocks/io/mocks.h
@@ -51,7 +51,7 @@ public:
   MOCK_METHOD(uint64_t, write, (const Buffer::RawSlice* slices, uint64_t num_slice));
   MOCK_METHOD(void, onAccept, (Request * req, int32_t result, bool injected));
   MOCK_METHOD(void, onConnect, (Request * req, int32_t result, bool injected));
-  MOCK_METHOD(void, onRead, (Request * req, int32_t result, bool injected));
+  MOCK_METHOD(void, onRead, (Request * req, int32_t result, bool injected, uint32_t flags));
   MOCK_METHOD(void, onWrite, (Request * req, int32_t result, bool injected));
   MOCK_METHOD(void, onClose, (Request * req, int32_t result, bool injected));
   MOCK_METHOD(void, onCancel, (Request * req, int32_t result, bool injected));


### PR DESCRIPTION
Commit Message:
io_uring: switch server-socket read path to multishot recv

Switches `IoUringServerSocket`'s read path from a per-read `readv` +
heap-allocated `uint8_t[]` to a single multishot `IORING_OP_RECV` SQE that
pulls buffers from a kernel-managed buf-ring. Each completion hands the
upper layer one kernel-selected buffer wrapped in a `BufferFragmentImpl`
whose release callback recycles it back to the ring.

The current readv path has two costs on every read: a
`make_unique<uint8_t[]>(size)` (and a paired `delete[]`), and a fresh SQE
submission. With multishot + provided buffers the kernel keeps the SQE armed
across many recv completions and pulls from a pre-registered buffer pool —
eliminating both costs on the hot path.

Mechanics:
- New `Request::RequestType::RecvMultishot` distinguishes the multishot SQE
  so the worker's completion dispatch knows to keep the `Request*` alive
  while `IORING_CQE_F_MORE` is set (the kernel reuses the same user_data for
  further completions).
- `IoUringSocket::onRead` virtual gains a `uint32_t flags` argument carrying
  the raw `cqe->flags`. The buffer ID is in the upper bits when
  `IORING_CQE_F_BUFFER` is set; `F_MORE` indicates the SQE is still armed.
- `IoUringServerSocket::onRead` only clears `read_req_` when the SQE has
  terminated. While armed the bottom-of-function `submitReadRequest`
  short-circuits because `read_req_` is still non-null. When `F_MORE`
  clears, `read_req_` is freed and a new multishot SQE is submitted.
- `IoUringWorkerImpl::makeMultishotBufferFragment` wraps the kernel buffer
  with a release callback that calls `recycleBuffer` — buffer return is
  driven by the upper-layer drain.

Depends on:
- #44667 (`CompletionCb` flags arg)
- #44668 (buf-ring + `prepareRecvMultishot` API)

Additional Description:
The worker constructor gains two new defaulted args
(`enable_multishot_recv = false`, `multishot_recv_buffer_count = 256`) so all
existing call sites compile unchanged. When multishot is requested but the
kernel/liburing doesn't support it, `setupBufRing` returns `Failed` and the
worker silently falls back to readv.

The proto config + factory wiring to actually expose this option lives in
#44670. Until that lands, the readv path is the only one used in production.

AI usage disclosure: Portions of the code and/or PR description were drafted
with the assistance of Claude (Anthropic). I reviewed and understand all
submitted code.

Risk Level: Medium
(Materially different read path for io_uring server sockets, but defaulted
off via worker constructor args and not yet reachable from proto config.
With the default, no behavior changes.)

Testing:
- `MultishotRecvSetupAndSubmit` — buf-ring setup + first submit picks the
  multishot path and produces a `RecvMultishot` request.
- `MultishotRecvFallbackOnUnsupportedKernel` — when `setupBufRing` fails,
  the worker falls back to `prepareReadv`.
- `MultishotRecvDeliversBufferAndStaysArmed` — completion with
  `F_BUFFER | F_MORE` delivers the buffer and does not re-arm.
- `MultishotRecvReArmOnFMoreClear` — completion with `F_BUFFER` but no
  `F_MORE` triggers a fresh `prepareRecvMultishot`.
- Existing io_uring unit and integration tests on Linux CI.

Docs Changes: N/A. New `onRead` `flags` arg is documented inline in
`envoy/common/io/io_uring.h`.

Release Notes: N/A (read path change is unreachable from configuration until
#44670 lands; the public-facing release note belongs there.)

Platform Specific Features:
io_uring is Linux-only. Multishot recv requires kernel 6.0+; on older
kernels the worker falls back to readv via the `setupBufRing` failure path.
No platform support change beyond existing io_uring build gating.

Runtime guard: N/A in this PR — the new path is gated by a constructor arg
that defaults to off and is unreachable from configuration. The config-level
gate (and any release-note runtime guard) lives in #44670.
