### PR TITLE
dynamic_modules: serialize Struct configs to JSON on per-route and upstream bridge paths

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -39,6 +39,13 @@ bug_fixes:
     Fixed a crashing bug in the HTTP filter when a stream was already above the downstream write-buffer
     high watermark at filter-chain construction time. Downstream watermark callback registration is
     now deferred until the in-module filter has been constructed.
+- area: dynamic_modules
+  change: |
+    Fixed a bug where the HTTP filter per-route configuration and the upstream HTTP TCP bridge
+    configuration did not handle the ``google.protobuf.Struct`` configuration message as the API
+    definition requires. Both factories now serialize the ``Struct`` to a JSON string and pass the
+    string to the dynamic module side as the configuration, matching the behavior already in place
+    for every other dynamic module extension factory.
 - area: oauth2
   change: |
     Fixed a crash in the OAuth2 filter where AES-CBC decryption of token cookies could spuriously

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -245,7 +245,7 @@ DynamicModuleConfigFactory::createRouteSpecificFilterConfigTyped(
 
   std::string config;
   if (proto_config.has_filter_config()) {
-    auto config_or_error = MessageUtil::anyToBytes(proto_config.filter_config());
+    auto config_or_error = MessageUtil::knownAnyToBytes(proto_config.filter_config());
     RETURN_IF_NOT_OK_REF(config_or_error.status());
     config = std::move(config_or_error.value());
   }

--- a/source/extensions/upstreams/http/dynamic_modules/config.cc
+++ b/source/extensions/upstreams/http/dynamic_modules/config.cc
@@ -37,7 +37,7 @@ absl::StatusOr<BridgeConfigSharedPtr> getOrCreateBridgeConfig(
 
   std::string bridge_config_bytes;
   if (proto_config.has_bridge_config()) {
-    auto config_or_error = MessageUtil::anyToBytes(proto_config.bridge_config());
+    auto config_or_error = MessageUtil::knownAnyToBytes(proto_config.bridge_config());
     if (!config_or_error.ok()) {
       return absl::InvalidArgumentError("failed to parse bridge_config: " +
                                         std::string(config_or_error.status().message()));

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -89,6 +89,40 @@ filter_config:
       proto_config, context.server_factory_context_, context.messageValidationVisitor());
 }
 
+TEST(DynamicModuleConfigFactory, LoadOKPerRouteWithStruct) {
+  TestEnvironment::setEnvVar(
+      "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+      TestEnvironment::substitute("{{ test_rundir }}/test/extensions/dynamic_modules/test_data/c"),
+      1);
+
+  // ``google.protobuf.Struct`` per-route configs must be serialized to a JSON string instead of
+  // being forwarded as raw protobuf binary, matching the behavior of the regular filter config.
+  const std::string yaml = R"EOF(
+dynamic_module_config:
+    name: no_op
+    do_not_close: true
+    load_globally: false
+filter_name: foo
+filter_config:
+    "@type": "type.googleapis.com/google.protobuf.Struct"
+    value:
+        key: value
+)EOF";
+
+  envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilterPerRoute proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  Api::ApiPtr api = Api::createApiForTest();
+  EXPECT_CALL(context.server_factory_context_, api()).WillRepeatedly(testing::ReturnRef(*api));
+  ON_CALL(context.server_factory_context_.options_, concurrency())
+      .WillByDefault(testing::Return(1));
+
+  Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
+  auto result = factory.createRouteSpecificFilterConfig(
+      proto_config, context.server_factory_context_, context.messageValidationVisitor());
+}
+
 TEST(DynamicModuleConfigFactory, DEPRECATED_FEATURE_TEST(LoadOKPerRouteWithLegacyName)) {
   TestEnvironment::setEnvVar(
       "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -22,7 +22,7 @@ public:
   initializeFilter(const std::string& filter_name, const std::string& config = "",
                    const std::string& per_route_config = "",
                    const std::string& type_url = "type.googleapis.com/google.protobuf.StringValue",
-                   bool upstream_filter = false) {
+                   bool upstream_filter = false, const std::string& per_route_type_url = "") {
     std::string module_name = "http_integration_test";
     if (GetParam() != "rust_static") {
       TestEnvironment::setEnvVar(
@@ -48,6 +48,10 @@ typed_config:
 )EOF";
 
     if (!per_route_config.empty()) {
+      // The per-route config defaults to using ``type_url`` so existing callers continue to share
+      // the same Any type for both the filter and per-route configuration.
+      const std::string& effective_per_route_type_url =
+          per_route_type_url.empty() ? type_url : per_route_type_url;
       constexpr auto filter_per_route_config = R"EOF(
 dynamic_module_config:
   name: {}
@@ -59,7 +63,7 @@ filter_config:
       envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilterPerRoute
           per_route_config_proto;
       TestUtility::loadFromYaml(fmt::format(filter_per_route_config, module_name, filter_name,
-                                            type_url, per_route_config),
+                                            effective_per_route_type_url, per_route_config),
                                 per_route_config_proto);
 
       config_helper_.addConfigModifier(
@@ -307,6 +311,48 @@ TEST_P(DynamicModulesIntegrationTest, PerRouteConfig) {
                      .get(Http::LowerCaseString("x-per-route-config"))[0]
                      ->value()
                      .getStringView());
+}
+
+// Verifies that a ``google.protobuf.Struct`` per-route configuration is serialized to a JSON
+// string before being passed to the dynamic module.
+TEST_P(DynamicModulesIntegrationTest, PerRouteStructConfig) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    // The per_route_config test filter that surfaces the raw config bytes back as a header is
+    // implemented by the Rust integration test data, so the Struct check is scoped to those
+    // language flavors.
+    return;
+  }
+
+  // The regular filter config remains a ``StringValue``, preserving the existing semantics of
+  // the per_route_config test filter for the ``x-config`` header, while the per-route override
+  // is supplied as a ``google.protobuf.Struct``.
+  initializeFilter("per_route_config", "a", R"({"struct_key":"struct_value"})",
+                   "type.googleapis.com/google.protobuf.StringValue", false,
+                   "type.googleapis.com/google.protobuf.Struct");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{{"foo", "bar"},
+                                                 {":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("a", upstream_request_->headers()
+                     .get(Http::LowerCaseString("x-config"))[0]
+                     ->value()
+                     .getStringView());
+  // The per-route ``Struct`` must arrive as its JSON serialization rather than as raw protobuf
+  // binary bytes (which would have started with a ``0x0a`` wire-tag byte and broken any module
+  // that attempted to ``json.Unmarshal`` the payload). See
+  // https://github.com/envoyproxy/envoy/issues/44733.
+  EXPECT_EQ(R"({"struct_key":"struct_value"})",
+            upstream_request_->headers()
+                .get(Http::LowerCaseString("x-per-route-config"))[0]
+                ->value()
+                .getStringView());
 }
 
 TEST_P(DynamicModulesIntegrationTest, BodyCallbacks) {

--- a/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
@@ -592,6 +592,28 @@ TEST_F(DynamicModuleGenericConnPoolFactoryTest, BridgeConfigParseFailure) {
   EXPECT_EQ(pool, nullptr);
 }
 
+// Smoke test that a ``google.protobuf.Struct`` ``bridge_config`` is accepted by the factory.
+// See https://github.com/envoyproxy/envoy/issues/44733. The previous ``MessageUtil::anyToBytes``
+// implementation did not handle ``Struct`` per the API contract; ``knownAnyToBytes`` unpacks the
+// ``Struct`` and serializes it to a JSON string before handing it to the bridge module. Note
+// that the ``upstream_bridge_no_op`` test module deliberately ignores the config bytes, so this
+// test only locks in that the ``Struct`` unpack and JSON serialization path does not surface as
+// an error to the factory; the byte-level semantics are covered by the HTTP per-route
+// integration test which exercises the same ``knownAnyToBytes`` helper.
+TEST_F(DynamicModuleGenericConnPoolFactoryTest, BridgeConfigWithStruct) {
+  auto config = createProtoConfig();
+  config.set_bridge_name("struct_test_bridge");
+
+  Protobuf::Struct struct_value;
+  (*struct_value.mutable_fields())["key"].set_string_value("value");
+  config.mutable_bridge_config()->PackFrom(struct_value);
+
+  auto pool = factory_.createGenericConnPool(
+      host_, cm_.thread_local_cluster_, Router::GenericConnPoolFactory::UpstreamProtocol::HTTP,
+      Upstream::ResourcePriority::Default, absl::nullopt, nullptr, config);
+  EXPECT_NE(pool, nullptr);
+}
+
 TEST_F(DynamicModuleGenericConnPoolFactoryTest, NameAndCategory) {
   EXPECT_EQ("envoy.upstreams.http.dynamic_modules", factory_.name());
   EXPECT_EQ("envoy.upstreams", factory_.category());


### PR DESCRIPTION
## Description

The HTTP filter per-route configuration and the upstream HTTP TCP bridge configuration were calling `MessageUtil::anyToBytes` instead of `MessageUtil::knownAnyToBytes`, so a `google.protobuf.Struct` payload was forwarded to the dynamic module as raw protobuf wire bytes instead of as a JSON string. 

This PR migrates both the call sites to `knownAnyToBytes`, matching every other dynamic-module extension factory and the regular (non-per-route) HTTP filter path that was already fixed in #43753.

Fix https://github.com/envoyproxy/envoy/issues/44733

---

**Commit Message:** dynamic_modules: serialize Struct configs to JSON on per-route and upstream bridge paths
**Additional Description:** Migrates both the call sites to `knownAnyToBytes`, matching every other dynamic-module extension factory
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added