### PR TITLE
reverse_tunnels: fix lds handling on the downstream side.

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -28,6 +28,7 @@ DownstreamReverseConnectionIOHandle::~DownstreamReverseConnectionIOHandle() {
       debug,
       "DownstreamReverseConnectionIOHandle: destroying handle for FD: {} with connection key: {}",
       fd_, connection_key_);
+  SET_SOCKET_INVALID(fd_);
 }
 
 void DownstreamReverseConnectionIOHandle::onPingMessage() {
@@ -47,16 +48,6 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
       debug,
       "DownstreamReverseConnectionIOHandle: closing handle for FD: {} with connection key: {}", fd_,
       connection_key_);
-
-  // If we're ignoring close calls during socket hand-off, just return success.
-  if (ignore_close_and_shutdown_) {
-    ENVOY_LOG(
-        debug,
-        "DownstreamReverseConnectionIOHandle: ignoring close() call during socket hand-off for "
-        "connection key: {}",
-        connection_key_);
-    return Api::ioCallUint64ResultNoError();
-  }
 
   // Prevent double-closing by checking if already closed.
   if (fd_ < 0) {
@@ -80,7 +71,8 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
   if (owned_socket_) {
     owned_socket_.reset();
   }
-  return IoSocketHandleImpl::close();
+  SET_SOCKET_INVALID(fd_);
+  return Api::ioCallUint64ResultNoError();
 }
 
 Api::SysCallIntResult DownstreamReverseConnectionIOHandle::shutdown(int how) {
@@ -89,17 +81,11 @@ Api::SysCallIntResult DownstreamReverseConnectionIOHandle::shutdown(int how) {
             "key: {}",
             how, fd_, connection_key_);
 
-  // If shutdown is ignored during socket hand-off, return success.
-  if (ignore_close_and_shutdown_) {
-    ENVOY_LOG(
-        debug,
-        "DownstreamReverseConnectionIOHandle: ignoring shutdown() call during socket hand-off for "
-        "connection key: {}",
-        connection_key_);
-    return Api::SysCallIntResult{0, 0};
+  if (owned_socket_) {
+    return owned_socket_->ioHandle().shutdown(how);
   }
 
-  return IoSocketHandleImpl::shutdown(how);
+  return Api::SysCallIntResult{0, 0};
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -43,13 +43,6 @@ public:
   void onPingMessage() override;
 
   /**
-   * Tell this IO handle to ignore close() and shutdown() calls.
-   * This is called by the HTTP filter during socket hand-off to prevent
-   * the handed-off socket from being affected by connection cleanup.
-   */
-  void ignoreCloseAndShutdown() { ignore_close_and_shutdown_ = true; }
-
-  /**
    * Get the owned socket for read-only access.
    */
   const Network::ConnectionSocket& getSocket() const { return *owned_socket_; }
@@ -61,8 +54,6 @@ private:
   ReverseConnectionIOHandle* parent_;
   // Connection key for tracking this specific connection.
   std::string connection_key_;
-  // Flag to ignore close and shutdown calls during socket hand-off.
-  bool ignore_close_and_shutdown_{false};
 };
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -246,25 +246,9 @@ void RCConnectionWrapper::shutdown() {
   ENVOY_LOG(debug, "RCConnectionWrapper: Shutting down connection ID: {}, state: {}", connection_id,
             static_cast<int>(state));
 
-  // Remove connection callbacks first to prevent recursive calls during shutdown.
-  if (state != Network::Connection::State::Closed) {
-    connection_->removeConnectionCallbacks(*this);
-    ENVOY_LOG(debug, "Connection callbacks removed");
-  }
-
-  // Close the connection if it's still open.
-  state = connection_->state();
-  if (state == Network::Connection::State::Open) {
-    ENVOY_LOG(debug, "Closing open connection gracefully");
-    connection_->close(Network::ConnectionCloseType::FlushWrite);
-  } else if (state == Network::Connection::State::Closing) {
-    ENVOY_LOG(debug, "Connection already closing");
-  } else {
-    ENVOY_LOG(debug, "Connection already closed");
-  }
-
   // Clear the connection pointer after shutdown.
-  connection_.reset();
+  connection_->removeConnectionCallbacks(*this);
+  connection_->dispatcher().deferredDelete(std::move(connection_));
   ENVOY_LOG(debug, "RCConnectionWrapper: Connection cleared after shutdown");
   ENVOY_LOG(debug, "RCConnectionWrapper: Shutdown completed");
 }

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -4,12 +4,12 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "envoy/event/deferred_deletable.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/event/real_time_system.h"
@@ -57,6 +57,7 @@ void ReverseConnectionIOHandle::cleanup() {
                  "trigger_pipe_write_fd_={}, trigger_pipe_read_fd_={}",
                  trigger_pipe_write_fd_, trigger_pipe_read_fd_);
   resetFileEvents();
+  SET_SOCKET_INVALID(trigger_pipe_read_fd_);
 
   // Clean up pipe trigger mechanism first to prevent use-after-free.
   ENVOY_LOG_MISC(trace,
@@ -64,47 +65,8 @@ void ReverseConnectionIOHandle::cleanup() {
                  "trigger_pipe_write_fd_={}, trigger_pipe_read_fd_={}",
                  trigger_pipe_write_fd_, trigger_pipe_read_fd_);
   if (trigger_pipe_write_fd_ >= 0) {
-    ::close(trigger_pipe_write_fd_);
+    Api::OsSysCallsSingleton::get().close(trigger_pipe_write_fd_);
     trigger_pipe_write_fd_ = -1;
-  }
-  if (trigger_pipe_read_fd_ >= 0) {
-    ::close(trigger_pipe_read_fd_);
-    trigger_pipe_read_fd_ = -1;
-  }
-
-  // Reset the retry timer. Don't call enabled() here — it asserts
-  // dispatcher_.isThreadSafe(), which fails when the destructor runs on the main
-  // thread during shutdown (the timer was created on a worker thread).
-  if (rev_conn_retry_timer_) {
-    ENVOY_LOG_MISC(trace, "reverse_tunnel: resetting retry timer.");
-    rev_conn_retry_timer_.reset();
-  }
-
-  // Graceful shutdown of connection wrappers with exception safety.
-  ENVOY_LOG_MISC(debug, "Gracefully shutting down {} connection wrappers.",
-                 connection_wrappers_.size());
-
-  // Move wrappers for deferred cleanup.
-  std::vector<std::unique_ptr<RCConnectionWrapper>> wrappers_to_delete;
-  for (auto& wrapper : connection_wrappers_) {
-    if (wrapper) {
-      ENVOY_LOG(debug, "Moving connection wrapper for deferred cleanup.");
-      wrappers_to_delete.push_back(std::move(wrapper));
-    }
-  }
-
-  // Clear containers safely.
-  connection_wrappers_.clear();
-  conn_wrapper_to_host_map_.clear();
-
-  // Clean up wrappers with safe deletion.
-  for (auto& wrapper : wrappers_to_delete) {
-    if (wrapper && isThreadLocalDispatcherAvailable()) {
-      getThreadLocalDispatcher().deferredDelete(std::move(wrapper));
-    } else {
-      // Direct cleanup when dispatcher not available.
-      wrapper.reset();
-    }
   }
 
   // Clear cluster to hosts mapping.
@@ -343,9 +305,9 @@ Api::IoCallUint64Result ReverseConnectionIOHandle::close() {
   ENVOY_LOG(error, "reverse_tunnel: performing graceful shutdown.");
 
   // Clean up original socket FD
-  if (original_socket_fd_ != -1) {
+  if (original_socket_fd_ != fd_ && original_socket_fd_ >= 0) {
     ENVOY_LOG(error, "Closing original socket FD: {}.", original_socket_fd_);
-    ::close(original_socket_fd_);
+    Api::OsSysCallsSingleton::get().close(original_socket_fd_);
     original_socket_fd_ = -1;
   }
 
@@ -1214,12 +1176,7 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
   if (wrapper_vector_it != connection_wrappers_.end()) {
     auto wrapper_to_delete = std::move(*wrapper_vector_it);
     connection_wrappers_.erase(wrapper_vector_it);
-
-    // Use deferred deletion to prevent crash during cleanup.
-    std::unique_ptr<Event::DeferredDeletable> deletable_wrapper(
-        static_cast<Event::DeferredDeletable*>(wrapper_to_delete.release()));
-    getThreadLocalDispatcher().deferredDelete(std::move(deletable_wrapper));
-    ENVOY_LOG(debug, "reverse_tunnel: Deferred delete of connection wrapper");
+    getThreadLocalDispatcher().deferredDelete(std::move(wrapper_to_delete));
   }
 }
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -80,6 +80,7 @@ envoy_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "@envoy_api//envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -8,6 +8,7 @@
 #include "envoy/server/factory_context.h"
 #include "envoy/thread_local/thread_local.h"
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/io_socket_error_impl.h"
@@ -23,6 +24,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -221,37 +223,6 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, GetSocket) {
 
   // Test that getSocket() works before close() is called.
   EXPECT_EQ(handle->fdDoNotUse(), 42);
-}
-
-// Test ignoreCloseAndShutdown() functionality.
-TEST_F(DownstreamReverseConnectionIOHandleTest, IgnoreCloseAndShutdown) {
-  auto handle = createHandle(io_handle_.get(), "test_key");
-
-  // Initially, close and shutdown should work normally
-  // Test shutdown before ignoring - we don't check the result since it depends on base
-  // implementation
-  handle->shutdown(SHUT_RDWR);
-
-  // Now enable ignore mode
-  handle->ignoreCloseAndShutdown();
-
-  // Test that close() is ignored when flag is set
-  auto close_result = handle->close();
-  EXPECT_EQ(close_result.err_, nullptr); // Should return success but do nothing
-
-  // Test that shutdown() is ignored when flag is set
-  auto shutdown_result2 = handle->shutdown(SHUT_RDWR);
-  EXPECT_EQ(shutdown_result2.return_value_, 0);
-  EXPECT_EQ(shutdown_result2.errno_, 0);
-
-  // Test different shutdown modes are all ignored
-  auto shutdown_rd = handle->shutdown(SHUT_RD);
-  EXPECT_EQ(shutdown_rd.return_value_, 0);
-  EXPECT_EQ(shutdown_rd.errno_, 0);
-
-  auto shutdown_wr = handle->shutdown(SHUT_WR);
-  EXPECT_EQ(shutdown_wr.return_value_, 0);
-  EXPECT_EQ(shutdown_wr.errno_, 0);
 }
 
 TEST_F(DownstreamReverseConnectionIOHandleTest, OnPingMessageWritesRpingToSocket) {
@@ -565,6 +536,81 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadEchoDisabledAndErrorHandling
     EXPECT_EQ(result.err_, nullptr);    // No error, just EOF
     EXPECT_EQ(buffer.length(), 0);
   }
+}
+
+// Verify that close() + destructor results in exactly one FD close syscall.
+TEST_F(DownstreamReverseConnectionIOHandleTest, CloseAndDestructorNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->close();
+  handle.reset();
+
+  ::close(fds[1]);
+}
+
+// Verify that calling close() twice results in exactly one FD close.
+TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleCloseCallNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->close();
+  handle->close();
+  handle.reset();
+
+  ::close(fds[1]);
+}
+
+// Verify that calling close() twice results in exactly one FD close.
+TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleShutdownCallNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->shutdown(0);
+  handle->shutdown(0);
+
+  // After close(), owned_socket_ is null so shutdown() returns {0,0}.
+  handle->close();
+  auto result = handle->shutdown(0);
+  EXPECT_EQ(result.return_value_, 0);
+  EXPECT_EQ(result.errno_, 0);
+
+  handle.reset();
+
+  ::close(fds[1]);
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -32,6 +32,14 @@ namespace ReverseConnection {
 
 // RCConnectionWrapper Tests.
 
+std::unique_ptr<NiceMock<Network::MockClientConnection>>
+getDeletableConn(Event::Dispatcher& dispatcher) {
+  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  EXPECT_CALL(*mock_connection, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  return mock_connection;
+}
+
 class RCConnectionWrapperTest : public testing::Test {
 protected:
   void SetUp() override {
@@ -52,6 +60,9 @@ protected:
   void TearDown() override {
     io_handle_.reset();
     extension_.reset();
+    while (dispatcher_.to_delete_.size()) {
+      dispatcher_.to_delete_.pop_front();
+    }
   }
 
   void setupThreadLocalSlot() {
@@ -127,7 +138,7 @@ protected:
 
   // Helper method to set up mock connection with proper socket expectations.
   std::unique_ptr<NiceMock<Network::MockClientConnection>> setupMockConnection() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
 
     // Create a mock socket for the connection.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -179,7 +190,7 @@ protected:
 // Test RCConnectionWrapper::connect() method with HTTP/1.1 handshake success
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeSuccess) {
   // Create a mock connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -217,7 +228,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeSuccess) {
 // Test RCConnectionWrapper::connect() method with HTTP proxy (internal address) scenario.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithHttpProxy) {
   // Create a mock connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -263,7 +274,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithHttpProxy) {
 
 // Test RCConnectionWrapper::connect() honors custom request paths.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithCustomRequestPath) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -306,7 +317,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithCustomRequestPath) {
 
 // Test RCConnectionWrapper::connect() includes additional headers in the handshake request.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithAdditionalHeaders) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -357,7 +368,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithAdditionalHeaders) {
 
 // Test that additional headers with OVERWRITE_IF_EXISTS_OR_ADD replace existing headers.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwrite) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -406,7 +417,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwrite) 
 
 // Test ADD_IF_ABSENT: header is added when absent, skipped when present.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersAddIfAbsent) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -463,7 +474,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersAddIfAbsent
 
 // Test OVERWRITE_IF_EXISTS: overwrites existing header, does nothing for absent header.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwriteIfExists) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -522,7 +533,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwriteIf
 // Test RCConnectionWrapper::connect() method with connection write failure.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWriteFailure) {
   // Create a mock connection that fails to write.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -1065,7 +1076,7 @@ TEST_F(RCConnectionWrapperTest, DecodeHeadersNonOk) {
 // Test dispatchHttp1 error path by initializing codec via connect() and
 // then feeding invalid bytes to the parser.
 TEST_F(RCConnectionWrapperTest, DispatchHttp1ErrorPath) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -1105,7 +1116,6 @@ TEST_F(RCConnectionWrapperTest, DestructorInvokesShutdown) {
 
   EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-  EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(777));
 
   {
@@ -1206,7 +1216,6 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
     // Set up connection expectations for open connection.
     EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-    EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12345));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
@@ -1266,13 +1275,12 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
   }
   // Test 5: Multiple shutdown calls (should be safe)
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
     auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
 
     // Set up connection expectations.
     EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-    EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12348));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
@@ -1304,11 +1312,14 @@ protected:
         *stats_scope_); // Use the created scope
   }
 
-  void TearDown() override { io_handle_.reset(); }
+  void TearDown() override {
+    io_handle_.reset();
+    dispatcher_.clearDeferredDeleteList();
+  }
 
   // Helper to create a mock RCConnectionWrapper.
   std::unique_ptr<RCConnectionWrapper> createMockWrapper() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
     auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
     return std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection), mock_host,
                                                  "test-cluster");
@@ -1323,6 +1334,7 @@ protected:
   Stats::IsolatedStoreImpl stats_store_;
   Stats::ScopeSharedPtr stats_scope_;
   std::unique_ptr<ReverseConnectionIOHandle> io_handle_;
+  NiceMock<Event::MockDispatcher> dispatcher_{"worker_0"};
 };
 
 TEST_F(SimpleConnReadFilterTest, OnDataWithNullParent) {
@@ -1464,6 +1476,26 @@ TEST_F(RCConnectionWrapperTest, NoOpMethods) {
 
   wrapper.onMaxStreamsChanged(0);
   wrapper.onMaxStreamsChanged(100);
+}
+
+// Verify shutdown with already-null connection doesn't crash.
+TEST_F(RCConnectionWrapperTest, ShutdownEnqueuesConnectionOnlyOnce) {
+  auto mock_connection = getDeletableConn(dispatcher_);
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(999));
+  auto wrapper = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection),
+                                                       mock_host, "test-cluster");
+
+  wrapper->shutdown();
+  ASSERT_EQ(dispatcher_.to_delete_.size(), 1);
+  auto conn = dynamic_cast<Network::Connection*>(dispatcher_.to_delete_.front().get());
+  ASSERT_EQ(conn->id(), 999);
+
+  wrapper->shutdown();
+  ASSERT_EQ(dispatcher_.to_delete_.size(), 1);
+
+  wrapper.reset();
+  ASSERT_EQ(dispatcher_.to_delete_.size(), 1);
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -75,6 +75,9 @@ protected:
     io_handle_.reset();
     extension_.reset();
     socket_interface_.reset();
+    while (dispatcher_.to_delete_.size()) {
+      dispatcher_.to_delete_.pop_front();
+    }
   }
 
   // Helper to create a ReverseConnectionIOHandle with specified configuration.
@@ -287,9 +290,16 @@ protected:
     return mock_host;
   }
 
+  std::unique_ptr<NiceMock<Network::MockClientConnection>> getDeletableConn() {
+    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    EXPECT_CALL(*mock_connection, dispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
+
+    return mock_connection;
+  }
+
   // Helper method to set up mock connection with proper socket expectations.
   std::unique_ptr<NiceMock<Network::MockClientConnection>> setupMockConnection() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket for the connection.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -1179,7 +1189,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionSuccess) {
   addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
 
   // Set up mock for successful connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data;
   success_conn_data.connection_ = mock_connection.get();
   success_conn_data.host_description_ = mock_host;
@@ -1254,7 +1264,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateReverseConnectionWithCustomScope) 
   addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
 
   // Set up mock for successful connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data;
   success_conn_data.connection_ = mock_connection.get();
   success_conn_data.host_description_ = mock_host;
@@ -1370,6 +1380,27 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionNonExistentClu
   EXPECT_EQ(wrapper_to_host_map.size(), 0);
 }
 
+// Null cluster info returns false without crashing.
+TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionNullClusterInfo) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  EXPECT_NE(io_handle_, nullptr);
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  EXPECT_CALL(*mock_thread_local_cluster, info()).WillRepeatedly(Return(nullptr));
+
+  auto mock_host = createMockHost("192.168.1.1");
+  bool result = initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host);
+  EXPECT_FALSE(result);
+
+  auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.cannot_connect"], 1);
+}
+
 // Test mixed success and failure scenarios for multiple connection attempts.
 TEST_F(ReverseConnectionIOHandleTest, InitiateMultipleConnectionsMixedResults) {
   // Set up thread local slot first so stats can be properly tracked.
@@ -1414,8 +1445,8 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateMultipleConnectionsMixedResults) {
   // 3. Third host: successful connection
 
   // Prepare mock connections that will be transferred to the wrappers.
-  auto mock_connection1 = std::make_unique<NiceMock<Network::MockClientConnection>>();
-  auto mock_connection3 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection1 = getDeletableConn();
+  auto mock_connection3 = getDeletableConn();
 
   // Set up connection info for the connections.
   auto local_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.2", 40000);
@@ -1588,12 +1619,12 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
 
   // Set up successful connections for both hosts.
-  auto mock_connection1 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection1 = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data1;
   success_conn_data1.connection_ = mock_connection1.get();
   success_conn_data1.host_description_ = mock_host1;
 
-  auto mock_connection2 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection2 = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data2;
   success_conn_data2.connection_ = mock_connection2.get();
   success_conn_data2.host_description_ = mock_host2;
@@ -2438,14 +2469,14 @@ TEST_F(ReverseConnectionIOHandleTest, CleanupClosesEstablishedConnections) {
   // Create two mock connections and add them to the established queue.
   // 1) An open connection should be closed with FlushWrite.
   {
-    auto open_conn = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto open_conn = getDeletableConn();
     EXPECT_CALL(*open_conn, state()).WillOnce(Return(Network::Connection::State::Open));
     EXPECT_CALL(*open_conn, close(Network::ConnectionCloseType::FlushWrite));
     addConnectionToEstablishedQueue(std::move(open_conn));
   }
   // 2) A closed connection should not be closed again.
   {
-    auto closed_conn = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto closed_conn = getDeletableConn();
     EXPECT_CALL(*closed_conn, state()).WillOnce(Return(Network::Connection::State::Closed));
     // No close() expected for closed connection.
     addConnectionToEstablishedQueue(std::move(closed_conn));
@@ -2902,7 +2933,7 @@ TEST_F(ReverseConnectionIOHandleTest, AcceptMethodSocketAndFdFailures) {
 
   // Test Case 1: Original socket not available or not open.
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket that returns isOpen() = false.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -2952,7 +2983,7 @@ TEST_F(ReverseConnectionIOHandleTest, AcceptMethodSocketAndFdFailures) {
 
   // Test Case 2: Failed to duplicate file descriptor.
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket with IO handle that fails to duplicate.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -3151,6 +3182,51 @@ TEST_F(ReverseConnectionIOHandleTest, OnConnectionDoneTlsConnectionDynamicCastFa
   auto stat_map = extension_->getCrossWorkerStatMap();
   EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.connected"], 1);
   EXPECT_EQ(stat_map["test_scope.reverse_connections.cluster.test-cluster.connected"], 1);
+}
+
+// Verify ReverseConnectionIOHandle::close() doesn't double-close original_socket_fd_ when it equals
+// fd_.
+TEST_F(ReverseConnectionIOHandleTest, CloseNoDoubleCloseWhenOriginalEqualsFd) {
+  auto config = createDefaultTestConfig();
+  int test_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_GE(test_fd, 0);
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(test_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto handle = std::make_unique<ReverseConnectionIOHandle>(test_fd, config, cluster_manager_,
+                                                            extension_.get(), *stats_scope_);
+  handle->close();
+  handle.reset();
+}
+
+// Verify that after initializeFileEvent (pipe created), close+destructor closes each FD exactly
+// once. After initializeFileEvent: fd_ = pipe_read_fd, original_socket_fd_ = original_fd,
+// pipe_write_fd separate. close() should close original_fd once (manual) and pipe_read_fd once (via
+// IoSocketHandleImpl::close). cleanup() closes pipe_write_fd once.
+TEST_F(ReverseConnectionIOHandleTest, CloseNoDoubleCloseWithPipeFds) {
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(io_handle_->fdDoNotUse()))
+      .WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  ASSERT_TRUE(isTriggerPipeReady());
+
+  os_fd_t pipe_read_fd = getTriggerPipeReadFd();
+  os_fd_t pipe_write_fd = getTriggerPipeWriteFd();
+  EXPECT_CALL(mock_os_syscalls, close(pipe_read_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+  EXPECT_CALL(mock_os_syscalls, close(pipe_write_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  io_handle_->close();
+  io_handle_.reset();
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -368,6 +368,23 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, UpdateConnectionStatsWithDetailedSta
   EXPECT_FALSE(found_detailed_stats);
 }
 
+// incrementHandshakeStats should no-op when detailed stats are disabled.
+TEST_F(ReverseTunnelInitiatorExtensionTest, IncrementHandshakeStatsWithDetailedStatsDisabled) {
+  envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+      DownstreamReverseConnectionSocketInterface no_stats_config;
+  no_stats_config.set_stat_prefix("reverse_connections");
+  no_stats_config.set_enable_detailed_stats(false);
+
+  auto no_stats_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, no_stats_config);
+
+  no_stats_extension->incrementHandshakeStats("cluster1", true, "");
+  no_stats_extension->incrementHandshakeStats("cluster2", false, "timeout");
+
+  auto cross_worker_stat_map = no_stats_extension->getCrossWorkerStatMap();
+  EXPECT_TRUE(cross_worker_stat_map.empty());
+}
+
 // Test per-worker stats aggregation for one thread only (test thread)
 TEST_F(ReverseTunnelInitiatorExtensionTest, GetPerWorkerStatMapSingleThread) {
   // Set up thread local slot first.


### PR DESCRIPTION
## Commit Message
fix lds handling on the downstream side.

## Additional Description
There were some fd double closes in the lds path of resetFileEvents -> close -> destroy on some of the classes ie downstreamReverseConnectionIoHandle, rcwrapper, reverse_connection_io_handle just removed them.

Removed some dead code in the downstreamReverseConnectionIoHandle.

## Testing
Unit and Integ tests.