### PR TITLE
dynamic_modules: harden cache-hit module load + atomic stat_creation_frozen_

### DIFF
--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -17,8 +17,10 @@ envoy_cc_library(
     ],
     deps = [
         "//envoy/common:exception_lib",
+        "//source/common/common:hex_lib",
         "//source/common/common:utility_lib",
         "//source/extensions/dynamic_modules/abi",
+        "@boringssl//:crypto",
     ],
 )
 

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -15,12 +15,12 @@ envoy_cc_library(
     hdrs = [
         "dynamic_modules.h",
     ],
+    external_deps = ["ssl"],
     deps = [
         "//envoy/common:exception_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:utility_lib",
         "//source/extensions/dynamic_modules/abi",
-        "@boringssl//:crypto",
     ],
 )
 

--- a/source/extensions/dynamic_modules/dynamic_modules.cc
+++ b/source/extensions/dynamic_modules/dynamic_modules.cc
@@ -4,14 +4,19 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <fstream>
 #include <string>
 
 #include "envoy/common/exception.h"
 
+#include "source/common/common/hex.h"
 #include "source/common/common/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
 
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
+#include "openssl/evp.h"
+#include "openssl/sha.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -153,6 +158,49 @@ void* DynamicModule::getSymbol(const absl::string_view symbol_ref) const {
 
 std::filesystem::path moduleTempPath(const absl::string_view sha256) {
   return std::filesystem::temp_directory_path() / fmt::format("envoy_dynamic_module_{}.so", sha256);
+}
+
+absl::Status verifyFileSha256(const std::filesystem::path& path,
+                              absl::string_view expected_sha256_hex) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    return absl::InternalError(absl::StrCat(
+        "Failed to open file for SHA256 verification: ", path.string(), ": ", errorDetails(errno)));
+  }
+  bssl::ScopedEVP_MD_CTX ctx;
+  if (EVP_DigestInit(ctx.get(), EVP_sha256()) != 1) {
+    return absl::InternalError("Failed to initialize SHA256 digest context");
+  }
+  // 64 KiB chunks: large enough to keep syscall overhead low, small enough to keep stack clean.
+  std::array<char, 65536> buf;
+  while (file) {
+    file.read(buf.data(), buf.size());
+    const std::streamsize got = file.gcount();
+    if (got > 0 && EVP_DigestUpdate(ctx.get(), buf.data(), static_cast<size_t>(got)) != 1) {
+      return absl::InternalError("Failed to update SHA256 digest");
+    }
+    if (file.bad()) {
+      return absl::InternalError(
+          absl::StrCat("I/O error reading file for SHA256 verification: ", path.string()));
+    }
+  }
+  std::array<uint8_t, SHA256_DIGEST_LENGTH> digest;
+  if (EVP_DigestFinal(ctx.get(), digest.data(), nullptr) != 1) {
+    return absl::InternalError("Failed to finalize SHA256 digest");
+  }
+  std::string actual_hex = Hex::encode(digest.data(), digest.size());
+  // The expected hash is operator-supplied (proto config, not user input) and the actual digest
+  // is computed from a file the attacker may control; the only information leaked by an
+  // early-exit comparison is "wrong remote module", which carries no secret. A constant-time
+  // compare is therefore not warranted here.
+  std::string expected_normalised{expected_sha256_hex};
+  absl::AsciiStrToLower(&expected_normalised);
+  if (actual_hex != expected_normalised) {
+    return absl::FailedPreconditionError(
+        absl::StrCat("SHA256 mismatch for cached dynamic module at ", path.string(), ": expected ",
+                     expected_normalised, " got ", actual_hex));
+  }
+  return absl::OkStatus();
 }
 
 absl::Status writeDynamicModuleBytesToDisk(const absl::string_view module_bytes,

--- a/source/extensions/dynamic_modules/dynamic_modules.h
+++ b/source/extensions/dynamic_modules/dynamic_modules.h
@@ -145,6 +145,24 @@ absl::Status writeDynamicModuleBytesToDisk(absl::string_view module_bytes,
  */
 std::filesystem::path moduleTempPath(absl::string_view sha256);
 
+/**
+ * Verifies that the file at ``path`` has SHA256 digest equal to ``expected_sha256_hex``.
+ *
+ * This is used to defend the cache-hit fast path in remote-module loading: ``moduleTempPath``
+ * is a deterministic location under ``/tmp`` derived from the expected hash. Without this
+ * check, an attacker who can write to ``/tmp`` (a co-tenant container or shared host) can
+ * pre-populate the path with a malicious shared object that Envoy will then dlopen, yielding
+ * attacker-controlled code execution.
+ *
+ * @param path absolute path to the file to verify.
+ * @param expected_sha256_hex the hex-encoded expected SHA256 digest (64 chars). The
+ *        comparison is case-insensitive.
+ * @return OkStatus when the on-disk SHA256 matches; FailedPreconditionError on mismatch;
+ *         InternalError on any I/O failure.
+ */
+absl::Status verifyFileSha256(const std::filesystem::path& path,
+                              absl::string_view expected_sha256_hex);
+
 } // namespace DynamicModules
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -457,7 +457,9 @@ envoy_dynamic_module_callback_http_filter_config_define_counter(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* counter_id_ptr) {
   auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
-  if (filter_config->stat_creation_frozen_) {
+  // Acquire-load pairs with the release-store in the factory's
+  // ``newDynamicModuleHttpFilterConfig``. See filter_config.h for the memory-order contract.
+  if (filter_config->stat_creation_frozen_.load(std::memory_order_acquire)) {
     return envoy_dynamic_module_type_metrics_result_Frozen;
   }
   absl::string_view name_view(name.ptr, name.length);
@@ -517,7 +519,9 @@ envoy_dynamic_module_callback_http_filter_config_define_gauge(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* gauge_id_ptr) {
   auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
-  if (filter_config->stat_creation_frozen_) {
+  // Acquire-load pairs with the release-store in the factory's
+  // ``newDynamicModuleHttpFilterConfig``. See filter_config.h for the memory-order contract.
+  if (filter_config->stat_creation_frozen_.load(std::memory_order_acquire)) {
     return envoy_dynamic_module_type_metrics_result_Frozen;
   }
   absl::string_view name_view(name.ptr, name.length);
@@ -630,7 +634,9 @@ envoy_dynamic_module_callback_http_filter_config_define_histogram(
     envoy_dynamic_module_type_module_buffer* label_names, size_t label_names_length,
     size_t* histogram_id_ptr) {
   auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
-  if (filter_config->stat_creation_frozen_) {
+  // Acquire-load pairs with the release-store in the factory's
+  // ``newDynamicModuleHttpFilterConfig``. See filter_config.h for the memory-order contract.
+  if (filter_config->stat_creation_frozen_.load(std::memory_order_acquire)) {
     return envoy_dynamic_module_type_metrics_result_Frozen;
   }
   absl::string_view name_view(name.ptr, name.length);

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -1,10 +1,13 @@
 #include "source/extensions/filters/http/dynamic_modules/factory.h"
 
 #include <filesystem>
+#include <system_error>
 
+#include "source/common/common/logger.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/extensions/common/wasm/remote_async_datasource.h"
 #include "source/extensions/dynamic_modules/background_fetch_manager.h"
+#include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
 
@@ -95,18 +98,38 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
       // filesystem itself acts as the cache.
       auto cached_path = Extensions::DynamicModules::moduleTempPath(sha256);
       if (std::filesystem::exists(cached_path)) {
-        dynamic_module = Extensions::DynamicModules::newDynamicModule(
-            cached_path, module_config.do_not_close(), module_config.load_globally());
-        if (dynamic_module.ok()) {
-          Extensions::DynamicModules::BackgroundFetchManager::singleton(context.singletonManager())
-              ->erase(sha256);
-          return buildFilterFactoryCallback(std::move(dynamic_module.value()), proto_config,
-                                            module_config, context, scope);
+        // Re-verify SHA256 of the cached file before dlopen. The cache path is in /tmp, which
+        // may be writable by other processes (co-tenant containers, shared hosts); without this
+        // check, an attacker who pre-populates ``/tmp/envoy_dynamic_module_<expected_sha>.so``
+        // with a malicious shared object turns the cache-hit fast path into arbitrary code
+        // execution. The fetch path that wrote the cached file already verified the hash, but
+        // we cannot trust that the file was not replaced between writes.
+        const auto verify_status =
+            Extensions::DynamicModules::verifyFileSha256(cached_path, sha256);
+        if (!verify_status.ok()) {
+          // Tampered or corrupted cache entry — remove it and fall through to the fetch path
+          // below so the legitimate remote source can re-supply correct bytes.
+          std::error_code ec;
+          std::filesystem::remove(cached_path, ec);
+          ENVOY_LOG_MISC(warn,
+                         "dynamic_modules: removed cached file failing SHA256 verification: {}",
+                         verify_status.message());
+          // Fall through to the fetch logic below.
+        } else {
+          dynamic_module = Extensions::DynamicModules::newDynamicModule(
+              cached_path, module_config.do_not_close(), module_config.load_globally());
+          if (dynamic_module.ok()) {
+            Extensions::DynamicModules::BackgroundFetchManager::singleton(
+                context.singletonManager())
+                ->erase(sha256);
+            return buildFilterFactoryCallback(std::move(dynamic_module.value()), proto_config,
+                                              module_config, context, scope);
+          }
+          // File exists, hash matches, but failed to load — re-fetching the same SHA256 would
+          // produce identical bytes, so there is no point in falling through.
+          return absl::InvalidArgumentError("Cached remote module failed to load: " +
+                                            std::string(dynamic_module.status().message()));
         }
-        // File exists but failed to load — re-fetching the same SHA256 would produce
-        // identical bytes, so there is no point in falling through to the remote path.
-        return absl::InvalidArgumentError("Cached remote module failed to load: " +
-                                          std::string(dynamic_module.status().message()));
       }
 
       // In NACK mode, reject the config and kick off a background fetch. The control

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -214,7 +214,12 @@ absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilte
   }
 
   config->terminal_filter_ = terminal_filter;
-  config->stat_creation_frozen_ = true;
+  // Release-store: pairs with the acquire-loads in the per-request ``define_*`` callbacks
+  // (in abi_impl.cc) so a worker thread that observes ``stat_creation_frozen_=true`` is
+  // guaranteed to also observe all preceding writes to ``config``. Defends against an
+  // adversarial module spawning a worker inside ``on_http_filter_config_new`` that reads the
+  // flag before the C++-side shared_ptr publication establishes happens-before.
+  config->stat_creation_frozen_.store(true, std::memory_order_release);
 
   config->in_module_config_ = filter_config_envoy_ptr;
   config->on_http_filter_config_destroy_ = on_config_destroy.value();

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "envoy/server/factory_context.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -134,7 +136,15 @@ public:
   // We only allow the module to create stats during envoy_dynamic_module_on_http_filter_config_new,
   // and not later during request handling, so that we don't have to wrap the stat storage in a
   // lock.
-  bool stat_creation_frozen_ = false;
+  //
+  // ``stat_creation_frozen_`` is set by the factory (main thread, before any worker observes
+  // this config) and read by the per-request ``define_*`` ABI callbacks (worker thread). The
+  // store/load pair establishes the necessary happens-before via release/acquire ordering;
+  // pre-fix this was a plain ``bool`` whose load was racy with the publishing store under the
+  // C++ memory model, even though steady-state shared_ptr publication usually masked it. An
+  // adversarial module spawning a worker thread inside ``on_http_filter_config_new`` could
+  // observe the stale ``false`` and reproduce the seed StatNamePool race.
+  std::atomic<bool> stat_creation_frozen_{false};
 
   bool terminal_filter_ = false;
 

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -36,6 +36,9 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         ":util",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:hex_lib",
+        "//source/common/crypto:utility_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//test/extensions/dynamic_modules/test_data/c:matcher_no_op_static",

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -1,10 +1,14 @@
 #include <fstream>
 
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/hex.h"
+#include "source/common/crypto/utility.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/ascii.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -230,6 +234,100 @@ TEST(NewDynamicModuleFromBytes, InvalidBytes) {
 
   // The invalid file should have been cleaned up.
   EXPECT_FALSE(std::filesystem::exists(temp_path));
+}
+
+TEST(VerifyFileSha256, RoundTripWithComputedDigest) {
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_round_trip.bin";
+  const std::string contents = "the quick brown fox jumps over the lazy dog";
+  {
+    std::ofstream out(tmp, std::ios::binary);
+    out << contents;
+  }
+  Buffer::OwnedImpl hash_buffer(contents);
+  const std::string expected_hex =
+      Hex::encode(Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
+  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  std::filesystem::remove(tmp);
+}
+
+TEST(VerifyFileSha256, MismatchReturnsFailedPrecondition) {
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_mismatch.bin";
+  {
+    std::ofstream out(tmp, std::ios::binary);
+    out << "envoy";
+  }
+  const std::string wrong_sha = "0000000000000000000000000000000000000000000000000000000000000000";
+  auto status = verifyFileSha256(tmp, wrong_sha);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()), testing::HasSubstr("SHA256 mismatch"));
+  EXPECT_THAT(std::string(status.message()), testing::HasSubstr(wrong_sha));
+  std::filesystem::remove(tmp);
+}
+
+TEST(VerifyFileSha256, MissingFileReturnsInternal) {
+  const std::filesystem::path missing =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_missing.bin";
+  std::filesystem::remove(missing);
+  ASSERT_FALSE(std::filesystem::exists(missing));
+  auto status =
+      verifyFileSha256(missing, "0000000000000000000000000000000000000000000000000000000000000000");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInternal);
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("Failed to open file for SHA256 verification"));
+}
+
+TEST(VerifyFileSha256, EmptyFileMatchesEmptyDigest) {
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_empty.bin";
+  { std::ofstream out(tmp, std::ios::binary); }
+  // SHA256 of the empty input.
+  const std::string empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  EXPECT_TRUE(verifyFileSha256(tmp, empty_sha).ok());
+  std::filesystem::remove(tmp);
+}
+
+TEST(VerifyFileSha256, LargeFileExceedingChunkSize) {
+  // Force the helper through multiple iterations of its 64 KiB read loop. 200 KiB picks up
+  // three full chunks plus a partial tail, exercising the streaming `SHA256_Update` path.
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_large.bin";
+  std::string contents(200 * 1024, '\0');
+  for (size_t i = 0; i < contents.size(); ++i) {
+    contents[i] = static_cast<char>(i & 0xFF);
+  }
+  {
+    std::ofstream out(tmp, std::ios::binary);
+    out.write(contents.data(), contents.size());
+  }
+  Buffer::OwnedImpl hash_buffer(contents);
+  const std::string expected_hex =
+      Hex::encode(Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
+  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  std::filesystem::remove(tmp);
+}
+
+TEST(VerifyFileSha256, MixedCaseExpectedHexNormalised) {
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() / "envoy_verify_sha256_mixed_case.bin";
+  const std::string contents = "case-insensitive-hash";
+  {
+    std::ofstream out(tmp, std::ios::binary);
+    out << contents;
+  }
+  Buffer::OwnedImpl hash_buffer(contents);
+  std::string expected_hex =
+      Hex::encode(Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
+  // Upper-case the expected hex and verify it still matches (the helper lower-cases before
+  // comparing).
+  for (char& c : expected_hex) {
+    c = absl::ascii_toupper(c);
+  }
+  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  std::filesystem::remove(tmp);
 }
 
 TEST(NewDynamicModuleFromBytes, RepeatedLoadReusesDlopenHandle) {

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2422,7 +2422,7 @@ TEST(ABIImpl, Stats) {
   EXPECT_EQ(result, envoy_dynamic_module_type_metrics_result_InvalidLabels);
 
   // test stat creation after freezing
-  filter_config->stat_creation_frozen_ = true;
+  filter_config->stat_creation_frozen_.store(true, std::memory_order_release);
   result = envoy_dynamic_module_callback_http_filter_config_define_counter(
       filter_config.get(), {counter_vec_name.data(), counter_vec_name.size()},
       counter_vec_labels.data(), counter_vec_labels.size(), &counter_vec_id);

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -505,6 +505,60 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeCacheHit) {
   std::filesystem::remove(cached_path);
 }
 
+// When the cache path holds a file whose contents do not match the expected SHA256, the
+// factory must remove the tampered file and refuse to dlopen it. The fall-through fetch
+// path then reports the cache miss in NACK mode.
+TEST_F(DynamicModuleFilterConfigTest, NackModeCacheHitTamperedFileIsRejected) {
+  const std::string module_path = Extensions::DynamicModules::testSharedObjectPath("no_op", "c");
+  std::ifstream input(module_path, std::ios::binary);
+  ASSERT_TRUE(input.good());
+  const std::string module_bytes((std::istreambuf_iterator<char>(input)),
+                                 std::istreambuf_iterator<char>());
+
+  Buffer::OwnedImpl hash_buffer(module_bytes);
+  const std::string expected_sha256 =
+      Hex::encode(Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
+
+  // Pre-populate the cache path with attacker-controlled bytes that hash to something other
+  // than ``expected_sha256``. Without the SHA256 verification this would be dlopen'd as is.
+  auto cached_path = Extensions::DynamicModules::moduleTempPath(expected_sha256);
+  std::filesystem::create_directories(cached_path.parent_path());
+  {
+    std::ofstream tampered(cached_path, std::ios::binary);
+    tampered << "not the expected module bytes";
+  }
+  ASSERT_TRUE(std::filesystem::exists(cached_path));
+
+  const std::string yaml = TestEnvironment::substitute(absl::StrCat(R"EOF(
+  dynamic_module_config:
+    module:
+      remote:
+        http_uri:
+          uri: https://example.com/module.so
+          cluster: cluster_1
+          timeout: 5s
+        sha256: ")EOF",
+                                                                    expected_sha256, R"EOF("
+    do_not_close: true
+    nack_on_cache_miss: true
+  filter_name: "test_filter"
+  )EOF"));
+
+  envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilter proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  DynamicModuleConfigFactory factory;
+  auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
+  // The verification step removes the tampered file and the code falls through to the fetch
+  // path; in NACK mode the fetch path reports "not cached".
+  EXPECT_FALSE(cb_or_error.ok());
+  EXPECT_THAT(cb_or_error.status().message(), testing::HasSubstr("not cached"));
+
+  // The tampered cache entry must have been removed by the factory so a subsequent legitimate
+  // fetch can repopulate it.
+  EXPECT_FALSE(std::filesystem::exists(cached_path));
+}
+
 // A cache miss with nack_on_cache_miss rejects the config.
 TEST_F(DynamicModuleFilterConfigTest, NackModeCacheMissReturnsError) {
   const std::string yaml = R"EOF(


### PR DESCRIPTION
## Description

This PR hardens the cache-hit module load and atomic stat_creation_frozen_.

---

**Commit Message:** dynamic_modules: harden cache-hit module load + atomic stat_creation_frozen_
**Additional Description:** Harden cache-hit module load + atomic stat_creation_frozen_
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A