### PR TITLE
ci/rust: Move (rustfmt) bazel invokation out of bazel

### DIFF
--- a/ci/format_pre.sh
+++ b/ci/format_pre.sh
@@ -75,6 +75,9 @@ bazel "${BAZEL_STARTUP_OPTIONS[@]}" test "${BAZEL_BUILD_OPTIONS[@]}" //tools/cod
 CURRENT=spelling
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/spelling:check_spelling_pedantic -- --mark check --target_root="$PWD"
 
+CURRENT=rustfmt
+bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" @rules_rust//:rustfmt
+
 CURRENT=check_format
 bazel "${BAZEL_STARTUP_OPTIONS[@]}" run "${BAZEL_BUILD_OPTIONS[@]}" //tools/code_format:check_format -- fix --fail_on_diff
 

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1050,7 +1050,6 @@ class FormatChecker:
         self.config.buildifier_path
         self.config.buildozer_path
         self.check_visibility()
-        self.run_rustfmt()
         # We first run formatting on non-BUILD files, since the BUILD file format
         # requires analysis of srcs/hdrs in the BUILD file, and we don't want these
         # to be rewritten by other multiprocessing pooled processes.
@@ -1093,28 +1092,6 @@ class FormatChecker:
         except subprocess.CalledProcessError as e:
             if (e.returncode != 0 and e.returncode != 1):
                 self.error_messages.append("Failed to check visibility with command %s" % command)
-
-    def run_rustfmt(self):
-        # Run bazel
-        command = "bazel run @rules_rust//:rustfmt"
-        try:
-            subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).strip()
-        except subprocess.CalledProcessError as e:
-            self.error_messages.append(
-                f"ERROR: something went wrong while executing: {e.cmd}\n{e.output.decode()}")
-            return
-        if self.args.operation_type == "check":
-            try:
-                diff = subprocess.check_output(
-                    "git diff --name-only -- '*.rs'", shell=True,
-                    stderr=subprocess.STDOUT).strip().decode()
-                if diff:
-                    self.error_messages.append(
-                        f"ERROR: rustfmt diff detected. Please run 'bazel run @rules_rust//:rustfmt':\n{diff}"
-                    )
-            except subprocess.CalledProcessError as e:
-                self.error_messages.append(
-                    f"ERROR: git diff failed: {e.output.decode()}")
 
     def included_for_memcpy(self, file_path):
         return file_path in self.config.paths["memcpy"]["include"]


### PR DESCRIPTION
currently bazel is invoked from within a bazel invokation

this creates a new bazel workspace with none of the bazel setup that is configured, and is inherently error prone