### PR TITLE
tracing(perf): register inline header for zipkin and opentelemetry

### DIFF
--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -26,6 +26,13 @@ using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 
 namespace {
 
+// Also covers the Zipkin tracer's W3C fallback (it depends on this library).
+// If removed from here, the Zipkin tracer must register them itself.
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_traceparent(Http::LowerCaseString("traceparent"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_tracestate(Http::LowerCaseString("tracestate"));
+
 const Tracing::TraceContextHandler& traceParentHeader() {
   CONSTRUCT_ON_FIRST_USE(Tracing::TraceContextHandler, "traceparent");
 }

--- a/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
+++ b/source/extensions/tracers/zipkin/zipkin_tracer_impl.cc
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "envoy/config/trace/v3/zipkin.pb.h"
+#include "envoy/http/header_map.h"
 
 #include "source/common/common/enum_to_int.h"
 #include "source/common/config/utility.h"
@@ -20,6 +21,22 @@ namespace Tracers {
 namespace Zipkin {
 
 namespace {
+
+// W3C traceparent / tracestate are registered by the OpenTelemetry tracer,
+// which this extension depends on for W3C fallback.
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_x_b3_traceid(Http::LowerCaseString("x-b3-traceid"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_x_b3_spanid(Http::LowerCaseString("x-b3-spanid"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_x_b3_parentspanid(Http::LowerCaseString("x-b3-parentspanid"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_x_b3_sampled(Http::LowerCaseString("x-b3-sampled"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_x_b3_flags(Http::LowerCaseString("x-b3-flags"));
+Http::RegisterCustomInlineHeader<Http::CustomInlineHeaderRegistry::Type::RequestHeaders>
+    register_b3(Http::LowerCaseString("b3"));
+
 // Helper function to parse URI and extract hostname and path
 std::pair<std::string, std::string> parseUri(absl::string_view uri) {
   // Find the scheme separator


### PR DESCRIPTION
Consumes ~1% of cpu on our envoy instances with Zipkin tracing.

**Commit Message:**
tracing(perf): register inline header for zipkin and opentelemetry
**Additional Description:**
Adds the Zipkin and Opentelemetry headers to the registered inline header list.

Risk Level: Low
Testing: done
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

----

before
<img width="894" height="130" alt="image" src="https://github.com/user-attachments/assets/3eac36e8-d349-4e98-b7f8-39db77e8b7d8" />

after
<img width="520" height="130" alt="image" src="https://github.com/user-attachments/assets/9b5c1042-5bcb-4970-a8b0-1485729644c9" />

