### PR TITLE
Fix static assert in prometheus_stats.cc

### DIFF
--- a/source/server/admin/prometheus_stats.cc
+++ b/source/server/admin/prometheus_stats.cc
@@ -146,7 +146,7 @@ private:
                          std::is_same_v<Stats::PrimitiveGaugeSnapshot, StatType>) {
       type = "gauge";
     } else {
-      static_assert(false, "Unexpected StatsType");
+      static_assert(sizeof(StatType) == 0, "Unexpected StatsType");
     }
 
     generateTypeOutput(output, type, prefixed_tag_extracted_name);


### PR DESCRIPTION
Some compilers pass through the static assert during template parsing

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Fix static assert in prometheus_stats.cc. Some compiler that passes through the static assert during template parsing
Additional Description:  NA
Risk Level: Low
Testing: NA
Docs Changes: No
Release Notes: fix pometheus_stats static_assert that might fire during template parsing on some compiler
Platform Specific Features: NA