### PR TITLE
mcp: add req/res body size limit in the bridge filter.

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -101,7 +101,8 @@ message McpJsonRestBridge {
   // If the request body exceeds this size, the request is rejected with ``413 Payload Too Large``.
   // This limit applies to prevent unbounded buffering.
   //
-  // It defaults to 64KB (65536 bytes).
+  // It defaults to 64KB (65536 bytes) as the MCP calls (tools, resources, or prompts)
+  // only pass small arguments or identifiers.
   //
   // Setting it to 0 would disable the limit. It is not recommended to do so in production.
   google.protobuf.UInt32Value max_request_body_size = 3;
@@ -110,7 +111,8 @@ message McpJsonRestBridge {
   // If the response body exceeds this size, the response is rejected with an appropriate error.
   // This limit applies to prevent unbounded buffering.
   //
-  // It defaults to 64KB (65536 bytes).
+  // It defaults to 1MB (1048576 bytes) to prevent transcoding failures on large payloads like
+  // file reads, while aligning with Envoy's standard default connection buffer limit.
   //
   // Setting it to 0 would disable the limit. It is not recommended to do so in production.
   google.protobuf.UInt32Value max_response_body_size = 4;

--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -96,6 +96,24 @@ message McpJsonRestBridge {
 
   // Configuration for the MCP tools.
   ServerToolConfig tool_config = 2;
+
+  // Maximum size of the request body to buffer for transcoding and validation.
+  // If the request body exceeds this size, the request is rejected with ``413 Payload Too Large``.
+  // This limit applies to prevent unbounded buffering.
+  //
+  // It defaults to 64KB (65536 bytes).
+  //
+  // Setting it to 0 would disable the limit. It is not recommended to do so in production.
+  google.protobuf.UInt32Value max_request_body_size = 3;
+
+  // Maximum size of the response body to buffer for transcoding.
+  // If the response body exceeds this size, the response is rejected with an appropriate error.
+  // This limit applies to prevent unbounded buffering.
+  //
+  // It defaults to 64KB (65536 bytes).
+  //
+  // Setting it to 0 would disable the limit. It is not recommended to do so in production.
+  google.protobuf.UInt32Value max_response_body_size = 4;
 }
 
 // Configuration for the server metadata.

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -30,8 +30,8 @@ namespace {
 using ::nlohmann::json;
 namespace McpConstants = Envoy::Extensions::Filters::Common::Mcp::McpConstants;
 
-constexpr uint32_t DEFAULT_MAX_REQUEST_BODY_SIZE = 65536;
-constexpr uint32_t DEFAULT_MAX_RESPONSE_BODY_SIZE = 65536;
+constexpr uint32_t DEFAULT_MAX_REQUEST_BODY_SIZE = 1024 * 64;    // 64KB
+constexpr uint32_t DEFAULT_MAX_RESPONSE_BODY_SIZE = 1024 * 1024; // 1MB
 
 bool isMcpProtocolVersionSupported(absl::string_view protocol_version) {
   static const absl::NoDestructor<absl::flat_hash_set<absl::string_view>> supported_mcp_versions({
@@ -195,11 +195,6 @@ McpJsonRestBridgeFilter::decodeHeaders(Http::RequestHeaderMap& request_headers, 
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  const uint32_t max_request_body_size = config_->maxRequestBodySize();
-  if (max_request_body_size > 0 && max_request_body_size > decoder_callbacks_->bufferLimit()) {
-    decoder_callbacks_->setBufferLimit(max_request_body_size);
-  }
-
   return Http::FilterHeadersStatus::StopIteration;
 }
 
@@ -220,7 +215,7 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
   }
 
   if (!end_stream) {
-    return Http::FilterDataStatus::StopIterationAndWatermark;
+    return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
   const size_t total_size = request_body_.length();
@@ -274,11 +269,6 @@ Http::FilterHeadersStatus McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseH
     return Http::FilterHeadersStatus::Continue;
   }
 
-  const uint32_t max_response_body_size = config_->maxResponseBodySize();
-  if (max_response_body_size > 0 && max_response_body_size > encoder_callbacks_->bufferLimit()) {
-    encoder_callbacks_->setBufferLimit(max_response_body_size);
-  }
-
   return Http::FilterHeadersStatus::StopIteration;
 }
 
@@ -312,7 +302,7 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& dat
   }
 
   if (!end_stream) {
-    return Http::FilterDataStatus::StopIterationAndWatermark;
+    return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
   encodeJsonRpcData(encoder_callbacks_->responseHeaders());

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -30,6 +30,9 @@ namespace {
 using ::nlohmann::json;
 namespace McpConstants = Envoy::Extensions::Filters::Common::Mcp::McpConstants;
 
+constexpr uint32_t DEFAULT_MAX_REQUEST_BODY_SIZE = 65536;
+constexpr uint32_t DEFAULT_MAX_RESPONSE_BODY_SIZE = 65536;
+
 bool isMcpProtocolVersionSupported(absl::string_view protocol_version) {
   static const absl::NoDestructor<absl::flat_hash_set<absl::string_view>> supported_mcp_versions({
       McpConstants::LATEST_SUPPORTED_MCP_VERSION,
@@ -133,7 +136,11 @@ McpJsonRestBridgeFilterConfig::McpJsonRestBridgeFilterConfig(
         proto_config)
     : proto_config_(proto_config), fallback_protocol_version_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
                                        proto_config_.server_info(), fallback_protocol_version,
-                                       std::string(McpConstants::FALLBACK_PROTOCOL_VERSION))) {
+                                       std::string(McpConstants::FALLBACK_PROTOCOL_VERSION))),
+      max_request_body_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config_, max_request_body_size,
+                                                             DEFAULT_MAX_REQUEST_BODY_SIZE)),
+      max_response_body_size_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config_, max_response_body_size,
+                                                              DEFAULT_MAX_RESPONSE_BODY_SIZE)) {
   for (const auto& tool : proto_config.tool_config().tools()) {
     tool_to_http_rule_[tool.name()] = tool.http_rule();
   }
@@ -188,6 +195,11 @@ McpJsonRestBridgeFilter::decodeHeaders(Http::RequestHeaderMap& request_headers, 
     return Http::FilterHeadersStatus::StopIteration;
   }
 
+  const uint32_t max_request_body_size = config_->maxRequestBodySize();
+  if (max_request_body_size > 0 && max_request_body_size > decoder_callbacks_->bufferLimit()) {
+    decoder_callbacks_->setBufferLimit(max_request_body_size);
+  }
+
   return Http::FilterHeadersStatus::StopIteration;
 }
 
@@ -197,11 +209,18 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
     return Http::FilterDataStatus::Continue;
   }
 
-  // TODO(guoyilin42): Add hard limit for the buffer size and flow control if possible.
   request_body_.move(data);
+  const uint32_t max_request_body_size = config_->maxRequestBodySize();
+  if (max_request_body_size > 0 && request_body_.length() > max_request_body_size) {
+    ENVOY_STREAM_LOG(error, "Request body exceeds limit. Size: {}, Limit: {}", *decoder_callbacks_,
+                     request_body_.length(), max_request_body_size);
+    sendErrorResponse(Http::Code::PayloadTooLarge, "mcp_json_rest_bridge_filter_request_too_large",
+                      generateErrorJsonResponse(-32000, "Request body too large").dump());
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
 
   if (!end_stream) {
-    return Http::FilterDataStatus::StopIterationNoBuffer;
+    return Http::FilterDataStatus::StopIterationAndWatermark;
   }
 
   const size_t total_size = request_body_.length();
@@ -225,6 +244,7 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
   if (mcp_operation_ == McpOperation::Initialization ||
       mcp_operation_ == McpOperation::InitializationAck ||
       mcp_operation_ == McpOperation::OperationFailed) {
+    // sendLocalReply was called in handleMcpMethod for these operations.
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
@@ -250,8 +270,16 @@ Http::FilterHeadersStatus McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseH
   // or throw exceptions because they expect a valid JSON-RPC response with a
   // matching ID. Envoy should generate a synthetic JSON-RPC response (e.g., an
   // empty ToolResult or a generic error) to ensure client stability.
-  return end_stream ? Http::FilterHeadersStatus::Continue
-                    : Http::FilterHeadersStatus::StopIteration;
+  if (end_stream) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+
+  const uint32_t max_response_body_size = config_->maxResponseBodySize();
+  if (max_response_body_size > 0 && max_response_body_size > encoder_callbacks_->bufferLimit()) {
+    encoder_callbacks_->setBufferLimit(max_response_body_size);
+  }
+
+  return Http::FilterHeadersStatus::StopIteration;
 }
 
 Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& data,
@@ -262,10 +290,29 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& dat
       mcp_operation_ == McpOperation::InitializationAck) {
     return Http::FilterDataStatus::Continue;
   }
+
   response_body_.move(data);
+  const uint32_t max_response_body_size = config_->maxResponseBodySize();
+  if (max_response_body_size > 0 && response_body_.length() > max_response_body_size) {
+    ENVOY_STREAM_LOG(error, "Response body exceeds limit. Size: {}, Limit: {}", *encoder_callbacks_,
+                     response_body_.length(), max_response_body_size);
+    json error_json = {
+        {McpConstants::JSONRPC_FIELD, McpConstants::JSONRPC_VERSION},
+        // If the ID is missing in the request, the ID in the response should be null.
+        {McpConstants::ID_FIELD, session_id_.has_value() ? *session_id_ : json(nullptr)},
+        {McpConstants::ERROR_FIELD, generateErrorJsonResponse(-32000, "Response body too large")}};
+    encoder_callbacks_->sendLocalReply(
+        Http::Code::InternalServerError, error_json.dump(),
+        [](Http::ResponseHeaderMap& headers) {
+          headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
+        },
+        Grpc::Status::WellKnownGrpcStatus::Internal,
+        "mcp_json_rest_bridge_filter_response_too_large");
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
 
   if (!end_stream) {
-    return Http::FilterDataStatus::StopIterationNoBuffer;
+    return Http::FilterDataStatus::StopIterationAndWatermark;
   }
 
   encodeJsonRpcData(encoder_callbacks_->responseHeaders());

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -204,15 +204,17 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
     return Http::FilterDataStatus::Continue;
   }
 
-  request_body_.move(data);
   const uint32_t max_request_body_size = config_->maxRequestBodySize();
-  if (max_request_body_size > 0 && request_body_.length() > max_request_body_size) {
+  if (max_request_body_size > 0 &&
+      (request_body_.length() + data.length()) > max_request_body_size) {
     ENVOY_STREAM_LOG(error, "Request body exceeds limit. Size: {}, Limit: {}", *decoder_callbacks_,
-                     request_body_.length(), max_request_body_size);
+                     request_body_.length() + data.length(), max_request_body_size);
     sendErrorResponse(Http::Code::PayloadTooLarge, "mcp_json_rest_bridge_filter_request_too_large",
                       generateErrorJsonResponse(-32000, "Request body too large").dump());
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
+
+  request_body_.move(data);
 
   if (!end_stream) {
     return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -265,11 +267,8 @@ Http::FilterHeadersStatus McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseH
   // or throw exceptions because they expect a valid JSON-RPC response with a
   // matching ID. Envoy should generate a synthetic JSON-RPC response (e.g., an
   // empty ToolResult or a generic error) to ensure client stability.
-  if (end_stream) {
-    return Http::FilterHeadersStatus::Continue;
-  }
-
-  return Http::FilterHeadersStatus::StopIteration;
+  return end_stream ? Http::FilterHeadersStatus::Continue
+                    : Http::FilterHeadersStatus::StopIteration;
 }
 
 Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& data,
@@ -281,11 +280,11 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& dat
     return Http::FilterDataStatus::Continue;
   }
 
-  response_body_.move(data);
   const uint32_t max_response_body_size = config_->maxResponseBodySize();
-  if (max_response_body_size > 0 && response_body_.length() > max_response_body_size) {
+  if (max_response_body_size > 0 &&
+      (response_body_.length() + data.length()) > max_response_body_size) {
     ENVOY_STREAM_LOG(error, "Response body exceeds limit. Size: {}, Limit: {}", *encoder_callbacks_,
-                     response_body_.length(), max_response_body_size);
+                     response_body_.length() + data.length(), max_response_body_size);
     json error_json = {
         {McpConstants::JSONRPC_FIELD, McpConstants::JSONRPC_VERSION},
         // If the ID is missing in the request, the ID in the response should be null.
@@ -300,6 +299,8 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& dat
         "mcp_json_rest_bridge_filter_response_too_large");
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
+
+  response_body_.move(data);
 
   if (!end_stream) {
     return Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -40,12 +40,17 @@ public:
 
   const std::string& fallbackProtocolVersion() const { return fallback_protocol_version_; }
 
+  uint32_t maxRequestBodySize() const { return max_request_body_size_; }
+  uint32_t maxResponseBodySize() const { return max_response_body_size_; }
+
 private:
   absl::flat_hash_map<std::string,
                       envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule>
       tool_to_http_rule_;
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config_;
   std::string fallback_protocol_version_;
+  uint32_t max_request_body_size_;
+  uint32_t max_response_body_size_;
 };
 
 using McpJsonRestBridgeFilterConfigSharedPtr = std::shared_ptr<McpJsonRestBridgeFilterConfig>;

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -687,10 +687,10 @@ TEST_F(McpJsonRestBridgeFilterTest, BackendErrorReturnsToolCallError) {
             Http::FilterHeadersStatus::StopIteration);
 
   Buffer::OwnedImpl request_body(
-      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/cloudesf-codelab","key":{"displayName":"display-key"}}}})json");
+      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
   EXPECT_EQ(filter_->decodeData(request_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
-  EXPECT_THAT(request_headers_.getPathValue(), StrEq("/v1/projects/cloudesf-codelab/apiKeys"));
+  EXPECT_THAT(request_headers_.getPathValue(), StrEq("/v1/projects/test-codelab/apiKeys"));
   EXPECT_THAT(request_headers_.getMethodValue(), StrEq("POST"));
   EXPECT_EQ(nlohmann::json::parse(request_body.toString()),
             nlohmann::json::parse(R"json({"displayName":"display-key"})json"));
@@ -717,7 +717,7 @@ TEST_F(McpJsonRestBridgeFilterTest, RejectInvalidUtf8BackendResponse) {
   EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
   Buffer::OwnedImpl request_body(
-      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/cloudesf-codelab","key":{"displayName":"display-key"}}}})json");
+      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
   EXPECT_EQ(filter_->decodeData(request_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
   response_headers_ = {
@@ -1207,7 +1207,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ResponseBodyExceedsLimitReturnsError) {
 
   request_headers_ = {{":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
   Buffer::OwnedImpl request_body(
-      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
+      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test","key":{"displayName":"display-key"}}}})json");
   request_headers_.setContentLength(request_body.toString().size());
 
   EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -747,7 +747,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolListRewritePathForRequestAndTranslateRes
   // Assumes the request body is split into different parts.
   Buffer::OwnedImpl request_first_body(R"json({"jsonrpc":"2.0")json");
   EXPECT_EQ(filter_->decodeData(request_first_body, /*end_stream=*/false),
-            Http::FilterDataStatus::StopIterationNoBuffer);
+            Http::FilterDataStatus::StopIterationAndWatermark);
   Buffer::OwnedImpl request_second_body(R"json(,"id":12,"method":"tools/list"})json");
   EXPECT_EQ(filter_->decodeData(request_second_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
@@ -769,6 +769,38 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolListRewritePathForRequestAndTranslateRes
       nlohmann::json::parse(response_body.toString()),
       nlohmann::json::parse(
           R"json({"jsonrpc":"2.0","id":12,"result":{"tools":[{"name":"google.api.CreateApiKey"}]}})json"));
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, EncodeDataReturnsStopIterationAndWatermarkWhenNotEndOfStream) {
+  request_headers_ = {{":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+  Buffer::OwnedImpl request_body(
+      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
+  request_headers_.setContentLength(request_body.toString().size());
+
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_EQ(filter_->decodeData(request_body, /*end_stream=*/true),
+            Http::FilterDataStatus::Continue);
+
+  response_headers_ = {
+      {":status", "200"}, {"content-type", "text/plain"}, {"content-length", "123456"}};
+  EXPECT_EQ(filter_->encodeHeaders(response_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  Buffer::OwnedImpl first_chunk("part1");
+  EXPECT_EQ(filter_->encodeData(first_chunk, /*end_stream=*/false),
+            Http::FilterDataStatus::StopIterationAndWatermark);
+  EXPECT_TRUE(first_chunk.toString().empty());
+  Buffer::OwnedImpl second_chunk("part2");
+  EXPECT_EQ(filter_->encodeData(second_chunk, /*end_stream=*/true),
+            Http::FilterDataStatus::Continue);
+  EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
+  EXPECT_THAT(response_headers_.getContentLengthValue(),
+              StrEq(std::to_string(second_chunk.length())));
+  EXPECT_EQ(
+      nlohmann::json::parse(second_chunk.toString()),
+      nlohmann::json::parse(
+          R"json({"jsonrpc":"2.0","id":123,"result":{"content":[{"text":"part1part2","type":"text"}],"isError":false}})json"));
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolListWithNumericStringId) {
@@ -1129,6 +1161,74 @@ TEST_F(McpJsonRestBridgeFilterTest, InitializeRequestIgnoreProtocolVersionHeader
   Buffer::OwnedImpl response_body("initialize response");
   EXPECT_EQ(filter_->encodeData(response_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, RequestBodyExceedsLimitReturnsError) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config =
+      ParseTextProtoOrDie(R"pb(
+    max_request_body_size { value: 10 }
+  )pb");
+  config_ = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  filter_ = std::make_unique<McpJsonRestBridgeFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  request_headers_ = {{":method", "POST"}, {":path", "/mcp"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(10));
+  EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Eq(Http::Code::PayloadTooLarge), _, _, _,
+                             StrEq("mcp_json_rest_bridge_filter_request_too_large")));
+  Buffer::OwnedImpl body("12345678901"); // 11 bytes
+  EXPECT_EQ(filter_->decodeData(body, /*end_stream=*/true),
+            Http::FilterDataStatus::StopIterationNoBuffer);
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, ResponseBodyExceedsLimitReturnsError) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config =
+      ParseTextProtoOrDie(R"pb(
+    max_response_body_size { value: 10 }
+    tool_config {
+      tools {
+        name: "create_api_key"
+        http_rule: {
+          post: "/v1/{parent=projects/*}/apiKeys"
+          body: "key"
+        }
+      }
+    }
+  )pb");
+  config_ = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  filter_ = std::make_unique<McpJsonRestBridgeFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  request_headers_ = {{":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+  Buffer::OwnedImpl request_body(
+      R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
+  request_headers_.setContentLength(request_body.toString().size());
+
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+  EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_EQ(filter_->decodeData(request_body, /*end_stream=*/true),
+            Http::FilterDataStatus::Continue);
+
+  EXPECT_CALL(encoder_callbacks_, setBufferLimit(10));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_CALL(
+      encoder_callbacks_,
+      sendLocalReply(
+          Eq(Http::Code::InternalServerError),
+          StrEq(
+              R"json({"error":{"code":-32000,"message":"Response body too large"},"id":123,"jsonrpc":"2.0"})json"),
+          _, _, StrEq("mcp_json_rest_bridge_filter_response_too_large")));
+  Buffer::OwnedImpl body("12345678901"); // 11 bytes
+  EXPECT_EQ(filter_->encodeData(body, /*end_stream=*/true),
+            Http::FilterDataStatus::StopIterationNoBuffer);
 }
 
 class McpHttpMethodFilterTest : public testing::TestWithParam<std::string> {

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -747,7 +747,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolListRewritePathForRequestAndTranslateRes
   // Assumes the request body is split into different parts.
   Buffer::OwnedImpl request_first_body(R"json({"jsonrpc":"2.0")json");
   EXPECT_EQ(filter_->decodeData(request_first_body, /*end_stream=*/false),
-            Http::FilterDataStatus::StopIterationAndWatermark);
+            Http::FilterDataStatus::StopIterationNoBuffer);
   Buffer::OwnedImpl request_second_body(R"json(,"id":12,"method":"tools/list"})json");
   EXPECT_EQ(filter_->decodeData(request_second_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
@@ -771,7 +771,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolListRewritePathForRequestAndTranslateRes
           R"json({"jsonrpc":"2.0","id":12,"result":{"tools":[{"name":"google.api.CreateApiKey"}]}})json"));
 }
 
-TEST_F(McpJsonRestBridgeFilterTest, EncodeDataReturnsStopIterationAndWatermarkWhenNotEndOfStream) {
+TEST_F(McpJsonRestBridgeFilterTest, EncodeDataReturnsStopIterationNoBufferWhenNotEndOfStream) {
   request_headers_ = {{":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
   Buffer::OwnedImpl request_body(
       R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"create_api_key","arguments":{"parent":"projects/test-codelab","key":{"displayName":"display-key"}}}})json");
@@ -789,7 +789,7 @@ TEST_F(McpJsonRestBridgeFilterTest, EncodeDataReturnsStopIterationAndWatermarkWh
             Http::FilterHeadersStatus::StopIteration);
   Buffer::OwnedImpl first_chunk("part1");
   EXPECT_EQ(filter_->encodeData(first_chunk, /*end_stream=*/false),
-            Http::FilterDataStatus::StopIterationAndWatermark);
+            Http::FilterDataStatus::StopIterationNoBuffer);
   EXPECT_TRUE(first_chunk.toString().empty());
   Buffer::OwnedImpl second_chunk("part2");
   EXPECT_EQ(filter_->encodeData(second_chunk, /*end_stream=*/true),
@@ -1175,7 +1175,6 @@ TEST_F(McpJsonRestBridgeFilterTest, RequestBodyExceedsLimitReturnsError) {
 
   request_headers_ = {{":method", "POST"}, {":path", "/mcp"}};
 
-  EXPECT_CALL(decoder_callbacks_, setBufferLimit(10));
   EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
   EXPECT_CALL(decoder_callbacks_,
@@ -1216,7 +1215,6 @@ TEST_F(McpJsonRestBridgeFilterTest, ResponseBodyExceedsLimitReturnsError) {
   EXPECT_EQ(filter_->decodeData(request_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
 
-  EXPECT_CALL(encoder_callbacks_, setBufferLimit(10));
   EXPECT_EQ(filter_->encodeHeaders(response_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
   EXPECT_CALL(

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -197,6 +197,124 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallTranscoding) {
   EXPECT_EQ(nlohmann::json::parse(response->body()), nlohmann::json::parse(expected_rpc_response));
 }
 
+TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallRequestBodyExceedsLimit) {
+  const std::string config = R"EOF(
+    name: envoy.filters.http.mcp_json_rest_bridge
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_json_rest_bridge.v3.McpJsonRestBridge
+      max_request_body_size: 10
+      tool_config:
+        tools:
+          - name: "create_api_key"
+            http_rule:
+              post: "/v1/{parent=projects/*}/keys"
+              body: "key"
+  )EOF";
+
+  initializeFilter(config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "id": 321,
+    "method": "tools/call",
+    "params": {
+      "name": "create_api_key",
+      "arguments": {
+        "parent": "projects/foo",
+        "key": {
+          "displayName": "bar"
+        }
+      }
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("413"));
+  EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
+  EXPECT_THAT(response->headers().getContentLengthValue(),
+              StrEq(std::to_string(response->body().size())));
+  EXPECT_EQ(
+      nlohmann::json::parse(response->body()),
+      nlohmann::json::parse(
+          R"json({"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"Request body too large"}})json"));
+}
+
+TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallResponseBodyExceedsLimit) {
+  const std::string config = R"EOF(
+    name: envoy.filters.http.mcp_json_rest_bridge
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_json_rest_bridge.v3.McpJsonRestBridge
+      max_response_body_size: 10
+      tool_config:
+        tools:
+          - name: "create_api_key"
+            http_rule:
+              post: "/v1/{parent=projects/*}/keys"
+              body: "key"
+  )EOF";
+
+  initializeFilter(config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "id": 321,
+    "method": "tools/call",
+    "params": {
+      "name": "create_api_key",
+      "arguments": {
+        "parent": "projects/foo",
+        "key": {
+          "displayName": "bar"
+        }
+      }
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  waitForNextUpstreamRequest();
+  EXPECT_THAT(upstream_request_->headers().getMethodValue(), StrEq("POST"));
+  EXPECT_THAT(upstream_request_->headers().getPathValue(), StrEq("/v1/projects/foo/keys"));
+
+  Http::TestResponseHeaderMapImpl response_headers;
+  response_headers.setStatus(200);
+  response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
+
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  Buffer::OwnedImpl response_data;
+  response_data.add("12345678901"); // 11 bytes, exceeds 10
+  upstream_request_->encodeData(response_data, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("500"));
+  EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
+  EXPECT_THAT(response->headers().getContentLengthValue(),
+              StrEq(std::to_string(response->body().size())));
+  EXPECT_EQ(
+      nlohmann::json::parse(response->body()),
+      nlohmann::json::parse(
+          R"json({"jsonrpc":"2.0","id":321,"error":{"code":-32000,"message":"Response body too large"}})json"));
+}
+
 TEST_P(McpJsonRestBridgeIntegrationTest, ToolsListTranscoding) {
   const std::string config = R"EOF(
     name: envoy.filters.http.mcp_json_rest_bridge


### PR DESCRIPTION
Commit Message: mcp: add req/res body size limit in the bridge filter.

Additional Description: 
This PR introduces `max_request_body_size` and `max_response_body_size` configuration fields to the `McpJsonRestBridge` filter to prevent unbounded buffering. By default, both are set to 64KB (65536 bytes). If the request or response body exceeds the configured limit, the filter now rejects it and returns a JSON-RPC error response with code `-32000` and message "Request/Response body too large".

Risk Level: 
Low. This actually reduces the risk of memory exhaustion by introducing sensible defaults to bound payload buffering.

Testing: 
Added unit tests (`RequestBodyExceedsLimitReturnsError`, `ResponseBodyExceedsLimitReturnsError`) and integration tests (`ToolsCallRequestBodyExceedsLimit`, `ToolsCallResponseBodyExceedsLimit`) to verify the new size limits.

Docs Changes: 
Inline documentation added to the `mcp_json_rest_bridge.proto` configuration fields.

Release Notes: 
mcp_json_rest_bridge: Added `max_request_body_size` and `max_response_body_size` config limits to prevent unbounded buffering (defaults to 64KB).

Platform Specific Features: 
N/A
