### PR TITLE
Apply weak pointer semantics to streams in HTTP1 codec

### DIFF
--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1061,7 +1061,7 @@ void ClientConnectionImpl::dumpAdditionalState(std::ostream& os, int indent_leve
   os << spaces << "Dumping corresponding downstream request:";
   if (pending_response_.has_value()) {
     os << '\n';
-    const ResponseDecoder* decoder = pending_response_.value().decoder_;
+    const ResponseDecoder* decoder = pending_response_.value().decoder_handle_->get().ptr();
     DUMP_DETAILS(decoder);
   } else {
     os << " null\n";
@@ -1250,7 +1250,13 @@ Envoy::StatusOr<CallbackResult> ServerConnectionImpl::onHeadersCompleteBase() {
     if (parser_->isChunked() ||
         (parser_->contentLength().has_value() && parser_->contentLength().value() > 0) ||
         handling_upgrade_) {
-      active_request_->request_decoder_->decodeHeaders(std::move(headers), false);
+      RequestDecoder* decoder =
+          active_request_->request_decoder_handle_->get().ptr();
+      ENVOY_BUG(decoder != nullptr,
+                "RequestDecoder is null in onHeadersCompleteBase");
+      if (decoder) {
+        decoder->decodeHeaders(std::move(headers), false);
+      }
 
       // If the connection has been closed (or is closing) after decoding headers, pause the parser
       // so we return control to the caller.
@@ -1269,7 +1275,9 @@ Status ServerConnectionImpl::onMessageBeginBase() {
   if (!resetStreamCalled()) {
     ASSERT(active_request_ == nullptr);
     active_request_ = std::make_unique<ActiveRequest>(*this, std::move(bytes_meter_before_stream_));
-    active_request_->request_decoder_ = &callbacks_.newStream(active_request_->response_encoder_);
+    active_request_->request_decoder_handle_ =
+        callbacks_.newStream(active_request_->response_encoder_)
+            .getRequestDecoderHandle();
 
     // Check for pipelined request flood as we prepare to accept a new request.
     // Parse errors that happen prior to onMessageBegin result in stream termination, it is not
@@ -1293,7 +1301,12 @@ void ServerConnectionImpl::onBody(Buffer::Instance& data) {
   ASSERT(!deferred_end_stream_headers_);
   if (active_request_) {
     ENVOY_CONN_LOG(trace, "body size={}", connection_, data.length());
-    active_request_->request_decoder_->decodeData(data, false);
+    RequestDecoder* decoder =
+        active_request_->request_decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "RequestDecoder is null in onBody");
+    if (decoder) {
+      decoder->decodeData(data, false);
+    }
   }
 }
 
@@ -1329,19 +1342,29 @@ CallbackResult ServerConnectionImpl::onMessageCompleteBase() {
   if (active_request_) {
 
     // The request_decoder should be non-null after we've called the newStream on callbacks.
-    ASSERT(active_request_->request_decoder_);
+    RequestDecoder* decoder =
+        active_request_->request_decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr,
+              "request_decoder_handle_ is null in onMessageCompleteBase");
     active_request_->remote_complete_ = true;
 
     if (deferred_end_stream_headers_) {
-      active_request_->request_decoder_->decodeHeaders(
-          std::move(absl::get<RequestHeaderMapPtr>(headers_or_trailers_)), true);
+      if (decoder) {
+        decoder->decodeHeaders(
+            std::move(absl::get<RequestHeaderMapPtr>(headers_or_trailers_)),
+            true);
+      }
       deferred_end_stream_headers_ = false;
     } else if (processing_trailers_) {
-      active_request_->request_decoder_->decodeTrailers(
-          std::move(absl::get<RequestTrailerMapPtr>(headers_or_trailers_)));
+      if (decoder) {
+        decoder->decodeTrailers(
+            std::move(absl::get<RequestTrailerMapPtr>(headers_or_trailers_)));
+      }
     } else {
       Buffer::OwnedImpl buffer;
-      active_request_->request_decoder_->decodeData(buffer, true);
+      if (decoder) {
+        decoder->decodeData(buffer, true);
+      }
     }
 
     // Reset to ensure no information from one requests persists to the next.
@@ -1386,8 +1409,14 @@ Status ServerConnectionImpl::sendProtocolError(absl::string_view details) {
 
   active_request_->response_encoder_.setDetails(details);
   if (!active_request_->response_encoder_.startedResponse()) {
-    active_request_->request_decoder_->sendLocalReply(
-        error_code_, CodeUtility::toString(error_code_), nullptr, absl::nullopt, details);
+    RequestDecoder* decoder =
+        active_request_->request_decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr,
+              "RequestDecoder is null in sendProtocolError");
+    if (decoder) {
+      decoder->sendLocalReply(error_code_, CodeUtility::toString(error_code_),
+                              nullptr, absl::nullopt, details);
+    }
   }
   return okStatus();
 }
@@ -1487,7 +1516,7 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& response_decode
 
   ASSERT(!pending_response_.has_value());
   ASSERT(pending_response_done_);
-  pending_response_.emplace(*this, std::move(bytes_meter_before_stream_), &response_decoder);
+  pending_response_.emplace(*this, std::move(bytes_meter_before_stream_), response_decoder.createResponseDecoderHandle());
   pending_response_done_ = false;
   return pending_response_.value().encoder_;
 }
@@ -1544,12 +1573,16 @@ Envoy::StatusOr<CallbackResult> ClientConnectionImpl::onHeadersCompleteBase() {
       }
     }
 
-    if (HeaderUtility::isSpecial1xx(*headers)) {
-      pending_response_.value().decoder_->decode1xxHeaders(std::move(headers));
-    } else if (cannotHaveBody() && !handling_upgrade_) {
-      deferred_end_stream_headers_ = true;
-    } else {
-      pending_response_.value().decoder_->decodeHeaders(std::move(headers), false);
+    ResponseDecoder* decoder = pending_response_.value().decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "ResponseDecoder is null in onHeadersCompleteBase");
+    if (decoder) {
+      if (HeaderUtility::isSpecial1xx(*headers)) {
+        decoder->decode1xxHeaders(std::move(headers));
+      } else if (cannotHaveBody() && !handling_upgrade_) {
+        deferred_end_stream_headers_ = true;
+      } else {
+        decoder->decodeHeaders(std::move(headers), false);
+      }
     }
 
     // http-parser treats 1xx headers as their own complete response. Swallow the spurious
@@ -1580,7 +1613,11 @@ void ClientConnectionImpl::onBody(Buffer::Instance& data) {
   ASSERT(!deferred_end_stream_headers_);
   if (pending_response_.has_value()) {
     ASSERT(!pending_response_done_);
-    pending_response_.value().decoder_->decodeData(data, false);
+    ResponseDecoder* decoder = pending_response_.value().decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "ResponseDecoder is null in onBody");
+    if (decoder) {
+      decoder->decodeData(data, false);
+    }
   }
 }
 
@@ -1598,16 +1635,20 @@ CallbackResult ClientConnectionImpl::onMessageCompleteBase() {
     // be reset just yet. Preserve the state in pending_response_done_ instead.
     pending_response_done_ = true;
 
-    if (deferred_end_stream_headers_) {
-      response.decoder_->decodeHeaders(
-          std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
-      deferred_end_stream_headers_ = false;
-    } else if (processing_trailers_) {
-      response.decoder_->decodeTrailers(
-          std::move(absl::get<ResponseTrailerMapPtr>(headers_or_trailers_)));
-    } else {
-      Buffer::OwnedImpl buffer;
-      response.decoder_->decodeData(buffer, true);
+    ResponseDecoder* decoder = response.decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "ResponseDecoder is null in onMessageCompleteBase");
+    if (decoder) {
+      if (deferred_end_stream_headers_) {
+        decoder->decodeHeaders(
+            std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
+        deferred_end_stream_headers_ = false;
+      } else if (processing_trailers_) {
+        decoder->decodeTrailers(
+            std::move(absl::get<ResponseTrailerMapPtr>(headers_or_trailers_)));
+      } else {
+        Buffer::OwnedImpl buffer;
+        decoder->decodeData(buffer, true);
+      }
     }
 
     if (force_reset_on_premature_upstream_half_close_ && !encode_complete_) {

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -1250,10 +1250,8 @@ Envoy::StatusOr<CallbackResult> ServerConnectionImpl::onHeadersCompleteBase() {
     if (parser_->isChunked() ||
         (parser_->contentLength().has_value() && parser_->contentLength().value() > 0) ||
         handling_upgrade_) {
-      RequestDecoder* decoder =
-          active_request_->request_decoder_handle_->get().ptr();
-      ENVOY_BUG(decoder != nullptr,
-                "RequestDecoder is null in onHeadersCompleteBase");
+      RequestDecoder* decoder = active_request_->request_decoder_handle_->get().ptr();
+      ENVOY_BUG(decoder != nullptr, "RequestDecoder is null in onHeadersCompleteBase");
       if (decoder) {
         decoder->decodeHeaders(std::move(headers), false);
       }
@@ -1276,8 +1274,7 @@ Status ServerConnectionImpl::onMessageBeginBase() {
     ASSERT(active_request_ == nullptr);
     active_request_ = std::make_unique<ActiveRequest>(*this, std::move(bytes_meter_before_stream_));
     active_request_->request_decoder_handle_ =
-        callbacks_.newStream(active_request_->response_encoder_)
-            .getRequestDecoderHandle();
+        callbacks_.newStream(active_request_->response_encoder_).getRequestDecoderHandle();
 
     // Check for pipelined request flood as we prepare to accept a new request.
     // Parse errors that happen prior to onMessageBegin result in stream termination, it is not
@@ -1301,8 +1298,7 @@ void ServerConnectionImpl::onBody(Buffer::Instance& data) {
   ASSERT(!deferred_end_stream_headers_);
   if (active_request_) {
     ENVOY_CONN_LOG(trace, "body size={}", connection_, data.length());
-    RequestDecoder* decoder =
-        active_request_->request_decoder_handle_->get().ptr();
+    RequestDecoder* decoder = active_request_->request_decoder_handle_->get().ptr();
     ENVOY_BUG(decoder != nullptr, "RequestDecoder is null in onBody");
     if (decoder) {
       decoder->decodeData(data, false);
@@ -1342,23 +1338,19 @@ CallbackResult ServerConnectionImpl::onMessageCompleteBase() {
   if (active_request_) {
 
     // The request_decoder should be non-null after we've called the newStream on callbacks.
-    RequestDecoder* decoder =
-        active_request_->request_decoder_handle_->get().ptr();
-    ENVOY_BUG(decoder != nullptr,
-              "request_decoder_handle_ is null in onMessageCompleteBase");
+    RequestDecoder* decoder = active_request_->request_decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "request_decoder_handle_ is null in onMessageCompleteBase");
     active_request_->remote_complete_ = true;
 
     if (deferred_end_stream_headers_) {
       if (decoder) {
-        decoder->decodeHeaders(
-            std::move(absl::get<RequestHeaderMapPtr>(headers_or_trailers_)),
-            true);
+        decoder->decodeHeaders(std::move(absl::get<RequestHeaderMapPtr>(headers_or_trailers_)),
+                               true);
       }
       deferred_end_stream_headers_ = false;
     } else if (processing_trailers_) {
       if (decoder) {
-        decoder->decodeTrailers(
-            std::move(absl::get<RequestTrailerMapPtr>(headers_or_trailers_)));
+        decoder->decodeTrailers(std::move(absl::get<RequestTrailerMapPtr>(headers_or_trailers_)));
       }
     } else {
       Buffer::OwnedImpl buffer;
@@ -1409,13 +1401,11 @@ Status ServerConnectionImpl::sendProtocolError(absl::string_view details) {
 
   active_request_->response_encoder_.setDetails(details);
   if (!active_request_->response_encoder_.startedResponse()) {
-    RequestDecoder* decoder =
-        active_request_->request_decoder_handle_->get().ptr();
-    ENVOY_BUG(decoder != nullptr,
-              "RequestDecoder is null in sendProtocolError");
+    RequestDecoder* decoder = active_request_->request_decoder_handle_->get().ptr();
+    ENVOY_BUG(decoder != nullptr, "RequestDecoder is null in sendProtocolError");
     if (decoder) {
-      decoder->sendLocalReply(error_code_, CodeUtility::toString(error_code_),
-                              nullptr, absl::nullopt, details);
+      decoder->sendLocalReply(error_code_, CodeUtility::toString(error_code_), nullptr,
+                              absl::nullopt, details);
     }
   }
   return okStatus();
@@ -1516,7 +1506,8 @@ RequestEncoder& ClientConnectionImpl::newStream(ResponseDecoder& response_decode
 
   ASSERT(!pending_response_.has_value());
   ASSERT(pending_response_done_);
-  pending_response_.emplace(*this, std::move(bytes_meter_before_stream_), response_decoder.createResponseDecoderHandle());
+  pending_response_.emplace(*this, std::move(bytes_meter_before_stream_),
+                            response_decoder.createResponseDecoderHandle());
   pending_response_done_ = false;
   return pending_response_.value().encoder_;
 }
@@ -1639,12 +1630,11 @@ CallbackResult ClientConnectionImpl::onMessageCompleteBase() {
     ENVOY_BUG(decoder != nullptr, "ResponseDecoder is null in onMessageCompleteBase");
     if (decoder) {
       if (deferred_end_stream_headers_) {
-        decoder->decodeHeaders(
-            std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)), true);
+        decoder->decodeHeaders(std::move(absl::get<ResponseHeaderMapPtr>(headers_or_trailers_)),
+                               true);
         deferred_end_stream_headers_ = false;
       } else if (processing_trailers_) {
-        decoder->decodeTrailers(
-            std::move(absl::get<ResponseTrailerMapPtr>(headers_or_trailers_)));
+        decoder->decodeTrailers(std::move(absl::get<ResponseTrailerMapPtr>(headers_or_trailers_)));
       } else {
         Buffer::OwnedImpl buffer;
         decoder->decodeData(buffer, true);

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -475,7 +475,7 @@ protected:
 
     void dumpState(std::ostream& os, int indent_level) const;
     HeaderString request_url_;
-    RequestDecoder* request_decoder_{};
+    RequestDecoderHandlePtr request_decoder_handle_;
     ResponseEncoderImpl response_encoder_;
     bool remote_complete_{};
   };
@@ -588,10 +588,10 @@ public:
 private:
   struct PendingResponse {
     PendingResponse(ConnectionImpl& connection, StreamInfo::BytesMeterSharedPtr&& bytes_meter,
-                    ResponseDecoder* decoder)
-        : encoder_(connection, std::move(bytes_meter)), decoder_(decoder) {}
+                    ResponseDecoderHandlePtr&& decoder_handle)
+        : encoder_(connection, std::move(bytes_meter)), decoder_handle_(std::move(decoder_handle)) {}
     RequestEncoderImpl encoder_;
-    ResponseDecoder* decoder_;
+    ResponseDecoderHandlePtr decoder_handle_;
   };
 
   bool cannotHaveBody();

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -589,7 +589,8 @@ private:
   struct PendingResponse {
     PendingResponse(ConnectionImpl& connection, StreamInfo::BytesMeterSharedPtr&& bytes_meter,
                     ResponseDecoderHandlePtr&& decoder_handle)
-        : encoder_(connection, std::move(bytes_meter)), decoder_handle_(std::move(decoder_handle)) {}
+        : encoder_(connection, std::move(bytes_meter)), decoder_handle_(std::move(decoder_handle)) {
+    }
     RequestEncoderImpl encoder_;
     ResponseDecoderHandlePtr decoder_handle_;
   };

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -47,6 +47,14 @@ Extensions::Bootstrap::ReverseConnection::UpstreamSocketManager* getThreadLocalS
   return tls_registry->socketManager();
 }
 
+class RequestDecoderHandleImpl : public Http::RequestDecoderHandle {
+public:
+  explicit RequestDecoderHandleImpl(Http::RequestDecoder& decoder) : decoder_(decoder) {}
+  OptRef<Http::RequestDecoder> get() override { return decoder_; }
+private:
+  Http::RequestDecoder& decoder_;
+};
+
 } // namespace
 
 // Stats helper implementation.
@@ -326,7 +334,7 @@ AccessLog::InstanceSharedPtrVector ReverseTunnelFilter::RequestDecoderImpl::acce
 }
 
 Http::RequestDecoderHandlePtr ReverseTunnelFilter::RequestDecoderImpl::getRequestDecoderHandle() {
-  return nullptr;
+  return std::make_unique<RequestDecoderHandleImpl>(*this);
 }
 
 void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream) {

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -51,6 +51,7 @@ class RequestDecoderHandleImpl : public Http::RequestDecoderHandle {
 public:
   explicit RequestDecoderHandleImpl(Http::RequestDecoder& decoder) : decoder_(decoder) {}
   OptRef<Http::RequestDecoder> get() override { return decoder_; }
+
 private:
   Http::RequestDecoder& decoder_;
 };

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -53,7 +53,8 @@ void setupRequestDecoderMock(Http::MockRequestDecoder& request_decoder) {
   EXPECT_CALL(request_decoder, getRequestDecoderHandle())
       .WillRepeatedly(Invoke([&request_decoder]() {
         auto handle = std::make_unique<NiceMock<Http::MockRequestDecoderHandle>>();
-        ON_CALL(*handle, get()).WillByDefault(Return(OptRef<Http::RequestDecoder>(request_decoder)));
+        ON_CALL(*handle, get())
+            .WillByDefault(Return(OptRef<Http::RequestDecoder>(request_decoder)));
         return handle;
       }));
 }
@@ -308,6 +309,7 @@ void Http1ServerConnectionImplTest::expectHeadersTest(Protocol p, bool allow_abs
 
   MockRequestDecoder decoder;
   setupRequestDecoderMock(decoder);
+
   InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
@@ -505,9 +507,10 @@ void Http1ServerConnectionImplTest::testServerAllowChunkedContentLength(uint32_t
 TEST_F(Http1ServerConnectionImplTest, EmptyHeader) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -571,9 +574,10 @@ TEST_F(Http1ServerConnectionImplTest, UnsupportedEncoding) {
 TEST_F(Http1ServerConnectionImplTest, LargeBodyOptimization) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   std::string post = "POST / HTTP/1.1\r\ncontent-length: 1000000\r\n\r\n";
@@ -601,9 +605,10 @@ TEST_F(Http1ServerConnectionImplTest, LargeBodyOptimization) {
 TEST_F(Http1ServerConnectionImplTest, ContentLengthAllBitsSet) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -624,9 +629,10 @@ TEST_F(Http1ServerConnectionImplTest, ContentLengthAllBitsSet) {
 TEST_F(Http1ServerConnectionImplTest, ChunkedBody) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -655,9 +661,10 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBody) {
 TEST_F(Http1ServerConnectionImplTest, ChunkedBodySplitOverTwoDispatches) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -693,9 +700,10 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodySplitOverTwoDispatches) {
 TEST_F(Http1ServerConnectionImplTest, ChunkedBodyFragmentedBuffer) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -722,9 +730,10 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodyFragmentedBuffer) {
 TEST_F(Http1ServerConnectionImplTest, ChunkedBodyCase) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -749,9 +758,10 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedBodyCase) {
 TEST_F(Http1ServerConnectionImplTest, InvalidChunkHeader) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -781,9 +791,10 @@ TEST_F(Http1ServerConnectionImplTest, IdentityAndChunkedBody) {
 
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("POST / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: "
@@ -920,9 +931,10 @@ TEST_F(Http1ServerConnectionImplTest, Http10) {
   codec_settings_.accept_http_10_ = true;
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
@@ -940,9 +952,10 @@ TEST_F(Http1ServerConnectionImplTest, Http10HostAdded) {
   codec_settings_.default_host_for_http_10_ = "example.com";
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -982,6 +995,7 @@ TEST_F(Http1ServerConnectionImplTest, Http10MultipleResponses) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   // Send a full HTTP/1.0 request and proxy a response.
   {
     Buffer::OwnedImpl buffer(
@@ -1041,9 +1055,10 @@ TEST_F(Http1ServerConnectionImplTest, HttpVersion) {
     const absl::optional<absl::string_view>& expected_error = test_case.expected_error_;
     initialize();
 
-    InSequence sequence;
-
     MockRequestDecoder decoder;
+    setupRequestDecoderMock(decoder);
+
+    InSequence sequence;
     EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
     if (expected_error.has_value()) {
       EXPECT_CALL(decoder,
@@ -1132,6 +1147,7 @@ TEST_F(Http1ServerConnectionImplTest, Http11InvalidTrailerPost) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   EXPECT_CALL(decoder, decodeHeaders_(_, false));
@@ -1205,9 +1221,10 @@ TEST_F(Http1ServerConnectionImplTest, Http11Options) {
 TEST_F(Http1ServerConnectionImplTest, SimpleGet) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{{":path", "/"}, {":method", "GET"}};
@@ -1223,9 +1240,10 @@ TEST_F(Http1ServerConnectionImplTest, SimpleGet) {
 TEST_F(Http1ServerConnectionImplTest, ProtocolStreamId) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -1247,6 +1265,7 @@ TEST_F(Http1ServerConnectionImplTest, BadRequestNoStream) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   // Check that before any headers are parsed, requests do not look like HEAD or gRPC requests.
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
@@ -1260,6 +1279,7 @@ TEST_F(Http1ServerConnectionImplTest, RejectCustomMethod) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
 
@@ -1275,6 +1295,7 @@ TEST_F(Http1ServerConnectionImplTest, RejectInvalidCharacterInMethod) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
 
@@ -1291,6 +1312,7 @@ TEST_F(Http1ServerConnectionImplTest, AllowCustomMethod) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("BAD / HTTP/1.1\r\n");
@@ -1310,6 +1332,7 @@ TEST_F(Http1ServerConnectionImplTest, BadRequestStartedStream) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("G");
@@ -1371,9 +1394,10 @@ TEST_F(Http1ServerConnectionImplTest, FloodProtection) {
 TEST_F(Http1ServerConnectionImplTest, HostHeaderTranslation) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -1392,6 +1416,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidCharsRejection) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -1488,6 +1513,7 @@ TEST_F(Http1ServerConnectionImplTest, HeaderInvalidAuthority) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -1511,9 +1537,10 @@ TEST_F(Http1ServerConnectionImplTest, HeaderMutateEmbeddedNul) {
   for (size_t n = 0; n < example_input.size(); ++n) {
     initialize();
 
-    InSequence sequence;
-
     MockRequestDecoder decoder;
+    setupRequestDecoderMock(decoder);
+
+    InSequence sequence;
     EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
     Buffer::OwnedImpl buffer(
@@ -1540,9 +1567,10 @@ TEST_F(Http1ServerConnectionImplTest, TrailerMutateEmbeddedNul) {
   for (size_t n = 0; n < trailers.size(); ++n) {
     initialize();
 
-    InSequence sequence;
-
     MockRequestDecoder decoder;
+    setupRequestDecoderMock(decoder);
+
+    InSequence sequence;
     EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
     Buffer::OwnedImpl buffer(absl::StrCat(headers_and_body, trailers.substr(0, n), kNullCharacter,
@@ -1582,9 +1610,10 @@ TEST_F(Http1ServerConnectionImplTest, HeaderMutateEmbeddedCRLF) {
 TEST_F(Http1ServerConnectionImplTest, CloseDuringHeadersComplete) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -1604,9 +1633,10 @@ TEST_F(Http1ServerConnectionImplTest, CloseDuringHeadersComplete) {
 TEST_F(Http1ServerConnectionImplTest, PostWithContentLength) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -1630,9 +1660,10 @@ TEST_F(Http1ServerConnectionImplTest, PostWithContentLength) {
 TEST_F(Http1ServerConnectionImplTest, PostWithContentLengthFragmentedBuffer) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -1914,6 +1945,9 @@ TEST_F(Http1ServerConnectionImplTest, ChunkedResponse) {
 
 TEST_F(Http1ServerConnectionImplTest, VerifyRequestHeaderTrailerMapMaxLimits) {
   initialize();
+  MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+
   InSequence sequence;
 
   codec_settings_.allow_absolute_url_ = true;
@@ -1923,7 +1957,6 @@ TEST_F(Http1ServerConnectionImplTest, VerifyRequestHeaderTrailerMapMaxLimits) {
       max_request_headers_count_, envoy::config::core::v3::HttpProtocolOptions::ALLOW,
       overload_manager_);
 
-  MockRequestDecoder decoder;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   TestRequestHeaderMapImpl expected_headers{
       {{":path", "/"}, {":method", "POST"}, {"transfer-encoding", "chunked"}},
@@ -2483,6 +2516,7 @@ TEST_F(Http1ServerConnectionImplTest, LoadShedPointCanCloseConnectionOnDispatchO
 
   EXPECT_CALL(mock_abort_dispatch, shouldShedLoad()).WillOnce(Return(true));
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
 
@@ -2534,6 +2568,7 @@ TEST_F(Http1ServerConnectionImplTest, LoadShedPointCanCloseConnectionOnDispatchO
 
   EXPECT_CALL(mock_abort_dispatch, shouldShedLoad()).WillOnce(Return(false));
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl request_line_buffer("GET / HTTP/1.1\r\n");
@@ -3631,6 +3666,7 @@ TEST_F(Http1ServerConnectionImplTest, Utf8Path) {
   initialize();
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
   Buffer::OwnedImpl buffer("GET /δ¶/δt/pope?q=1#narf HXXP/1.1\r\n\r\n");
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
@@ -4488,12 +4524,12 @@ TEST_F(Http1ClientConnectionImplTest, DecoderDestroyedBeforeMessageComplete) {
 
   // Send final chunk. This triggers onMessageCompleteBase.
   Buffer::OwnedImpl final_chunk("0\r\n\r\n");
-  EXPECT_ENVOY_BUG(status = codec_->dispatch(final_chunk), "ResponseDecoder is null in onMessageCompleteBase");
+  EXPECT_ENVOY_BUG(status = codec_->dispatch(final_chunk),
+                   "ResponseDecoder is null in onMessageCompleteBase");
   EXPECT_TRUE(status.ok());
 }
 
-TEST_F(Http1ServerConnectionImplTest,
-       RequestDecoderDestroyedBeforeMessageComplete) {
+TEST_F(Http1ServerConnectionImplTest, RequestDecoderDestroyedBeforeMessageComplete) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
@@ -4504,8 +4540,7 @@ TEST_F(Http1ServerConnectionImplTest,
   EXPECT_CALL(decoder, getRequestDecoderHandle())
       .WillOnce(Return(testing::ByMove(std::move(handle_ptr))));
 
-  EXPECT_CALL(*handle, get())
-      .WillRepeatedly(Return(OptRef<Http::RequestDecoder>(decoder)));
+  EXPECT_CALL(*handle, get()).WillRepeatedly(Return(OptRef<Http::RequestDecoder>(decoder)));
 
   Buffer::OwnedImpl headers_buffer(
       "GET / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: chunked\r\n\r\n");
@@ -4515,8 +4550,7 @@ TEST_F(Http1ServerConnectionImplTest,
   auto status = codec_->dispatch(headers_buffer);
   EXPECT_TRUE(status.ok());
 
-  EXPECT_CALL(*handle, get())
-      .WillRepeatedly(Return(OptRef<Http::RequestDecoder>{}));
+  EXPECT_CALL(*handle, get()).WillRepeatedly(Return(OptRef<Http::RequestDecoder>{}));
 
   Buffer::OwnedImpl final_chunk("0\r\n\r\n");
 
@@ -5269,6 +5303,7 @@ TEST_F(Http1ServerConnectionImplTest, RequestAfterConnectionClose) {
 
   {
     MockRequestDecoder decoder;
+    setupRequestDecoderMock(decoder);
     EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
     EXPECT_CALL(decoder, decodeHeaders_(_, true));
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -49,6 +49,15 @@ namespace Envoy {
 namespace Http {
 namespace {
 
+void setupRequestDecoderMock(Http::MockRequestDecoder& request_decoder) {
+  EXPECT_CALL(request_decoder, getRequestDecoderHandle())
+      .WillRepeatedly(Invoke([&request_decoder]() {
+        auto handle = std::make_unique<NiceMock<Http::MockRequestDecoderHandle>>();
+        ON_CALL(*handle, get()).WillByDefault(Return(OptRef<Http::RequestDecoder>(request_decoder)));
+        return handle;
+      }));
+}
+
 constexpr absl::string_view kNullCharacter("\0", 1);
 
 std::string createHeaderOrTrailerFragment(int num_headers) {
@@ -98,7 +107,9 @@ class MockRequestDecoderShimWithUhv : public Http::MockRequestDecoder {
 public:
   MockRequestDecoderShimWithUhv(Http::ServerHeaderValidator* header_validator,
                                 Network::MockConnection& connection)
-      : header_validator_(header_validator), connection_(connection) {}
+      : header_validator_(header_validator), connection_(connection) {
+    setupRequestDecoderMock(*this);
+  }
 
   void setResponseEncoder(Http::ResponseEncoder* response_encoder) {
     response_encoder_ = response_encoder;
@@ -208,6 +219,7 @@ public:
   sendAndValidateRequestAndSendResponse(Buffer::Instance& buffer,
                                         const TestRequestHeaderMapImpl& expected_request_headers) {
     NiceMock<MockRequestDecoder> decoder;
+    setupRequestDecoderMock(decoder);
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
         .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -258,8 +270,6 @@ protected:
 void Http1ServerConnectionImplTest::expect400(Buffer::OwnedImpl& buffer,
                                               absl::string_view expected_details,
                                               absl::string_view expected_message) {
-  InSequence sequence;
-
   codec_settings_.allow_absolute_url_ = true;
   codec_ = std::make_unique<Http1::ServerConnectionImpl>(
       connection_, http1CodecStats(), callbacks_, codec_settings_, max_request_headers_kb_,
@@ -267,6 +277,8 @@ void Http1ServerConnectionImplTest::expect400(Buffer::OwnedImpl& buffer,
       overload_manager_);
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -285,8 +297,6 @@ void Http1ServerConnectionImplTest::expect400(Buffer::OwnedImpl& buffer,
 void Http1ServerConnectionImplTest::expectHeadersTest(Protocol p, bool allow_absolute_url,
                                                       Buffer::OwnedImpl& buffer,
                                                       TestRequestHeaderMapImpl& expected_headers) {
-  InSequence sequence;
-
   // Make a new 'codec' with the right settings
   if (allow_absolute_url) {
     codec_settings_.allow_absolute_url_ = allow_absolute_url;
@@ -297,6 +307,8 @@ void Http1ServerConnectionImplTest::expectHeadersTest(Protocol p, bool allow_abs
   }
 
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, decodeHeaders_(HeaderMapEqual(&expected_headers), true));
 
@@ -318,8 +330,9 @@ void Http1ServerConnectionImplTest::expectTrailersTest(bool enable_trailers) {
         overload_manager_);
   }
 
-  InSequence sequence;
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   EXPECT_CALL(decoder, decodeHeaders_(_, false));
@@ -516,9 +529,8 @@ TEST_F(Http1ServerConnectionImplTest, EmptyHeader) {
 TEST_F(Http1ServerConnectionImplTest, IdentityEncodingNoChunked) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: identity\r\n\r\n");
@@ -536,9 +548,8 @@ TEST_F(Http1ServerConnectionImplTest, IdentityEncodingNoChunked) {
 TEST_F(Http1ServerConnectionImplTest, UnsupportedEncoding) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\nHost: host\r\ntransfer-encoding: gzip\r\n\r\n");
@@ -2346,8 +2357,8 @@ TEST_F(Http1ServerConnectionImplTest, ConnectRequestWithEarlyData) {
 TEST_F(Http1ServerConnectionImplTest, ConnectRequestWithTEChunked) {
   initialize();
 
-  InSequence sequence;
   MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
         decoder.setResponseEncoder(&encoder);
@@ -4020,6 +4031,8 @@ TEST_F(Http1ServerConnectionImplTest, ParseUrl) {
     initialize();
 
     StrictMock<MockRequestDecoder> decoder;
+    setupRequestDecoderMock(decoder);
+    EXPECT_CALL(decoder, decodeHeaders_(_, _)).Times(testing::AnyNumber());
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
         .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4039,9 +4052,9 @@ TEST_F(Http1ServerConnectionImplTest, ParseUrl) {
   for (const char* invalid_first_line : kInvalidFirstLines) {
     initialize();
 
-    InSequence sequence;
-
     StrictMock<MockRequestDecoder> decoder;
+    setupRequestDecoderMock(decoder);
+    InSequence sequence;
     Http::ResponseEncoder* response_encoder = nullptr;
     EXPECT_CALL(callbacks_, newStream(_, _))
         .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4148,6 +4161,7 @@ TEST_F(Http1ServerConnectionImplTest, ValidMethodFirstCharacter) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer1("G");
@@ -4180,8 +4194,6 @@ TEST_F(Http1ClientConnectionImplTest, InvalidResponseFirstCharacter) {
 // A first read of zero bytes when parsing a request is ignored.
 TEST_F(Http1ServerConnectionImplTest, FirstReadEOF) {
   initialize();
-  InSequence s;
-
   // A read of zero bytes does not trigger creation of a new stream.
   EXPECT_CALL(callbacks_, newStream(_, _)).Times(0);
 
@@ -4190,6 +4202,8 @@ TEST_F(Http1ServerConnectionImplTest, FirstReadEOF) {
   ASSERT_TRUE(status.ok());
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\n");
@@ -4224,9 +4238,9 @@ TEST_F(Http1ClientConnectionImplTest, FirstReadEOF) {
 // A read of zero bytes during the first line of a request is an error.
 TEST_F(Http1ServerConnectionImplTest, EOFDuringHeaders) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4271,9 +4285,9 @@ TEST_F(Http1ClientConnectionImplTest, EOFDuringHeaders) {
 // A read of zero bytes during chunked request body is an error.
 TEST_F(Http1ServerConnectionImplTest, EOFDuringChunkedBody) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4329,9 +4343,9 @@ TEST_F(Http1ClientConnectionImplTest, EOFDuringChunkedBody) {
 // A read of zero bytes before Content-Length bytes of request body are read is an error.
 TEST_F(Http1ServerConnectionImplTest, EOFDuringContentLengthBody) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4386,9 +4400,9 @@ TEST_F(Http1ClientConnectionImplTest, EOFDuringContentLengthBody) {
 // body but without a Content-Length (or Transfer-Encoding: chunked) header.
 TEST_F(Http1ServerConnectionImplTest, NoContentLengthRequest) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4453,12 +4467,70 @@ TEST_F(Http1ClientConnectionImplTest, NoContentLengthResponse) {
   }
 }
 
+TEST_F(Http1ClientConnectionImplTest, DecoderDestroyedBeforeMessageComplete) {
+  initialize();
+
+  auto response_decoder = std::make_unique<StrictMock<MockResponseDecoder>>();
+  Http::RequestEncoder& request_encoder = codec_->newStream(*response_decoder);
+  TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
+
+  EXPECT_CALL(*response_decoder, decodeHeaders_(_, false));
+  EXPECT_CALL(*response_decoder, decodeData(BufferStringEqual("hello"), false));
+
+  Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+                             "5\r\nhello\r\n");
+  auto status = codec_->dispatch(response);
+  EXPECT_TRUE(status.ok());
+
+  // Destroy the decoder!
+  response_decoder.reset();
+
+  // Send final chunk. This triggers onMessageCompleteBase.
+  Buffer::OwnedImpl final_chunk("0\r\n\r\n");
+  EXPECT_ENVOY_BUG(status = codec_->dispatch(final_chunk), "ResponseDecoder is null in onMessageCompleteBase");
+  EXPECT_TRUE(status.ok());
+}
+
+TEST_F(Http1ServerConnectionImplTest,
+       RequestDecoderDestroyedBeforeMessageComplete) {
+  initialize();
+
+  StrictMock<MockRequestDecoder> decoder;
+  auto* handle = new NiceMock<Http::MockRequestDecoderHandle>();
+  auto handle_ptr = std::unique_ptr<Http::MockRequestDecoderHandle>(handle);
+
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
+  EXPECT_CALL(decoder, getRequestDecoderHandle())
+      .WillOnce(Return(testing::ByMove(std::move(handle_ptr))));
+
+  EXPECT_CALL(*handle, get())
+      .WillRepeatedly(Return(OptRef<Http::RequestDecoder>(decoder)));
+
+  Buffer::OwnedImpl headers_buffer(
+      "GET / HTTP/1.1\r\nHost: host\r\nTransfer-Encoding: chunked\r\n\r\n");
+
+  EXPECT_CALL(decoder, decodeHeaders_(_, false));
+
+  auto status = codec_->dispatch(headers_buffer);
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_CALL(*handle, get())
+      .WillRepeatedly(Return(OptRef<Http::RequestDecoder>{}));
+
+  Buffer::OwnedImpl final_chunk("0\r\n\r\n");
+
+  EXPECT_ENVOY_BUG(status = codec_->dispatch(final_chunk),
+                   "request_decoder_handle_ is null in onMessageCompleteBase");
+  EXPECT_TRUE(status.ok());
+}
+
 // Regression test for https://github.com/envoyproxy/envoy/issues/25458.
 TEST_F(Http1ServerConnectionImplTest, EmptyFieldName) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4483,9 +4555,8 @@ TEST_F(Http1ServerConnectionImplTest, EmptyFieldName) {
 // Multiple Transfer-Encoding request headers are not allowed, regardless of their value.
 TEST_F(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
   initialize();
-  InSequence s;
-
   MockRequestDecoderShimWithUhv decoder(header_validator_.get(), connection_);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4514,9 +4585,9 @@ TEST_F(Http1ServerConnectionImplTest, MultipleTransferEncoding) {
 
 TEST_F(Http1ServerConnectionImplTest, Http10Rejected) {
   initialize();
-  InSequence s;
-
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence s;
   Http::ResponseEncoder* response_encoder = nullptr;
   EXPECT_CALL(callbacks_, newStream(_, _))
       .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
@@ -4556,6 +4627,7 @@ TEST_F(Http1ServerConnectionImplTest, SeparatorInHeaderName) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder,
               sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
@@ -4594,6 +4666,7 @@ TEST_F(Http1ServerConnectionImplTest, SpaceInHeaderName) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   EXPECT_CALL(decoder,
@@ -4630,6 +4703,7 @@ TEST_F(Http1ServerConnectionImplTest, ExtendedAsciiInHeaderName) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder,
               sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
@@ -4664,6 +4738,7 @@ TEST_F(Http1ServerConnectionImplTest, Char22InHeaderValue) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder, sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _,
                                       "http1.invalid_characters"));
@@ -4698,6 +4773,7 @@ TEST_F(Http1ServerConnectionImplTest, MultipleContentLength) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder,
               sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
@@ -4771,6 +4847,7 @@ TEST_F(Http1ServerConnectionImplTest, ObsFold) {
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -4819,6 +4896,7 @@ void Http1ServerConnectionImplTest::testRequestWithValueExpectSuccess(
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   TestRequestHeaderMapImpl expected_headers{
       {":path", "/"},
       {":method", "GET"},
@@ -4840,6 +4918,7 @@ void Http1ServerConnectionImplTest::testRequestWithValueExpectFailure(
   initialize();
 
   StrictMock<MockRequestDecoder> decoder;
+  setupRequestDecoderMock(decoder);
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder,
               sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, expected_error_details));
@@ -5015,9 +5094,9 @@ TEST_F(Http1ClientConnectionImplTest, ValueEndsWithLF) {
 TEST_F(Http1ServerConnectionImplTest, FirstLineInvalidCR) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -5066,9 +5145,9 @@ TEST_F(Http1ClientConnectionImplTest, FirstLineInvalidCR) {
 TEST_F(Http1ServerConnectionImplTest, HeaderNameInvalidCR) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
   EXPECT_CALL(decoder,
               sendLocalReply(Http::Code::BadRequest, "Bad Request", _, _, "http1.codec_error"));
@@ -5110,9 +5189,9 @@ TEST_F(Http1ClientConnectionImplTest, HeaderNameInvalidCR) {
 TEST_F(Http1ServerConnectionImplTest, ChunkExtensionInvalidCR) {
   initialize();
 
-  InSequence sequence;
-
   MockRequestDecoder decoder;
+  setupRequestDecoderMock(decoder);
+  InSequence sequence;
   EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(decoder));
 
   TestRequestHeaderMapImpl expected_headers{
@@ -5170,6 +5249,7 @@ TEST_F(Http1ServerConnectionImplTest, RequestAfterConnectionClose) {
   {
     Http::ResponseEncoder* response_encoder = nullptr;
     MockRequestDecoder decoder;
+    setupRequestDecoderMock(decoder);
     EXPECT_CALL(callbacks_, newStream(_, _))
         .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
           response_encoder = &encoder;

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -438,7 +438,8 @@ TEST_F(ReverseTunnelFilterUnitTest, RequestDecoderInterfaceCoverageViaNewStream)
   auto logs = decoder.accessLogHandlers();
   EXPECT_TRUE(logs.empty());
   auto handle = decoder.getRequestDecoderHandle();
-  EXPECT_EQ(nullptr, handle.get());
+  EXPECT_NE(nullptr, handle.get());
+  EXPECT_EQ(&decoder, handle->get().ptr());
 }
 
 // Test configuration with custom ping interval.

--- a/test/mocks/http/stream_decoder.cc
+++ b/test/mocks/http/stream_decoder.cc
@@ -19,7 +19,7 @@ MockRequestDecoder::MockRequestDecoder() {
         ASSERT_NE(nullptr, headers->Method());
       }));
   ON_CALL(*this, getRequestDecoderHandle()).WillByDefault(Invoke([this]() {
-    auto handle = std::make_unique<MockRequestDecoderHandle>();
+    auto handle = std::make_unique<testing::NiceMock<MockRequestDecoderHandle>>();
     ON_CALL(*handle, get()).WillByDefault(Return(OptRef<RequestDecoder>(*this)));
     return handle;
   }));


### PR DESCRIPTION
Commit Message: Apply weak pointer semantics to HTTP/1 streams in ServerConnectionImpl and ClientConnectionImpl
Additional Description:
This change applies [an existing pattern](https://github.com/envoyproxy/envoy/commit/b701b033689be044e31e714f60a0f9265d2800ce) used to fix use-after-free issues in h2/h3 to both `ServerConnectionImpl` and `ClientConnectionImpl` in the HTTP/1 codec to safely access decoders. We replaced raw pointers to `RequestDecoder` and `ResponseDecoder` with `RequestDecoderHandlePtr` and `ResponseDecoderHandlePtr` respectively. This allows safe verification of whether the decoder is still valid before attempting to access it. We have also added `ENVOY_BUG` assertions to catch instances where the decoder is unexpectedly null. After running all tests internally, expectedly, there are no existing instances of the ENVOY_BUGs. Tests have been added/updated for both paths to verify that the `ENVOY_BUG` is triggered as expected when decoders are destroyed before message completion.

*Disclosure: Used Gen AI to help generate the code and tests*
Risk Level: Low (safety improvement using established patterns).
Testing: Updated `ResponseDecoderDestroyedBeforeMessageComplete` and added `RequestDecoderDestroyedBeforeMessageComplete` in `codec_impl_test.cc`. All tests passed.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.