### PR TITLE
otel: add option to disable service.name resource attribute

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message OpenTelemetryConfig {
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.
@@ -72,4 +72,8 @@ message OpenTelemetryConfig {
   //
   // If not specified, the default is to set these attributes.
   google.protobuf.BoolValue set_telemetry_sdk_resource_attributes = 7;
+
+  // Specifies whether to set the ``service.name`` resource attribute.
+  // If not specified, the default is to set this attribute.
+  google.protobuf.BoolValue set_service_name_resource_attribute = 8;
 }

--- a/source/extensions/stat_sinks/open_telemetry/config.cc
+++ b/source/extensions/stat_sinks/open_telemetry/config.cc
@@ -26,7 +26,7 @@ OpenTelemetrySinkFactory::createStatsSink(const Protobuf::Message& config,
       sink_config,
       resource_provider->getResource(sink_config.resource_detectors(), server,
                                      /*service_name=*/"",
-                                     /*set_telemetry_sdk_resource_attributes=*/true),
+                                     Tracers::OpenTelemetry::ResourceProviderOptions{}),
       server);
   std::shared_ptr<OtlpMetricsFlusher> otlp_metrics_flusher =
       std::make_shared<OtlpMetricsFlusherImpl>(otlp_options);

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -76,17 +76,22 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
           POOL_COUNTER_PREFIX(context.serverFactoryContext().scope(), "tracing.opentelemetry"))} {
   auto& factory_context = context.serverFactoryContext();
 
-  bool set_telemetry_sdk_resource_attributes = true;
+  ResourceProviderOptions options;
   if (opentelemetry_config.has_set_telemetry_sdk_resource_attributes()) {
-    set_telemetry_sdk_resource_attributes =
+    options.set_telemetry_sdk_resource_attributes_ =
         opentelemetry_config.set_telemetry_sdk_resource_attributes().value();
+  }
+
+  if (opentelemetry_config.has_set_service_name_resource_attribute()) {
+    options.set_service_name_resource_attribute_ =
+        opentelemetry_config.set_service_name_resource_attribute().value();
   }
 
   Resource resource = resource_provider.getResource(
       opentelemetry_config.resource_detectors(), context.serverFactoryContext(),
       opentelemetry_config.service_name().empty() ? kDefaultServiceName
                                                   : opentelemetry_config.service_name(),
-      set_telemetry_sdk_resource_attributes);
+      options);
   ResourceConstSharedPtr resource_ptr = std::make_shared<Resource>(std::move(resource));
 
   if (opentelemetry_config.has_grpc_service() && opentelemetry_config.has_http_service()) {

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -77,15 +77,10 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
   auto& factory_context = context.serverFactoryContext();
 
   ResourceProviderOptions options;
-  if (opentelemetry_config.has_set_telemetry_sdk_resource_attributes()) {
-    options.set_telemetry_sdk_resource_attributes_ =
-        opentelemetry_config.set_telemetry_sdk_resource_attributes().value();
-  }
-
-  if (opentelemetry_config.has_set_service_name_resource_attribute()) {
-    options.set_service_name_resource_attribute_ =
-        opentelemetry_config.set_service_name_resource_attribute().value();
-  }
+  options.set_telemetry_sdk_resource_attributes = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      opentelemetry_config, set_telemetry_sdk_resource_attributes, true);
+  options.set_service_name_resource_attribute = PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+      opentelemetry_config, set_service_name_resource_attribute, true);
 
   Resource resource = resource_provider.getResource(
       opentelemetry_config.resource_detectors(), context.serverFactoryContext(),

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
@@ -15,15 +15,15 @@ namespace {
 bool isEmptyResource(const Resource& resource) { return resource.attributes_.empty(); }
 
 Resource createInitialResource(absl::string_view service_name,
-                               bool set_telemetry_sdk_resource_attributes) {
+                               const ResourceProviderOptions& options) {
   Resource resource{};
 
   // Creates initial resource with the static service.name and telemetry.sdk.* attributes.
-  if (!service_name.empty()) {
+  if (options.set_service_name_resource_attribute_ && !service_name.empty()) {
     resource.attributes_[kServiceNameKey] = service_name;
   }
 
-  if (set_telemetry_sdk_resource_attributes) {
+  if (options.set_telemetry_sdk_resource_attributes_) {
     resource.attributes_[kTelemetrySdkLanguageKey] = kDefaultTelemetrySdkLanguage;
     resource.attributes_[kTelemetrySdkNameKey] = kDefaultTelemetrySdkName;
     resource.attributes_[kTelemetrySdkVersionKey] = Envoy::VersionInfo::version();
@@ -88,9 +88,9 @@ Resource ResourceProviderImpl::getResource(
     const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
         resource_detectors,
     Envoy::Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
-    bool set_telemetry_sdk_resource_attributes) const {
+    const ResourceProviderOptions& options) const {
 
-  Resource resource = createInitialResource(service_name, set_telemetry_sdk_resource_attributes);
+  Resource resource = createInitialResource(service_name, options);
 
   for (const auto& detector_config : resource_detectors) {
     ResourceDetectorPtr detector;

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.cc
@@ -19,11 +19,11 @@ Resource createInitialResource(absl::string_view service_name,
   Resource resource{};
 
   // Creates initial resource with the static service.name and telemetry.sdk.* attributes.
-  if (options.set_service_name_resource_attribute_ && !service_name.empty()) {
+  if (options.set_service_name_resource_attribute && !service_name.empty()) {
     resource.attributes_[kServiceNameKey] = service_name;
   }
 
-  if (options.set_telemetry_sdk_resource_attributes_) {
+  if (options.set_telemetry_sdk_resource_attributes) {
     resource.attributes_[kTelemetrySdkLanguageKey] = kDefaultTelemetrySdkLanguage;
     resource.attributes_[kTelemetrySdkNameKey] = kDefaultTelemetrySdkName;
     resource.attributes_[kTelemetrySdkVersionKey] = Envoy::VersionInfo::version();

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
@@ -29,16 +29,13 @@ struct ResourceProviderOptions {
    * @brief Whether to automatically include telemetry SDK metadata attributes
    * (`telemetry.sdk.language`, `telemetry.sdk.name`, `telemetry.sdk.version`).
    */
-  bool set_telemetry_sdk_resource_attributes_{true};
+  bool set_telemetry_sdk_resource_attributes{true};
   /**
    * @brief Whether to automatically include the `service.name` resource attribute.
    */
-  bool set_service_name_resource_attribute_{true};
+  bool set_service_name_resource_attribute{true};
 
-  bool operator==(const ResourceProviderOptions& other) const {
-    return set_telemetry_sdk_resource_attributes_ == other.set_telemetry_sdk_resource_attributes_ &&
-           set_service_name_resource_attribute_ == other.set_service_name_resource_attribute_;
-  }
+  bool operator==(const ResourceProviderOptions& other) const = default;
 };
 
 class ResourceProvider : public Logger::Loggable<Logger::Id::tracing> {

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_provider.h
@@ -20,6 +20,27 @@ constexpr absl::string_view kDefaultTelemetrySdkName = "envoy";
 
 constexpr absl::string_view kTelemetrySdkVersionKey = "telemetry.sdk.version";
 
+/**
+ * @brief Configuration options controlling the population of optional attributes in the emitted
+ * OpenTelemetry resource object.
+ */
+struct ResourceProviderOptions {
+  /**
+   * @brief Whether to automatically include telemetry SDK metadata attributes
+   * (`telemetry.sdk.language`, `telemetry.sdk.name`, `telemetry.sdk.version`).
+   */
+  bool set_telemetry_sdk_resource_attributes_{true};
+  /**
+   * @brief Whether to automatically include the `service.name` resource attribute.
+   */
+  bool set_service_name_resource_attribute_{true};
+
+  bool operator==(const ResourceProviderOptions& other) const {
+    return set_telemetry_sdk_resource_attributes_ == other.set_telemetry_sdk_resource_attributes_ &&
+           set_service_name_resource_attribute_ == other.set_service_name_resource_attribute_;
+  }
+};
+
 class ResourceProvider : public Logger::Loggable<Logger::Id::tracing> {
 public:
   virtual ~ResourceProvider() = default;
@@ -39,7 +60,7 @@ public:
   getResource(const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                   resource_detectors,
               Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
-              bool set_telemetry_sdk_resource_attributes) const PURE;
+              const ResourceProviderOptions& options) const PURE;
 };
 using ResourceProviderPtr = std::shared_ptr<ResourceProvider>;
 
@@ -49,7 +70,7 @@ public:
   getResource(const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                   resource_detectors,
               Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
-              bool set_telemetry_sdk_resource_attributes) const override;
+              const ResourceProviderOptions& options) const override;
 };
 
 } // namespace OpenTelemetry

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -35,7 +35,7 @@ public:
               (const Protobuf::RepeatedPtrField<envoy::config::core::v3::TypedExtensionConfig>&
                    resource_detectors,
                Server::Configuration::ServerFactoryContext& context, absl::string_view service_name,
-               bool set_telemetry_sdk_resource_attributes),
+               const ResourceProviderOptions& options),
               (const));
 };
 
@@ -148,7 +148,10 @@ TEST_F(OpenTelemetryDriverTest, PassSetTelemetrySdkResourceAttributesFalse) {
   Resource resource;
   auto mock_resource_provider = NiceMock<MockResourceProvider>();
 
-  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, false)).WillOnce(Return(resource));
+  ResourceProviderOptions expected_options;
+  expected_options.set_telemetry_sdk_resource_attributes_ = false;
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
+      .WillOnce(Return(resource));
 
   driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
 }
@@ -178,7 +181,75 @@ TEST_F(OpenTelemetryDriverTest, PassSetTelemetrySdkResourceAttributesDefaultTrue
   Resource resource;
   auto mock_resource_provider = NiceMock<MockResourceProvider>();
 
-  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, true)).WillOnce(Return(resource));
+  ResourceProviderOptions expected_options;
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
+      .WillOnce(Return(resource));
+
+  driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
+}
+
+// Verifies that set_service_name_resource_attribute=false is passed to ResourceProvider
+TEST_F(OpenTelemetryDriverTest, PassSetServiceNameResourceAttributeFalse) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    set_service_name_resource_attribute: false
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto mock_client_factory = std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
+  auto mock_client = std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
+  mock_client_ = mock_client.get();
+  ON_CALL(*mock_client_factory, createUncachedRawAsyncClient())
+      .WillByDefault(Return(ByMove(std::move(mock_client))));
+  auto& factory_context = context_.server_factory_context_;
+  ON_CALL(factory_context, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(factory_context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
+  ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
+
+  Resource resource;
+  auto mock_resource_provider = NiceMock<MockResourceProvider>();
+
+  ResourceProviderOptions expected_options;
+  expected_options.set_service_name_resource_attribute_ = false;
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
+      .WillOnce(Return(resource));
+
+  driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
+}
+
+// Verifies that set_service_name_resource_attribute defaults to true
+TEST_F(OpenTelemetryDriverTest, PassSetServiceNameResourceAttributeDefaultTrue) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  auto mock_client_factory = std::make_unique<NiceMock<Grpc::MockAsyncClientFactory>>();
+  auto mock_client = std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
+  mock_client_ = mock_client.get();
+  ON_CALL(*mock_client_factory, createUncachedRawAsyncClient())
+      .WillByDefault(Return(ByMove(std::move(mock_client))));
+  auto& factory_context = context_.server_factory_context_;
+  ON_CALL(factory_context, runtime()).WillByDefault(ReturnRef(runtime_));
+  ON_CALL(factory_context.cluster_manager_.async_client_manager_, factoryForGrpcService(_, _, _))
+      .WillByDefault(Return(ByMove(std::move(mock_client_factory))));
+  ON_CALL(factory_context, scope()).WillByDefault(ReturnRef(scope_));
+
+  Resource resource;
+  auto mock_resource_provider = NiceMock<MockResourceProvider>();
+
+  ResourceProviderOptions expected_options;
+  EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
+      .WillOnce(Return(resource));
 
   driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
 }

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -149,7 +149,7 @@ TEST_F(OpenTelemetryDriverTest, PassSetTelemetrySdkResourceAttributesFalse) {
   auto mock_resource_provider = NiceMock<MockResourceProvider>();
 
   ResourceProviderOptions expected_options;
-  expected_options.set_telemetry_sdk_resource_attributes_ = false;
+  expected_options.set_telemetry_sdk_resource_attributes = false;
   EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
       .WillOnce(Return(resource));
 
@@ -215,7 +215,7 @@ TEST_F(OpenTelemetryDriverTest, PassSetServiceNameResourceAttributeFalse) {
   auto mock_resource_provider = NiceMock<MockResourceProvider>();
 
   ResourceProviderOptions expected_options;
-  expected_options.set_service_name_resource_attribute_ = false;
+  expected_options.set_service_name_resource_attribute = false;
   EXPECT_CALL(mock_resource_provider, getResource(_, _, _, expected_options))
       .WillOnce(Return(resource));
 

--- a/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
@@ -78,9 +78,9 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfigured) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   EXPECT_EQ(resource.schema_url_, "");
 
@@ -115,14 +115,42 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfiguredAttributesDisabled) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
+  ResourceProviderOptions options;
+  options.set_telemetry_sdk_resource_attributes_ = false;
   Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
                                                     server_factory_context_,
-                                                    opentelemetry_config.service_name(), false);
+                                                    opentelemetry_config.service_name(), options);
 
   // Verify that telemetry SDK attributes are NOT present
   EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.language") == resource.attributes_.end());
   EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.name") == resource.attributes_.end());
   EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.version") == resource.attributes_.end());
+}
+
+// Verifies a resource without service name is returned when service name attribute is disabled
+TEST_F(ResourceProviderTest, NoResourceDetectorsConfiguredServiceNameDisabled) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    service_name: my-service
+    set_service_name_resource_attribute: false
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  ResourceProviderImpl resource_provider;
+  ResourceProviderOptions options;
+  options.set_service_name_resource_attribute_ = false;
+  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
+                                                    server_factory_context_,
+                                                    opentelemetry_config.service_name(), options);
+
+  // Verify that service.name attribute is NOT present
+  EXPECT_TRUE(resource.attributes_.find("service.name") == resource.attributes_.end());
+  // Verify other attributes are still present since only service.name was disabled
+  EXPECT_TRUE(resource.attributes_.find("telemetry.sdk.language") != resource.attributes_.end());
 }
 
 // Verifies it is possible to configure multiple resource detectors
@@ -171,9 +199,9 @@ TEST_F(ResourceProviderTest, MultipleResourceDetectorsConfigured) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   EXPECT_EQ(resource.schema_url_, "");
 
@@ -209,7 +237,7 @@ TEST_F(ResourceProviderTest, UnknownResourceDetectors) {
   EXPECT_THROW_WITH_MESSAGE(
       resource_provider.getResource(opentelemetry_config.resource_detectors(),
                                     server_factory_context_, opentelemetry_config.service_name(),
-                                    true),
+                                    ResourceProviderOptions{}),
       EnvoyException,
       "Resource detector factory not found: "
       "'envoy.tracers.opentelemetry.resource_detectors.UnkownResourceDetector'");
@@ -241,7 +269,7 @@ TEST_F(ResourceProviderTest, ProblemCreatingResourceDetector) {
   ResourceProviderImpl resource_provider;
   EXPECT_THROW_WITH_MESSAGE(resource_provider.getResource(
                                 opentelemetry_config.resource_detectors(), server_factory_context_,
-                                opentelemetry_config.service_name(), true),
+                                opentelemetry_config.service_name(), ResourceProviderOptions{}),
                             EnvoyException,
                             "Resource detector could not be created: "
                             "'envoy.tracers.opentelemetry.resource_detectors.a'");
@@ -291,9 +319,9 @@ TEST_F(ResourceProviderTest, OldSchemaEmptyUpdatingSet) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   // OTel spec says the updating schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
@@ -343,9 +371,9 @@ TEST_F(ResourceProviderTest, OldSchemaSetUpdatingEmpty) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   // OTel spec says the updating schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
@@ -395,9 +423,9 @@ TEST_F(ResourceProviderTest, OldAndUpdatingSchemaAreEqual) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   EXPECT_EQ(expected_schema_url, resource.schema_url_);
 }
@@ -446,9 +474,9 @@ TEST_F(ResourceProviderTest, OldAndUpdatingSchemaAreDifferent) {
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
   ResourceProviderImpl resource_provider;
-  Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
-                                                    server_factory_context_,
-                                                    opentelemetry_config.service_name(), true);
+  Resource resource = resource_provider.getResource(
+      opentelemetry_config.resource_detectors(), server_factory_context_,
+      opentelemetry_config.service_name(), ResourceProviderOptions{});
 
   // OTel spec says Old schema should be used
   EXPECT_EQ(expected_schema_url, resource.schema_url_);

--- a/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
+++ b/test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc
@@ -116,7 +116,7 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfiguredAttributesDisabled) {
 
   ResourceProviderImpl resource_provider;
   ResourceProviderOptions options;
-  options.set_telemetry_sdk_resource_attributes_ = false;
+  options.set_telemetry_sdk_resource_attributes = false;
   Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
                                                     server_factory_context_,
                                                     opentelemetry_config.service_name(), options);
@@ -142,7 +142,7 @@ TEST_F(ResourceProviderTest, NoResourceDetectorsConfiguredServiceNameDisabled) {
 
   ResourceProviderImpl resource_provider;
   ResourceProviderOptions options;
-  options.set_service_name_resource_attribute_ = false;
+  options.set_service_name_resource_attribute = false;
   Resource resource = resource_provider.getResource(opentelemetry_config.resource_detectors(),
                                                     server_factory_context_,
                                                     opentelemetry_config.service_name(), options);


### PR DESCRIPTION
Commit Message: otel: add option to disable service.name resource attribute

Additional Description:

Currently, the OpenTelemetry tracer always populates the `service.name` resource attribute. If no name is configured in the YAML, it defaults to `unknown_service:envoy` which ends up being forcefully emitted into the resource spans.

Similar to #44689, we have use cases where we do not want to set or leak the `service.name` resource attribute.

This PR introduces a new configuration option `set_service_name_resource_attribute` (default true) in `OpenTelemetryConfig` to allow opting-out of populating this attribute. When set to false, the `service.name` key will be omitted from the emitted resource object entirely.

As part of this change, the internal parameter propagation in `ResourceProvider` was refactored to use an options pattern (`ResourceProviderOptions`) to aggregate boolean configuration flags rather than extending method signatures with consecutive bool primitives.

The new behavior is opt-in (default behavior is unchanged) to preserve backward compatibility.

Risk Level: Low
Testing:
- Unit tests in `test/extensions/tracers/opentelemetry/resource_detectors/resource_provider_test.cc` have been updated and a new test added to validate that the `service.name` attribute is omitted when disabled.
- Unit tests in `test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc` have been updated to verify the configuration flags are propagated correctly via the new options struct.

Docs Changes: None. 
Release Notes: Added a configuration option to disable populating the `service.name` resource attribute in the OpenTelemetry tracer.
Platform Specific Features: None.
Runtime guard: None.

[Disclosed usage of generative AI: Yes, used to assist in code modifications and refactoring.]
