### PR TITLE
reverse_tunnels: skip async close in favor of connectionImpl's close

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -246,24 +246,7 @@ void RCConnectionWrapper::shutdown() {
   ENVOY_LOG(debug, "RCConnectionWrapper: Shutting down connection ID: {}, state: {}", connection_id,
             static_cast<int>(state));
 
-  // Remove connection callbacks first to prevent recursive calls during shutdown.
-  if (state != Network::Connection::State::Closed) {
-    connection_->removeConnectionCallbacks(*this);
-    ENVOY_LOG(debug, "Connection callbacks removed");
-  }
-
-  // Close the connection if it's still open.
-  state = connection_->state();
-  if (state == Network::Connection::State::Open) {
-    ENVOY_LOG(debug, "Closing open connection gracefully");
-    connection_->close(Network::ConnectionCloseType::FlushWrite);
-  } else if (state == Network::Connection::State::Closing) {
-    ENVOY_LOG(debug, "Connection already closing");
-  } else {
-    ENVOY_LOG(debug, "Connection already closed");
-  }
-
-  // Clear the connection pointer after shutdown.
+  connection_->removeConnectionCallbacks(*this);
   connection_.reset();
   ENVOY_LOG(debug, "RCConnectionWrapper: Connection cleared after shutdown");
   ENVOY_LOG(debug, "RCConnectionWrapper: Shutdown completed");

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -32,6 +32,14 @@ namespace ReverseConnection {
 
 // RCConnectionWrapper Tests.
 
+std::unique_ptr<NiceMock<Network::MockClientConnection>>
+getDeletableConn(Event::Dispatcher& dispatcher) {
+  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  EXPECT_CALL(*mock_connection, dispatcher()).WillRepeatedly(ReturnRef(dispatcher));
+
+  return mock_connection;
+}
+
 class RCConnectionWrapperTest : public testing::Test {
 protected:
   void SetUp() override {
@@ -52,6 +60,9 @@ protected:
   void TearDown() override {
     io_handle_.reset();
     extension_.reset();
+    while (dispatcher_.to_delete_.size()) {
+      dispatcher_.to_delete_.pop_front();
+    }
   }
 
   void setupThreadLocalSlot() {
@@ -127,7 +138,7 @@ protected:
 
   // Helper method to set up mock connection with proper socket expectations.
   std::unique_ptr<NiceMock<Network::MockClientConnection>> setupMockConnection() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
 
     // Create a mock socket for the connection.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -179,7 +190,7 @@ protected:
 // Test RCConnectionWrapper::connect() method with HTTP/1.1 handshake success
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeSuccess) {
   // Create a mock connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -217,7 +228,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeSuccess) {
 // Test RCConnectionWrapper::connect() method with HTTP proxy (internal address) scenario.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithHttpProxy) {
   // Create a mock connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -263,7 +274,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithHttpProxy) {
 
 // Test RCConnectionWrapper::connect() honors custom request paths.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithCustomRequestPath) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -306,7 +317,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithCustomRequestPath) {
 
 // Test RCConnectionWrapper::connect() includes additional headers in the handshake request.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithAdditionalHeaders) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -357,7 +368,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWithAdditionalHeaders) {
 
 // Test that additional headers with OVERWRITE_IF_EXISTS_OR_ADD replace existing headers.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwrite) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -406,7 +417,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwrite) 
 
 // Test ADD_IF_ABSENT: header is added when absent, skipped when present.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersAddIfAbsent) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -463,7 +474,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersAddIfAbsent
 
 // Test OVERWRITE_IF_EXISTS: overwrites existing header, does nothing for absent header.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwriteIfExists) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -522,7 +533,7 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeAdditionalHeadersOverwriteIf
 // Test RCConnectionWrapper::connect() method with connection write failure.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWriteFailure) {
   // Create a mock connection that fails to write.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   // Set up connection expectations.
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
@@ -1065,7 +1076,7 @@ TEST_F(RCConnectionWrapperTest, DecodeHeadersNonOk) {
 // Test dispatchHttp1 error path by initializing codec via connect() and
 // then feeding invalid bytes to the parser.
 TEST_F(RCConnectionWrapperTest, DispatchHttp1ErrorPath) {
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
 
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -1105,7 +1116,6 @@ TEST_F(RCConnectionWrapperTest, DestructorInvokesShutdown) {
 
   EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-  EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
   EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(777));
 
   {
@@ -1206,7 +1216,6 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
     // Set up connection expectations for open connection.
     EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-    EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12345));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
@@ -1266,13 +1275,12 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
   }
   // Test 5: Multiple shutdown calls (should be safe)
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
     auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
 
     // Set up connection expectations.
     EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
-    EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::FlushWrite));
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12348));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
@@ -1304,11 +1312,14 @@ protected:
         *stats_scope_); // Use the created scope
   }
 
-  void TearDown() override { io_handle_.reset(); }
+  void TearDown() override {
+    io_handle_.reset();
+    dispatcher_.clearDeferredDeleteList();
+  }
 
   // Helper to create a mock RCConnectionWrapper.
   std::unique_ptr<RCConnectionWrapper> createMockWrapper() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn(dispatcher_);
     auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
     return std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection), mock_host,
                                                  "test-cluster");
@@ -1323,6 +1334,7 @@ protected:
   Stats::IsolatedStoreImpl stats_store_;
   Stats::ScopeSharedPtr stats_scope_;
   std::unique_ptr<ReverseConnectionIOHandle> io_handle_;
+  NiceMock<Event::MockDispatcher> dispatcher_{"worker_0"};
 };
 
 TEST_F(SimpleConnReadFilterTest, OnDataWithNullParent) {
@@ -1464,6 +1476,24 @@ TEST_F(RCConnectionWrapperTest, NoOpMethods) {
 
   wrapper.onMaxStreamsChanged(0);
   wrapper.onMaxStreamsChanged(100);
+}
+
+// Verify shutdown with already-null connection doesn't crash.
+TEST_F(RCConnectionWrapperTest, ShutdownIsIdempotent) {
+  auto mock_connection = getDeletableConn(dispatcher_);
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(999));
+  EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
+  auto wrapper = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection),
+                                                       mock_host, "test-cluster");
+
+  wrapper->shutdown();
+  ASSERT_EQ(wrapper->getConnection(), nullptr);
+
+  wrapper->shutdown();
+  ASSERT_EQ(wrapper->getConnection(), nullptr);
+
+  wrapper.reset();
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -73,6 +73,9 @@ protected:
 
   void TearDown() override {
     io_handle_.reset();
+    while (!dispatcher_.to_delete_.empty()) {
+      dispatcher_.to_delete_.pop_front();
+    }
     extension_.reset();
     socket_interface_.reset();
   }


### PR DESCRIPTION
## Commit Message
Simplify RCConnectionWrapper::shutdown()

## Additional Description
Skip the explicit async close via `connection_->close(FlushWrite)` and defer-delete the connection instead. The base `ConnectionImpl` destructor performs `close(NoFlush)`, which is sufficient. This prevents use-after-free when the HTTP/1 codec parses a response after the connection is already being torn down.

## Testing
Unit tests.