### PR TITLE
cache_v2: add passthrough test for upstream reset handling with null headers

### DIFF
--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -841,6 +841,50 @@ TEST_F(CacheSessionsTest, RangeRequestWhenLengthIsUnknownReturnsNotSatisfiable) 
   Mock::VerifyAndClearExpectations(&headers_callback1);
 }
 
+
+TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWithNullPointer) {
+  Mock::VerifyAndClearExpectations(mock_cacheable_response_checker_.get());
+  EXPECT_CALL(*mock_cacheable_response_checker_, isCacheableResponse)
+      .Times(testing::AnyNumber())
+      .WillOnce(testing::Return(false));
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+
+  ActiveLookupResultPtr result1;
+  cache_sessions_->lookup(testLookupRequest("/a"),
+                          [&result1](ActiveLookupResultPtr r) { result1 = std::move(r); });
+  pumpDispatcher();
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+  // Upstream request should have been sent.
+  ASSERT_THAT(fake_upstreams_.size(), Eq(1));
+  ASSERT_THAT(fake_upstream_get_headers_callbacks_.size(), Eq(1));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(uncacheableResponseHeaders(),
+                                                           EndStream::End);
+  pumpDispatcher();
+  ASSERT_THAT(result1, NotNull());
+  EXPECT_THAT(result1->status_, Eq(CacheEntryStatus::Uncacheable));
+
+  
+  ActiveLookupResultPtr result2;
+  cache_sessions_->lookup(testLookupRequest("/a"),
+                          [&result2](ActiveLookupResultPtr r) { result2 = std::move(r); });
+  pumpDispatcher();
+  ASSERT_THAT(result2, NotNull());
+  EXPECT_THAT(result2->status_, Eq(CacheEntryStatus::Uncacheable));
+  ASSERT_THAT(fake_upstreams_.size(), Eq(2));
+  ASSERT_THAT(fake_upstream_get_headers_callbacks_.size(), Eq(2));
+  EXPECT_THAT(fake_upstream_get_headers_callbacks_[1], IsNull());
+  Http::ResponseHeaderMapPtr headers2;
+  result2->http_source_->getHeaders(
+      [&headers2](Http::ResponseHeaderMapPtr h, EndStream) { headers2 = std::move(h); });
+  ASSERT_THAT(fake_upstream_get_headers_callbacks_[1], NotNull());
+  // Simulate an upstream reset by calling the get headers callback with a nullptr and reset end stream.
+  consumeCallback(fake_upstream_get_headers_callbacks_[1])(nullptr,
+                                                           EndStream::Reset);
+  EXPECT_THAT(headers2, IsNull());
+}
+
 // TODO: UpdateHeadersSkipSpecificHeaders
 // TODO: Vary
 

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -841,7 +841,6 @@ TEST_F(CacheSessionsTest, RangeRequestWhenLengthIsUnknownReturnsNotSatisfiable) 
   Mock::VerifyAndClearExpectations(&headers_callback1);
 }
 
-
 TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWithNullPointer) {
   Mock::VerifyAndClearExpectations(mock_cacheable_response_checker_.get());
   EXPECT_CALL(*mock_cacheable_response_checker_, isCacheableResponse)
@@ -865,7 +864,6 @@ TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWit
   ASSERT_THAT(result1, NotNull());
   EXPECT_THAT(result1->status_, Eq(CacheEntryStatus::Uncacheable));
 
-  
   ActiveLookupResultPtr result2;
   cache_sessions_->lookup(testLookupRequest("/a"),
                           [&result2](ActiveLookupResultPtr r) { result2 = std::move(r); });
@@ -879,9 +877,9 @@ TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWit
   result2->http_source_->getHeaders(
       [&headers2](Http::ResponseHeaderMapPtr h, EndStream) { headers2 = std::move(h); });
   ASSERT_THAT(fake_upstream_get_headers_callbacks_[1], NotNull());
-  // Simulate an upstream reset by calling the get headers callback with a nullptr and reset end stream.
-  consumeCallback(fake_upstream_get_headers_callbacks_[1])(nullptr,
-                                                           EndStream::Reset);
+  // Simulate an upstream reset by calling the get headers callback with a nullptr and reset end
+  // stream.
+  consumeCallback(fake_upstream_get_headers_callbacks_[1])(nullptr, EndStream::Reset);
   EXPECT_THAT(headers2, IsNull());
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: cache_v2: add passthrough test for upstream reset handling with null headers
Additional Description: Adding test coverage for https://github.com/envoyproxy/envoy/pull/44636
Risk Level: Low/None (only test changes)
Testing: unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
