### PR TITLE
reverse_tunnel: fix initiator crash on SIGINT shutdown

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -72,9 +72,11 @@ void ReverseConnectionIOHandle::cleanup() {
     trigger_pipe_read_fd_ = -1;
   }
 
-  // Cancel the retry timer safely.
-  if (rev_conn_retry_timer_ && rev_conn_retry_timer_->enabled()) {
-    ENVOY_LOG_MISC(trace, "reverse_tunnel: cancelling and resetting retry timer.");
+  // Reset the retry timer. Don't call enabled() here — it asserts
+  // dispatcher_.isThreadSafe(), which fails when the destructor runs on the main
+  // thread during shutdown (the timer was created on a worker thread).
+  if (rev_conn_retry_timer_) {
+    ENVOY_LOG_MISC(trace, "reverse_tunnel: resetting retry timer.");
     rev_conn_retry_timer_.reset();
   }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

  Commit Message: reverse_tunnel: fix initiator crash on SIGINT shutdown
  Additional Description:
  `ReverseConnectionIOHandle::cleanup()` called `rev_conn_retry_timer_->enabled()`
  which asserts `dispatcher_.isThreadSafe()` (timer_impl.cc:56). During shutdown,
  the destructor chain (`InstanceBase → ListenerManager → ListenerImpl → SocketFactory
  → Socket → ReverseConnectionIOHandle`) runs on the main thread, not the worker
  thread that created the timer — so the assertion fails and the process aborts.

  The fix removes the `enabled()` guard. `unique_ptr::reset()` is safe regardless of
  timer state. The `close()` method already uses this exact pattern at line 360.

  This PR was authored with the assistance of generative AI (Claude). All code is
  fully understood and verified by the author.

  Risk Level: Low
  Testing: Unit tests (`reverse_connection_io_handle_test`), integration test
  (`reverse_connection_cluster_integration_test`), and manual SIGINT test all pass.
  Docs Changes: N/A
  Release Notes: N/A
  Platform Specific Features: N/A
