### PR TITLE
Revert "bazel: Use bazel mirrors where available (#44729)"

### DIFF
--- a/api/bazel/repository_locations.bzl
+++ b/api/bazel/repository_locations.bzl
@@ -3,10 +3,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     bazel_skylib = dict(
         version = "1.9.0",
         sha256 = "3b5b49006181f5f8ff626ef8ddceaa95e9bb8ad294f7b5d7b11ea9f7ddaf8c59",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz",
-        ],
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{version}/bazel-skylib-{version}.tar.gz"],
     ),
     com_envoyproxy_protoc_gen_validate = dict(
         sha256 = "20da84f8efe8f53c10cbde79d2cdd1e63365b0ae1ad9de22af56aa1a49d59330",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -32,10 +32,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     bazel_gazelle = dict(
         version = "0.47.0",
         sha256 = "675114d8b433d0a9f54d81171833be96ebc4113115664b791e6f204d58e93446",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v{version}/bazel-gazelle-v{version}.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v{version}/bazel-gazelle-v{version}.tar.gz",
-        ],
+        urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v{version}/bazel-gazelle-v{version}.tar.gz"],
     ),
     build_bazel_rules_apple = dict(
         version = "3.20.1",
@@ -455,10 +452,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     io_bazel_rules_go = dict(
         version = "0.60.0",
         sha256 = "86d3dc8f59d253524f933aaf2f3c05896cb0b605fc35b460c0b4b039996124c6",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v{version}/rules_go-v{version}.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v{version}/rules_go-v{version}.zip",
-        ],
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/v{version}/rules_go-v{version}.zip"],
     ),
     rules_cc = dict(
         version = "0.2.17",
@@ -500,10 +494,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         version = "0.7.1",
         sha256 = "3709d1745ba4be4ef054449647b62e424267066eca887bb00dd29242cb8463a0",
         strip_prefix = "rules_shell-{version}",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_shell/releases/download/v{version}/rules_shell-v{version}.tar.gz",
-            "https://github.com/bazelbuild/rules_shell/releases/download/v{version}/rules_shell-v{version}.tar.gz",
-        ],
+        urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v{version}/rules_shell-v{version}.tar.gz"],
     ),
     wamr = dict(
         version = "WAMR-2.4.4",
@@ -677,10 +668,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     rules_license = dict(
         version = "1.0.0",
         sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/{version}/rules_license-{version}.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/{version}/rules_license-{version}.tar.gz",
-        ],
+        urls = ["https://github.com/bazelbuild/rules_license/releases/download/{version}/rules_license-{version}.tar.gz"],
     ),
     libmaxminddb = dict(
         version = "1.13.3",


### PR DESCRIPTION
This reverts commit 329bb772300a3aa1113e1fb74a67010817f7e582.

This does not work in the same way when using remote downloader and breaks it currently

