### PR TITLE
header_to_metadata: refactor shared_ptr to unique_ptr

### DIFF
--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.cc
@@ -61,9 +61,9 @@ Rule::Rule(const ProtoRule& rule, Regex::Engine& regex_engine, absl::Status& cre
   // Initialize the shared pointer.
   if (!rule.header().empty()) {
     selector_ =
-        std::make_shared<HeaderValueSelector>(Http::LowerCaseString(rule.header()), rule.remove());
+        std::make_unique<HeaderValueSelector>(Http::LowerCaseString(rule.header()), rule.remove());
   } else if (!rule.cookie().empty()) {
-    selector_ = std::make_shared<CookieValueSelector>(rule.cookie());
+    selector_ = std::make_unique<CookieValueSelector>(rule.cookie());
   } else {
     creation_status =
         absl::InvalidArgumentError("One of Cookie or Header option needs to be specified");

--- a/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
+++ b/source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -112,7 +113,7 @@ public:
   static absl::StatusOr<Rule> create(const ProtoRule& rule, Regex::Engine& regex_engine);
   const ProtoRule& rule() const { return rule_; }
   const absl::optional<Matcher::RegexReplace>& regexReplace() const { return regex_replace_; }
-  std::shared_ptr<const ValueSelector> selector_;
+  std::unique_ptr<const ValueSelector> selector_;
 
 private:
   Rule(const ProtoRule& rule, Regex::Engine& regex_engine, absl::Status& creation_status);


### PR DESCRIPTION
Commit Message: header_to_metadata: refactor shared_ptr to unique_ptr
Additional Description:
Minor refactor to use a unique_ptr instead of a shared_ptr (no need for shared_ptr).

Risk Level: low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
