### PR TITLE
Update QUICHE from e68fe05e7 to 13384c955

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-04-20"
+  release_date: "2026-04-30"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -2113,6 +2113,26 @@ envoy_quic_cc_library(
 )
 
 envoy_quic_cc_library(
+    name = "quic_core_congestion_control_bbr3_sender_lib",
+    srcs = ["quiche/quic/core/congestion_control/bbr3_sender.cc"],
+    hdrs = ["quiche/quic/core/congestion_control/bbr3_sender.h"],
+    deps = [
+        ":quic_core_bandwidth_lib",
+        ":quic_core_congestion_control_bandwidth_sampler_lib",
+        ":quic_core_congestion_control_bbr2_lib",
+        ":quic_core_congestion_control_bbr_lib",
+        ":quic_core_congestion_control_congestion_control_interface_lib",
+        ":quic_core_congestion_control_rtt_stats_lib",
+        ":quic_core_congestion_control_windowed_filter_lib",
+        ":quic_core_crypto_encryption_lib",
+        ":quic_core_tag_lib",
+        ":quic_core_types_lib",
+        ":quic_platform_base",
+        ":quiche_common_print_elements_lib",
+    ],
+)
+
+envoy_quic_cc_library(
     name = "quic_core_congestion_control_general_loss_algorithm_lib",
     srcs = ["quiche/quic/core/congestion_control/general_loss_algorithm.cc"],
     hdrs = ["quiche/quic/core/congestion_control/general_loss_algorithm.h"],
@@ -2159,6 +2179,7 @@ envoy_quic_cc_library(
         ":quic_core_bandwidth_lib",
         ":quic_core_config_lib",
         ":quic_core_congestion_control_bbr2_lib",
+        ":quic_core_congestion_control_bbr3_sender_lib",
         ":quic_core_congestion_control_bbr_lib",
         ":quic_core_congestion_control_prague_sender_lib",
         ":quic_core_congestion_control_tcp_cubic_bytes_lib",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "e68fe05e70da74a3ea282d927c76f76b4bc4e710",
-        sha256 = "08033a0886b470d4ea836a6b785ef6ef7d638265e5523a37718cdd6d1ef6a409",
+        version = "13384c955f76e3a2b157f7b613ce6c02d594770f",
+        sha256 = "a2310cab30a46e9ccf533cd10632d44852d46784f4192e202cc53b6e353d5876",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -210,13 +210,6 @@ quic::QuicSpdyStream* EnvoyQuicClientSession::CreateIncomingStream(quic::QuicStr
   return nullptr;
 }
 
-quic::QuicSpdyStream*
-EnvoyQuicClientSession::CreateIncomingStream(quic::PendingStream* /*pending*/) {
-  // Envoy doesn't support server push.
-  IS_ENVOY_BUG("unexpectes server push call");
-  return nullptr;
-}
-
 bool EnvoyQuicClientSession::hasDataToWrite() { return HasDataToWrite(); }
 
 const quic::QuicConnection* EnvoyQuicClientSession::quicConnection() const {

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -122,7 +122,6 @@ protected:
   std::unique_ptr<quic::QuicSpdyClientStream> CreateClientStream() override;
   // quic::QuicSpdySession
   quic::QuicSpdyStream* CreateIncomingStream(quic::QuicStreamId id) override;
-  quic::QuicSpdyStream* CreateIncomingStream(quic::PendingStream* pending) override;
   std::unique_ptr<quic::QuicCryptoClientStreamBase> CreateQuicCryptoStream() override;
   bool ShouldCreateOutgoingBidirectionalStream() override {
     // quic::QuicSpdyClientSession::ShouldCreateOutgoingBidirectionalStream()

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -118,12 +118,6 @@ quic::QuicSpdyStream* EnvoyQuicServerSession::CreateIncomingStream(quic::QuicStr
   return stream;
 }
 
-quic::QuicSpdyStream*
-EnvoyQuicServerSession::CreateIncomingStream(quic::PendingStream* /*pending*/) {
-  IS_ENVOY_BUG("Unexpected disallowed server push call");
-  return nullptr;
-}
-
 quic::QuicSpdyStream* EnvoyQuicServerSession::CreateOutgoingBidirectionalStream() {
   IS_ENVOY_BUG("Unexpected disallowed server initiated stream");
   return nullptr;

--- a/source/common/quic/envoy_quic_server_session.h
+++ b/source/common/quic/envoy_quic_server_session.h
@@ -140,7 +140,6 @@ protected:
   // quic::QuicSession
   // Overridden to create stream as encoder and associate it with an decoder.
   quic::QuicSpdyStream* CreateIncomingStream(quic::QuicStreamId id) override;
-  quic::QuicSpdyStream* CreateIncomingStream(quic::PendingStream* pending) override;
   quic::QuicSpdyStream* CreateOutgoingBidirectionalStream() override;
 
   quic::HttpDatagramSupport LocalHttpDatagramSupport() override { return http_datagram_support_; }


### PR DESCRIPTION
   Update QUICHE from e68fe05e7 to 13384c955
    https://github.com/google/quiche/compare/e68fe05e7..13384c955
    
    ```
    $ git log e68fe05e7..13384c955 --date=short --no-merges --format="%ad %al %s"
    
    2026-04-29 ianswett Enable gfe2_reloadable_flag_quic_reject_empty_cid_in_ncid in Chrome.
    2026-04-29 ianswett Deprecate gfe2_reloadable_flag_quic_no_path_degrading_before_handshake_confirmed.
    2026-04-28 ripere Add gzip response decompression support to Masque OHTTP client.
    2026-04-28 dschinazi MasqueOhttpClient: Print chunked body to stdout
    2026-04-27 dschinazi Deprecate quic_stop_sending_legacy_version_info and quic_stop_parsing_legacy_version_info
    2026-04-27 ianswett BBR3: Update startup pacing gain, drain gain, and max ack height window to match the BBR IETF draft: https://datatracker.ietf.org/doc/draft-ietf-ccwg-bbr/
    2026-04-23 rch Additional PendingStream cleanup * Remove unused constructors * Pass PendingStream by reference in CreateIncomingStream
    2026-04-23 rch Remove unused QuicSession::CreateIncomingStream(PendingStream*). Remove overrides in subclasses which considered it an error to call this method. Move from override to virtual in those subclasses which actually use this method.
    2026-04-22 wub No public description
    2026-04-22 rch Refactor QuicSession PendingStream methods to take references.
    2026-04-22 ianswett Refactor: Cache Bbr2DebugState in simulator tests.
    2026-04-22 rch Refactor QuicStream constructor to take PendingStream by reference.
    2026-04-21 martinduke Allow MoqtClient and MoqtServer to control session parameters.
    2026-04-21 martinduke Move some non-message-related data structures out of moqt_messages.h
    2026-04-21 ianswett Refactor BBR2/BBR3 initialization and inline some methods.
    2026-04-21 rch Convert quic::PendingStream constructor to take QuicSession reference.
    2026-04-20 ianswett Refactor BBR2/BBR3 parameters by moving kDefaultMinimumCongestionWindow and kInitialPacingGain into Bbr2Params.
    2026-04-20 quiche-dev Add ohttp_ping_pong_mode_{gateway_name} to test ping-pong interactive chunking. It guarantees there is no buffering between the client and server, bidirectionally.
    2026-04-20 ianswett Refactor: Extract DebugState from Bbr2Sender and Bbr3Sender to a common header.
    2026-04-20 martinduke Get rid of moqt::SubscribeWindow.
    2026-04-20 ianswett Refactor and simplify BBR3.
    ```

Risk Level: low
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
