### PR TITLE
Fix Ephemeral Port Exhaustion With upstream_bind_config

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -37,6 +37,13 @@ minor_behavior_changes:
 
 bug_fixes:
 # *Changes expected to improve the state of the world and are unlikely to have negative effects*
+- area: upstream
+  change: |
+    Set ``IP_BIND_ADDRESS_NO_PORT`` socket option on upstream connections when ``upstream_bind_config``
+    specifies a source address with port 0. This defers ephemeral port allocation from ``bind()`` to
+    ``connect()`` time, allowing the kernel to assign ports unique to each (src_ip, src_port, dst_ip,
+    dst_port) 4-tuple and preventing ephemeral port exhaustion when connecting to multiple destination
+    endpoints. This is the same fix applied to the original_src filter in release 1.34.0.
 - area: load_report
   change: |
     Fixed a bug in load stats reporting where reports were dropped if only custom metrics or completed

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -247,6 +247,17 @@ parseBindConfig(::Envoy::OptRef<const envoy::config::core::v3::BindConfig> bind_
                                             base_socket_options);
     ::Envoy::Network::Socket::appendOptions(upstream_local_address.socket_options_,
                                             cluster_socket_options);
+    // When binding to a specific IP with port 0, set IP_BIND_ADDRESS_NO_PORT to defer
+    // ephemeral port allocation from bind() to connect() time. This allows the kernel to
+    // assign ports unique to each (src_ip, src_port, dst_ip, dst_port) 4-tuple, preventing
+    // ephemeral port exhaustion when connecting to multiple destinations.
+    if (upstream_local_address.address_ != nullptr &&
+        upstream_local_address.address_->ip() != nullptr &&
+        upstream_local_address.address_->ip()->port() == 0) {
+      ::Envoy::Network::Socket::appendOptions(
+          upstream_local_address.socket_options_,
+          ::Envoy::Network::SocketOptionFactory::buildBindAddressNoPort());
+    }
 
     upstream_local_addresses.push_back(upstream_local_address);
 
@@ -271,6 +282,13 @@ parseBindConfig(::Envoy::OptRef<const envoy::config::core::v3::BindConfig> bind_
         ::Envoy::Network::Socket::appendOptions(extra_upstream_local_address.socket_options_,
                                                 cluster_socket_options);
       }
+      if (extra_upstream_local_address.address_ != nullptr &&
+          extra_upstream_local_address.address_->ip() != nullptr &&
+          extra_upstream_local_address.address_->ip()->port() == 0) {
+        ::Envoy::Network::Socket::appendOptions(
+            extra_upstream_local_address.socket_options_,
+            ::Envoy::Network::SocketOptionFactory::buildBindAddressNoPort());
+      }
       upstream_local_addresses.push_back(extra_upstream_local_address);
     }
 
@@ -286,6 +304,13 @@ parseBindConfig(::Envoy::OptRef<const envoy::config::core::v3::BindConfig> bind_
                                               base_socket_options);
       ::Envoy::Network::Socket::appendOptions(additional_upstream_local_address.socket_options_,
                                               cluster_socket_options);
+      if (additional_upstream_local_address.address_ != nullptr &&
+          additional_upstream_local_address.address_->ip() != nullptr &&
+          additional_upstream_local_address.address_->ip()->port() == 0) {
+        ::Envoy::Network::Socket::appendOptions(
+            additional_upstream_local_address.socket_options_,
+            ::Envoy::Network::SocketOptionFactory::buildBindAddressNoPort());
+      }
       upstream_local_addresses.push_back(additional_upstream_local_address);
     }
   } else {

--- a/test/common/upstream/cluster_manager_misc_test.cc
+++ b/test/common/upstream/cluster_manager_misc_test.cc
@@ -758,6 +758,110 @@ TEST_F(SockOptsTest, SockOptsWithExtraSourceAddressAndClusterManagerOpts) {
   expectSetsockopts(names_vals);
 }
 
+// Validate that IP_BIND_ADDRESS_NO_PORT is automatically set when upstream_bind_config
+// specifies a source address with port 0. This defers ephemeral port allocation from
+// bind() to connect() time, preventing ephemeral port exhaustion when connecting to
+// multiple destination endpoints.
+TEST_F(SockOptsTest, BindAddressNoPortWithPortZero) {
+  if (!ENVOY_SOCKET_IP_BIND_ADDRESS_NO_PORT.hasValue()) {
+    GTEST_SKIP() << "IP_BIND_ADDRESS_NO_PORT is not supported on this platform";
+  }
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: SockOptsCluster
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+      load_assignment:
+        cluster_name: SockOptsCluster
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 11001
+      upstream_bind_config:
+        source_address:
+          address: 127.0.0.6
+          port_value: 0
+  )EOF";
+  initialize(yaml);
+  NameVals names_vals{{ENVOY_SOCKET_IP_BIND_ADDRESS_NO_PORT, 1}};
+  if (ENVOY_SOCKET_SO_NOSIGPIPE.hasValue()) {
+    names_vals.emplace_back(std::make_pair(ENVOY_SOCKET_SO_NOSIGPIPE, 1));
+  }
+  expectSetsockopts(names_vals);
+}
+
+// Validate that IP_BIND_ADDRESS_NO_PORT is NOT set when the source address has a non-zero port.
+TEST_F(SockOptsTest, NoBindAddressNoPortWithNonZeroPort) {
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: SockOptsCluster
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+      load_assignment:
+        cluster_name: SockOptsCluster
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 11001
+      upstream_bind_config:
+        source_address:
+          address: 127.0.0.6
+          port_value: 12345
+  )EOF";
+  initialize(yaml);
+  if (ENVOY_SOCKET_SO_NOSIGPIPE.hasValue()) {
+    expectOnlyNoSigpipeOptions();
+  } else {
+    expectNoSocketOptions();
+  }
+}
+
+// Validate that IP_BIND_ADDRESS_NO_PORT is set on the bootstrap cluster manager
+// upstream_bind_config when port is 0.
+TEST_F(SockOptsTest, BindAddressNoPortClusterManagerBindConfig) {
+  if (!ENVOY_SOCKET_IP_BIND_ADDRESS_NO_PORT.hasValue()) {
+    GTEST_SKIP() << "IP_BIND_ADDRESS_NO_PORT is not supported on this platform";
+  }
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: SockOptsCluster
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+      load_assignment:
+        cluster_name: SockOptsCluster
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 11001
+  cluster_manager:
+    upstream_bind_config:
+      source_address:
+        address: 127.0.0.6
+        port_value: 0
+  )EOF";
+  initialize(yaml);
+  NameVals names_vals{{ENVOY_SOCKET_IP_BIND_ADDRESS_NO_PORT, 1}};
+  if (ENVOY_SOCKET_SO_NOSIGPIPE.hasValue()) {
+    names_vals.emplace_back(std::make_pair(ENVOY_SOCKET_SO_NOSIGPIPE, 1));
+  }
+  expectSetsockopts(names_vals);
+}
+
 // Validate that when tcp keepalives are set in the Cluster, we see the socket
 // option propagated to setsockopt(). This is as close to an end-to-end test as we have for this
 // feature, due to the complexity of creating an integration test involving the network stack. We


### PR DESCRIPTION
Commit Message: Ephemeral Port Exhaustion With upstream_bind_config
Additional Description: https://github.com/envoyproxy/envoy/issues/44747
Risk Level: LOW
Testing: Unit Tests
Docs Changes: NO
Release Notes: NO 
Platform Specific Features: NO
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
