### PR TITLE
dynamic_modules: replace debug-only ASSERTs with release-mode thread guards on ABI entries

### DIFF
--- a/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
+++ b/source/extensions/bootstrap/dynamic_modules/abi_impl.cc
@@ -492,11 +492,15 @@ bool envoy_dynamic_module_callback_bootstrap_extension_timer_enabled(
 void envoy_dynamic_module_callback_bootstrap_extension_timer_delete(
     envoy_dynamic_module_type_bootstrap_extension_timer_module_ptr timer_ptr) {
   using namespace Envoy;
-  // The underlying `Event::Timer` `deregisters` from the dispatcher's timer list in its
-  // destructor, which is only safe on the dispatcher thread. Callers that hold the timer handle
-  // from a context that may be dropped off the main thread must route deletion through the
-  // scheduler ABI.
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  // The underlying `Event::Timer` is removed from the dispatcher's timer list in its destructor,
+  // which is only safe on the dispatcher thread. The previous `ASSERT_IS_MAIN_OR_TEST_THREAD` is
+  // compiled out under NDEBUG, so guard explicitly and skip the deletion to avoid corrupting the
+  // timer list.
+  if (!Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_bootstrap_extension_timer_delete must be called "
+                 "on the main thread");
+    return;
+  }
   delete static_cast<DynamicModuleBootstrapExtensionTimer*>(timer_ptr);
 }
 

--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -3,6 +3,7 @@
 // This file provides host-side implementations for the cluster dynamic module ABI callbacks.
 
 #include "source/common/common/assert.h"
+#include "source/common/common/thread.h"
 #include "source/common/http/message_impl.h"
 #include "source/extensions/clusters/dynamic_modules/cluster.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -91,6 +92,14 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
     const envoy_dynamic_module_type_module_buffer* sub_zones,
     const envoy_dynamic_module_type_module_buffer* metadata_pairs, size_t metadata_pairs_per_host,
     size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs) {
+  // `cluster_add_hosts` mutates `priority_set_` and runs member-update callbacks; both are
+  // main-thread-only. The previous `ASSERT_IS_MAIN_OR_TEST_THREAD` is compiled out under NDEBUG,
+  // so guard explicitly and fail closed.
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG(
+        "envoy_dynamic_module_callback_cluster_add_hosts must be called on the main thread");
+    return false;
+  }
   auto* cluster = getCluster(cluster_envoy_ptr);
   std::vector<std::string> address_strings;
   address_strings.reserve(count);
@@ -139,6 +148,11 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
 size_t envoy_dynamic_module_callback_cluster_remove_hosts(
     envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
     const envoy_dynamic_module_type_cluster_host_envoy_ptr* host_envoy_ptrs, size_t count) {
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG(
+        "envoy_dynamic_module_callback_cluster_remove_hosts must be called on the main thread");
+    return 0;
+  }
   auto* cluster = getCluster(cluster_envoy_ptr);
   std::vector<Envoy::Upstream::HostSharedPtr> hosts;
   hosts.reserve(count);
@@ -152,6 +166,11 @@ bool envoy_dynamic_module_callback_cluster_update_host_health(
     envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
     envoy_dynamic_module_type_cluster_host_envoy_ptr host_envoy_ptr,
     envoy_dynamic_module_type_host_health health_status) {
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_update_host_health must be called on the "
+                 "main thread");
+    return false;
+  }
   auto* cluster = getCluster(cluster_envoy_ptr);
   auto host = cluster->findHost(host_envoy_ptr);
   return cluster->updateHostHealth(std::move(host), health_status);
@@ -172,6 +191,11 @@ envoy_dynamic_module_callback_cluster_find_host_by_address(
 
 void envoy_dynamic_module_callback_cluster_pre_init_complete(
     envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr) {
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_pre_init_complete must be called on the "
+                 "main thread");
+    return;
+  }
   getCluster(cluster_envoy_ptr)->preInitComplete();
 }
 

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -69,15 +69,35 @@ void envoy_dynamic_module_callback_log(envoy_dynamic_module_type_log_level level
 
 uint32_t envoy_dynamic_module_callback_get_concurrency() {
   using namespace Envoy;
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  // The previous `ASSERT_IS_MAIN_OR_TEST_THREAD` is compiled out under NDEBUG and the
+  // `getExisting()` thread-local lookup returns nullptr off the main thread, so guard explicitly
+  // and fail closed.
+  if (!Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_get_concurrency must be called on the main thread");
+    return 0;
+  }
   auto context = Server::Configuration::ServerFactoryContextInstance::getExisting();
+  if (context == nullptr) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_get_concurrency called before the server context "
+                 "was initialized");
+    return 0;
+  }
   return context->options().concurrency();
 }
 
 bool envoy_dynamic_module_callback_is_validation_mode() {
   using namespace Envoy;
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  if (!Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG(
+        "envoy_dynamic_module_callback_is_validation_mode must be called on the main thread");
+    return false;
+  }
   auto context = Server::Configuration::ServerFactoryContextInstance::getExisting();
+  if (context == nullptr) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_is_validation_mode called before the server "
+                 "context was initialized");
+    return false;
+  }
   return context->options().mode() == Server::Mode::Validate;
 }
 

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.h"
 
@@ -3250,6 +3252,94 @@ TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
         Upstream::HostSetImpl::partitionHosts(all_hosts, Upstream::HostsPerLocalityImpl::empty()),
         {}, {hosts[1]}, {}, absl::nullopt, absl::nullopt);
   }
+}
+
+// =============================================================================
+// Off-main-thread guard tests for cluster ABI callbacks.
+// =============================================================================
+
+// Verifies that `cluster_add_hosts` is fail-closed when called off the main thread.
+TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_module_buffer addr = {"127.0.0.1:10001", 15};
+  uint32_t weight = 1;
+  envoy_dynamic_module_type_module_buffer empty = {"", 0};
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;
+  void* cluster_ptr = cluster.get();
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_FALSE(envoy_dynamic_module_callback_cluster_add_hosts(
+              cluster_ptr, 0, &addr, &weight, &empty, &empty, &empty, nullptr, 0, 1, &host_ptr));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_add_hosts must be called on the main thread");
+}
+
+// Verifies that `cluster_remove_hosts` is fail-closed when called off the main thread.
+TEST_F(DynamicModuleClusterTest, RemoveHostsOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptrs[1] = {nullptr};
+  void* cluster_ptr = cluster.get();
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_EQ(0u,
+                    envoy_dynamic_module_callback_cluster_remove_hosts(cluster_ptr, host_ptrs, 1));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_remove_hosts must be called on the main thread");
+}
+
+// Verifies that `cluster_update_host_health` is fail-closed when called off the main thread.
+TEST_F(DynamicModuleClusterTest, UpdateHostHealthOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  void* cluster_ptr = cluster.get();
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_FALSE(envoy_dynamic_module_callback_cluster_update_host_health(
+              cluster_ptr, nullptr, envoy_dynamic_module_type_host_health_Healthy));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_update_host_health must be called on the main "
+      "thread");
+}
+
+// Verifies that `cluster_pre_init_complete` is a safe no-op when called off the main thread.
+TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  void* cluster_ptr = cluster.get();
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t(
+            [&] { envoy_dynamic_module_callback_cluster_pre_init_complete(cluster_ptr); });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_pre_init_complete must be called on the main thread");
 }
 
 } // namespace

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
 #include "test/mocks/server/server_factory_context.h"
@@ -38,6 +40,60 @@ TEST(CommonAbiImplTest, IsValidationModeReturnsFalseInInitOnlyMode) {
 
   ScopedThreadLocalServerContextSetter setter(context);
   EXPECT_FALSE(envoy_dynamic_module_callback_is_validation_mode());
+}
+
+// Verifies that `is_validation_mode` is fail-closed when called off the main thread.
+TEST(CommonAbiImplTest, IsValidationModeOffMainThreadFailsClosed) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, mode()).WillByDefault(Return(Server::Mode::Validate));
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([] { EXPECT_FALSE(envoy_dynamic_module_callback_is_validation_mode()); });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_is_validation_mode must be called on the main thread");
+}
+
+// Verifies that `is_validation_mode` is fail-closed when called before the server context is
+// installed.
+TEST(CommonAbiImplTest, IsValidationModeBeforeServerContextFailsClosed) {
+  EXPECT_ENVOY_BUG(EXPECT_FALSE(envoy_dynamic_module_callback_is_validation_mode()),
+                   "envoy_dynamic_module_callback_is_validation_mode called before the server "
+                   "context was initialized");
+}
+
+// =============================================================================
+// Concurrency Tests
+// =============================================================================
+
+TEST(CommonAbiImplTest, GetConcurrencyReturnsConfiguredValue) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, concurrency()).WillByDefault(Return(4));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_EQ(4u, envoy_dynamic_module_callback_get_concurrency());
+}
+
+// Verifies that `get_concurrency` is fail-closed when called off the main thread.
+TEST(CommonAbiImplTest, GetConcurrencyOffMainThreadFailsClosed) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.options_, concurrency()).WillByDefault(Return(4));
+  ScopedThreadLocalServerContextSetter setter(context);
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([] { EXPECT_EQ(0u, envoy_dynamic_module_callback_get_concurrency()); });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_get_concurrency must be called on the main thread");
+}
+
+// Verifies that `get_concurrency` is fail-closed when called before the server context is
+// installed.
+TEST(CommonAbiImplTest, GetConcurrencyBeforeServerContextFailsClosed) {
+  EXPECT_ENVOY_BUG(EXPECT_EQ(0u, envoy_dynamic_module_callback_get_concurrency()),
+                   "envoy_dynamic_module_callback_get_concurrency called before the server "
+                   "context was initialized");
 }
 
 // =============================================================================

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "source/extensions/bootstrap/dynamic_modules/extension.h"
 #include "source/extensions/bootstrap/dynamic_modules/extension_config.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -1311,6 +1313,20 @@ TEST_F(BootstrapAbiImplTest, TimerFired) {
 
   // Clean up.
   envoy_dynamic_module_callback_bootstrap_extension_timer_delete(timer_ptr);
+}
+
+// Verifies that `bootstrap_extension_timer_delete` is a safe no-op when called off the main
+// thread. The guard short-circuits before any pointer dereference, so passing a null timer is
+// safe here.
+TEST_F(BootstrapAbiImplTest, TimerDeleteOffMainThreadFailsClosed) {
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t(
+            [] { envoy_dynamic_module_callback_bootstrap_extension_timer_delete(nullptr); });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_bootstrap_extension_timer_delete must be called on the main "
+      "thread");
 }
 
 // Test that the timer callback safely handles a destroyed config via weak_ptr.


### PR DESCRIPTION
## Description

The dynamic-module ABI documents that several callbacks must be called only on the main thread. For example, `cluster_add_hosts`, `cluster_remove_hosts`, `cluster_update_host_health`, `cluster_pre_init_complete`, `bootstrap_extension_timer_delete`, `get_concurrency`, `is_validation_mode`, etc. 

Pre-fix, those preconditions were enforced with `ASSERT_IS_MAIN_OR_TEST_THREAD()`, which compiles out under NDEBUG, leaving release builds with no guard at all. Module misuse. For example, a tokio-driven DNS watcher calling `cluster_add_hosts` would corrupt `Common::CallbackManager`'s `std::list` or the dispatcher's intrusive timer list or null-deref `ServerFactoryContextInstance::getExisting()` on a non-main thread.

This PR replaces it with release-surviving guards that `IS_ENVOY_BUG`-log and fail-closed.

---

**Commit Message:** dynamic_modules: replace debug-only ASSERTs with release-mode thread guards on ABI entries
**Additional Description:** Replace debug-only ASSERTs with release-mode thread guards on ABI entries.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A