### PR TITLE
lua: store stat name in wrappers to avoid stale references

### DIFF
--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -532,7 +532,7 @@ int RouteWrapper::luaMetadata(lua_State* state) {
 }
 
 int CounterWrapper::luaInc(lua_State*) {
-  counter_.inc();
+  counter().inc();
   return 0;
 }
 
@@ -541,22 +541,22 @@ int CounterWrapper::luaAdd(lua_State* state) {
   if (amount < 0) {
     luaL_error(state, "counter add amount must be non-negative");
   }
-  counter_.add(static_cast<uint64_t>(amount));
+  counter().add(static_cast<uint64_t>(amount));
   return 0;
 }
 
 int CounterWrapper::luaValue(lua_State* state) {
-  lua_pushnumber(state, static_cast<lua_Number>(counter_.value()));
+  lua_pushnumber(state, static_cast<lua_Number>(counter().value()));
   return 1;
 }
 
 int GaugeWrapper::luaInc(lua_State*) {
-  gauge_.inc();
+  gauge().inc();
   return 0;
 }
 
 int GaugeWrapper::luaDec(lua_State*) {
-  gauge_.dec();
+  gauge().dec();
   return 0;
 }
 
@@ -565,7 +565,7 @@ int GaugeWrapper::luaAdd(lua_State* state) {
   if (amount < 0) {
     luaL_error(state, "gauge add amount must be non-negative");
   }
-  gauge_.add(static_cast<uint64_t>(amount));
+  gauge().add(static_cast<uint64_t>(amount));
   return 0;
 }
 
@@ -574,7 +574,7 @@ int GaugeWrapper::luaSub(lua_State* state) {
   if (amount < 0) {
     luaL_error(state, "gauge sub amount must be non-negative");
   }
-  gauge_.sub(static_cast<uint64_t>(amount));
+  gauge().sub(static_cast<uint64_t>(amount));
   return 0;
 }
 
@@ -583,12 +583,12 @@ int GaugeWrapper::luaSet(lua_State* state) {
   if (value < 0) {
     luaL_error(state, "gauge set value must be non-negative");
   }
-  gauge_.set(static_cast<uint64_t>(value));
+  gauge().set(static_cast<uint64_t>(value));
   return 0;
 }
 
 int GaugeWrapper::luaValue(lua_State* state) {
-  lua_pushnumber(state, static_cast<lua_Number>(gauge_.value()));
+  lua_pushnumber(state, static_cast<lua_Number>(gauge().value()));
   return 1;
 }
 
@@ -597,24 +597,19 @@ int HistogramWrapper::luaRecordValue(lua_State* state) {
   if (value < 0) {
     luaL_error(state, "histogram value must be non-negative");
   }
-  histogram_.recordValue(static_cast<uint64_t>(value));
+  histogram().recordValue(static_cast<uint64_t>(value));
   return 0;
 }
 
 int StatsScopeWrapper::luaCounter(lua_State* state) {
   const char* name = luaL_checkstring(state, 2);
-  Stats::Counter& counter = Stats::Utility::counterFromElements(scope_, {Stats::DynamicName(name)});
-  CounterWrapper::create(state, counter);
+  CounterWrapper::create(state, scope_, std::string(name));
   return 1;
 }
 
 int StatsScopeWrapper::luaGauge(lua_State* state) {
   const char* name = luaL_checkstring(state, 2);
-  // Use NeverImport mode - Lua gauges track local state and should not be
-  // accumulated across hot restarts.
-  Stats::Gauge& gauge = Stats::Utility::gaugeFromElements(scope_, {Stats::DynamicName(name)},
-                                                          Stats::Gauge::ImportMode::NeverImport);
-  GaugeWrapper::create(state, gauge);
+  GaugeWrapper::create(state, scope_, std::string(name));
   return 1;
 }
 
@@ -641,9 +636,7 @@ int StatsScopeWrapper::luaHistogram(lua_State* state) {
     }
   }
 
-  Stats::Histogram& histogram =
-      Stats::Utility::histogramFromElements(scope_, {Stats::DynamicName(name)}, unit);
-  HistogramWrapper::create(state, histogram);
+  HistogramWrapper::create(state, scope_, std::string(name), unit);
   return 1;
 }
 

--- a/source/extensions/filters/http/lua/wrappers.h
+++ b/source/extensions/filters/http/lua/wrappers.h
@@ -524,11 +524,12 @@ private:
 };
 
 /**
- * Lua wrapper for a stats Counter.
+ * Lua wrapper for a stats Counter. Stores the stat name and re-queries the scope on each use
+ * to avoid holding a reference that could outlive the stats store.
  */
 class CounterWrapper : public Filters::Common::Lua::BaseLuaObject<CounterWrapper> {
 public:
-  explicit CounterWrapper(Stats::Counter& counter) : counter_(counter) {}
+  CounterWrapper(Stats::Scope& scope, std::string name) : scope_(scope), name_(std::move(name)) {}
 
   static ExportedFunctions exportedFunctions() {
     return {{"inc", static_luaInc}, {"add", static_luaAdd}, {"value", static_luaValue}};
@@ -554,15 +555,21 @@ private:
    */
   DECLARE_LUA_FUNCTION(CounterWrapper, luaValue);
 
-  Stats::Counter& counter_;
+  Stats::Counter& counter() {
+    return Stats::Utility::counterFromElements(scope_, {Stats::DynamicName(name_)});
+  }
+
+  Stats::Scope& scope_;
+  const std::string name_;
 };
 
 /**
- * Lua wrapper for a stats Gauge.
+ * Lua wrapper for a stats Gauge. Stores the stat name and re-queries the scope on each use
+ * to avoid holding a reference that could outlive the stats store.
  */
 class GaugeWrapper : public Filters::Common::Lua::BaseLuaObject<GaugeWrapper> {
 public:
-  explicit GaugeWrapper(Stats::Gauge& gauge) : gauge_(gauge) {}
+  GaugeWrapper(Stats::Scope& scope, std::string name) : scope_(scope), name_(std::move(name)) {}
 
   static ExportedFunctions exportedFunctions() {
     return {{"inc", static_luaInc}, {"dec", static_luaDec}, {"add", static_luaAdd},
@@ -609,15 +616,23 @@ private:
    */
   DECLARE_LUA_FUNCTION(GaugeWrapper, luaValue);
 
-  Stats::Gauge& gauge_;
+  Stats::Gauge& gauge() {
+    return Stats::Utility::gaugeFromElements(scope_, {Stats::DynamicName(name_)},
+                                             Stats::Gauge::ImportMode::NeverImport);
+  }
+
+  Stats::Scope& scope_;
+  const std::string name_;
 };
 
 /**
- * Lua wrapper for a stats Histogram.
+ * Lua wrapper for a stats Histogram. Stores the stat name and re-queries the scope on each use
+ * to avoid holding a reference that could outlive the stats store.
  */
 class HistogramWrapper : public Filters::Common::Lua::BaseLuaObject<HistogramWrapper> {
 public:
-  explicit HistogramWrapper(Stats::Histogram& histogram) : histogram_(histogram) {}
+  HistogramWrapper(Stats::Scope& scope, std::string name, Stats::Histogram::Unit unit)
+      : scope_(scope), name_(std::move(name)), unit_(unit) {}
 
   static ExportedFunctions exportedFunctions() { return {{"recordValue", static_luaRecordValue}}; }
 
@@ -629,7 +644,13 @@ private:
    */
   DECLARE_LUA_FUNCTION(HistogramWrapper, luaRecordValue);
 
-  Stats::Histogram& histogram_;
+  Stats::Histogram& histogram() {
+    return Stats::Utility::histogramFromElements(scope_, {Stats::DynamicName(name_)}, unit_);
+  }
+
+  Stats::Scope& scope_;
+  const std::string name_;
+  const Stats::Histogram::Unit unit_;
 };
 
 /**

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -1919,6 +1919,35 @@ TEST_F(LuaStatsScopeWrapperTest, CounterOperations) {
   wrapper.reset();
 }
 
+// Verify that two separately obtained wrappers for the same counter name share the same
+// underlying stat. This validates that re-querying the scope finds the existing stat
+// rather than creating a new one each time.
+TEST_F(LuaStatsScopeWrapperTest, CounterSharedIdentity) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      local c1 = object:counter("shared")
+      c1:inc()
+      local c2 = object:counter("shared")
+      c2:add(4)
+      testPrint(tostring(c1:value()))
+      testPrint(tostring(c2:value()))
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Filters::Common::Lua::LuaDeathRef<StatsScopeWrapper> wrapper(
+      StatsScopeWrapper::create(coroutine_->luaState(), *store_.rootScope()->createScope("lua")),
+      true);
+  EXPECT_CALL(printer_, testPrint("5"));
+  EXPECT_CALL(printer_, testPrint("5"));
+  start("callMe");
+
+  EXPECT_EQ(5, store_.counter("lua.shared").value());
+  wrapper.reset();
+}
+
 // Test counter with negative add fails.
 TEST_F(LuaStatsScopeWrapperTest, CounterNegativeAddFails) {
   const std::string SCRIPT{R"EOF(
@@ -1974,6 +2003,34 @@ TEST_F(LuaStatsScopeWrapperTest, GaugeOperations) {
 
   // Verify the gauge was created with the correct prefix.
   EXPECT_EQ(105, store_.gauge("lua.test_gauge", Stats::Gauge::ImportMode::NeverImport).value());
+  wrapper.reset();
+}
+
+// Verify that two separately obtained wrappers for the same gauge name share the same
+// underlying stat.
+TEST_F(LuaStatsScopeWrapperTest, GaugeSharedIdentity) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      local g1 = object:gauge("shared")
+      g1:set(10)
+      local g2 = object:gauge("shared")
+      g2:add(5)
+      testPrint(tostring(g1:value()))
+      testPrint(tostring(g2:value()))
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Filters::Common::Lua::LuaDeathRef<StatsScopeWrapper> wrapper(
+      StatsScopeWrapper::create(coroutine_->luaState(), *store_.rootScope()->createScope("lua")),
+      true);
+  EXPECT_CALL(printer_, testPrint("15"));
+  EXPECT_CALL(printer_, testPrint("15"));
+  start("callMe");
+
+  EXPECT_EQ(15, store_.gauge("lua.shared", Stats::Gauge::ImportMode::NeverImport).value());
   wrapper.reset();
 }
 
@@ -2051,6 +2108,33 @@ TEST_F(LuaStatsScopeWrapperTest, HistogramOperations) {
   auto histogram = store_.findHistogramByString("lua.test_histogram");
   ASSERT_TRUE(histogram.has_value());
   EXPECT_EQ(Stats::Histogram::Unit::Unspecified, histogram->get().unit());
+  wrapper.reset();
+}
+
+// Verify that two separately obtained wrappers for the same histogram name share the same
+// underlying stat — i.e. only one histogram is registered in the store.
+TEST_F(LuaStatsScopeWrapperTest, HistogramSharedIdentity) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      local h1 = object:histogram("shared", "ms")
+      h1:recordValue(10)
+      local h2 = object:histogram("shared", "ms")
+      h2:recordValue(20)
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Filters::Common::Lua::LuaDeathRef<StatsScopeWrapper> wrapper(
+      StatsScopeWrapper::create(coroutine_->luaState(), *store_.rootScope()->createScope("lua")),
+      true);
+  start("callMe");
+
+  // Verify only one histogram was created, not two.
+  ASSERT_TRUE(store_.findHistogramByString("lua.shared").has_value());
+  EXPECT_EQ(Stats::Histogram::Unit::Milliseconds,
+            store_.findHistogramByString("lua.shared")->get().unit());
   wrapper.reset();
 }
 


### PR DESCRIPTION
Commit Message: lua: store stat name in wrappers to avoid stale references

Additional Description:
The `CounterWrapper`, `GaugeWrapper`, and `HistogramWrapper` for the Lua stats API previously stored raw references to stat objects obtained at wrapper construction. This is unsafe when per-scope stat limits are configured (e.g. via `envoy.stats_matcher` metadata): the stats system can evict a stat from its lookup index while the scope remains alive, leaving the wrapper pointing at a tombstoned object that no longer receives updates.

The fix stores the scope reference and stat name string instead, and re-queries the scope on each use via `counterFromElements` / `gaugeFromElements` / `histogramFromElements`. Post-eviction, re-querying produces a fresh live stat rather than operating on a removed one.

This was flagged in the review of #44334.

Risk Level: low
Testing: existing `wrappers_test`, `lua_filter_test`, and `lua_integration_test` — all pass
Docs Changes: none
Release Notes: none
Platform Specific Features: none