### PR TITLE
Refactor DownstreamReverseConnectionIOHandle close/shutdown

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -28,6 +28,7 @@ DownstreamReverseConnectionIOHandle::~DownstreamReverseConnectionIOHandle() {
       debug,
       "DownstreamReverseConnectionIOHandle: destroying handle for FD: {} with connection key: {}",
       fd_, connection_key_);
+  SET_SOCKET_INVALID(fd_);
 }
 
 void DownstreamReverseConnectionIOHandle::onPingMessage() {
@@ -47,16 +48,6 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
       debug,
       "DownstreamReverseConnectionIOHandle: closing handle for FD: {} with connection key: {}", fd_,
       connection_key_);
-
-  // If we're ignoring close calls during socket hand-off, just return success.
-  if (ignore_close_and_shutdown_) {
-    ENVOY_LOG(
-        debug,
-        "DownstreamReverseConnectionIOHandle: ignoring close() call during socket hand-off for "
-        "connection key: {}",
-        connection_key_);
-    return Api::ioCallUint64ResultNoError();
-  }
 
   // Prevent double-closing by checking if already closed.
   if (fd_ < 0) {
@@ -80,7 +71,8 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
   if (owned_socket_) {
     owned_socket_.reset();
   }
-  return IoSocketHandleImpl::close();
+  SET_SOCKET_INVALID(fd_);
+  return Api::ioCallUint64ResultNoError();
 }
 
 Api::SysCallIntResult DownstreamReverseConnectionIOHandle::shutdown(int how) {
@@ -89,17 +81,11 @@ Api::SysCallIntResult DownstreamReverseConnectionIOHandle::shutdown(int how) {
             "key: {}",
             how, fd_, connection_key_);
 
-  // If shutdown is ignored during socket hand-off, return success.
-  if (ignore_close_and_shutdown_) {
-    ENVOY_LOG(
-        debug,
-        "DownstreamReverseConnectionIOHandle: ignoring shutdown() call during socket hand-off for "
-        "connection key: {}",
-        connection_key_);
-    return Api::SysCallIntResult{0, 0};
+  if (owned_socket_) {
+    return owned_socket_->ioHandle().shutdown(how);
   }
 
-  return IoSocketHandleImpl::shutdown(how);
+  return Api::SysCallIntResult{0, 0};
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -43,13 +43,6 @@ public:
   void onPingMessage() override;
 
   /**
-   * Tell this IO handle to ignore close() and shutdown() calls.
-   * This is called by the HTTP filter during socket hand-off to prevent
-   * the handed-off socket from being affected by connection cleanup.
-   */
-  void ignoreCloseAndShutdown() { ignore_close_and_shutdown_ = true; }
-
-  /**
    * Get the owned socket for read-only access.
    */
   const Network::ConnectionSocket& getSocket() const { return *owned_socket_; }
@@ -61,8 +54,6 @@ private:
   ReverseConnectionIOHandle* parent_;
   // Connection key for tracking this specific connection.
   std::string connection_key_;
-  // Flag to ignore close and shutdown calls during socket hand-off.
-  bool ignore_close_and_shutdown_{false};
 };
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -80,6 +80,7 @@ envoy_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:threadsafe_singleton_injector_lib",
         "@envoy_api//envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -8,6 +8,7 @@
 #include "envoy/server/factory_context.h"
 #include "envoy/thread_local/thread_local.h"
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/io_socket_error_impl.h"
@@ -23,6 +24,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -221,37 +223,6 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, GetSocket) {
 
   // Test that getSocket() works before close() is called.
   EXPECT_EQ(handle->fdDoNotUse(), 42);
-}
-
-// Test ignoreCloseAndShutdown() functionality.
-TEST_F(DownstreamReverseConnectionIOHandleTest, IgnoreCloseAndShutdown) {
-  auto handle = createHandle(io_handle_.get(), "test_key");
-
-  // Initially, close and shutdown should work normally
-  // Test shutdown before ignoring - we don't check the result since it depends on base
-  // implementation
-  handle->shutdown(SHUT_RDWR);
-
-  // Now enable ignore mode
-  handle->ignoreCloseAndShutdown();
-
-  // Test that close() is ignored when flag is set
-  auto close_result = handle->close();
-  EXPECT_EQ(close_result.err_, nullptr); // Should return success but do nothing
-
-  // Test that shutdown() is ignored when flag is set
-  auto shutdown_result2 = handle->shutdown(SHUT_RDWR);
-  EXPECT_EQ(shutdown_result2.return_value_, 0);
-  EXPECT_EQ(shutdown_result2.errno_, 0);
-
-  // Test different shutdown modes are all ignored
-  auto shutdown_rd = handle->shutdown(SHUT_RD);
-  EXPECT_EQ(shutdown_rd.return_value_, 0);
-  EXPECT_EQ(shutdown_rd.errno_, 0);
-
-  auto shutdown_wr = handle->shutdown(SHUT_WR);
-  EXPECT_EQ(shutdown_wr.return_value_, 0);
-  EXPECT_EQ(shutdown_wr.errno_, 0);
 }
 
 TEST_F(DownstreamReverseConnectionIOHandleTest, OnPingMessageWritesRpingToSocket) {
@@ -565,6 +536,81 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadEchoDisabledAndErrorHandling
     EXPECT_EQ(result.err_, nullptr);    // No error, just EOF
     EXPECT_EQ(buffer.length(), 0);
   }
+}
+
+// Verify that close() + destructor results in exactly one FD close syscall.
+TEST_F(DownstreamReverseConnectionIOHandleTest, CloseAndDestructorNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->close();
+  handle.reset();
+
+  ::close(fds[1]);
+}
+
+// Verify that calling close() twice results in exactly one FD close.
+TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleCloseCallNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->close();
+  handle->close();
+  handle.reset();
+
+  ::close(fds[1]);
+}
+
+// Verify that calling close() twice results in exactly one FD close.
+TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleShutdownCallNoDoubleClose) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  os_fd_t target_fd = fds[0];
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(target_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  mock_socket->io_handle_ = std::make_unique<Network::IoSocketHandleImpl>(target_fd);
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
+
+  auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+  handle->shutdown(0);
+  handle->shutdown(0);
+
+  // After close(), owned_socket_ is null so shutdown() returns {0,0}.
+  handle->close();
+  auto result = handle->shutdown(0);
+  EXPECT_EQ(result.return_value_, 0);
+  EXPECT_EQ(result.errno_, 0);
+
+  handle.reset();
+
+  ::close(fds[1]);
 }
 
 } // namespace ReverseConnection


### PR DESCRIPTION
## Commit Message
Refactor DownstreamReverseConnectionIOHandle close/shutdown

## Additional Description
We saw some crashes when doing lds on reverse connections to remove them one of the suspects is the double close of fds in the downstreamiohandle -> this causes badfs and assert failures elsewhere we currently do not know how to track it but the tests became more stable after this.
Additionally removed some dead code which is not being used by anyone else.

## Testing
Unit tests and local tests stablize after this.