### PR TITLE
otel sink: add myself as a co-owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -159,7 +159,7 @@ extensions/filters/common/original_src @klarose @mattklein123
 /*/extensions/stat_sinks/graphite_statsd @vaccarium @mattklein123
 /*/extensions/stat_sinks/hystrix @trabetti @paul-r-gall
 /*/extensions/stat_sinks/metrics_service @ramaraochavali @paul-r-gall
-/*/extensions/stat_sinks/open_telemetry @ohadvano @mattklein123
+/*/extensions/stat_sinks/open_telemetry @ohadvano @mattklein123 @kyessenov
 # webassembly stat-sink extensions
 /*/extensions/stat_sinks/wasm @mpwarres @kyessenov @lizan
 /*/extensions/resource_monitors/injected_resource @eziskind @yanavlasov


### PR DESCRIPTION
Change-Id: I32b91db7dcafbc89823e5d974454a91e5dc333cf

Commit Message: Google is shipping products using OTLP export to telemetry.googleapis.com, I've been reviewing PRs in the area anyways, e.g. https://github.com/envoyproxy/envoy/pull/43716.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
