### PR TITLE
Fix double free in experimental uring

### DIFF
--- a/source/common/io/io_uring_impl.cc
+++ b/source/common/io/io_uring_impl.cc
@@ -79,14 +79,9 @@ void IoUringImpl::forEveryCompletion(const CompletionCb& completion_cb) {
   // long.
   // Iterate the injected completion.
   while (!injected_completions_.empty()) {
-    auto& completion = injected_completions_.front();
-    completion_cb(completion.user_data_, completion.result_, true);
-    // The socket may closed in the completion_cb and all the related completions are
-    // removed.
-    if (injected_completions_.empty()) {
-      break;
-    }
+    auto completion = injected_completions_.front();
     injected_completions_.pop_front();
+    completion_cb(completion.user_data_, completion.result_, true);
   }
 }
 

--- a/test/common/io/io_uring_impl_test.cc
+++ b/test/common/io/io_uring_impl_test.cc
@@ -257,6 +257,9 @@ TEST_F(IoUringImplTest, NestRemoveInjectCompletion) {
                 EXPECT_EQ(-11, res);
               } else {
                 io_uring_->removeInjectedCompletion(fd2);
+                EXPECT_EQ(2, data2);
+                // Simulate deletion in IoUringWorkerImpl
+                delete user_data;
                 EXPECT_EQ(-1, data2);
               }
               completions_nr++;

--- a/test/common/io/io_uring_worker_impl_test.cc
+++ b/test/common/io/io_uring_worker_impl_test.cc
@@ -693,6 +693,55 @@ TEST(IoUringWorkerImplTest, NoEnableReadOnConnectError) {
   delete static_cast<Request*>(connect_req);
 }
 
+class ReproSocket : public IoUringSocketEntry {
+public:
+  ReproSocket(os_fd_t fd, IoUringWorkerImpl& parent)
+      : IoUringSocketEntry(fd, parent, [](uint32_t) { return absl::OkStatus(); }, false) {}
+
+  void onRead(Request* req, int32_t result, bool injected) override {
+    IoUringSocketEntry::onRead(req, result, injected);
+    if (injected) {
+      cleanup();
+    }
+  }
+
+  void write(Buffer::Instance&) override {}
+  uint64_t write(const Buffer::RawSlice*, uint64_t) override { return 0; }
+  void shutdown(int) override {}
+};
+
+class IoUringWorkerRepro : public IoUringWorkerImpl {
+public:
+  using IoUringWorkerImpl::IoUringWorkerImpl;
+  IoUringSocket& addReproSocket(os_fd_t fd) {
+    return addSocket(std::make_unique<ReproSocket>(fd, *this));
+  }
+};
+
+TEST(IoUringWorkerImplTest, DoubleFreeOnSocketCloseDuringInjectedCompletion) {
+  if (!isIoUringSupported()) {
+    GTEST_SKIP() << "io_uring not supported on this kernel";
+  }
+
+  Event::MockDispatcher dispatcher;
+  auto io_uring = std::make_unique<IoUringImpl>(64, false);
+  Event::FileReadyCb file_event_callback;
+  EXPECT_CALL(dispatcher, createFileEvent_(_, _, _, _))
+      .WillOnce(testing::DoAll(testing::SaveArg<1>(&file_event_callback),
+                               testing::ReturnNew<testing::NiceMock<Event::MockFileEvent>>()));
+
+  IoUringWorkerRepro worker(std::move(io_uring), 8192, 1000, dispatcher);
+  os_fd_t fd = 1;
+  auto& socket = worker.addReproSocket(fd);
+
+  worker.injectCompletion(socket, Request::RequestType::Read, 0);
+
+  EXPECT_CALL(dispatcher, deferredDelete_(testing::_));
+  file_event_callback(Event::FileReadyType::Read).IgnoreError();
+
+  EXPECT_CALL(dispatcher, clearDeferredDeleteList());
+}
+
 } // namespace
 } // namespace Io
 } // namespace Envoy


### PR DESCRIPTION
Added test DoubleFreeOnSocketCloseDuringInjectedCompletion to prevent regression
of a double free.

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
