### PR TITLE
dynamic_modules: fix StatNamePool data race in metric increment callbacks

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -1542,6 +1542,9 @@ envoy_dynamic_module_callback_access_logger_config_define_counter(
     envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleAccessLogConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Counter& c = Stats::Utility::counterFromStatNames(*config->stats_scope_, {main_stat_name});
@@ -1567,6 +1570,9 @@ envoy_dynamic_module_callback_access_logger_config_define_gauge(
     envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleAccessLogConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Gauge& g = Stats::Utility::gaugeFromStatNames(*config->stats_scope_, {main_stat_name},
@@ -1618,6 +1624,9 @@ envoy_dynamic_module_callback_access_logger_config_define_histogram(
     envoy_dynamic_module_type_access_logger_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleAccessLogConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Histogram& h = Stats::Utility::histogramFromStatNames(

--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.cc
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.cc
@@ -77,6 +77,7 @@ absl::StatusOr<DynamicModuleAccessLogConfigSharedPtr> newDynamicModuleAccessLogC
   if (config->in_module_config_ == nullptr) {
     return absl::InvalidArgumentError("Failed to initialize dynamic module access logger config");
   }
+  config->stat_creation_frozen_ = true;
   return config;
 }
 

--- a/source/extensions/access_loggers/dynamic_modules/access_log_config.h
+++ b/source/extensions/access_loggers/dynamic_modules/access_log_config.h
@@ -143,6 +143,9 @@ public:
   // Stats scope for metric creation.
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during the in-module config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock.
+  bool stat_creation_frozen_ = false;
 
 private:
   // Allow the factory function to access private members for initialization.

--- a/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
+++ b/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
@@ -196,16 +196,17 @@ void envoy_dynamic_module_callback_bootstrap_extension_iterate_gauges(
 
 namespace {
 
-// Helper to build a StatNameTagVector from label names and label values.
+// Builds the tag vector using a caller-owned stack-local pool so the shared `stat_name_pool_`
+// is not mutated from worker threads. Returned tags borrow storage from `dynamic_pool`.
 Envoy::Stats::StatNameTagVector buildTagsForBootstrapMetric(
-    DynamicModuleBootstrapExtensionConfig& config, const Envoy::Stats::StatNameVec& label_names,
+    Envoy::Stats::StatNameDynamicPool& dynamic_pool, const Envoy::Stats::StatNameVec& label_names,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length) {
   ASSERT(label_values_length == label_names.size());
   Envoy::Stats::StatNameTagVector tags;
   tags.reserve(label_values_length);
   for (size_t i = 0; i < label_values_length; i++) {
     absl::string_view label_value_view(label_values[i].ptr, label_values[i].length);
-    auto label_value = config.stat_name_pool_.add(label_value_view);
+    auto label_value = dynamic_pool.add(label_value_view);
     tags.push_back(Envoy::Stats::StatNameTag(label_names[i], label_value));
   }
   return tags;
@@ -222,6 +223,9 @@ envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleBootstrapExtensionConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
 
@@ -266,7 +270,8 @@ envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
   if (label_values_length != counter->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForBootstrapMetric(*config, counter->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForBootstrapMetric(dynamic_pool, counter->getLabelNames(), label_values,
                                           label_values_length);
   counter->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -279,6 +284,9 @@ envoy_dynamic_module_callback_bootstrap_extension_config_define_gauge(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleBootstrapExtensionConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Gauge::ImportMode import_mode = Envoy::Stats::Gauge::ImportMode::Accumulate;
@@ -322,7 +330,8 @@ envoy_dynamic_module_callback_bootstrap_extension_config_set_gauge(
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForBootstrapMetric(*config, gauge->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForBootstrapMetric(dynamic_pool, gauge->getLabelNames(), label_values,
                                           label_values_length);
   gauge->set(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -350,7 +359,8 @@ envoy_dynamic_module_callback_bootstrap_extension_config_increment_gauge(
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForBootstrapMetric(*config, gauge->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForBootstrapMetric(dynamic_pool, gauge->getLabelNames(), label_values,
                                           label_values_length);
   gauge->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -378,7 +388,8 @@ envoy_dynamic_module_callback_bootstrap_extension_config_decrement_gauge(
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForBootstrapMetric(*config, gauge->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForBootstrapMetric(dynamic_pool, gauge->getLabelNames(), label_values,
                                           label_values_length);
   gauge->sub(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -391,6 +402,9 @@ envoy_dynamic_module_callback_bootstrap_extension_config_define_histogram(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleBootstrapExtensionConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Histogram::Unit unit = Envoy::Stats::Histogram::Unit::Unspecified;
@@ -434,7 +448,8 @@ envoy_dynamic_module_callback_bootstrap_extension_config_record_histogram_value(
   if (label_values_length != histogram->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForBootstrapMetric(*config, histogram->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForBootstrapMetric(dynamic_pool, histogram->getLabelNames(), label_values,
                                           label_values_length);
   histogram->recordValue(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.cc
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.cc
@@ -378,6 +378,8 @@ newDynamicModuleBootstrapExtensionConfig(
   config->on_bootstrap_extension_listener_add_or_update_ = on_listener_add_or_update.value();
   config->on_bootstrap_extension_listener_removal_ = on_listener_removal.value();
 
+  config->stat_creation_frozen_ = true;
+
   return config;
 }
 

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -395,6 +395,11 @@ public:
   // Stats scope for metric creation.
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during on_bootstrap_extension_config_new, and not
+  // later from worker threads, so that we don't have to wrap stat_name_pool_ in a lock.
+  // Per-request label values use a stack-local Stats::StatNameDynamicPool in the increment
+  // callbacks (see abi_impl.cc).
+  bool stat_creation_frozen_ = false;
 
   // Temporary storage for the admin response body. Set by the
   // envoy_dynamic_module_callback_bootstrap_extension_admin_set_response callback during

--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -64,16 +64,17 @@ getClusterHostMetadataValue(envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_en
   return &field_it->second;
 }
 
+// Builds the tag vector using a caller-owned stack-local pool so the shared `stat_name_pool_`
+// is not mutated from worker threads. Returned tags borrow storage from `dynamic_pool`.
 Envoy::Stats::StatNameTagVector buildTagsForClusterMetric(
-    Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterConfig& config,
-    const Envoy::Stats::StatNameVec& label_names,
+    Envoy::Stats::StatNameDynamicPool& dynamic_pool, const Envoy::Stats::StatNameVec& label_names,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length) {
   ASSERT(label_values_length == label_names.size());
   Envoy::Stats::StatNameTagVector tags;
   tags.reserve(label_values_length);
   for (size_t i = 0; i < label_values_length; i++) {
     absl::string_view label_value_view(label_values[i].ptr, label_values[i].length);
-    auto label_value = config.stat_name_pool_.add(label_value_view);
+    auto label_value = dynamic_pool.add(label_value_view);
     tags.push_back(Envoy::Stats::StatNameTag(label_names[i], label_value));
   }
   return tags;
@@ -839,6 +840,9 @@ envoy_dynamic_module_callback_cluster_config_define_counter(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* counter_id_ptr) {
   auto* config = getConfig(cluster_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
 
@@ -885,7 +889,8 @@ envoy_dynamic_module_callback_cluster_config_increment_counter(
   if (label_values_length != counter->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForClusterMetric(*config, counter->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForClusterMetric(dynamic_pool, counter->getLabelNames(), label_values,
                                         label_values_length);
   counter->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -897,6 +902,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_cluster_c
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* gauge_id_ptr) {
   auto* config = getConfig(cluster_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Gauge::ImportMode import_mode = Envoy::Stats::Gauge::ImportMode::Accumulate;
@@ -943,8 +951,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_cluster_c
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForClusterMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForClusterMetric(dynamic_pool, gauge->getLabelNames(), label_values,
+                                        label_values_length);
   gauge->set(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -975,8 +984,9 @@ envoy_dynamic_module_callback_cluster_config_increment_gauge(
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForClusterMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForClusterMetric(dynamic_pool, gauge->getLabelNames(), label_values,
+                                        label_values_length);
   gauge->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -1007,8 +1017,9 @@ envoy_dynamic_module_callback_cluster_config_decrement_gauge(
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForClusterMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForClusterMetric(dynamic_pool, gauge->getLabelNames(), label_values,
+                                        label_values_length);
   gauge->sub(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -1020,6 +1031,9 @@ envoy_dynamic_module_callback_cluster_config_define_histogram(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* histogram_id_ptr) {
   auto* config = getConfig(cluster_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Histogram::Unit unit = Envoy::Stats::Histogram::Unit::Unspecified;
@@ -1067,7 +1081,8 @@ envoy_dynamic_module_callback_cluster_config_record_histogram_value(
   if (label_values_length != histogram->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForClusterMetric(*config, histogram->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForClusterMetric(dynamic_pool, histogram->getLabelNames(), label_values,
                                         label_values_length);
   histogram->recordValue(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -135,6 +135,8 @@ absl::StatusOr<std::shared_ptr<DynamicModuleClusterConfig>> DynamicModuleCluster
     return absl::InvalidArgumentError("Failed to create in-module cluster configuration");
   }
 
+  config->stat_creation_frozen_ = true;
+
   return config;
 }
 

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -261,6 +261,11 @@ public:
 
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during on_cluster_config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock. Per-request label
+  // values use a stack-local Stats::StatNameDynamicPool in the increment callbacks (see
+  // abi_impl.cc).
+  bool stat_creation_frozen_ = false;
 
 private:
   DynamicModuleClusterConfig(const std::string& cluster_name, const std::string& cluster_config,

--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -980,6 +980,9 @@ envoy_dynamic_module_callback_listener_filter_config_define_counter(
     envoy_dynamic_module_type_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Counter& c = Stats::Utility::counterFromStatNames(*config->stats_scope_, {main_stat_name});
@@ -1005,6 +1008,9 @@ envoy_dynamic_module_callback_listener_filter_config_define_gauge(
     envoy_dynamic_module_type_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Gauge& g = Stats::Utility::gaugeFromStatNames(*config->stats_scope_, {main_stat_name},
@@ -1056,6 +1062,9 @@ envoy_dynamic_module_callback_listener_filter_config_define_histogram(
     envoy_dynamic_module_type_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Histogram& h = Stats::Utility::histogramFromStatNames(

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.cc
@@ -119,6 +119,7 @@ absl::StatusOr<DynamicModuleListenerFilterConfigSharedPtr> newDynamicModuleListe
   if (config->in_module_config_ == nullptr) {
     return absl::InvalidArgumentError("Failed to initialize dynamic module listener filter config");
   }
+  config->stat_creation_frozen_ = true;
   return config;
 }
 

--- a/source/extensions/filters/listener/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter_config.h
@@ -181,6 +181,9 @@ public:
   // Stats scope for metric creation.
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during the in-module config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock.
+  bool stat_creation_frozen_ = false;
 
 private:
   // Allow the factory function to access private members for initialization.

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -837,6 +837,9 @@ envoy_dynamic_module_callback_network_filter_config_define_counter(
     envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Counter& c = Stats::Utility::counterFromStatNames(*config->stats_scope_, {main_stat_name});
@@ -862,6 +865,9 @@ envoy_dynamic_module_callback_network_filter_config_define_gauge(
     envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Gauge& g = Stats::Utility::gaugeFromStatNames(*config->stats_scope_, {main_stat_name},
@@ -913,6 +919,9 @@ envoy_dynamic_module_callback_network_filter_config_define_histogram(
     envoy_dynamic_module_type_network_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleNetworkFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Stats::Histogram& h = Stats::Utility::histogramFromStatNames(

--- a/source/extensions/filters/network/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.cc
@@ -129,6 +129,7 @@ absl::StatusOr<DynamicModuleNetworkFilterConfigSharedPtr> newDynamicModuleNetwor
   if (config->in_module_config_ == nullptr) {
     return absl::InvalidArgumentError("Failed to initialize dynamic module network filter config");
   }
+  config->stat_creation_frozen_ = true;
   return config;
 }
 

--- a/source/extensions/filters/network/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/network/dynamic_modules/filter_config.h
@@ -186,6 +186,9 @@ public:
   // Stats scope for metric creation.
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during the in-module config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock.
+  bool stat_creation_frozen_ = false;
 
 private:
   // Allow the factory function to access private members for initialization.

--- a/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
@@ -179,6 +179,9 @@ envoy_dynamic_module_callback_udp_listener_filter_config_define_counter(
     envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Envoy::Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Envoy::Stats::Counter& c =
@@ -205,6 +208,9 @@ envoy_dynamic_module_callback_udp_listener_filter_config_define_gauge(
     envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Envoy::Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Envoy::Stats::Gauge& g = Envoy::Stats::Utility::gaugeFromStatNames(
@@ -257,6 +263,9 @@ envoy_dynamic_module_callback_udp_listener_filter_config_define_histogram(
     envoy_dynamic_module_type_udp_listener_filter_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name, size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleUdpListenerFilterConfig*>(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   Envoy::Stats::StatName main_stat_name =
       config->stat_name_pool_.add(absl::string_view(name.ptr, name.length));
   Envoy::Stats::Histogram& h = Envoy::Stats::Utility::histogramFromStatNames(

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.cc
@@ -67,6 +67,7 @@ DynamicModuleUdpListenerFilterConfig::DynamicModuleUdpListenerFilterConfig(
   in_module_config_ =
       on_filter_config_new_(static_cast<void*>(this), {filter_name_.c_str(), filter_name_.size()},
                             {filter_config_.data(), filter_config_.size()});
+  stat_creation_frozen_ = true;
 }
 
 DynamicModuleUdpListenerFilterConfig::~DynamicModuleUdpListenerFilterConfig() {

--- a/source/extensions/filters/udp/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter_config.h
@@ -120,6 +120,9 @@ public:
   // Stats scope for metric creation.
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during the in-module config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock.
+  bool stat_creation_frozen_ = false;
 
 private:
   // Metric storage.

--- a/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/abi_impl.cc
@@ -642,16 +642,17 @@ envoy_dynamic_module_callback_lb_get_host_stat(envoy_dynamic_module_type_lb_envo
 
 namespace {
 
-Envoy::Stats::StatNameTagVector
-buildTagsForLbMetric(DynamicModuleLbConfig& config, const Envoy::Stats::StatNameVec& label_names,
-                     envoy_dynamic_module_type_module_buffer* label_values,
-                     size_t label_values_length) {
+// Builds the tag vector using a caller-owned stack-local pool so the shared `stat_name_pool_`
+// is not mutated from worker threads. Returned tags borrow storage from `dynamic_pool`.
+Envoy::Stats::StatNameTagVector buildTagsForLbMetric(
+    Envoy::Stats::StatNameDynamicPool& dynamic_pool, const Envoy::Stats::StatNameVec& label_names,
+    envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length) {
   ASSERT(label_values_length == label_names.size());
   Envoy::Stats::StatNameTagVector tags;
   tags.reserve(label_values_length);
   for (size_t i = 0; i < label_values_length; i++) {
     absl::string_view label_value_view(label_values[i].ptr, label_values[i].length);
-    auto label_value = config.stat_name_pool_.add(label_value_view);
+    auto label_value = dynamic_pool.add(label_value_view);
     tags.push_back(Envoy::Stats::StatNameTag(label_names[i], label_value));
   }
   return tags;
@@ -667,6 +668,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* counter_id_ptr) {
   auto* config = static_cast<DynamicModuleLbConfig*>(lb_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
 
@@ -713,8 +717,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
   if (label_values_length != counter->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForLbMetric(*config, counter->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForLbMetric(dynamic_pool, counter->getLabelNames(), label_values,
+                                   label_values_length);
   counter->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -725,6 +730,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* gauge_id_ptr) {
   auto* config = static_cast<DynamicModuleLbConfig*>(lb_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Gauge::ImportMode import_mode = Envoy::Stats::Gauge::ImportMode::Accumulate;
@@ -771,8 +779,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
   auto tags =
-      buildTagsForLbMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+      buildTagsForLbMetric(dynamic_pool, gauge->getLabelNames(), label_values, label_values_length);
   gauge->set(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -802,8 +811,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
   auto tags =
-      buildTagsForLbMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+      buildTagsForLbMetric(dynamic_pool, gauge->getLabelNames(), label_values, label_values_length);
   gauge->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -833,8 +843,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
   auto tags =
-      buildTagsForLbMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+      buildTagsForLbMetric(dynamic_pool, gauge->getLabelNames(), label_values, label_values_length);
   gauge->sub(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }
@@ -845,6 +856,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_lb_config
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* histogram_id_ptr) {
   auto* config = static_cast<DynamicModuleLbConfig*>(lb_config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   Envoy::Stats::StatName main_stat_name = config->stat_name_pool_.add(name_view);
   Envoy::Stats::Histogram::Unit unit = Envoy::Stats::Histogram::Unit::Unspecified;
@@ -892,8 +906,9 @@ envoy_dynamic_module_callback_lb_config_record_histogram_value(
   if (label_values_length != histogram->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForLbMetric(*config, histogram->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForLbMetric(dynamic_pool, histogram->getLabelNames(), label_values,
+                                   label_values_length);
   histogram->recordValue(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
@@ -48,6 +48,8 @@ DynamicModuleLbConfig::create(const std::string& lb_policy_name, const std::stri
     return absl::InvalidArgumentError("failed to create in-module load balancer configuration");
   }
 
+  config->stat_creation_frozen_ = true;
+
   return config;
 }
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.h
@@ -234,6 +234,10 @@ public:
 
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during on_lb_config_new, and not later from worker
+  // threads, so that we don't have to wrap stat_name_pool_ in a lock. Per-request label values
+  // use a stack-local Stats::StatNameDynamicPool in the increment callbacks (see abi_impl.cc).
+  bool stat_creation_frozen_ = false;
 
 private:
   DynamicModuleLbConfig(const std::string& lb_policy_name, const std::string& lb_config,

--- a/source/extensions/tracers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/tracers/dynamic_modules/abi_impl.cc
@@ -139,16 +139,17 @@ bool envoy_dynamic_module_callback_tracer_get_trace_context_method(
 
 // ----------------------- Metrics Operations ----------------------------------
 
+// Builds the tag vector using a caller-owned stack-local pool so the shared `stat_name_pool_`
+// is not mutated from worker threads. Returned tags borrow storage from `dynamic_pool`.
 static Envoy::Stats::StatNameTagVector buildTagsForTracerMetric(
-    Envoy::Extensions::Tracers::DynamicModules::DynamicModuleTracerConfig& config,
-    const Envoy::Stats::StatNameVec& label_names,
+    Envoy::Stats::StatNameDynamicPool& dynamic_pool, const Envoy::Stats::StatNameVec& label_names,
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length) {
   ASSERT(label_values_length == label_names.size());
   Envoy::Stats::StatNameTagVector tags;
   tags.reserve(label_values_length);
   for (size_t i = 0; i < label_values_length; i++) {
     absl::string_view label_value_view(label_values[i].ptr, label_values[i].length);
-    auto label_value = config.stat_name_pool_.add(label_value_view);
+    auto label_value = dynamic_pool.add(label_value_view);
     tags.push_back(Envoy::Stats::StatNameTag(label_names[i], label_value));
   }
   return tags;
@@ -160,6 +161,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_tracer_de
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* counter_id_ptr) {
   auto* config = getConfig(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   auto stat_name = config->stat_name_pool_.add(name_view);
 
@@ -188,6 +192,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_tracer_de
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* gauge_id_ptr) {
   auto* config = getConfig(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   auto stat_name = config->stat_name_pool_.add(name_view);
   auto import_mode = Envoy::Stats::Gauge::ImportMode::NeverImport;
@@ -217,6 +224,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_tracer_de
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* histogram_id_ptr) {
   auto* config = getConfig(config_envoy_ptr);
+  if (config->stat_creation_frozen_) {
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   absl::string_view name_view(name.ptr, name.length);
   auto stat_name = config->stat_name_pool_.add(name_view);
   auto unit = Envoy::Stats::Histogram::Unit::Unspecified;
@@ -262,7 +272,8 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_tracer_in
   if (label_values_length != counter->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForTracerMetric(*config, counter->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForTracerMetric(dynamic_pool, counter->getLabelNames(), label_values,
                                        label_values_length);
   counter->add(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -291,7 +302,8 @@ envoy_dynamic_module_callback_tracer_record_histogram_value(
   if (label_values_length != histogram->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags = buildTagsForTracerMetric(*config, histogram->getLabelNames(), label_values,
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForTracerMetric(dynamic_pool, histogram->getLabelNames(), label_values,
                                        label_values_length);
   histogram->recordValue(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
@@ -319,8 +331,9 @@ envoy_dynamic_module_type_metrics_result envoy_dynamic_module_callback_tracer_se
   if (label_values_length != gauge->getLabelNames().size()) {
     return envoy_dynamic_module_type_metrics_result_InvalidLabels;
   }
-  auto tags =
-      buildTagsForTracerMetric(*config, gauge->getLabelNames(), label_values, label_values_length);
+  Envoy::Stats::StatNameDynamicPool dynamic_pool(config->stats_scope_->symbolTable());
+  auto tags = buildTagsForTracerMetric(dynamic_pool, gauge->getLabelNames(), label_values,
+                                       label_values_length);
   gauge->set(*config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
 }

--- a/source/extensions/tracers/dynamic_modules/tracer_config.cc
+++ b/source/extensions/tracers/dynamic_modules/tracer_config.cc
@@ -101,6 +101,7 @@ absl::StatusOr<DynamicModuleTracerConfigSharedPtr> newDynamicModuleTracerConfig(
   if (config->in_module_config_ == nullptr) {
     return absl::InvalidArgumentError("Failed to initialize dynamic module tracer config");
   }
+  config->stat_creation_frozen_ = true;
   return config;
 }
 

--- a/source/extensions/tracers/dynamic_modules/tracer_config.h
+++ b/source/extensions/tracers/dynamic_modules/tracer_config.h
@@ -237,6 +237,11 @@ public:
 
   const Stats::ScopeSharedPtr stats_scope_;
   Stats::StatNamePool stat_name_pool_;
+  // We only allow the module to create stats during on_tracer_config_new, and not later from
+  // worker threads, so that we don't have to wrap stat_name_pool_ in a lock. Per-request label
+  // values use a stack-local Stats::StatNameDynamicPool in the increment callbacks (see
+  // abi_impl.cc).
+  bool stat_creation_frozen_ = false;
 
 private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleTracerConfig>> newDynamicModuleTracerConfig(

--- a/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/access_log_test.cc
@@ -39,6 +39,8 @@ public:
                                         std::move(dynamic_module.value()), *stats_.rootScope());
     EXPECT_TRUE(config.ok()) << config.status().message();
     config_ = std::move(config.value());
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    config_->stat_creation_frozen_ = false;
   }
 
   Stats::IsolatedStoreImpl stats_;
@@ -326,6 +328,22 @@ TEST_F(DynamicModuleAccessLogTest, MetricsInvalidId) {
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_MetricNotFound,
             envoy_dynamic_module_callback_access_logger_record_histogram_value(
                 static_cast<void*>(config_.get()), 999, 1));
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModuleAccessLogTest, MetricsFrozenAfterInit) {
+  config_->stat_creation_frozen_ = true;
+  envoy_dynamic_module_type_module_buffer name = {.ptr = "frozen_counter", .length = 14};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_access_logger_config_define_counter(
+                static_cast<void*>(config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_access_logger_config_define_gauge(
+                static_cast<void*>(config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_access_logger_config_define_histogram(
+                static_cast<void*>(config_.get()), name, &out_id));
 }
 
 } // namespace

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -1,3 +1,6 @@
+#include <atomic>
+#include <thread>
+
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.h"
 
@@ -18,6 +21,7 @@
 #include "test/test_common/thread_factory_for_test.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -65,6 +69,11 @@ public:
     Upstream::ClusterFactoryContextImpl factory_context(server_context_, nullptr, nullptr, false);
     DynamicModuleClusterFactory factory;
     return factory.create(cluster_config, factory_context);
+  }
+
+  // Re-opens stat creation so tests can call `define_*` from the test thread.
+  static void unfreezeStatCreation(DynamicModuleClusterConfig& config) {
+    config.stat_creation_frozen_ = false;
   }
 
   std::string makeYamlConfig(const std::string& module_name,
@@ -1336,6 +1345,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndIncrementCounter) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a scalar counter.
   size_t counter_id = 0;
@@ -1359,6 +1369,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndUseGauge) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a scalar gauge.
   size_t gauge_id = 0;
@@ -1388,6 +1399,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndRecordHistogram) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a scalar histogram.
   size_t histogram_id = 0;
@@ -1411,6 +1423,7 @@ TEST_F(DynamicModuleClusterTest, MetricsNotFoundForInvalidId) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Increment a counter that was never defined.
   EXPECT_EQ(
@@ -1444,6 +1457,7 @@ TEST_F(DynamicModuleClusterTest, MetricsCounterVecWithLabels) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a counter vec with two labels.
   size_t counter_id = 0;
@@ -1488,6 +1502,7 @@ TEST_F(DynamicModuleClusterTest, MetricsGaugeVecWithLabels) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a gauge vec.
   size_t gauge_id = 0;
@@ -1523,6 +1538,7 @@ TEST_F(DynamicModuleClusterTest, MetricsHistogramVecWithLabels) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a histogram vec.
   size_t histogram_id = 0;
@@ -1554,6 +1570,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecScalarIdConflictErrors) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   envoy_dynamic_module_type_module_buffer label_name = {const_cast<char*>("lbl"), strlen("lbl")};
 
@@ -1608,6 +1625,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecWrongLabelCount) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   // Define a gauge vec with one label.
   envoy_dynamic_module_type_module_buffer gauge_name = {const_cast<char*>("gwl"), strlen("gwl")};
@@ -1652,6 +1670,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecNotFoundWithLabels) {
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
 
   envoy_dynamic_module_type_module_buffer label_val = {const_cast<char*>("val"), strlen("val")};
 
@@ -3249,6 +3268,90 @@ TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
         0,
         Upstream::HostSetImpl::partitionHosts(all_hosts, Upstream::HostsPerLocalityImpl::empty()),
         {}, {hosts[1]}, {}, absl::nullopt, absl::nullopt);
+  }
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModuleClusterTest, MetricsFrozenAfterInit) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  auto* config = cluster->config().get();
+  EXPECT_TRUE(config->stat_creation_frozen_);
+
+  envoy_dynamic_module_type_module_buffer name = {const_cast<char*>("frozen_counter"), 14};
+  envoy_dynamic_module_type_module_buffer label = {const_cast<char*>("label"), 5};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_cluster_config_define_counter(config, name, nullptr, 0,
+                                                                        &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_cluster_config_define_counter(config, name, &label, 1,
+                                                                        &out_id));
+  EXPECT_EQ(
+      envoy_dynamic_module_type_metrics_result_Frozen,
+      envoy_dynamic_module_callback_cluster_config_define_gauge(config, name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_cluster_config_define_histogram(config, name, nullptr, 0,
+                                                                          &out_id));
+}
+
+// Drives concurrent labeled increments from multiple threads to verify no data race in the
+// shared `stat_name_pool_`. Run under `--config=tsan` to verify.
+TEST_F(DynamicModuleClusterTest, MetricsConcurrentIncrementCounterVecNoRace) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  auto* config = cluster->config().get();
+  unfreezeStatCreation(*config);
+
+  envoy_dynamic_module_type_module_buffer name = {const_cast<char*>("race_counter"), 12};
+  envoy_dynamic_module_type_module_buffer label_names = {const_cast<char*>("status"), 6};
+  size_t counter_id = 0;
+  ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+            envoy_dynamic_module_callback_cluster_config_define_counter(config, name, &label_names,
+                                                                        1, &counter_id));
+
+  constexpr int kNumThreads = 8;
+  constexpr int kIncrementsPerThread = 2000;
+
+  // Pre-warm the test scope's counter cache so workers only hit the cache. `TestScope` uses an
+  // unsynchronized map for counter caching that would otherwise race independently of the path
+  // under test.
+  for (int t = 0; t < kNumThreads; ++t) {
+    const std::string label_value_str = absl::StrCat("worker_", t);
+    envoy_dynamic_module_type_module_buffer label_value = {
+        const_cast<char*>(label_value_str.data()), label_value_str.size()};
+    ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+              envoy_dynamic_module_callback_cluster_config_increment_counter(config, counter_id,
+                                                                             &label_value, 1, 0));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  std::atomic<int> ready{0};
+  std::atomic<bool> go{false};
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string label_value_str = absl::StrCat("worker_", t);
+      envoy_dynamic_module_type_module_buffer label_value = {
+          const_cast<char*>(label_value_str.data()), label_value_str.size()};
+      ready.fetch_add(1, std::memory_order_relaxed);
+      while (!go.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < kIncrementsPerThread; ++i) {
+        ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+                  envoy_dynamic_module_callback_cluster_config_increment_counter(
+                      config, counter_id, &label_value, 1, 1));
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) < kNumThreads) {
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& th : threads) {
+    th.join();
   }
 }
 

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -1,3 +1,6 @@
+#include <atomic>
+#include <thread>
+
 #include "source/extensions/bootstrap/dynamic_modules/extension.h"
 #include "source/extensions/bootstrap/dynamic_modules/extension_config.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -17,6 +20,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -28,6 +32,11 @@ class BootstrapAbiImplTest : public testing::Test {
 protected:
   std::string testDataDir() {
     return TestEnvironment::runfilesPath("test/extensions/dynamic_modules/test_data/c");
+  }
+
+  // Re-opens stat creation so tests can call `define_*` from the test thread.
+  static void unfreezeStatCreation(DynamicModuleBootstrapExtensionConfig& config) {
+    config.stat_creation_frozen_ = false;
   }
 
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
@@ -44,7 +53,6 @@ TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -64,7 +72,6 @@ TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -96,7 +103,6 @@ TEST_F(BootstrapAbiImplTest, OnScheduledCallback) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -131,7 +137,6 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
     ASSERT_TRUE(config.ok()) << config.status();
-
     // Create a scheduler via the ABI callback.
     auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
         config.value()->thisAsVoidPtr());
@@ -168,7 +173,6 @@ TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
   EXPECT_NE(scheduler_ptr, nullptr);
@@ -192,7 +196,6 @@ TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Call onScheduled directly - this should call the in-module hook.
   config.value()->onScheduled(789);
 }
@@ -215,7 +218,6 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // The C no-op module already called signal_init_complete during config creation.
   // Calling it again verifies that duplicate calls are safe.
   envoy_dynamic_module_callback_bootstrap_extension_config_signal_init_complete(
@@ -236,7 +238,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock to return nullptr for the cluster lookup.
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("nonexistent_cluster"))
       .WillOnce(testing::Return(nullptr));
@@ -269,7 +270,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Headers missing :method, :path, and host.
   std::vector<envoy_dynamic_module_type_module_http_header> headers = {
       {"x-custom", 8, "value", 5},
@@ -296,7 +296,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -355,7 +354,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -404,7 +402,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -454,7 +451,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -492,7 +488,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -549,7 +544,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -601,7 +595,6 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutWithBody) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -666,7 +659,6 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -690,7 +682,6 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueNonExistent) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -716,7 +707,6 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -740,7 +730,6 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueNonExistent) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -768,7 +757,6 @@ TEST_F(BootstrapAbiImplTest, IterateCounters) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -805,7 +793,6 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -842,6 +829,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a counter without labels.
   size_t counter_id = 0;
@@ -876,7 +864,6 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Try to increment a counter with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1);
@@ -893,6 +880,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a gauge without labels.
   size_t gauge_id = 0;
@@ -932,7 +920,6 @@ TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Try to set, increment, and decrement a gauge with an invalid ID.
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_set_gauge(
                 config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1),
@@ -955,6 +942,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a histogram without labels.
   size_t histogram_id = 0;
@@ -985,7 +973,6 @@ TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Try to record a histogram value with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_record_histogram_value(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 42);
@@ -1002,6 +989,7 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define multiple counters.
   size_t counter_id_0 = 0;
@@ -1060,6 +1048,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a counter vec with labels.
   size_t counter_vec_id = 0;
@@ -1091,6 +1080,7 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a counter vec with 2 labels.
   size_t counter_vec_id = 0;
@@ -1117,6 +1107,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a gauge vec with labels.
   size_t gauge_vec_id = 0;
@@ -1155,6 +1146,7 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define a histogram vec with labels.
   size_t histogram_vec_id = 0;
@@ -1186,6 +1178,7 @@ TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
 
   // Define vec metrics with a single label each.
   size_t counter_vec_id = 0;
@@ -1262,7 +1255,6 @@ TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1296,7 +1288,6 @@ TEST_F(BootstrapAbiImplTest, TimerFired) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a timer via the ABI callback. This will use the MockTimer we set up.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1335,7 +1326,6 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
     ASSERT_TRUE(config.ok()) << config.status();
-
     // Create a timer via the ABI callback.
     timer_ptr = envoy_dynamic_module_callback_bootstrap_extension_timer_new(
         config.value()->thisAsVoidPtr());
@@ -1372,7 +1362,6 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Add a watch for a specific path and events.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1401,7 +1390,6 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Add a watch to capture the callback.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1439,7 +1427,6 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
     ASSERT_TRUE(config.ok()) << config.status();
-
     // Add a watch to capture the callback.
     envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
     bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1471,7 +1458,6 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Add a watch - should fail and return false.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1493,7 +1479,6 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Expect the admin handler to be registered.
   EXPECT_CALL(context_.admin_, addHandler("/test_prefix", "Test help text", _, true, false, _))
       .WillOnce(testing::Return(true));
@@ -1515,7 +1500,6 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Expect the admin handler registration to fail.
   EXPECT_CALL(context_.admin_, addHandler("/duplicate", "Duplicate handler", _, false, true, _))
       .WillOnce(testing::Return(false));
@@ -1540,7 +1524,6 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   envoy_dynamic_module_type_module_buffer help_text = {"No admin", 8};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_register_admin_handler(
@@ -1558,7 +1541,6 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   EXPECT_CALL(context_.admin_, removeHandler("/test_prefix")).WillOnce(testing::Return(true));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/test_prefix", 12};
@@ -1577,7 +1559,6 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   EXPECT_CALL(context_.admin_, removeHandler("/nonexistent")).WillOnce(testing::Return(false));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/nonexistent", 12};
@@ -1599,7 +1580,6 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_remove_admin_handler(
       config.value()->thisAsVoidPtr(), path_prefix);
@@ -1616,7 +1596,6 @@ TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Capture the handler callback when addHandler is called.
   Server::Admin::HandlerCb captured_handler;
   EXPECT_CALL(context_.admin_, addHandler("/test_admin", "Test admin handler", _, true, false, _))
@@ -1664,7 +1643,6 @@ TEST_F(BootstrapAbiImplTest, TimerReEnable) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1692,7 +1670,6 @@ TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Expect the callback registration to go through ClusterManager.
   EXPECT_CALL(context_.cluster_manager_, addThreadLocalClusterUpdateCallbacks_(_))
       .WillOnce(testing::ReturnNew<Upstream::MockClusterUpdateCallbacksHandle>());
@@ -1717,7 +1694,6 @@ TEST_F(BootstrapAbiImplTest, ClusterAddOrUpdateCallback) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Invoke onClusterAddOrUpdate directly on the config to test the callback forwarding.
   Upstream::ThreadLocalClusterCommand get_cluster = []() -> Upstream::ThreadLocalCluster& {
     PANIC("should not be called");
@@ -1735,7 +1711,6 @@ TEST_F(BootstrapAbiImplTest, ClusterRemovalCallback) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Invoke onClusterRemoval directly on the config.
   config.value()->onClusterRemoval("test_cluster");
 }
@@ -1750,7 +1725,6 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycle) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -1778,7 +1752,6 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycleBeforeServerInit) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Do not set listener manager - simulate calling before server init.
   EXPECT_LOG_CONTAINS("error", "cannot enable listener lifecycle before server is initialized", {
     bool result = envoy_dynamic_module_callback_bootstrap_extension_enable_listener_lifecycle(
@@ -1797,7 +1770,6 @@ TEST_F(BootstrapAbiImplTest, ListenerAddOrUpdateCallback) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Invoke onListenerAddOrUpdate directly on the config to test the callback forwarding.
   NiceMock<Network::MockListenerConfig> mock_listener_config;
   config.value()->onListenerAddOrUpdate("test_listener", mock_listener_config);
@@ -1813,9 +1785,97 @@ TEST_F(BootstrapAbiImplTest, ListenerRemovalCallback) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
-
   // Invoke onListenerRemoval directly on the config.
   config.value()->onListenerRemoval("test_listener");
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(BootstrapAbiImplTest, MetricsFrozenAfterInit) {
+  auto dynamic_module =
+      Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
+  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
+  ASSERT_TRUE(config.ok()) << config.status();
+  EXPECT_TRUE(config.value()->stat_creation_frozen_);
+
+  envoy_dynamic_module_type_module_buffer name = {"frozen_counter", 14};
+  envoy_dynamic_module_type_module_buffer label = {"label", 5};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
+                config.value()->thisAsVoidPtr(), name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
+                config.value()->thisAsVoidPtr(), name, &label, 1, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_bootstrap_extension_config_define_gauge(
+                config.value()->thisAsVoidPtr(), name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_bootstrap_extension_config_define_histogram(
+                config.value()->thisAsVoidPtr(), name, nullptr, 0, &out_id));
+}
+
+// Drives concurrent labeled increments from multiple threads to verify no data race in the
+// shared `stat_name_pool_`. Run under `--config=tsan` to verify.
+TEST_F(BootstrapAbiImplTest, MetricsConcurrentIncrementCounterVecNoRace) {
+  auto dynamic_module =
+      Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
+  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
+                                                         std::move(dynamic_module.value()),
+                                                         dispatcher_, context_, context_.store_);
+  ASSERT_TRUE(config.ok()) << config.status();
+  unfreezeStatCreation(*config.value());
+
+  envoy_dynamic_module_type_module_buffer name = {"race_counter", 12};
+  envoy_dynamic_module_type_module_buffer label_names = {"status", 6};
+  size_t counter_id = 0;
+  ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+            envoy_dynamic_module_callback_bootstrap_extension_config_define_counter(
+                config.value()->thisAsVoidPtr(), name, &label_names, 1, &counter_id));
+
+  constexpr int kNumThreads = 8;
+  constexpr int kIncrementsPerThread = 2000;
+
+  // Pre-warm the test scope's counter cache so workers only hit the cache. `TestScope` uses an
+  // unsynchronized map for counter caching that would otherwise race independently of the path
+  // under test.
+  for (int t = 0; t < kNumThreads; ++t) {
+    const std::string label_value_str = absl::StrCat("worker_", t);
+    envoy_dynamic_module_type_module_buffer label_value = {
+        const_cast<char*>(label_value_str.data()), label_value_str.size()};
+    ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+              envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
+                  config.value()->thisAsVoidPtr(), counter_id, &label_value, 1, 0));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  std::atomic<int> ready{0};
+  std::atomic<bool> go{false};
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string label_value_str = absl::StrCat("worker_", t);
+      envoy_dynamic_module_type_module_buffer label_value = {
+          const_cast<char*>(label_value_str.data()), label_value_str.size()};
+      ready.fetch_add(1, std::memory_order_relaxed);
+      while (!go.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < kIncrementsPerThread; ++i) {
+        ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+                  envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
+                      config.value()->thisAsVoidPtr(), counter_id, &label_value, 1, 1));
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) < kNumThreads) {
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& th : threads) {
+    th.join();
+  }
 }
 
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -3524,8 +3524,7 @@ public:
   std::shared_ptr<DynamicModuleHttpFilter> filter_;
 };
 
-// Covers the happy path: `commit` posts to the dispatcher cached when decoder callbacks were
-// wired.
+// Verifies that `commit` posts to the dispatcher cached when decoder callbacks are wired.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitPostsToWorkerDispatcher) {
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
@@ -3543,7 +3542,7 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitPostsToWor
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the `!filter_shared` early return.
+// Verifies that `commit` is a no-op when the filter weak_ptr can no longer be locked.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterFilterDestroyedIsNoOp) {
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
@@ -3558,7 +3557,7 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterFilte
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the `dispatcher == nullptr` early return after `onDestroy()` clears the cache.
+// Verifies that `commit` is a no-op after `onDestroy()` clears the cached dispatcher.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterOnDestroyIsNoOp) {
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
@@ -3573,8 +3572,8 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterOnDes
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the `dispatcher == nullptr` early return when decoder callbacks have not been wired
-// (so the cached dispatcher has not been published).
+// Verifies that `commit` is a no-op when decoder callbacks have not been wired and no dispatcher
+// has been cached.
 TEST_F(DynamicModuleHttpFilterSchedulerTest,
        HttpFilterSchedulerCommitWithoutDecoderCallbacksIsNoOp) {
   auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
@@ -3586,7 +3585,7 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest,
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the happy path for the config scheduler: `commit` posts to the main thread dispatcher.
+// Verifies that the config scheduler `commit` posts to the main thread dispatcher.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterConfigSchedulerCommitPostsToMainDispatcher) {
   auto* scheduler = envoy_dynamic_module_callback_http_filter_config_scheduler_new(configPtr());
   ASSERT_NE(nullptr, scheduler);
@@ -3602,7 +3601,7 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterConfigSchedulerCommitPost
   envoy_dynamic_module_callback_http_filter_config_scheduler_delete(scheduler);
 }
 
-// Covers the `!config_shared` early return of the config scheduler.
+// Verifies that the config scheduler `commit` is a no-op after the config has been destroyed.
 TEST_F(DynamicModuleHttpFilterSchedulerTest,
        HttpFilterConfigSchedulerCommitAfterConfigDestroyedIsNoOp) {
   auto* scheduler = envoy_dynamic_module_callback_http_filter_config_scheduler_new(configPtr());

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -73,6 +73,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     ON_CALL(callbacks_, dispatcher()).WillByDefault(testing::ReturnRef(worker_thread_dispatcher_));
 
@@ -2087,8 +2089,8 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   envoy_dynamic_module_callback_listener_filter_config_scheduler_delete(scheduler);
 }
 
-// Covers the `dispatcher == nullptr` early return of the listener filter scheduler when the
-// filter has not yet received `onAccept` (so the cached dispatcher has not been published).
+// Verifies that `commit` is a no-op when `onAccept` has not yet wired callbacks and no dispatcher
+// has been cached.
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterSchedulerCommitBeforeOnAcceptIsNoOp) {
   auto fresh_filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
@@ -2367,6 +2369,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     ON_CALL(callbacks_, dispatcher()).WillByDefault(testing::ReturnRef(worker_thread_dispatcher_));
 
@@ -2661,7 +2665,7 @@ TEST_F(DynamicModuleListenerFilterHttpCalloutTest, FilterDestructionCancelsPendi
   filter_.reset();
 }
 
-// Covers the `on_listener_filter_http_callout_done_ == nullptr` branch of `onSuccess`.
+// Verifies that `onSuccess` is a safe no-op when `on_listener_filter_http_callout_done_` is null.
 TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnSuccessWithoutCalloutDoneHook) {
   NiceMock<Upstream::MockThreadLocalCluster> cluster;
   NiceMock<Http::MockAsyncClient> async_client;
@@ -2699,8 +2703,8 @@ TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnSuccessWithoutCa
       ->onSuccess(request, std::move(response));
 }
 
-// Covers the `on_listener_filter_http_callout_done_ == nullptr` branch of `onFailure` along with
-// the `ExceedResponseBufferLimit` path of the reason switch.
+// Verifies that `onFailure` is a safe no-op when `on_listener_filter_http_callout_done_` is null,
+// exercising the `ExceedResponseBufferLimit` path of the reason switch.
 TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnFailureWithoutCalloutDoneHook) {
   NiceMock<Upstream::MockThreadLocalCluster> cluster;
   NiceMock<Http::MockAsyncClient> async_client;
@@ -2735,19 +2739,35 @@ TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutOnFailureWithoutCa
       ->onFailure(request, Http::AsyncClient::FailureReason::ExceedResponseBufferLimit);
 }
 
-// Covers `DynamicModuleListenerFilter::onScheduled` when `in_module_filter_` is null.
+// Verifies that `onScheduled` is a safe no-op when `in_module_filter_` is null.
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterOnScheduledWithoutInModuleFilterIsNoOp) {
   auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
   filter->onScheduled(42);
 }
 
-// Covers the `on_listener_filter_config_scheduled_ == nullptr` branch of
-// `DynamicModuleListenerFilterConfig::onScheduled`.
+// Verifies that `DynamicModuleListenerFilterConfig::onScheduled` is a safe no-op when
+// `on_listener_filter_config_scheduled_` is null.
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterConfigOnScheduledWithoutHookIsNoOp) {
   filter_config_->on_listener_filter_config_scheduled_ = nullptr;
   filter_config_->onScheduled(42);
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, MetricsFrozenAfterInit) {
+  filter_config_->stat_creation_frozen_ = true;
+  envoy_dynamic_module_type_module_buffer name = {const_cast<char*>("frozen_counter"), 14};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_listener_filter_config_define_counter(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_listener_filter_config_define_gauge(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_listener_filter_config_define_histogram(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
 }
 
 } // namespace ListenerFilters

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -51,6 +51,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     ON_CALL(callbacks_, dispatcher()).WillByDefault(testing::ReturnRef(dispatcher));
   }

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -95,6 +95,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     filter_ = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
 
@@ -1597,6 +1599,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     filter_ = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
 
@@ -2524,6 +2528,22 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, AboveHighWatermark) {
 
   EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_above_high_watermark(filterPtr()));
   EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_above_high_watermark(filterPtr()));
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, MetricsFrozenAfterInit) {
+  filter_config_->stat_creation_frozen_ = true;
+  envoy_dynamic_module_type_module_buffer name = {const_cast<char*>("frozen_counter"), 14};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_network_filter_config_define_counter(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_network_filter_config_define_gauge(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_network_filter_config_define_histogram(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
 }
 
 } // namespace NetworkFilters

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -26,6 +26,8 @@ public:
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
     EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     ON_CALL(connection_, dispatcher()).WillByDefault(testing::ReturnRef(worker_thread_dispatcher_));
     ON_CALL(read_callbacks_, connection()).WillByDefault(testing::ReturnRef(connection_));

--- a/test/extensions/dynamic_modules/udp/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/udp/abi_impl_test.cc
@@ -28,6 +28,8 @@ public:
 
     filter_config_ = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
         proto_config, std::move(dynamic_module.value()), *stats_.rootScope());
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
 
     filter_ = std::make_shared<DynamicModuleUdpListenerFilter>(callbacks_, filter_config_, 1);
   }
@@ -582,6 +584,22 @@ TEST_F(DynamicModuleUdpListenerFilterAbiCallbackTest, GetWorkerIndex) {
   uint32_t worker_index =
       envoy_dynamic_module_callback_udp_listener_filter_get_worker_index(filterPtr());
   EXPECT_EQ(1u, worker_index);
+}
+
+// Verifies the constructor auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModuleUdpListenerFilterAbiCallbackTest, MetricsFrozenAfterInit) {
+  filter_config_->stat_creation_frozen_ = true;
+  envoy_dynamic_module_type_module_buffer name = {const_cast<char*>("frozen_counter"), 14};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_udp_listener_filter_config_define_counter(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_udp_listener_filter_config_define_gauge(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_udp_listener_filter_config_define_histogram(
+                static_cast<void*>(filter_config_.get()), name, &out_id));
 }
 
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -25,6 +25,8 @@ public:
 
     filter_config_ = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
         proto_config, std::move(dynamic_module.value()), *stats_.rootScope());
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    filter_config_->stat_creation_frozen_ = false;
   }
 
   Stats::IsolatedStoreImpl stats_;

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -1,3 +1,6 @@
+#include <atomic>
+#include <thread>
+
 #include "envoy/extensions/load_balancing_policies/dynamic_modules/v3/dynamic_modules.pb.h"
 
 #include "source/common/upstream/upstream_impl.h"
@@ -14,6 +17,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -215,6 +219,11 @@ protected:
 
     ON_CALL(priority_set_, hostSetsPerPriority())
         .WillByDefault(ReturnRef(priority_set_.host_sets_));
+  }
+
+  // Re-opens stat creation so tests can call `define_*` from the test thread.
+  static void unfreezeStatCreation(DynamicModuleLbConfig& config) {
+    config.stat_creation_frozen_ = false;
   }
 
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
@@ -1748,6 +1757,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsCounterDefineAndIncrement) {
   ASSERT_NE(typed_config, nullptr);
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a counter (no labels).
   envoy_dynamic_module_type_module_buffer name = {.ptr = "test_counter", .length = 12};
@@ -1789,6 +1799,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsGaugeDefineAndManipulate) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a gauge (no labels).
   envoy_dynamic_module_type_module_buffer name = {.ptr = "test_gauge", .length = 10};
@@ -1833,6 +1844,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsHistogramDefineAndRecord) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a histogram (no labels).
   envoy_dynamic_module_type_module_buffer name = {.ptr = "test_histogram", .length = 14};
@@ -1862,6 +1874,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsInvalidId) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Using invalid IDs should return MetricNotFound (no labels).
   EXPECT_EQ(
@@ -1915,6 +1928,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsMultipleCounters) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define two counters.
   envoy_dynamic_module_type_module_buffer name1 = {.ptr = "counter_a", .length = 9};
@@ -1957,6 +1971,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsCounterVecWithLabels) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a counter vec with two labels.
   envoy_dynamic_module_type_module_buffer name = {.ptr = "req_total", .length = 9};
@@ -2003,6 +2018,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsGaugeVecWithLabels) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a gauge vec with one label.
   envoy_dynamic_module_type_module_buffer name = {.ptr = "active_conns", .length = 12};
@@ -2045,6 +2061,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsHistogramVecWithLabels) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a histogram vec with one label.
   envoy_dynamic_module_type_module_buffer name = {.ptr = "latency", .length = 7};
@@ -2088,6 +2105,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecScalarIdConflictErrors) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a counter vec (ID 1 in vec space).
   envoy_dynamic_module_type_module_buffer counter_name = {.ptr = "cv", .length = 2};
@@ -2148,6 +2166,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecWrongLabelCount) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Define a gauge vec with one label.
   envoy_dynamic_module_type_module_buffer gauge_name = {.ptr = "gwl", .length = 3};
@@ -2185,6 +2204,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecNotFoundWithLabels) {
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
   auto lb_config = typed_config->config();
   auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
 
   // Using non-existent vec IDs with labels should return MetricNotFound.
   envoy_dynamic_module_type_module_buffer label_val = {.ptr = "val", .length = 3};
@@ -2194,6 +2214,127 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecNotFoundWithLabels) {
   EXPECT_EQ(
       envoy_dynamic_module_type_metrics_result_MetricNotFound,
       envoy_dynamic_module_callback_lb_config_decrement_gauge(config_ptr, 999, &label_val, 1, 5));
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(DynamicModulesLoadBalancerTest, MetricsFrozenAfterInit) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto* typed_config =
+      dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
+  ASSERT_NE(typed_config, nullptr);
+  auto lb_config = typed_config->config();
+  auto* config_ptr = static_cast<void*>(lb_config.get());
+  EXPECT_TRUE(lb_config->stat_creation_frozen_);
+
+  envoy_dynamic_module_type_module_buffer name = {.ptr = "frozen_counter", .length = 14};
+  envoy_dynamic_module_type_module_buffer label_name = {.ptr = "label", .length = 5};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_lb_config_define_counter(config_ptr, name, nullptr, 0,
+                                                                   &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_lb_config_define_counter(config_ptr, name, &label_name, 1,
+                                                                   &out_id));
+  EXPECT_EQ(
+      envoy_dynamic_module_type_metrics_result_Frozen,
+      envoy_dynamic_module_callback_lb_config_define_gauge(config_ptr, name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_lb_config_define_gauge(config_ptr, name, &label_name, 1,
+                                                                 &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_lb_config_define_histogram(config_ptr, name, nullptr, 0,
+                                                                     &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_lb_config_define_histogram(config_ptr, name, &label_name,
+                                                                     1, &out_id));
+}
+
+// Drives concurrent labeled increments from multiple threads to verify no data race in the
+// shared `stat_name_pool_`. Run under `--config=tsan` to verify.
+TEST_F(DynamicModulesLoadBalancerTest, MetricsConcurrentIncrementCounterVecNoRace) {
+  envoy::extensions::load_balancing_policies::dynamic_modules::v3::DynamicModulesLoadBalancerConfig
+      config;
+  config.mutable_dynamic_module_config()->set_name("lb_round_robin");
+  config.set_lb_policy_name("test_lb");
+
+  Factory factory;
+  auto lb_config_or_error = factory.loadConfig(factory_context_, config);
+  ASSERT_TRUE(lb_config_or_error.ok());
+
+  auto* typed_config =
+      dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
+  ASSERT_NE(typed_config, nullptr);
+  auto lb_config = typed_config->config();
+  auto* config_ptr = static_cast<void*>(lb_config.get());
+  unfreezeStatCreation(*lb_config);
+
+  envoy_dynamic_module_type_module_buffer name = {.ptr = "race_counter", .length = 12};
+  std::string label_name_str = "status";
+  envoy_dynamic_module_type_module_buffer label_names[1] = {
+      {.ptr = const_cast<char*>(label_name_str.data()), .length = label_name_str.size()}};
+  size_t counter_id = 0;
+  ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+            envoy_dynamic_module_callback_lb_config_define_counter(config_ptr, name, label_names, 1,
+                                                                   &counter_id));
+
+  constexpr int kNumThreads = 8;
+  constexpr int kIncrementsPerThread = 2000;
+
+  // Pre-warm the test scope's counter cache so workers only hit the cache. `TestScope` uses an
+  // unsynchronized map for counter caching that would otherwise race independently of the path
+  // under test.
+  for (int t = 0; t < kNumThreads; ++t) {
+    const std::string label_value_str = absl::StrCat("worker_", t);
+    envoy_dynamic_module_type_module_buffer label_value = {
+        .ptr = const_cast<char*>(label_value_str.data()), .length = label_value_str.size()};
+    ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+              envoy_dynamic_module_callback_lb_config_increment_counter(config_ptr, counter_id,
+                                                                        &label_value, 1, 0));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  std::atomic<int> ready{0};
+  std::atomic<bool> go{false};
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string label_value_str = absl::StrCat("worker_", t);
+      envoy_dynamic_module_type_module_buffer label_value = {
+          .ptr = const_cast<char*>(label_value_str.data()), .length = label_value_str.size()};
+      ready.fetch_add(1, std::memory_order_relaxed);
+      while (!go.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < kIncrementsPerThread; ++i) {
+        ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+                  envoy_dynamic_module_callback_lb_config_increment_counter(config_ptr, counter_id,
+                                                                            &label_value, 1, 1));
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) < kNumThreads) {
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  uint64_t total = 0;
+  for (int t = 0; t < kNumThreads; ++t) {
+    auto counter = TestUtility::findCounter(
+        factory_context_.store_,
+        absl::StrCat("dynamicmodulescustom.race_counter.status.worker_", t));
+    ASSERT_NE(nullptr, counter) << "missing counter for worker_" << t;
+    total += counter->value();
+  }
+  EXPECT_EQ(static_cast<uint64_t>(kNumThreads) * kIncrementsPerThread, total);
 }
 
 } // namespace

--- a/test/extensions/tracers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/tracers/dynamic_modules/abi_impl_test.cc
@@ -1,3 +1,6 @@
+#include <atomic>
+#include <thread>
+
 #include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/tracers/dynamic_modules/tracer_config.h"
 
@@ -6,6 +9,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -35,6 +39,8 @@ public:
                                                   std::move(module.value()), *store_.rootScope());
     EXPECT_TRUE(config_or.ok());
     config_ = config_or.value();
+    // Re-open stat creation so tests can call `define_*` from the test thread.
+    config_->stat_creation_frozen_ = false;
     driver_ = std::make_shared<DynamicModuleDriver>(config_);
   }
 
@@ -516,6 +522,80 @@ TEST_F(AbiImplTest, RecordHistogramVecNotFound) {
   auto result = envoy_dynamic_module_callback_tracer_record_histogram_value(
       static_cast<void*>(config_.get()), 999, label_values, 1, 1);
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_MetricNotFound);
+}
+
+// Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
+TEST_F(AbiImplTest, MetricsFrozenAfterInit) {
+  config_->stat_creation_frozen_ = true;
+  envoy_dynamic_module_type_module_buffer name = {.ptr = "frozen_counter", .length = 14};
+  envoy_dynamic_module_type_module_buffer label_name = {.ptr = "label", .length = 5};
+  size_t out_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_tracer_define_counter(static_cast<void*>(config_.get()),
+                                                                name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_tracer_define_counter(static_cast<void*>(config_.get()),
+                                                                name, &label_name, 1, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_tracer_define_gauge(static_cast<void*>(config_.get()),
+                                                              name, nullptr, 0, &out_id));
+  EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+            envoy_dynamic_module_callback_tracer_define_histogram(static_cast<void*>(config_.get()),
+                                                                  name, nullptr, 0, &out_id));
+}
+
+// Drives concurrent labeled increments from multiple threads to verify no data race in the
+// shared `stat_name_pool_`. Run under `--config=tsan` to verify.
+TEST_F(AbiImplTest, MetricsConcurrentIncrementCounterVecNoRace) {
+  envoy_dynamic_module_type_module_buffer name = {.ptr = "race_counter", .length = 12};
+  std::string label_name_str = "status";
+  envoy_dynamic_module_type_module_buffer label_names[1] = {
+      {.ptr = const_cast<char*>(label_name_str.data()), .length = label_name_str.size()}};
+  size_t counter_id = 0;
+  ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+            envoy_dynamic_module_callback_tracer_define_counter(static_cast<void*>(config_.get()),
+                                                                name, label_names, 1, &counter_id));
+
+  constexpr int kNumThreads = 8;
+  constexpr int kIncrementsPerThread = 2000;
+
+  // Pre-warm the test scope's counter cache so workers only hit the cache. `TestScope` uses an
+  // unsynchronized map for counter caching that would otherwise race independently of the path
+  // under test.
+  for (int t = 0; t < kNumThreads; ++t) {
+    const std::string label_value_str = absl::StrCat("worker_", t);
+    envoy_dynamic_module_type_module_buffer label_value = {
+        .ptr = const_cast<char*>(label_value_str.data()), .length = label_value_str.size()};
+    ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+              envoy_dynamic_module_callback_tracer_increment_counter(
+                  static_cast<void*>(config_.get()), counter_id, &label_value, 1, 0));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  std::atomic<int> ready{0};
+  std::atomic<bool> go{false};
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      const std::string label_value_str = absl::StrCat("worker_", t);
+      envoy_dynamic_module_type_module_buffer label_value = {
+          .ptr = const_cast<char*>(label_value_str.data()), .length = label_value_str.size()};
+      ready.fetch_add(1, std::memory_order_relaxed);
+      while (!go.load(std::memory_order_acquire)) {
+      }
+      for (int i = 0; i < kIncrementsPerThread; ++i) {
+        ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success,
+                  envoy_dynamic_module_callback_tracer_increment_counter(
+                      static_cast<void*>(config_.get()), counter_id, &label_value, 1, 1));
+      }
+    });
+  }
+  while (ready.load(std::memory_order_acquire) < kNumThreads) {
+  }
+  go.store(true, std::memory_order_release);
+  for (auto& th : threads) {
+    th.join();
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Description

The metric increment callbacks across the LB, tracer, cluster, and bootstrap dynamic-module ABIs mutated a per-config `Stats::StatNamePool` on every labeled metric increment. `StatNamePool::add` does an unsynchronized `std::vector::emplace_back` and the same pool is shared across every Envoy worker thread, so concurrent `increment_counter_vec`, `set_gauge_vec`, `record_histogram_value` calls would race the vector reallocation in the slow path and **SIGSEGV**.

This PR fixes it by building a per-request tag vectors using a stack-local `Stats::StatNameDynamicPool`. The shared pool is no longer mutated from the request path, eliminating both the data race and an unbounded `storage_vector_` growth that previously leaked one entry per label per increment.

---

**Commit Message:** dynamic_modules: fix StatNamePool data race in metric increment callbacks
**Additional Description:** Fixed StatNamePool data race in metric increment callbacks.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A