### PR TITLE
Make character tables more readable

### DIFF
--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -82,6 +82,9 @@ envoy_cc_library(
 envoy_cc_library(
     name = "character_set_validation_lib",
     hdrs = ["character_set_validation.h"],
+    deps = [
+        "@abseil-cpp//absl/strings:string_view",
+    ],
 )
 
 envoy_cc_library(

--- a/source/common/http/character_set_validation.h
+++ b/source/common/http/character_set_validation.h
@@ -29,26 +29,6 @@ struct CharTable {
     }
     return {table};
   }
-  static inline constexpr CharTable uppercase() {
-    // Bits 65 (A) to 90 (Z)
-    return {{0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0, 0}};
-  }
-  static inline constexpr CharTable lowercase() {
-    // Bits 97 (a) to 122 (z)
-    return {{0, 0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0}};
-  }
-  static inline constexpr CharTable printable() {
-    // Bits 33 (!) to 127 (~).
-    return {{0, 0x7fffffff, 0xffffffff, 0xfffffffe, 0, 0, 0, 0}};
-  }
-  static inline constexpr CharTable extendedAscii() {
-    // Bits 129 to 255.
-    return {{0, 0, 0, 0, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}};
-  }
-  static inline constexpr CharTable digits() {
-    // Bits 48 ('0') to 57 ('9')
-    return {{0, 0b00000000000000001111111111000000, 0, 0, 0, 0, 0, 0}};
-  }
   constexpr CharTable operator|(const CharTable& o) const {
     std::array<uint32_t, 8> table;
     for (int i = 0; i < 8; i++) {
@@ -70,9 +50,24 @@ struct CharTable {
     }
     return {table};
   }
-  static inline constexpr CharTable alphanumeric() { return uppercase() | lowercase() | digits(); }
 };
 
+namespace CharTables {
+// Bits 65 (A) to 90 (Z)
+static inline constexpr CharTable kUppercase{
+    {0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0, 0}};
+// Bits 97 (a) to 122 (z)
+static inline constexpr CharTable kLowercase{
+    {0, 0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0}};
+// Bits 33 (!) to 127 (~).
+static inline constexpr CharTable kPrintable{{0, 0x7fffffff, 0xffffffff, 0xfffffffe, 0, 0, 0, 0}};
+// Bits 129 to 255.
+static inline constexpr CharTable kExtendedAscii{
+    {0, 0, 0, 0, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}};
+// Bits 48 ('0') to 57 ('9')
+static inline constexpr CharTable kDigits{
+    {0, 0b00000000000000001111111111000000, 0, 0, 0, 0, 0, 0}};
+static inline constexpr CharTable kAlphanumeric = kUppercase | kLowercase | kDigits;
 // Header name character table.
 // From RFC 9110, https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1:
 //
@@ -85,8 +80,8 @@ struct CharTable {
 //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
 //                / DIGIT / ALPHA
 // SPELLCHECKER(on)
-inline constexpr CharTable kGenericHeaderNameCharTable =
-    CharTable::alphanumeric() | CharTable::fromChars("!#$%&'*+-.^_`|~");
+inline constexpr CharTable kGenericHeaderName =
+    kAlphanumeric | CharTable::fromChars("!#$%&'*+-.^_`|~");
 
 // A URI query and fragment character table. From RFC 3986:
 // https://datatracker.ietf.org/doc/html/rfc3986#section-3.4
@@ -100,12 +95,13 @@ inline constexpr CharTable kGenericHeaderNameCharTable =
 // pct-encoded   = "%" HEXDIG HEXDIG
 // sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 // SPELLCHECKER(on)
-inline constexpr CharTable kUriQueryAndFragmentCharTable =
-    CharTable::alphanumeric() | CharTable::fromChars("/?"
-                                                     ":@"
-                                                     "-._~"
-                                                     "%"
-                                                     "!$&'()*+,;=");
+inline constexpr CharTable kUriQueryAndFragment =
+    kAlphanumeric | CharTable::fromChars("/?"
+                                         ":@"
+                                         "-._~"
+                                         "%"
+                                         "!$&'()*+,;=");
+} // namespace CharTables
 
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/character_set_validation.h
+++ b/source/common/http/character_set_validation.h
@@ -3,23 +3,75 @@
 #include <array>
 #include <cstdint>
 
+#include "absl/strings/string_view.h"
+
 // A set of tables for validating that a character is in a specific
 // character set. Used to validate RFC compliance for various HTTP protocol elements.
 
 namespace Envoy {
 namespace Http {
 
-inline constexpr bool testCharInTable(const std::array<uint32_t, 8>& table, char c) {
-  // CPU cache friendly version of a lookup in a bit table of size 256.
-  // The table is organized as 8 32 bit words.
-  // This function looks up a bit from the `table` at the index `c`.
-  // This function is used to test whether a character `c` is allowed
-  // or not based on the value of a bit at index `c`.
-  uint8_t tmp = static_cast<uint8_t>(c);
-  // The `tmp >> 5` determines which of the 8 uint32_t words has the bit at index `uc`.
-  // The `0x80000000 >> (tmp & 0x1f)` determines the index of the bit within the 32 bit word.
-  return (table[tmp >> 5] & (0x80000000 >> (tmp & 0x1f))) != 0;
-}
+struct CharTable {
+  const std::array<uint32_t, 8> table_;
+
+  static inline constexpr uint32_t row(char c) { return static_cast<uint8_t>(c) >> 5; }
+  static inline constexpr uint32_t mask(char c) {
+    return 0x80000000 >> (static_cast<uint8_t>(c) & 0x1f);
+  }
+  inline constexpr bool hasChar(char c) const { return (table_[row(c)] & mask(c)) != 0; }
+  inline static constexpr void set(std::array<uint32_t, 8>& table, char c) {
+    table[row(c)] |= mask(c);
+  }
+  static inline constexpr CharTable fromChars(absl::string_view chars) {
+    std::array<uint32_t, 8> table{};
+    for (char c : chars) {
+      set(table, c);
+    }
+    return {table};
+  }
+  static inline constexpr CharTable uppercase() {
+    // Bits 65 (A) to 90 (Z)
+    return {{0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0, 0}};
+  }
+  static inline constexpr CharTable lowercase() {
+    // Bits 97 (a) to 122 (z)
+    return {{0, 0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0}};
+  }
+  static inline constexpr CharTable printable() {
+    // Bits 33 (!) to 127 (~).
+    return {{0, 0x7fffffff, 0xffffffff, 0xfffffffe, 0, 0, 0, 0}};
+  }
+  static inline constexpr CharTable extendedAscii() {
+    // Bits 129 to 255.
+    return {{0, 0, 0, 0, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}};
+  }
+  static inline constexpr CharTable digits() {
+    // Bits 48 ('0') to 57 ('9')
+    return {{0, 0b00000000000000001111111111000000, 0, 0, 0, 0, 0, 0}};
+  }
+  constexpr CharTable operator|(const CharTable& o) const {
+    std::array<uint32_t, 8> table;
+    for (int i = 0; i < 8; i++) {
+      table[i] = table_[i] | o.table_[i];
+    }
+    return {table};
+  }
+  constexpr CharTable operator&(const CharTable& o) const {
+    std::array<uint32_t, 8> table;
+    for (int i = 0; i < 8; i++) {
+      table[i] = table_[i] & o.table_[i];
+    }
+    return {table};
+  }
+  constexpr CharTable operator~() const {
+    std::array<uint32_t, 8> table;
+    for (int i = 0; i < 8; i++) {
+      table[i] = ~table_[i];
+    }
+    return {table};
+  }
+  static inline constexpr CharTable alphanumeric() { return uppercase() | lowercase() | digits(); }
+};
 
 // Header name character table.
 // From RFC 9110, https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1:
@@ -33,21 +85,8 @@ inline constexpr bool testCharInTable(const std::array<uint32_t, 8>& table, char
 //                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
 //                / DIGIT / ALPHA
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kGenericHeaderNameCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01011111001101101111111111000000,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111111111111111111111111100011,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b11111111111111111111111111101010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr CharTable kGenericHeaderNameCharTable =
+    CharTable::alphanumeric() | CharTable::fromChars("!#$%&'*+-.^_`|~");
 
 // A URI query and fragment character table. From RFC 3986:
 // https://datatracker.ietf.org/doc/html/rfc3986#section-3.4
@@ -55,22 +94,18 @@ inline constexpr std::array<uint32_t, 8> kGenericHeaderNameCharTable = {
 // SPELLCHECKER(off)
 // query       = *( pchar / "/" / "?" )
 // fragment    = *( pchar / "/" / "?" )
+//
+// pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+// unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+// pct-encoded   = "%" HEXDIG HEXDIG
+// sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kUriQueryAndFragmentCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01001111111111111111111111110101,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b11111111111111111111111111100001,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b01111111111111111111111111100010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr CharTable kUriQueryAndFragmentCharTable =
+    CharTable::alphanumeric() | CharTable::fromChars("/?"
+                                                     ":@"
+                                                     "-._~"
+                                                     "%"
+                                                     "!$&'()*+,;=");
 
 } // namespace Http
 } // namespace Envoy

--- a/source/common/http/character_set_validation.h
+++ b/source/common/http/character_set_validation.h
@@ -12,17 +12,13 @@ namespace Envoy {
 namespace Http {
 
 struct CharTable {
-  const std::array<uint32_t, 8> table_;
+  const std::array<uint32_t, 8> table;
 
-  static inline constexpr uint32_t row(char c) { return static_cast<uint8_t>(c) >> 5; }
-  static inline constexpr uint32_t mask(char c) {
-    return 0x80000000 >> (static_cast<uint8_t>(c) & 0x1f);
-  }
-  inline constexpr bool hasChar(char c) const { return (table_[row(c)] & mask(c)) != 0; }
-  inline static constexpr void set(std::array<uint32_t, 8>& table, char c) {
-    table[row(c)] |= mask(c);
-  }
-  static inline constexpr CharTable fromChars(absl::string_view chars) {
+  static constexpr uint32_t row(char c) { return static_cast<uint8_t>(c) >> 5; }
+  static constexpr uint32_t mask(char c) { return 0x80000000 >> (static_cast<uint8_t>(c) & 0x1f); }
+  constexpr bool hasChar(char c) const { return (table[row(c)] & mask(c)) != 0; }
+  static constexpr void set(std::array<uint32_t, 8>& table, char c) { table[row(c)] |= mask(c); }
+  static constexpr CharTable fromChars(absl::string_view chars) {
     std::array<uint32_t, 8> table{};
     for (char c : chars) {
       set(table, c);
@@ -30,44 +26,41 @@ struct CharTable {
     return {table};
   }
   constexpr CharTable operator|(const CharTable& o) const {
-    std::array<uint32_t, 8> table;
+    std::array<uint32_t, 8> result;
     for (int i = 0; i < 8; i++) {
-      table[i] = table_[i] | o.table_[i];
+      result[i] = table[i] | o.table[i];
     }
-    return {table};
+    return {result};
   }
   constexpr CharTable operator&(const CharTable& o) const {
-    std::array<uint32_t, 8> table;
+    std::array<uint32_t, 8> result;
     for (int i = 0; i < 8; i++) {
-      table[i] = table_[i] & o.table_[i];
+      result[i] = table[i] & o.table[i];
     }
-    return {table};
+    return {result};
   }
   constexpr CharTable operator~() const {
-    std::array<uint32_t, 8> table;
+    std::array<uint32_t, 8> result;
     for (int i = 0; i < 8; i++) {
-      table[i] = ~table_[i];
+      result[i] = ~table[i];
     }
-    return {table};
+    return {result};
   }
 };
 
 namespace CharTables {
 // Bits 65 (A) to 90 (Z)
-static inline constexpr CharTable kUppercase{
-    {0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0, 0}};
+inline constexpr CharTable kUppercase{{0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0, 0}};
 // Bits 97 (a) to 122 (z)
-static inline constexpr CharTable kLowercase{
-    {0, 0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0}};
+inline constexpr CharTable kLowercase{{0, 0, 0, 0b01111111111111111111111111100000, 0, 0, 0, 0}};
 // Bits 33 (!) to 127 (~).
-static inline constexpr CharTable kPrintable{{0, 0x7fffffff, 0xffffffff, 0xfffffffe, 0, 0, 0, 0}};
+inline constexpr CharTable kPrintable{{0, 0x7fffffff, 0xffffffff, 0xfffffffe, 0, 0, 0, 0}};
 // Bits 129 to 255.
-static inline constexpr CharTable kExtendedAscii{
+inline constexpr CharTable kExtendedAscii{
     {0, 0, 0, 0, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}};
 // Bits 48 ('0') to 57 ('9')
-static inline constexpr CharTable kDigits{
-    {0, 0b00000000000000001111111111000000, 0, 0, 0, 0, 0, 0}};
-static inline constexpr CharTable kAlphanumeric = kUppercase | kLowercase | kDigits;
+inline constexpr CharTable kDigits{{0, 0b00000000000000001111111111000000, 0, 0, 0, 0, 0, 0}};
+inline constexpr CharTable kAlphanumeric = kUppercase | kLowercase | kDigits;
 // Header name character table.
 // From RFC 9110, https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1:
 //

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -144,7 +144,7 @@ bool HeaderUtility::headerNameIsValid(absl::string_view header_key) {
   // TODO(yanavlasov): make validation in HTTP/2 case stricter.
   bool is_valid = true;
   for (auto iter = header_key.begin(); iter != header_key.end() && is_valid; ++iter) {
-    is_valid &= testCharInTable(kGenericHeaderNameCharTable, *iter);
+    is_valid &= kGenericHeaderNameCharTable.hasChar(*iter);
   }
   return is_valid;
 }

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -144,7 +144,7 @@ bool HeaderUtility::headerNameIsValid(absl::string_view header_key) {
   // TODO(yanavlasov): make validation in HTTP/2 case stricter.
   bool is_valid = true;
   for (auto iter = header_key.begin(); iter != header_key.end() && is_valid; ++iter) {
-    is_valid &= kGenericHeaderNameCharTable.hasChar(*iter);
+    is_valid &= CharTables::kGenericHeaderName.hasChar(*iter);
   }
   return is_valid;
 }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1325,12 +1325,12 @@ namespace {
 // ALPHA | DIGIT | * | - | . | _
 // SPACE is encoded as %20, NOT as the + character
 constexpr CharTable kUrlEncodedCharTable =
-    ~(CharTable::alphanumeric() | CharTable::fromChars("*-._"));
+    ~(CharTables::kAlphanumeric | CharTable::fromChars("*-._"));
 
 // The set of characters which, if they are percent-encoded, should be
 // decoded.
 constexpr CharTable kUrlDecodedCharTable =
-    CharTable::alphanumeric() | CharTable::fromChars("!#$%&'()*+,-./:;=?@[]_`~");
+    CharTables::kAlphanumeric | CharTable::fromChars("!#$%&'()*+,-./:;=?@[]_`~");
 
 constexpr bool shouldPercentEncodeChar(char c) { return kUrlEncodedCharTable.hasChar(c); }
 
@@ -1647,7 +1647,7 @@ bool Utility::isValidRefererValue(absl::string_view value) {
       seen_slash = true;
       continue;
     default:
-      if (!kUriQueryAndFragmentCharTable.hasChar(c)) {
+      if (!CharTables::kUriQueryAndFragment.hasChar(c)) {
         return false;
       }
     }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1324,41 +1324,17 @@ namespace {
 // %-encode all ASCII character codepoints, EXCEPT:
 // ALPHA | DIGIT | * | - | . | _
 // SPACE is encoded as %20, NOT as the + character
-constexpr std::array<uint32_t, 8> kUrlEncodedCharTable = {
-    // control characters
-    0b11111111111111111111111111111111,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b11111111110110010000000000111111,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b10000000000000000000000000011110,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b10000000000000000000000000011111,
-    // extended ascii
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-};
+constexpr CharTable kUrlEncodedCharTable =
+    ~(CharTable::alphanumeric() | CharTable::fromChars("*-._"));
 
-constexpr std::array<uint32_t, 8> kUrlDecodedCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01011111111111111111111111110101,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b11111111111111111111111111110101,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b11111111111111111111111111100010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+// The set of characters which, if they are percent-encoded, should be
+// decoded.
+constexpr CharTable kUrlDecodedCharTable =
+    CharTable::alphanumeric() | CharTable::fromChars("!#$%&'()*+,-./:;=?@[]_`~");
 
-bool shouldPercentEncodeChar(char c) { return testCharInTable(kUrlEncodedCharTable, c); }
+constexpr bool shouldPercentEncodeChar(char c) { return kUrlEncodedCharTable.hasChar(c); }
 
-bool shouldPercentDecodeChar(char c) { return testCharInTable(kUrlDecodedCharTable, c); }
+constexpr bool shouldPercentDecodeChar(char c) { return kUrlDecodedCharTable.hasChar(c); }
 } // namespace
 
 std::string Utility::PercentEncoding::urlEncode(absl::string_view value) {
@@ -1671,7 +1647,7 @@ bool Utility::isValidRefererValue(absl::string_view value) {
       seen_slash = true;
       continue;
     default:
-      if (!testCharInTable(kUriQueryAndFragmentCharTable, c)) {
+      if (!kUriQueryAndFragmentCharTable.hasChar(c)) {
         return false;
       }
     }

--- a/source/extensions/http/header_validators/envoy_default/character_tables.h
+++ b/source/extensions/http/header_validators/envoy_default/character_tables.h
@@ -25,7 +25,7 @@ namespace EnvoyDefault {
 //                   ; visible (printing) characters
 // SPELLCHECKER(on)
 inline constexpr ::Envoy::Http::CharTable kGenericHeaderValueCharTable =
-    ::Envoy::Http::CharTable::printable() | ::Envoy::Http::CharTable::extendedAscii() |
+    ::Envoy::Http::CharTables::kPrintable | ::Envoy::Http::CharTables::kExtendedAscii |
     ::Envoy::Http::CharTable::fromChars("\t ");
 
 // :method header character table.
@@ -38,7 +38,7 @@ inline constexpr ::Envoy::Http::CharTable kGenericHeaderValueCharTable =
 //        /  "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 // SPELLCHECKER(on)
 inline constexpr ::Envoy::Http::CharTable kMethodHeaderCharTable =
-    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTables::kAlphanumeric |
     ::Envoy::Http::CharTable::fromChars("!#$%&'*+-.^_`|~");
 
 // :path header character table.
@@ -65,7 +65,7 @@ inline constexpr ::Envoy::Http::CharTable kMethodHeaderCharTable =
 // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
 // SPELLCHECKER(on)
 inline constexpr ::Envoy::Http::CharTable kPathHeaderCharTable =
-    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTables::kAlphanumeric |
     ::Envoy::Http::CharTable::fromChars("!$%&'()*+,-./:;=@_~");
 
 // Unreserved characters.
@@ -73,7 +73,7 @@ inline constexpr ::Envoy::Http::CharTable kPathHeaderCharTable =
 //
 // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 inline constexpr ::Envoy::Http::CharTable kUnreservedCharTable =
-    ::Envoy::Http::CharTable::alphanumeric() | ::Envoy::Http::CharTable::fromChars("-._~");
+    ::Envoy::Http::CharTables::kAlphanumeric | ::Envoy::Http::CharTable::fromChars("-._~");
 
 // Transfer-Encoding HTTP/1.1 header character table.
 // From RFC 9110: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4
@@ -84,7 +84,7 @@ inline constexpr ::Envoy::Http::CharTable kUnreservedCharTable =
 // transfer-parameter  = token BWS "=" BWS ( token / quoted-string )
 // SPELLCHECKER(on)
 inline constexpr ::Envoy::Http::CharTable kTransferEncodingHeaderCharTable =
-    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTables::kAlphanumeric |
     ::Envoy::Http::CharTable::fromChars("\t !\"#$%&'*+,-.;=^_`|~");
 
 // An IPv6 address, excluding the surrounding "[" and "]" characters. This is based on RFC 3986,
@@ -100,7 +100,7 @@ inline constexpr ::Envoy::Http::CharTable kHostIPv6AddressCharTable =
 // reg-name    = *( unreserved / pct-encoded / sub-delims )
 // SPELLCHECKER(on)
 inline constexpr ::Envoy::Http::CharTable kHostRegNameCharTable =
-    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTables::kAlphanumeric |
     ::Envoy::Http::CharTable::fromChars("!$%&'()*+,-.;=_~");
 
 } // namespace EnvoyDefault

--- a/source/extensions/http/header_validators/envoy_default/character_tables.h
+++ b/source/extensions/http/header_validators/envoy_default/character_tables.h
@@ -24,21 +24,9 @@ namespace EnvoyDefault {
 // VCHAR          =  %x21-7E
 //                   ; visible (printing) characters
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kGenericHeaderValueCharTable = {
-    // control characters
-    0b00000000010000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b11111111111111111111111111111111,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b11111111111111111111111111111111,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b11111111111111111111111111111110,
-    // extended ascii
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-    0b11111111111111111111111111111111,
-};
+inline constexpr ::Envoy::Http::CharTable kGenericHeaderValueCharTable =
+    ::Envoy::Http::CharTable::printable() | ::Envoy::Http::CharTable::extendedAscii() |
+    ::Envoy::Http::CharTable::fromChars("\t ");
 
 // :method header character table.
 // From RFC 9110: https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1
@@ -49,21 +37,9 @@ inline constexpr std::array<uint32_t, 8> kGenericHeaderValueCharTable = {
 // tchar  = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "."
 //        /  "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kMethodHeaderCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01011111001101101111111111000000,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111111111111111111111111100011,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b11111111111111111111111111101010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kMethodHeaderCharTable =
+    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTable::fromChars("!#$%&'*+-.^_`|~");
 
 // :path header character table.
 // From RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986#section-3.3
@@ -88,41 +64,16 @@ inline constexpr std::array<uint32_t, 8> kMethodHeaderCharTable = {
 //
 // pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kPathHeaderCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01001111111111111111111111110100,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b11111111111111111111111111100001,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b01111111111111111111111111100010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kPathHeaderCharTable =
+    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTable::fromChars("!$%&'()*+,-./:;=@_~");
 
 // Unreserved characters.
 // From RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
 //
 // unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
-inline constexpr std::array<uint32_t, 8> kUnreservedCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b00000000000001101111111111000000,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111111111111111111111111100001,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b01111111111111111111111111100010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kUnreservedCharTable =
+    ::Envoy::Http::CharTable::alphanumeric() | ::Envoy::Http::CharTable::fromChars("-._~");
 
 // Transfer-Encoding HTTP/1.1 header character table.
 // From RFC 9110: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.4
@@ -132,40 +83,15 @@ inline constexpr std::array<uint32_t, 8> kUnreservedCharTable = {
 // transfer-coding     = token *( OWS ";" OWS transfer-parameter )
 // transfer-parameter  = token BWS "=" BWS ( token / quoted-string )
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kTransferEncodingHeaderCharTable = {
-    // control characters
-    0b00000000010000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b11111111001111101111111111010100,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111111111111111111111111100011,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b11111111111111111111111111101010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kTransferEncodingHeaderCharTable =
+    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTable::fromChars("\t !\"#$%&'*+,-.;=^_`|~");
 
 // An IPv6 address, excluding the surrounding "[" and "]" characters. This is based on RFC 3986,
 // https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2, that only allows hex digits and the
 // ":" separator.
-inline constexpr std::array<uint32_t, 8> kHostIPv6AddressCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b00000000000000001111111111100000,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111110000000000000000000000000,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b01111110000000000000000000000000,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kHostIPv6AddressCharTable =
+    ::Envoy::Http::CharTable::fromChars("0123456789:ABCDEFabcdef");
 
 // A host reg-name character table, which covers both IPv4 addresses and hostnames.
 // From RFC 3986: https://www.rfc-editor.org/rfc/rfc3986.html#section-3.2.2
@@ -173,21 +99,9 @@ inline constexpr std::array<uint32_t, 8> kHostIPv6AddressCharTable = {
 // SPELLCHECKER(off)
 // reg-name    = *( unreserved / pct-encoded / sub-delims )
 // SPELLCHECKER(on)
-inline constexpr std::array<uint32_t, 8> kHostRegNameCharTable = {
-    // control characters
-    0b00000000000000000000000000000000,
-    // !"#$%&'()*+,-./0123456789:;<=>?
-    0b01001111111111101111111111010100,
-    //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-    0b01111111111111111111111111100001,
-    //`abcdefghijklmnopqrstuvwxyz{|}~
-    0b01111111111111111111111111100010,
-    // extended ascii
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-    0b00000000000000000000000000000000,
-};
+inline constexpr ::Envoy::Http::CharTable kHostRegNameCharTable =
+    ::Envoy::Http::CharTable::alphanumeric() |
+    ::Envoy::Http::CharTable::fromChars("!$%&'()*+,-.;=_~");
 
 } // namespace EnvoyDefault
 } // namespace HeaderValidators

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -199,7 +199,7 @@ HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
        iter != key_string_view.end() && is_valid && !reject_due_to_underscore; ++iter) {
     c = *iter;
     if (c != '_') {
-      is_valid &= ::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c);
+      is_valid &= ::Envoy::Http::CharTables::kGenericHeaderName.hasChar(c);
     } else {
       reject_due_to_underscore = reject_header_names_with_underscores;
     }
@@ -421,7 +421,7 @@ HeaderValidator::validateHostHeaderRegName(absl::string_view host) {
 HeaderValidator::HeaderValueValidationResult
 HeaderValidator::validatePathHeaderCharacters(const HeaderString& value) {
   return validatePathHeaderCharacterSet(value, kPathHeaderCharTable,
-                                        ::Envoy::Http::kUriQueryAndFragmentCharTable);
+                                        ::Envoy::Http::CharTables::kUriQueryAndFragment);
 }
 
 HeaderValidator::HeaderValueValidationResult HeaderValidator::validatePathHeaderCharacterSet(
@@ -487,7 +487,7 @@ void HeaderValidator::encodeAdditionalCharactersInPath(
 
     ::Envoy::Http::RequestHeaderMap& header_map) {
   static constexpr ::Envoy::Http::CharTable kCharactersToEncode =
-      ::Envoy::Http::CharTable::extendedAscii() |
+      ::Envoy::Http::CharTables::kExtendedAscii |
       ::Envoy::Http::CharTable::fromChars("\"<>^`{}|\t ");
 
   absl::string_view path = header_map.getPathValue();

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -6,7 +6,6 @@
 
 #include "source/common/http/path_utility.h"
 #include "source/common/runtime/runtime_features.h"
-#include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 
 #include "absl/container/node_hash_set.h"
 #include "absl/strings/match.h"
@@ -29,7 +28,6 @@ using ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderVal
 using ::Envoy::Http::HeaderString;
 using ::Envoy::Http::PathUtil;
 using ::Envoy::Http::Protocol;
-using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 HeaderValidator::HeaderValidator(const HeaderValidatorConfig& config, Protocol protocol,
@@ -101,7 +99,7 @@ HeaderValidator::validateMethodHeader(const HeaderString& value) {
   } else {
     is_valid = !method.empty();
     for (auto iter = method.begin(); iter != method.end() && is_valid; ++iter) {
-      is_valid &= testCharInTable(kMethodHeaderCharTable, *iter);
+      is_valid &= kMethodHeaderCharTable.hasChar(*iter);
     }
   }
 
@@ -201,7 +199,7 @@ HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
        iter != key_string_view.end() && is_valid && !reject_due_to_underscore; ++iter) {
     c = *iter;
     if (c != '_') {
-      is_valid &= testCharInTable(::Envoy::Http::kGenericHeaderNameCharTable, c);
+      is_valid &= ::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c);
     } else {
       reject_due_to_underscore = reject_header_names_with_underscores;
     }
@@ -240,7 +238,7 @@ HeaderValidator::validateGenericHeaderValue(const HeaderString& value) {
   bool is_valid = true;
 
   for (auto iter = value_string_view.begin(); iter != value_string_view.end() && is_valid; ++iter) {
-    is_valid &= testCharInTable(kGenericHeaderValueCharTable, *iter);
+    is_valid &= kGenericHeaderValueCharTable.hasChar(*iter);
   }
 
   if (!is_valid) {
@@ -375,7 +373,7 @@ HeaderValidator::validateHostHeaderIPv6(absl::string_view host) {
     }
     // Validate each char is hex digit
     for (char c : cur_component) {
-      if (!testCharInTable(kHostIPv6AddressCharTable, c)) {
+      if (!kHostIPv6AddressCharTable.hasChar(c)) {
         return HostHeaderValidationResult::reject(UhvResponseCodeDetail::get().InvalidHost);
       }
     }
@@ -408,7 +406,7 @@ HeaderValidator::validateHostHeaderRegName(absl::string_view host) {
 
   // Validate the reg-name characters
   for (auto iter = address.begin(); iter != address.end() && is_valid; ++iter) {
-    is_valid &= testCharInTable(kHostRegNameCharTable, *iter);
+    is_valid &= kHostRegNameCharTable.hasChar(*iter);
   }
 
   if (!is_valid) {
@@ -427,8 +425,8 @@ HeaderValidator::validatePathHeaderCharacters(const HeaderString& value) {
 }
 
 HeaderValidator::HeaderValueValidationResult HeaderValidator::validatePathHeaderCharacterSet(
-    const HeaderString& value, const std::array<uint32_t, 8>& allowed_path_chracters,
-    const std::array<uint32_t, 8>& allowed_query_fragment_characters) {
+    const HeaderString& value, const ::Envoy::Http::CharTable& allowed_path_characters,
+    const ::Envoy::Http::CharTable& allowed_query_fragment_characters) {
   static const HeaderValueValidationResult bad_path_result{
       HeaderValueValidationResult::Action::Reject, UhvResponseCodeDetail::get().InvalidUrl};
   const auto& path = value.getStringView();
@@ -447,7 +445,7 @@ HeaderValidator::HeaderValueValidationResult HeaderValidator::validatePathHeader
       break;
     }
 
-    if (!testCharInTable(allowed_path_chracters, *iter)) {
+    if (!allowed_path_characters.hasChar(*iter)) {
       return bad_path_result;
     }
   }
@@ -460,7 +458,7 @@ HeaderValidator::HeaderValueValidationResult HeaderValidator::validatePathHeader
         break;
       }
 
-      if (!testCharInTable(allowed_query_fragment_characters, *iter)) {
+      if (!allowed_query_fragment_characters.hasChar(*iter)) {
         return bad_path_result;
       }
     }
@@ -475,7 +473,7 @@ HeaderValidator::HeaderValueValidationResult HeaderValidator::validatePathHeader
     // Validate the fragment component of the URI
     ++iter;
     for (; iter != end; ++iter) {
-      if (!testCharInTable(allowed_query_fragment_characters, *iter)) {
+      if (!allowed_query_fragment_characters.hasChar(*iter)) {
         return bad_path_result;
       }
     }
@@ -488,27 +486,14 @@ void HeaderValidator::encodeAdditionalCharactersInPath(
     // TODO(#28780): reuse Utility::PercentEncoding class for this code.
 
     ::Envoy::Http::RequestHeaderMap& header_map) {
-  // " < > ^ ` { } | TAB space extended-ASCII
-  static constexpr std::array<uint32_t, 8> kCharactersToEncode = {
-      // control characters
-      0b00000000010000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b10100000000000000000000000001010,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b00000000000000000000000000000010,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b10000000000000000000000000011100,
-      // extended ascii
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-  };
+  static constexpr ::Envoy::Http::CharTable kCharactersToEncode =
+      ::Envoy::Http::CharTable::extendedAscii() |
+      ::Envoy::Http::CharTable::fromChars("\"<>^`{}|\t ");
 
   absl::string_view path = header_map.getPathValue();
   // Check if URL path contains any characters in the kCharactersToEncode set
   auto char_to_encode = path.begin();
-  for (; char_to_encode != path.end() && !testCharInTable(kCharactersToEncode, *char_to_encode);
+  for (; char_to_encode != path.end() && !kCharactersToEncode.hasChar(*char_to_encode);
        ++char_to_encode) {
     // Return early if we got to query or fragment without finding any characters that has to be
     // encoded.
@@ -526,7 +511,7 @@ void HeaderValidator::encodeAdditionalCharactersInPath(
     if (*char_to_encode == '?' || *char_to_encode == '#') {
       break;
     }
-    if (testCharInTable(kCharactersToEncode, *char_to_encode)) {
+    if (kCharactersToEncode.hasChar(*char_to_encode)) {
       absl::StrAppend(&encoded_path,
                       fmt::format("%{:02X}", static_cast<const unsigned char&>(*char_to_encode)));
     } else {

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -6,6 +6,7 @@
 #include "envoy/http/header_validator.h"
 
 #include "source/common/http/headers.h"
+#include "source/extensions/http/header_validators/envoy_default/character_tables.h"
 #include "source/extensions/http/header_validators/envoy_default/config_overrides.h"
 #include "source/extensions/http/header_validators/envoy_default/path_normalizer.h"
 
@@ -170,8 +171,8 @@ protected:
    */
   HeaderValueValidationResult
   validatePathHeaderCharacterSet(const ::Envoy::Http::HeaderString& value,
-                                 const std::array<uint32_t, 8>& allowed_path_chracters,
-                                 const std::array<uint32_t, 8>& allowed_query_fragment_characters);
+                                 const ::Envoy::Http::CharTable& allowed_path_chracters,
+                                 const ::Envoy::Http::CharTable& allowed_query_fragment_characters);
 
   // URL-encode additional characters in URL path. This method is called iff
   // `envoy.uhv.allow_non_compliant_characters_in_path` is true.

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -65,14 +65,14 @@ Http1HeaderValidator::validatePathHeaderWithAdditionalCharacters(
   // runtime value is set to "true".
   // This is the same as all printable characters except ? and #
   static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
-      ::Envoy::Http::CharTable::printable() & ~::Envoy::Http::CharTable::fromChars("?#");
+      ::Envoy::Http::CharTables::kPrintable & ~::Envoy::Http::CharTable::fromChars("?#");
 
-  // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
+  // Same table as CharTables::kUriQueryAndFragment but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | # This table is used when the
   // "envoy.uhv.allow_non_compliant_characters_in_path" runtime value is set to "true".
   // This ends up being the same thing as all printable characters.
   static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
-      ::Envoy::Http::CharTable::printable();
+      ::Envoy::Http::CharTables::kPrintable;
 
   return HeaderValidator::validatePathHeaderCharacterSet(
       path_header_value, kPathHeaderCharTableWithAdditionalCharacters,

--- a/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http1_header_validator.cc
@@ -63,40 +63,17 @@ Http1HeaderValidator::validatePathHeaderWithAdditionalCharacters(
   // " < > [ ] ^ ` { } \ |
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kPathHeaderCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01101111111111111111111111111110,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-  };
+  // This is the same as all printable characters except ? and #
+  static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
+      ::Envoy::Http::CharTable::printable() & ~::Envoy::Http::CharTable::fromChars("?#");
 
   // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | # This table is used when the
   // "envoy.uhv.allow_non_compliant_characters_in_path" runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kQueryAndFragmentCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01111111111111111111111111111111,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-  };
+  // This ends up being the same thing as all printable characters.
+  static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
+      ::Envoy::Http::CharTable::printable();
+
   return HeaderValidator::validatePathHeaderCharacterSet(
       path_header_value, kPathHeaderCharTableWithAdditionalCharacters,
       kQueryAndFragmentCharTableWithAdditionalCharacters);

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -119,14 +119,14 @@ Http2HeaderValidator::validatePathHeaderWithAdditionalCharactersHttp2(
   // runtime value is set to "true".
   static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
       kPathHeaderCharTable | ::Envoy::Http::CharTable::fromChars("\"<>[]^`{}\\|") |
-      ::Envoy::Http::CharTable::extendedAscii();
+      ::Envoy::Http::CharTables::kExtendedAscii;
 
-  // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
+  // Same table as  CharTables::kUriQueryAndFragment but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | # and all extended ASCII.
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
   static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
-      ::Envoy::Http::kUriQueryAndFragmentCharTable | ::Envoy::Http::CharTable::extendedAscii() |
+      ::Envoy::Http::CharTables::kUriQueryAndFragment | ::Envoy::Http::CharTables::kExtendedAscii |
       ::Envoy::Http::CharTable::fromChars("\"<>[]^`{}\\|#");
 
   return HeaderValidator::validatePathHeaderCharacterSet(
@@ -144,15 +144,15 @@ Http2HeaderValidator::validatePathHeaderWithAdditionalCharactersHttp3(
   // runtime value is set to "true".
   // This is the same as all printable characters except # and ?.
   static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
-      ::Envoy::Http::CharTable::printable() & ~::Envoy::Http::CharTable::fromChars("?#");
+      ::Envoy::Http::CharTables::kPrintable & ~::Envoy::Http::CharTable::fromChars("?#");
 
-  // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
+  // Same table as CharTables::kUriQueryAndFragment but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | #
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
   // This is the same as all printable chars.
   static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
-      ::Envoy::Http::CharTable::printable();
+      ::Envoy::Http::CharTables::kPrintable;
   return HeaderValidator::validatePathHeaderCharacterSet(
       path_header_value, kPathHeaderCharTableWithAdditionalCharacters,
       kQueryAndFragmentCharTableWithAdditionalCharacters);
@@ -440,7 +440,7 @@ Http2HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
        iter != key_string_view.end() && is_valid && !reject_due_to_underscore; ++iter) {
     c = *iter;
     if (c != '_') {
-      is_valid &= ::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z');
+      is_valid &= ::Envoy::Http::CharTables::kGenericHeaderName.hasChar(c) && (c < 'A' || c > 'Z');
     } else {
       reject_due_to_underscore = reject_header_names_with_underscores;
     }

--- a/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/http2_header_validator.cc
@@ -24,7 +24,6 @@ using ::envoy::extensions::http::header_validators::envoy_default::v3::HeaderVal
 using ::Envoy::Http::HeaderString;
 using ::Envoy::Http::HeaderUtility;
 using ::Envoy::Http::Protocol;
-using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
 using ValidationResult = ::Envoy::Http::HeaderValidator::ValidationResult;
 
@@ -118,41 +117,18 @@ Http2HeaderValidator::validatePathHeaderWithAdditionalCharactersHttp2(
   // " < > [ ] ^ ` { } \ | and all extended ASCII.
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kPathHeaderCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01101111111111111111111111111110,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-  };
+  static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
+      kPathHeaderCharTable | ::Envoy::Http::CharTable::fromChars("\"<>[]^`{}\\|") |
+      ::Envoy::Http::CharTable::extendedAscii();
 
   // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | # and all extended ASCII.
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kQueryAndFragmentCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01111111111111111111111111111111,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-      0b11111111111111111111111111111111,
-  };
+  static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
+      ::Envoy::Http::kUriQueryAndFragmentCharTable | ::Envoy::Http::CharTable::extendedAscii() |
+      ::Envoy::Http::CharTable::fromChars("\"<>[]^`{}\\|#");
+
   return HeaderValidator::validatePathHeaderCharacterSet(
       path_header_value, kPathHeaderCharTableWithAdditionalCharacters,
       kQueryAndFragmentCharTableWithAdditionalCharacters);
@@ -166,41 +142,17 @@ Http2HeaderValidator::validatePathHeaderWithAdditionalCharactersHttp3(
   // " < > [ ] ^ ` { } \ |
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kPathHeaderCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01101111111111111111111111111110,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-  };
+  // This is the same as all printable characters except # and ?.
+  static constexpr ::Envoy::Http::CharTable kPathHeaderCharTableWithAdditionalCharacters =
+      ::Envoy::Http::CharTable::printable() & ~::Envoy::Http::CharTable::fromChars("?#");
 
   // Same table as the kUriQueryAndFragmentCharTable but with the following additional character
   // allowed " < > [ ] ^ ` { } \ | #
   // This table is used when the "envoy.uhv.allow_non_compliant_characters_in_path"
   // runtime value is set to "true".
-  static constexpr std::array<uint32_t, 8> kQueryAndFragmentCharTableWithAdditionalCharacters = {
-      // control characters
-      0b00000000000000000000000000000000,
-      // !"#$%&'()*+,-./0123456789:;<=>?
-      0b01111111111111111111111111111111,
-      //@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
-      0b11111111111111111111111111111111,
-      //`abcdefghijklmnopqrstuvwxyz{|}~
-      0b11111111111111111111111111111110,
-      // extended ascii
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-      0b00000000000000000000000000000000,
-  };
+  // This is the same as all printable chars.
+  static constexpr ::Envoy::Http::CharTable kQueryAndFragmentCharTableWithAdditionalCharacters =
+      ::Envoy::Http::CharTable::printable();
   return HeaderValidator::validatePathHeaderCharacterSet(
       path_header_value, kPathHeaderCharTableWithAdditionalCharacters,
       kQueryAndFragmentCharTableWithAdditionalCharacters);
@@ -488,8 +440,7 @@ Http2HeaderValidator::validateGenericHeaderName(const HeaderString& name) {
        iter != key_string_view.end() && is_valid && !reject_due_to_underscore; ++iter) {
     c = *iter;
     if (c != '_') {
-      is_valid &=
-          testCharInTable(::Envoy::Http::kGenericHeaderNameCharTable, c) && (c < 'A' || c > 'Z');
+      is_valid &= ::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z');
     } else {
       reject_due_to_underscore = reject_header_names_with_underscores;
     }

--- a/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
+++ b/source/extensions/http/header_validators/envoy_default/path_normalizer.cc
@@ -21,7 +21,6 @@ using ::envoy::extensions::http::header_validators::envoy_default::v3::
 using ::Envoy::Http::HeaderUtility;
 using ::Envoy::Http::PathNormalizerResponseCodeDetail;
 using ::Envoy::Http::RequestHeaderMap;
-using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 PathNormalizer::PathNormalizer(const HeaderValidatorConfig& config,
@@ -83,7 +82,7 @@ PathNormalizer::normalizeAndDecodeOctet(std::string::iterator iter,
     ch += factor * (nibble >= 'A' ? (nibble - 'A' + 10) : (nibble - '0'));
   }
 
-  if (testCharInTable(kUnreservedCharTable, ch)) {
+  if (kUnreservedCharTable.hasChar(ch)) {
     // Based on RFC, only decode characters in the UNRESERVED set.
     return {PercentDecodeResult::Decoded, ch};
   }

--- a/test/common/http/character_set_validation_test.cc
+++ b/test/common/http/character_set_validation_test.cc
@@ -79,9 +79,7 @@ TEST(CharacterSetValidationTest, FromCharsInitializesCorrectly) {
 }
 
 // Primary template - selected if expression CAN be constexpr
-template <typename Lambda>
-constexpr auto is_constexpr_impl(Lambda lambda, int)
-    -> decltype((void)std::integral_constant<bool, (lambda(), true)>::value, bool{}) {
+template <typename Lambda, int = (Lambda{}(), 0)> constexpr bool is_constexpr_impl(Lambda, int) {
   return true;
 }
 

--- a/test/common/http/character_set_validation_test.cc
+++ b/test/common/http/character_set_validation_test.cc
@@ -1,5 +1,8 @@
+#include <type_traits>
+
 #include "source/common/http/character_set_validation.h"
 
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -34,7 +37,7 @@ TEST(CharacterSetValidationTest, RawInitializationWorksCorrectly) {
 }
 
 TEST(CharacterSetValidationTest, AlphanumericsAndCharsInitializesCorrectly) {
-  constexpr CharTable kCharTable = CharTable::alphanumeric() | CharTable::fromChars("!");
+  constexpr CharTable kCharTable = CharTables::kAlphanumeric | CharTable::fromChars("!");
 
   for (unsigned c = 0; c < 256; ++c) {
     bool result = kCharTable.hasChar(c);
@@ -45,7 +48,7 @@ TEST(CharacterSetValidationTest, AlphanumericsAndCharsInitializesCorrectly) {
 }
 
 TEST(CharacterSetValidationTest, NotOperatorInitializesCorrectly) {
-  constexpr CharTable kCharTable = ~(CharTable::alphanumeric() | CharTable::fromChars("!"));
+  constexpr CharTable kCharTable = ~(CharTables::kAlphanumeric | CharTable::fromChars("!"));
 
   for (unsigned c = 0; c < 256; ++c) {
     bool result = kCharTable.hasChar(c);
@@ -56,7 +59,7 @@ TEST(CharacterSetValidationTest, NotOperatorInitializesCorrectly) {
 }
 
 TEST(CharacterSetValidationTest, AndNotOperatorInitializesCorrectly) {
-  constexpr CharTable kCharTable = CharTable::alphanumeric() & ~CharTable::uppercase();
+  constexpr CharTable kCharTable = CharTables::kAlphanumeric & ~CharTables::kUppercase;
 
   for (unsigned c = 0; c < 256; ++c) {
     bool result = kCharTable.hasChar(c);
@@ -71,6 +74,35 @@ TEST(CharacterSetValidationTest, FromCharsInitializesCorrectly) {
   for (unsigned c = 0; c < 256; ++c) {
     bool result = kCharTable.hasChar(c);
     bool expected = (c == '!');
+    EXPECT_EQ(result, expected) << c;
+  }
+}
+
+// Primary template - selected if expression CAN be constexpr
+template <typename Lambda>
+constexpr auto is_constexpr_impl(Lambda lambda,
+                                 int) -> decltype(std::integral_constant<int, (lambda(), 0)>{},
+                                                  bool{}) {
+  return true;
+}
+
+// Fallback - selected if expression CANNOT be constexpr
+template <typename Lambda> constexpr bool is_constexpr_impl(Lambda, long) { return false; }
+
+TEST(CharacterSetValidationTest, WorksFromDynamicData) {
+  // Code coverage says none of the functions are covered if we don't test using them
+  // with dynamic data, since all constexpr usage is compiled-out!
+  // absl::StrCat doesn't have a constexpr variant so this forces non-constexpr usage.
+  static_assert(
+      !is_constexpr_impl([]() { return absl::StrCat("!"); }, 0),
+      "Oh no, StrCat can be constexpr-evaluated - replace StrCat with something that can't!");
+  const CharTable kCharTable =
+      CharTable::fromChars(absl::StrCat("!")) |
+      CharTable::fromChars(absl::StrCat("@$")) & ~CharTable::fromChars(absl::StrCat("$"));
+
+  for (unsigned c = 0; c < 256; ++c) {
+    bool result = kCharTable.hasChar(c);
+    bool expected = (c == '!' || c == '@');
     EXPECT_EQ(result, expected) << c;
   }
 }

--- a/test/common/http/character_set_validation_test.cc
+++ b/test/common/http/character_set_validation_test.cc
@@ -5,11 +5,11 @@
 namespace Envoy {
 namespace Http {
 
-TEST(CharacterSetValidationTest, Test) {
+TEST(CharacterSetValidationTest, RawInitializationWorksCorrectly) {
   // This table has the following characters "enabled"
   // every 8th character in a 32 character row
   // and every row is shifted by 1
-  constexpr std::array<uint32_t, 8> kCharTable = {
+  constexpr CharTable kCharTable = {{
       // control characters
       0b10000000100000001000000010000000,
       // !"#$%&'()*+,-./0123456789:;<=>?
@@ -23,13 +23,55 @@ TEST(CharacterSetValidationTest, Test) {
       0b00000100000001000000010000000100,
       0b00000010000000100000001000000010,
       0b00000001000000010000000100000001,
-  };
+  }};
 
   for (unsigned c = 0; c < 256; ++c) {
-    bool result = testCharInTable(kCharTable, static_cast<unsigned char>(c));
+    bool result = kCharTable.hasChar(c);
     // c / 32 is the shift value of every row
     // ((c % 32) % 8) is the 8th character in that row
-    ASSERT_EQ(result, ((c % 32) % 8) == c / 32);
+    ASSERT_EQ(result, ((c % 32) % 8) == c / 32) << c;
+  }
+}
+
+TEST(CharacterSetValidationTest, AlphanumericsAndCharsInitializesCorrectly) {
+  constexpr CharTable kCharTable = CharTable::alphanumeric() | CharTable::fromChars("!");
+
+  for (unsigned c = 0; c < 256; ++c) {
+    bool result = kCharTable.hasChar(c);
+    bool expected =
+        (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '!';
+    EXPECT_EQ(result, expected) << c;
+  }
+}
+
+TEST(CharacterSetValidationTest, NotOperatorInitializesCorrectly) {
+  constexpr CharTable kCharTable = ~(CharTable::alphanumeric() | CharTable::fromChars("!"));
+
+  for (unsigned c = 0; c < 256; ++c) {
+    bool result = kCharTable.hasChar(c);
+    bool expected =
+        !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '!');
+    EXPECT_EQ(result, expected) << c;
+  }
+}
+
+TEST(CharacterSetValidationTest, AndNotOperatorInitializesCorrectly) {
+  constexpr CharTable kCharTable = CharTable::alphanumeric() & ~CharTable::uppercase();
+
+  for (unsigned c = 0; c < 256; ++c) {
+    bool result = kCharTable.hasChar(c);
+    bool expected = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+    EXPECT_EQ(result, expected) << c;
+  }
+}
+
+TEST(CharacterSetValidationTest, FromCharsInitializesCorrectly) {
+  constexpr CharTable kCharTable = CharTable::fromChars("!");
+
+  for (unsigned c = 0; c < 256; ++c) {
+    bool result = kCharTable.hasChar(c);
+    bool expected = (c == '!');
+    EXPECT_EQ(result, expected) << c;
   }
 }
 

--- a/test/common/http/character_set_validation_test.cc
+++ b/test/common/http/character_set_validation_test.cc
@@ -80,9 +80,8 @@ TEST(CharacterSetValidationTest, FromCharsInitializesCorrectly) {
 
 // Primary template - selected if expression CAN be constexpr
 template <typename Lambda>
-constexpr auto is_constexpr_impl(Lambda lambda,
-                                 int) -> decltype(std::integral_constant<int, (lambda(), 0)>{},
-                                                  bool{}) {
+constexpr auto is_constexpr_impl(Lambda lambda, int)
+    -> decltype((void)std::integral_constant<bool, (lambda(), true)>::value, bool{}) {
   return true;
 }
 
@@ -97,8 +96,8 @@ TEST(CharacterSetValidationTest, WorksFromDynamicData) {
       !is_constexpr_impl([]() { return absl::StrCat("!"); }, 0),
       "Oh no, StrCat can be constexpr-evaluated - replace StrCat with something that can't!");
   const CharTable kCharTable =
-      CharTable::fromChars(absl::StrCat("!")) |
-      CharTable::fromChars(absl::StrCat("@$")) & ~CharTable::fromChars(absl::StrCat("$"));
+      (CharTable::fromChars(absl::StrCat("!")) | CharTable::fromChars(absl::StrCat("@$"))) &
+      ~CharTable::fromChars(absl::StrCat("$"));
 
   for (unsigned c = 0; c < 256; ++c) {
     bool result = kCharTable.hasChar(c);

--- a/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
@@ -110,7 +110,7 @@ TEST_F(BaseHeaderValidatorTest, ValidateGenericHeaderName) {
     setHeaderStringUnvalidated(header_string, name);
 
     auto result = uhv->validateGenericHeaderName(header_string);
-    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c)) {
+    if (::Envoy::Http::CharTables::kGenericHeaderName.hasChar(c)) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);

--- a/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
@@ -15,7 +15,6 @@ namespace EnvoyDefault {
 
 using ::Envoy::Http::HeaderString;
 using ::Envoy::Http::Protocol;
-using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::UhvResponseCodeDetail;
 
 class BaseHeaderValidatorTest : public HeaderValidatorUtils, public testing::Test {
@@ -111,7 +110,7 @@ TEST_F(BaseHeaderValidatorTest, ValidateGenericHeaderName) {
     setHeaderStringUnvalidated(header_string, name);
 
     auto result = uhv->validateGenericHeaderName(header_string);
-    if (testCharInTable(::Envoy::Http::kGenericHeaderNameCharTable, c)) {
+    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c)) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);
@@ -148,7 +147,7 @@ TEST_F(BaseHeaderValidatorTest, ValidateGenericHeaderValue) {
     setHeaderStringUnvalidated(header_string, name);
 
     auto result = uhv->validateGenericHeaderValue(header_string);
-    if (testCharInTable(kGenericHeaderValueCharTable, c)) {
+    if (kGenericHeaderValueCharTable.hasChar(c)) {
       EXPECT_ACCEPT(result);
     } else {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidValueCharacters);

--- a/test/extensions/http/header_validators/envoy_default/header_validator_utils.cc
+++ b/test/extensions/http/header_validators/envoy_default/header_validator_utils.cc
@@ -23,7 +23,7 @@ void HeaderValidatorUtils::validateAllCharactersInUrlPath(
     ::Envoy::Http::TestRequestHeaderMapImpl headers{
         {":scheme", "https"}, {":authority", "envoy.com"}, {":method", "GET"}};
     headers.addViaMove(HeaderString(absl::string_view(":path")), std::move(invalid_value));
-    if (::Envoy::Http::testCharInTable(kPathHeaderCharTable, static_cast<char>(ascii)) ||
+    if (kPathHeaderCharTable.hasChar(static_cast<char>(ascii)) ||
         absl::StrContains(additionally_allowed_characters, static_cast<char>(ascii))) {
       EXPECT_ACCEPT(validator.validateRequestHeaders(headers))
           << " for character " << static_cast<char>(ascii) << " " << ascii;

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -18,7 +18,6 @@ namespace {
 using ::Envoy::Extensions::Http::HeaderValidators::EnvoyDefault::Http2HeaderValidator;
 using ::Envoy::Http::HeaderString;
 using ::Envoy::Http::Protocol;
-using ::Envoy::Http::testCharInTable;
 using ::Envoy::Http::TestRequestHeaderMapImpl;
 using ::Envoy::Http::TestRequestTrailerMapImpl;
 using ::Envoy::Http::TestResponseHeaderMapImpl;
@@ -621,7 +620,7 @@ TEST_F(Http2HeaderValidatorTest, ValidateRequestGenericHeaderName) {
                                HeaderString(absl::string_view("some value")));
 
     auto result = uhv->validateRequestHeaders(request_headers);
-    if (testCharInTable(::Envoy::Http::kGenericHeaderNameCharTable, c) && (c < 'A' || c > 'Z')) {
+    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z')) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);
@@ -644,7 +643,7 @@ TEST_F(Http2HeaderValidatorTest, ValidateResponseGenericHeaderName) {
     headers.addViaMove(std::move(header_string), HeaderString(absl::string_view("some value")));
 
     auto result = uhv->validateResponseHeaders(headers);
-    if (testCharInTable(::Envoy::Http::kGenericHeaderNameCharTable, c) && (c < 'A' || c > 'Z')) {
+    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z')) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -620,7 +620,7 @@ TEST_F(Http2HeaderValidatorTest, ValidateRequestGenericHeaderName) {
                                HeaderString(absl::string_view("some value")));
 
     auto result = uhv->validateRequestHeaders(request_headers);
-    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z')) {
+    if (::Envoy::Http::CharTables::kGenericHeaderName.hasChar(c) && (c < 'A' || c > 'Z')) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);
@@ -643,7 +643,7 @@ TEST_F(Http2HeaderValidatorTest, ValidateResponseGenericHeaderName) {
     headers.addViaMove(std::move(header_string), HeaderString(absl::string_view("some value")));
 
     auto result = uhv->validateResponseHeaders(headers);
-    if (::Envoy::Http::kGenericHeaderNameCharTable.hasChar(c) && (c < 'A' || c > 'Z')) {
+    if (::Envoy::Http::CharTables::kGenericHeaderName.hasChar(c) && (c < 'A' || c > 'Z')) {
       EXPECT_ACCEPT(result);
     } else if (c != '_') {
       EXPECT_REJECT_WITH_DETAILS(result, UhvResponseCodeDetail::get().InvalidNameCharacters);

--- a/test/integration/default_header_validator_integration_test.cc
+++ b/test/integration/default_header_validator_integration_test.cc
@@ -18,8 +18,7 @@ public:
   // is not in either set, then the request is expected to be rejected.
   using PathFormatter = std::function<std::string(char)>;
   void
-  validateCharacterSetInUrl(PathFormatter path_formatter,
-                            const std::array<uint32_t, 8>& uhv_allowed_characters,
+  validateCharacterSetInUrl(PathFormatter path_formatter, Http::CharTable& uhv_allowed_characters,
                             absl::string_view additionally_allowed_characters,
                             const std::function<std::string(uint32_t)>& expected_path_builder) {
     std::vector<FakeStreamPtr> upstream_requests;
@@ -47,7 +46,7 @@ public:
       headers.addViaMove(Http::HeaderString(absl::string_view(":path")), std::move(invalid_value));
       auto response = client->makeHeaderOnlyRequest(headers);
 
-      if (Http::testCharInTable(uhv_allowed_characters, static_cast<char>(ascii)) ||
+      if (uhv_allowed_characters.hasChar(ascii) ||
           absl::StrContains(additionally_allowed_characters, static_cast<char>(ascii))) {
         waitForNextUpstreamRequest();
         std::string expected_path = expected_path_builder(ascii);

--- a/test/integration/default_header_validator_integration_test.cc
+++ b/test/integration/default_header_validator_integration_test.cc
@@ -18,7 +18,8 @@ public:
   // is not in either set, then the request is expected to be rejected.
   using PathFormatter = std::function<std::string(char)>;
   void
-  validateCharacterSetInUrl(PathFormatter path_formatter, Http::CharTable& uhv_allowed_characters,
+  validateCharacterSetInUrl(PathFormatter path_formatter,
+                            const Http::CharTable& uhv_allowed_characters,
                             absl::string_view additionally_allowed_characters,
                             const std::function<std::string(uint32_t)>& expected_path_builder) {
     std::vector<FakeStreamPtr> upstream_requests;

--- a/test/integration/default_header_validator_integration_test.cc
+++ b/test/integration/default_header_validator_integration_test.cc
@@ -286,7 +286,7 @@ TEST_P(DownstreamUhvIntegrationTest, CharacterValidationInPathWithPathNormalizat
     return fmt::format("/path/with/ad{:c}itional/characters", c);
   };
   validateCharacterSetInUrl(
-      path_formatter, Http::kUriQueryAndFragmentCharTable, additionally_allowed_characters,
+      path_formatter, Http::CharTables::kUriQueryAndFragment, additionally_allowed_characters,
       [&encoded_characters](uint32_t ascii) -> std::string {
         if (ascii == '#') {
           return "/path/with/ad";
@@ -322,7 +322,7 @@ TEST_P(DownstreamUhvIntegrationTest, CharacterValidationInQuery) {
   PathFormatter path_formatter = [](char c) {
     return fmt::format("/query?with=a{:c}ditional&characters", c);
   };
-  validateCharacterSetInUrl(path_formatter, Http::kUriQueryAndFragmentCharTable,
+  validateCharacterSetInUrl(path_formatter, Http::CharTables::kUriQueryAndFragment,
                             additionally_allowed_characters, [](uint32_t ascii) -> std::string {
                               return ascii == '#'
                                          ? "/query?with=a"
@@ -348,7 +348,7 @@ TEST_P(DownstreamUhvIntegrationTest, CharacterValidationInFragment) {
   PathFormatter path_formatter = [](char c) {
     return fmt::format("/query?with=a#frag{:c}ment", c);
   };
-  validateCharacterSetInUrl(path_formatter, Http::kUriQueryAndFragmentCharTable,
+  validateCharacterSetInUrl(path_formatter, Http::CharTables::kUriQueryAndFragment,
                             additionally_allowed_characters,
                             [](uint32_t) -> std::string { return "/query?with=a"; });
 }


### PR DESCRIPTION
Commit Message: Make character tables more readable
Additional Description: Character tables have been created as an array of binary values with comments. This PR uses modern constexpr to generate them with code, so they're still constexpr and performance should be identical, but the code is more readable, no need to manually read every bit to see what's happening. (At C++23 this could be even clearer using `std::bitset`, but until C++23 bitset isn't constexpr enough.)
Risk Level: Should be no change, but there is some risk that I missed or added one bit. The existing test coverage is fairly aggressive with checking every character, so I think the risk of that is low.
Testing: Added some tests that the constexpr generators are generating the expected outcomes.
Docs Changes: n/a
Release Notes: n/a
