### PR TITLE
ci: add skip-on-failure input and use continue-on-error for CI steps

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -43,6 +43,7 @@ jobs:
       rbe: true
       request: ${{ inputs.request }}
       skip: ${{ matrix.skip != false && true || false }}
+      skip-on-failure: ${{ matrix.skip-on-failure || false }}
       slack-channel: ${{ matrix.slack-channel || '' }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -139,6 +139,11 @@ on:
       skip:
         type: boolean
         default: false
+      skip-on-failure:
+        type: boolean
+        default: false
+        description: >-
+          If true, the job will not fail even if the CI step fails.
       slack-channel:
         type: string
         default: ''
@@ -394,7 +399,9 @@ jobs:
     # NOTE: This is where untrusted code can be run!!!
     #  Only post-failure notification steps (which don't use any repo code) should follow this step.
     - uses: envoyproxy/toolshed/actions/github/run@3c6fada5be38699cba49c9883d731ebe503d0b9d  # v0.4.10
+      id: ci-run
       name: Run CI ${{ inputs.command }} ${{ inputs.target }}
+      continue-on-error: ${{ inputs.skip-on-failure }}
       with:
         args: ${{ inputs.args != '--' && inputs.args || inputs.target }}
         catch-errors: ${{ inputs.catch-errors }}
@@ -450,7 +457,7 @@ jobs:
         ENVOY_PUBLISH_DRY_RUN: ${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}
 
     - name: Notify Slack on failure
-      if: ${{ failure() && inputs.slack-channel != '' }}
+      if: ${{ steps.ci-run.outcome == 'failure' && inputs.slack-channel != '' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       env:
         JOB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
The OpenSSL check currently masks failures inside do_ci.sh to avoid blocking PRs, but this also prevents the Slack notification step from detecting failures (since the CI step always exits successfully).

Add a `skip-on-failure` input to _run.yml that sets `continue-on-error` on the CI step. When enabled, the step's real outcome is still accessible via `steps.ci-run.outcome`, allowing the Slack notification to fire, while the overall job reports success so the PR check stays green.

This is kept independent from `slack-channel` so that future jobs can use either capability without implying the other.

The OpenSSL check will be the first user of this feature in a follow-up change.
