### PR TITLE
dym: extract shared utility for path-based dynamic metadata access

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/BUILD
+++ b/source/extensions/access_loggers/dynamic_modules/BUILD
@@ -32,12 +32,12 @@ envoy_cc_library(
     deps = [
         ":access_log_config_lib",
         "//envoy/access_log:access_log_interface",
-        "//source/common/config:metadata_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:utility_lib",
         "//source/extensions/access_loggers/common:access_log_base",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
+        "//source/extensions/dynamic_modules:metadata_utils_lib",
     ],
 )
 

--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -1,4 +1,3 @@
-#include "source/common/config/metadata.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
@@ -6,8 +5,8 @@
 #include "source/extensions/access_loggers/dynamic_modules/access_log.h"
 #include "source/extensions/access_loggers/dynamic_modules/access_log_config.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/metadata_utils.h"
 
-#include "absl/strings/str_split.h"
 #include "access_log.h"
 
 namespace Envoy {
@@ -799,27 +798,8 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(
     envoy_dynamic_module_type_module_buffer filter_name,
     envoy_dynamic_module_type_module_buffer path, envoy_dynamic_module_type_envoy_buffer* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
-  std::string filter_name_str(filter_name.ptr, filter_name.length);
-  std::string path_str(path.ptr, path.length);
-  std::vector<std::string> path_parts = absl::StrSplit(path_str, '.');
-
-  const auto& metadata = logger->stream_info_->dynamicMetadata();
-  const auto& value =
-      Envoy::Config::Metadata::metadataValue(&metadata, filter_name_str, path_parts);
-
-  if (value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
-    return false;
-  }
-
-  // Note: Currently only string values are supported. Complex types would require serialization
-  // to a buffer, but the ABI uses zero-copy pointers to Envoy memory.
-  if (value.kind_case() == Protobuf::Value::kStringValue) {
-    const auto& str = value.string_value();
-    *result = {const_cast<char*>(str.data()), str.size()};
-    return true;
-  }
-
-  return false;
+  return Envoy::Extensions::DynamicModules::getDynamicMetadataStringByPath(
+      logger->stream_info_->dynamicMetadata(), filter_name, path, result);
 }
 
 bool envoy_dynamic_module_callback_access_logger_get_filter_state(

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -36,6 +36,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "metadata_utils_lib",
+    srcs = ["metadata_utils.cc"],
+    hdrs = ["metadata_utils.h"],
+    deps = [
+        "//source/common/config:metadata_lib",
+        "//source/extensions/dynamic_modules/abi",
+        "@abseil-cpp//absl/strings",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "abi_impl",
     srcs = ["abi_impl.cc"],
     deps = [

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -2154,6 +2154,26 @@ bool envoy_dynamic_module_callback_http_get_metadata_list_bool(
     envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
     size_t index, bool* result);
 
+/**
+ * envoy_dynamic_module_callback_http_get_dynamic_metadata is called by the module to get
+ * a string value from dynamic metadata by filter name and dotted key path.
+ * Supports nested key access with dot-separated paths (e.g., "a.b.c").
+ *
+ * Only dynamic metadata is supported (not route/cluster/host metadata).
+ * Currently only string values are supported; non-string values return false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param filter_name is the filter namespace in dynamic metadata.
+ * @param path is the key path within the filter namespace (dot-separated for nested access).
+ * @param result is the pointer to the envoy_buffer where the string value will be stored.
+ * @return true if the value exists and is a string, false otherwise.
+ */
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, envoy_dynamic_module_type_envoy_buffer* result);
+
 // -------------------------- Filter State Callbacks ---------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -3220,6 +3220,14 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_http_get_metadata_list_
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_http_get_dynamic_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_get_dynamic_metadata: "
+               "not implemented in this context");
+  return false;
+}
+
 // DNS resolver callbacks.
 __attribute__((weak)) void envoy_dynamic_module_callback_dns_resolve_complete(
     envoy_dynamic_module_type_dns_resolver_envoy_ptr, uint64_t,

--- a/source/extensions/dynamic_modules/metadata_utils.cc
+++ b/source/extensions/dynamic_modules/metadata_utils.cc
@@ -1,0 +1,39 @@
+#include "source/extensions/dynamic_modules/metadata_utils.h"
+
+#include "source/common/config/metadata.h"
+
+#include "absl/strings/str_split.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+
+bool getDynamicMetadataStringByPath(const envoy::config::core::v3::Metadata& metadata,
+                                    envoy_dynamic_module_type_module_buffer filter_name,
+                                    envoy_dynamic_module_type_module_buffer path,
+                                    envoy_dynamic_module_type_envoy_buffer* result) {
+  std::string filter_name_str(filter_name.ptr, filter_name.length);
+  std::string path_str(path.ptr, path.length);
+  std::vector<std::string> path_parts = absl::StrSplit(path_str, '.');
+
+  const auto& value =
+      Envoy::Config::Metadata::metadataValue(&metadata, filter_name_str, path_parts);
+
+  if (value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
+    return false;
+  }
+
+  // Only string values are supported. Complex types would require serialization
+  // to a buffer, but the ABI uses zero-copy pointers to Envoy memory.
+  if (value.kind_case() == Protobuf::Value::kStringValue) {
+    const auto& str = value.string_value();
+    *result = {const_cast<char*>(str.data()), str.size()};
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/dynamic_modules/metadata_utils.h
+++ b/source/extensions/dynamic_modules/metadata_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "envoy/config/core/v3/base.pb.h"
+
+#include "source/extensions/dynamic_modules/abi/abi.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+
+// Look up a string value in dynamic metadata by filter name and dotted key path.
+bool getDynamicMetadataStringByPath(const envoy::config::core::v3::Metadata& metadata,
+                                    envoy_dynamic_module_type_module_buffer filter_name,
+                                    envoy_dynamic_module_type_module_buffer path,
+                                    envoy_dynamic_module_type_envoy_buffer* result);
+
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -782,6 +782,23 @@ func (h *dymHttpFilterHandle) GetMetadataListBool(source shared.MetadataSourceTy
 	return bool(value), true
 }
 
+func (h *dymHttpFilterHandle) GetDynamicMetadata(filterName, path string) (shared.UnsafeEnvoyBuffer, bool) {
+	var result C.envoy_dynamic_module_type_envoy_buffer
+	ret := C.envoy_dynamic_module_callback_http_get_dynamic_metadata(
+		h.hostPluginPtr,
+		stringToModuleBuffer(filterName),
+		stringToModuleBuffer(path),
+		&result,
+	)
+	if !bool(ret) || result.ptr == nil || result.length == 0 {
+		return shared.UnsafeEnvoyBuffer{}, false
+	}
+
+	runtime.KeepAlive(filterName)
+	runtime.KeepAlive(path)
+	return envoyBufferToUnsafeEnvoyBuffer(result), true
+}
+
 func (h *dymHttpFilterHandle) SetMetadata(metadataNamespace, key string, value any) {
 	var numValue float64 = 0
 	var isNum bool = false

--- a/source/extensions/dynamic_modules/sdk/go/shared/base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/base.go
@@ -456,6 +456,13 @@ type HttpFilterHandle interface {
 	// the element is not a bool.
 	GetMetadataListBool(source MetadataSourceType, metadataNamespace, key string, index int) (bool, bool)
 
+	// GetDynamicMetadata retrieves a string value from dynamic metadata by filter name
+	// and dotted key path (e.g., "a.b.c" traverses nested structs).
+	// Only string values are supported; non-string values return false.
+	// NOTE: The memory of underlying data may not be managed by Go GC. So you should
+	// copy the data if you need to keep it and use it later.
+	GetDynamicMetadata(filterName, path string) (UnsafeEnvoyBuffer, bool)
+
 	// GetFilterState retrieves the serialized filter state value of the stream.
 	// @Param key the filter state key.
 	// @Return the filter state value if found, otherwise an empty UnsafeEnvoyBuffer.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_base.go
@@ -986,6 +986,21 @@ func (mr *MockHttpFilterHandleMockRecorder) GetData(key any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetData", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetData), key)
 }
 
+// GetDynamicMetadata mocks base method.
+func (m *MockHttpFilterHandle) GetDynamicMetadata(filterName, path string) (shared.UnsafeEnvoyBuffer, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDynamicMetadata", filterName, path)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetDynamicMetadata indicates an expected call of GetDynamicMetadata.
+func (mr *MockHttpFilterHandleMockRecorder) GetDynamicMetadata(filterName, path any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicMetadata", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetDynamicMetadata), filterName, path)
+}
+
 // GetFilterState mocks base method.
 func (m *MockHttpFilterHandle) GetFilterState(key string) (shared.UnsafeEnvoyBuffer, bool) {
 	m.ctrl.T.Helper()

--- a/source/extensions/dynamic_modules/sdk/go/shared/utility/utility_test.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/utility/utility_test.go
@@ -3,6 +3,7 @@ package utility
 import (
 	"testing"
 
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
 	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared/fake"
 	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared/mocks"
 	gomock "go.uber.org/mock/gomock"
@@ -139,4 +140,39 @@ func TestClearRouteCache_MockIsCalled(t *testing.T) {
 	handle := mocks.NewMockHttpFilterHandle(ctrl)
 	handle.EXPECT().ClearRouteCache().Times(1)
 	handle.ClearRouteCache()
+}
+
+func TestGetDynamicMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		filter   string
+		path     string
+		value    string
+		expectOk bool
+	}{
+		{"missing namespace", "no_such_filter", "method", "", false},
+		{"flat string key", "mcp_filter", "method", "tools/call", true},
+		{"dotted path", "mcp_filter", "params.protocolVersion", "2025-11-25", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var retBuf shared.UnsafeEnvoyBuffer
+			if tt.expectOk {
+				retBuf = fake.NewFakeBodyBuffer([]byte(tt.value)).GetChunks()[0]
+			}
+
+			handle := mocks.NewMockHttpFilterHandle(ctrl)
+			handle.EXPECT().GetDynamicMetadata(tt.filter, tt.path).Return(retBuf, tt.expectOk)
+
+			result, ok := handle.GetDynamicMetadata(tt.filter, tt.path)
+			if ok != tt.expectOk {
+				t.Fatalf("got ok=%v, want %v", ok, tt.expectOk)
+			}
+			if ok && result.Len != uint64(len(tt.value)) {
+				t.Errorf("got len=%d, want %d", result.Len, len(tt.value))
+			}
+		})
+	}
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -992,6 +992,15 @@ pub trait EnvoyHttpFilter {
     index: usize,
   ) -> Option<bool>;
 
+  /// Get a string value from dynamic metadata by filter name and dotted key path.
+  /// Supports nested access with dot-separated paths (e.g., "a.b.c").
+  /// Only string values are supported; non-string values return `None`.
+  fn get_dynamic_metadata<'a>(
+    &'a self,
+    filter_name: &str,
+    path: &str,
+  ) -> Option<EnvoyBuffer<'a>>;
+
   /// Get the bytes-typed filter state value with the given key.
   /// If the filter state is not found or is the wrong type, this returns `None`.
   fn get_filter_state_bytes<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
@@ -2570,6 +2579,26 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     };
     if success {
       Some(value)
+    } else {
+      None
+    }
+  }
+
+  fn get_dynamic_metadata(&self, filter_name: &str, path: &str) -> Option<EnvoyBuffer<'_>> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_dynamic_metadata(
+        self.raw_ptr,
+        str_to_module_buffer(filter_name),
+        str_to_module_buffer(path),
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
     } else {
       None
     }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -238,6 +238,25 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
   assert!(ON_STREAM_COMPLETE_CALLED.load(std::sync::atomic::Ordering::SeqCst));
 }
 
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_http_get_dynamic_metadata(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+  _filter_name: abi::envoy_dynamic_module_type_module_buffer,
+  _path: abi::envoy_dynamic_module_type_module_buffer,
+  _result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+) -> bool {
+  false
+}
+
+#[test]
+fn test_http_filter_get_dynamic_metadata_weak_stub() {
+  let envoy_filter = http::EnvoyHttpFilterImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+  assert!(envoy_filter.get_dynamic_metadata("mcp_filter", "method").is_none());
+  assert!(envoy_filter.get_dynamic_metadata("mcp_filter", "params.protocolVersion").is_none());
+}
+
 // =============================================================================
 // Listener Filter Tests
 // =============================================================================

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
         "//source/common/tracing:tracer_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
+        "//source/extensions/dynamic_modules:metadata_utils_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -13,6 +13,7 @@
 #include "source/common/tracing/null_span_impl.h"
 #include "source/common/tracing/tracer_impl.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/metadata_utils.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 namespace Envoy {
@@ -2426,6 +2427,21 @@ void envoy_dynamic_module_callback_http_clear_route_cluster_cache(
     return;
   }
   downstream_callbacks->refreshRouteCluster();
+}
+
+bool envoy_dynamic_module_callback_http_get_dynamic_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, envoy_dynamic_module_type_envoy_buffer* result) {
+  auto* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto* stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return false;
+  }
+  return Envoy::Extensions::DynamicModules::getDynamicMetadataStringByPath(
+      stream_info->dynamicMetadata(), filter_name, path, result);
 }
 
 } // extern "C"

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -53,6 +53,15 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "metadata_utils_test",
+    srcs = ["metadata_utils_test.cc"],
+    deps = [
+        "//source/extensions/dynamic_modules:metadata_utils_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "util",
     srcs = ["util.cc"],

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1247,6 +1247,58 @@ TEST(ABIImpl, metadata_list) {
       {"scalar_key", 10}, &list_size));
 }
 
+TEST(ABIImpl, get_dynamic_metadata) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+
+  const std::string ns = "mcp_filter";
+  const std::string method_key = "method";
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+
+  // No stream info.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata(
+      &filter, {ns.data(), ns.size()}, {method_key.data(), method_key.size()}, &result));
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  // Flat string key.
+  Protobuf::Struct struct_obj;
+  (*struct_obj.mutable_fields())["method"] = ValueUtil::stringValue("tools/call");
+  (*metadata.mutable_filter_metadata())["mcp_filter"] = struct_obj;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata(
+      &filter, {ns.data(), ns.size()}, {method_key.data(), method_key.size()}, &result));
+  EXPECT_EQ(absl::string_view(result.ptr, result.length), "tools/call");
+
+  // Dotted path into nested struct.
+  auto& fields = *(*metadata.mutable_filter_metadata())["mcp_filter"].mutable_fields();
+  (*fields["params"].mutable_struct_value()->mutable_fields())["protocolVersion"].set_string_value(
+      "2025-11-25");
+
+  const std::string dotted_path = "params.protocolVersion";
+  ASSERT_TRUE(envoy_dynamic_module_callback_http_get_dynamic_metadata(
+      &filter, {ns.data(), ns.size()}, {dotted_path.data(), dotted_path.size()}, &result));
+  EXPECT_EQ(absl::string_view(result.ptr, result.length), "2025-11-25");
+
+  // Missing nested key.
+  const std::string missing_path = "params.nonExistent";
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata(
+      &filter, {ns.data(), ns.size()}, {missing_path.data(), missing_path.size()}, &result));
+
+  // Non-string value.
+  (*fields["params"].mutable_struct_value()->mutable_fields())["count"].set_number_value(42);
+  const std::string number_path = "params.count";
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_get_dynamic_metadata(
+      &filter, {ns.data(), ns.size()}, {number_path.data(), number_path.size()}, &result));
+}
+
 TEST(ABIImpl, attribute_bool) {
   Stats::SymbolTableImpl symbol_table;
   DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -332,6 +332,8 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
   envoy::config::core::v3::Metadata metadata;
   EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
 
   stream_info.route_ = route;
   EXPECT_CALL(callbacks, clusterInfo()).Times(testing::AnyNumber());
@@ -351,6 +353,13 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   upstream_info->upstream_host_ = upstream_host;
   Envoy::Config::Metadata::mutableMetadataValue(*host_metadata, "metadata", "host_key")
       .set_string_value("host");
+
+  // Pre-populate nested dynamic metadata for dotted-path traversal via GetDynamicMetadata.
+  (*(*metadata.mutable_filter_metadata())["nested_ns"].mutable_fields())["params"]
+      .mutable_struct_value()
+      ->mutable_fields()
+      ->insert({"protocolVersion", ValueUtil::stringValue("2025-11-25")});
+
   filter->setDecoderFilterCallbacks(callbacks);
 
   Http::TestRequestHeaderMapImpl request_headers{};

--- a/test/extensions/dynamic_modules/metadata_utils_test.cc
+++ b/test/extensions/dynamic_modules/metadata_utils_test.cc
@@ -1,0 +1,77 @@
+#include "source/extensions/dynamic_modules/metadata_utils.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+namespace {
+
+TEST(MetadataUtilsTest, FlatStringValue) {
+  envoy::config::core::v3::Metadata metadata;
+  Protobuf::Struct struct_obj;
+  (*struct_obj.mutable_fields())["method"] = ValueUtil::stringValue("tools/call");
+  (*metadata.mutable_filter_metadata())["mcp_filter"] = struct_obj;
+
+  envoy_dynamic_module_type_module_buffer filter = {"mcp_filter", 10};
+  envoy_dynamic_module_type_module_buffer path = {"method", 6};
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+
+  ASSERT_TRUE(getDynamicMetadataStringByPath(metadata, filter, path, &result));
+  EXPECT_EQ("tools/call", std::string(result.ptr, result.length));
+}
+
+TEST(MetadataUtilsTest, NestedDottedPath) {
+  envoy::config::core::v3::Metadata metadata;
+  auto& fields = *(*metadata.mutable_filter_metadata())["mcp_filter"].mutable_fields();
+  (*fields["params"].mutable_struct_value()->mutable_fields())["protocolVersion"].set_string_value(
+      "2025-11-25");
+
+  envoy_dynamic_module_type_module_buffer filter = {"mcp_filter", 10};
+  envoy_dynamic_module_type_module_buffer path = {"params.protocolVersion", 22};
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+
+  ASSERT_TRUE(getDynamicMetadataStringByPath(metadata, filter, path, &result));
+  EXPECT_EQ("2025-11-25", std::string(result.ptr, result.length));
+}
+
+TEST(MetadataUtilsTest, MissingNamespace) {
+  envoy::config::core::v3::Metadata metadata;
+  envoy_dynamic_module_type_module_buffer filter = {"no_such_filter", 14};
+  envoy_dynamic_module_type_module_buffer path = {"key", 3};
+  envoy_dynamic_module_type_envoy_buffer result{};
+
+  EXPECT_FALSE(getDynamicMetadataStringByPath(metadata, filter, path, &result));
+}
+
+TEST(MetadataUtilsTest, NonStringValue) {
+  envoy::config::core::v3::Metadata metadata;
+  Protobuf::Struct struct_obj;
+  (*struct_obj.mutable_fields())["count"] = ValueUtil::numberValue(42.0);
+  (*metadata.mutable_filter_metadata())["mcp_filter"] = struct_obj;
+
+  envoy_dynamic_module_type_module_buffer filter = {"mcp_filter", 10};
+  envoy_dynamic_module_type_module_buffer path = {"count", 5};
+  envoy_dynamic_module_type_envoy_buffer result{};
+
+  EXPECT_FALSE(getDynamicMetadataStringByPath(metadata, filter, path, &result));
+}
+
+TEST(MetadataUtilsTest, MissingNestedKey) {
+  envoy::config::core::v3::Metadata metadata;
+  auto& fields = *(*metadata.mutable_filter_metadata())["mcp_filter"].mutable_fields();
+  (*fields["params"].mutable_struct_value()->mutable_fields())["name"].set_string_value("myTool");
+
+  envoy_dynamic_module_type_module_buffer filter = {"mcp_filter", 10};
+  envoy_dynamic_module_type_module_buffer path = {"params.nonExistent", 18};
+  envoy_dynamic_module_type_envoy_buffer result{};
+
+  EXPECT_FALSE(getDynamicMetadataStringByPath(metadata, filter, path, &result));
+}
+
+} // namespace
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -539,6 +539,20 @@ func (p *dynamicMetadataCallbacksFilter) OnRequestHeaders(headers shared.HeaderM
 		panic(fmt.Sprintf("host metadata mismatch: %v", val))
 	}
 
+	// Read nested dynamic metadata by dotted path (pre-populated by C++ test).
+	if val, ok := p.handle.GetDynamicMetadata("nested_ns", "params.protocolVersion"); !ok || val.ToUnsafeString() != "2025-11-25" {
+		panic(fmt.Sprintf("dynamic metadata dotted path mismatch: %v", val))
+	}
+	// Set and read back a flat string.
+	p.handle.SetMetadata("ns_dynamic", "method", "tools/call")
+	if val, ok := p.handle.GetDynamicMetadata("ns_dynamic", "method"); !ok || val.ToUnsafeString() != "tools/call" {
+		panic(fmt.Sprintf("dynamic metadata flat key mismatch: %v", val))
+	}
+	// Non-string value returns false.
+	if _, ok := p.handle.GetDynamicMetadata("ns_req_header", "key"); ok {
+		panic("expected false for number value via GetDynamicMetadata")
+	}
+
 	return shared.HeadersStatusContinue
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -732,6 +732,16 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     );
     assert_eq!(metadata.unwrap().as_slice(), b"host");
 
+    // Read nested dynamic metadata by dotted path (pre-populated by C++ test).
+    let nested = envoy_filter.get_dynamic_metadata("nested_ns", "params.protocolVersion");
+    assert_eq!(nested.unwrap().as_slice(), b"2025-11-25");
+    // Set and read back a flat string.
+    envoy_filter.set_dynamic_metadata_string("ns_dynamic", "method", "tools/call");
+    let flat = envoy_filter.get_dynamic_metadata("ns_dynamic", "method");
+    assert_eq!(flat.unwrap().as_slice(), b"tools/call");
+    // Non-string value returns false.
+    assert!(envoy_filter.get_dynamic_metadata("ns_req_header", "key").is_none());
+
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -326,6 +326,29 @@ fn test_dynamic_metadata_callbacks_on_response_body() {
     })
     .returning(|_, _, _| Some(EnvoyBuffer::new(b"host")))
     .once();
+  // Dotted path into nested dynamic metadata.
+  envoy_filter
+    .expect_get_dynamic_metadata()
+    .withf(|ns, path| ns == "nested_ns" && path == "params.protocolVersion")
+    .returning(|_, _| Some(EnvoyBuffer::new(b"2025-11-25")))
+    .once();
+  // Set and read back a flat string via get_dynamic_metadata.
+  envoy_filter
+    .expect_set_dynamic_metadata_string()
+    .withf(|ns, key, val| ns == "ns_dynamic" && key == "method" && val == "tools/call")
+    .return_const(())
+    .once();
+  envoy_filter
+    .expect_get_dynamic_metadata()
+    .withf(|ns, path| ns == "ns_dynamic" && path == "method")
+    .returning(|_, _| Some(EnvoyBuffer::new(b"tools/call")))
+    .once();
+  // Non-string value returns None.
+  envoy_filter
+    .expect_get_dynamic_metadata()
+    .withf(|ns, path| ns == "ns_req_header" && path == "key")
+    .returning(|_, _| None)
+    .once();
   assert_eq!(
     f.on_request_headers(&mut envoy_filter, false),
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue


### PR DESCRIPTION
The access logger SDK already has get_dynamic_metadata with dotted-path traversal via Envoy::Config::Metadata::metadataValue. Extract the shared logic into metadata_utils so both access logger and HTTP filter SDKs use the same implementation. Add the callback to both Go and Rust SDKs.

Risk Level: Low — new additive callback, access logger refactored to use shared utility (no behavioral change)
Testing: Unit tests for shared utility, HTTP filter callback, access logger regression, Go/Rust SDK integration tests
Docs Changes: N/A
Release Notes: N/A