### PR TITLE
dynamic_modules: replace `from_utf8_unchecked` and bare `from_raw_parts` UB at FFI seam

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -1278,18 +1278,19 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> *const c_void {
   catch_unwind(AssertUnwindSafe(|| {
-    // The name and config originate from protobuf string/bytes fields, so they are valid
-    // UTF-8 and within bounds when received here. Mirrors the http filter FFI entry point.
-    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ));
-    let config_bytes = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    // SAFETY: `name` is a protobuf string (UTF-8 by contract) and `config` is opaque bytes.
+    // The helpers additionally tolerate `(nullptr, 0)` empty inputs, and `str_lossy_from_raw`
+    // substitutes `U+FFFD` for any malformed UTF-8 rather than triggering UB.
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_bytes = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+    };
     let ctx = ConfigContext::new(config_envoy_ptr);
 
     envoy_dynamic_module_on_access_logger_config_new_impl(
       &ctx,
-      name_str,
+      name_str.as_ref(),
       config_bytes,
       crate::NEW_ACCESS_LOGGER_CONFIG_FUNCTION
         .get()

--- a/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
@@ -1241,7 +1241,8 @@ impl EnvoyBootstrapExtension for EnvoyBootstrapExtensionImpl {
       if wrapper.stopped {
         return abi::envoy_dynamic_module_type_stats_iteration_action::Stop;
       }
-      let name_slice = unsafe { std::slice::from_raw_parts(name.ptr as *const u8, name.length) };
+      let name_slice =
+        unsafe { crate::ffi_helpers::slice_from_raw_or_empty(name.ptr as *const u8, name.length) };
       let name_str = std::str::from_utf8(name_slice).unwrap_or("");
       if (wrapper.callback)(name_str, value) {
         abi::envoy_dynamic_module_type_stats_iteration_action::Continue
@@ -1280,7 +1281,8 @@ impl EnvoyBootstrapExtension for EnvoyBootstrapExtensionImpl {
       if wrapper.stopped {
         return abi::envoy_dynamic_module_type_stats_iteration_action::Stop;
       }
-      let name_slice = unsafe { std::slice::from_raw_parts(name.ptr as *const u8, name.length) };
+      let name_slice =
+        unsafe { crate::ffi_helpers::slice_from_raw_or_empty(name.ptr as *const u8, name.length) };
       let name_str = std::str::from_utf8(name_slice).unwrap_or("");
       if (wrapper.callback)(name_str, value) {
         abi::envoy_dynamic_module_type_stats_iteration_action::Continue
@@ -1315,16 +1317,14 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_config_new(
   catch_unwind(AssertUnwindSafe(|| {
     let mut envoy_extension_config =
       EnvoyBootstrapExtensionConfigImpl::new(envoy_extension_config_ptr);
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
     init_bootstrap_extension_config(
       &mut envoy_extension_config,
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_BOOTSTRAP_EXTENSION_CONFIG_FUNCTION
         .get()
@@ -1539,14 +1539,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_http_callou
 
     let headers = if headers_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
       })
     } else {
       None
     };
     let body = if body_chunks_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          body_chunks as *const EnvoyBuffer,
+          body_chunks_size,
+        )
       })
     } else {
       None
@@ -1607,16 +1613,12 @@ pub extern "C" fn envoy_dynamic_module_on_bootstrap_extension_file_changed(
     let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
     let extension_config = unsafe { &**extension_config };
 
-    let path_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        path.ptr as *const u8,
-        path.length,
-      ))
-    };
+    let path_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(path.ptr as *const u8, path.length) };
 
     extension_config.on_file_changed(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      path_str,
+      path_str.as_ref(),
       events,
     );
   }))
@@ -1651,24 +1653,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_admin_reque
     let extension_config = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
     let extension_config = unsafe { &**extension_config };
 
-    let method_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        method.ptr as *const u8,
-        method.length,
-      ))
-    };
-    let path_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        path.ptr as *const u8,
-        path.length,
-      ))
-    };
-    let body_slice = unsafe { std::slice::from_raw_parts(body.ptr as *const u8, body.length) };
+    let method_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(method.ptr as *const u8, method.length) };
+    let path_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(path.ptr as *const u8, path.length) };
+    let body_slice =
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(body.ptr as *const u8, body.length) };
 
     let (status_code, response_str) = extension_config.on_admin_request(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      method_str,
-      path_str,
+      method_str.as_ref(),
+      path_str.as_ref(),
       body_slice,
     );
 
@@ -1714,15 +1709,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_cluster_add
     let extension_config = unsafe { &**extension_config };
 
     let cluster_name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        cluster_name.ptr as *const u8,
-        cluster_name.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(cluster_name.ptr as *const u8, cluster_name.length)
     };
 
     extension_config.on_cluster_add_or_update(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      cluster_name_str,
+      cluster_name_str.as_ref(),
     );
   }))
   .map_err(|panic| {
@@ -1750,15 +1742,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_cluster_rem
     let extension_config = unsafe { &**extension_config };
 
     let cluster_name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        cluster_name.ptr as *const u8,
-        cluster_name.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(cluster_name.ptr as *const u8, cluster_name.length)
     };
 
     extension_config.on_cluster_removal(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      cluster_name_str,
+      cluster_name_str.as_ref(),
     );
   }))
   .map_err(|panic| {
@@ -1786,15 +1775,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_listener_ad
     let extension_config = unsafe { &**extension_config };
 
     let listener_name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        listener_name.ptr as *const u8,
-        listener_name.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(listener_name.ptr as *const u8, listener_name.length)
     };
 
     extension_config.on_listener_add_or_update(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      listener_name_str,
+      listener_name_str.as_ref(),
     );
   }))
   .map_err(|panic| {
@@ -1822,15 +1808,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_listener_re
     let extension_config = unsafe { &**extension_config };
 
     let listener_name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        listener_name.ptr as *const u8,
-        listener_name.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(listener_name.ptr as *const u8, listener_name.length)
     };
 
     extension_config.on_listener_removal(
       &mut EnvoyBootstrapExtensionConfigImpl::new(envoy_ptr),
-      listener_name_str,
+      listener_name_str.as_ref(),
     );
   }))
   .map_err(|panic| {

--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -52,9 +52,15 @@ impl EnvoyBuffer<'_> {
   }
 
   pub fn as_slice(&self) -> &[u8] {
+    // The null guard is inlined here rather than going through `ffi_helpers` so that this
+    // method does not transitively reference `envoy_log_*`. `as_slice` is reached by SDK
+    // doc tests, which compile without `#[cfg(test)]` and so cannot link the host-provided
+    // `envoy_dynamic_module_callback_log` symbols that the logging macros expand to.
     if self.raw_ptr.is_null() {
       return &[];
     }
+    // Safety: caller invariant from `new` / `new_from_raw` that `(raw_ptr, length)` describes
+    // a live region of `length` bytes for the buffer's lifetime.
     unsafe { std::slice::from_raw_parts(self.raw_ptr, self.length) }
   }
 }
@@ -107,17 +113,22 @@ impl EnvoyMutBuffer<'_> {
 
   /// This returns an immutable slice to the underlying memory region managed by Envoy.
   pub fn as_slice(&self) -> &[u8] {
+    // See `EnvoyBuffer::as_slice` for why the null guard is inlined here.
     if self.raw_ptr.is_null() {
       return &[];
     }
+    // Safety: caller invariant from `new` / `new_from_raw`.
     unsafe { std::slice::from_raw_parts(self.raw_ptr, self.length) }
   }
 
   /// This returns a mutable slice to the underlying memory region managed by Envoy.
   pub fn as_mut_slice(&mut self) -> &mut [u8] {
+    // See `EnvoyBuffer::as_slice` for why the null guard is inlined here.
     if self.raw_ptr.is_null() {
       return &mut [];
     }
+    // Safety: caller invariant from `new` / `new_from_raw`, plus exclusive borrow on
+    // the underlying memory for the duration of the returned slice.
     unsafe { std::slice::from_raw_parts_mut(self.raw_ptr, self.length) }
   }
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
@@ -255,13 +255,13 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_cert_validator_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ));
-    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+    };
     init_cert_validator_config(
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_CERT_VALIDATOR_CONFIG_FUNCTION
         .get()
@@ -325,21 +325,23 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_do_verify_cert_c
 
     let envoy_cert_validator = EnvoyCertValidator::new(config_envoy_ptr);
 
-    let cert_buffers = std::slice::from_raw_parts(certs, certs_count);
+    // `certs` may be null when `certs_count` is 0 (for example, a TLS handshake with no
+    // client certificate). `slice_from_raw_or_empty` returns an empty slice for null without
+    // dereferencing.
+    let cert_buffers: &[crate::abi::envoy_dynamic_module_type_envoy_buffer] =
+      crate::ffi_helpers::slice_from_raw_or_empty(certs, certs_count);
     let cert_slices: Vec<&[u8]> = cert_buffers
       .iter()
-      .map(|buf| std::slice::from_raw_parts(buf.ptr as *const u8, buf.length))
+      .map(|buf| crate::ffi_helpers::slice_from_raw_or_empty(buf.ptr as *const u8, buf.length))
       .collect();
 
-    let host_name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      host_name.ptr as *const _,
-      host_name.length,
-    ));
+    let host_name_str =
+      crate::ffi_helpers::str_lossy_from_raw(host_name.ptr as *const u8, host_name.length);
 
     let result = config.do_verify_cert_chain(
       &envoy_cert_validator,
       &cert_slices,
-      host_name_str,
+      host_name_str.as_ref(),
       is_server,
     );
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -986,11 +986,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
       String::new()
     } else {
       unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       }
     }
   }
@@ -1024,11 +1020,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -1088,11 +1080,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -1144,29 +1132,19 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
         let region_str = if region.ptr.is_null() || region.length == 0 {
           String::new()
         } else {
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            region.ptr as *const u8,
-            region.length,
-          ))
-          .to_string()
+          crate::ffi_helpers::str_lossy_from_raw(region.ptr as *const u8, region.length)
+            .into_owned()
         };
         let zone_str = if zone.ptr.is_null() || zone.length == 0 {
           String::new()
         } else {
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            zone.ptr as *const u8,
-            zone.length,
-          ))
-          .to_string()
+          crate::ffi_helpers::str_lossy_from_raw(zone.ptr as *const u8, zone.length).into_owned()
         };
         let sub_zone_str = if sub_zone.ptr.is_null() || sub_zone.length == 0 {
           String::new()
         } else {
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            sub_zone.ptr as *const u8,
-            sub_zone.length,
-          ))
-          .to_string()
+          crate::ffi_helpers::str_lossy_from_raw(sub_zone.ptr as *const u8, sub_zone.length)
+            .into_owned()
         };
         Some((region_str, zone_str, sub_zone_str))
       }
@@ -1220,11 +1198,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -1320,11 +1294,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -1356,11 +1326,7 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const u8,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -1771,15 +1737,10 @@ impl ClusterLbContext for ClusterLbContextImpl {
       raw_headers
         .iter()
         .map(|h| unsafe {
-          let key = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            h.key_ptr as *const u8,
-            h.key_length,
-          ));
-          let value = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            h.value_ptr as *const u8,
-            h.value_length,
-          ));
-          (key.to_string(), value.to_string())
+          let key = crate::ffi_helpers::str_lossy_from_raw(h.key_ptr as *const u8, h.key_length);
+          let value =
+            crate::ffi_helpers::str_lossy_from_raw(h.value_ptr as *const u8, h.value_length);
+          (key.into_owned(), value.into_owned())
         })
         .collect(),
     )
@@ -1805,12 +1766,9 @@ impl ClusterLbContext for ClusterLbContextImpl {
       return None;
     }
     let value = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        result_buffer.ptr as *const u8,
-        result_buffer.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(result_buffer.ptr as *const u8, result_buffer.length)
     };
-    Some((value.to_string(), total_size))
+    Some((value.into_owned(), total_size))
   }
 
   fn get_host_selection_retry_count(&self) -> u32 {
@@ -1848,13 +1806,9 @@ impl ClusterLbContext for ClusterLbContextImpl {
     if !ok {
       return None;
     }
-    let addr_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const u8,
-        address.length,
-      ))
-    };
-    Some((addr_str.to_string(), strict))
+    let addr_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((addr_str.into_owned(), strict))
   }
 
   fn get_downstream_connection_sni(&self) -> Option<String> {
@@ -1872,12 +1826,9 @@ impl ClusterLbContext for ClusterLbContextImpl {
       return None;
     }
     let sni = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        result_buffer.ptr as *const u8,
-        result_buffer.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(result_buffer.ptr as *const u8, result_buffer.length)
     };
-    Some(sni.to_string())
+    Some(sni.into_owned())
   }
 }
 
@@ -1894,19 +1845,21 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_cluster_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    // SAFETY: Envoy guarantees name and config are valid UTF-8 per the ABI contract.
-    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ));
-    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    // SAFETY: `name` is a protobuf string (UTF-8 by contract) and `config` is opaque bytes.
+    // The helpers additionally tolerate `(nullptr, 0)` empty inputs, and `str_lossy_from_raw`
+    // substitutes `U+FFFD` for any malformed UTF-8 rather than triggering UB.
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+    };
     let new_config_fn = NEW_CLUSTER_CONFIG_FUNCTION
       .get()
       .expect("NEW_CLUSTER_CONFIG_FUNCTION must be set");
     let envoy_cluster_metrics: Arc<dyn EnvoyClusterMetrics> = Arc::new(EnvoyClusterMetricsImpl {
       raw: config_envoy_ptr,
     });
-    match new_config_fn(name_str, config_slice, envoy_cluster_metrics) {
+    match new_config_fn(name_str.as_ref(), config_slice, envoy_cluster_metrics) {
       Some(config) => wrap_into_c_void_ptr!(config),
       None => std::ptr::null(),
     }
@@ -2248,7 +2201,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
     let cluster = &mut *cluster;
 
     let headers = if headers_size > 0 {
-      Some(std::slice::from_raw_parts(
+      Some(crate::ffi_helpers::slice_from_raw_or_empty(
         headers as *const (EnvoyBuffer, EnvoyBuffer),
         headers_size,
       ))
@@ -2256,7 +2209,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
       None
     };
     let body = if body_chunks_size > 0 {
-      Some(std::slice::from_raw_parts(
+      Some(crate::ffi_helpers::slice_from_raw_or_empty(
         body_chunks as *const EnvoyBuffer,
         body_chunks_size,
       ))

--- a/source/extensions/dynamic_modules/sdk/rust/src/dns_resolver.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/dns_resolver.rs
@@ -614,15 +614,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_dns_resolver_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    // SAFETY: Envoy guarantees name and config are valid UTF-8 per the ABI contract.
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const u8,
-        name.length,
-      ))
+    // SAFETY: `name` is a protobuf string (UTF-8 by contract) and `config` is opaque bytes.
+    // The helpers additionally tolerate `(nullptr, 0)` empty inputs, and `str_lossy_from_raw`
+    // substitutes `U+FFFD` for any malformed UTF-8 rather than triggering UB.
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice =
-      unsafe { std::slice::from_raw_parts(config.ptr as *const u8, config.length) };
     let new_config_fn = crate::NEW_DNS_RESOLVER_CONFIG_FUNCTION
       .get()
       .expect("NEW_DNS_RESOLVER_CONFIG_FUNCTION must be set");
@@ -630,7 +629,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolver_config_new(
       Arc::new(EnvoyDnsResolverConfigImpl {
         raw: config_envoy_ptr,
       });
-    match new_config_fn(name_str, config_slice, envoy_dns_resolver_config) {
+    match new_config_fn(name_str.as_ref(), config_slice, envoy_dns_resolver_config) {
       Some(config) => wrap_into_c_void_ptr!(config),
       None => std::ptr::null(),
     }
@@ -711,12 +710,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolve(
 ) -> abi::envoy_dynamic_module_type_dns_query_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let wrapper = unsafe { &*(resolver_module_ptr as *const DnsResolverWrapper) };
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        dns_name.ptr as *const u8,
-        dns_name.length,
-      ))
-    };
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(dns_name.ptr as *const u8, dns_name.length) };
 
     let family = match lookup_family {
       abi::envoy_dynamic_module_type_dns_lookup_family::V4Only => DnsLookupFamily::V4Only,
@@ -726,7 +721,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_dns_resolve(
       abi::envoy_dynamic_module_type_dns_lookup_family::All => DnsLookupFamily::All,
     };
 
-    match wrapper.resolver.resolve(name_str, family, query_id) {
+    match wrapper
+      .resolver
+      .resolve(name_str.as_ref(), family, query_id)
+    {
       Some(query) => {
         let boxed = Box::new(query);
         Box::into_raw(boxed) as abi::envoy_dynamic_module_type_dns_query_module_ptr

--- a/source/extensions/dynamic_modules/sdk/rust/src/ffi_helpers.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/ffi_helpers.rs
@@ -1,0 +1,211 @@
+//! Safe wrappers over `slice::from_raw_parts` and `str::from_utf8_unchecked` for the FFI seam.
+//!
+//! Two well-known footguns motivate this module:
+//!
+//! 1. `slice::from_raw_parts(ptr, len)` is undefined behaviour if `ptr` is null, even when `len ==
+//!    0`. Per the [Rust reference][1], the pointer must be non-null and aligned regardless of
+//!    length. C ABIs routinely pass `(nullptr, 0)` to mean "empty".
+//!
+//! 2. `str::from_utf8_unchecked` is undefined behaviour on invalid UTF-8. Many ABI buffers carry
+//!    attacker-influenced bytes (HTTP header values, TLS SNI, EDS metadata) that are not
+//!    contractually UTF-8.
+//!
+//! [1]: https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety
+//!
+//! These helpers are `#[doc(hidden)] pub` so SDK-provided macros that expand in user crates
+//! can reach them; users should call them via the macros rather than directly.
+
+use std::borrow::Cow;
+
+/// Constructs a `&[T]` slice from an FFI-supplied `(ptr, len)` pair.
+///
+/// Common element types include `u8` (byte buffers), `EnvoyBuffer` (chunk arrays), and
+/// `(EnvoyBuffer, EnvoyBuffer)` (header-pair arrays).
+///
+/// - When `ptr` is null, returns an empty slice regardless of `len`. The C convention of passing
+///   `(nullptr, 0)` for "empty" is the well-defined path. A non-zero `len` paired with a null `ptr`
+///   is a caller-side contract violation; this function logs an error via `envoy_log_error!` and
+///   still returns an empty slice rather than dereferencing.
+/// - Otherwise dereferences `(ptr, len)` exactly as `std::slice::from_raw_parts` would.
+///
+/// # Safety
+///
+/// When `ptr` is non-null, the caller must guarantee:
+///   - `ptr` is properly aligned for `T`.
+///   - `ptr` points to `len` consecutive initialised values of `T`.
+///   - The memory outlives the lifetime `'a`. `'a` is freely chosen by the caller; choosing a
+///     lifetime longer than the underlying memory is a contract violation.
+///
+/// When `ptr` is null this function never reads any memory; passing `(nullptr, 0)` is safe.
+#[inline]
+#[doc(hidden)]
+pub unsafe fn slice_from_raw_or_empty<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
+  if ptr.is_null() {
+    if len != 0 {
+      crate::envoy_log_error!(
+        "ffi_helpers::slice_from_raw_or_empty: null ptr with len={len} (treating as empty)"
+      );
+    }
+    return &[];
+  }
+  // Safety: caller upholds the non-null branch's invariants.
+  unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+/// Mutable variant of [`slice_from_raw_or_empty`]. Same semantics; same null-ptr handling.
+///
+/// # Safety
+///
+/// Same constraints as [`slice_from_raw_or_empty`], plus exclusive-borrow on the underlying
+/// values for the lifetime `'a`.
+#[inline]
+#[doc(hidden)]
+pub unsafe fn slice_from_raw_or_empty_mut<'a, T>(ptr: *mut T, len: usize) -> &'a mut [T] {
+  if ptr.is_null() {
+    if len != 0 {
+      crate::envoy_log_error!(
+        "ffi_helpers::slice_from_raw_or_empty_mut: null ptr with len={len} (treating as empty)"
+      );
+    }
+    // `&mut []` is a valid empty mutable slice of any lifetime; no memory is ever written.
+    return &mut [];
+  }
+  // Safety: caller upholds the non-null branch's invariants.
+  unsafe { std::slice::from_raw_parts_mut(ptr, len) }
+}
+
+/// Lossy UTF-8 conversion of an FFI-supplied byte buffer.
+///
+/// Always succeeds: invalid UTF-8 is replaced with `U+FFFD REPLACEMENT CHARACTER` per
+/// [`String::from_utf8_lossy`]. Returns `Cow<'a, str>` so the common case of valid UTF-8
+/// avoids allocation.
+///
+/// Use this helper for any ABI buffer where UTF-8 is the desired representation but not
+/// contractually guaranteed. Examples: filter / cluster / module names from operator config,
+/// HTTP header values, SNI strings, EDS metadata keys/values.
+///
+/// Callers that need "invalid UTF-8 maps to empty" semantics (for example, the
+/// `declare_matcher!` macro, which uses the name as a registry key where `U+FFFD` substitution
+/// would route to a different entry) should call [`slice_from_raw_or_empty`] followed by
+/// `str::from_utf8(...).unwrap_or("")` instead.
+///
+/// # Safety
+///
+/// Same constraints as [`slice_from_raw_or_empty`]. Passing `(nullptr, 0)` is safe and
+/// produces an empty `Cow::Borrowed("")`.
+#[inline]
+#[doc(hidden)]
+pub unsafe fn str_lossy_from_raw<'a>(ptr: *const u8, len: usize) -> Cow<'a, str> {
+  let bytes = unsafe { slice_from_raw_or_empty::<'a>(ptr, len) };
+  String::from_utf8_lossy(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn slice_from_null_ptr_with_zero_len_is_empty() {
+    // Safety: null ptr with zero len is the documented safe path.
+    let slice: &[u8] = unsafe { slice_from_raw_or_empty(std::ptr::null(), 0) };
+    assert!(slice.is_empty());
+  }
+
+  #[test]
+  fn slice_from_valid_ptr_round_trips() {
+    let data = b"hello";
+    // Safety: the borrow lives through the call.
+    let slice: &[u8] = unsafe { slice_from_raw_or_empty(data.as_ptr(), data.len()) };
+    assert_eq!(slice, b"hello");
+  }
+
+  #[test]
+  fn str_lossy_handles_valid_utf8_without_alloc() {
+    let data = b"hello";
+    // Safety: the borrow lives through the call.
+    let s = unsafe { str_lossy_from_raw(data.as_ptr(), data.len()) };
+    assert_eq!(s, "hello");
+    assert!(matches!(s, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn str_lossy_replaces_invalid_utf8() {
+    // 0xff is never a valid UTF-8 byte.
+    let data = [0xff_u8, b'a'];
+    // Safety: the borrow lives through the call.
+    let s = unsafe { str_lossy_from_raw(data.as_ptr(), data.len()) };
+    // U+FFFD followed by 'a'.
+    assert_eq!(s.as_ref(), "\u{fffd}a");
+    assert!(matches!(s, Cow::Owned(_)));
+  }
+
+  #[test]
+  fn str_lossy_from_null_ptr_is_empty() {
+    // Safety: null ptr with zero len is the documented safe path.
+    let s = unsafe { str_lossy_from_raw(std::ptr::null(), 0) };
+    assert_eq!(s, "");
+  }
+
+  #[test]
+  fn slice_mut_from_null_ptr_with_zero_len_is_empty() {
+    // Safety: null ptr with zero len is the documented safe path.
+    let slice: &mut [u8] = unsafe { slice_from_raw_or_empty_mut(std::ptr::null_mut(), 0) };
+    assert!(slice.is_empty());
+  }
+
+  #[test]
+  fn slice_mut_from_valid_ptr_round_trips() {
+    let mut data: [u8; 5] = *b"hello";
+    // Safety: the borrow lives through the call.
+    let slice: &mut [u8] = unsafe { slice_from_raw_or_empty_mut(data.as_mut_ptr(), data.len()) };
+    slice[0] = b'H';
+    assert_eq!(&data, b"Hello");
+  }
+
+  #[test]
+  fn slice_from_null_ptr_with_nonzero_len_returns_empty_and_does_not_panic() {
+    // Contract violation path: caller passed `(null, len > 0)`. The helper logs an error
+    // and returns an empty slice rather than dereferencing.
+    // Safety: null ptr is the documented safe-but-misuse path.
+    let slice: &[u8] = unsafe { slice_from_raw_or_empty(std::ptr::null(), 5) };
+    assert!(slice.is_empty());
+  }
+
+  #[test]
+  fn slice_mut_from_null_ptr_with_nonzero_len_returns_empty_and_does_not_panic() {
+    // Safety: null ptr is the documented safe-but-misuse path.
+    let slice: &mut [u8] = unsafe { slice_from_raw_or_empty_mut(std::ptr::null_mut(), 5) };
+    assert!(slice.is_empty());
+  }
+
+  #[test]
+  fn slice_from_struct_ptr_round_trips() {
+    // Generic over arbitrary `T`; verify with an `(EnvoyBuffer, EnvoyBuffer)`-shaped tuple.
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    struct Pair {
+      a: u32,
+      b: u32,
+    }
+    let data = [
+      Pair { a: 1, b: 2 },
+      Pair { a: 3, b: 4 },
+      Pair { a: 5, b: 6 },
+    ];
+    // Safety: the borrow lives through the call.
+    let slice: &[Pair] = unsafe { slice_from_raw_or_empty(data.as_ptr(), data.len()) };
+    assert_eq!(slice, &data);
+  }
+
+  #[test]
+  fn slice_from_null_struct_ptr_with_nonzero_len_returns_empty() {
+    #[repr(C)]
+    struct Pair {
+      _a: u32,
+      _b: u32,
+    }
+    // Safety: null ptr is the documented safe-but-misuse path.
+    let slice: &[Pair] = unsafe { slice_from_raw_or_empty(std::ptr::null::<Pair>(), 5) };
+    assert!(slice.is_empty());
+  }
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1812,7 +1812,9 @@ impl EnvoySpan for EnvoySpanImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(String::from_utf8_lossy(slice).to_string())
     } else {
       None
@@ -1841,7 +1843,9 @@ impl EnvoySpan for EnvoySpanImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(String::from_utf8_lossy(slice).to_string())
     } else {
       None
@@ -1860,7 +1864,9 @@ impl EnvoySpan for EnvoySpanImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(String::from_utf8_lossy(slice).to_string())
     } else {
       None
@@ -3425,7 +3431,9 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(slice.to_vec())
     } else {
       None
@@ -3803,15 +3811,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_http_filter_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
-    // it is a String at protobuf level.
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    // The name is sourced from a protobuf string field (and thus UTF-8 by contract); we still
+    // route through `str_lossy_from_raw` so a malformed input on the FFI seam produces a lossy
+    // decode rather than undefined behaviour.
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
 
     let mut envoy_filter_config = EnvoyHttpFilterConfigImpl {
       raw_ptr: envoy_filter_config_ptr,
@@ -3819,7 +3826,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_new(
 
     envoy_dynamic_module_on_http_filter_config_new_impl(
       &mut envoy_filter_config,
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_HTTP_FILTER_CONFIG_FUNCTION
         .get()
@@ -3894,18 +3901,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_per_route_config_ne
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_http_filter_per_route_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    // This assumes that the name is a valid UTF-8 string. Should we relax? At the moment,
-    // it is a String at protobuf level.
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    // See `envoy_dynamic_module_on_http_filter_config_new`: route through `str_lossy_from_raw`
+    // so a malformed input on the FFI seam produces a lossy decode rather than undefined
+    // behaviour.
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
 
     envoy_dynamic_module_on_http_filter_per_route_config_new_impl(
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION
         .get()
@@ -4178,14 +4184,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_callout_done(
     let filter = &mut **filter;
     let headers = if headers_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
       })
     } else {
       None
     };
     let body = if body_chunks_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          body_chunks as *const EnvoyBuffer,
+          body_chunks_size,
+        )
       })
     } else {
       None
@@ -4319,7 +4331,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_headers
     let filter = &mut **filter;
     let headers = if headers_size > 0 {
       unsafe {
-        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
       }
     } else {
       &[]
@@ -4356,7 +4371,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_data(
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
     let data = if data_count > 0 {
-      unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(data as *const EnvoyBuffer, data_count) }
     } else {
       &[]
     };
@@ -4392,7 +4407,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_trailer
     let filter = &mut **filter;
     let trailers = if trailers_size > 0 {
       unsafe {
-        std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          trailers as *const (EnvoyBuffer, EnvoyBuffer),
+          trailers_size,
+        )
       }
     } else {
       &[]
@@ -4482,14 +4500,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_callout
     let config = &**config;
     let headers = if headers_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
       })
     } else {
       None
     };
     let body = if body_chunks_size > 0 {
       Some(unsafe {
-        std::slice::from_raw_parts(body_chunks as *const EnvoyBuffer, body_chunks_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          body_chunks as *const EnvoyBuffer,
+          body_chunks_size,
+        )
       })
     } else {
       None
@@ -4530,7 +4554,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
     let config = &**config;
     let headers = if headers_size > 0 {
       unsafe {
-        std::slice::from_raw_parts(headers as *const (EnvoyBuffer, EnvoyBuffer), headers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
       }
     } else {
       &[]
@@ -4569,7 +4596,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
     let config = &**config;
     let data = if data_count > 0 {
-      unsafe { std::slice::from_raw_parts(data as *const EnvoyBuffer, data_count) }
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(data as *const EnvoyBuffer, data_count) }
     } else {
       &[]
     };
@@ -4607,7 +4634,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
     let config = &**config;
     let trailers = if trailers_size > 0 {
       unsafe {
-        std::slice::from_raw_parts(trailers as *const (EnvoyBuffer, EnvoyBuffer), trailers_size)
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          trailers as *const (EnvoyBuffer, EnvoyBuffer),
+          trailers_size,
+        )
       }
     } else {
       &[]

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -12,6 +12,11 @@ pub mod catch_unwind;
 pub mod cert_validator;
 pub mod cluster;
 pub mod dns_resolver;
+// Implementation detail. Public so SDK-provided macros (for example, `declare_matcher!`) that
+// expand in user crates can reach the safe helpers; users should not depend on this module
+// directly.
+#[doc(hidden)]
+pub mod ffi_helpers;
 pub mod http;
 pub mod listener;
 pub mod load_balancer;
@@ -416,8 +421,8 @@ macro_rules! set_factory_once {
       if !::std::ptr::fn_addr_eq(*$static.get().unwrap(), new_val) {
         $crate::envoy_log_critical!(
           "Duplicate factory registration for {}. A different module already registered this \
-           factory. Check dynamic_module_config for conflicting standalone and consolidated \
-           .so loads.",
+           factory. Check dynamic_module_config for conflicting standalone and consolidated .so \
+           loads.",
           $name,
         );
         // Return the "init failed" sentinel rather than panicking; unwinding across the

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3222,6 +3222,116 @@ fn test_cert_validator_do_verify_cert_chain_failed() {
 }
 
 #[test]
+fn test_cert_validator_do_verify_cert_chain_with_null_certs_and_zero_count() {
+  // TLS handshake with no client certificate: Envoy may pass `(certs=null, certs_count=0)`.
+  // The FFI entry must accept this without dereferencing the null pointer.
+  struct TestCertValidatorConfig;
+  impl cert_validator::CertValidatorConfig for TestCertValidatorConfig {
+    fn do_verify_cert_chain(
+      &self,
+      _envoy_cert_validator: &cert_validator::EnvoyCertValidator,
+      certs: &[&[u8]],
+      _host_name: &str,
+      _is_server: bool,
+    ) -> cert_validator::ValidationResult {
+      assert!(certs.is_empty());
+      cert_validator::ValidationResult::successful()
+    }
+    fn get_ssl_verify_mode(&self, _handshaker_provides_certificates: bool) -> i32 {
+      0x03
+    }
+    fn update_digest(&self) -> &[u8] {
+      b"test"
+    }
+  }
+
+  let config: Box<dyn cert_validator::CertValidatorConfig> = Box::new(TestCertValidatorConfig);
+  let config_ptr = Box::into_raw(Box::new(config)) as *const ::std::os::raw::c_void;
+
+  let host_name = "example.com";
+  let host_name_buf = abi::envoy_dynamic_module_type_envoy_buffer {
+    ptr: host_name.as_ptr() as *const _,
+    length: host_name.len(),
+  };
+
+  let result = unsafe {
+    envoy_dynamic_module_on_cert_validator_do_verify_cert_chain(
+      std::ptr::null_mut(),
+      config_ptr,
+      std::ptr::null_mut(),
+      0,
+      host_name_buf,
+      false,
+    )
+  };
+  assert_eq!(
+    result.status,
+    abi::envoy_dynamic_module_type_cert_validator_validation_status::Successful
+  );
+
+  unsafe {
+    envoy_dynamic_module_on_cert_validator_config_destroy(config_ptr);
+  }
+}
+
+#[test]
+fn test_cert_validator_do_verify_cert_chain_with_null_certs_and_nonzero_count_is_safe() {
+  // Caller-side contract violation: `(certs=null, certs_count > 0)`. The FFI entry must log
+  // and treat the cert list as empty rather than dereferencing the null pointer.
+  struct TestCertValidatorConfig;
+  impl cert_validator::CertValidatorConfig for TestCertValidatorConfig {
+    fn do_verify_cert_chain(
+      &self,
+      _envoy_cert_validator: &cert_validator::EnvoyCertValidator,
+      certs: &[&[u8]],
+      _host_name: &str,
+      _is_server: bool,
+    ) -> cert_validator::ValidationResult {
+      assert!(certs.is_empty());
+      cert_validator::ValidationResult::failed(
+        cert_validator::ClientValidationStatus::Failed,
+        None,
+        None,
+      )
+    }
+    fn get_ssl_verify_mode(&self, _handshaker_provides_certificates: bool) -> i32 {
+      0x03
+    }
+    fn update_digest(&self) -> &[u8] {
+      b"test"
+    }
+  }
+
+  let config: Box<dyn cert_validator::CertValidatorConfig> = Box::new(TestCertValidatorConfig);
+  let config_ptr = Box::into_raw(Box::new(config)) as *const ::std::os::raw::c_void;
+
+  let host_name = "example.com";
+  let host_name_buf = abi::envoy_dynamic_module_type_envoy_buffer {
+    ptr: host_name.as_ptr() as *const _,
+    length: host_name.len(),
+  };
+
+  let result = unsafe {
+    envoy_dynamic_module_on_cert_validator_do_verify_cert_chain(
+      std::ptr::null_mut(),
+      config_ptr,
+      std::ptr::null_mut(),
+      5,
+      host_name_buf,
+      false,
+    )
+  };
+  assert_eq!(
+    result.status,
+    abi::envoy_dynamic_module_type_cert_validator_validation_status::Failed
+  );
+
+  unsafe {
+    envoy_dynamic_module_on_cert_validator_config_destroy(config_ptr);
+  }
+}
+
+#[test]
 fn test_cert_validator_filter_state_methods() {
   // Test that EnvoyCertValidator filter state methods call the ABI functions correctly.
   // In unit tests, the ABI functions are weak stubs that return false, so we verify
@@ -5734,4 +5844,308 @@ fn test_outer_ffi_pattern_returns_fail_closed_bool_on_panic() {
     false
   });
   assert!(!result);
+}
+
+// Regression tests for the `*const EnvoyBuffer` / `*const (EnvoyBuffer, EnvoyBuffer)`
+// null-guard migration. Each test invokes a migrated FFI entry with `(null, 0)` for the
+// header- and body-array pairs and verifies that the trait callback receives the empty
+// representation (`None` or `Vec::new()`) without dereferencing the null pointer.
+
+#[test]
+fn test_http_filter_callout_done_with_null_buffers_yields_none() {
+  static GOT_NONE_HEADERS: AtomicBool = AtomicBool::new(false);
+  static GOT_NONE_BODY: AtomicBool = AtomicBool::new(false);
+
+  struct TestHttpFilterConfig;
+  impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for TestHttpFilterConfig {
+    fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+      Box::new(TestHttpFilter)
+    }
+  }
+
+  struct TestHttpFilter;
+  impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for TestHttpFilter {
+    fn on_http_callout_done(
+      &mut self,
+      _envoy_filter: &mut EHF,
+      _callout_id: u64,
+      _result: abi::envoy_dynamic_module_type_http_callout_result,
+      response_headers: Option<&[(EnvoyBuffer, EnvoyBuffer)]>,
+      response_body: Option<&[EnvoyBuffer]>,
+    ) {
+      if response_headers.is_none() {
+        GOT_NONE_HEADERS.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+      if response_body.is_none() {
+        GOT_NONE_BODY.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+  }
+
+  let filter_config = TestHttpFilterConfig;
+  let filter = envoy_dynamic_module_on_http_filter_new_impl(
+    &mut EnvoyHttpFilterImpl {
+      raw_ptr: std::ptr::null_mut(),
+    },
+    &filter_config,
+  );
+
+  unsafe {
+    http::envoy_dynamic_module_on_http_filter_http_callout_done(
+      std::ptr::null_mut(),
+      filter,
+      1,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+    envoy_dynamic_module_on_http_filter_destroy(filter);
+  }
+
+  assert!(GOT_NONE_HEADERS.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(GOT_NONE_BODY.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_network_filter_callout_done_with_null_buffers_yields_empty_vecs() {
+  static GOT_EMPTY_HEADERS: AtomicBool = AtomicBool::new(false);
+  static GOT_EMPTY_BODY: AtomicBool = AtomicBool::new(false);
+
+  struct TestNetworkFilterConfig;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for TestNetworkFilterConfig {
+    fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+      Box::new(TestNetworkFilter)
+    }
+  }
+
+  struct TestNetworkFilter;
+  impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for TestNetworkFilter {
+    fn on_http_callout_done(
+      &mut self,
+      _envoy_filter: &mut ENF,
+      _callout_id: u64,
+      _result: abi::envoy_dynamic_module_type_http_callout_result,
+      headers: Vec<(EnvoyBuffer, EnvoyBuffer)>,
+      body_chunks: Vec<EnvoyBuffer>,
+    ) {
+      if headers.is_empty() {
+        GOT_EMPTY_HEADERS.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+      if body_chunks.is_empty() {
+        GOT_EMPTY_BODY.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+  }
+
+  let filter_config = TestNetworkFilterConfig;
+  let filter = network::envoy_dynamic_module_on_network_filter_new_impl(
+    &mut EnvoyNetworkFilterImpl {
+      raw: std::ptr::null_mut(),
+    },
+    &filter_config,
+  );
+
+  unsafe {
+    network::envoy_dynamic_module_on_network_filter_http_callout_done(
+      std::ptr::null_mut(),
+      filter,
+      1,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+    envoy_dynamic_module_on_network_filter_destroy(filter);
+  }
+
+  assert!(GOT_EMPTY_HEADERS.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(GOT_EMPTY_BODY.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_listener_filter_callout_done_with_null_buffers_yields_empty_vecs() {
+  static GOT_EMPTY_HEADERS: AtomicBool = AtomicBool::new(false);
+  static GOT_EMPTY_BODY: AtomicBool = AtomicBool::new(false);
+
+  struct TestListenerFilterConfig;
+  impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for TestListenerFilterConfig {
+    fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+      Box::new(TestListenerFilter)
+    }
+  }
+
+  struct TestListenerFilter;
+  impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for TestListenerFilter {
+    fn on_http_callout_done(
+      &mut self,
+      _envoy_filter: &mut ELF,
+      _callout_id: u64,
+      _result: abi::envoy_dynamic_module_type_http_callout_result,
+      response_headers: Vec<(EnvoyBuffer, EnvoyBuffer)>,
+      response_body: Vec<EnvoyBuffer>,
+    ) {
+      if response_headers.is_empty() {
+        GOT_EMPTY_HEADERS.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+      if response_body.is_empty() {
+        GOT_EMPTY_BODY.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+  }
+
+  let filter_config = TestListenerFilterConfig;
+  let filter = listener::envoy_dynamic_module_on_listener_filter_new_impl(
+    &mut EnvoyListenerFilterImpl {
+      raw: std::ptr::null_mut(),
+    },
+    &filter_config,
+  );
+
+  unsafe {
+    listener::envoy_dynamic_module_on_listener_filter_http_callout_done(
+      std::ptr::null_mut(),
+      filter,
+      1,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+    envoy_dynamic_module_on_listener_filter_destroy(filter);
+  }
+
+  assert!(GOT_EMPTY_HEADERS.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(GOT_EMPTY_BODY.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_bootstrap_extension_callout_done_with_null_buffers_yields_none() {
+  static GOT_NONE_HEADERS: AtomicBool = AtomicBool::new(false);
+  static GOT_NONE_BODY: AtomicBool = AtomicBool::new(false);
+
+  struct TestBootstrapExtensionConfig;
+  impl BootstrapExtensionConfig for TestBootstrapExtensionConfig {
+    fn new_bootstrap_extension(
+      &self,
+      _envoy_extension: &mut dyn EnvoyBootstrapExtension,
+    ) -> Box<dyn BootstrapExtension> {
+      Box::new(TestBootstrapExtension)
+    }
+
+    fn on_http_callout_done(
+      &self,
+      _envoy_extension_config: &mut dyn EnvoyBootstrapExtensionConfig,
+      _callout_id: u64,
+      _result: abi::envoy_dynamic_module_type_http_callout_result,
+      response_headers: Option<&[(EnvoyBuffer, EnvoyBuffer)]>,
+      response_body: Option<&[EnvoyBuffer]>,
+    ) {
+      if response_headers.is_none() {
+        GOT_NONE_HEADERS.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+      if response_body.is_none() {
+        GOT_NONE_BODY.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+  }
+
+  struct TestBootstrapExtension;
+  impl BootstrapExtension for TestBootstrapExtension {}
+
+  fn new_config(
+    _envoy_extension_config: &mut dyn EnvoyBootstrapExtensionConfig,
+    _name: &str,
+    _config: &[u8],
+  ) -> Option<Box<dyn BootstrapExtensionConfig>> {
+    Some(Box::new(TestBootstrapExtensionConfig))
+  }
+
+  let mut envoy_config = bootstrap::EnvoyBootstrapExtensionConfigImpl::new(std::ptr::null_mut());
+  let config_ptr = bootstrap::init_bootstrap_extension_config(
+    &mut envoy_config,
+    "test",
+    b"config",
+    &(new_config as NewBootstrapExtensionConfigFunction),
+  );
+  assert!(!config_ptr.is_null());
+
+  unsafe {
+    bootstrap::envoy_dynamic_module_on_bootstrap_extension_http_callout_done(
+      std::ptr::null_mut(),
+      config_ptr,
+      1,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+    envoy_dynamic_module_on_bootstrap_extension_config_destroy(config_ptr);
+  }
+
+  assert!(GOT_NONE_HEADERS.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(GOT_NONE_BODY.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_cluster_callout_done_with_null_buffers_yields_none() {
+  use cluster::{Cluster, ClusterLb, EnvoyCluster, EnvoyClusterLoadBalancer};
+
+  static GOT_NONE_HEADERS: AtomicBool = AtomicBool::new(false);
+  static GOT_NONE_BODY: AtomicBool = AtomicBool::new(false);
+
+  struct TestCluster;
+  impl Cluster for TestCluster {
+    fn on_init(&mut self, _envoy_cluster: &dyn EnvoyCluster) {}
+    fn new_load_balancer(&self, _envoy_lb: &dyn EnvoyClusterLoadBalancer) -> Box<dyn ClusterLb> {
+      unimplemented!("not exercised by this test")
+    }
+
+    fn on_http_callout_done(
+      &mut self,
+      _envoy_cluster: &dyn EnvoyCluster,
+      _callout_id: u64,
+      _result: abi::envoy_dynamic_module_type_http_callout_result,
+      response_headers: Option<&[(EnvoyBuffer, EnvoyBuffer)]>,
+      response_body: Option<&[EnvoyBuffer]>,
+    ) {
+      if response_headers.is_none() {
+        GOT_NONE_HEADERS.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+      if response_body.is_none() {
+        GOT_NONE_BODY.store(true, std::sync::atomic::Ordering::SeqCst);
+      }
+    }
+  }
+
+  // Construct the cluster_module_ptr directly without going through the factory chain;
+  // the FFI entry only requires a `*mut Box<dyn Cluster>`, which is what the SDK's
+  // `wrap_into_c_void_ptr!` produces internally.
+  let test_cluster: Box<dyn Cluster> = Box::new(TestCluster);
+  let cluster_ptr =
+    Box::into_raw(Box::new(test_cluster)) as abi::envoy_dynamic_module_type_cluster_module_ptr;
+  let cluster_envoy_ptr = std::ptr::null_mut::<std::os::raw::c_void>()
+    as abi::envoy_dynamic_module_type_cluster_envoy_ptr;
+
+  unsafe {
+    cluster::envoy_dynamic_module_on_cluster_http_callout_done(
+      cluster_envoy_ptr,
+      cluster_ptr,
+      1,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+
+    drop(Box::from_raw(cluster_ptr as *mut Box<dyn Cluster>));
+  }
+
+  assert!(GOT_NONE_HEADERS.load(std::sync::atomic::Ordering::SeqCst));
+  assert!(GOT_NONE_BODY.load(std::sync::atomic::Ordering::SeqCst));
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -568,13 +568,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_local_address(&self) -> Option<(String, u32)> {
@@ -593,13 +589,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_direct_remote_address(&self) -> Option<(String, u32)> {
@@ -618,13 +610,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_direct_local_address(&self) -> Option<(String, u32)> {
@@ -643,13 +631,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_original_dst(&self) -> Option<(String, u32)> {
@@ -668,13 +652,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_address_type(&self) -> abi::envoy_dynamic_module_type_address_type {
@@ -722,13 +702,9 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let value_str = unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const _,
-          result.length,
-        ))
-      };
-      Some(value_str.to_string())
+      let value_str =
+        unsafe { crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length) };
+      Some(value_str.into_owned())
     } else {
       None
     }
@@ -1220,16 +1196,14 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_config_new(
 ) -> abi::envoy_dynamic_module_type_listener_filter_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let mut envoy_filter_config = EnvoyListenerFilterConfigImpl::new(envoy_filter_config_ptr);
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
     init_listener_filter_config(
       &mut envoy_filter_config,
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_LISTENER_FILTER_CONFIG_FUNCTION
         .get()
@@ -1428,31 +1402,25 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_listener_filter_http_callout_do
     let filter = unsafe { &mut *filter };
 
     // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
-    let header_vec = if headers.is_null() || headers_size == 0 {
-      Vec::new()
-    } else {
-      let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
-      headers_slice
-        .iter()
-        .map(|h| {
-          (
-            unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
-            unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
-          )
-        })
-        .collect()
-    };
+    let headers_slice =
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(headers, headers_size) };
+    let header_vec: Vec<(EnvoyBuffer, EnvoyBuffer)> = headers_slice
+      .iter()
+      .map(|h| {
+        (
+          unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
+          unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
+        )
+      })
+      .collect();
 
     // Convert body chunks to Vec<EnvoyBuffer>.
-    let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
-      Vec::new()
-    } else {
-      let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
-      chunks_slice
-        .iter()
-        .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
-        .collect()
-    };
+    let chunks_slice =
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(body_chunks, body_chunks_size) };
+    let body_vec: Vec<EnvoyBuffer> = chunks_slice
+      .iter()
+      .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
+      .collect();
 
     filter.on_http_callout_done(
       &mut EnvoyListenerFilterImpl::new(envoy_ptr),

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -214,11 +214,7 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     unsafe {
       abi::envoy_dynamic_module_callback_lb_get_cluster_name(self.lb_ptr, &mut result);
       if !result.ptr.is_null() && result.length > 0 {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const _,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       } else {
         String::new()
       }
@@ -257,11 +253,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found && !result.ptr.is_null() && result.length > 0 {
       unsafe {
         Some(
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            result.ptr as *const _,
-            result.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length)
+            .into_owned(),
         )
       }
     } else {
@@ -323,11 +316,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found && !result.ptr.is_null() && result.length > 0 {
       unsafe {
         Some(
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            result.ptr as *const _,
-            result.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length)
+            .into_owned(),
         )
       }
     } else {
@@ -378,29 +368,18 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     }
     unsafe {
       let region_str = if !region.ptr.is_null() && region.length > 0 {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          region.ptr as *const _,
-          region.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(region.ptr as *const u8, region.length).into_owned()
       } else {
         String::new()
       };
       let zone_str = if !zone.ptr.is_null() && zone.length > 0 {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          zone.ptr as *const _,
-          zone.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(zone.ptr as *const u8, zone.length).into_owned()
       } else {
         String::new()
       };
       let sub_zone_str = if !sub_zone.ptr.is_null() && sub_zone.length > 0 {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          sub_zone.ptr as *const _,
-          sub_zone.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(sub_zone.ptr as *const u8, sub_zone.length)
+          .into_owned()
       } else {
         String::new()
       };
@@ -458,11 +437,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found && !result.ptr.is_null() && result.length > 0 {
       unsafe {
         Some(
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            result.ptr as *const _,
-            result.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length)
+            .into_owned(),
         )
       }
     } else {
@@ -572,11 +548,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found && !result.ptr.is_null() && result.length > 0 {
       unsafe {
         Some(
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            result.ptr as *const _,
-            result.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length)
+            .into_owned(),
         )
       }
     } else {
@@ -609,11 +582,7 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     };
     if found && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const _,
-          result.length,
-        ))
-        .to_string()
+        crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length).into_owned()
       })
     } else {
       None
@@ -679,16 +648,10 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
         .iter()
         .map(|h| unsafe {
           (
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-              h.key_ptr as *const _,
-              h.key_length,
-            ))
-            .to_string(),
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-              h.value_ptr as *const _,
-              h.value_length,
-            ))
-            .to_string(),
+            crate::ffi_helpers::str_lossy_from_raw(h.key_ptr as *const u8, h.key_length)
+              .into_owned(),
+            crate::ffi_helpers::str_lossy_from_raw(h.value_ptr as *const u8, h.value_length)
+              .into_owned(),
           )
         })
         .collect(),
@@ -720,11 +683,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found {
       unsafe {
         Some((
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            result.ptr as *const _,
-            result.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length)
+            .into_owned(),
           count,
         ))
       }
@@ -775,11 +735,8 @@ impl EnvoyLoadBalancer for EnvoyLoadBalancerImpl {
     if found {
       unsafe {
         Some((
-          std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            address.ptr as *const _,
-            address.length,
-          ))
-          .to_string(),
+          crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length)
+            .into_owned(),
           strict,
         ))
       }
@@ -1310,18 +1267,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_lb_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    let name_str = std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-      name.ptr as *const _,
-      name.length,
-    ));
-    let config_slice = std::slice::from_raw_parts(config.ptr as *const _, config.length);
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+    };
     let new_config_fn = NEW_LOAD_BALANCER_CONFIG_FUNCTION
       .get()
       .expect("NEW_LOAD_BALANCER_CONFIG_FUNCTION must be set");
     let envoy_lb_config: Arc<dyn EnvoyLbConfig> = Arc::new(EnvoyLbConfigImpl {
       raw: lb_config_envoy_ptr,
     });
-    match new_config_fn(name_str, config_slice, envoy_lb_config) {
+    match new_config_fn(name_str.as_ref(), config_slice, envoy_lb_config) {
       Some(config) => wrap_into_c_void_ptr!(config),
       None => std::ptr::null(),
     }

--- a/source/extensions/dynamic_modules/sdk/rust/src/matcher.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/matcher.rs
@@ -5,7 +5,7 @@
 
 use crate::abi;
 use std::ffi::c_void;
-use std::{ptr, slice};
+use std::ptr;
 
 /// Read-only context for accessing HTTP matching data during match evaluation.
 ///
@@ -92,8 +92,8 @@ impl MatchContext {
         .iter()
         .map(|h| unsafe {
           (
-            slice::from_raw_parts(h.key_ptr as *const u8, h.key_length),
-            slice::from_raw_parts(h.value_ptr as *const u8, h.value_length),
+            crate::ffi_helpers::slice_from_raw_or_empty(h.key_ptr as *const u8, h.key_length),
+            crate::ffi_helpers::slice_from_raw_or_empty(h.value_ptr as *const u8, h.value_length),
           )
         })
         .collect(),
@@ -125,7 +125,7 @@ impl MatchContext {
       )
     } {
       unsafe {
-        Some(slice::from_raw_parts(
+        Some(crate::ffi_helpers::slice_from_raw_or_empty(
           result.ptr as *const u8,
           result.length,
         ))
@@ -206,12 +206,17 @@ macro_rules! declare_matcher {
       config: $crate::abi::envoy_dynamic_module_type_envoy_buffer,
     ) -> *const ::std::ffi::c_void {
       ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
-        let name_str = unsafe {
-          let slice = ::std::slice::from_raw_parts(name.ptr as *const u8, name.length);
-          ::std::str::from_utf8(slice).unwrap_or("")
+        // Safe under `(nullptr, 0)` via `ffi_helpers`. The matcher name is used as a registry
+        // lookup key by user `MatcherConfig::new` implementations, so invalid UTF-8 must map to
+        // the empty string rather than being rewritten with `U+FFFD` substitutions; the latter
+        // would silently route invalid bytes to a different registry entry.
+        let name_slice = unsafe {
+          $crate::ffi_helpers::slice_from_raw_or_empty(name.ptr as *const u8, name.length)
         };
-        let config_bytes =
-          unsafe { ::std::slice::from_raw_parts(config.ptr as *const u8, config.length) };
+        let name_str: &str = ::std::str::from_utf8(name_slice).unwrap_or("");
+        let config_bytes = unsafe {
+          $crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+        };
 
         match <$config_type as $crate::matcher::MatcherConfig>::new(name_str, config_bytes) {
           Ok(c) => Box::into_raw(Box::new(c)) as *const ::std::ffi::c_void,

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -886,13 +886,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return (String::new(), 0);
     }
-    let address = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    (address.to_string(), port)
+    let address =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    (address.into_owned(), port)
   }
 
   fn get_local_address(&self) -> (String, u32) {
@@ -911,13 +907,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return (String::new(), 0);
     }
-    let address = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    (address.to_string(), port)
+    let address =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    (address.into_owned(), port)
   }
 
   fn is_ssl(&self) -> bool {
@@ -1162,13 +1154,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let value_str = unsafe {
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-          result.ptr as *const _,
-          result.length,
-        ))
-      };
-      Some(value_str.to_string())
+      let value_str =
+        unsafe { crate::ffi_helpers::str_lossy_from_raw(result.ptr as *const u8, result.length) };
+      Some(value_str.into_owned())
     } else {
       None
     }
@@ -1304,7 +1292,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       )
     };
     if success && !result.ptr.is_null() && result.length > 0 {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(slice.to_vec())
     } else {
       None
@@ -1345,8 +1335,11 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
           abi::envoy_dynamic_module_type_socket_option_value_type::Bytes => {
             if !opt.byte_value.ptr.is_null() && opt.byte_value.length > 0 {
               let bytes = unsafe {
-                std::slice::from_raw_parts(opt.byte_value.ptr as *const u8, opt.byte_value.length)
-                  .to_vec()
+                crate::ffi_helpers::slice_from_raw_or_empty(
+                  opt.byte_value.ptr as *const u8,
+                  opt.byte_value.length,
+                )
+                .to_vec()
               };
               SocketOptionValue::Bytes(bytes)
             } else {
@@ -1530,13 +1523,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_upstream_host_hostname(&self) -> Option<String> {
@@ -1553,13 +1542,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     if !result || hostname.length == 0 || hostname.ptr.is_null() {
       return None;
     }
-    let hostname_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        hostname.ptr as *const _,
-        hostname.length,
-      ))
-    };
-    Some(hostname_str.to_string())
+    let hostname_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(hostname.ptr as *const u8, hostname.length) };
+    Some(hostname_str.into_owned())
   }
 
   fn get_upstream_host_cluster(&self) -> Option<String> {
@@ -1577,12 +1562,9 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       return None;
     }
     let cluster_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        cluster_name.ptr as *const _,
-        cluster_name.length,
-      ))
+      crate::ffi_helpers::str_lossy_from_raw(cluster_name.ptr as *const u8, cluster_name.length)
     };
-    Some(cluster_str.to_string())
+    Some(cluster_str.into_owned())
   }
 
   fn has_upstream_host(&self) -> bool {
@@ -1656,16 +1638,14 @@ pub extern "C" fn envoy_dynamic_module_on_network_filter_config_new(
 ) -> abi::envoy_dynamic_module_type_network_filter_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let mut envoy_filter_config = EnvoyNetworkFilterConfigImpl::new(envoy_filter_config_ptr);
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
     init_network_filter_config(
       &mut envoy_filter_config,
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_NETWORK_FILTER_CONFIG_FUNCTION
         .get()
@@ -1855,31 +1835,25 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_network_filter_http_callout_don
     let filter = unsafe { &mut *filter };
 
     // Convert headers to Vec<(EnvoyBuffer, EnvoyBuffer)>.
-    let header_vec = if headers.is_null() || headers_size == 0 {
-      Vec::new()
-    } else {
-      let headers_slice = unsafe { std::slice::from_raw_parts(headers, headers_size) };
-      headers_slice
-        .iter()
-        .map(|h| {
-          (
-            unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
-            unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
-          )
-        })
-        .collect()
-    };
+    let headers_slice =
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(headers, headers_size) };
+    let header_vec: Vec<(EnvoyBuffer, EnvoyBuffer)> = headers_slice
+      .iter()
+      .map(|h| {
+        (
+          unsafe { EnvoyBuffer::new_from_raw(h.key_ptr as *const _, h.key_length) },
+          unsafe { EnvoyBuffer::new_from_raw(h.value_ptr as *const _, h.value_length) },
+        )
+      })
+      .collect();
 
     // Convert body chunks to Vec<EnvoyBuffer>.
-    let body_vec = if body_chunks.is_null() || body_chunks_size == 0 {
-      Vec::new()
-    } else {
-      let chunks_slice = unsafe { std::slice::from_raw_parts(body_chunks, body_chunks_size) };
-      chunks_slice
-        .iter()
-        .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
-        .collect()
-    };
+    let chunks_slice =
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(body_chunks, body_chunks_size) };
+    let body_vec: Vec<EnvoyBuffer> = chunks_slice
+      .iter()
+      .map(|c| unsafe { EnvoyBuffer::new_from_raw(c.ptr as *const _, c.length) })
+      .collect();
 
     filter.on_http_callout_done(
       &mut EnvoyNetworkFilterImpl::new(envoy_ptr),

--- a/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/tracer.rs
@@ -448,7 +448,9 @@ impl EnvoyTracerSpanImpl {
     };
     let found = unsafe { getter(self.raw, &mut result) };
     if found && !result.ptr.is_null() {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(slice.to_vec())
     } else {
       None
@@ -471,7 +473,9 @@ impl EnvoyTracerSpan for EnvoyTracerSpanImpl {
       )
     };
     if found && !result.ptr.is_null() {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       Some(slice.to_vec())
     } else {
       None
@@ -551,15 +555,18 @@ impl SpanWrapper {
 // Panic-safe FFI helper
 // -----------------------------------------------------------------------------
 
-/// Decode an envoy_buffer into a `&str` without UTF-8 validation.
+/// Decode an envoy_buffer into a `Cow<'static, str>` with lossy UTF-8 fallback.
+///
+/// Routes through [`crate::ffi_helpers::str_lossy_from_raw`] so a malformed input on the FFI
+/// seam produces a lossy decode rather than undefined behaviour.
 ///
 /// # Safety
 ///
-/// The buffer must contain valid UTF-8 data and the pointer must be valid for the given length.
-unsafe fn envoy_buffer_to_str(buf: abi::envoy_dynamic_module_type_envoy_buffer) -> &'static str {
-  unsafe {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(buf.ptr as *const _, buf.length))
-  }
+/// Same constraints as [`crate::ffi_helpers::str_lossy_from_raw`].
+unsafe fn envoy_buffer_to_str(
+  buf: abi::envoy_dynamic_module_type_envoy_buffer,
+) -> std::borrow::Cow<'static, str> {
+  unsafe { crate::ffi_helpers::str_lossy_from_raw(buf.ptr as *const u8, buf.length) }
 }
 
 // -----------------------------------------------------------------------------
@@ -578,14 +585,16 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_config_new(
 ) -> abi::envoy_dynamic_module_type_tracer_config_module_ptr {
   let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let name_str = unsafe { envoy_buffer_to_str(name) };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
+    };
     let ctx = TracerConfigContext {
       envoy_ptr: config_envoy_ptr,
     };
     let new_config_fn = NEW_TRACER_CONFIG_FUNCTION
       .get()
       .expect("NEW_TRACER_CONFIG_FUNCTION must be set");
-    match new_config_fn(ctx, name_str, config_slice) {
+    match new_config_fn(ctx, name_str.as_ref(), config_slice) {
       Some(config) => wrap_into_c_void_ptr!(config),
       None => std::ptr::null(),
     }
@@ -636,7 +645,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_start_span(
     let config = unsafe { &**config };
     let envoy_span = EnvoyTracerSpanImpl::new(span_envoy_ptr);
     let op_name = unsafe { envoy_buffer_to_str(operation_name) };
-    match config.start_span(&envoy_span, op_name, traced, reason.into()) {
+    match config.start_span(&envoy_span, op_name.as_ref(), traced, reason.into()) {
       Some(span) => {
         let wrapper = SpanWrapper::new(span);
         wrap_into_c_void_ptr!(wrapper)
@@ -665,7 +674,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_set_operation(
   let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let op = unsafe { envoy_buffer_to_str(operation) };
-    wrapper.inner.set_operation(op);
+    wrapper.inner.set_operation(op.as_ref());
   }));
 }
 
@@ -683,7 +692,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_set_tag(
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let k = unsafe { envoy_buffer_to_str(key) };
     let v = unsafe { envoy_buffer_to_str(value) };
-    wrapper.inner.set_tag(k, v);
+    wrapper.inner.set_tag(k.as_ref(), v.as_ref());
   }));
 }
 
@@ -700,7 +709,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_log(
   let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let e = unsafe { envoy_buffer_to_str(event) };
-    wrapper.inner.log(timestamp_ns, e);
+    wrapper.inner.log(timestamp_ns, e.as_ref());
   }));
 }
 
@@ -747,7 +756,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_spawn_child(
   let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let n = unsafe { envoy_buffer_to_str(name) };
-    match wrapper.inner.spawn_child(n, start_time_ns) {
+    match wrapper.inner.spawn_child(n.as_ref(), start_time_ns) {
       Some(child) => {
         let child_wrapper = SpanWrapper::new(child);
         wrap_into_c_void_ptr!(child_wrapper)
@@ -807,7 +816,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_get_baggage(
   let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let k = unsafe { envoy_buffer_to_str(key) };
-    match wrapper.inner.get_baggage(k) {
+    match wrapper.inner.get_baggage(k.as_ref()) {
       Some(val) => {
         wrapper.write_scratch_to_out(val, value_out);
         true
@@ -847,7 +856,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_tracer_span_set_baggage(
     let wrapper = unsafe { &mut *(span_module_ptr as *mut SpanWrapper) };
     let k = unsafe { envoy_buffer_to_str(key) };
     let v = unsafe { envoy_buffer_to_str(value) };
-    wrapper.inner.set_baggage(k, v);
+    wrapper.inner.set_baggage(k.as_ref(), v.as_ref());
   }));
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
@@ -406,8 +406,9 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_factory_config
   is_upstream: bool,
 ) -> abi::envoy_dynamic_module_type_transport_socket_factory_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    let name_bytes =
-      unsafe { std::slice::from_raw_parts(socket_name.ptr as *const u8, socket_name.length) };
+    let name_bytes = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(socket_name.ptr as *const u8, socket_name.length)
+    };
     let name_str = match std::str::from_utf8(name_bytes) {
       Ok(s) => s,
       Err(_) => {
@@ -415,8 +416,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_transport_socket_factory_config
         return std::ptr::null();
       },
     };
-    let config_slice =
-      unsafe { std::slice::from_raw_parts(socket_config.ptr as *const u8, socket_config.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(
+        socket_config.ptr as *const u8,
+        socket_config.length,
+      )
+    };
     let Some(new_config_fn) = crate::NEW_TRANSPORT_SOCKET_FACTORY_CONFIG_FUNCTION.get() else {
       crate::envoy_log_error!(
         "transport socket factory config function not registered; ensure \

--- a/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
@@ -259,13 +259,9 @@ impl EnvoyUdpListenerFilter for EnvoyUdpListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn get_local_address(&self) -> Option<(String, u32)> {
@@ -284,13 +280,9 @@ impl EnvoyUdpListenerFilter for EnvoyUdpListenerFilterImpl {
     if !result || address.length == 0 || address.ptr.is_null() {
       return None;
     }
-    let address_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        address.ptr as *const _,
-        address.length,
-      ))
-    };
-    Some((address_str.to_string(), port))
+    let address_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(address.ptr as *const u8, address.length) };
+    Some((address_str.into_owned(), port))
   }
 
   fn send_datagram(&mut self, data: &[u8], peer_address: &str, peer_port: u32) -> bool {
@@ -401,16 +393,14 @@ pub extern "C" fn envoy_dynamic_module_on_udp_listener_filter_config_new(
 ) -> abi::envoy_dynamic_module_type_udp_listener_filter_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let mut envoy_filter_config = EnvoyUdpListenerFilterConfigImpl::new(envoy_filter_config_ptr);
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
     init_udp_listener_filter_config(
       &mut envoy_filter_config,
-      name_str,
+      name_str.as_ref(),
       config_slice,
       NEW_UDP_LISTENER_FILTER_CONFIG_FUNCTION
         .get()

--- a/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
@@ -140,7 +140,8 @@ impl EnvoyUpstreamHttpTcpBridgeImpl {
     let mut result = Vec::new();
     for buf in buffers.iter().take(num_slices) {
       if !buf.ptr.is_null() && buf.length > 0 {
-        let slice = unsafe { std::slice::from_raw_parts(buf.ptr as *const u8, buf.length) };
+        let slice =
+          unsafe { crate::ffi_helpers::slice_from_raw_or_empty(buf.ptr as *const u8, buf.length) };
         result.extend_from_slice(slice);
       }
     }
@@ -180,7 +181,9 @@ impl EnvoyUpstreamHttpTcpBridge for EnvoyUpstreamHttpTcpBridgeImpl {
       )
     };
     if found && !result.ptr.is_null() {
-      let slice = unsafe { std::slice::from_raw_parts(result.ptr as *const u8, result.length) };
+      let slice = unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(result.ptr as *const u8, result.length)
+      };
       (Some(slice.to_vec()), total_count)
     } else {
       (None, total_count)
@@ -220,8 +223,10 @@ impl EnvoyUpstreamHttpTcpBridge for EnvoyUpstreamHttpTcpBridgeImpl {
       .iter()
       .map(|h| unsafe {
         (
-          std::slice::from_raw_parts(h.key_ptr as *const u8, h.key_length).to_vec(),
-          std::slice::from_raw_parts(h.value_ptr as *const u8, h.value_length).to_vec(),
+          crate::ffi_helpers::slice_from_raw_or_empty(h.key_ptr as *const u8, h.key_length)
+            .to_vec(),
+          crate::ffi_helpers::slice_from_raw_or_empty(h.value_ptr as *const u8, h.value_length)
+            .to_vec(),
         )
       })
       .collect()
@@ -320,17 +325,15 @@ pub extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_config_new(
   config: abi::envoy_dynamic_module_type_envoy_buffer,
 ) -> abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_config_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    let name_str = unsafe {
-      std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        name.ptr as *const _,
-        name.length,
-      ))
+    let name_str =
+      unsafe { crate::ffi_helpers::str_lossy_from_raw(name.ptr as *const u8, name.length) };
+    let config_slice = unsafe {
+      crate::ffi_helpers::slice_from_raw_or_empty(config.ptr as *const u8, config.length)
     };
-    let config_slice = unsafe { std::slice::from_raw_parts(config.ptr as *const _, config.length) };
     let new_config_fn = NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION
       .get()
       .expect("NEW_UPSTREAM_HTTP_TCP_BRIDGE_CONFIG_FUNCTION must be set");
-    match new_config_fn(name_str, config_slice) {
+    match new_config_fn(name_str.as_ref(), config_slice) {
       Some(config) => wrap_into_c_void_ptr!(config),
       None => std::ptr::null(),
     }


### PR DESCRIPTION
## Description

Replaces all unsafe `std::slice::from_raw_parts` and `std::str::from_utf8_unchecked` call sites at the C-Rust FFI boundary with safe wrappers in a new `ffi_helpers` module. The wrappers null-guard FFI inputs and lossy-decode invalid UTF-8 instead of UB, and emit a structured error log on contract violation.

This closes the `(nullptr, 0)` UB class for both `*const u8` byte buffers and `*const T` struct arrays such as `*const EnvoyBuffer` and `*const (EnvoyBuffer, EnvoyBuffer)` header pairs.

---

**Commit Message:** dynamic_modules: replace `from_utf8_unchecked` and bare `from_raw_parts` UB at FFI seam
**Additional Description:** Replaced `from_utf8_unchecked` and bare `from_raw_parts` UB at FFI seam
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A