### PR TITLE
dynamic_modules: wrap every Rust SDK FFI entry point in catch_unwind

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -9,6 +9,7 @@
 
 use crate::{abi, EnvoyBuffer};
 use std::ffi::c_void;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
 // -----------------------------------------------------------------------------
@@ -1276,24 +1277,30 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> *const c_void {
-  // The name and config originate from protobuf string/bytes fields, so they are valid
-  // UTF-8 and within bounds when received here. Mirrors the http filter FFI entry point.
-  let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-    name.ptr as *const _,
-    name.length,
-  ));
-  let config_bytes = std::slice::from_raw_parts(config.ptr as *const _, config.length);
-  let ctx = ConfigContext::new(config_envoy_ptr);
+  catch_unwind(AssertUnwindSafe(|| {
+    // The name and config originate from protobuf string/bytes fields, so they are valid
+    // UTF-8 and within bounds when received here. Mirrors the http filter FFI entry point.
+    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      name.ptr as *const _,
+      name.length,
+    ));
+    let config_bytes = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    let ctx = ConfigContext::new(config_envoy_ptr);
 
-  envoy_dynamic_module_on_access_logger_config_new_impl(
-    &ctx,
-    name_str,
-    config_bytes,
-    crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_ACCESS_LOGGER_CONFIG_FUNCTION must be set"),
-    config_envoy_ptr,
-  )
+    envoy_dynamic_module_on_access_logger_config_new_impl(
+      &ctx,
+      name_str,
+      config_bytes,
+      crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_ACCESS_LOGGER_CONFIG_FUNCTION must be set"),
+      config_envoy_ptr,
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_access_logger_config_new", panic);
+    ptr::null()
+  })
 }
 
 /// Testable wrapper for [`envoy_dynamic_module_on_access_logger_config_new`].
@@ -1325,7 +1332,15 @@ pub fn envoy_dynamic_module_on_access_logger_config_new_impl(
 pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_destroy(
   config_ptr: *const c_void,
 ) {
-  drop(Box::from_raw(config_ptr as *mut AccessLoggerConfigHandle));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop(Box::from_raw(config_ptr as *mut AccessLoggerConfigHandle));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_access_logger_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1337,10 +1352,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_new(
   config_ptr: *const c_void,
   logger_envoy_ptr: *mut c_void,
 ) -> *const c_void {
-  let handle = &*(config_ptr as *const AccessLoggerConfigHandle);
-  let metrics = MetricsContext::new(handle.config_envoy_ptr);
-  let logger: Box<dyn AccessLogger> = handle.inner.create_logger(metrics, logger_envoy_ptr);
-  crate::wrap_into_c_void_ptr!(logger)
+  catch_unwind(AssertUnwindSafe(|| {
+    let handle = &*(config_ptr as *const AccessLoggerConfigHandle);
+    let metrics = MetricsContext::new(handle.config_envoy_ptr);
+    let logger: Box<dyn AccessLogger> = handle.inner.create_logger(metrics, logger_envoy_ptr);
+    crate::wrap_into_c_void_ptr!(logger)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_access_logger_new", panic);
+    ptr::null()
+  })
 }
 
 /// # Safety
@@ -1353,10 +1374,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_log(
   logger_ptr: *mut c_void,
   log_type: abi::envoy_dynamic_module_type_access_log_type,
 ) {
-  let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
-  let access_log_type = AccessLogType::from_abi(log_type);
-  let ctx = LogContext::new(envoy_ptr, access_log_type);
-  logger.log(&ctx);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+    let access_log_type = AccessLogType::from_abi(log_type);
+    let ctx = LogContext::new(envoy_ptr, access_log_type);
+    logger.log(&ctx);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_access_logger_log", panic);
+  });
 }
 
 /// # Safety
@@ -1365,7 +1391,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_log(
 /// by the Envoy dynamic module ABI.
 #[no_mangle]
 pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_destroy(logger_ptr: *mut c_void) {
-  crate::drop_wrapped_c_void_ptr!(logger_ptr, AccessLogger);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    crate::drop_wrapped_c_void_ptr!(logger_ptr, AccessLogger);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_access_logger_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -1374,8 +1405,13 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_destroy(logger_pt
 /// by the Envoy dynamic module ABI.
 #[no_mangle]
 pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_flush(logger_ptr: *mut c_void) {
-  let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
-  logger.flush();
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+    logger.flush();
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_access_logger_flush", panic);
+  });
 }
 
 /// Declare access-logger entry points for a single user-supplied config type.
@@ -1458,12 +1494,20 @@ macro_rules! declare_access_logger {
           Err(_) => ::std::option::Option::None,
         }
       }
-      $crate::set_factory_once!(
-        $crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION,
-        __single_access_logger_factory as $crate::NewAccessLoggerConfigFunction,
-        "NEW_ACCESS_LOGGER_CONFIG_FUNCTION"
-      );
-      $crate::abi::envoy_dynamic_modules_abi_version.as_ptr() as *const ::std::os::raw::c_char
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        $crate::set_factory_once!(
+          $crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION,
+          __single_access_logger_factory as $crate::NewAccessLoggerConfigFunction,
+          "NEW_ACCESS_LOGGER_CONFIG_FUNCTION"
+        );
+        $crate::abi::envoy_dynamic_modules_abi_version.as_ptr() as *const ::std::os::raw::c_char
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
+      }
     }
   };
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
@@ -6,6 +6,7 @@ use crate::{
   NewBootstrapExtensionConfigFunction, NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// EnvoyBootstrapExtensionConfig is the Envoy-side bootstrap extension configuration.
 /// This is a handle to the Envoy configuration object.
@@ -1311,23 +1312,32 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr {
-  let mut envoy_extension_config =
-    EnvoyBootstrapExtensionConfigImpl::new(envoy_extension_config_ptr);
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
-  init_bootstrap_extension_config(
-    &mut envoy_extension_config,
-    name_str,
-    config_slice,
-    NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION must be set"),
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_extension_config =
+      EnvoyBootstrapExtensionConfigImpl::new(envoy_extension_config_ptr);
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    init_bootstrap_extension_config(
+      &mut envoy_extension_config,
+      name_str,
+      config_slice,
+      NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_config_new",
+      panic,
+    );
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn init_bootstrap_extension_config(
@@ -1351,7 +1361,15 @@ pub(crate) fn init_bootstrap_extension_config(
 pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_config_destroy(
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(extension_config_ptr, BootstrapExtensionConfig);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(extension_config_ptr, BootstrapExtensionConfig);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1363,12 +1381,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_new(
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   envoy_extension_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_bootstrap_extension_module_ptr {
-  let mut envoy_extension = EnvoyBootstrapExtensionImpl::new(envoy_extension_ptr);
-  let extension_config = {
-    let raw = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-    &**raw
-  };
-  envoy_dynamic_module_on_bootstrap_extension_new_impl(&mut envoy_extension, extension_config)
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_extension = EnvoyBootstrapExtensionImpl::new(envoy_extension_ptr);
+    let extension_config = {
+      let raw = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+      &**raw
+    };
+    envoy_dynamic_module_on_bootstrap_extension_new_impl(&mut envoy_extension, extension_config)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_bootstrap_extension_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn envoy_dynamic_module_on_bootstrap_extension_new_impl(
@@ -1384,9 +1408,17 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_server_initialized
   envoy_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
   extension_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_module_ptr,
 ) {
-  let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
-  let extension = unsafe { &mut *extension };
-  extension.on_server_initialized(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
+    let extension = unsafe { &mut *extension };
+    extension.on_server_initialized(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_server_initialized",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1394,9 +1426,17 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_worker_thread_init
   envoy_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
   extension_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_module_ptr,
 ) {
-  let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
-  let extension = unsafe { &mut *extension };
-  extension.on_worker_thread_initialized(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
+    let extension = unsafe { &mut *extension };
+    extension.on_worker_thread_initialized(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_worker_thread_initialized",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1404,9 +1444,17 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_drain_started(
   envoy_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_envoy_ptr,
   extension_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_module_ptr,
 ) {
-  let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
-  let extension = unsafe { &mut *extension };
-  extension.on_drain_started(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
+    let extension = unsafe { &mut *extension };
+    extension.on_drain_started(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_drain_started",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1416,17 +1464,30 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_shutdown(
   completion_callback: abi::envoy_dynamic_module_type_event_cb,
   completion_context: *mut std::os::raw::c_void,
 ) {
-  let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
-  let extension = unsafe { &mut *extension };
-  let completion = CompletionCallback::new(completion_callback, completion_context);
-  extension.on_shutdown(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr), completion);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension = extension_ptr as *mut Box<dyn BootstrapExtension>;
+    let extension = unsafe { &mut *extension };
+    let completion = CompletionCallback::new(completion_callback, completion_context);
+    extension.on_shutdown(&mut EnvoyBootstrapExtensionImpl::new(envoy_ptr), completion);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_shutdown",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_destroy(
   extension_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_module_ptr,
 ) {
-  let _ = unsafe { Box::from_raw(extension_ptr as *mut Box<dyn BootstrapExtension>) };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let _ = unsafe { Box::from_raw(extension_ptr as *mut Box<dyn BootstrapExtension>) };
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_bootstrap_extension_destroy", panic);
+  });
 }
 
 #[no_mangle]
@@ -1435,12 +1496,20 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_config_scheduled(
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   event_id: u64,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
-  extension_config.on_scheduled(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    event_id,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
+    extension_config.on_scheduled(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      event_id,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_config_scheduled",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when an HTTP callout initiated by a bootstrap extension completes.
@@ -1464,29 +1533,39 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_http_callou
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let headers = if headers_size > 0 {
-    Some(unsafe {
-      std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
-    })
-  } else {
-    None
-  };
-  let body = if body_chunks_size > 0 {
-    Some(unsafe { std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size) })
-  } else {
-    None
-  };
+    let headers = if headers_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+      })
+    } else {
+      None
+    };
+    let body = if body_chunks_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+      })
+    } else {
+      None
+    };
 
-  extension_config.on_http_callout_done(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    callout_id,
-    result,
-    headers,
-    body,
-  );
+    extension_config.on_http_callout_done(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      callout_id,
+      result,
+      headers,
+      body,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_http_callout_done",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when a timer created by a bootstrap extension fires.
@@ -1496,16 +1575,24 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_timer_fired(
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   timer_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_timer_module_ptr,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  // Create a non-owning reference to the timer so the module can re-enable it.
-  let timer_ref = EnvoyBootstrapExtensionTimerRef { raw_ptr: timer_ptr };
+    // Create a non-owning reference to the timer so the module can re-enable it.
+    let timer_ref = EnvoyBootstrapExtensionTimerRef { raw_ptr: timer_ptr };
 
-  extension_config.on_timer_fired(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    &timer_ref,
-  );
+    extension_config.on_timer_fired(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      &timer_ref,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_timer_fired",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when a watched file changes for a bootstrap extension.
@@ -1516,21 +1603,29 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_file_changed(
   path: abi::envoy_dynamic_module_type_envoy_buffer,
   events: u32,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let path_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      path.ptr as *const u8,
-      path.length,
-    ))
-  };
+    let path_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        path.ptr as *const u8,
+        path.length,
+      ))
+    };
 
-  extension_config.on_file_changed(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    path_str,
-    events,
-  );
+    extension_config.on_file_changed(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      path_str,
+      events,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_file_changed",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when an admin endpoint registered by a bootstrap extension is
@@ -1552,44 +1647,54 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_admin_reque
   path: abi::envoy_dynamic_module_type_envoy_buffer,
   body: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> u32 {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let method_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      method.ptr as *const u8,
-      method.length,
-    ))
-  };
-  let path_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      path.ptr as *const u8,
-      path.length,
-    ))
-  };
-  let body_slice = unsafe { std::slice::from_raw_parts(body.ptr as *const u8, body.length) };
-
-  let (status_code, response_str) = extension_config.on_admin_request(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    method_str,
-    path_str,
-    body_slice,
-  );
-
-  // Pass the response body to Envoy via the callback. Envoy copies the buffer immediately,
-  // so the string only needs to live until the call returns.
-  if !response_str.is_empty() {
-    let response_buf = abi::envoy_dynamic_module_type_module_buffer {
-      ptr: response_str.as_ptr() as *const _,
-      length: response_str.len(),
+    let method_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        method.ptr as *const u8,
+        method.length,
+      ))
     };
-    abi::envoy_dynamic_module_callback_bootstrap_extension_admin_set_response(
-      envoy_ptr,
-      response_buf,
-    );
-  }
+    let path_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        path.ptr as *const u8,
+        path.length,
+      ))
+    };
+    let body_slice = unsafe { std::slice::from_raw_parts(body.ptr as *const u8, body.length) };
 
-  status_code
+    let (status_code, response_str) = extension_config.on_admin_request(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      method_str,
+      path_str,
+      body_slice,
+    );
+
+    // Pass the response body to Envoy via the callback. Envoy copies the buffer immediately,
+    // so the string only needs to live until the call returns.
+    if !response_str.is_empty() {
+      let response_buf = abi::envoy_dynamic_module_type_module_buffer {
+        ptr: response_str.as_ptr() as *const _,
+        length: response_str.len(),
+      };
+      abi::envoy_dynamic_module_callback_bootstrap_extension_admin_set_response(
+        envoy_ptr,
+        response_buf,
+      );
+    }
+
+    status_code
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_admin_request",
+      panic,
+    );
+    // Fail-closed: 500 Internal Server Error.
+    500
+  })
 }
 
 /// Event hook called by Envoy when a cluster is added to or updated in the ClusterManager.
@@ -1604,20 +1709,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_cluster_add
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   cluster_name: abi::envoy_dynamic_module_type_envoy_buffer,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let cluster_name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      cluster_name.ptr as *const u8,
-      cluster_name.length,
-    ))
-  };
+    let cluster_name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        cluster_name.ptr as *const u8,
+        cluster_name.length,
+      ))
+    };
 
-  extension_config.on_cluster_add_or_update(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    cluster_name_str,
-  );
+    extension_config.on_cluster_add_or_update(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      cluster_name_str,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when a cluster is removed from the ClusterManager.
@@ -1632,20 +1745,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_cluster_rem
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   cluster_name: abi::envoy_dynamic_module_type_envoy_buffer,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let cluster_name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      cluster_name.ptr as *const u8,
-      cluster_name.length,
-    ))
-  };
+    let cluster_name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        cluster_name.ptr as *const u8,
+        cluster_name.length,
+      ))
+    };
 
-  extension_config.on_cluster_removal(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    cluster_name_str,
-  );
+    extension_config.on_cluster_removal(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      cluster_name_str,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_cluster_removal",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when a listener is added to or updated in the ListenerManager.
@@ -1660,20 +1781,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_listener_ad
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   listener_name: abi::envoy_dynamic_module_type_envoy_buffer,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let listener_name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      listener_name.ptr as *const u8,
-      listener_name.length,
-    ))
-  };
+    let listener_name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        listener_name.ptr as *const u8,
+        listener_name.length,
+      ))
+    };
 
-  extension_config.on_listener_add_or_update(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    listener_name_str,
-  );
+    extension_config.on_listener_add_or_update(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      listener_name_str,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update",
+      panic,
+    );
+  });
 }
 
 /// Event hook called by Envoy when a listener is removed from the ListenerManager.
@@ -1688,18 +1817,26 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_listener_re
   extension_config_ptr: abi::envoy_dynamic_module_type_bootstrap_extension_config_module_ptr,
   listener_name: abi::envoy_dynamic_module_type_envoy_buffer,
 ) {
-  let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-  let extension_config = unsafe { &**extension_config };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
+    let extension_config = unsafe { &**extension_config };
 
-  let listener_name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      listener_name.ptr as *const u8,
-      listener_name.length,
-    ))
-  };
+    let listener_name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        listener_name.ptr as *const u8,
+        listener_name.length,
+      ))
+    };
 
-  extension_config.on_listener_removal(
-    &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-    listener_name_str,
-  );
+    extension_config.on_listener_removal(
+      &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
+      listener_name_str,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_bootstrap_extension_listener_removal",
+      panic,
+    );
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
@@ -44,6 +44,7 @@
 //! ```
 
 use crate::{abi, bytes_to_module_buffer, EnvoyBuffer};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// Wrapper around the Envoy cert validator config pointer, providing access to
 /// Envoy-side operations such as filter state during certificate validation.
@@ -253,18 +254,24 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_cert_validator_config_module_ptr {
-  let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-    name.ptr as *const _,
-    name.length,
-  ));
-  let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
-  init_cert_validator_config(
-    name_str,
-    config_slice,
-    NEW_CERT_VALIDATOR_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_CERT_VALIDATOR_CONFIG_FUNCTION must be set"),
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      name.ptr as *const _,
+      name.length,
+    ));
+    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    init_cert_validator_config(
+      name_str,
+      config_slice,
+      NEW_CERT_VALIDATOR_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_CERT_VALIDATOR_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cert_validator_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn init_cert_validator_config(
@@ -286,7 +293,15 @@ pub(crate) fn init_cert_validator_config(
 pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_config_destroy(
   config_ptr: abi::envoy_dynamic_module_type_cert_validator_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(config_ptr, CertValidatorConfig);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(config_ptr, CertValidatorConfig);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cert_validator_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -302,45 +317,57 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_do_verify_cert_c
   host_name: abi::envoy_dynamic_module_type_envoy_buffer,
   is_server: bool,
 ) -> abi::envoy_dynamic_module_type_cert_validator_validation_result {
-  let config = {
-    let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-    &**raw
-  };
-
-  let envoy_cert_validator = EnvoyCertValidator::new(config_envoy_ptr);
-
-  let cert_buffers = std::slice::from_raw_parts(certs, certs_count);
-  let cert_slices: Vec<&[u8]> = cert_buffers
-    .iter()
-    .map(|buf| std::slice::from_raw_parts(buf.ptr as *const u8, buf.length))
-    .collect();
-
-  let host_name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-    host_name.ptr as *const _,
-    host_name.length,
-  ));
-
-  let result = config.do_verify_cert_chain(
-    &envoy_cert_validator,
-    &cert_slices,
-    host_name_str,
-    is_server,
-  );
-
-  // If the module provided error details, pass them to Envoy via the callback.
-  // Envoy copies the buffer immediately, so the string only needs to live until the call returns.
-  if let Some(ref error) = result.error_details {
-    let error_buf = abi::envoy_dynamic_module_type_module_buffer {
-      ptr: error.as_ptr() as *const _,
-      length: error.len(),
+  catch_unwind(AssertUnwindSafe(|| {
+    let config = {
+      let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
+      &**raw
     };
-    abi::envoy_dynamic_module_callback_cert_validator_set_error_details(
-      config_envoy_ptr,
-      error_buf,
-    );
-  }
 
-  abi::envoy_dynamic_module_type_cert_validator_validation_result::from(&result)
+    let envoy_cert_validator = EnvoyCertValidator::new(config_envoy_ptr);
+
+    let cert_buffers = std::slice::from_raw_parts(certs, certs_count);
+    let cert_slices: Vec<&[u8]> = cert_buffers
+      .iter()
+      .map(|buf| std::slice::from_raw_parts(buf.ptr as *const u8, buf.length))
+      .collect();
+
+    let host_name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      host_name.ptr as *const _,
+      host_name.length,
+    ));
+
+    let result = config.do_verify_cert_chain(
+      &envoy_cert_validator,
+      &cert_slices,
+      host_name_str,
+      is_server,
+    );
+
+    // If the module provided error details, pass them to Envoy via the callback.
+    // Envoy copies the buffer immediately, so the string only needs to live until the call returns.
+    if let Some(ref error) = result.error_details {
+      let error_buf = abi::envoy_dynamic_module_type_module_buffer {
+        ptr: error.as_ptr() as *const _,
+        length: error.len(),
+      };
+      abi::envoy_dynamic_module_callback_cert_validator_set_error_details(
+        config_envoy_ptr,
+        error_buf,
+      );
+    }
+
+    abi::envoy_dynamic_module_type_cert_validator_validation_result::from(&result)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cert_validator_do_verify_cert_chain",
+      panic,
+    );
+    // Fail-closed: a panic during cert validation must not appear as success.
+    abi::envoy_dynamic_module_type_cert_validator_validation_result::from(
+      &ValidationResult::failed(ClientValidationStatus::Failed, None, None),
+    )
+  })
 }
 
 /// # Safety
@@ -352,11 +379,22 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_get_ssl_verify_m
   config_module_ptr: abi::envoy_dynamic_module_type_cert_validator_config_module_ptr,
   handshaker_provides_certificates: bool,
 ) -> std::os::raw::c_int {
-  let config = {
-    let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-    &**raw
-  };
-  config.get_ssl_verify_mode(handshaker_provides_certificates)
+  catch_unwind(AssertUnwindSafe(|| {
+    let config = {
+      let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
+      &**raw
+    };
+    config.get_ssl_verify_mode(handshaker_provides_certificates)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cert_validator_get_ssl_verify_mode",
+      panic,
+    );
+    // Fail-closed: SSL_VERIFY_PEER (0x01) | SSL_VERIFY_FAIL_IF_NO_PEER_CERT (0x02) = 0x03,
+    // the strictest mode. A panic must not silently degrade to SSL_VERIFY_NONE (0x00).
+    0x03
+  })
 }
 
 /// # Safety
@@ -368,11 +406,25 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_update_digest(
   config_module_ptr: abi::envoy_dynamic_module_type_cert_validator_config_module_ptr,
   out_data: *mut abi::envoy_dynamic_module_type_module_buffer,
 ) {
-  let config = {
-    let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-    &**raw
-  };
-  let digest = config.update_digest();
-  (*out_data).ptr = digest.as_ptr() as *const _;
-  (*out_data).length = digest.len();
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = {
+      let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
+      &**raw
+    };
+    let digest = config.update_digest();
+    (*out_data).ptr = digest.as_ptr() as *const _;
+    (*out_data).length = digest.len();
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cert_validator_update_digest",
+      panic,
+    );
+    // On panic, leave `out_data` as an empty buffer so Envoy contributes nothing to the
+    // session context hash and avoids reading uninitialized memory.
+    if !out_data.is_null() {
+      (*out_data).ptr = std::ptr::null();
+      (*out_data).length = 0;
+    }
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -5,6 +5,7 @@ use crate::{
   EnvoyHistogramId, EnvoyHistogramVecId, NEW_CLUSTER_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 /// The module-side cluster configuration.
@@ -1892,22 +1893,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_cluster_config_module_ptr {
-  // SAFETY: Envoy guarantees name and config are valid UTF-8 per the ABI contract.
-  let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-    name.ptr as *const _,
-    name.length,
-  ));
-  let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
-  let new_config_fn = NEW_CLUSTER_CONFIG_FUNCTION
-    .get()
-    .expect("NEW_CLUSTER_CONFIG_FUNCTION must be set");
-  let envoy_cluster_metrics: Arc<dyn EnvoyClusterMetrics> = Arc::new(EnvoyClusterMetricsImpl {
-    raw: config_envoy_ptr,
-  });
-  match new_config_fn(name_str, config_slice, envoy_cluster_metrics) {
-    Some(config) => wrap_into_c_void_ptr!(config),
-    None => std::ptr::null(),
-  }
+  catch_unwind(AssertUnwindSafe(|| {
+    // SAFETY: Envoy guarantees name and config are valid UTF-8 per the ABI contract.
+    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      name.ptr as *const _,
+      name.length,
+    ));
+    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    let new_config_fn = NEW_CLUSTER_CONFIG_FUNCTION
+      .get()
+      .expect("NEW_CLUSTER_CONFIG_FUNCTION must be set");
+    let envoy_cluster_metrics: Arc<dyn EnvoyClusterMetrics> = Arc::new(EnvoyClusterMetricsImpl {
+      raw: config_envoy_ptr,
+    });
+    match new_config_fn(name_str, config_slice, envoy_cluster_metrics) {
+      Some(config) => wrap_into_c_void_ptr!(config),
+      None => std::ptr::null(),
+    }
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -1918,7 +1925,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_config_new(
 pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_config_destroy(
   config_module_ptr: abi::envoy_dynamic_module_type_cluster_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(config_module_ptr, ClusterConfig);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(config_module_ptr, ClusterConfig);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_config_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -1930,11 +1942,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_new(
   config_module_ptr: abi::envoy_dynamic_module_type_cluster_config_module_ptr,
   cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_cluster_module_ptr {
-  let config = config_module_ptr as *const *const dyn ClusterConfig;
-  let config = &**config;
-  let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
-  let cluster = config.new_cluster(&envoy_cluster);
-  wrap_into_c_void_ptr!(cluster)
+  catch_unwind(AssertUnwindSafe(|| {
+    let config = config_module_ptr as *const *const dyn ClusterConfig;
+    let config = &**config;
+    let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
+    let cluster = config.new_cluster(&envoy_cluster);
+    wrap_into_c_void_ptr!(cluster)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_new", panic);
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -1946,10 +1964,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_init(
   cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
 ) {
-  let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-  let cluster = &mut *cluster;
-  let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
-  cluster.on_init(&envoy_cluster);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
+    let cluster = &mut *cluster;
+    let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
+    cluster.on_init(&envoy_cluster);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_init", panic);
+  });
 }
 
 /// # Safety
@@ -1960,7 +1983,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_init(
 pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_destroy(
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(cluster_module_ptr, Cluster);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(cluster_module_ptr, Cluster);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_destroy", panic);
+  });
 }
 
 /// Wrapper that pairs a module-side load balancer with the Envoy-side LB pointer.
@@ -1980,12 +2008,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_new(
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
   lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_cluster_lb_module_ptr {
-  let cluster = cluster_module_ptr as *const *const dyn Cluster;
-  let cluster = &**cluster;
-  let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
-  let lb = cluster.new_load_balancer(&envoy_lb);
-  let wrapper = Box::new(ClusterLbWrapper { lb, lb_envoy_ptr });
-  Box::into_raw(wrapper) as abi::envoy_dynamic_module_type_cluster_lb_module_ptr
+  catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *const *const dyn Cluster;
+    let cluster = &**cluster;
+    let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
+    let lb = cluster.new_load_balancer(&envoy_lb);
+    let wrapper = Box::new(ClusterLbWrapper { lb, lb_envoy_ptr });
+    Box::into_raw(wrapper) as abi::envoy_dynamic_module_type_cluster_lb_module_ptr
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_lb_new", panic);
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -1996,8 +2030,13 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_new(
 pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_destroy(
   lb_module_ptr: abi::envoy_dynamic_module_type_cluster_lb_module_ptr,
 ) {
-  let wrapper = lb_module_ptr as *mut ClusterLbWrapper;
-  let _ = Box::from_raw(wrapper);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let wrapper = lb_module_ptr as *mut ClusterLbWrapper;
+    let _ = Box::from_raw(wrapper);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_lb_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -2011,41 +2050,54 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_choose_host(
   host_out: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
   async_handle_out: *mut abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr,
 ) {
-  let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
-  let context = if context_envoy_ptr.is_null() {
-    None
-  } else {
-    Some(ClusterLbContextImpl::new(
-      context_envoy_ptr,
-      wrapper.lb_envoy_ptr,
-    ))
-  };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    let context = if context_envoy_ptr.is_null() {
+      None
+    } else {
+      Some(ClusterLbContextImpl::new(
+        context_envoy_ptr,
+        wrapper.lb_envoy_ptr,
+      ))
+    };
 
-  let async_completion = Box::new(EnvoyAsyncHostSelectionCompleteImpl {
-    raw_lb: wrapper.lb_envoy_ptr,
-    raw_context: context_envoy_ptr,
+    let async_completion = Box::new(EnvoyAsyncHostSelectionCompleteImpl {
+      raw_lb: wrapper.lb_envoy_ptr,
+      raw_context: context_envoy_ptr,
+    });
+
+    let result = wrapper.lb.choose_host(
+      context.as_ref().map(|c| c as &dyn ClusterLbContext),
+      async_completion,
+    );
+
+    match result {
+      HostSelectionResult::Selected(host) => {
+        *host_out = host;
+        *async_handle_out = std::ptr::null_mut();
+      },
+      HostSelectionResult::NoHost => {
+        *host_out = std::ptr::null_mut();
+        *async_handle_out = std::ptr::null_mut();
+      },
+      HostSelectionResult::AsyncPending(handle) => {
+        *host_out = std::ptr::null_mut();
+        *async_handle_out = Box::into_raw(Box::new(handle))
+          as abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr;
+      },
+    }
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_lb_choose_host", panic);
+    // Fail-closed: signal NoHost so Envoy returns 503 rather than dispatching to
+    // a stale or uninitialised pointer.
+    if !host_out.is_null() {
+      *host_out = std::ptr::null_mut();
+    }
+    if !async_handle_out.is_null() {
+      *async_handle_out = std::ptr::null_mut();
+    }
   });
-
-  let result = wrapper.lb.choose_host(
-    context.as_ref().map(|c| c as &dyn ClusterLbContext),
-    async_completion,
-  );
-
-  match result {
-    HostSelectionResult::Selected(host) => {
-      *host_out = host;
-      *async_handle_out = std::ptr::null_mut();
-    },
-    HostSelectionResult::NoHost => {
-      *host_out = std::ptr::null_mut();
-      *async_handle_out = std::ptr::null_mut();
-    },
-    HostSelectionResult::AsyncPending(handle) => {
-      *host_out = std::ptr::null_mut();
-      *async_handle_out = Box::into_raw(Box::new(handle))
-        as abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr;
-    },
-  }
 }
 
 /// # Safety
@@ -2057,9 +2109,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_cancel_host_selectio
   _lb_module_ptr: abi::envoy_dynamic_module_type_cluster_lb_module_ptr,
   async_handle_module_ptr: abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr,
 ) {
-  let handle = async_handle_module_ptr as *mut Box<dyn AsyncHostSelectionHandle>;
-  let mut handle = Box::from_raw(handle);
-  handle.cancel();
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let handle = async_handle_module_ptr as *mut Box<dyn AsyncHostSelectionHandle>;
+    let mut handle = Box::from_raw(handle);
+    handle.cancel();
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cluster_lb_cancel_host_selection",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -2073,11 +2133,19 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_on_host_membership_u
   num_hosts_added: usize,
   num_hosts_removed: usize,
 ) {
-  let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
-  let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
-  wrapper
-    .lb
-    .on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
+    wrapper
+      .lb
+      .on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_cluster_lb_on_host_membership_update",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -2090,9 +2158,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_scheduled(
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
   event_id: u64,
 ) {
-  let cluster = cluster_module_ptr as *const *const dyn Cluster;
-  let cluster = &**cluster;
-  cluster.on_scheduled(&EnvoyClusterImpl::new(cluster_envoy_ptr), event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *const *const dyn Cluster;
+    let cluster = &**cluster;
+    cluster.on_scheduled(&EnvoyClusterImpl::new(cluster_envoy_ptr), event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_scheduled", panic);
+  });
 }
 
 /// # Safety
@@ -2104,9 +2177,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_server_initialized(
   cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
 ) {
-  let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-  let cluster = &mut *cluster;
-  cluster.on_server_initialized(&EnvoyClusterImpl::new(cluster_envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
+    let cluster = &mut *cluster;
+    cluster.on_server_initialized(&EnvoyClusterImpl::new(cluster_envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_server_initialized", panic);
+  });
 }
 
 /// # Safety
@@ -2118,9 +2196,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_drain_started(
   cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
   cluster_module_ptr: abi::envoy_dynamic_module_type_cluster_module_ptr,
 ) {
-  let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-  let cluster = &mut *cluster;
-  cluster.on_drain_started(&EnvoyClusterImpl::new(cluster_envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
+    let cluster = &mut *cluster;
+    cluster.on_drain_started(&EnvoyClusterImpl::new(cluster_envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_drain_started", panic);
+  });
 }
 
 /// # Safety
@@ -2134,10 +2217,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_shutdown(
   completion_callback: abi::envoy_dynamic_module_type_event_cb,
   completion_context: *mut std::os::raw::c_void,
 ) {
-  let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-  let cluster = &mut *cluster;
-  let completion = CompletionCallback::new(completion_callback, completion_context);
-  cluster.on_shutdown(&EnvoyClusterImpl::new(cluster_envoy_ptr), completion);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
+    let cluster = &mut *cluster;
+    let completion = CompletionCallback::new(completion_callback, completion_context);
+    cluster.on_shutdown(&EnvoyClusterImpl::new(cluster_envoy_ptr), completion);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_shutdown", panic);
+  });
 }
 
 /// # Safety
@@ -2155,31 +2243,36 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-  let cluster = &mut *cluster;
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
+    let cluster = &mut *cluster;
 
-  let headers = if headers_size > 0 {
-    Some(std::slice::from_raw_parts(
-      headers as *const (EnvoyBuffer, EnvoyBuffer),
-      headers_size,
-    ))
-  } else {
-    None
-  };
-  let body = if body_chunks_size > 0 {
-    Some(std::slice::from_raw_parts(
-      body_chunks as *const EnvoyBuffer,
-      body_chunks_size,
-    ))
-  } else {
-    None
-  };
+    let headers = if headers_size > 0 {
+      Some(std::slice::from_raw_parts(
+        headers as *const (EnvoyBuffer, EnvoyBuffer),
+        headers_size,
+      ))
+    } else {
+      None
+    };
+    let body = if body_chunks_size > 0 {
+      Some(std::slice::from_raw_parts(
+        body_chunks as *const EnvoyBuffer,
+        body_chunks_size,
+      ))
+    } else {
+      None
+    };
 
-  cluster.on_http_callout_done(
-    &EnvoyClusterImpl::new(cluster_envoy_ptr),
-    callout_id,
-    result,
-    headers,
-    body,
-  );
+    cluster.on_http_callout_done(
+      &EnvoyClusterImpl::new(cluster_envoy_ptr),
+      callout_id,
+      result,
+      headers,
+      body,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_http_callout_done", panic);
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/dns_resolver.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/dns_resolver.rs
@@ -636,7 +636,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_config_new(
     }
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolver_config_new", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolver_config_new", panic);
     std::ptr::null()
   })
 }
@@ -653,7 +653,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_config_destroy(
     drop_wrapped_c_void_ptr!(config_module_ptr, DnsResolverConfig);
   }))
   .map_err(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolver_config_destroy", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolver_config_destroy", panic);
   });
 }
 
@@ -676,7 +676,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_new(
     Box::into_raw(wrapper) as abi::envoy_dynamic_module_type_dns_resolver_module_ptr
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolver_new", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolver_new", panic);
     std::ptr::null()
   })
 }
@@ -694,7 +694,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_destroy(
     let _ = unsafe { Box::from_raw(wrapper) };
   }))
   .map_err(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolver_destroy", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolver_destroy", panic);
   });
 }
 
@@ -735,7 +735,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolve(
     }
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolve", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolve", panic);
     std::ptr::null_mut()
   })
 }
@@ -755,7 +755,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolve_cancel(
     query.cancel();
   }))
   .map_err(|panic| {
-    log_panic("envoy_dynamic_module_on_dns_resolve_cancel", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_dns_resolve_cancel", panic);
   });
 }
 
@@ -772,18 +772,9 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_reset_networking(
     wrapper.resolver.reset_networking();
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_dns_resolver_reset_networking",
       panic,
     );
   });
-}
-
-/// Log a panic caught at an FFI boundary.
-fn log_panic(function_name: &str, panic: Box<dyn std::any::Any + Send>) {
-  crate::envoy_log_error!(
-    "{}: caught panic: {}",
-    function_name,
-    crate::panic_payload_to_string(panic)
-  );
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use mockall::*;
 use std::any::Any;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The trait that represents the configuration for an Envoy Http filter configuration.
 /// This has one to one mapping with the [`EnvoyHttpFilterConfig`] object.
@@ -3801,28 +3802,34 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_http_filter_config_module_ptr {
-  // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
-  // it is a String at protobuf level.
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+  catch_unwind(AssertUnwindSafe(|| {
+    // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
+    // it is a String at protobuf level.
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
 
-  let mut envoy_filter_config = EnvoyHttpFilterConfigImpl {
-    raw_ptr: envoy_filter_config_ptr,
-  };
+    let mut envoy_filter_config = EnvoyHttpFilterConfigImpl {
+      raw_ptr: envoy_filter_config_ptr,
+    };
 
-  envoy_dynamic_module_on_http_filter_config_new_impl(
-    &mut envoy_filter_config,
-    name_str,
-    config_slice,
-    NEW_HTTP_FILTER_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_HTTP_FILTER_CONFIG_FUNCTION must be set"),
-  )
+    envoy_dynamic_module_on_http_filter_config_new_impl(
+      &mut envoy_filter_config,
+      name_str,
+      config_slice,
+      NEW_HTTP_FILTER_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_HTTP_FILTER_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub fn envoy_dynamic_module_on_http_filter_config_new_impl(
@@ -3846,7 +3853,12 @@ pub fn envoy_dynamic_module_on_http_filter_config_new_impl(
 pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_destroy(
   config_ptr: abi::envoy_dynamic_module_type_http_filter_config_module_ptr,
 ) {
-  crate::drop_wrapped_c_void_ptr!(config_ptr, HttpFilterConfig<EnvoyHttpFilterImpl>);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    crate::drop_wrapped_c_void_ptr!(config_ptr, HttpFilterConfig<EnvoyHttpFilterImpl>);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_config_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -3859,9 +3871,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_scheduled(
   config_ptr: abi::envoy_dynamic_module_type_http_filter_config_module_ptr,
   event_id: u64,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  config.on_scheduled(event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    config.on_scheduled(event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_scheduled",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -3873,23 +3893,32 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_per_route_config_ne
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_http_filter_per_route_config_module_ptr {
-  // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
-  // it is a String at protobuf level.
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+  catch_unwind(AssertUnwindSafe(|| {
+    // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
+    // it is a String at protobuf level.
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
 
-  envoy_dynamic_module_on_http_filter_per_route_config_new_impl(
-    name_str,
-    config_slice,
-    NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION must be set"),
-  )
+    envoy_dynamic_module_on_http_filter_per_route_config_new_impl(
+      name_str,
+      config_slice,
+      NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_per_route_config_new",
+      panic,
+    );
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -3900,8 +3929,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_per_route_config_ne
 pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_per_route_config_destroy(
   config_ptr: abi::envoy_dynamic_module_type_http_filter_per_route_config_module_ptr,
 ) {
-  let ptr = config_ptr as *mut std::sync::Arc<dyn Any>;
-  std::mem::drop(Box::from_raw(ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let ptr = config_ptr as *mut std::sync::Arc<dyn Any>;
+    std::mem::drop(Box::from_raw(ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_per_route_config_destroy",
+      panic,
+    );
+  });
 }
 
 pub fn envoy_dynamic_module_on_http_filter_per_route_config_new_impl(
@@ -3927,14 +3964,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_new(
   filter_config_ptr: abi::envoy_dynamic_module_type_http_filter_config_module_ptr,
   filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_http_filter_module_ptr {
-  let mut envoy_filter = EnvoyHttpFilterImpl {
-    raw_ptr: filter_envoy_ptr,
-  };
-  let filter_config = {
-    let raw = filter_config_ptr as *const *const dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    &**raw
-  };
-  envoy_dynamic_module_on_http_filter_new_impl(&mut envoy_filter, filter_config)
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter = EnvoyHttpFilterImpl {
+      raw_ptr: filter_envoy_ptr,
+    };
+    let filter_config = {
+      let raw = filter_config_ptr as *const *const dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+      &**raw
+    };
+    envoy_dynamic_module_on_http_filter_new_impl(&mut envoy_filter, filter_config)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub fn envoy_dynamic_module_on_http_filter_new_impl(
@@ -3953,7 +3996,12 @@ pub fn envoy_dynamic_module_on_http_filter_new_impl(
 pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_destroy(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) {
-  crate::drop_wrapped_c_void_ptr!(filter_ptr, HttpFilter<EnvoyHttpFilterImpl>);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    crate::drop_wrapped_c_void_ptr!(filter_ptr, HttpFilter<EnvoyHttpFilterImpl>);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -3965,9 +4013,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_stream_complete(
   envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_stream_complete", panic);
+  });
 }
 
 /// # Safety
@@ -3980,9 +4033,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_headers(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   end_of_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_request_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_request_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_request_headers", panic);
+    // Fail-closed: stop iteration so the request never reaches upstream after a panic.
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  })
 }
 
 /// # Safety
@@ -3995,9 +4055,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_body(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   end_of_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_request_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_request_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_request_body", panic);
+    // Fail-closed: stop iteration without buffering further data.
+    abi::envoy_dynamic_module_type_on_http_filter_request_body_status::StopIterationNoBuffer
+  })
 }
 
 /// # Safety
@@ -4009,9 +4076,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_trailers(
   envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_request_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_request_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_request_trailers",
+      panic,
+    );
+    abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::StopIteration
+  })
 }
 
 /// # Safety
@@ -4024,9 +4100,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_headers(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   end_of_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_response_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_response_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_response_headers",
+      panic,
+    );
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration
+  })
 }
 
 /// # Safety
@@ -4039,9 +4124,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_body(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   end_of_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_response_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_response_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_response_body", panic);
+    abi::envoy_dynamic_module_type_on_http_filter_response_body_status::StopIterationNoBuffer
+  })
 }
 
 /// # Safety
@@ -4053,9 +4144,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_trailers(
   envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_response_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_response_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_response_trailers",
+      panic,
+    );
+    abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::StopIteration
+  })
 }
 
 /// # Safety
@@ -4073,27 +4173,37 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_callout_done(
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  let headers = if headers_size > 0 {
-    Some(unsafe {
-      std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
-    })
-  } else {
-    None
-  };
-  let body = if body_chunks_size > 0 {
-    Some(unsafe { std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size) })
-  } else {
-    None
-  };
-  filter.on_http_callout_done(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    callout_id,
-    result,
-    headers,
-    body,
-  )
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    let headers = if headers_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+      })
+    } else {
+      None
+    };
+    let body = if body_chunks_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+      })
+    } else {
+      None
+    };
+    filter.on_http_callout_done(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      callout_id,
+      result,
+      headers,
+      body,
+    )
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_callout_done",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4106,9 +4216,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_scheduled(
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   event_id: u64,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_scheduled(&mut EnvoyHttpFilterImpl::new(envoy_ptr), event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_scheduled(&mut EnvoyHttpFilterImpl::new(envoy_ptr), event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_scheduled", panic);
+  });
 }
 
 /// # Safety
@@ -4120,9 +4235,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_downstream_above_wr
   envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_downstream_above_write_buffer_high_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter
+      .on_downstream_above_write_buffer_high_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_downstream_above_write_buffer_high_watermark",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4134,9 +4258,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_downstream_below_wr
   envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_downstream_below_write_buffer_low_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_downstream_below_write_buffer_low_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_downstream_below_write_buffer_low_watermark",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4151,15 +4283,22 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_local_reply(
   details: abi::envoy_dynamic_module_type_envoy_buffer,
   reset_imminent: bool,
 ) -> abi::envoy_dynamic_module_type_on_http_filter_local_reply_status {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  let details_buffer = EnvoyBuffer::new_from_raw(details.ptr as *const u8, details.length);
-  filter.on_local_reply(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    response_code,
-    details_buffer,
-    reset_imminent,
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    let details_buffer = EnvoyBuffer::new_from_raw(details.ptr as *const u8, details.length);
+    filter.on_local_reply(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      response_code,
+      details_buffer,
+      reset_imminent,
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_local_reply", panic);
+    // Continue with the planned local reply; do not escalate to a stream reset on panic.
+    abi::envoy_dynamic_module_type_on_http_filter_local_reply_status::Continue
+  })
 }
 
 /// # Safety
@@ -4175,21 +4314,29 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_headers
   headers_size: usize,
   end_stream: bool,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  let headers = if headers_size > 0 {
-    unsafe {
-      std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
-    }
-  } else {
-    &[]
-  };
-  filter.on_http_stream_headers(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    stream_handle,
-    headers,
-    end_stream,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    let headers = if headers_size > 0 {
+      unsafe {
+        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+      }
+    } else {
+      &[]
+    };
+    filter.on_http_stream_headers(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      stream_handle,
+      headers,
+      end_stream,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_stream_headers",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4205,19 +4352,27 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_data(
   data_count: usize,
   end_stream: bool,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  let data = if data_count > 0 {
-    unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
-  } else {
-    &[]
-  };
-  filter.on_http_stream_data(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    stream_handle,
-    data,
-    end_stream,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    let data = if data_count > 0 {
+      unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
+    } else {
+      &[]
+    };
+    filter.on_http_stream_data(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      stream_handle,
+      data,
+      end_stream,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_stream_data",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4232,20 +4387,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_trailer
   trailers: *const abi::envoy_dynamic_module_type_envoy_http_header,
   trailers_size: usize,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  let trailers = if trailers_size > 0 {
-    unsafe {
-      std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
-    }
-  } else {
-    &[]
-  };
-  filter.on_http_stream_trailers(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    stream_handle,
-    trailers,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    let trailers = if trailers_size > 0 {
+      unsafe {
+        std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
+      }
+    } else {
+      &[]
+    };
+    filter.on_http_stream_trailers(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      stream_handle,
+      trailers,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_stream_trailers",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4258,9 +4421,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_complet
   filter_ptr: abi::envoy_dynamic_module_type_http_filter_module_ptr,
   stream_handle: u64,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_http_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr), stream_handle);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_http_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr), stream_handle);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_stream_complete",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4274,13 +4445,21 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_reset(
   stream_handle: u64,
   reset_reason: abi::envoy_dynamic_module_type_http_stream_reset_reason,
 ) {
-  let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-  let filter = &mut **filter;
-  filter.on_http_stream_reset(
-    &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-    stream_handle,
-    reset_reason,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
+    let filter = &mut **filter;
+    filter.on_http_stream_reset(
+      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
+      stream_handle,
+      reset_reason,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_http_stream_reset",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4298,29 +4477,39 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_callout
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  let headers = if headers_size > 0 {
-    Some(unsafe {
-      std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
-    })
-  } else {
-    None
-  };
-  let body = if body_chunks_size > 0 {
-    Some(unsafe { std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size) })
-  } else {
-    None
-  };
-  config.on_http_callout_done(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    callout_id,
-    result,
-    headers,
-    body,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    let headers = if headers_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+      })
+    } else {
+      None
+    };
+    let body = if body_chunks_size > 0 {
+      Some(unsafe {
+        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+      })
+    } else {
+      None
+    };
+    config.on_http_callout_done(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      callout_id,
+      result,
+      headers,
+      body,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_callout_done",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4336,23 +4525,31 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
   headers_size: usize,
   end_stream: bool,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  let headers = if headers_size > 0 {
-    unsafe {
-      std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
-    }
-  } else {
-    &[]
-  };
-  config.on_http_stream_headers(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    stream_handle,
-    headers,
-    end_stream,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    let headers = if headers_size > 0 {
+      unsafe {
+        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+      }
+    } else {
+      &[]
+    };
+    config.on_http_stream_headers(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      stream_handle,
+      headers,
+      end_stream,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_stream_headers",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4368,21 +4565,29 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
   data_count: usize,
   end_stream: bool,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  let data = if data_count > 0 {
-    unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
-  } else {
-    &[]
-  };
-  config.on_http_stream_data(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    stream_handle,
-    data,
-    end_stream,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    let data = if data_count > 0 {
+      unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
+    } else {
+      &[]
+    };
+    config.on_http_stream_data(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      stream_handle,
+      data,
+      end_stream,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_stream_data",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4397,22 +4602,30 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
   trailers: *const abi::envoy_dynamic_module_type_envoy_http_header,
   trailers_size: usize,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  let trailers = if trailers_size > 0 {
-    unsafe {
-      std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
-    }
-  } else {
-    &[]
-  };
-  config.on_http_stream_trailers(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    stream_handle,
-    trailers,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    let trailers = if trailers_size > 0 {
+      unsafe {
+        std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
+      }
+    } else {
+      &[]
+    };
+    config.on_http_stream_trailers(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      stream_handle,
+      trailers,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_stream_trailers",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4425,14 +4638,22 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
   config_ptr: abi::envoy_dynamic_module_type_http_filter_config_module_ptr,
   stream_handle: u64,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  config.on_http_stream_complete(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    stream_handle,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    config.on_http_stream_complete(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      stream_handle,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_stream_complete",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -4446,13 +4667,21 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
   stream_handle: u64,
   reset_reason: abi::envoy_dynamic_module_type_http_stream_reset_reason,
 ) {
-  let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-  let config = &**config;
-  config.on_http_stream_reset(
-    &mut EnvoyHttpFilterConfigImpl {
-      raw_ptr: envoy_config_ptr,
-    },
-    stream_handle,
-    reset_reason,
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
+    let config = &**config;
+    config.on_http_stream_reset(
+      &mut EnvoyHttpFilterConfigImpl {
+        raw_ptr: envoy_config_ptr,
+      },
+      stream_handle,
+      reset_reason,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_http_filter_config_http_stream_reset",
+      panic,
+    );
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -46,7 +46,11 @@ use crate::abi::envoy_dynamic_module_type_metrics_result;
 use std::any::Any;
 use std::sync::OnceLock;
 
-pub(crate) fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+/// Convert a panic payload (as captured by [`std::panic::catch_unwind`]) into a printable
+/// string. Public so that [`declare_matcher!`] and other macros can format the payload from
+/// the consuming crate.
+#[doc(hidden)]
+pub fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
   match payload.downcast::<String>() {
     Ok(s) => *s,
     Err(payload) => match payload.downcast::<&str>() {
@@ -54,6 +58,23 @@ pub(crate) fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
       Err(_) => "<non-string panic payload>".to_string(),
     },
   }
+}
+
+/// Log a panic caught at an FFI boundary. Exposed via `#[doc(hidden)]` so SDK-provided macros
+/// such as `declare_matcher!` and `declare_init_functions!` can call it from user crates after
+/// expansion.
+///
+/// Logging runs after `catch_unwind` has already captured the original panic, so a secondary
+/// panic inside `format!` or `envoy_log_error!` would unwind into `libc::abort` rather than
+/// across the FFI boundary. That is intentional: a recursive panic in the log path indicates
+/// the process is too broken to continue safely.
+#[doc(hidden)]
+pub fn log_ffi_panic(function_name: &str, payload: Box<dyn Any + Send>) {
+  crate::envoy_log_error!(
+    "{}: caught panic at FFI boundary: {}",
+    function_name,
+    crate::panic_payload_to_string(payload)
+  );
 }
 
 /// This module contains the generated bindings for the envoy dynamic modules ABI.
@@ -99,37 +120,53 @@ macro_rules! declare_init_functions {
   ($f:ident, $new_http_filter_config_fn:expr, $new_http_filter_per_route_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
-        $new_http_filter_config_fn,
-        "NEW_HTTP_FILTER_CONFIG_FUNCTION"
-      );
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
-        $new_http_filter_per_route_config_fn,
-        "NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
+          $new_http_filter_config_fn,
+          "NEW_HTTP_FILTER_CONFIG_FUNCTION"
+        );
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
+          $new_http_filter_per_route_config_fn,
+          "NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
   ($f:ident, $new_http_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
-        $new_http_filter_config_fn,
-        "NEW_HTTP_FILTER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_HTTP_FILTER_CONFIG_FUNCTION,
+          $new_http_filter_config_fn,
+          "NEW_HTTP_FILTER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -362,18 +399,16 @@ macro_rules! envoy_log {
 
 /// Guard macro that ensures each factory `OnceLock` is registered by exactly one module.
 ///
-/// When the same module is re-initialized (e.g. static modules loaded multiple times via
-/// `newDynamicModuleByName`, or per-route config triggering a second init), the function
+/// When the same module is re-initialized (for example, static modules loaded multiple times
+/// via `newDynamicModuleByName`, or per-route config triggering a second init), the function
 /// pointer will be identical and the re-registration is silently accepted (idempotent).
 ///
 /// If a *different* module (standalone `.so` or consolidated `.so`) tries to register a
 /// different factory function for the same slot, this macro logs a critical message via
-/// `envoy_log_critical!` and panics. The panic is caught at the FFI boundary by Envoy,
-/// which converts it into a null return from `envoy_dynamic_module_on_program_init`,
-/// causing Envoy to refuse to start — the correct behaviour for a data-correctness issue.
-///
-/// In contrast, the previous `get_or_init` approach silently ignored the second writer,
-/// making the second module's factories unreachable at runtime with no diagnostic.
+/// `envoy_log_critical!` and returns `null` from the surrounding `on_program_init`, causing
+/// Envoy to refuse to start — the correct behaviour for a data-correctness issue. The macro
+/// is only invoked inside `envoy_dynamic_module_on_program_init` (signature
+/// `-> *const c_char`), where the null return is the documented "init failed" sentinel.
 #[macro_export]
 macro_rules! set_factory_once {
   ($static:expr, $fn:expr, $name:literal) => {
@@ -385,12 +420,9 @@ macro_rules! set_factory_once {
            .so loads.",
           $name,
         );
-        panic!(
-          "Duplicate factory registration for {}. A different module already registered this \
-           factory. Check dynamic_module_config for conflicting standalone and consolidated \
-           .so loads.",
-          $name,
-        );
+        // Return the "init failed" sentinel rather than panicking; unwinding across the
+        // `extern "C"` boundary is undefined behavior on the default `panic="unwind"`.
+        return ::std::ptr::null();
       }
     }
   };
@@ -569,16 +601,24 @@ macro_rules! declare_network_filter_init_functions {
   ($f:ident, $new_network_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION,
-        $new_network_filter_config_fn,
-        "NEW_NETWORK_FILTER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_NETWORK_FILTER_CONFIG_FUNCTION,
+          $new_network_filter_config_fn,
+          "NEW_NETWORK_FILTER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -697,14 +737,22 @@ macro_rules! declare_all_init_functions {
   ($f:ident, $($filter_type:ident : $filter_fn:expr),+ $(,)?) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      $(
-        declare_all_init_functions!(@register $filter_type : $filter_fn);
-      )+
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        $(
+          declare_all_init_functions!(@register $filter_type : $filter_fn);
+        )+
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -853,16 +901,24 @@ macro_rules! declare_listener_filter_init_functions {
     pub extern "C" fn envoy_dynamic_module_on_program_init(
       server_factory_context_ptr: abi::envoy_dynamic_module_type_server_factory_context_envoy_ptr,
     ) -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION,
-        $new_listener_filter_config_fn,
-        "NEW_LISTENER_FILTER_CONFIG_FUNCTION"
-      );
-      if ($f(server_factory_context_ptr)) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION,
+          $new_listener_filter_config_fn,
+          "NEW_LISTENER_FILTER_CONFIG_FUNCTION"
+        );
+        if ($f(server_factory_context_ptr)) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -911,16 +967,24 @@ macro_rules! declare_udp_listener_filter_init_functions {
   ($f:ident, $new_udp_listener_filter_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION,
-        $new_udp_listener_filter_config_fn,
-        "NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION,
+          $new_udp_listener_filter_config_fn,
+          "NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1018,16 +1082,24 @@ macro_rules! declare_bootstrap_init_functions {
   ($f:ident, $new_bootstrap_extension_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION,
-        $new_bootstrap_extension_config_fn,
-        "NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION,
+          $new_bootstrap_extension_config_fn,
+          "NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1152,16 +1224,24 @@ macro_rules! declare_cluster_init_functions {
   ($f:ident, $new_cluster_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION,
-        $new_cluster_config_fn,
-        "NEW_CLUSTER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_CLUSTER_CONFIG_FUNCTION,
+          $new_cluster_config_fn,
+          "NEW_CLUSTER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1256,16 +1336,24 @@ macro_rules! declare_load_balancer_init_functions {
   ($f:ident, $new_lb_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION,
-        $new_lb_config_fn,
-        "NEW_LOAD_BALANCER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_LOAD_BALANCER_CONFIG_FUNCTION,
+          $new_lb_config_fn,
+          "NEW_LOAD_BALANCER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1330,16 +1418,24 @@ macro_rules! declare_cert_validator_init_functions {
   ($f:ident, $new_cert_validator_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION,
-        $new_cert_validator_config_fn,
-        "NEW_CERT_VALIDATOR_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_CERT_VALIDATOR_CONFIG_FUNCTION,
+          $new_cert_validator_config_fn,
+          "NEW_CERT_VALIDATOR_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1447,16 +1543,24 @@ macro_rules! declare_dns_resolver_init_functions {
   ($f:ident, $new_dns_resolver_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION,
-        $new_dns_resolver_config_fn,
-        "NEW_DNS_RESOLVER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_DNS_RESOLVER_CONFIG_FUNCTION,
+          $new_dns_resolver_config_fn,
+          "NEW_DNS_RESOLVER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };
@@ -1509,16 +1613,24 @@ macro_rules! declare_transport_socket_init_functions {
   ($f:ident, $new_transport_socket_factory_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION,
-        $new_transport_socket_factory_config_fn,
-        "NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION,
+          $new_transport_socket_factory_config_fn,
+          "NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -5666,3 +5666,72 @@ fn test_envoy_dynamic_module_on_access_logger_new_destroy() {
   }
   assert!(LOGGER_DROPPED.load(std::sync::atomic::Ordering::SeqCst));
 }
+
+// =================================================================================================
+// FFI panic-handling helpers
+// =================================================================================================
+
+#[test]
+fn test_panic_payload_to_string_handles_string_payload() {
+  let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("formatted panic message"));
+  assert_eq!(panic_payload_to_string(payload), "formatted panic message");
+}
+
+#[test]
+fn test_panic_payload_to_string_handles_str_payload() {
+  let payload: Box<dyn std::any::Any + Send> = Box::new("static panic message");
+  assert_eq!(panic_payload_to_string(payload), "static panic message");
+}
+
+#[test]
+fn test_panic_payload_to_string_falls_back_for_unknown_payload() {
+  let payload: Box<dyn std::any::Any + Send> = Box::new(42_i32);
+  assert_eq!(
+    panic_payload_to_string(payload),
+    "<non-string panic payload>"
+  );
+}
+
+#[test]
+fn test_log_ffi_panic_handles_unknown_payload_without_panicking() {
+  // The logging path must not itself panic when the payload type is not recognized; otherwise
+  // the secondary panic would unwind across the FFI boundary that the outer `catch_unwind` is
+  // there to prevent.
+  let payload: Box<dyn std::any::Any + Send> = Box::new(42_i32);
+  log_ffi_panic("test_entry_point", payload);
+}
+
+#[test]
+fn test_outer_ffi_pattern_returns_fail_closed_pointer_on_panic() {
+  // Mirrors the exact `catch_unwind` + `unwrap_or_else` shape used by every FFI entry that
+  // returns a pointer, exercised end-to-end with the SDK's `log_ffi_panic` helper.
+  let result: *const std::ffi::c_void = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+    || -> *const std::ffi::c_void {
+      panic!("simulated factory panic");
+    },
+  ))
+  .unwrap_or_else(|payload| {
+    log_ffi_panic(
+      "test_outer_ffi_pattern_returns_fail_closed_pointer_on_panic",
+      payload,
+    );
+    std::ptr::null()
+  });
+  assert!(result.is_null());
+}
+
+#[test]
+fn test_outer_ffi_pattern_returns_fail_closed_bool_on_panic() {
+  // Mirrors the FFI shape used by entries that return a bool (e.g. `on_program_init`).
+  let result: bool = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> bool {
+    panic!("simulated factory panic");
+  }))
+  .unwrap_or_else(|payload| {
+    log_ffi_panic(
+      "test_outer_ffi_pattern_returns_fail_closed_bool_on_panic",
+      payload,
+    );
+    false
+  });
+  assert!(!result);
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -5,6 +5,7 @@ use crate::{
   NEW_LISTENER_FILTER_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The trait that represents the Envoy listener filter configuration.
 /// This is used in [`NewListenerFilterConfigFunction`] to pass the Envoy filter configuration
@@ -1217,22 +1218,28 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_listener_filter_config_module_ptr {
-  let mut envoy_filter_config = EnvoyListenerFilterConfigImpl::new(envoy_filter_config_ptr);
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
-  init_listener_filter_config(
-    &mut envoy_filter_config,
-    name_str,
-    config_slice,
-    NEW_LISTENER_FILTER_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_LISTENER_FILTER_CONFIG_FUNCTION must be set"),
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter_config = EnvoyListenerFilterConfigImpl::new(envoy_filter_config_ptr);
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    init_listener_filter_config(
+      &mut envoy_filter_config,
+      name_str,
+      config_slice,
+      NEW_LISTENER_FILTER_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_LISTENER_FILTER_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn init_listener_filter_config<
@@ -1259,10 +1266,18 @@ pub(crate) fn init_listener_filter_config<
 pub unsafe extern "C" fn envoy_dynamic_module_on_listener_filter_config_destroy(
   filter_config_ptr: abi::envoy_dynamic_module_type_listener_filter_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(
-    filter_config_ptr,
-    ListenerFilterConfig<EnvoyListenerFilterImpl>
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(
+      filter_config_ptr,
+      ListenerFilterConfig<EnvoyListenerFilterImpl>
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_listener_filter_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1274,12 +1289,19 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_listener_filter_new(
   filter_config_ptr: abi::envoy_dynamic_module_type_listener_filter_config_module_ptr,
   envoy_filter_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_listener_filter_module_ptr {
-  let mut envoy_filter = EnvoyListenerFilterImpl::new(envoy_filter_ptr);
-  let filter_config = {
-    let raw = filter_config_ptr as *const *const dyn ListenerFilterConfig<EnvoyListenerFilterImpl>;
-    &**raw
-  };
-  envoy_dynamic_module_on_listener_filter_new_impl(&mut envoy_filter, filter_config)
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter = EnvoyListenerFilterImpl::new(envoy_filter_ptr);
+    let filter_config = {
+      let raw =
+        filter_config_ptr as *const *const dyn ListenerFilterConfig<EnvoyListenerFilterImpl>;
+      &**raw
+    };
+    envoy_dynamic_module_on_listener_filter_new_impl(&mut envoy_filter, filter_config)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn envoy_dynamic_module_on_listener_filter_new_impl(
@@ -1295,9 +1317,15 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_on_accept(
   envoy_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
-  let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_accept(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_accept(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_on_accept", panic);
+    abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
+  })
 }
 
 #[no_mangle]
@@ -1305,9 +1333,15 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_on_data(
   envoy_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
-  let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_data(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_data(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_on_data", panic);
+    abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
+  })
 }
 
 #[no_mangle]
@@ -1315,17 +1349,27 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_on_close(
   envoy_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_close(&mut EnvoyListenerFilterImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_close(&mut EnvoyListenerFilterImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_on_close", panic);
+  });
 }
 
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_on_listener_filter_destroy(
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
 ) {
-  let _ =
-    unsafe { Box::from_raw(filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>) };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let _ =
+      unsafe { Box::from_raw(filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>) };
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_destroy", panic);
+  });
 }
 
 #[no_mangle]
@@ -1334,9 +1378,14 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_scheduled(
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
   event_id: u64,
 ) {
-  let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_scheduled(&mut EnvoyListenerFilterImpl::new(envoy_ptr), event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_scheduled(&mut EnvoyListenerFilterImpl::new(envoy_ptr), event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_scheduled", panic);
+  });
 }
 
 #[no_mangle]
@@ -1345,10 +1394,18 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_config_scheduled(
   filter_config_module_ptr: abi::envoy_dynamic_module_type_listener_filter_config_module_ptr,
   event_id: u64,
 ) {
-  let filter_config =
-    filter_config_module_ptr as *const *const dyn ListenerFilterConfig<EnvoyListenerFilterImpl>;
-  let filter_config = unsafe { &**filter_config };
-  filter_config.on_config_scheduled(event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter_config =
+      filter_config_module_ptr as *const *const dyn ListenerFilterConfig<EnvoyListenerFilterImpl>;
+    let filter_config = unsafe { &**filter_config };
+    filter_config.on_config_scheduled(event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_listener_filter_config_scheduled",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1366,41 +1423,49 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_listener_filter_http_callout_do
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
 
-  // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
-  let header_vec = if headers.is_null() || headers_size == 0 {
-    Vec::new()
-  } else {
-    let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
-    headers_slice
-      .iter()
-      .map(|h| {
-        (
-          unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
-          unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
-        )
-      })
-      .collect()
-  };
+    // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
+    let header_vec = if headers.is_null() || headers_size == 0 {
+      Vec::new()
+    } else {
+      let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
+      headers_slice
+        .iter()
+        .map(|h| {
+          (
+            unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
+            unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
+          )
+        })
+        .collect()
+    };
 
-  // Convert body chunks to Vec<EnvoyBuffer>.
-  let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
-    Vec::new()
-  } else {
-    let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
-    chunks_slice
-      .iter()
-      .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
-      .collect()
-  };
+    // Convert body chunks to Vec<EnvoyBuffer>.
+    let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
+      Vec::new()
+    } else {
+      let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
+      chunks_slice
+        .iter()
+        .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
+        .collect()
+    };
 
-  filter.on_http_callout_done(
-    &mut EnvoyListenerFilterImpl::new(envoy_ptr),
-    callout_id,
-    result,
-    header_vec,
-    body_vec,
-  );
+    filter.on_http_callout_done(
+      &mut EnvoyListenerFilterImpl::new(envoy_ptr),
+      callout_id,
+      result,
+      header_vec,
+      body_vec,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_listener_filter_http_callout_done",
+      panic,
+    );
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -4,6 +4,7 @@ use crate::{
   EnvoyHistogramVecId, NEW_LOAD_BALANCER_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 /// Trait for interacting with the Envoy load balancer and its context.
@@ -1308,21 +1309,27 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_lb_config_module_ptr {
-  let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-    name.ptr as *const _,
-    name.length,
-  ));
-  let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
-  let new_config_fn = NEW_LOAD_BALANCER_CONFIG_FUNCTION
-    .get()
-    .expect("NEW_LOAD_BALANCER_CONFIG_FUNCTION must be set");
-  let envoy_lb_config: Arc<dyn EnvoyLbConfig> = Arc::new(EnvoyLbConfigImpl {
-    raw: lb_config_envoy_ptr,
-  });
-  match new_config_fn(name_str, config_slice, envoy_lb_config) {
-    Some(config) => wrap_into_c_void_ptr!(config),
-    None => std::ptr::null(),
-  }
+  catch_unwind(AssertUnwindSafe(|| {
+    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+      name.ptr as *const _,
+      name.length,
+    ));
+    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    let new_config_fn = NEW_LOAD_BALANCER_CONFIG_FUNCTION
+      .get()
+      .expect("NEW_LOAD_BALANCER_CONFIG_FUNCTION must be set");
+    let envoy_lb_config: Arc<dyn EnvoyLbConfig> = Arc::new(EnvoyLbConfigImpl {
+      raw: lb_config_envoy_ptr,
+    });
+    match new_config_fn(name_str, config_slice, envoy_lb_config) {
+      Some(config) => wrap_into_c_void_ptr!(config),
+      None => std::ptr::null(),
+    }
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_lb_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -1333,7 +1340,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_config_new(
 pub unsafe extern "C" fn envoy_dynamic_module_on_lb_config_destroy(
   config_ptr: abi::envoy_dynamic_module_type_lb_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(config_ptr, LoadBalancerConfig);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(config_ptr, LoadBalancerConfig);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_lb_config_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -1345,14 +1357,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_new(
   config_ptr: abi::envoy_dynamic_module_type_lb_config_module_ptr,
   lb_envoy_ptr: abi::envoy_dynamic_module_type_lb_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_lb_module_ptr {
-  // During new_load_balancer, context is not available.
-  let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
-  let lb_config = {
-    let raw = config_ptr as *const *const dyn LoadBalancerConfig;
-    &**raw
-  };
-  let lb = lb_config.new_load_balancer(&envoy_lb);
-  wrap_into_c_void_ptr!(lb)
+  catch_unwind(AssertUnwindSafe(|| {
+    // During new_load_balancer, context is not available.
+    let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
+    let lb_config = {
+      let raw = config_ptr as *const *const dyn LoadBalancerConfig;
+      &**raw
+    };
+    let lb = lb_config.new_load_balancer(&envoy_lb);
+    wrap_into_c_void_ptr!(lb)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_lb_new", panic);
+    std::ptr::null()
+  })
 }
 
 /// # Safety
@@ -1367,19 +1385,27 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_choose_host(
   result_priority: *mut u32,
   result_index: *mut u32,
 ) -> bool {
-  let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, context_envoy_ptr);
-  let lb = {
-    let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
-    &mut **raw
-  };
-  match lb.choose_host(&envoy_lb) {
-    Some(selection) => {
-      *result_priority = selection.priority;
-      *result_index = selection.index;
-      true
-    },
-    None => false,
-  }
+  catch_unwind(AssertUnwindSafe(|| {
+    let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, context_envoy_ptr);
+    let lb = {
+      let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
+      &mut **raw
+    };
+    match lb.choose_host(&envoy_lb) {
+      Some(selection) => {
+        *result_priority = selection.priority;
+        *result_index = selection.index;
+        true
+      },
+      None => false,
+    }
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_lb_choose_host", panic);
+    // Fail-closed: return `false` so Envoy treats this as "no host selected"
+    // rather than reading the (uninitialised) out parameters.
+    false
+  })
 }
 
 /// # Safety
@@ -1393,12 +1419,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_on_host_membership_update(
   num_hosts_added: usize,
   num_hosts_removed: usize,
 ) {
-  let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
-  let lb = {
-    let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
-    &mut **raw
-  };
-  lb.on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
+    let lb = {
+      let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
+      &mut **raw
+    };
+    lb.on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_lb_on_host_membership_update",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1409,5 +1443,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_on_host_membership_update(
 pub unsafe extern "C" fn envoy_dynamic_module_on_lb_destroy(
   lb_module_ptr: abi::envoy_dynamic_module_type_lb_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(lb_module_ptr, LoadBalancer);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(lb_module_ptr, LoadBalancer);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_lb_destroy", panic);
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/matcher.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/matcher.rs
@@ -205,26 +205,35 @@ macro_rules! declare_matcher {
       name: $crate::abi::envoy_dynamic_module_type_envoy_buffer,
       config: $crate::abi::envoy_dynamic_module_type_envoy_buffer,
     ) -> *const ::std::ffi::c_void {
-      let name_str = unsafe {
-        let slice = ::std::slice::from_raw_parts(name.ptr as *const u8, name.length);
-        ::std::str::from_utf8(slice).unwrap_or("")
-      };
-      let config_bytes =
-        unsafe { ::std::slice::from_raw_parts(config.ptr as *const u8, config.length) };
+      ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        let name_str = unsafe {
+          let slice = ::std::slice::from_raw_parts(name.ptr as *const u8, name.length);
+          ::std::str::from_utf8(slice).unwrap_or("")
+        };
+        let config_bytes =
+          unsafe { ::std::slice::from_raw_parts(config.ptr as *const u8, config.length) };
 
-      match <$config_type as $crate::matcher::MatcherConfig>::new(name_str, config_bytes) {
-        Ok(c) => Box::into_raw(Box::new(c)) as *const ::std::ffi::c_void,
-        Err(_) => ::std::ptr::null(),
-      }
+        match <$config_type as $crate::matcher::MatcherConfig>::new(name_str, config_bytes) {
+          Ok(c) => Box::into_raw(Box::new(c)) as *const ::std::ffi::c_void,
+          Err(_) => ::std::ptr::null(),
+        }
+      }))
+      .unwrap_or_else(|panic| {
+        $crate::log_ffi_panic("envoy_dynamic_module_on_matcher_config_new", panic);
+        ::std::ptr::null()
+      })
     }
 
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_matcher_config_destroy(
       config_ptr: *const ::std::ffi::c_void,
     ) {
-      unsafe {
+      let _ = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| unsafe {
         drop(Box::from_raw(config_ptr as *mut $config_type));
-      }
+      }))
+      .map_err(|panic| {
+        $crate::log_ffi_panic("envoy_dynamic_module_on_matcher_config_destroy", panic);
+      });
     }
 
     #[no_mangle]
@@ -232,9 +241,16 @@ macro_rules! declare_matcher {
       config_ptr: *const ::std::ffi::c_void,
       matcher_input_envoy_ptr: *mut ::std::ffi::c_void,
     ) -> bool {
-      let config = unsafe { &*(config_ptr as *const $config_type) };
-      let ctx = $crate::matcher::MatchContext::new(matcher_input_envoy_ptr);
-      config.on_matcher_match(&ctx)
+      ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        let config = unsafe { &*(config_ptr as *const $config_type) };
+        let ctx = $crate::matcher::MatchContext::new(matcher_input_envoy_ptr);
+        config.on_matcher_match(&ctx)
+      }))
+      .unwrap_or_else(|panic| {
+        $crate::log_ffi_panic("envoy_dynamic_module_on_matcher_match", panic);
+        // Fail-closed: a panic during match evaluation must not look like "matched".
+        false
+      })
     }
   };
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -6,6 +6,7 @@ use crate::{
   NEW_NETWORK_FILTER_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The trait that represents the Envoy network filter configuration.
 /// This is used in [`NewNetworkFilterConfigFunction`] to pass the Envoy filter configuration
@@ -1653,22 +1654,28 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_network_filter_config_module_ptr {
-  let mut envoy_filter_config = EnvoyNetworkFilterConfigImpl::new(envoy_filter_config_ptr);
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
-  init_network_filter_config(
-    &mut envoy_filter_config,
-    name_str,
-    config_slice,
-    NEW_NETWORK_FILTER_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_NETWORK_FILTER_CONFIG_FUNCTION must be set"),
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter_config = EnvoyNetworkFilterConfigImpl::new(envoy_filter_config_ptr);
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    init_network_filter_config(
+      &mut envoy_filter_config,
+      name_str,
+      config_slice,
+      NEW_NETWORK_FILTER_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_NETWORK_FILTER_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_config_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn init_network_filter_config<EC: EnvoyNetworkFilterConfig, ENF: EnvoyNetworkFilter>(
@@ -1692,10 +1699,18 @@ pub(crate) fn init_network_filter_config<EC: EnvoyNetworkFilterConfig, ENF: Envo
 pub unsafe extern "C" fn envoy_dynamic_module_on_network_filter_config_destroy(
   filter_config_ptr: abi::envoy_dynamic_module_type_network_filter_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(
-    filter_config_ptr,
-    NetworkFilterConfig<EnvoyNetworkFilterImpl>
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(
+      filter_config_ptr,
+      NetworkFilterConfig<EnvoyNetworkFilterImpl>
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -1707,12 +1722,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_network_filter_new(
   filter_config_ptr: abi::envoy_dynamic_module_type_network_filter_config_module_ptr,
   envoy_filter_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_network_filter_module_ptr {
-  let mut envoy_filter = EnvoyNetworkFilterImpl::new(envoy_filter_ptr);
-  let filter_config = {
-    let raw = filter_config_ptr as *const *const dyn NetworkFilterConfig<EnvoyNetworkFilterImpl>;
-    &**raw
-  };
-  envoy_dynamic_module_on_network_filter_new_impl(&mut envoy_filter, filter_config)
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter = EnvoyNetworkFilterImpl::new(envoy_filter_ptr);
+    let filter_config = {
+      let raw = filter_config_ptr as *const *const dyn NetworkFilterConfig<EnvoyNetworkFilterImpl>;
+      &**raw
+    };
+    envoy_dynamic_module_on_network_filter_new_impl(&mut envoy_filter, filter_config)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn envoy_dynamic_module_on_network_filter_new_impl(
@@ -1728,9 +1749,18 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_new_connection(
   envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_new_connection(&mut EnvoyNetworkFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_new_connection(&mut EnvoyNetworkFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_new_connection",
+      panic,
+    );
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::StopIteration
+  })
 }
 
 #[no_mangle]
@@ -1740,13 +1770,19 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_read(
   data_length: usize,
   end_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_read(
-    &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
-    data_length,
-    end_stream,
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_read(
+      &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
+      data_length,
+      end_stream,
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_read", panic);
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::StopIteration
+  })
 }
 
 #[no_mangle]
@@ -1756,13 +1792,19 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_write(
   data_length: usize,
   end_stream: bool,
 ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_write(
-    &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
-    data_length,
-    end_stream,
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_write(
+      &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
+      data_length,
+      end_stream,
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_write", panic);
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::StopIteration
+  })
 }
 
 #[no_mangle]
@@ -1771,17 +1813,27 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_event(
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
   event: abi::envoy_dynamic_module_type_network_connection_event,
 ) {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_event(&mut EnvoyNetworkFilterImpl::new(envoy_ptr), event);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_event(&mut EnvoyNetworkFilterImpl::new(envoy_ptr), event);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_event", panic);
+  });
 }
 
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_on_network_filter_destroy(
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
 ) {
-  let _ =
-    unsafe { Box::from_raw(filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>) };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let _ =
+      unsafe { Box::from_raw(filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>) };
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_destroy", panic);
+  });
 }
 
 #[no_mangle]
@@ -1798,43 +1850,51 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_network_filter_http_callout_don
   body_chunks: *const abi::envoy_dynamic_module_type_envoy_buffer,
   body_chunks_size: usize,
 ) {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
 
-  // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
-  let header_vec = if headers.is_null() || headers_size == 0 {
-    Vec::new()
-  } else {
-    let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
-    headers_slice
-      .iter()
-      .map(|h| {
-        (
-          unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
-          unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
-        )
-      })
-      .collect()
-  };
+    // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
+    let header_vec = if headers.is_null() || headers_size == 0 {
+      Vec::new()
+    } else {
+      let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
+      headers_slice
+        .iter()
+        .map(|h| {
+          (
+            unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
+            unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
+          )
+        })
+        .collect()
+    };
 
-  // Convert body chunks to Vec<EnvoyBuffer>.
-  let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
-    Vec::new()
-  } else {
-    let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
-    chunks_slice
-      .iter()
-      .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
-      .collect()
-  };
+    // Convert body chunks to Vec<EnvoyBuffer>.
+    let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
+      Vec::new()
+    } else {
+      let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
+      chunks_slice
+        .iter()
+        .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
+        .collect()
+    };
 
-  filter.on_http_callout_done(
-    &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
-    callout_id,
-    result,
-    header_vec,
-    body_vec,
-  );
+    filter.on_http_callout_done(
+      &mut EnvoyNetworkFilterImpl::new(envoy_ptr),
+      callout_id,
+      result,
+      header_vec,
+      body_vec,
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_http_callout_done",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1843,9 +1903,14 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_scheduled(
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
   event_id: u64,
 ) {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_scheduled(&mut EnvoyNetworkFilterImpl::new(envoy_ptr), event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_scheduled(&mut EnvoyNetworkFilterImpl::new(envoy_ptr), event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_network_filter_scheduled", panic);
+  });
 }
 
 #[no_mangle]
@@ -1853,11 +1918,19 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_config_scheduled(
   filter_config_ptr: abi::envoy_dynamic_module_type_network_filter_config_module_ptr,
   event_id: u64,
 ) {
-  let filter_config = {
-    let raw = filter_config_ptr as *const *const dyn NetworkFilterConfig<EnvoyNetworkFilterImpl>;
-    unsafe { &**raw }
-  };
-  filter_config.on_config_scheduled(event_id);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter_config = {
+      let raw = filter_config_ptr as *const *const dyn NetworkFilterConfig<EnvoyNetworkFilterImpl>;
+      unsafe { &**raw }
+    };
+    filter_config.on_config_scheduled(event_id);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_config_scheduled",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1865,9 +1938,17 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_above_write_buffer_high
   envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_above_write_buffer_high_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_above_write_buffer_high_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_above_write_buffer_high_watermark",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -1875,7 +1956,15 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_below_write_buffer_low_
   envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_network_filter_module_ptr,
 ) {
-  let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_below_write_buffer_low_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn NetworkFilter<EnvoyNetworkFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_below_write_buffer_low_watermark(&mut EnvoyNetworkFilterImpl::new(envoy_ptr));
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_network_filter_below_write_buffer_low_watermark",
+      panic,
+    );
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
@@ -593,10 +593,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_config_new(
   match result {
     Ok(ptr) => ptr,
     Err(panic) => {
-      crate::envoy_log_error!(
-        "on_tracer_config_new: caught panic: {}",
-        crate::panic_payload_to_string(panic)
-      );
+      crate::log_ffi_panic("envoy_dynamic_module_on_tracer_config_new", panic);
       std::ptr::null()
     },
   }
@@ -610,11 +607,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_config_new(
 pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_config_destroy(
   config_module_ptr: abi::envoy_dynamic_module_type_tracer_config_module_ptr,
 ) {
-  let config = config_module_ptr as *mut *mut dyn TracerConfig;
-  unsafe {
-    let _outer = Box::from_raw(config);
-    let _inner = Box::from_raw(*config);
-  }
+  let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let config = config_module_ptr as *mut *mut dyn TracerConfig;
+    unsafe {
+      let _outer = Box::from_raw(config);
+      let _inner = Box::from_raw(*config);
+    }
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_tracer_config_destroy", panic);
+  });
 }
 
 /// # Safety
@@ -645,10 +647,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_start_span(
   match result {
     Ok(ptr) => ptr,
     Err(panic) => {
-      crate::envoy_log_error!(
-        "on_tracer_start_span: caught panic: {}",
-        crate::panic_payload_to_string(panic)
-      );
+      crate::log_ffi_panic("envoy_dynamic_module_on_tracer_start_span", panic);
       std::ptr::null()
     },
   }
@@ -759,10 +758,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_spawn_child(
   match result {
     Ok(ptr) => ptr,
     Err(panic) => {
-      crate::envoy_log_error!(
-        "on_tracer_span_spawn_child: caught panic: {}",
-        crate::panic_payload_to_string(panic)
-      );
+      crate::log_ffi_panic("envoy_dynamic_module_on_tracer_span_spawn_child", panic);
       std::ptr::null()
     },
   }
@@ -937,10 +933,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_get_span_id(
 pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_destroy(
   span_module_ptr: abi::envoy_dynamic_module_type_tracer_span_module_ptr,
 ) {
-  let wrapper = span_module_ptr as *mut SpanWrapper;
-  unsafe {
-    let _ = Box::from_raw(wrapper);
-  }
+  let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    let wrapper = span_module_ptr as *mut SpanWrapper;
+    unsafe {
+      let _ = Box::from_raw(wrapper);
+    }
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_tracer_span_destroy", panic);
+  });
 }
 
 /// Declare the init functions for the tracer dynamic module.
@@ -952,16 +953,24 @@ macro_rules! declare_tracer_init_functions {
   ($f:ident, $new_tracer_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION,
-        $new_tracer_config_fn,
-        "NEW_TRACER_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_TRACER_CONFIG_FUNCTION,
+          $new_tracer_config_fn,
+          "NEW_TRACER_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };

--- a/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
@@ -430,7 +430,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_factory_config
     }
   }))
   .unwrap_or_else(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_factory_config_new",
       panic,
     );
@@ -453,7 +453,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_factory_config
     );
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_factory_config_destroy",
       panic,
     );
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_new(
     Box::into_raw(wrapper) as abi::envoy_dynamic_module_type_transport_socket_module_ptr
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_transport_socket_new", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_transport_socket_new", panic);
     std::ptr::null()
   })
 }
@@ -497,7 +497,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_destroy(
     let _ = unsafe { Box::from_raw(wrapper) };
   }))
   .map_err(|panic| {
-    log_panic("envoy_dynamic_module_on_transport_socket_destroy", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_transport_socket_destroy", panic);
   });
 }
 
@@ -516,7 +516,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_set_callbacks(
     wrapper.socket.on_set_callbacks(&mut envoy);
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_set_callbacks",
       panic,
     );
@@ -538,7 +538,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_on_connected(
     wrapper.socket.on_connected(&mut envoy);
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_on_connected",
       panic,
     );
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_do_read(
     io.into()
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_transport_socket_do_read", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_transport_socket_do_read", panic);
     IoResult::close(0, false).into()
   })
 }
@@ -584,7 +584,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_do_write(
     io.into()
   }))
   .unwrap_or_else(|panic| {
-    log_panic("envoy_dynamic_module_on_transport_socket_do_write", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_transport_socket_do_write", panic);
     IoResult::close(0, false).into()
   })
 }
@@ -605,7 +605,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_close(
     wrapper.socket.on_close(&mut envoy, event.into());
   }))
   .map_err(|panic| {
-    log_panic("envoy_dynamic_module_on_transport_socket_close", panic);
+    crate::log_ffi_panic("envoy_dynamic_module_on_transport_socket_close", panic);
   });
 }
 
@@ -626,7 +626,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_get_protocol(
     fill_string_buffer_out(&GET_PROTOCOL_BUF, result, &s);
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_get_protocol",
       panic,
     );
@@ -650,7 +650,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_get_failure_re
     fill_string_buffer_out(&GET_FAILURE_REASON_BUF, result, &s);
   }))
   .map_err(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_get_failure_reason",
       panic,
     );
@@ -672,19 +672,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_can_flush_clos
     wrapper.socket.can_flush_close(&mut envoy)
   }))
   .unwrap_or_else(|panic| {
-    log_panic(
+    crate::log_ffi_panic(
       "envoy_dynamic_module_on_transport_socket_can_flush_close",
       panic,
     );
     false
   })
-}
-
-/// Log a panic caught at an FFI boundary.
-fn log_panic(function_name: &str, panic: Box<dyn std::any::Any + Send>) {
-  crate::envoy_log_error!(
-    "{}: caught panic: {}",
-    function_name,
-    crate::panic_payload_to_string(panic)
-  );
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
@@ -5,6 +5,7 @@ use crate::{
   NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The trait that represents the Envoy UDP listener filter configuration.
 /// This is used in [`NewUdpListenerFilterConfigFunction`] to pass the Envoy filter configuration
@@ -398,22 +399,31 @@ pub extern "C" fn envoy_dynamic_module_on_udp_listener_filter_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_udp_listener_filter_config_module_ptr {
-  let mut envoy_filter_config = EnvoyUdpListenerFilterConfigImpl::new(envoy_filter_config_ptr);
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
-  init_udp_listener_filter_config(
-    &mut envoy_filter_config,
-    name_str,
-    config_slice,
-    NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION
-      .get()
-      .expect("NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION must be set"),
-  )
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter_config = EnvoyUdpListenerFilterConfigImpl::new(envoy_filter_config_ptr);
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    init_udp_listener_filter_config(
+      &mut envoy_filter_config,
+      name_str,
+      config_slice,
+      NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION
+        .get()
+        .expect("NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION must be set"),
+    )
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_udp_listener_filter_config_new",
+      panic,
+    );
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn init_udp_listener_filter_config<
@@ -440,10 +450,18 @@ pub(crate) fn init_udp_listener_filter_config<
 pub unsafe extern "C" fn envoy_dynamic_module_on_udp_listener_filter_config_destroy(
   filter_config_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(
-    filter_config_ptr,
-    UdpListenerFilterConfig<EnvoyUdpListenerFilterImpl>
-  );
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(
+      filter_config_ptr,
+      UdpListenerFilterConfig<EnvoyUdpListenerFilterImpl>
+    );
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_udp_listener_filter_config_destroy",
+      panic,
+    );
+  });
 }
 
 /// # Safety
@@ -455,13 +473,19 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_udp_listener_filter_new(
   filter_config_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_config_module_ptr,
   envoy_filter_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_udp_listener_filter_module_ptr {
-  let mut envoy_filter = EnvoyUdpListenerFilterImpl::new(envoy_filter_ptr);
-  let filter_config = {
-    let raw =
-      filter_config_ptr as *const *const dyn UdpListenerFilterConfig<EnvoyUdpListenerFilterImpl>;
-    &**raw
-  };
-  envoy_dynamic_module_on_udp_listener_filter_new_impl(&mut envoy_filter, filter_config)
+  catch_unwind(AssertUnwindSafe(|| {
+    let mut envoy_filter = EnvoyUdpListenerFilterImpl::new(envoy_filter_ptr);
+    let filter_config = {
+      let raw =
+        filter_config_ptr as *const *const dyn UdpListenerFilterConfig<EnvoyUdpListenerFilterImpl>;
+      &**raw
+    };
+    envoy_dynamic_module_on_udp_listener_filter_new_impl(&mut envoy_filter, filter_config)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_udp_listener_filter_new", panic);
+    std::ptr::null()
+  })
 }
 
 pub(crate) fn envoy_dynamic_module_on_udp_listener_filter_new_impl(
@@ -477,16 +501,27 @@ pub extern "C" fn envoy_dynamic_module_on_udp_listener_filter_on_data(
   envoy_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_module_ptr,
 ) -> abi::envoy_dynamic_module_type_on_udp_listener_filter_status {
-  let filter = filter_ptr as *mut Box<dyn UdpListenerFilter<EnvoyUdpListenerFilterImpl>>;
-  let filter = unsafe { &mut *filter };
-  filter.on_data(&mut EnvoyUdpListenerFilterImpl::new(envoy_ptr))
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn UdpListenerFilter<EnvoyUdpListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.on_data(&mut EnvoyUdpListenerFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_udp_listener_filter_on_data", panic);
+    abi::envoy_dynamic_module_type_on_udp_listener_filter_status::StopIteration
+  })
 }
 
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_on_udp_listener_filter_destroy(
   filter_ptr: abi::envoy_dynamic_module_type_udp_listener_filter_module_ptr,
 ) {
-  let _ = unsafe {
-    Box::from_raw(filter_ptr as *mut Box<dyn UdpListenerFilter<EnvoyUdpListenerFilterImpl>>)
-  };
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let _ = unsafe {
+      Box::from_raw(filter_ptr as *mut Box<dyn UdpListenerFilter<EnvoyUdpListenerFilterImpl>>)
+    };
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_udp_listener_filter_destroy", panic);
+  });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
@@ -3,6 +3,7 @@ use crate::{
   NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION,
 };
 use mockall::*;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The module-side bridge configuration.
 ///
@@ -318,27 +319,44 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_config_new(
   name: abi::envoy_dynamic_module_type_envoy_buffer,
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_config_module_ptr {
-  let name_str = unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ))
-  };
-  let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
-  let new_config_fn = NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION
-    .get()
-    .expect("NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION must be set");
-  match new_config_fn(name_str, config_slice) {
-    Some(config) => wrap_into_c_void_ptr!(config),
-    None => std::ptr::null(),
-  }
+  catch_unwind(AssertUnwindSafe(|| {
+    let name_str = unsafe {
+      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+        name.ptr as *const _,
+        name.length,
+      ))
+    };
+    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    let new_config_fn = NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION
+      .get()
+      .expect("NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION must be set");
+    match new_config_fn(name_str, config_slice) {
+      Some(config) => wrap_into_c_void_ptr!(config),
+      None => std::ptr::null(),
+    }
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_config_new",
+      panic,
+    );
+    std::ptr::null()
+  })
 }
 
 #[no_mangle]
 unsafe extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_config_destroy(
   config_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_config_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(config_module_ptr, UpstreamHttpTcpBridgeConfig);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(config_module_ptr, UpstreamHttpTcpBridgeConfig);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_config_destroy",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -346,11 +364,20 @@ unsafe extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_new(
   config_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_config_module_ptr,
   bridge_envoy_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr {
-  let config = config_module_ptr as *const *const dyn UpstreamHttpTcpBridgeConfig;
-  let config = &**config;
-  let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
-  let bridge = config.new_bridge(&envoy_bridge);
-  wrap_into_c_void_ptr!(bridge)
+  catch_unwind(AssertUnwindSafe(|| {
+    let config = config_module_ptr as *const *const dyn UpstreamHttpTcpBridgeConfig;
+    let config = &**config;
+    let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
+    let bridge = config.new_bridge(&envoy_bridge);
+    wrap_into_c_void_ptr!(bridge)
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_new",
+      panic,
+    );
+    std::ptr::null()
+  })
 }
 
 #[no_mangle]
@@ -359,10 +386,18 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_header
   bridge_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr,
   end_of_stream: bool,
 ) {
-  let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
-  let bridge = unsafe { &mut *bridge };
-  let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
-  bridge.on_encode_headers(&envoy_bridge, end_of_stream);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
+    let bridge = unsafe { &mut *bridge };
+    let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
+    bridge.on_encode_headers(&envoy_bridge, end_of_stream);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_headers",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -371,10 +406,18 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_data(
   bridge_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr,
   end_of_stream: bool,
 ) {
-  let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
-  let bridge = unsafe { &mut *bridge };
-  let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
-  bridge.on_encode_data(&envoy_bridge, end_of_stream);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
+    let bridge = unsafe { &mut *bridge };
+    let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
+    bridge.on_encode_data(&envoy_bridge, end_of_stream);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_data",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -382,10 +425,18 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_traile
   bridge_envoy_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_envoy_ptr,
   bridge_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr,
 ) {
-  let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
-  let bridge = unsafe { &mut *bridge };
-  let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
-  bridge.on_encode_trailers(&envoy_bridge);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
+    let bridge = unsafe { &mut *bridge };
+    let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
+    bridge.on_encode_trailers(&envoy_bridge);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_encode_trailers",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
@@ -394,17 +445,33 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_on_upstream_d
   bridge_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr,
   end_of_stream: bool,
 ) {
-  let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
-  let bridge = unsafe { &mut *bridge };
-  let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
-  bridge.on_upstream_data(&envoy_bridge, end_of_stream);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let bridge = bridge_module_ptr as *mut Box<dyn UpstreamHttpTcpBridge>;
+    let bridge = unsafe { &mut *bridge };
+    let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
+    bridge.on_upstream_data(&envoy_bridge, end_of_stream);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_on_upstream_data",
+      panic,
+    );
+  });
 }
 
 #[no_mangle]
 unsafe extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_destroy(
   bridge_module_ptr: abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr,
 ) {
-  drop_wrapped_c_void_ptr!(bridge_module_ptr, UpstreamHttpTcpBridge);
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    drop_wrapped_c_void_ptr!(bridge_module_ptr, UpstreamHttpTcpBridge);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_upstream_http_tcp_bridge_destroy",
+      panic,
+    );
+  });
 }
 
 /// Declare the init functions for the upstream HTTP TCP bridge dynamic module.
@@ -417,16 +484,24 @@ macro_rules! declare_upstream_http_tcp_bridge_init_functions {
   ($f:ident, $new_bridge_config_fn:expr) => {
     #[no_mangle]
     pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
-      envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
-        envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION,
-        $new_bridge_config_fn,
-        "NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION"
-      );
-      if ($f()) {
-        envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
-          as *const ::std::os::raw::c_char
-      } else {
-        ::std::ptr::null()
+      match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
+        envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
+          envoy_proxy_dynamic_modules_rust_sdk::NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION,
+          $new_bridge_config_fn,
+          "NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION"
+        );
+        if ($f()) {
+          envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
+            as *const ::std::os::raw::c_char
+        } else {
+          ::std::ptr::null()
+        }
+      })) {
+        ::std::result::Result::Ok(v) => v,
+        ::std::result::Result::Err(payload) => {
+          $crate::log_ffi_panic("envoy_dynamic_module_on_program_init", payload);
+          ::std::ptr::null()
+        },
       }
     }
   };


### PR DESCRIPTION
## Description

The SDK's `pub (unsafe) extern "C" fn envoy_dynamic_module_*` entries are the C <-> Rust ABI boundary. On default cdylib `panic="unwind"` (Rust ≥1.81), letting a panic unwind across `extern "C"` is undefined behavior which can typically abort the process, but with no Envoy-side log of which module which entry point triggered it. `transport_socket.rs`, `dns_resolver.rs`, and `tracer.rs` already wrapped their entries but the rest of the modules does not.

This change closes the gap. Every uncovered FFI entry across the 11 remaining SDK files including access_log, bootstrap, cert_validator, cluster, http, listener, load_balancer, matcher, network, udp_listener, upstream_http_tcp_bridge, etc. is now wrapped in `std::panic::catch_unwind` with a fail-closed sentinel chosen per the Envoy-side `abi_impl.cc` interpretation.

---

**Commit Message:** dynamic_modules: wrap every Rust SDK FFI entry point in catch_unwind
**Additional Description:** Wraps every Rust SDK FFI entry point in catch_unwind.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A