### PR TITLE
test/ext_proc: Remove unused mock dep/include

### DIFF
--- a/test/extensions/filters/http/ext_proc/BUILD
+++ b/test/extensions/filters/http/ext_proc/BUILD
@@ -583,7 +583,6 @@ envoy_extension_cc_test(
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/common/http:common_lib",
         "//test/integration:http_integration_lib",
-        "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",
         "@abseil-cpp//absl/strings",
         "@envoy_api//envoy/extensions/filters/http/ext_proc/v3:pkg_cc_proto",

--- a/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
@@ -8,7 +8,6 @@
 #include "test/common/http/common.h"
 #include "test/extensions/filters/http/ext_proc/ext_proc_integration_common.h"
 #include "test/integration/http_integration.h"
-#include "test/mocks/http/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/string_view.h"


### PR DESCRIPTION
came across this while investigating a ci timeout

