### PR TITLE
dynamic_modules: replace per-LB single-slot async state with per-context map

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -1237,26 +1237,32 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
     details_str.assign(details.ptr, details.length);
   }
 
-  // The module may invoke this callback on any thread and race the load balancer destructor.
-  // Validate the raw pointer against the live registry and snapshot the state we need under the
-  // registry lock.
-  std::shared_ptr<std::atomic<bool>> cancelled;
-  Envoy::Event::Dispatcher* dispatcher = nullptr;
+  // The module may invoke this callback on any thread and race the load balancer destructor or
+  // overlapping `chooseHost` calls. Validate the raw pointer against the live registry and look
+  // up the per-pending-selection slot keyed by `context_envoy_ptr`. The slot is owned jointly
+  // by the load balancer's `async_slots_` map and the async selection handle; keeping a strong
+  // ref via `shared_ptr` lets us drop the load balancer lock before posting.
+  using Envoy::Extensions::Clusters::DynamicModules::AsyncHostSelectionSlot;
+  std::shared_ptr<AsyncHostSelectionSlot> slot;
   DynamicModuleClusterHandleSharedPtr handle;
   const bool found = DynamicModuleLoadBalancer::withActiveInstance(
       lb_raw, [&](const DynamicModuleLoadBalancer& lb) {
-        cancelled = lb.activeAsyncCancelled();
-        dispatcher = lb.activeAsyncDispatcher();
+        slot = lb.lookupAsyncSlot(context_envoy_ptr);
         handle = lb.handle();
       });
-  if (!found) {
+  if (!found || slot == nullptr) {
+    // Either the load balancer was destroyed or no in-flight selection matches this context.
+    // Drop silently; this is also the path that closes the residual address-reuse window when
+    // the load balancer pointer has been recycled to a new instance.
     return;
   }
 
-  if (dispatcher != nullptr) {
-    // Post to the worker thread. The handle keeps the cluster alive until the callback runs.
-    dispatcher->post([context_envoy_ptr, host, details_str = std::move(details_str),
-                      cancelled = std::move(cancelled), handle = std::move(handle)]() {
+  if (slot->dispatcher != nullptr) {
+    // Post to the worker thread. The cluster handle keeps the cluster alive until the callback
+    // runs. The slot's `cancelled` flag is re-checked on the worker side so a router-side
+    // cancel that fires after the post is queued still wins.
+    slot->dispatcher->post([context_envoy_ptr, host, details_str = std::move(details_str),
+                            cancelled = slot->cancelled, handle = std::move(handle)]() {
       if (cancelled != nullptr && cancelled->load(std::memory_order_acquire)) {
         return;
       }
@@ -1268,7 +1274,11 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       context->onAsyncHostSelection(std::move(host_shared), std::string(details_str));
     });
   } else {
-    // No worker dispatcher. Complete inline on the calling thread.
+    // No worker dispatcher captured for this slot. Complete inline on the calling thread; the
+    // cancellation flag is honored here too so a router-side cancel that landed first wins.
+    if (slot->cancelled != nullptr && slot->cancelled->load(std::memory_order_acquire)) {
+      return;
+    }
     auto* context = getContext(context_envoy_ptr);
     Envoy::Upstream::HostConstSharedPtr host_shared;
     if (host != nullptr) {

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -762,30 +762,42 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return {nullptr};
   }
 
-  // Pre-capture the worker dispatcher and prepare the cancellation flag before calling into the
-  // module. The module's choose_host may spawn a background thread that calls
-  // async_host_selection_complete, which reads these fields. Setting them beforehand establishes
-  // a happens-before relationship via the thread::spawn synchronization in the module.
+  // Build a fresh per-pending-selection slot before calling into the module. The slot carries
+  // the dispatcher and cancellation flag for this `chooseHost` call only and is never reused
+  // across overlapping selections.
   const auto* connection = context != nullptr ? context->downstreamConnection() : nullptr;
-  active_async_dispatcher_ = connection != nullptr ? &connection->dispatcher() : nullptr;
-  active_async_cancelled_ = std::make_shared<std::atomic<bool>>(false);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = connection != nullptr ? &connection->dispatcher() : nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
 
   envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;
   envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle = nullptr;
+
+  // Publish the slot into the per-LB map before the module call. The module may spawn a
+  // background thread that immediately calls `async_host_selection_complete`; the completion
+  // path looks up the slot by `context` in this map and the mutex publish establishes
+  // happens-before for that read. If the module returns synchronously below, we erase the slot
+  // so a misbehaved module that fires completion after a sync return cannot deliver to the
+  // wrong context.
+  {
+    absl::MutexLock lock(&async_slots_mutex_);
+    async_slots_[context] = slot;
+  }
   handle_->cluster_->config()->on_cluster_lb_choose_host_(in_module_lb_, context, &host_ptr,
                                                           &async_handle);
 
   if (async_handle != nullptr) {
-    // Async pending: the module will call the completion callback later.
-    auto cancelable = std::make_unique<DynamicModuleAsyncHostSelectionHandle>(
+    auto cancellable = std::make_unique<DynamicModuleAsyncHostSelectionHandle>(
         async_handle, in_module_lb_,
-        handle_->cluster_->config()->on_cluster_lb_cancel_host_selection_, active_async_cancelled_);
-    return Upstream::HostSelectionResponse{nullptr, std::move(cancelable)};
+        handle_->cluster_->config()->on_cluster_lb_cancel_host_selection_, slot, this, context);
+    return Upstream::HostSelectionResponse{nullptr, std::move(cancellable)};
   }
 
-  // Synchronous result or no host. Clear the async state.
-  active_async_dispatcher_ = nullptr;
-  active_async_cancelled_ = nullptr;
+  // Synchronous result: the slot we pre-published is unused. Erase it under the lock.
+  {
+    absl::MutexLock lock(&async_slots_mutex_);
+    async_slots_.erase(context);
+  }
 
   if (host_ptr == nullptr) {
     return {nullptr};
@@ -796,7 +808,37 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   return {host};
 }
 
+std::shared_ptr<AsyncHostSelectionSlot> DynamicModuleLoadBalancer::lookupAsyncSlot(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const {
+  absl::MutexLock lock(&async_slots_mutex_);
+  auto it = async_slots_.find(context);
+  return it == async_slots_.end() ? nullptr : it->second;
+}
+
+void DynamicModuleLoadBalancer::removeAsyncSlot(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const {
+  absl::MutexLock lock(&async_slots_mutex_);
+  async_slots_.erase(context);
+}
+
+void DynamicModuleLoadBalancer::insertAsyncSlotForTest(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context,
+    std::shared_ptr<AsyncHostSelectionSlot> slot) const {
+  absl::MutexLock lock(&async_slots_mutex_);
+  async_slots_[context] = std::move(slot);
+}
+
 DynamicModuleAsyncHostSelectionHandle::~DynamicModuleAsyncHostSelectionHandle() {
+  // Erase the slot from the load balancer's map so a late completion is silently dropped. The
+  // call routes through `withActiveInstance` (registry-mutex-guarded) because per-worker load
+  // balancers can be recreated on host-membership changes, so the cached `lb_` pointer may
+  // already refer to a freed instance. The registry lookup verifies liveness under the lock.
+  if (lb_ != nullptr) {
+    DynamicModuleLoadBalancer::withActiveInstance(lb_,
+                                                  [this](const DynamicModuleLoadBalancer& live_lb) {
+                                                    live_lb.removeAsyncSlot(context_key_);
+                                                  });
+  }
   // Free the module-side async handle. The cancel function takes ownership of the handle and
   // drops it, so this works for both cancellation and normal completion paths.
   if (async_handle_ != nullptr && cancel_fn_ != nullptr) {
@@ -806,7 +848,22 @@ DynamicModuleAsyncHostSelectionHandle::~DynamicModuleAsyncHostSelectionHandle() 
 }
 
 void DynamicModuleAsyncHostSelectionHandle::cancel() {
-  cancelled_->store(true, std::memory_order_release);
+  // Set the cancellation flag first so any in-flight module-thread completion observes it. The
+  // `slot_` shared_ptr is held independently of the load balancer, so this write is safe even
+  // if the load balancer has already been destroyed.
+  if (slot_ != nullptr && slot_->cancelled != nullptr) {
+    slot_->cancelled->store(true, std::memory_order_release);
+  }
+  // Then erase from the load balancer's map so a subsequent completion never finds the slot.
+  // `withActiveInstance` validates that `lb_` is still in the live registry under the mutex; if
+  // the load balancer has already been destroyed the callback is skipped, and the slot is torn
+  // down by the load balancer's destructor.
+  if (lb_ != nullptr) {
+    DynamicModuleLoadBalancer::withActiveInstance(lb_,
+                                                  [this](const DynamicModuleLoadBalancer& live_lb) {
+                                                    live_lb.removeAsyncSlot(context_key_);
+                                                  });
+  }
 }
 
 const Upstream::PrioritySet& DynamicModuleLoadBalancer::prioritySet() const {

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -780,7 +780,7 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   // so a misbehaved module that fires completion after a sync return cannot deliver to the
   // wrong context.
   {
-    absl::MutexLock lock(&async_slots_mutex_);
+    absl::MutexLock lock(async_slots_mutex_);
     async_slots_[context] = slot;
   }
   handle_->cluster_->config()->on_cluster_lb_choose_host_(in_module_lb_, context, &host_ptr,
@@ -795,7 +795,7 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
 
   // Synchronous result: the slot we pre-published is unused. Erase it under the lock.
   {
-    absl::MutexLock lock(&async_slots_mutex_);
+    absl::MutexLock lock(async_slots_mutex_);
     async_slots_.erase(context);
   }
 
@@ -810,21 +810,21 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
 
 std::shared_ptr<AsyncHostSelectionSlot> DynamicModuleLoadBalancer::lookupAsyncSlot(
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const {
-  absl::MutexLock lock(&async_slots_mutex_);
+  absl::MutexLock lock(async_slots_mutex_);
   auto it = async_slots_.find(context);
   return it == async_slots_.end() ? nullptr : it->second;
 }
 
 void DynamicModuleLoadBalancer::removeAsyncSlot(
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const {
-  absl::MutexLock lock(&async_slots_mutex_);
+  absl::MutexLock lock(async_slots_mutex_);
   async_slots_.erase(context);
 }
 
 void DynamicModuleLoadBalancer::insertAsyncSlotForTest(
     envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context,
     std::shared_ptr<AsyncHostSelectionSlot> slot) const {
-  absl::MutexLock lock(&async_slots_mutex_);
+  absl::MutexLock lock(async_slots_mutex_);
   async_slots_[context] = std::move(slot);
 }
 

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -28,6 +28,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/synchronization/mutex.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -520,6 +521,26 @@ private:
   std::weak_ptr<DynamicModuleCluster> cluster_;
 };
 
+class DynamicModuleLoadBalancer;
+
+/**
+ * Per-pending-selection state owned jointly by the async-selection handle (router side) and the
+ * load balancer's `async_slots_` map (module-completion side). One slot exists per in-flight
+ * async host selection. Both fields are immutable post-construction except `cancelled`, which is
+ * set with release ordering.
+ *
+ * Note: the `async_slots_` map is keyed by raw `LoadBalancerContext*`. If the router frees a
+ * context after cancel and a new context is later allocated at the same address for which the
+ * load balancer issues another async pick, a late module completion for the original request
+ * would resolve to the new slot. The lookup never dereferences freed memory, so the worst case
+ * is wrong-request delivery rather than a use-after-free. Closing this fully requires
+ * round-tripping a per-selection cookie through the C ABI; that is a follow-up.
+ */
+struct AsyncHostSelectionSlot {
+  Event::Dispatcher* dispatcher;
+  std::shared_ptr<std::atomic<bool>> cancelled;
+};
+
 /**
  * Async host selection handle that bridges the dynamic module's async host selection to Envoy's
  * LoadBalancerContext::onAsyncHostSelection. This is created when the module returns an async
@@ -531,9 +552,11 @@ public:
   DynamicModuleAsyncHostSelectionHandle(
       envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle,
       envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb,
-      OnClusterLbCancelHostSelectionType cancel_fn, std::shared_ptr<std::atomic<bool>> cancelled)
+      OnClusterLbCancelHostSelectionType cancel_fn, std::shared_ptr<AsyncHostSelectionSlot> slot,
+      const DynamicModuleLoadBalancer* lb,
+      envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_key)
       : async_handle_(async_handle), in_module_lb_(in_module_lb), cancel_fn_(cancel_fn),
-        cancelled_(std::move(cancelled)) {}
+        slot_(std::move(slot)), lb_(lb), context_key_(context_key) {}
 
   ~DynamicModuleAsyncHostSelectionHandle() override;
 
@@ -543,7 +566,11 @@ private:
   envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_{nullptr};
   OnClusterLbCancelHostSelectionType cancel_fn_;
-  std::shared_ptr<std::atomic<bool>> cancelled_;
+  // Shared with the load balancer's `async_slots_` map; setting `slot_->cancelled` from
+  // `cancel()` is observed by the completion-callback's posted lambda.
+  std::shared_ptr<AsyncHostSelectionSlot> slot_;
+  const DynamicModuleLoadBalancer* lb_;
+  envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_key_;
 };
 
 /**
@@ -579,20 +606,26 @@ public:
   const DynamicModuleClusterHandleSharedPtr& handle() const { return handle_; }
 
   /**
-   * Returns the shared cancellation flag for the current async host selection. When the router
-   * cancels the selection (e.g., stream timeout), the flag is set so the posted completion
-   * callback becomes a no-op. Returns nullptr when there is no active async selection.
+   * Looks up the per-pending-selection slot for `context`. Called from any thread by the
+   * async-host-selection completion ABI callback under `withActiveInstance`'s registry lock.
+   * Returns nullptr if no in-flight selection matches.
    */
-  std::shared_ptr<std::atomic<bool>> activeAsyncCancelled() const {
-    return active_async_cancelled_;
-  }
+  std::shared_ptr<AsyncHostSelectionSlot>
+  lookupAsyncSlot(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const;
 
   /**
-   * Returns the worker thread's dispatcher captured during chooseHost. Used by the async
-   * completion callback in abi_impl.cc to post to the correct worker thread without accessing
-   * the LoadBalancerContext from a background thread.
+   * Removes the per-pending-selection slot for `context`, if present. Called by the async
+   * selection handle on cancel and destruction so subsequent module completions for this
+   * context are dropped.
    */
-  Event::Dispatcher* activeAsyncDispatcher() const { return active_async_dispatcher_; }
+  void removeAsyncSlot(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const;
+
+  /**
+   * Test-only entry point that publishes an async slot for `context`. Production code reaches
+   * this state via `chooseHost` returning an async pending result.
+   */
+  void insertAsyncSlotForTest(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context,
+                              std::shared_ptr<AsyncHostSelectionSlot> slot) const;
 
   // Per-host custom data storage.
   bool setHostData(uint32_t priority, size_t index, uintptr_t data);
@@ -620,12 +653,15 @@ private:
   const Upstream::PrioritySet& priority_set_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
 
-  // Shared cancellation flag for the active async host selection. Set in chooseHost when the
-  // module returns AsyncPending, and read by the posted completion callback in abi_impl.cc.
-  std::shared_ptr<std::atomic<bool>> active_async_cancelled_;
-
-  // Worker thread dispatcher captured during chooseHost for async completion posting.
-  Event::Dispatcher* active_async_dispatcher_{nullptr};
+  // Per-pending-selection slot map, keyed by the `LoadBalancerContext*` the module sees in
+  // `choose_host` and returns through `async_host_selection_complete`. The mutex serializes
+  // concurrent module-thread reads against worker-thread `chooseHost`, `cancel`, and destructor
+  // mutations. The handle holds its own `shared_ptr` to each slot so cancel-vs-completion races
+  // resolve without a use-after-free.
+  mutable absl::Mutex async_slots_mutex_;
+  mutable absl::flat_hash_map<envoy_dynamic_module_type_cluster_lb_context_envoy_ptr,
+                              std::shared_ptr<AsyncHostSelectionSlot>>
+      async_slots_ ABSL_GUARDED_BY(async_slots_mutex_);
 
   // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
   absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -2429,10 +2429,15 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleCancel) {
       reinterpret_cast<envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr>(0xCAFE);
   auto* dummy_lb = reinterpret_cast<envoy_dynamic_module_type_cluster_lb_module_ptr>(0xBEEF);
 
-  auto cancelled = std::make_shared<std::atomic<bool>>(false);
-  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, cancelled);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  // Pass a null load balancer pointer so the handle skips the map-removal step; this isolates
+  // the cancellation-flag logic from any load balancer state.
+  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, slot, nullptr,
+                                               nullptr);
   handle.cancel();
-  EXPECT_TRUE(cancelled->load());
+  EXPECT_TRUE(slot->cancelled->load());
 }
 
 // Test DynamicModuleAsyncHostSelectionHandle cancel with null cancel_fn.
@@ -2441,9 +2446,12 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleCancelNullFn) {
       reinterpret_cast<envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr>(0xCAFE);
   auto* dummy_lb = reinterpret_cast<envoy_dynamic_module_type_cluster_lb_module_ptr>(0xBEEF);
 
-  auto cancelled = std::make_shared<std::atomic<bool>>(false);
-  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, cancelled);
-  // Should not crash with nullptr cancel function.
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, slot, nullptr,
+                                               nullptr);
+  // Should not crash with a null cancel function.
   handle.cancel();
 }
 
@@ -2475,6 +2483,12 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteWithHost) {
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
+  // The production path inserts the slot inside `chooseHost` when the module returns an async
+  // pending result; insert directly here to isolate the completion-callback behavior.
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  lb_instance->insertAsyncSlotForTest(context_ptr, slot);
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       lb_envoy_ptr, context_ptr, raw_host_ptr, {"resolved", 8});
@@ -2499,6 +2513,10 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteNullHost) {
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  lb_instance->insertAsyncSlotForTest(context_ptr, slot);
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       lb_envoy_ptr, context_ptr, nullptr, {"dns_failure", 11});
@@ -2523,6 +2541,10 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  lb_instance->insertAsyncSlotForTest(context_ptr, slot);
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(lb_envoy_ptr, context_ptr,
                                                                          nullptr, {nullptr, 0});
@@ -2547,6 +2569,162 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteAfterLbDestroyedDrops
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       raw_lb_ptr, static_cast<void*>(&context), nullptr, {"dropped", 7});
+}
+
+// Verifies that overlapping in-flight async host selections on the same load balancer have
+// independent slots: cancelling one does not cancel the other, and the completion callback only
+// drops the cancelled context's delivery.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionOverlappingSelectionsHaveIndependentSlots) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  // Two distinct `LoadBalancerContext` pointers represent two overlapping in-flight requests.
+  NiceMock<Upstream::MockLoadBalancerContext> ctx_a;
+  NiceMock<Upstream::MockLoadBalancerContext> ctx_b;
+
+  auto slot_a = std::make_shared<AsyncHostSelectionSlot>();
+  slot_a->dispatcher = nullptr;
+  slot_a->cancelled = std::make_shared<std::atomic<bool>>(false);
+  auto slot_b = std::make_shared<AsyncHostSelectionSlot>();
+  slot_b->dispatcher = nullptr;
+  slot_b->cancelled = std::make_shared<std::atomic<bool>>(false);
+
+  lb_instance->insertAsyncSlotForTest(static_cast<void*>(&ctx_a), slot_a);
+  lb_instance->insertAsyncSlotForTest(static_cast<void*>(&ctx_b), slot_b);
+
+  // Cancel `ctx_a`'s slot; `ctx_b`'s slot must remain unaffected.
+  slot_a->cancelled->store(true, std::memory_order_release);
+  EXPECT_TRUE(slot_a->cancelled->load(std::memory_order_acquire));
+  EXPECT_FALSE(slot_b->cancelled->load(std::memory_order_acquire))
+      << "overlapping async selection's cancellation flag was clobbered";
+
+  // Completion for `ctx_a` is dropped because the slot was cancelled.
+  EXPECT_CALL(ctx_a, onAsyncHostSelection(_, _)).Times(0);
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&ctx_a), nullptr, {"a", 1});
+
+  // Completion for `ctx_b` is delivered normally.
+  EXPECT_CALL(ctx_b, onAsyncHostSelection(_, _))
+      .WillOnce([](Upstream::HostConstSharedPtr&& host, std::string&& details) {
+        EXPECT_EQ(host, nullptr);
+        EXPECT_EQ(details, "b");
+      });
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&ctx_b), nullptr, {"b", 1});
+}
+
+// Verifies that `cancel()` on a handle bound to a live load balancer removes the slot from the
+// load balancer's map so subsequent completion callbacks for the same context are dropped.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleCancelRemovesSlotFromLiveLb) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto cluster_handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance =
+      std::make_unique<DynamicModuleLoadBalancer>(cluster_handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto* context_ptr = static_cast<void*>(&context);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  lb_instance->insertAsyncSlotForTest(context_ptr, slot);
+  ASSERT_NE(nullptr, lb_instance->lookupAsyncSlot(context_ptr));
+
+  auto* dummy_async_handle =
+      reinterpret_cast<envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr>(0xCAFE);
+  auto* dummy_lb = reinterpret_cast<envoy_dynamic_module_type_cluster_lb_module_ptr>(0xBEEF);
+  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, slot,
+                                               lb_instance.get(), context_ptr);
+  handle.cancel();
+  EXPECT_TRUE(slot->cancelled->load(std::memory_order_acquire));
+  EXPECT_EQ(nullptr, lb_instance->lookupAsyncSlot(context_ptr));
+}
+
+// Verifies that destroying the handle while the load balancer is still alive removes the slot
+// from the load balancer's map.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleDestructorRemovesSlotFromLiveLb) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto cluster_handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance =
+      std::make_unique<DynamicModuleLoadBalancer>(cluster_handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto* context_ptr = static_cast<void*>(&context);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+  lb_instance->insertAsyncSlotForTest(context_ptr, slot);
+  ASSERT_NE(nullptr, lb_instance->lookupAsyncSlot(context_ptr));
+
+  auto* dummy_async_handle =
+      reinterpret_cast<envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr>(0xCAFE);
+  auto* dummy_lb = reinterpret_cast<envoy_dynamic_module_type_cluster_lb_module_ptr>(0xBEEF);
+  {
+    DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, slot,
+                                                 lb_instance.get(), context_ptr);
+  }
+  EXPECT_EQ(nullptr, lb_instance->lookupAsyncSlot(context_ptr));
+}
+
+// Verifies that `cancel()` on a handle whose load balancer has already been destroyed is a safe
+// no-op and still sets the slot's cancellation flag (the flag is owned independently of the
+// load balancer).
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleCancelAfterLbDestroyedIsSafe) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto cluster_handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance =
+      std::make_unique<DynamicModuleLoadBalancer>(cluster_handle, cluster->prioritySet());
+  const auto* raw_lb_ptr = lb_instance.get();
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto* context_ptr = static_cast<void*>(&context);
+  auto slot = std::make_shared<AsyncHostSelectionSlot>();
+  slot->dispatcher = nullptr;
+  slot->cancelled = std::make_shared<std::atomic<bool>>(false);
+
+  auto* dummy_async_handle =
+      reinterpret_cast<envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr>(0xCAFE);
+  auto* dummy_lb = reinterpret_cast<envoy_dynamic_module_type_cluster_lb_module_ptr>(0xBEEF);
+  DynamicModuleAsyncHostSelectionHandle handle(dummy_async_handle, dummy_lb, nullptr, slot,
+                                               raw_lb_ptr, context_ptr);
+  lb_instance.reset();
+  handle.cancel();
+  EXPECT_TRUE(slot->cancelled->load(std::memory_order_acquire));
+}
+
+// Verifies that a completion callback for a context that was never registered with the load
+// balancer is dropped silently rather than delivered to the router.
+TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteForUnknownContextIsDropped) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok());
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  // Intentionally skip publishing a slot for this context.
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  EXPECT_CALL(context, onAsyncHostSelection(_, _)).Times(0);
+
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&context), nullptr, {"x", 1});
 }
 
 // Covers pointer reuse: a new load balancer allocated at the same address as a freed one must


### PR DESCRIPTION
## Description

Today, `DynamicModuleLoadBalancer` holds a single `active_async_dispatcher_` or `active_async_cancelled_` pair, overwritten on every `chooseHost` call. Two overlapping in-flight async host selections on the same LB therefore share one cancellation flag and one dispatcher pointer. Cancel of one silences the other, and a torn `shared_ptr` read of the cancellation flag could cause intermittent **SIGSEGV** on the foreign-thread completion path.

This PR replace the single slot with a mutex-protected `flat_hash_map<LoadBalancerContext*, shared_ptr<AsyncHostSelectionSlot>>` per LB. Each `chooseHost` call publishes its own slot before calling into the module so a synchronously-spawned completion thread can find it. The cancelable retains a `shared_ptr` to the slot independently, so `cancel` can race the foreign-thread completion safely. Cancel sets the flag and erases the map entry and the completion re-checks the flag before delivery.

---

**Commit Message:** dynamic_modules: replace per-LB single-slot async state with per-context map
**Additional Description:** Replaces per-LB single-slot async state with per-context map
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A