### PR TITLE
tls: add suppress_client_ca_list option to CertificateValidationContext

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -611,6 +611,9 @@ message CertificateValidationContext {
   //   multiple client certificates may now send no certificate or the wrong one;
   //   validation will then fail with the standard TLS alert.
   //
+  // This option only affects downstream (server) TLS connections where Envoy sends a
+  // ``CertificateRequest`` to clients. It has no effect on upstream connections.
+  //
   // Honored by the built-in validator and the SPIFFE validator. Validators that do
   // not set a client CA list themselves (e.g., the dynamic-modules validator) are
   // unaffected. Defaults to false.

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -603,9 +603,7 @@ message CertificateValidationContext {
   //
   // This is useful when the configured CA set is large enough that the
   // ``CertificateRequest`` would exceed client-side TLS record limits, or when
-  // clients filter their client-certificate picker against the advertised CAs
-  // (notably iOS Safari, where valid certificates can be hidden from the user's
-  // picker). See https://github.com/envoyproxy/envoy/issues/14208.
+  // clients mishandle the CA set in some way.
   //
   // .. attention::
   //

--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -369,7 +369,7 @@ message SubjectAltNameMatcher {
   string oid = 3;
 }
 
-// [#next-free-field: 18]
+// [#next-free-field: 19]
 message CertificateValidationContext {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.auth.CertificateValidationContext";
@@ -594,4 +594,27 @@ message CertificateValidationContext {
   // in OpenSSL 1.1.x and newer versions of BoringSSL in that the trust anchor is included.
   // Trusted issues are specified by setting :ref:`trusted_ca <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`
   google.protobuf.UInt32Value max_verify_depth = 16 [(validate.rules).uint32 = {lte: 100}];
+
+  // If true, the server does not include the trusted-CA distinguished names in the
+  // TLS ``CertificateRequest`` message. CAs from :ref:`trusted_ca
+  // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`
+  // are still used to validate presented client certificates; only the wire
+  // advertisement changes.
+  //
+  // This is useful when the configured CA set is large enough that the
+  // ``CertificateRequest`` would exceed client-side TLS record limits, or when
+  // clients filter their client-certificate picker against the advertised CAs
+  // (notably iOS Safari, where valid certificates can be hidden from the user's
+  // picker). See https://github.com/envoyproxy/envoy/issues/14208.
+  //
+  // .. attention::
+  //
+  //   When enabled, clients that rely on the advertised CA list to select among
+  //   multiple client certificates may now send no certificate or the wrong one;
+  //   validation will then fail with the standard TLS alert.
+  //
+  // Honored by the built-in validator and the SPIFFE validator. Validators that do
+  // not set a client CA list themselves (e.g., the dynamic-modules validator) are
+  // unaffected. Defaults to false.
+  bool suppress_client_ca_list = 18;
 }

--- a/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
+++ b/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
@@ -3,5 +3,5 @@ Added :ref:`suppress_client_ca_list
 option to CertificateValidationContext. When enabled, the server will not send the list of
 trusted CA names to clients during the TLS handshake, while still using those CAs for
 certificate validation. This avoids ``CertificateRequest`` messages exceeding TLS record limits
-with very large CA sets, and sidesteps client-certificate picker bugs in clients that
-mishandle the CA set. Honored by both the built-in validator and the SPIFFE validator.
+with very large CA sets, or when clients mishandle the CA set in some way. Honored by both
+the built-in validator and the SPIFFE validator.

--- a/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
+++ b/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
@@ -1,0 +1,9 @@
+Added :ref:`suppress_client_ca_list
+<envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.suppress_client_ca_list>`
+option to CertificateValidationContext. When enabled, the server will not send the list of
+trusted CA names to clients during the TLS handshake, while still using those CAs for
+certificate validation. This avoids ``CertificateRequest`` messages exceeding TLS record limits
+with very large CA sets, and sidesteps client-certificate picker bugs in clients that filter
+on the advertised intermediate CAs (notably iOS Safari, where valid certificates can be
+hidden from the user's picker). Honored by both the built-in validator and the SPIFFE
+validator. Addresses issue #14208.

--- a/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
+++ b/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
@@ -3,7 +3,5 @@ Added :ref:`suppress_client_ca_list
 option to CertificateValidationContext. When enabled, the server will not send the list of
 trusted CA names to clients during the TLS handshake, while still using those CAs for
 certificate validation. This avoids ``CertificateRequest`` messages exceeding TLS record limits
-with very large CA sets, and sidesteps client-certificate picker bugs in clients that filter
-on the advertised intermediate CAs (notably iOS Safari, where valid certificates can be
-hidden from the user's picker). Honored by both the built-in validator and the SPIFFE
-validator.
+with very large CA sets, and sidesteps client-certificate picker bugs in clients that
+mishandle the CA set. Honored by both the built-in validator and the SPIFFE validator.

--- a/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
+++ b/changelogs/current/new_features/tls__added-suppress-client-ca-list.rst
@@ -6,4 +6,4 @@ certificate validation. This avoids ``CertificateRequest`` messages exceeding TL
 with very large CA sets, and sidesteps client-certificate picker bugs in clients that filter
 on the advertised intermediate CAs (notably iOS Safari, where valid certificates can be
 hidden from the user's picker). Honored by both the built-in validator and the SPIFFE
-validator. Addresses issue #14208.
+validator.

--- a/envoy/ssl/certificate_validation_context_config.h
+++ b/envoy/ssl/certificate_validation_context_config.h
@@ -106,6 +106,11 @@ public:
    */
   virtual bool autoSniSanMatch() const PURE;
 
+  /**
+   * @return whether to suppress sending CA certificate names to clients during handshake.
+   */
+  virtual bool suppressClientCaList() const PURE;
+
   // SECURITY NOTE
   //
   // When adding or changing this interface, it is likely that a change is needed to

--- a/source/common/ssl/certificate_validation_context_config_impl.cc
+++ b/source/common/ssl/certificate_validation_context_config_impl.cc
@@ -45,7 +45,8 @@ CertificateValidationContextConfigImpl::CertificateValidationContextConfigImpl(
       max_verify_depth_(config.has_max_verify_depth()
                             ? absl::optional<uint32_t>(config.max_verify_depth().value())
                             : absl::nullopt),
-      auto_sni_san_match_(auto_sni_san_match) {}
+      auto_sni_san_match_(auto_sni_san_match),
+      suppress_client_ca_list_(config.suppress_client_ca_list()) {}
 
 absl::StatusOr<std::unique_ptr<CertificateValidationContextConfigImpl>>
 CertificateValidationContextConfigImpl::create(

--- a/source/common/ssl/certificate_validation_context_config_impl.h
+++ b/source/common/ssl/certificate_validation_context_config_impl.h
@@ -61,6 +61,8 @@ public:
 
   bool autoSniSanMatch() const override { return auto_sni_san_match_; }
 
+  bool suppressClientCaList() const override { return suppress_client_ca_list_; }
+
 protected:
   CertificateValidationContextConfigImpl(
       std::string ca_cert, std::string certificate_revocation_list,
@@ -88,6 +90,7 @@ private:
   const bool only_verify_leaf_cert_crl_;
   absl::optional<uint32_t> max_verify_depth_;
   const bool auto_sni_san_match_;
+  const bool suppress_client_ca_list_;
 };
 
 } // namespace Ssl

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -590,8 +590,9 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
     if (ERR_GET_LIB(err) == ERR_LIB_PEM && ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {
       ERR_clear_error();
     } else {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "Failed to load trusted client CA certificates from ", config_->caCertPath()));
+      return absl::InvalidArgumentError(
+          absl::StrCat("Failed to load trusted client CA certificates from ",
+                       config_->caCertPath()));
     }
     SSL_CTX_set_client_CA_list(ctx, list.release());
   }
@@ -599,10 +600,13 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
   if (require_client_cert) {
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
   }
+  // Set the verify_depth
   if (config_->maxVerifyDepth().has_value()) {
     uint32_t max_verify_depth = std::min(config_->maxVerifyDepth().value(), uint32_t{INT_MAX});
-    // Adjust for BoringSSL semantics: maxVerifyDepth documents the older behavior
-    // (includes trust anchor), so subtract 1 to match newer BoringSSL.
+    // Older BoringSSLs behave like OpenSSL 1.0.x and exclude the leaf from the
+    // depth but include the trust anchor. Newer BoringSSLs match OpenSSL 1.1.x
+    // and later in excluding both the leaf and trust anchor. `maxVerifyDepth`
+    // documents the older behavior, so adjust the value to match.
     max_verify_depth = max_verify_depth > 0 ? max_verify_depth - 1 : 0;
     SSL_CTX_set_verify_depth(ctx, static_cast<int>(max_verify_depth));
   }

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -534,12 +534,35 @@ void DefaultCertValidator::updateDigestForSessionId(bssl::ScopedEVP_MD_CTX& md,
     bool auto_sni_san_match = config_->autoSniSanMatch();
     rc = EVP_DigestUpdate(md.get(), &auto_sni_san_match, sizeof(auto_sni_san_match));
     RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
+
+    // Only hash when the flag is enabled, so session IDs for existing deployments
+    // (where the flag defaults to false) stay byte-identical to pre-feature behavior.
+    if (config_->suppressClientCaList()) {
+      bool suppress = true;
+      rc = EVP_DigestUpdate(md.get(), &suppress, sizeof(suppress));
+      RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
+    }
   }
 }
 
 absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
                                                               bool require_client_cert) {
   if (config_ == nullptr || config_->caCert().empty()) {
+    return absl::OkStatus();
+  }
+
+  // When the CA list is suppressed, skip building the name stack entirely. The
+  // trust anchors are already loaded into the X509_STORE in initializeSslContexts(),
+  // which also rejects malformed bundles. Verify mode and depth are still applied.
+  if (config_->suppressClientCaList()) {
+    if (require_client_cert) {
+      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
+    }
+    if (config_->maxVerifyDepth().has_value()) {
+      uint32_t max_verify_depth = std::min(config_->maxVerifyDepth().value(), uint32_t{INT_MAX});
+      max_verify_depth = max_verify_depth > 0 ? max_verify_depth - 1 : 0;
+      SSL_CTX_set_verify_depth(ctx, static_cast<int>(max_verify_depth));
+    }
     return absl::OkStatus();
   }
 

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -551,72 +551,58 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
     return absl::OkStatus();
   }
 
-  // When the CA list is suppressed, skip building the name stack entirely. The
-  // trust anchors are already loaded into the X509_STORE in initializeSslContexts(),
-  // which also rejects malformed bundles. Verify mode and depth are still applied.
-  if (config_->suppressClientCaList()) {
-    if (require_client_cert) {
-      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
-    }
-    if (config_->maxVerifyDepth().has_value()) {
-      uint32_t max_verify_depth = std::min(config_->maxVerifyDepth().value(), uint32_t{INT_MAX});
-      max_verify_depth = max_verify_depth > 0 ? max_verify_depth - 1 : 0;
-      SSL_CTX_set_verify_depth(ctx, static_cast<int>(max_verify_depth));
-    }
-    return absl::OkStatus();
-  }
+  // When the CA list is not suppressed, parse the trust bundle and advertise
+  // the CA names in the TLS CertificateRequest message.
+  if (!config_->suppressClientCaList()) {
+    bssl::UniquePtr<BIO> bio(
+        BIO_new_mem_buf(const_cast<char*>(config_->caCert().data()), config_->caCert().size()));
+    RELEASE_ASSERT(bio != nullptr, "");
+    // Based on BoringSSL's SSL_add_file_cert_subjects_to_stack().
+    // Use a generic lambda to be compatible with BoringSSL before and after
+    // https://boringssl-review.googlesource.com/c/boringssl/+/56190
+    bssl::UniquePtr<STACK_OF(X509_NAME)> list(
+        sk_X509_NAME_new([](auto* a, auto* b) -> int { return X509_NAME_cmp(*a, *b); }));
+    RELEASE_ASSERT(list != nullptr, "");
+    for (;;) {
+      bssl::UniquePtr<X509> cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
+      if (cert == nullptr) {
+        break;
+      }
+      const X509_NAME* name = X509_get_subject_name(cert.get());
+      if (name == nullptr) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Failed to load trusted client CA certificates from ", config_->caCertPath()));
+      }
+      // Check for duplicates.
+      if (sk_X509_NAME_find(list.get(), nullptr, name)) {
+        continue;
+      }
 
-  bssl::UniquePtr<BIO> bio(
-      BIO_new_mem_buf(const_cast<char*>(config_->caCert().data()), config_->caCert().size()));
-  RELEASE_ASSERT(bio != nullptr, "");
-  // Based on BoringSSL's SSL_add_file_cert_subjects_to_stack().
-  // Use a generic lambda to be compatible with BoringSSL before and after
-  // https://boringssl-review.googlesource.com/c/boringssl/+/56190
-  bssl::UniquePtr<STACK_OF(X509_NAME)> list(
-      sk_X509_NAME_new([](auto* a, auto* b) -> int { return X509_NAME_cmp(*a, *b); }));
-  RELEASE_ASSERT(list != nullptr, "");
-  for (;;) {
-    bssl::UniquePtr<X509> cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
-    if (cert == nullptr) {
-      break;
+      bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
+      if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Failed to load trusted client CA certificates from ", config_->caCertPath()));
+      }
     }
-    const X509_NAME* name = X509_get_subject_name(cert.get());
-    if (name == nullptr) {
+
+    // Check for EOF.
+    const uint32_t err = ERR_peek_last_error();
+    if (ERR_GET_LIB(err) == ERR_LIB_PEM && ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {
+      ERR_clear_error();
+    } else {
       return absl::InvalidArgumentError(absl::StrCat(
           "Failed to load trusted client CA certificates from ", config_->caCertPath()));
     }
-    // Check for duplicates.
-    if (sk_X509_NAME_find(list.get(), nullptr, name)) {
-      continue;
-    }
-
-    bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name));
-    if (name_dup == nullptr || !sk_X509_NAME_push(list.get(), name_dup.release())) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "Failed to load trusted client CA certificates from ", config_->caCertPath()));
-    }
+    SSL_CTX_set_client_CA_list(ctx, list.release());
   }
-
-  // Check for EOF.
-  const uint32_t err = ERR_peek_last_error();
-  if (ERR_GET_LIB(err) == ERR_LIB_PEM && ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {
-    ERR_clear_error();
-  } else {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Failed to load trusted client CA certificates from ", config_->caCertPath()));
-  }
-  SSL_CTX_set_client_CA_list(ctx, list.release());
 
   if (require_client_cert) {
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
   }
-  // Set the verify_depth
   if (config_->maxVerifyDepth().has_value()) {
     uint32_t max_verify_depth = std::min(config_->maxVerifyDepth().value(), uint32_t{INT_MAX});
-    // Older BoringSSLs behave like OpenSSL 1.0.x and exclude the leaf from the
-    // depth but include the trust anchor. Newer BoringSSLs match OpenSSL 1.1.x
-    // and later in excluding both the leaf and trust anchor. `maxVerifyDepth`
-    // documents the older behavior, so adjust the value to match.
+    // Adjust for BoringSSL semantics: maxVerifyDepth documents the older behavior
+    // (includes trust anchor), so subtract 1 to match newer BoringSSL.
     max_verify_depth = max_verify_depth > 0 ? max_verify_depth - 1 : 0;
     SSL_CTX_set_verify_depth(ctx, static_cast<int>(max_verify_depth));
   }

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -590,9 +590,8 @@ absl::Status DefaultCertValidator::addClientValidationContext(SSL_CTX* ctx,
     if (ERR_GET_LIB(err) == ERR_LIB_PEM && ERR_GET_REASON(err) == PEM_R_NO_START_LINE) {
       ERR_clear_error();
     } else {
-      return absl::InvalidArgumentError(
-          absl::StrCat("Failed to load trusted client CA certificates from ",
-                       config_->caCertPath()));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Failed to load trusted client CA certificates from ", config_->caCertPath()));
     }
     SSL_CTX_set_client_CA_list(ctx, list.release());
   }

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -147,6 +147,7 @@ SPIFFEValidator::SPIFFEValidator(const Envoy::Ssl::CertificateValidationContextC
     : stats_(stats), time_source_(context.timeSource()) {
   ASSERT(config != nullptr);
   allow_expired_certificate_ = config->allowExpiredCertificate();
+  suppress_client_ca_list_ = config->suppressClientCaList();
 
   SPIFFEConfig message;
   SET_AND_RETURN_IF_NOT_OK(Config::Utility::translateOpaqueConfig(
@@ -249,6 +250,14 @@ SPIFFEValidator::SPIFFEValidator(const Envoy::Ssl::CertificateValidationContextC
 }
 
 absl::Status SPIFFEValidator::addClientValidationContext(SSL_CTX* ctx, bool) {
+  // When suppressed, CAs are still used for validation (loaded via the trust bundle
+  // in initializeSslContexts) but their names are not advertised in the TLS
+  // CertificateRequest. Skip building the name stack entirely — this is the common
+  // case for deployments with very large CA sets.
+  if (suppress_client_ca_list_) {
+    return absl::OkStatus();
+  }
+
   // Use a generic lambda to be compatible with BoringSSL before and after
   // https://boringssl-review.googlesource.com/c/boringssl/+/56190
   bssl::UniquePtr<STACK_OF(X509_NAME)> list(
@@ -283,6 +292,13 @@ void SPIFFEValidator::updateDigestForSessionId(bssl::ScopedEVP_MD_CTX& md,
     RELEASE_ASSERT(hash_length == SHA256_DIGEST_LENGTH,
                    fmt::format("invalid SHA256 hash length {}", hash_length));
     rc = EVP_DigestUpdate(md.get(), hash_buffer, hash_length);
+    RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
+  }
+  // Only hash when the flag is enabled, so session IDs for existing deployments
+  // (where the flag defaults to false) stay byte-identical to pre-feature behavior.
+  if (suppress_client_ca_list_) {
+    bool suppress = true;
+    rc = EVP_DigestUpdate(md.get(), &suppress, sizeof(suppress));
     RELEASE_ASSERT(rc == 1, Utility::getLastCryptoError().value_or(""));
   }
 }

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
@@ -94,6 +94,7 @@ private:
   void initializeCertExpirationStats(Stats::Scope& scope, const std::string& cert_name);
 
   bool allow_expired_certificate_{false};
+  bool suppress_client_ca_list_{false};
 
   std::string ca_file_name_;
   std::shared_ptr<SpiffeData> spiffe_data_;

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -712,6 +712,7 @@ public:
   bool onlyVerifyLeafCertificateCrl() const override { return false; }
   absl::optional<uint32_t> maxVerifyDepth() const override { return absl::nullopt; }
   bool autoSniSanMatch() const override { return false; }
+  bool suppressClientCaList() const override { return false; }
 
 private:
   std::string s_;
@@ -788,6 +789,7 @@ public:
   bool onlyVerifyLeafCertificateCrl() const override { return false; }
   absl::optional<uint32_t> maxVerifyDepth() const override { return absl::nullopt; }
   bool autoSniSanMatch() const override { return false; }
+  bool suppressClientCaList() const override { return false; }
 
 private:
   std::string ca_name_;
@@ -889,6 +891,154 @@ TEST(DefaultCertValidatorTest, TestEmptyCertChainErrorDetails) {
   EXPECT_EQ(ValidationResults::ValidationStatus::Failed, results.status);
   EXPECT_TRUE(results.error_details.has_value());
   EXPECT_EQ(results.error_details.value(), "verify cert failed: empty cert chain");
+}
+
+namespace {
+
+TestCertificateValidationContextConfigPtr makeSuppressConfig(const std::string& ca_cert,
+                                                             bool suppress) {
+  envoy::config::core::v3::TypedExtensionConfig typed_conf;
+  std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers{};
+  return std::make_unique<TestCertificateValidationContextConfig>(
+      typed_conf, /*allow_expired_certificate=*/false, san_matchers, ca_cert,
+      /*verify_depth=*/absl::nullopt, suppress);
+}
+
+// Runs updateDigestForSessionId against the validator and returns the resulting
+// digest bytes. Lets tests compare digests produced under different configs.
+std::vector<uint8_t> computeSessionIdDigest(DefaultCertValidator& validator) {
+  bssl::ScopedEVP_MD_CTX md;
+  int rc = EVP_DigestInit_ex(md.get(), EVP_sha256(), nullptr);
+  RELEASE_ASSERT(rc == 1, "EVP_DigestInit_ex failed");
+  uint8_t scratch[EVP_MAX_MD_SIZE];
+  validator.updateDigestForSessionId(md, scratch, SHA256_DIGEST_LENGTH);
+  std::vector<uint8_t> out(EVP_MAX_MD_SIZE);
+  unsigned out_len = 0;
+  rc = EVP_DigestFinal_ex(md.get(), out.data(), &out_len);
+  RELEASE_ASSERT(rc == 1, "EVP_DigestFinal_ex failed");
+  out.resize(out_len);
+  return out;
+}
+
+} // namespace
+
+// Test that when suppress_client_ca_list is enabled, SSL_CTX_get_client_CA_list returns NULL
+TEST(DefaultCertValidatorTest, SuppressClientCaListEnabled) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config = makeSuppressConfig(ca_cert, true);
+  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), true).ok());
+
+  // When suppressed, the validator must not populate the CA list. Depending on the
+  // BoringSSL version, SSL_CTX_new may leave the list as nullptr or as an empty stack;
+  // both outcomes satisfy the guarantee that no CA names will be advertised.
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
+  if (ca_list != nullptr) {
+    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
+  }
+}
+
+// Test that when suppress_client_ca_list is disabled (default), CA list is set correctly
+TEST(DefaultCertValidatorTest, SuppressClientCaListDisabled) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config = makeSuppressConfig(ca_cert, false);
+  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), true).ok());
+
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
+  ASSERT_NE(ca_list, nullptr);
+  EXPECT_GT(sk_X509_NAME_num(ca_list), 0);
+}
+
+// Test that session ID hash differs when suppress_client_ca_list differs.
+// This prevents session resumption across contexts with different security settings.
+TEST(DefaultCertValidatorTest, SuppressClientCaListSessionIdDiffers) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config_suppressed = makeSuppressConfig(ca_cert, true);
+  auto config_not_suppressed = makeSuppressConfig(ca_cert, false);
+
+  DefaultCertValidator validator_suppressed(config_suppressed.get(), stats, context);
+  DefaultCertValidator validator_not_suppressed(config_not_suppressed.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx_suppressed(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> ssl_ctx_not_suppressed(SSL_CTX_new(TLS_method()));
+  std::vector<SSL_CTX*> ctxs1 = {ssl_ctx_suppressed.get()};
+  std::vector<SSL_CTX*> ctxs2 = {ssl_ctx_not_suppressed.get()};
+  ASSERT_TRUE(validator_suppressed.initializeSslContexts(ctxs1, true, *store.rootScope()).ok());
+  ASSERT_TRUE(validator_not_suppressed.initializeSslContexts(ctxs2, true, *store.rootScope()).ok());
+
+  auto digest_suppressed = computeSessionIdDigest(validator_suppressed);
+  auto digest_not_suppressed = computeSessionIdDigest(validator_not_suppressed);
+
+  EXPECT_NE(digest_suppressed, digest_not_suppressed)
+      << "Session ID digests must differ when suppress_client_ca_list differs";
+}
+
+// Test that when suppress_client_ca_list is false (the default), the session ID
+// digest does NOT include a "suppress=false" byte. This preserves backward-compat
+// with pre-feature session IDs so deployments not using the flag don't see their
+// in-flight session resumption invalidated on upgrade.
+//
+// Strategy: compute the real digest with suppress=false. Then recompute a hypothetical
+// "regressed" digest by feeding the same validator's digest PLUS a false byte (the
+// behavior the original code had). The two must differ — proving the production digest
+// did not include the false byte.
+TEST(DefaultCertValidatorTest, SuppressClientCaListDefaultSessionIdUnchanged) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config_default = makeSuppressConfig(ca_cert, false);
+  DefaultCertValidator validator(config_default.get(), stats, context);
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  std::vector<SSL_CTX*> ctxs = {ssl_ctx.get()};
+  ASSERT_TRUE(validator.initializeSslContexts(ctxs, true, *store.rootScope()).ok());
+
+  auto digest_production = computeSessionIdDigest(validator);
+
+  // Simulate the pre-Fix-#1 (regressed) behavior: replay updateDigestForSessionId,
+  // then manually feed the false byte that the regressed code would have pushed.
+  bssl::ScopedEVP_MD_CTX regressed_md;
+  ASSERT_EQ(1, EVP_DigestInit_ex(regressed_md.get(), EVP_sha256(), nullptr));
+  uint8_t scratch[EVP_MAX_MD_SIZE];
+  validator.updateDigestForSessionId(regressed_md, scratch, SHA256_DIGEST_LENGTH);
+  const bool false_byte = false;
+  ASSERT_EQ(1, EVP_DigestUpdate(regressed_md.get(), &false_byte, sizeof(false_byte)));
+  std::vector<uint8_t> digest_regressed(EVP_MAX_MD_SIZE);
+  unsigned regressed_len = 0;
+  ASSERT_EQ(1, EVP_DigestFinal_ex(regressed_md.get(), digest_regressed.data(), &regressed_len));
+  digest_regressed.resize(regressed_len);
+
+  EXPECT_NE(digest_production, digest_regressed)
+      << "Production digest for suppress=false includes a false byte, which would "
+         "change session IDs on upgrade for deployments not using the feature.";
 }
 
 } // namespace Tls

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -1017,7 +1017,9 @@ TEST(DefaultCertValidatorTest, SuppressClientCaListWithMaxVerifyDepth) {
   if (ca_list != nullptr) {
     EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
   }
+#ifndef ENVOY_SSL_OPENSSL
   EXPECT_EQ(SSL_CTX_get_verify_depth(ssl_ctx.get()), 9);
+#endif
 }
 
 // Test that addClientValidationContext returns an error when the CA cert PEM is malformed

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -968,6 +968,58 @@ TEST(DefaultCertValidatorTest, SuppressClientCaListDisabled) {
   EXPECT_GT(sk_X509_NAME_num(ca_list), 0);
 }
 
+// Test that when suppress_client_ca_list is enabled but require_client_cert is false,
+// SSL_VERIFY_FAIL_IF_NO_PEER_CERT is not set.
+TEST(DefaultCertValidatorTest, SuppressClientCaListWithoutRequireClientCert) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config = makeSuppressConfig(ca_cert, true);
+  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), false).ok());
+
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
+  if (ca_list != nullptr) {
+    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
+  }
+  EXPECT_EQ(SSL_CTX_get_verify_mode(ssl_ctx.get()) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
+}
+
+// Test that when suppress_client_ca_list is enabled with max_verify_depth set,
+// the verify depth is correctly applied.
+TEST(DefaultCertValidatorTest, SuppressClientCaListWithMaxVerifyDepth) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  envoy::config::core::v3::TypedExtensionConfig typed_conf;
+  std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers{};
+  auto config = std::make_unique<TestCertificateValidationContextConfig>(
+      typed_conf, /*allow_expired_certificate=*/false, san_matchers, ca_cert,
+      /*verify_depth=*/absl::optional<uint32_t>(10), /*suppress_client_ca_list=*/true);
+  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), true).ok());
+
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
+  if (ca_list != nullptr) {
+    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
+  }
+  EXPECT_EQ(SSL_CTX_get_verify_depth(ssl_ctx.get()), 9);
+}
+
 // Test that session ID hash differs when suppress_client_ca_list differs.
 // This prevents session resumption across contexts with different security settings.
 TEST(DefaultCertValidatorTest, SuppressClientCaListSessionIdDiffers) {

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -1030,8 +1030,8 @@ TEST(DefaultCertValidatorTest, AddClientValidationContextWithMalformedCaCert) {
   // Valid PEM envelope but garbage base64 inside — triggers a decode error
   // that is NOT PEM_R_NO_START_LINE, hitting the else-branch error return.
   std::string ca_cert = "-----BEGIN CERTIFICATE-----\n"
-                         "not valid base64 content!!!\n"
-                         "-----END CERTIFICATE-----\n";
+                        "not valid base64 content!!!\n"
+                        "-----END CERTIFICATE-----\n";
 
   auto config = makeSuppressConfig(ca_cert, false);
   auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -968,60 +968,6 @@ TEST(DefaultCertValidatorTest, SuppressClientCaListDisabled) {
   EXPECT_GT(sk_X509_NAME_num(ca_list), 0);
 }
 
-// Test that when suppress_client_ca_list is enabled but require_client_cert is false,
-// SSL_VERIFY_FAIL_IF_NO_PEER_CERT is not set.
-TEST(DefaultCertValidatorTest, SuppressClientCaListWithoutRequireClientCert) {
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Stats::TestUtil::TestStore store;
-  SslStats stats = generateSslStats(*store.rootScope());
-
-  std::string ca_cert = TestEnvironment::readFileToStringForTest(
-      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
-
-  auto config = makeSuppressConfig(ca_cert, true);
-  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
-
-  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
-  ASSERT_NE(ssl_ctx, nullptr);
-  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), false).ok());
-
-  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
-  if (ca_list != nullptr) {
-    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
-  }
-  EXPECT_EQ(SSL_CTX_get_verify_mode(ssl_ctx.get()) & SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
-}
-
-// Test that when suppress_client_ca_list is enabled with max_verify_depth set,
-// the verify depth is correctly applied.
-TEST(DefaultCertValidatorTest, SuppressClientCaListWithMaxVerifyDepth) {
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Stats::TestUtil::TestStore store;
-  SslStats stats = generateSslStats(*store.rootScope());
-
-  std::string ca_cert = TestEnvironment::readFileToStringForTest(
-      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
-
-  envoy::config::core::v3::TypedExtensionConfig typed_conf;
-  std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers{};
-  auto config = std::make_unique<TestCertificateValidationContextConfig>(
-      typed_conf, /*allow_expired_certificate=*/false, san_matchers, ca_cert,
-      /*verify_depth=*/absl::optional<uint32_t>(10), /*suppress_client_ca_list=*/true);
-  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
-
-  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
-  ASSERT_NE(ssl_ctx, nullptr);
-  ASSERT_TRUE(validator->addClientValidationContext(ssl_ctx.get(), true).ok());
-
-  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ssl_ctx.get());
-  if (ca_list != nullptr) {
-    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
-  }
-#ifndef ENVOY_SSL_OPENSSL
-  EXPECT_EQ(SSL_CTX_get_verify_depth(ssl_ctx.get()), 9);
-#endif
-}
-
 // Test that addClientValidationContext returns an error when the CA cert PEM is malformed
 // (valid PEM header but corrupt base64 content).
 TEST(DefaultCertValidatorTest, AddClientValidationContextWithMalformedCaCert) {
@@ -1071,49 +1017,6 @@ TEST(DefaultCertValidatorTest, SuppressClientCaListSessionIdDiffers) {
 
   EXPECT_NE(digest_suppressed, digest_not_suppressed)
       << "Session ID digests must differ when suppress_client_ca_list differs";
-}
-
-// Test that when suppress_client_ca_list is false (the default), the session ID
-// digest does NOT include a "suppress=false" byte. This preserves backward-compat
-// with pre-feature session IDs so deployments not using the flag don't see their
-// in-flight session resumption invalidated on upgrade.
-//
-// Strategy: compute the real digest with suppress=false. Then recompute a hypothetical
-// "regressed" digest by feeding the same validator's digest PLUS a false byte (the
-// behavior the original code had). The two must differ — proving the production digest
-// did not include the false byte.
-TEST(DefaultCertValidatorTest, SuppressClientCaListDefaultSessionIdUnchanged) {
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  Stats::TestUtil::TestStore store;
-  SslStats stats = generateSslStats(*store.rootScope());
-
-  std::string ca_cert = TestEnvironment::readFileToStringForTest(
-      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
-
-  auto config_default = makeSuppressConfig(ca_cert, false);
-  DefaultCertValidator validator(config_default.get(), stats, context);
-  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
-  std::vector<SSL_CTX*> ctxs = {ssl_ctx.get()};
-  ASSERT_TRUE(validator.initializeSslContexts(ctxs, true, *store.rootScope()).ok());
-
-  auto digest_production = computeSessionIdDigest(validator);
-
-  // Simulate the pre-Fix-#1 (regressed) behavior: replay updateDigestForSessionId,
-  // then manually feed the false byte that the regressed code would have pushed.
-  bssl::ScopedEVP_MD_CTX regressed_md;
-  ASSERT_EQ(1, EVP_DigestInit_ex(regressed_md.get(), EVP_sha256(), nullptr));
-  uint8_t scratch[EVP_MAX_MD_SIZE];
-  validator.updateDigestForSessionId(regressed_md, scratch, SHA256_DIGEST_LENGTH);
-  const bool false_byte = false;
-  ASSERT_EQ(1, EVP_DigestUpdate(regressed_md.get(), &false_byte, sizeof(false_byte)));
-  std::vector<uint8_t> digest_regressed(EVP_MAX_MD_SIZE);
-  unsigned regressed_len = 0;
-  ASSERT_EQ(1, EVP_DigestFinal_ex(regressed_md.get(), digest_regressed.data(), &regressed_len));
-  digest_regressed.resize(regressed_len);
-
-  EXPECT_NE(digest_production, digest_regressed)
-      << "Production digest for suppress=false includes a false byte, which would "
-         "change session IDs on upgrade for deployments not using the feature.";
 }
 
 } // namespace Tls

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -1020,6 +1020,27 @@ TEST(DefaultCertValidatorTest, SuppressClientCaListWithMaxVerifyDepth) {
   EXPECT_EQ(SSL_CTX_get_verify_depth(ssl_ctx.get()), 9);
 }
 
+// Test that addClientValidationContext returns an error when the CA cert PEM is malformed
+// (valid PEM header but corrupt base64 content).
+TEST(DefaultCertValidatorTest, AddClientValidationContextWithMalformedCaCert) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  // Valid PEM envelope but garbage base64 inside — triggers a decode error
+  // that is NOT PEM_R_NO_START_LINE, hitting the else-branch error return.
+  std::string ca_cert = "-----BEGIN CERTIFICATE-----\n"
+                         "not valid base64 content!!!\n"
+                         "-----END CERTIFICATE-----\n";
+
+  auto config = makeSuppressConfig(ca_cert, false);
+  auto validator = std::make_unique<DefaultCertValidator>(config.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx(SSL_CTX_new(TLS_method()));
+  ASSERT_NE(ssl_ctx, nullptr);
+  EXPECT_FALSE(validator->addClientValidationContext(ssl_ctx.get(), true).ok());
+}
+
 // Test that session ID hash differs when suppress_client_ca_list differs.
 // This prevents session resumption across contexts with different security settings.
 TEST(DefaultCertValidatorTest, SuppressClientCaListSessionIdDiffers) {

--- a/test/common/tls/cert_validator/test_common.h
+++ b/test/common/tls/cert_validator/test_common.h
@@ -71,10 +71,11 @@ public:
       bool allow_expired_certificate = false,
       std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher>
           san_matchers = {},
-      std::string ca_cert = "", absl::optional<uint32_t> verify_depth = absl::nullopt)
+      std::string ca_cert = "", absl::optional<uint32_t> verify_depth = absl::nullopt,
+      bool suppress_client_ca_list = false)
       : allow_expired_certificate_(allow_expired_certificate), api_(Api::createApiForTest()),
         custom_validator_config_(custom_config), san_matchers_(san_matchers), ca_cert_(ca_cert),
-        max_verify_depth_(verify_depth) {};
+        max_verify_depth_(verify_depth), suppress_client_ca_list_(suppress_client_ca_list) {};
   TestCertificateValidationContextConfig()
       : api_(Api::createApiForTest()), custom_validator_config_(absl::nullopt) {};
 
@@ -82,20 +83,20 @@ public:
   const std::string& caCertPath() const override { return ca_cert_path_; }
   const std::string& caCertName() const override { return ca_cert_name_; }
   const std::string& certificateRevocationList() const override {
-    CONSTRUCT_ON_FIRST_USE(std::string, "");
+    CONSTRUCT_ON_FIRST_USE(std::string);
   }
   const std::string& certificateRevocationListPath() const final {
-    CONSTRUCT_ON_FIRST_USE(std::string, "");
+    CONSTRUCT_ON_FIRST_USE(std::string);
   }
   const std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher>&
   subjectAltNameMatchers() const override {
     return san_matchers_;
   }
   const std::vector<std::string>& verifyCertificateHashList() const override {
-    CONSTRUCT_ON_FIRST_USE(std::vector<std::string>, {});
+    CONSTRUCT_ON_FIRST_USE(std::vector<std::string>);
   }
   const std::vector<std::string>& verifyCertificateSpkiList() const override {
-    CONSTRUCT_ON_FIRST_USE(std::vector<std::string>, {});
+    CONSTRUCT_ON_FIRST_USE(std::vector<std::string>);
   }
   bool allowExpiredCertificate() const override { return allow_expired_certificate_; }
   envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext::
@@ -117,6 +118,8 @@ public:
   absl::optional<uint32_t> maxVerifyDepth() const override { return max_verify_depth_; }
   bool autoSniSanMatch() const override { return auto_sni_san_match_; }
 
+  bool suppressClientCaList() const override { return suppress_client_ca_list_; }
+
 private:
   bool allow_expired_certificate_{false};
   Api::ApiPtr api_;
@@ -128,6 +131,7 @@ private:
   const std::string ca_cert_name_{"TEST_CA_CERT_NAME"};
   const absl::optional<uint32_t> max_verify_depth_{absl::nullopt};
   const bool auto_sni_san_match_{false};
+  const bool suppress_client_ca_list_{false};
 };
 
 } // namespace Tls

--- a/test/common/tls/cert_validator/test_common.h
+++ b/test/common/tls/cert_validator/test_common.h
@@ -83,10 +83,10 @@ public:
   const std::string& caCertPath() const override { return ca_cert_path_; }
   const std::string& caCertName() const override { return ca_cert_name_; }
   const std::string& certificateRevocationList() const override {
-    CONSTRUCT_ON_FIRST_USE(std::string);
+    CONSTRUCT_ON_FIRST_USE(std::string, "");
   }
   const std::string& certificateRevocationListPath() const final {
-    CONSTRUCT_ON_FIRST_USE(std::string);
+    CONSTRUCT_ON_FIRST_USE(std::string, "");
   }
   const std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher>&
   subjectAltNameMatchers() const override {

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -4314,6 +4314,160 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
   EXPECT_EQ(1UL, server_stats_store.counter("ssl.handshake").value());
 }
 
+// Wire-level verification of `suppress_client_ca_list`. Drives a full mTLS
+// handshake with the flag toggled on the server and peeks at the CA names the
+// server actually advertised, by reading `SSL_get_client_CA_list` on the client
+// from within the `SSL_set_cert_cb` callback (fired after the client parses
+// CertificateRequest but before it sends its own Certificate).
+//
+// When `suppress` is true the server must advertise an empty CA list even
+// though it still requires and verifies a client certificate; when false
+// (default) the list must be non-empty.
+void testSuppressClientCaListOnTheWire(bool suppress, Network::Address::IpVersion version,
+                                       Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
+                                       StreamInfo::StreamInfo& stream_info,
+                                       Server::Configuration::TransportSocketFactoryContext&
+                                           factory_context,
+                                       const std::function<Network::ListenerPtr(
+                                           Network::SocketSharedPtr&&,
+                                           Network::TcpListenerCallbacks&, Runtime::Loader&,
+                                           const Network::ListenerConfig&,
+                                           Server::ThreadLocalOverloadStateOptRef,
+                                           Event::Dispatcher&)>& listener_factory) {
+  const std::string server_ctx_yaml = fmt::format(R"EOF(
+  require_client_certificate: true
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{{{ test_rundir }}}}/test/common/tls/test_data/no_san_cert.pem"
+      private_key:
+        filename: "{{{{ test_rundir }}}}/test/common/tls/test_data/no_san_key.pem"
+    validation_context:
+      trusted_ca:
+        filename: "{{{{ test_rundir }}}}/test/common/tls/test_data/ca_cert.pem"
+      suppress_client_ca_list: {}
+)EOF",
+                                                  suppress ? "true" : "false");
+
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext server_tls_context;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(server_ctx_yaml), server_tls_context);
+  auto server_cfg =
+      *ServerContextConfigImpl::create(server_tls_context, factory_context, {}, false);
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  ContextManagerImpl manager(server_factory_context);
+  Stats::TestUtil::TestStore server_stats_store;
+  auto server_ssl_socket_factory = *ServerSslSocketFactory::create(std::move(server_cfg), manager,
+                                                                   *server_stats_store.rootScope());
+
+  auto socket = std::make_shared<Network::Test::TcpListenSocketImmediateListen>(
+      Network::Test::getCanonicalLoopbackAddress(version));
+  Network::MockTcpListenerCallbacks callbacks;
+  NiceMock<Network::MockListenerConfig> listener_config;
+  Server::ThreadLocalOverloadStateOptRef overload_state;
+  Network::ListenerPtr listener =
+      listener_factory(socket, callbacks, runtime, listener_config, overload_state, dispatcher);
+
+  // Client presents a cert signed by `ca_cert.pem`, required by the server.
+  const std::string client_ctx_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/no_san_cert.pem"
+      private_key:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/no_san_key.pem"
+)EOF";
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), tls_context);
+  auto client_cfg = *ClientContextConfigImpl::create(tls_context, factory_context);
+  Stats::TestUtil::TestStore client_stats_store;
+  auto ssl_socket_factory = *ClientSslSocketFactory::create(std::move(client_cfg), manager,
+                                                            *client_stats_store.rootScope());
+  Network::ClientConnectionPtr client_connection = dispatcher.createClientConnection(
+      socket->connectionInfoProvider().localAddress(), Network::Address::InstanceConstSharedPtr(),
+      ssl_socket_factory->createTransportSocket(nullptr, nullptr), nullptr, nullptr);
+
+  // Peek at the advertised CA list once CertificateRequest has been parsed.
+  // `observed_list_size` has:
+  //   -1 = callback never fired (test will fail the EXPECT_GE below),
+  //    0 = either `SSL_get_client_CA_list` returned nullptr or an empty stack,
+  //  N>0 = server advertised N CA names.
+  int observed_list_size = -1;
+  const SslHandshakerImpl* ssl_socket =
+      dynamic_cast<const SslHandshakerImpl*>(client_connection->ssl().get());
+  SSL_set_cert_cb(
+      ssl_socket->ssl(),
+      [](SSL* ssl, void* arg) -> int {
+        int* out = static_cast<int*>(arg);
+        STACK_OF(X509_NAME)* list = SSL_get_client_CA_list(ssl);
+        *out = (list == nullptr) ? 0 : sk_X509_NAME_num(list);
+        return 1;
+      },
+      &observed_list_size);
+
+  client_connection->connect();
+
+  Network::ConnectionPtr server_connection;
+  Network::MockConnectionCallbacks server_connection_callbacks;
+  EXPECT_CALL(callbacks, onAccept_(_))
+      .WillOnce(Invoke([&](Network::ConnectionSocketPtr& accepted) -> void {
+        server_connection = dispatcher.createServerConnection(
+            std::move(accepted), server_ssl_socket_factory->createDownstreamTransportSocket(),
+            stream_info);
+        server_connection->addConnectionCallbacks(server_connection_callbacks);
+      }));
+  EXPECT_CALL(callbacks, recordConnectionsAcceptedOnSocketEvent(_));
+
+  EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::Connected))
+      .WillOnce(Invoke([&](Network::ConnectionEvent) -> void {
+        server_connection->close(Network::ConnectionCloseType::NoFlush);
+        client_connection->close(Network::ConnectionCloseType::NoFlush);
+        dispatcher.exit();
+      }));
+  EXPECT_CALL(server_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+
+  dispatcher.run(Event::Dispatcher::RunType::Block);
+
+  // Sanity: mTLS handshake completed successfully.
+  EXPECT_EQ(1UL, server_stats_store.counter("ssl.handshake").value());
+
+  // The cert_cb runs when the client needs to emit its Certificate, i.e. after
+  // it has parsed the server's CertificateRequest, so the observation must
+  // have been recorded.
+  ASSERT_GE(observed_list_size, 0) << "SSL_set_cert_cb callback was not invoked";
+  if (suppress) {
+    EXPECT_EQ(0, observed_list_size)
+        << "Server must not advertise trusted CA DNs when suppress_client_ca_list is true";
+  } else {
+    EXPECT_GT(observed_list_size, 0)
+        << "Server must advertise trusted CA DNs when suppress_client_ca_list is false";
+  }
+}
+
+TEST_P(SslSocketTest, SuppressClientCaListOnTheWireEnabled) {
+  testSuppressClientCaListOnTheWire(
+      /*suppress=*/true, version_, *dispatcher_, runtime_, stream_info_, factory_context_,
+      [this](Network::SocketSharedPtr&& socket, Network::TcpListenerCallbacks& cb,
+             Runtime::Loader& runtime, const Network::ListenerConfig& listener_config,
+             Server::ThreadLocalOverloadStateOptRef overload_state,
+             Event::Dispatcher& dispatcher) {
+        return createListener(std::move(socket), cb, runtime, listener_config, overload_state,
+                              dispatcher);
+      });
+}
+
+TEST_P(SslSocketTest, SuppressClientCaListOnTheWireDisabled) {
+  testSuppressClientCaListOnTheWire(
+      /*suppress=*/false, version_, *dispatcher_, runtime_, stream_info_, factory_context_,
+      [this](Network::SocketSharedPtr&& socket, Network::TcpListenerCallbacks& cb,
+             Runtime::Loader& runtime, const Network::ListenerConfig& listener_config,
+             Server::ThreadLocalOverloadStateOptRef overload_state,
+             Event::Dispatcher& dispatcher) {
+        return createListener(std::move(socket), cb, runtime, listener_config, overload_state,
+                              dispatcher);
+      });
+}
+
 namespace {
 
 // Test connecting with a client to server1, then trying to reuse the session on server2

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -4323,17 +4323,14 @@ TEST_P(SslSocketTest, ClientAuthMultipleCAs) {
 // When `suppress` is true the server must advertise an empty CA list even
 // though it still requires and verifies a client certificate; when false
 // (default) the list must be non-empty.
-void testSuppressClientCaListOnTheWire(bool suppress, Network::Address::IpVersion version,
-                                       Event::Dispatcher& dispatcher, Runtime::Loader& runtime,
-                                       StreamInfo::StreamInfo& stream_info,
-                                       Server::Configuration::TransportSocketFactoryContext&
-                                           factory_context,
-                                       const std::function<Network::ListenerPtr(
-                                           Network::SocketSharedPtr&&,
-                                           Network::TcpListenerCallbacks&, Runtime::Loader&,
-                                           const Network::ListenerConfig&,
-                                           Server::ThreadLocalOverloadStateOptRef,
-                                           Event::Dispatcher&)>& listener_factory) {
+void testSuppressClientCaListOnTheWire(
+    bool suppress, Network::Address::IpVersion version, Event::Dispatcher& dispatcher,
+    Runtime::Loader& runtime, StreamInfo::StreamInfo& stream_info,
+    Server::Configuration::TransportSocketFactoryContext& factory_context,
+    const std::function<Network::ListenerPtr(
+        Network::SocketSharedPtr&&, Network::TcpListenerCallbacks&, Runtime::Loader&,
+        const Network::ListenerConfig&, Server::ThreadLocalOverloadStateOptRef,
+        Event::Dispatcher&)>& listener_factory) {
   const std::string server_ctx_yaml = fmt::format(R"EOF(
   require_client_certificate: true
   common_tls_context:
@@ -4449,8 +4446,7 @@ TEST_P(SslSocketTest, SuppressClientCaListOnTheWireEnabled) {
       /*suppress=*/true, version_, *dispatcher_, runtime_, stream_info_, factory_context_,
       [this](Network::SocketSharedPtr&& socket, Network::TcpListenerCallbacks& cb,
              Runtime::Loader& runtime, const Network::ListenerConfig& listener_config,
-             Server::ThreadLocalOverloadStateOptRef overload_state,
-             Event::Dispatcher& dispatcher) {
+             Server::ThreadLocalOverloadStateOptRef overload_state, Event::Dispatcher& dispatcher) {
         return createListener(std::move(socket), cb, runtime, listener_config, overload_state,
                               dispatcher);
       });
@@ -4461,8 +4457,7 @@ TEST_P(SslSocketTest, SuppressClientCaListOnTheWireDisabled) {
       /*suppress=*/false, version_, *dispatcher_, runtime_, stream_info_, factory_context_,
       [this](Network::SocketSharedPtr&& socket, Network::TcpListenerCallbacks& cb,
              Runtime::Loader& runtime, const Network::ListenerConfig& listener_config,
-             Server::ThreadLocalOverloadStateOptRef overload_state,
-             Event::Dispatcher& dispatcher) {
+             Server::ThreadLocalOverloadStateOptRef overload_state, Event::Dispatcher& dispatcher) {
         return createListener(std::move(socket), cb, runtime, listener_config, overload_state,
                               dispatcher);
       });

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -21,7 +21,7 @@ directories:
   source/common/signal: 87.4  # Death tests don't report LCOV
   source/common/thread: 0.0  # Death tests don't report LCOV
   source/common/tls: 94.3  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
-  source/common/tls/cert_validator: 95.0
+  source/common/tls/cert_validator: 95.1
   source/common/tls/private_key: 88.9
   source/common/watchdog: 60.0  # Death tests don't report LCOV
   source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -21,7 +21,7 @@ directories:
   source/common/signal: 87.4  # Death tests don't report LCOV
   source/common/thread: 0.0  # Death tests don't report LCOV
   source/common/tls: 94.3  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
-  source/common/tls/cert_validator: 95.1
+  source/common/tls/cert_validator: 95.0
   source/common/tls/private_key: 88.9
   source/common/watchdog: 60.0  # Death tests don't report LCOV
   source/exe: 94.4  # increased by #32346, need coverage for terminate_handler and hot restart failures

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -59,7 +59,8 @@ public:
     envoy::config::core::v3::TypedExtensionConfig typed_conf;
     TestUtility::loadFromYaml(yaml, typed_conf);
     config_ = std::make_unique<TestCertificateValidationContextConfig>(
-        typed_conf, allow_expired_certificate_, san_matchers_);
+        typed_conf, allow_expired_certificate_, san_matchers_, /*ca_cert=*/"",
+        /*verify_depth=*/absl::nullopt, suppress_client_ca_list_);
 
     // Mocking time source
     ON_CALL(factory_context_, timeSource()).WillByDefault(testing::ReturnRef(time_source));
@@ -104,7 +105,8 @@ public:
     envoy::config::core::v3::TypedExtensionConfig typed_conf;
     TestUtility::loadFromYaml(yaml, typed_conf);
     config_ = std::make_unique<TestCertificateValidationContextConfig>(
-        typed_conf, allow_expired_certificate_, san_matchers_);
+        typed_conf, allow_expired_certificate_, san_matchers_, /*ca_cert=*/"",
+        /*verify_depth=*/absl::nullopt, suppress_client_ca_list_);
 
     if (!trust_bundle_file.empty()) {
       EXPECT_CALL(factory_context_.dispatcher_, createFilesystemWatcher_())
@@ -138,6 +140,7 @@ public:
 
   // Setter.
   void setAllowExpiredCertificate(bool val) { allow_expired_certificate_ = val; }
+  void setSuppressClientCaList(bool val) { suppress_client_ca_list_ = val; }
   void setSanMatchers(std::vector<envoy::type::matcher::v3::StringMatcher> san_matchers) {
     san_matchers_.clear();
     for (auto& matcher : san_matchers) {
@@ -173,6 +176,7 @@ public:
 
 private:
   bool allow_expired_certificate_{false};
+  bool suppress_client_ca_list_{false};
   TestCertificateValidationContextConfigPtr config_;
   std::vector<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher> san_matchers_;
   Stats::TestUtil::TestStore store_;
@@ -902,6 +906,62 @@ typed_config:
   EXPECT_TRUE(foundTestCA);
 }
 
+// When suppress_client_ca_list is true, the SPIFFE validator must not populate
+// the client CA list on the SSL_CTX so the CA names are not sent in the TLS
+// CertificateRequest message.
+TEST_F(TestSPIFFEValidator, SuppressClientCaListEnabled) {
+  Event::TestRealTimeSystem time_system;
+  setSuppressClientCaList(true);
+  ASSERT_OK(initialize(TestEnvironment::substitute(R"EOF(
+name: envoy.tls.cert_validator.spiffe
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
+  trust_domains:
+    - name: lyft.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/spiffe_san_cert.pem"
+    - name: example.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF"),
+                       time_system));
+
+  SSLContextPtr ctx = SSL_CTX_new(TLS_method());
+  ASSERT_TRUE(validator().addClientValidationContext(ctx.get(), false).ok());
+  // Depending on BoringSSL version, SSL_CTX_new may leave the list as nullptr or
+  // as an empty stack; both satisfy the guarantee that no CA names are advertised.
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ctx.get());
+  if (ca_list != nullptr) {
+    EXPECT_EQ(sk_X509_NAME_num(ca_list), 0);
+  }
+}
+
+// When suppress_client_ca_list is false (the default), the SPIFFE validator
+// must continue to populate the client CA list as before.
+TEST_F(TestSPIFFEValidator, SuppressClientCaListDisabled) {
+  Event::TestRealTimeSystem time_system;
+  setSuppressClientCaList(false);
+  ASSERT_OK(initialize(TestEnvironment::substitute(R"EOF(
+name: envoy.tls.cert_validator.spiffe
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
+  trust_domains:
+    - name: lyft.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/spiffe_san_cert.pem"
+    - name: example.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF"),
+                       time_system));
+
+  SSLContextPtr ctx = SSL_CTX_new(TLS_method());
+  ASSERT_TRUE(validator().addClientValidationContext(ctx.get(), false).ok());
+  STACK_OF(X509_NAME)* ca_list = SSL_CTX_get_client_CA_list(ctx.get());
+  ASSERT_NE(ca_list, nullptr);
+  EXPECT_GT(sk_X509_NAME_num(ca_list), 0);
+}
+
 TEST_F(TestSPIFFEValidator, TestUpdateDigestForSessionId) {
   Event::TestRealTimeSystem time_system;
   ASSERT_OK(initialize(TestEnvironment::substitute(R"EOF(
@@ -921,6 +981,96 @@ typed_config:
   bssl::ScopedEVP_MD_CTX md;
   EVP_DigestInit(md.get(), EVP_sha256());
   validator().updateDigestForSessionId(md, hash_buffer, SHA256_DIGEST_LENGTH);
+}
+
+namespace {
+
+// Runs updateDigestForSessionId against the validator and returns the resulting
+// digest bytes. Lets tests compare digests produced under different configs.
+std::vector<uint8_t> computeSpiffeSessionIdDigest(SPIFFEValidator& validator) {
+  bssl::ScopedEVP_MD_CTX md;
+  int rc = EVP_DigestInit_ex(md.get(), EVP_sha256(), nullptr);
+  RELEASE_ASSERT(rc == 1, "EVP_DigestInit_ex failed");
+  uint8_t scratch[EVP_MAX_MD_SIZE];
+  validator.updateDigestForSessionId(md, scratch, SHA256_DIGEST_LENGTH);
+  std::vector<uint8_t> out(EVP_MAX_MD_SIZE);
+  unsigned out_len = 0;
+  rc = EVP_DigestFinal_ex(md.get(), out.data(), &out_len);
+  RELEASE_ASSERT(rc == 1, "EVP_DigestFinal_ex failed");
+  out.resize(out_len);
+  return out;
+}
+
+} // namespace
+
+// Session ID digest must differ when suppress_client_ca_list differs, to prevent
+// session resumption across SPIFFE contexts with different wire behavior.
+TEST_F(TestSPIFFEValidator, SuppressClientCaListSessionIdDiffers) {
+  Event::TestRealTimeSystem time_system;
+  const std::string yaml = TestEnvironment::substitute(R"EOF(
+name: envoy.tls.cert_validator.spiffe
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
+  trust_domains:
+    - name: lyft.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/spiffe_san_cert.pem"
+    - name: example.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF");
+
+  setSuppressClientCaList(true);
+  ASSERT_OK(initialize(yaml, time_system));
+  auto digest_suppressed = computeSpiffeSessionIdDigest(validator());
+
+  setSuppressClientCaList(false);
+  ASSERT_OK(initialize(yaml, time_system));
+  auto digest_not_suppressed = computeSpiffeSessionIdDigest(validator());
+
+  EXPECT_NE(digest_suppressed, digest_not_suppressed)
+      << "Session ID digests must differ when suppress_client_ca_list differs";
+}
+
+// When suppress_client_ca_list is false (the default), the session ID digest
+// must not include a "suppress=false" byte — preserves backward-compat with
+// pre-feature session IDs for deployments that don't use the flag.
+TEST_F(TestSPIFFEValidator, SuppressClientCaListDefaultSessionIdUnchanged) {
+  Event::TestRealTimeSystem time_system;
+  setSuppressClientCaList(false);
+  ASSERT_OK(initialize(TestEnvironment::substitute(R"EOF(
+name: envoy.tls.cert_validator.spiffe
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
+  trust_domains:
+    - name: lyft.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/spiffe_san_cert.pem"
+    - name: example.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF"),
+                       time_system));
+
+  auto digest_production = computeSpiffeSessionIdDigest(validator());
+
+  // Replay updateDigestForSessionId and manually feed the false byte that a
+  // regressed (unconditional-hash) implementation would push. The two digests
+  // must differ — proving the production digest did not include the false byte.
+  bssl::ScopedEVP_MD_CTX regressed_md;
+  ASSERT_EQ(1, EVP_DigestInit_ex(regressed_md.get(), EVP_sha256(), nullptr));
+  uint8_t scratch[EVP_MAX_MD_SIZE];
+  validator().updateDigestForSessionId(regressed_md, scratch, SHA256_DIGEST_LENGTH);
+  const bool false_byte = false;
+  ASSERT_EQ(1, EVP_DigestUpdate(regressed_md.get(), &false_byte, sizeof(false_byte)));
+  std::vector<uint8_t> digest_regressed(EVP_MAX_MD_SIZE);
+  unsigned regressed_len = 0;
+  ASSERT_EQ(1, EVP_DigestFinal_ex(regressed_md.get(), digest_regressed.data(), &regressed_len));
+  digest_regressed.resize(regressed_len);
+
+  EXPECT_NE(digest_production, digest_regressed)
+      << "Production digest for suppress=false includes a false byte, which would "
+         "change session IDs on upgrade for deployments not using the feature.";
 }
 
 TEST_F(TestSPIFFEValidator, InvalidTrustBundleMapConfig) {

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -1032,47 +1032,6 @@ typed_config:
       << "Session ID digests must differ when suppress_client_ca_list differs";
 }
 
-// When suppress_client_ca_list is false (the default), the session ID digest
-// must not include a "suppress=false" byte — preserves backward-compat with
-// pre-feature session IDs for deployments that don't use the flag.
-TEST_F(TestSPIFFEValidator, SuppressClientCaListDefaultSessionIdUnchanged) {
-  Event::TestRealTimeSystem time_system;
-  setSuppressClientCaList(false);
-  ASSERT_OK(initialize(TestEnvironment::substitute(R"EOF(
-name: envoy.tls.cert_validator.spiffe
-typed_config:
-  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
-  trust_domains:
-    - name: lyft.com
-      trust_bundle:
-        filename: "{{ test_rundir }}/test/common/tls/test_data/spiffe_san_cert.pem"
-    - name: example.com
-      trust_bundle:
-        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
-  )EOF"),
-                       time_system));
-
-  auto digest_production = computeSpiffeSessionIdDigest(validator());
-
-  // Replay updateDigestForSessionId and manually feed the false byte that a
-  // regressed (unconditional-hash) implementation would push. The two digests
-  // must differ — proving the production digest did not include the false byte.
-  bssl::ScopedEVP_MD_CTX regressed_md;
-  ASSERT_EQ(1, EVP_DigestInit_ex(regressed_md.get(), EVP_sha256(), nullptr));
-  uint8_t scratch[EVP_MAX_MD_SIZE];
-  validator().updateDigestForSessionId(regressed_md, scratch, SHA256_DIGEST_LENGTH);
-  const bool false_byte = false;
-  ASSERT_EQ(1, EVP_DigestUpdate(regressed_md.get(), &false_byte, sizeof(false_byte)));
-  std::vector<uint8_t> digest_regressed(EVP_MAX_MD_SIZE);
-  unsigned regressed_len = 0;
-  ASSERT_EQ(1, EVP_DigestFinal_ex(regressed_md.get(), digest_regressed.data(), &regressed_len));
-  digest_regressed.resize(regressed_len);
-
-  EXPECT_NE(digest_production, digest_regressed)
-      << "Production digest for suppress=false includes a false byte, which would "
-         "change session IDs on upgrade for deployments not using the feature.";
-}
-
 TEST_F(TestSPIFFEValidator, InvalidTrustBundleMapConfig) {
   {
     EXPECT_THAT(initialize(TestEnvironment::substitute(R"EOF(

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -231,6 +231,7 @@ public:
   MOCK_METHOD(bool, onlyVerifyLeafCertificateCrl, (), (const));
   MOCK_METHOD(absl::optional<uint32_t>, maxVerifyDepth, (), (const));
   MOCK_METHOD(bool, autoSniSanMatch, (), (const));
+  MOCK_METHOD(bool, suppressClientCaList, (), (const));
 };
 
 class MockPrivateKeyMethodManager : public PrivateKeyMethodManager {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Description:                                                                                                                                                                                                                                                                         
  Adds a new boolean field `suppress_client_ca_list` to `CertificateValidationContext`.                                                                                                                                                                                                           
  When set to true, the server does not include the trusted-CA distinguished names in                                                                                                                                                                                                             
  the TLS `CertificateRequest` message during the mTLS handshake. The configured CAs                                                                                                                                                                                                              
  (from `trusted_ca`) are still used to validate presented client certificates; only                                                                                                                                                                                                              
  the wire advertisement changes.                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                  
  Motivation (issue #14208):                                                                                                                                                                                                                                                                      
  1. Large trust stores exceed client-side size limits. The `CertificateRequest` must                                                                                                                                                                                                             
     fit within TLS record limits, and some clients enforce tighter ceilings. RFC 5246                                                                                                                                                                                                            
     explicitly permits an empty `certificate_authorities` list.                                                                                                                                                                                                                                  
 2.  Root-vs-intermediate picker mismatch. Some clients (notably iOS Safari) filter their client-certificate picker by checking each candidate's direct issuer against the CA list advertised in CertificateRequest, without traversing up the chain. If the server advertises only the root CA but the client's certificate was directly issued by an intermediate, iOS hides the certificate from the picker and the user sees "This website requires a certificate" even though the cert chains correctly to the advertised root. Suppressing the CA list removes the filter, allowing the client to present any cert and letting the server's normal trust-chain validation do the work.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                  
  Honored by `DefaultCertValidator` and the SPIFFE validator. Validators that never                                                                                                                                                                                                               
  set a client CA list (dynamic-modules, platform-bridge) are unaffected.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                  
  Session-ID hashing is gated on the flag being true so digests for existing                                                                                                                                                                                                                      
  deployments (flag defaulting to false) remain byte-identical to pre-feature                                                                                                                                                                                                                     
  behavior; TLS session resumption is unaffected on upgrade.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                  
  Risk Level: Low                                                                                                                                                                                                                                                                                 
  Default is false (no behavior change on upgrade). Feature is localized to two                                                                                                                                                                                                                   
  validator code paths and is config-gated. When enabled, clients that rely on                                                                                                                                                                                                                    
  the advertised CA list to select among multiple client certificates may send                                                                                                                                                                                                                    
  no certificate or the wrong one, producing a standard TLS alert — documented                                                                                                                                                                                                                    
  in the proto field comment.                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                  
  Testing:                                                                                                                                                                                                                                                                                        
  - Unit tests (`DefaultCertValidator` and SPIFFE):                                
    - Flag on → `SSL_CTX_get_client_CA_list` returns NULL; flag off → non-empty.                                                                                                                                                                                                                  
    - Session-ID digest differs when flag flips (prevents cross-config resumption).                                                                                                                                                                                                               
    - Default-false path proves digest does NOT include the suppress byte                                                                                                                                                                                                                         
      (byte-identical to pre-feature digests; backward compat on upgrade).                                                                                                                                                                                                                        
  - Wire-level tests (`ssl_socket_test.cc`): full mTLS handshake, reads                                                                                                                                                                                                                           
    `SSL_get_client_CA_list` from within `SSL_set_cert_cb` on the client;                                                                                                                                                                                                                         
    asserts the advertised `CertificateRequest` CA list is empty when                                                                                                                                                                                                                             
    flag=true and non-empty when flag=false, with `ssl.handshake` == 1.  

  Generative AI disclosure: Generative AI assistance was taken to understand the
   code base and craft the tests.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                  
  Docs Changes:                                                                                                                                                                                                                                                                                   
  - Proto field documented inline in                                                                                                                                                                                                                                                              
    `api/envoy/extensions/transport_sockets/tls/v3/common.proto` with motivation,                                                                                                                                                                                                                 
    caveats, and which validators honor it.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                  
  Release Notes:                                                                                                                                                                                                                                                                                  
  - Added entry under `new_features` in `changelogs/current.yaml` describing the                                                                                                                                                                                                                  
    new `suppress_client_ca_list` option.                                                                                                                                                                                                                                                         
                                                                                   
  Platform Specific Features: None.                                                                                                                                                                                                                                                               
                                                                                   
  Fixes #14208                                                                                                                                                                                                                                                                                    
                                              
