### PR TITLE
Avoids copying std::function objects upon every buffer instance construction

### DIFF
--- a/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
+++ b/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
@@ -69,20 +69,23 @@ public:
 
   void initialize() override {
     EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
-        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) -> Buffer::Instance* {
-          client_write_buffer_ =
-              new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-          ON_CALL(*client_write_buffer_, move(_))
-              .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
-          ON_CALL(*client_write_buffer_, drain(_))
-              .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
-          return client_write_buffer_;
-        }))
-        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillOnce(
+            Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                       absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              client_write_buffer_ =
+                  new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
+              ON_CALL(*client_write_buffer_, move(_))
+                  .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
+              ON_CALL(*client_write_buffer_, drain(_))
+                  .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
+              return client_write_buffer_;
+            }))
+        .WillOnce(
+            Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                       absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
 
     // Create raw buffer and TLS transport socket factories.
     auto raw_config =
@@ -645,20 +648,23 @@ public:
 
   void initialize() override {
     EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
-        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) -> Buffer::Instance* {
-          client_write_buffer_ =
-              new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-          ON_CALL(*client_write_buffer_, move(_))
-              .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
-          ON_CALL(*client_write_buffer_, drain(_))
-              .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
-          return client_write_buffer_;
-        }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                  std::function<void()> above_overflow) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillOnce(
+            Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                       absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(
+                  std::move(below_low), std::move(above_high), std::move(above_overflow));
+              ON_CALL(*client_write_buffer_, move(_))
+                  .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
+              ON_CALL(*client_write_buffer_, drain(_))
+                  .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
+              return client_write_buffer_;
+            }))
+        .WillRepeatedly(
+            Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
 
     auto raw_config =
         std::make_unique<envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer>();

--- a/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
+++ b/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
@@ -72,8 +72,8 @@ public:
         .WillOnce(
             Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
                        absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
-              client_write_buffer_ =
-                  new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
+              client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(
+                  std::move(below_low), std::move(above_high), std::move(above_overflow));
               ON_CALL(*client_write_buffer_, move(_))
                   .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
               ON_CALL(*client_write_buffer_, drain(_))

--- a/envoy/buffer/buffer.h
+++ b/envoy/buffer/buffer.h
@@ -16,6 +16,7 @@
 #include "source/common/common/utility.h"
 
 #include "absl/container/inlined_vector.h"
+#include "absl/functional/any_invocable.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
@@ -552,9 +553,9 @@ public:
    *   high watermark.
    * @return a newly created InstancePtr.
    */
-  virtual InstancePtr createBuffer(std::function<void()> below_low_watermark,
-                                   std::function<void()> above_high_watermark,
-                                   std::function<void()> above_overflow_watermark) PURE;
+  virtual InstancePtr createBuffer(absl::AnyInvocable<void()> below_low_watermark,
+                                   absl::AnyInvocable<void()> above_high_watermark,
+                                   absl::AnyInvocable<void()> above_overflow_watermark) PURE;
 
   /**
    * Create and returns a buffer memory account.

--- a/mobile/test/common/integration/xds_test_server.cc
+++ b/mobile/test/common/integration/xds_test_server.cc
@@ -42,11 +42,12 @@ XdsTestServer::XdsTestServer()
       api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{mock_buffer_factory_});
 
   ON_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
-      .WillByDefault(Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
-                               absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
-                                           std::move(above_overflow));
-      }));
+      .WillByDefault(
+          Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                    absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));

--- a/mobile/test/common/integration/xds_test_server.cc
+++ b/mobile/test/common/integration/xds_test_server.cc
@@ -42,8 +42,8 @@ XdsTestServer::XdsTestServer()
       api_->allocateDispatcher("test_thread", Buffer::WatermarkFactoryPtr{mock_buffer_factory_});
 
   ON_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
-      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                               std::function<void()> above_overflow) -> Buffer::Instance* {
+      .WillByDefault(Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                               absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
         return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
                                            std::move(above_overflow));
       }));

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -9,6 +9,8 @@
 
 #include "source/common/buffer/buffer_impl.h"
 
+#include "absl/functional/any_invocable.h"
+
 namespace Envoy {
 namespace Buffer {
 
@@ -21,11 +23,12 @@ namespace Buffer {
 // It is only called on the first time the buffer overflows.
 class WatermarkBuffer : public OwnedImpl {
 public:
-  WatermarkBuffer(std::function<void()> below_low_watermark,
-                  std::function<void()> above_high_watermark,
-                  std::function<void()> above_overflow_watermark)
-      : below_low_watermark_(below_low_watermark), above_high_watermark_(above_high_watermark),
-        above_overflow_watermark_(above_overflow_watermark) {}
+  WatermarkBuffer(absl::AnyInvocable<void()> below_low_watermark,
+                  absl::AnyInvocable<void()> above_high_watermark,
+                  absl::AnyInvocable<void()> above_overflow_watermark)
+      : below_low_watermark_(std::move(below_low_watermark)),
+        above_high_watermark_(std::move(above_high_watermark)),
+        above_overflow_watermark_(std::move(above_overflow_watermark)) {}
 
   // Override all functions from Instance which can result in changing the size
   // of the underlying buffer.
@@ -61,9 +64,9 @@ private:
   void commit(uint64_t length, absl::Span<RawSlice> slices,
               ReservationSlicesOwnerPtr slices_owner) override;
 
-  std::function<void()> below_low_watermark_;
-  std::function<void()> above_high_watermark_;
-  std::function<void()> above_overflow_watermark_;
+  absl::AnyInvocable<void()> below_low_watermark_;
+  absl::AnyInvocable<void()> above_high_watermark_;
+  absl::AnyInvocable<void()> above_overflow_watermark_;
 
   // Used for enforcing buffer limits (off by default). If these are set to non-zero by a call to
   // setWatermarks() the watermark callbacks will be called as described above.
@@ -194,11 +197,12 @@ public:
 
   // Buffer::WatermarkFactory
   ~WatermarkBufferFactory() override;
-  InstancePtr createBuffer(std::function<void()> below_low_watermark,
-                           std::function<void()> above_high_watermark,
-                           std::function<void()> above_overflow_watermark) override {
-    return std::make_unique<WatermarkBuffer>(below_low_watermark, above_high_watermark,
-                                             above_overflow_watermark);
+  InstancePtr createBuffer(absl::AnyInvocable<void()> below_low_watermark,
+                           absl::AnyInvocable<void()> above_high_watermark,
+                           absl::AnyInvocable<void()> above_overflow_watermark) override {
+    return std::make_unique<WatermarkBuffer>(std::move(below_low_watermark),
+                                             std::move(above_high_watermark),
+                                             std::move(above_overflow_watermark));
   }
 
   BufferMemoryAccountSharedPtr createAccount(Http::StreamResetHandler& reset_handler) override;

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -239,15 +239,19 @@ protected:
     // Other calls for server sessions will by default get a normal OwnedImpl.
     EXPECT_CALL(*factory, createBuffer_(_, _, _))
         .Times(AnyNumber())
-        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) -> Buffer::Instance* {
-          client_write_buffer_ = new MockWatermarkBuffer(below_low, above_high, above_overflow);
-          return client_write_buffer_;
-        }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                  std::function<void()> above_overflow) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillOnce(
+            Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                       absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              client_write_buffer_ = new MockWatermarkBuffer(
+                  std::move(below_low), std::move(above_high), std::move(above_overflow));
+              return client_write_buffer_;
+            }))
+        .WillRepeatedly(
+            Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
   }
 
 protected:
@@ -262,12 +266,14 @@ protected:
   ConnectionMocks createConnectionMocks(bool create_timer = true) {
     auto dispatcher = std::make_unique<NiceMock<Event::MockDispatcher>>();
     EXPECT_CALL(dispatcher->buffer_factory_, createBuffer_(_, _, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                  std::function<void()> above_overflow) -> Buffer::Instance* {
-          // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls createBuffer_()
-          // and wraps the returned raw pointer below with a unique_ptr.
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillRepeatedly(
+            Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              // ConnectionImpl calls Envoy::MockBufferFactory::create(), which calls
+              // createBuffer_() and wraps the returned raw pointer below with a unique_ptr.
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
 
     if (create_timer) {
       // This timer will be returned (transferring ownership) to the ConnectionImpl when
@@ -2211,10 +2217,12 @@ TEST_P(ConnectionImplTest, FlushWriteAndDelayConfigDisabledTest) {
   NiceMock<MockConnectionCallbacks> callbacks;
   NiceMock<Event::MockDispatcher> dispatcher;
   EXPECT_CALL(dispatcher.buffer_factory_, createBuffer_(_, _, _))
-      .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                std::function<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-      }));
+      .WillRepeatedly(
+          Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                    absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
   IoHandlePtr io_handle = std::make_unique<Network::Test::IoSocketHandlePlatformImpl>(0);
   std::unique_ptr<Network::ConnectionImpl> server_connection(new Network::ConnectionImpl(
       dispatcher, std::make_unique<ConnectionSocketImpl>(std::move(io_handle), nullptr, nullptr),
@@ -3227,10 +3235,12 @@ public:
   void initializeConnection() {
     EXPECT_CALL(dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
     EXPECT_CALL(dispatcher_.buffer_factory_, createBuffer_(_, _, _))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                  std::function<void()> above_overflow) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillRepeatedly(
+            Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
 
     file_event_ = new NiceMock<Event::MockFileEvent>;
     EXPECT_CALL(dispatcher_, createFileEvent_(0, _, _, _))

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -6894,15 +6894,19 @@ protected:
     // By default, expect 4 buffers to be created - the client and server read and write buffers.
     EXPECT_CALL(*factory, createBuffer_(_, _, _))
         .Times(4)
-        .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                             std::function<void()> above_overflow) -> Buffer::Instance* {
-          client_write_buffer = new MockWatermarkBuffer(below_low, above_high, above_overflow);
+        .WillOnce(Invoke([&](absl::AnyInvocable<void()> below_low,
+                             absl::AnyInvocable<void()> above_high,
+                             absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+          client_write_buffer = new MockWatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                        std::move(above_overflow));
           return client_write_buffer;
         }))
-        .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                  std::function<void()> above_overflow) -> Buffer::Instance* {
-          return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-        }));
+        .WillRepeatedly(
+            Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+              return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                                 std::move(above_overflow));
+            }));
 
     initialize();
 

--- a/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
@@ -180,22 +180,25 @@ void StartTlsIntegrationTest::initialize() {
   EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
       // Connection constructor will first create write buffer.
       // Test tracks how many bytes are sent.
-      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                           std::function<void()> above_overflow) -> Buffer::Instance* {
-        client_write_buffer_ =
-            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-        ON_CALL(*client_write_buffer_, move(_))
-            .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
-        ON_CALL(*client_write_buffer_, drain(_))
-            .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
-        return client_write_buffer_;
-      }))
+      .WillOnce(
+          Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                     absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(
+                std::move(below_low), std::move(above_high), std::move(above_overflow));
+            ON_CALL(*client_write_buffer_, move(_))
+                .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
+            ON_CALL(*client_write_buffer_, drain(_))
+                .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
+            return client_write_buffer_;
+          }))
       // Connection constructor will also create read buffer, but the test does
       // not track received bytes.
-      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                           std::function<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-      }));
+      .WillOnce(
+          Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                     absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
   config_helper_.renameListener("tcp_proxy");
   addStartTlsSwitchFilter(config_helper_);
 

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -26,6 +26,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -57,10 +58,12 @@ BaseIntegrationTest::BaseIntegrationTest(const InstanceConstSharedPtrFn& upstrea
   // necessary right now.
   timeSystem().realSleepDoNotUseWithoutScrutiny(std::chrono::milliseconds(10));
   ON_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
-      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                               std::function<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-      }));
+      .WillByDefault(
+          Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                    absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope()).WillByDefault(ReturnRef(*stats_store_.rootScope()));
   ON_CALL(factory_context_.server_context_, sslContextManager())

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -43,16 +43,19 @@ IntegrationTcpClient::IntegrationTcpClient(
       callbacks_(new ConnectionCallbacks(*this)) {
   EXPECT_CALL(factory, createBuffer_(_, _, _))
       .Times(AtLeast(1))
-      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                           std::function<void()> above_overflow) -> Buffer::Instance* {
-        client_write_buffer_ =
-            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-        return client_write_buffer_;
-      }))
-      .WillRepeatedly(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                                std::function<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-      }));
+      .WillOnce(
+          Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                     absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(
+                std::move(below_low), std::move(above_high), std::move(above_overflow));
+            return client_write_buffer_;
+          }))
+      .WillRepeatedly(
+          Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                    absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
 
   connection_ = dispatcher.createClientConnection(
       *Network::Utility::resolveUrl(fmt::format(

--- a/test/integration/integration_tcp_client.cc
+++ b/test/integration/integration_tcp_client.cc
@@ -21,6 +21,7 @@
 #include "test/test_common/network_utility.h"
 #include "test/test_common/test_time_system.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/test/integration/tcp_proxy_integration.cc
+++ b/test/integration/tcp_proxy_integration.cc
@@ -1,5 +1,6 @@
 #include "test/integration/tcp_proxy_integration.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {

--- a/test/integration/tcp_proxy_integration.cc
+++ b/test/integration/tcp_proxy_integration.cc
@@ -32,16 +32,17 @@ BaseTcpProxySslIntegrationTest::ClientSslConnection::ClientSslConnection(
   // buffer. This allows us to track the bytes actually written to the socket.
   EXPECT_CALL(*parent.mock_buffer_factory_, createBuffer_(_, _, _))
       .Times(::testing::AtLeast(1))
-      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                           std::function<void()> above_overflow) -> Buffer::Instance* {
-        client_write_buffer_ =
-            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-        ON_CALL(*client_write_buffer_, move(_))
-            .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
-        ON_CALL(*client_write_buffer_, drain(_))
-            .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
-        return client_write_buffer_;
-      }));
+      .WillOnce(
+          Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                     absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            client_write_buffer_ = new NiceMock<MockWatermarkBuffer>(
+                std::move(below_low), std::move(above_high), std::move(above_overflow));
+            ON_CALL(*client_write_buffer_, move(_))
+                .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::baseMove));
+            ON_CALL(*client_write_buffer_, drain(_))
+                .WillByDefault(Invoke(client_write_buffer_, &MockWatermarkBuffer::trackDrains));
+            return client_write_buffer_;
+          }));
   // Set up the SSL client.
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(parent.version_, parent.lookupPort("tcp_proxy"));

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -25,6 +25,7 @@
 #include "test/integration/utility.h"
 #include "test/test_common/registry.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gtest/gtest.h"
 
 using testing::_;
@@ -2526,16 +2527,17 @@ TEST_P(TcpProxySslIntegrationTest, OnDownstreamTlsHandshakeModeWithEarlyData) {
   // buffer. This allows us to track the bytes actually written to the socket.
   EXPECT_CALL(*mock_buffer_factory_, createBuffer_(_, _, _))
       .Times(AtLeast(1))
-      .WillOnce(Invoke([&](std::function<void()> below_low, std::function<void()> above_high,
-                           std::function<void()> above_overflow) -> Buffer::Instance* {
-        client_write_buffer =
-            new NiceMock<MockWatermarkBuffer>(below_low, above_high, above_overflow);
-        ON_CALL(*client_write_buffer, move(_))
-            .WillByDefault(Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove));
-        ON_CALL(*client_write_buffer, drain(_))
-            .WillByDefault(Invoke(client_write_buffer, &MockWatermarkBuffer::trackDrains));
-        return client_write_buffer;
-      }));
+      .WillOnce(
+          Invoke([&](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                     absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            client_write_buffer = new NiceMock<MockWatermarkBuffer>(
+                std::move(below_low), std::move(above_high), std::move(above_overflow));
+            ON_CALL(*client_write_buffer, move(_))
+                .WillByDefault(Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove));
+            ON_CALL(*client_write_buffer, drain(_))
+                .WillByDefault(Invoke(client_write_buffer, &MockWatermarkBuffer::trackDrains));
+            return client_write_buffer;
+          }));
 
   // Set up the SSL client.
   Network::Address::InstanceConstSharedPtr address =

--- a/test/integration/tracked_watermark_buffer.cc
+++ b/test/integration/tracked_watermark_buffer.cc
@@ -27,9 +27,9 @@ TrackedWatermarkBufferFactory::~TrackedWatermarkBufferFactory() {
 }
 
 Buffer::InstancePtr
-TrackedWatermarkBufferFactory::createBuffer(std::function<void()> below_low_watermark,
-                                            std::function<void()> above_high_watermark,
-                                            std::function<void()> above_overflow_watermark) {
+TrackedWatermarkBufferFactory::createBuffer(absl::AnyInvocable<void()> below_low_watermark,
+                                            absl::AnyInvocable<void()> above_high_watermark,
+                                            absl::AnyInvocable<void()> above_overflow_watermark) {
   absl::MutexLock lock(mutex_);
   uint64_t idx = next_idx_++;
   ++active_buffer_count_;
@@ -88,7 +88,8 @@ TrackedWatermarkBufferFactory::createBuffer(std::function<void()> below_low_wate
           actively_bound_buffers_.emplace(buffer);
         }
       },
-      below_low_watermark, above_high_watermark, above_overflow_watermark);
+      std::move(below_low_watermark), std::move(above_high_watermark),
+      std::move(above_overflow_watermark));
 }
 
 BufferMemoryAccountSharedPtr

--- a/test/integration/tracked_watermark_buffer.h
+++ b/test/integration/tracked_watermark_buffer.h
@@ -9,6 +9,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/container/node_hash_map.h"
+#include "absl/functional/any_invocable.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
 
@@ -23,9 +24,11 @@ public:
       std::function<void(uint64_t watermark)> update_high_watermark,
       std::function<void(TrackedWatermarkBuffer*)> on_delete,
       std::function<void(BufferMemoryAccountSharedPtr&, TrackedWatermarkBuffer*)> on_bind,
-      std::function<void()> below_low_watermark, std::function<void()> above_high_watermark,
-      std::function<void()> above_overflow_watermark)
-      : WatermarkBuffer(below_low_watermark, above_high_watermark, above_overflow_watermark),
+      absl::AnyInvocable<void()> below_low_watermark,
+      absl::AnyInvocable<void()> above_high_watermark,
+      absl::AnyInvocable<void()> above_overflow_watermark)
+      : WatermarkBuffer(std::move(below_low_watermark), std::move(above_high_watermark),
+                        std::move(above_overflow_watermark)),
         update_size_(update_size), update_high_watermark_(update_high_watermark),
         on_delete_(on_delete), on_bind_(on_bind) {}
   ~TrackedWatermarkBuffer() override { on_delete_(this); }
@@ -66,9 +69,9 @@ public:
   TrackedWatermarkBufferFactory(uint32_t min_tracking_bytes);
   ~TrackedWatermarkBufferFactory() override;
   // Buffer::WatermarkFactory
-  Buffer::InstancePtr createBuffer(std::function<void()> below_low_watermark,
-                                   std::function<void()> above_high_watermark,
-                                   std::function<void()> above_overflow_watermark) override;
+  Buffer::InstancePtr createBuffer(absl::AnyInvocable<void()> below_low_watermark,
+                                   absl::AnyInvocable<void()> above_high_watermark,
+                                   absl::AnyInvocable<void()> above_overflow_watermark) override;
   BufferMemoryAccountSharedPtr createAccount(Http::StreamResetHandler& reset_handler) override;
   void unregisterAccount(const BufferMemoryAccountSharedPtr& account,
                          absl::optional<uint32_t> current_class) override;

--- a/test/mocks/buffer/mocks.cc
+++ b/test/mocks/buffer/mocks.cc
@@ -5,10 +5,11 @@
 namespace Envoy {
 
 template <>
-MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(std::function<void()> below_low,
-                                                        std::function<void()> above_high,
-                                                        std::function<void()> above_overflow)
-    : Buffer::WatermarkBuffer(below_low, above_high, above_overflow) {}
+MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(absl::AnyInvocable<void()> below_low,
+                                                        absl::AnyInvocable<void()> above_high,
+                                                        absl::AnyInvocable<void()> above_overflow)
+    : Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                              std::move(above_overflow)) {}
 
 template <>
 MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase()
@@ -16,8 +17,9 @@ MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase()
   ASSERT(0); // This constructor is not supported for WatermarkBuffer.
 }
 template <>
-MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()>, std::function<void()>,
-                                                  std::function<void()>) {
+MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(absl::AnyInvocable<void()>,
+                                                  absl::AnyInvocable<void()>,
+                                                  absl::AnyInvocable<void()>) {
   ASSERT(0); // This constructor is not supported for OwnedImpl.
 }
 

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -11,6 +11,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gmock/gmock.h"
 
 namespace Envoy {

--- a/test/mocks/buffer/mocks.h
+++ b/test/mocks/buffer/mocks.h
@@ -19,8 +19,8 @@ namespace Envoy {
 template <class BaseClass> class MockBufferBase : public BaseClass {
 public:
   MockBufferBase();
-  MockBufferBase(std::function<void()> below_low, std::function<void()> above_high,
-                 std::function<void()> above_overflow);
+  MockBufferBase(absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                 absl::AnyInvocable<void()> above_overflow);
 
   MOCK_METHOD(void, move, (Buffer::Instance & rhs));
   MOCK_METHOD(void, move, (Buffer::Instance & rhs, uint64_t length));
@@ -43,15 +43,15 @@ private:
 };
 
 template <>
-MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(std::function<void()> below_low,
-                                                        std::function<void()> above_high,
-                                                        std::function<void()> above_overflow);
+MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase(absl::AnyInvocable<void()> below_low,
+                                                        absl::AnyInvocable<void()> above_high,
+                                                        absl::AnyInvocable<void()> above_overflow);
 template <> MockBufferBase<Buffer::WatermarkBuffer>::MockBufferBase();
 
 template <>
-MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(std::function<void()> below_low,
-                                                  std::function<void()> above_high,
-                                                  std::function<void()> above_overflow);
+MockBufferBase<Buffer::OwnedImpl>::MockBufferBase(absl::AnyInvocable<void()> below_low,
+                                                  absl::AnyInvocable<void()> above_high,
+                                                  absl::AnyInvocable<void()> above_overflow);
 template <> MockBufferBase<Buffer::OwnedImpl>::MockBufferBase();
 
 class MockBuffer : public MockBufferBase<Buffer::OwnedImpl> {
@@ -65,9 +65,9 @@ class MockWatermarkBuffer : public MockBufferBase<Buffer::WatermarkBuffer> {
 public:
   using BaseClass = MockBufferBase<Buffer::WatermarkBuffer>;
 
-  MockWatermarkBuffer(std::function<void()> below_low, std::function<void()> above_high,
-                      std::function<void()> above_overflow)
-      : BaseClass(below_low, above_high, above_overflow) {
+  MockWatermarkBuffer(absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                      absl::AnyInvocable<void()> above_overflow)
+      : BaseClass(std::move(below_low), std::move(above_high), std::move(above_overflow)) {
     ON_CALL(*this, move(testing::_))
         .WillByDefault(testing::Invoke(this, &MockWatermarkBuffer::baseMove));
   }
@@ -78,17 +78,18 @@ public:
   MockBufferFactory();
   ~MockBufferFactory() override;
 
-  Buffer::InstancePtr createBuffer(std::function<void()> below_low,
-                                   std::function<void()> above_high,
-                                   std::function<void()> above_overflow) override {
-    auto buffer = Buffer::InstancePtr{createBuffer_(below_low, above_high, above_overflow)};
+  Buffer::InstancePtr createBuffer(absl::AnyInvocable<void()> below_low,
+                                   absl::AnyInvocable<void()> above_high,
+                                   absl::AnyInvocable<void()> above_overflow) override {
+    auto buffer = Buffer::InstancePtr{
+        createBuffer_(std::move(below_low), std::move(above_high), std::move(above_overflow))};
     ASSERT(buffer != nullptr);
     return buffer;
   }
 
   MOCK_METHOD(Buffer::Instance*, createBuffer_,
-              (std::function<void()> below_low, std::function<void()> above_high,
-               std::function<void()> above_overflow));
+              (absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+               absl::AnyInvocable<void()> above_overflow));
 
   MOCK_METHOD(Buffer::BufferMemoryAccountSharedPtr, createAccount, (Http::StreamResetHandler&));
   MOCK_METHOD(uint64_t, resetAccountsGivenPressure, (float));

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -1,5 +1,6 @@
 #include "mocks.h"
 
+#include "absl/functional/any_invocable.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -38,10 +39,12 @@ MockDispatcher::MockDispatcher(const std::string& name) : name_(name) {
   });
 
   ON_CALL(buffer_factory_, createBuffer_(_, _, _))
-      .WillByDefault(Invoke([](std::function<void()> below_low, std::function<void()> above_high,
-                               std::function<void()> above_overflow) -> Buffer::Instance* {
-        return new Buffer::WatermarkBuffer(below_low, above_high, above_overflow);
-      }));
+      .WillByDefault(
+          Invoke([](absl::AnyInvocable<void()> below_low, absl::AnyInvocable<void()> above_high,
+                    absl::AnyInvocable<void()> above_overflow) -> Buffer::Instance* {
+            return new Buffer::WatermarkBuffer(std::move(below_low), std::move(above_high),
+                                               std::move(above_overflow));
+          }));
   ON_CALL(*this, isThreadSafe()).WillByDefault([thread_factory, thread_id]() {
     return thread_factory->currentThreadId() == thread_id;
   });


### PR DESCRIPTION
This is accomplished by using `absl::AnyInvocable<void()>` rather than `std::function<void()>`. The Abseil type is similar, but move-only.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
