### PR TITLE
mobile: Add test version linkstamp

### DIFF
--- a/mobile/test/jni/BUILD
+++ b/mobile/test/jni/BUILD
@@ -160,6 +160,7 @@ cc_library(
     ],
     deps = [
         "//library/jni:jni_helper_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
     ],
     alwayslink = True,
 )
@@ -182,6 +183,7 @@ cc_library(
     deps = [
         "//library/common/http:header_utility_lib",
         "//library/jni:jni_utility_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
         "@envoy//test/test_common:utility_lib",
     ],
     alwayslink = True,

--- a/mobile/test/objective-c/BUILD
+++ b/mobile/test/objective-c/BUILD
@@ -14,6 +14,7 @@ envoy_mobile_objc_test(
     visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_objc_bridge_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
     ],
 )
 
@@ -27,6 +28,7 @@ envoy_mobile_objc_test(
     deps = [
         "//library/objective-c:envoy_key_value_store_bridge_impl_lib",
         "//library/objective-c:envoy_objc_bridge_lib",
+        "@envoy//test/test_common:test_version_linkstamp",
     ],
 )
 


### PR DESCRIPTION
fixes breakage from ff9e47a3ad74f6b4daf00bcdc502ad86200c3a10