### PR TITLE
otel: add option to disable telemetry SDK resource attributes

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message OpenTelemetryConfig {
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.
@@ -62,4 +62,12 @@ message OpenTelemetryConfig {
   // This field specifies the maximum number of spans that can be cached. If not specified, the
   // default is 1024.
   google.protobuf.UInt32Value max_cache_size = 6;
+
+  // Specifies whether to set the telemetry SDK resource attributes.
+  // The following attributes will be set:
+  //  - telemetry.sdk.language
+  //  - telemetry.sdk.name
+  //  - telemetry.sdk.version
+  // If not specified, the default is to set these attributes.
+  google.protobuf.BoolValue set_telemetry_sdk_resource_attributes = 7;
 }

--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -65,9 +65,11 @@ message OpenTelemetryConfig {
 
   // Specifies whether to set the telemetry SDK resource attributes.
   // The following attributes will be set:
-  //  - telemetry.sdk.language
-  //  - telemetry.sdk.name
-  //  - telemetry.sdk.version
+  //
+  // - telemetry.sdk.language
+  // - telemetry.sdk.name
+  // - telemetry.sdk.version
+  //
   // If not specified, the default is to set these attributes.
   google.protobuf.BoolValue set_telemetry_sdk_resource_attributes = 7;
 }

--- a/source/extensions/stat_sinks/open_telemetry/config.cc
+++ b/source/extensions/stat_sinks/open_telemetry/config.cc
@@ -25,7 +25,8 @@ OpenTelemetrySinkFactory::createStatsSink(const Protobuf::Message& config,
   auto otlp_options = std::make_shared<OtlpOptions>(
       sink_config,
       resource_provider->getResource(sink_config.resource_detectors(), server,
-                                     /*service_name=*/""),
+                                     /*service_name=*/"",
+                                     /*set_telemetry_sdk_resource_attributes=*/true),
       server);
   std::shared_ptr<OtlpMetricsFlusher> otlp_metrics_flusher =
       std::make_shared<OtlpMetricsFlusherImpl>(otlp_options);

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -76,10 +76,17 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
           POOL_COUNTER_PREFIX(context.serverFactoryContext().scope(), "tracing.opentelemetry"))} {
   auto& factory_context = context.serverFactoryContext();
 
+  bool set_telemetry_sdk_resource_attributes = true;
+  if (opentelemetry_config.has_set_telemetry_sdk_resource_attributes()) {
+    set_telemetry_sdk_resource_attributes =
+        opentelemetry_config.set_telemetry_sdk_resource_attributes().value();
+  }
+
   Resource resource = resource_provider.getResource(
       opentelemetry_config.resource_detectors(), context.serverFactoryContext(),
       opentelemetry_config.service_name().empty() ? kDefaultServiceName
-                                                  : opentelemetry_config.service_name());
+                                                  : opentelemetry_config.service_name(),
+      set_telemetry_sdk_resource_attributes);
   ResourceConstSharedPtr resource_ptr = std::make_shared<Resource>(std::move(resource));
 
   if (opentelemetry_config.has_grpc_service() && opentelemetry_config.has_http_service()) {

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
@@ -14,18 +14,20 @@ namespace OpenTelemetry {
 namespace {
 bool isEmptyResource(const Resource& resource) { return resource.attributes_.empty(); }
 
-Resource createInitialResource(absl::string_view service_name) {
+Resource createInitialResource(absl::string_view service_name,
+                               bool set_telemetry_sdk_resource_attributes) {
   Resource resource{};
 
   // Creates initial resource with the static service.name and telemetry.sdk.* attributes.
   if (!service_name.empty()) {
     resource.attributes_[kServiceNameKey] = service_name;
   }
-  resource.attributes_[kTelemetrySdkLanguageKey] = kDefaultTelemetrySdkLanguage;
 
-  resource.attributes_[kTelemetrySdkNameKey] = kDefaultTelemetrySdkName;
-
-  resource.attributes_[kTelemetrySdkVersionKey] = Envoy::VersionInfo::version();
+  if (set_telemetry_sdk_resource_attributes) {
+    resource.attributes_[kTelemetrySdkLanguageKey] = kDefaultTelemetrySdkLanguage;
+    resource.attributes_[kTelemetrySdkNameKey] = kDefaultTelemetrySdkName;
+    resource.attributes_[kTelemetrySdkVersionKey] = Envoy::VersionInfo::version();
+  }
 
   return resource;
 }
@@ -85,10 +87,10 @@ void mergeResource(Resource& old_resource, const Resource& updating_resource) {
 Resource ResourceProviderImpl::getResource(
     const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
         resource_detectors,
-    Envoy::Server::Configuration::ServerFactoryContext& context,
-    absl::string_view service_name) const {
+    Envoy::Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
+    bool set_telemetry_sdk_resource_attributes) const {
 
-  Resource resource = createInitialResource(service_name);
+  Resource resource = createInitialResource(service_name, set_telemetry_sdk_resource_attributes);
 
   for (const auto& detector_config : resource_detectors) {
     ResourceDetectorPtr detector;

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
@@ -38,8 +38,8 @@ public:
   virtual Resource
   getResource(const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                   resource_detectors,
-              Server::Configuration::ServerFactoryContext& context,
-              absl::string_view service_name) const PURE;
+              Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
+              bool set_telemetry_sdk_resource_attributes) const PURE;
 };
 using ResourceProviderPtr = std::shared_ptr<ResourceProvider>;
 
@@ -48,8 +48,8 @@ public:
   Resource
   getResource(const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                   resource_detectors,
-              Server::Configuration::ServerFactoryContext& context,
-              absl::string_view service_name) const override;
+              Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
+              bool set_telemetry_sdk_resource_attributes) const override;
 };
 
 } // namespace OpenTelemetry

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -34,8 +34,8 @@ public:
   MOCK_METHOD(Resource, getResource,
               (const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                    resource_detectors,
-               Server::Configuration::ServerFactoryContext& context,
-               absl::string_view service_name),
+               Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
+               bool set_telemetry_sdk_resource_attributes),
               (const));
 };
 
@@ -59,7 +59,7 @@ public:
     resource.attributes_.insert(std::pair<std::string, std::string>("key1", "val1"));
 
     auto mock_resource_provider = NiceMock<MockResourceProvider>();
-    EXPECT_CALL(mock_resource_provider, getResource(_, _, _)).WillRepeatedly(Return(resource));
+    EXPECT_CALL(mock_resource_provider, getResource(_, _, _, _)).WillRepeatedly(Return(resource));
 
     driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
   }
@@ -120,6 +120,67 @@ TEST_F(OpenTelemetryDriverTest, InitializeDriverValidConfig) {
 TEST_F(OpenTelemetryDriverTest, InitializeDriverValidConfigHttpExporter) {
   setupValidDriverWithHttpExporter();
   EXPECT_NE(driver_, nullptr);
+}
+
+// Verifies that set_telemetry_sdk_resource_attributes=false is passed to ResourceProvider
+TEST_F(OpenTelemetryDriverTest, PassSetTelemetrySdkResourceAttributesFalse) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    set_telemetry_sdk_resource_attributes: false
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto mock_client_factory = std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
+  auto mock_client = std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
+  mock_client_ = mock_client.get();
+  ON_CALL(*mock_client_factory, createUncachedRawAsyncClient())
+      .WillByDefault(Return(ByMove(std::move(mock_client))));
+  auto& factory_context = context_.server_factory_context_;
+  ON_CALL(factory_context, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(factory_context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
+  ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
+
+  Resource resource;
+  auto mock_resource_provider = NiceMock<MockResourceProvider>();
+
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, false)).WillOnce(Return(resource));
+
+  driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
+}
+
+// Verifies that set_telemetry_sdk_resource_attributes defaults to true
+TEST_F(OpenTelemetryDriverTest, PassSetTelemetrySdkResourceAttributesDefaultTrue) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto mock_client_factory = std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
+  auto mock_client = std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
+  mock_client_ = mock_client.get();
+  ON_CALL(*mock_client_factory, createUncachedRawAsyncClient())
+      .WillByDefault(Return(ByMove(std::move(mock_client))));
+  auto& factory_context = context_.server_factory_context_;
+  ON_CALL(factory_context, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(factory_context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
+  ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
+
+  Resource resource;
+  auto mock_resource_provider = NiceMock<MockResourceProvider>();
+
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, true)).WillOnce(Return(resource));
+
+  driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
 }
 
 // Verifies that the tracer cannot be configured with two exporters at the same time

--- a/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
@@ -78,9 +78,9 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfigured) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   EXPECT_EQ(resource.schema_url_, "");
 
@@ -99,6 +99,30 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfigured) {
     EXPECT_TRUE(expected != expected_attributes.end());
     EXPECT_EQ(expected->second, actual.second);
   }
+}
+
+// Verifies a resource with only service name is returned when telemetry SDK attributes are disabled
+TEST_F(ResourceProviderTest, NoResourceDetectorsConfiguredAttributesDisabled) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    set_telemetry_sdk_resource_attributes: false
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), false);
+
+  // Verify that telemetry SDK attributes are NOT present
+  EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.language") == resource.attributes_.end());
+  EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.name") == resource.attributes_.end());
+  EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.version") == resource.attributes_.end());
 }
 
 // Verifies it is possible to configure multiple resource detectors
@@ -147,9 +171,9 @@ TEST_F(ResourceProviderTest, MultipleResourceDetectorsConfigured) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   EXPECT_EQ(resource.schema_url_, "");
 
@@ -184,7 +208,8 @@ TEST_F(ResourceProviderTest, UnknownResourceDetectors) {
   ResourceProviderImpl resource_provider;
   EXPECT_THROW_WITH_MESSAGE(
       resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name()),
+                                    server_factory_context_, opentelemetry_config.service_name(),
+                                    true),
       EnvoyException,
       "Resource detector factory not found: "
       "'envoy.tracers.opentelemetry.resource_detectors.UnkownResourceDetector'");
@@ -214,9 +239,9 @@ TEST_F(ResourceProviderTest, ProblemCreatingResourceDetector) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  EXPECT_THROW_WITH_MESSAGE(resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                          server_factory_context_,
-                                                          opentelemetry_config.service_name()),
+  EXPECT_THROW_WITH_MESSAGE(resource_provider.getResource(
+                                opentelemetry_config.resource_detectors(), server_factory_context_,
+                                opentelemetry_config.service_name(), true),
                             EnvoyException,
                             "Resource detector could not be created: "
                             "'envoy.tracers.opentelemetry.resource_detectors.a'");
@@ -266,9 +291,9 @@ TEST_F(ResourceProviderTest, OldSchemaEmptyUpdatingSet) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   // OTel spec says the updating schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
@@ -318,9 +343,9 @@ TEST_F(ResourceProviderTest, OldSchemaSetUpdatingEmpty) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   // OTel spec says the updating schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
@@ -370,9 +395,9 @@ TEST_F(ResourceProviderTest, OldAndUpdatingSchemaAreEqual) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
 }
@@ -421,9 +446,9 @@ TEST_F(ResourceProviderTest, OldAndUpdatingSchemaAreDifferent) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource =
-      resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                    server_factory_context_, opentelemetry_config.service_name());
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), true);
 
   // OTel spec says Old schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);


### PR DESCRIPTION
Commit Message: otel: add option to disable telemetry SDK resource attributes

Additional Description:

Currently, the OpenTelemetry tracer always populates telemetry SDK attributes (`telemetry.sdk.language`, `telemetry.sdk.name`, `telemetry.sdk.version`). 

We have a customer-facing user interface for viewing traces and we don't want to leak internal Envoy details of our product. 

This PR introduces a new configuration option `set_telemetry_sdk_resource_attributes` (default true) in `OpenTelemetryConfig` to allow opting-out of populating these attributes. When set to false, the attributes listed above will be omitted from the resource spans.

The new behavior (omitting attributes) is default off to preserve backward compatibility.

Risk Level: Low

Testing: 
- Unit tests in test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc have been updated and a new test added to validate that attributes are omitted when disabled.
- Unit tests in test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc have been updated to verify the configuration flag is passed correctly.

Docs Changes: None.
Release Notes: Added a configuration option to disable populating telemetry SDK attributes in the OpenTelemetry tracer.
Platform Specific Features: None.
Runtime guard: None.

[Disclosed usage of generative AI: Yes, used to assist in code modifications.]