### PR TITLE
dynamic_modules: fix TOCTOU UAF in filter scheduler commit() across modules

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -33,6 +33,8 @@ void DynamicModuleHttpFilter::onStreamComplete() {
 
 void DynamicModuleHttpFilter::onDestroy() {
   destroyed_ = true;
+  // Clear the cached dispatcher so any concurrent foreign-thread `commit()` short-circuits.
+  cached_dispatcher_.store(nullptr, std::memory_order_release);
   // Pair with the register in maybeRegisterDownstreamWatermarkCallbacks(); the underlying
   // removeDownstreamWatermarkCallbacks() asserts the callback was previously added.
   if (decoder_callbacks_ != nullptr && downstream_watermark_callbacks_registered_) {

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "source/common/tracing/null_span_impl.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
@@ -42,6 +44,8 @@ public:
   FilterMetadataStatus decodeMetadata(MetadataMap&) override;
   void setDecoderFilterCallbacks(StreamDecoderFilterCallbacks& callbacks) override {
     decoder_callbacks_ = &callbacks;
+    // Publish the worker dispatcher for cross-thread `commit()`; see `dispatcher()`.
+    cached_dispatcher_.store(&callbacks.dispatcher(), std::memory_order_release);
     // Registration is deferred until the in-module filter exists: the factory wires callbacks
     // before initializeInModuleFilter(), and addDownstreamWatermarkCallbacks() synchronously
     // replays any pending onAboveWriteBufferHighWatermark() into the newly registered callback.
@@ -62,6 +66,12 @@ public:
 
   bool isDestroyed() const { return destroyed_; }
 
+  /**
+   * Returns the worker dispatcher this filter is running on; safe to call from any thread.
+   * Returns nullptr until callbacks are wired and after `onDestroy()`.
+   */
+  Event::Dispatcher* dispatcher() { return cached_dispatcher_.load(std::memory_order_acquire); }
+
   // ----------  Http::DownstreamWatermarkCallbacks  ----------
   void onAboveWriteBufferHighWatermark() override;
   void onBelowWriteBufferLowWatermark() override;
@@ -71,7 +81,8 @@ public:
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details);
 
-  // The callbacks for the filter. They are only valid until onDestroy() is called.
+  // The callbacks for the filter. Worker-thread only; foreign threads must use `dispatcher()`.
+  // They are only valid until onDestroy() is called.
   StreamDecoderFilterCallbacks* decoder_callbacks_ = nullptr;
   StreamEncoderFilterCallbacks* encoder_callbacks_ = nullptr;
   bool destroyed_ = false;
@@ -270,6 +281,9 @@ private:
   // asserts that the callback was previously added.
   bool downstream_watermark_callbacks_registered_ = false;
 
+  // Worker dispatcher published at callback-init, cleared on destroy. Read via `dispatcher()`.
+  std::atomic<Event::Dispatcher*> cached_dispatcher_{nullptr};
+
   /**
    * This implementation of the AsyncClient::Callbacks is used to handle the response from the HTTP
    * callout from the parent HTTP filter.
@@ -404,15 +418,19 @@ public:
   explicit DynamicModuleHttpFilterScheduler(DynamicModuleHttpFilterWeakPtr filter)
       : filter_(std::move(filter)) {}
 
+  // Safe to call from any thread. Reads only the weak_ptr and the atomic dispatcher cache (see
+  // `DynamicModuleHttpFilter::dispatcher()`); it never dereferences `decoder_callbacks_` from a
+  // foreign thread.
   void commit(uint64_t event_id) {
-    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
-    // `post`.
-    auto filter_shared = filter_.lock();
-    if (!filter_shared || filter_shared->isDestroyed() ||
-        filter_shared->decoder_callbacks_ == nullptr) {
+    DynamicModuleHttpFilterSharedPtr filter_shared = filter_.lock();
+    if (!filter_shared) {
       return;
     }
-    filter_shared->decoder_callbacks_->dispatcher().post([filter = filter_, event_id]() {
+    Event::Dispatcher* dispatcher = filter_shared->dispatcher();
+    if (dispatcher == nullptr) {
+      return;
+    }
+    dispatcher->post([filter = filter_, event_id]() {
       if (DynamicModuleHttpFilterSharedPtr fs = filter.lock()) {
         fs->onScheduled(event_id);
       }

--- a/source/extensions/filters/listener/dynamic_modules/filter.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter.cc
@@ -43,11 +43,15 @@ void DynamicModuleListenerFilter::destroy() {
     config_->on_listener_filter_destroy_(in_module_filter_);
     in_module_filter_ = nullptr;
   }
+  // Clear the cached dispatcher so any concurrent foreign-thread `commit()` short-circuits.
+  cached_dispatcher_.store(nullptr, std::memory_order_release);
   destroyed_ = true;
 }
 
 Network::FilterStatus DynamicModuleListenerFilter::onAccept(Network::ListenerFilterCallbacks& cb) {
   callbacks_ = &cb;
+  // Publish the worker dispatcher for cross-thread `commit()`; see `dispatcher()`.
+  cached_dispatcher_.store(&cb.dispatcher(), std::memory_order_release);
 
   const std::string& worker_name = cb.dispatcher().name();
   auto pos = worker_name.find_first_of('_');

--- a/source/extensions/filters/listener/dynamic_modules/filter.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "envoy/http/async_client.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listener_filter_buffer.h"
@@ -66,12 +68,10 @@ public:
   void onScheduled(uint64_t event_id);
 
   /**
-   * Get the dispatcher for the worker thread this filter is running on.
-   * Returns nullptr if callbacks are not set.
+   * Returns the worker dispatcher this filter is running on; safe to call from any thread.
+   * Returns nullptr until callbacks are wired and after the filter is destroyed.
    */
-  Event::Dispatcher* dispatcher() {
-    return callbacks_ != nullptr ? &callbacks_->dispatcher() : nullptr;
-  }
+  Event::Dispatcher* dispatcher() { return cached_dispatcher_.load(std::memory_order_acquire); }
 
   /**
    * Returns the worker index assigned to this filter.
@@ -99,6 +99,7 @@ private:
   const DynamicModuleListenerFilterConfigSharedPtr config_;
   envoy_dynamic_module_type_listener_filter_module_ptr in_module_filter_ = nullptr;
 
+  // Worker-thread only; foreign threads must use `dispatcher()`.
   Network::ListenerFilterCallbacks* callbacks_ = nullptr;
 
   // Current buffer, only valid during onData callback.
@@ -108,6 +109,9 @@ private:
   Network::Address::InstanceConstSharedPtr cached_original_dst_;
 
   bool destroyed_ = false;
+
+  // Worker dispatcher published at callback-init, cleared on destroy. Read via `dispatcher()`.
+  std::atomic<Event::Dispatcher*> cached_dispatcher_{nullptr};
 
   uint32_t worker_index_;
 
@@ -155,10 +159,11 @@ public:
   explicit DynamicModuleListenerFilterScheduler(DynamicModuleListenerFilterWeakPtr filter)
       : filter_(std::move(filter)) {}
 
+  // Safe to call from any thread. Reads only the weak_ptr and the atomic dispatcher cache (see
+  // `DynamicModuleListenerFilter::dispatcher()`); it never dereferences `callbacks_` from a
+  // foreign thread.
   void commit(uint64_t event_id) {
-    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
-    // `post`.
-    auto filter_shared = filter_.lock();
+    DynamicModuleListenerFilterSharedPtr filter_shared = filter_.lock();
     if (!filter_shared) {
       return;
     }

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -58,12 +58,16 @@ void DynamicModuleNetworkFilter::destroy() {
     config_->on_network_filter_destroy_(in_module_filter_);
     in_module_filter_ = nullptr;
   }
+  // Clear the cached dispatcher so any concurrent foreign-thread `commit()` short-circuits.
+  cached_dispatcher_.store(nullptr, std::memory_order_release);
   destroyed_ = true;
 }
 
 void DynamicModuleNetworkFilter::initializeReadFilterCallbacks(
     Network::ReadFilterCallbacks& callbacks) {
   read_callbacks_ = &callbacks;
+  // Publish the worker dispatcher for cross-thread `commit()`; see `dispatcher()`.
+  cached_dispatcher_.store(&callbacks.connection().dispatcher(), std::memory_order_release);
 
   const std::string& worker_name = callbacks.connection().dispatcher().name();
   auto pos = worker_name.find_first_of('_');

--- a/source/extensions/filters/network/dynamic_modules/filter.h
+++ b/source/extensions/filters/network/dynamic_modules/filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -145,12 +146,10 @@ public:
   void onScheduled(uint64_t event_id);
 
   /**
-   * Get the dispatcher for the worker thread this filter is running on.
-   * Returns nullptr if callbacks are not set.
+   * Returns the worker dispatcher this filter is running on; safe to call from any thread.
+   * Returns nullptr until callbacks are wired and after the filter is destroyed.
    */
-  Event::Dispatcher* dispatcher() {
-    return read_callbacks_ != nullptr ? &read_callbacks_->connection().dispatcher() : nullptr;
-  }
+  Event::Dispatcher* dispatcher() { return cached_dispatcher_.load(std::memory_order_acquire); }
 
   /**
    * Returns the worker index assigned to this filter.
@@ -177,6 +176,7 @@ private:
   const DynamicModuleNetworkFilterConfigSharedPtr config_;
   envoy_dynamic_module_type_network_filter_module_ptr in_module_filter_ = nullptr;
 
+  // Worker-thread only; foreign threads must use `dispatcher()`.
   Network::ReadFilterCallbacks* read_callbacks_ = nullptr;
   Network::WriteFilterCallbacks* write_callbacks_ = nullptr;
 
@@ -186,6 +186,9 @@ private:
   Buffer::Instance* current_write_buffer_ = nullptr;
 
   bool destroyed_ = false;
+
+  // Worker dispatcher published at callback-init, cleared on destroy. Read via `dispatcher()`.
+  std::atomic<Event::Dispatcher*> cached_dispatcher_{nullptr};
 
   uint32_t worker_index_;
 
@@ -244,10 +247,11 @@ public:
   explicit DynamicModuleNetworkFilterScheduler(DynamicModuleNetworkFilterWeakPtr filter)
       : filter_(std::move(filter)) {}
 
+  // Safe to call from any thread. Reads only the weak_ptr and the atomic dispatcher cache (see
+  // `DynamicModuleNetworkFilter::dispatcher()`); it never dereferences `read_callbacks_` from a
+  // foreign thread.
   void commit(uint64_t event_id) {
-    // Lock the filter so the dispatcher reference obtained via its callbacks stays valid across
-    // `post`.
-    auto filter_shared = filter_.lock();
+    DynamicModuleNetworkFilterSharedPtr filter_shared = filter_.lock();
     if (!filter_shared) {
       return;
     }

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <memory>
 #include <set>
+#include <thread>
 
 #include "envoy/registry/registry.h"
 
@@ -3523,7 +3524,8 @@ public:
   std::shared_ptr<DynamicModuleHttpFilter> filter_;
 };
 
-// Covers the happy path: `commit` posts to the dispatcher resolved via decoder callbacks.
+// Covers the happy path: `commit` posts to the dispatcher cached when decoder callbacks were
+// wired.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitPostsToWorkerDispatcher) {
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
@@ -3556,7 +3558,7 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterFilte
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the `filter_shared->isDestroyed()` early return.
+// Covers the `dispatcher == nullptr` early return after `onDestroy()` clears the cache.
 TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterOnDestroyIsNoOp) {
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
@@ -3571,7 +3573,8 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest, HttpFilterSchedulerCommitAfterOnDes
   envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
-// Covers the `decoder_callbacks_ == nullptr` early return.
+// Covers the `dispatcher == nullptr` early return when decoder callbacks have not been wired
+// (so the cached dispatcher has not been published).
 TEST_F(DynamicModuleHttpFilterSchedulerTest,
        HttpFilterSchedulerCommitWithoutDecoderCallbacksIsNoOp) {
   auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
@@ -3612,6 +3615,49 @@ TEST_F(DynamicModuleHttpFilterSchedulerTest,
   envoy_dynamic_module_callback_http_filter_config_scheduler_commit(scheduler, 456);
 
   envoy_dynamic_module_callback_http_filter_config_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread after `onDestroy()` is a safe no-op. Run under
+// `--config=tsan` to confirm no data race on `decoder_callbacks_`.
+TEST_F(DynamicModuleHttpFilterSchedulerTest,
+       HttpFilterSchedulerCommitFromForeignThreadAfterDestroyIsNoOp) {
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_->onDestroy();
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_)).Times(0);
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 999); });
+  foreign.join();
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread before destroy posts via the cached dispatcher and
+// that the lambda re-locks the weak_ptr correctly.
+TEST_F(DynamicModuleHttpFilterSchedulerTest,
+       HttpFilterSchedulerCommitFromForeignThreadBeforeDestroyPosts) {
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  auto* scheduler = envoy_dynamic_module_callback_http_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  Event::PostCb captured_cb;
+  EXPECT_CALL(worker_thread_dispatcher_, post(testing::_))
+      .WillOnce(testing::Invoke([&](Event::PostCb cb) { captured_cb = std::move(cb); }));
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_http_filter_scheduler_commit(scheduler, 42); });
+  foreign.join();
+
+  ASSERT_TRUE(captured_cb);
+  captured_cb();
+
+  envoy_dynamic_module_callback_http_filter_scheduler_delete(scheduler);
 }
 
 } // namespace HttpFilters

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <thread>
 #include <vector>
 
 #include "source/common/http/message_impl.h"
@@ -1954,10 +1955,6 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, MaxReadBytes) {
 // =============================================================================
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest, ListenerFilterSchedulerNewDelete) {
-  // Set up the dispatcher for the filter.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(callbacks_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
@@ -1965,19 +1962,14 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, ListenerFilterSchedulerNewDel
 }
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest, ListenerFilterSchedulerCommit) {
-  // Set up the dispatcher for the filter.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(callbacks_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
-  // Expect the callback to be posted.
-  EXPECT_CALL(worker_dispatcher, post(_));
+  // The dispatcher cached during `onAccept` (in SetUp) is `worker_thread_dispatcher_`.
+  EXPECT_CALL(worker_thread_dispatcher_, post(_));
 
   envoy_dynamic_module_callback_listener_filter_scheduler_commit(scheduler, 123);
 
-  // Clean up.
   envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
 }
 
@@ -2005,16 +1997,12 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, ListenerFilterConfigScheduler
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterSchedulerCommitInvokesOnScheduled) {
-  // Set up the dispatcher for the filter.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(callbacks_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
   // Capture the posted callback and invoke it to verify onScheduled is called.
   Event::PostCb captured_cb;
-  EXPECT_CALL(worker_dispatcher, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
     captured_cb = std::move(cb);
   }));
 
@@ -2025,7 +2013,6 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   // Since the no_op module's on_scheduled is a no-op, we just verify it doesn't crash.
   captured_cb();
 
-  // Clean up.
   envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
 }
 
@@ -2055,16 +2042,12 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterSchedulerCommitAfterFilterDestroyedDoesNotCrash) {
-  // Set up the dispatcher for the filter.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(callbacks_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
   // Capture the posted callback.
   Event::PostCb captured_cb;
-  EXPECT_CALL(worker_dispatcher, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
     captured_cb = std::move(cb);
   }));
 
@@ -2076,7 +2059,6 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   // Invoke the captured callback - should not crash because the scheduler holds a weak_ptr.
   captured_cb();
 
-  // Clean up.
   envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
 }
 
@@ -2105,16 +2087,56 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   envoy_dynamic_module_callback_listener_filter_config_scheduler_delete(scheduler);
 }
 
-// Covers the `dispatcher == nullptr` early return of the listener filter scheduler.
+// Covers the `dispatcher == nullptr` early return of the listener filter scheduler when the
+// filter has not yet received `onAccept` (so the cached dispatcher has not been published).
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
-       ListenerFilterSchedulerCommitWithoutCallbacksIsNoOp) {
-  auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
+       ListenerFilterSchedulerCommitBeforeOnAcceptIsNoOp) {
+  auto fresh_filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(
+      static_cast<void*>(fresh_filter.get()));
   ASSERT_NE(nullptr, scheduler);
-
-  filter_->setCallbacksForTest(nullptr);
 
   EXPECT_CALL(worker_thread_dispatcher_, post(_)).Times(0);
   envoy_dynamic_module_callback_listener_filter_scheduler_commit(scheduler, 123);
+
+  envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread before destroy posts via the cached dispatcher.
+// Run under `--config=tsan` to confirm no data race on `callbacks_`.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
+       ListenerFilterSchedulerCommitFromForeignThreadBeforeDestroyPosts) {
+  auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  Event::PostCb captured_cb;
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+    captured_cb = std::move(cb);
+  }));
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_listener_filter_scheduler_commit(scheduler, 42); });
+  foreign.join();
+
+  ASSERT_TRUE(captured_cb);
+  captured_cb();
+
+  envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread after the filter is destroyed is a safe no-op.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
+       ListenerFilterSchedulerCommitFromForeignThreadAfterDestroyIsNoOp) {
+  auto* scheduler = envoy_dynamic_module_callback_listener_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_.reset();
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).Times(0);
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_listener_filter_scheduler_commit(scheduler, 999); });
+  foreign.join();
 
   envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
 }

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -1,3 +1,4 @@
+#include <thread>
 #include <vector>
 
 #include "envoy/registry/registry.h"
@@ -2254,10 +2255,6 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, StartUpstreamSecureTransportNu
 // =============================================================================
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterSchedulerNewDelete) {
-  // Set up the dispatcher for the filter via connection.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(connection_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
@@ -2265,19 +2262,15 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterSchedulerNewDelet
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterSchedulerCommit) {
-  // Set up the dispatcher for the filter via connection.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(connection_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
-  // Expect the callback to be posted.
-  EXPECT_CALL(worker_dispatcher, post(_));
+  // The dispatcher cached during `initializeReadFilterCallbacks` (in SetUp) is
+  // `worker_thread_dispatcher_`.
+  EXPECT_CALL(worker_thread_dispatcher_, post(_));
 
   envoy_dynamic_module_callback_network_filter_scheduler_commit(scheduler, 12345);
 
-  // Clean up.
   envoy_dynamic_module_callback_network_filter_scheduler_delete(scheduler);
 }
 
@@ -2304,16 +2297,12 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterConfigSchedulerCo
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterSchedulerCommitInvokesOnScheduled) {
-  // Set up the dispatcher for the filter via connection.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(connection_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
   // Capture the posted callback and invoke it to verify onScheduled is called.
   Event::PostCb captured_cb;
-  EXPECT_CALL(worker_dispatcher, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
     captured_cb = std::move(cb);
   }));
 
@@ -2324,7 +2313,6 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, NetworkFilterSchedulerCommitIn
   // Since the no_op module's on_scheduled is a no-op, we just verify it doesn't crash.
   captured_cb();
 
-  // Clean up.
   envoy_dynamic_module_callback_network_filter_scheduler_delete(scheduler);
 }
 
@@ -2354,16 +2342,12 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
        NetworkFilterSchedulerCommitAfterFilterDestroyedDoesNotCrash) {
-  // Set up the dispatcher for the filter via connection.
-  NiceMock<Event::MockDispatcher> worker_dispatcher;
-  EXPECT_CALL(connection_, dispatcher()).WillRepeatedly(testing::ReturnRef(worker_dispatcher));
-
   auto scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
   EXPECT_NE(nullptr, scheduler);
 
   // Capture the posted callback.
   Event::PostCb captured_cb;
-  EXPECT_CALL(worker_dispatcher, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
     captured_cb = std::move(cb);
   }));
 
@@ -2375,7 +2359,45 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
   // The callback should not crash even though the filter is destroyed.
   captured_cb();
 
-  // Clean up.
+  envoy_dynamic_module_callback_network_filter_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread before destroy posts via the cached dispatcher.
+// Run under `--config=tsan` to confirm no data race on `read_callbacks_`.
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
+       NetworkFilterSchedulerCommitFromForeignThreadBeforeDestroyPosts) {
+  auto* scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  Event::PostCb captured_cb;
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+    captured_cb = std::move(cb);
+  }));
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_network_filter_scheduler_commit(scheduler, 42); });
+  foreign.join();
+
+  ASSERT_TRUE(captured_cb);
+  captured_cb();
+
+  envoy_dynamic_module_callback_network_filter_scheduler_delete(scheduler);
+}
+
+// Verifies `commit()` from a foreign thread after the filter is destroyed is a safe no-op.
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest,
+       NetworkFilterSchedulerCommitFromForeignThreadAfterDestroyIsNoOp) {
+  auto* scheduler = envoy_dynamic_module_callback_network_filter_scheduler_new(filterPtr());
+  ASSERT_NE(nullptr, scheduler);
+
+  filter_.reset();
+
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).Times(0);
+
+  std::thread foreign(
+      [&]() { envoy_dynamic_module_callback_network_filter_scheduler_commit(scheduler, 999); });
+  foreign.join();
+
   envoy_dynamic_module_callback_network_filter_scheduler_delete(scheduler);
 }
 


### PR DESCRIPTION
## Description

The HTTP, network, and listener filter schedulers expose a thread-safe `commit()` that the module may invoke from a foreign thread (e.g., a tokio worker / OS thread it owns). The pre-fix implementation read `decoder_callbacks_`, `read_callbacks_`, `callbacks_` from the foreign thread, then dereferenced `->dispatcher()` on the result. Those callback objects have lifetime independent of the filter's `shared_ptr` which is a worker-thread teardown of the FilterManager can free the callback object while the filter `shared_ptr` is still live, producing a UAF on `->dispatcher().post(...)`.

This change publishes the worker dispatcher pointer through a `std::atomic<Event::Dispatcher*> cached_dispatcher_` member, set with release ordering at callback-init time and cleared with release ordering on filter teardown. `commit()` now reads only the `weak_ptr` and the atomic dispatcher pointer and it never touches the FilterManager-owned callback object from a foreign thread. The dispatcher object itself is owned by `Worker::dispatcher_` and lives for the worker-thread lifetime, so the cached pointer is stable for any subsequent post.

---

**Commit Message:** dynamic_modules: fix TOCTOU UAF in filter scheduler commit() across modules
**Additional Description:** Fixes TOCTOU UAF in filter scheduler commit() across modules
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A