### PR TITLE
reverse_tunnels: fix ReverseConnectionIOHandle cleanup/close and improve coverage

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -74,6 +74,7 @@ envoy_cc_library(
         "//envoy/stats:stats_interface",
         "//envoy/stats:stats_macros",
         "//envoy/upstream:cluster_manager_interface",
+        "//source/common/api:os_sys_calls_lib",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:logger_lib",
         "//source/common/event:real_time_system_lib",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -4,12 +4,12 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "envoy/event/deferred_deletable.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/event/real_time_system.h"
@@ -57,6 +57,7 @@ void ReverseConnectionIOHandle::cleanup() {
                  "trigger_pipe_write_fd_={}, trigger_pipe_read_fd_={}",
                  trigger_pipe_write_fd_, trigger_pipe_read_fd_);
   resetFileEvents();
+  SET_SOCKET_INVALID(trigger_pipe_read_fd_);
 
   // Clean up pipe trigger mechanism first to prevent use-after-free.
   ENVOY_LOG_MISC(trace,
@@ -64,47 +65,17 @@ void ReverseConnectionIOHandle::cleanup() {
                  "trigger_pipe_write_fd_={}, trigger_pipe_read_fd_={}",
                  trigger_pipe_write_fd_, trigger_pipe_read_fd_);
   if (trigger_pipe_write_fd_ >= 0) {
-    ::close(trigger_pipe_write_fd_);
+    Api::OsSysCallsSingleton::get().close(trigger_pipe_write_fd_);
     trigger_pipe_write_fd_ = -1;
   }
-  if (trigger_pipe_read_fd_ >= 0) {
-    ::close(trigger_pipe_read_fd_);
-    trigger_pipe_read_fd_ = -1;
-  }
 
-  // Reset the retry timer. Don't call enabled() here — it asserts
-  // dispatcher_.isThreadSafe(), which fails when the destructor runs on the main
-  // thread during shutdown (the timer was created on a worker thread).
-  if (rev_conn_retry_timer_) {
-    ENVOY_LOG_MISC(trace, "reverse_tunnel: resetting retry timer.");
-    rev_conn_retry_timer_.reset();
-  }
-
-  // Graceful shutdown of connection wrappers with exception safety.
-  ENVOY_LOG_MISC(debug, "Gracefully shutting down {} connection wrappers.",
-                 connection_wrappers_.size());
-
-  // Move wrappers for deferred cleanup.
-  std::vector<std::unique_ptr<RCConnectionWrapper>> wrappers_to_delete;
-  for (auto& wrapper : connection_wrappers_) {
-    if (wrapper) {
-      ENVOY_LOG(debug, "Moving connection wrapper for deferred cleanup.");
-      wrappers_to_delete.push_back(std::move(wrapper));
-    }
-  }
-
-  // Clear containers safely.
-  connection_wrappers_.clear();
-  conn_wrapper_to_host_map_.clear();
-
-  // Clean up wrappers with safe deletion.
-  for (auto& wrapper : wrappers_to_delete) {
-    if (wrapper && isThreadLocalDispatcherAvailable()) {
-      getThreadLocalDispatcher().deferredDelete(std::move(wrapper));
-    } else {
-      // Direct cleanup when dispatcher not available.
-      wrapper.reset();
-    }
+  // If initializeFileEvent() ran, fd_ was reassigned to trigger_pipe_read_fd_ and the base class
+  // will close that. We must close original_socket_fd_ explicitly since nothing else owns it.
+  // This guards against cleanup() being called without close() (e.g. destructor-only path).
+  if (original_socket_fd_ != fd_ && original_socket_fd_ >= 0) {
+    ENVOY_LOG(debug, "cleanup: closing original socket FD: {}.", original_socket_fd_);
+    Api::OsSysCallsSingleton::get().close(original_socket_fd_);
+    original_socket_fd_ = -1;
   }
 
   // Clear cluster to hosts mapping.
@@ -342,12 +313,14 @@ ReverseConnectionIOHandle::connect(Envoy::Network::Address::InstanceConstSharedP
 Api::IoCallUint64Result ReverseConnectionIOHandle::close() {
   ENVOY_LOG(error, "reverse_tunnel: performing graceful shutdown.");
 
-  // Clean up original socket FD
-  if (original_socket_fd_ != -1) {
+  // If initializeFileEvent() ran, fd_ was reassigned to trigger_pipe_read_fd_ and the base class
+  // will close that. We must close original_socket_fd_ explicitly since nothing else owns it.
+  // If initializeFileEvent() did not run, fd_ == original_socket_fd_ and the base class handles it.
+  if (original_socket_fd_ != fd_ && original_socket_fd_ >= 0) {
     ENVOY_LOG(error, "Closing original socket FD: {}.", original_socket_fd_);
-    ::close(original_socket_fd_);
-    original_socket_fd_ = -1;
+    Api::OsSysCallsSingleton::get().close(original_socket_fd_);
   }
+  SET_SOCKET_INVALID(original_socket_fd_);
 
   // CRITICAL: If we're using pipe trigger FD, let the IoSocketHandleImpl::close()
   // close it and cleanup() set the pipe FDs to -1.
@@ -1214,12 +1187,7 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
   if (wrapper_vector_it != connection_wrappers_.end()) {
     auto wrapper_to_delete = std::move(*wrapper_vector_it);
     connection_wrappers_.erase(wrapper_vector_it);
-
-    // Use deferred deletion to prevent crash during cleanup.
-    std::unique_ptr<Event::DeferredDeletable> deletable_wrapper(
-        static_cast<Event::DeferredDeletable*>(wrapper_to_delete.release()));
-    getThreadLocalDispatcher().deferredDelete(std::move(deletable_wrapper));
-    ENVOY_LOG(debug, "reverse_tunnel: Deferred delete of connection wrapper");
+    getThreadLocalDispatcher().deferredDelete(std::move(wrapper_to_delete));
   }
 }
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -75,6 +75,9 @@ protected:
     io_handle_.reset();
     extension_.reset();
     socket_interface_.reset();
+    while (dispatcher_.to_delete_.size()) {
+      dispatcher_.to_delete_.pop_front();
+    }
   }
 
   // Helper to create a ReverseConnectionIOHandle with specified configuration.
@@ -287,9 +290,16 @@ protected:
     return mock_host;
   }
 
+  std::unique_ptr<NiceMock<Network::MockClientConnection>> getDeletableConn() {
+    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    EXPECT_CALL(*mock_connection, dispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
+
+    return mock_connection;
+  }
+
   // Helper method to set up mock connection with proper socket expectations.
   std::unique_ptr<NiceMock<Network::MockClientConnection>> setupMockConnection() {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket for the connection.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -1179,7 +1189,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionSuccess) {
   addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
 
   // Set up mock for successful connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data;
   success_conn_data.connection_ = mock_connection.get();
   success_conn_data.host_description_ = mock_host;
@@ -1254,7 +1264,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateReverseConnectionWithCustomScope) 
   addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
 
   // Set up mock for successful connection.
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data;
   success_conn_data.connection_ = mock_connection.get();
   success_conn_data.host_description_ = mock_host;
@@ -1370,6 +1380,27 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionNonExistentClu
   EXPECT_EQ(wrapper_to_host_map.size(), 0);
 }
 
+// Null cluster info returns false without crashing.
+TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionNullClusterInfo) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  EXPECT_NE(io_handle_, nullptr);
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  EXPECT_CALL(*mock_thread_local_cluster, info()).WillRepeatedly(Return(nullptr));
+
+  auto mock_host = createMockHost("192.168.1.1");
+  bool result = initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host);
+  EXPECT_FALSE(result);
+
+  auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.cannot_connect"], 1);
+}
+
 // Test mixed success and failure scenarios for multiple connection attempts.
 TEST_F(ReverseConnectionIOHandleTest, InitiateMultipleConnectionsMixedResults) {
   // Set up thread local slot first so stats can be properly tracked.
@@ -1414,8 +1445,8 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateMultipleConnectionsMixedResults) {
   // 3. Third host: successful connection
 
   // Prepare mock connections that will be transferred to the wrappers.
-  auto mock_connection1 = std::make_unique<NiceMock<Network::MockClientConnection>>();
-  auto mock_connection3 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection1 = getDeletableConn();
+  auto mock_connection3 = getDeletableConn();
 
   // Set up connection info for the connections.
   auto local_address = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.2", 40000);
@@ -1588,12 +1619,12 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
 
   // Set up successful connections for both hosts.
-  auto mock_connection1 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection1 = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data1;
   success_conn_data1.connection_ = mock_connection1.get();
   success_conn_data1.host_description_ = mock_host1;
 
-  auto mock_connection2 = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection2 = getDeletableConn();
   Upstream::MockHost::MockCreateConnectionData success_conn_data2;
   success_conn_data2.connection_ = mock_connection2.get();
   success_conn_data2.host_description_ = mock_host2;
@@ -2438,14 +2469,14 @@ TEST_F(ReverseConnectionIOHandleTest, CleanupClosesEstablishedConnections) {
   // Create two mock connections and add them to the established queue.
   // 1) An open connection should be closed with FlushWrite.
   {
-    auto open_conn = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto open_conn = getDeletableConn();
     EXPECT_CALL(*open_conn, state()).WillOnce(Return(Network::Connection::State::Open));
     EXPECT_CALL(*open_conn, close(Network::ConnectionCloseType::FlushWrite));
     addConnectionToEstablishedQueue(std::move(open_conn));
   }
   // 2) A closed connection should not be closed again.
   {
-    auto closed_conn = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto closed_conn = getDeletableConn();
     EXPECT_CALL(*closed_conn, state()).WillOnce(Return(Network::Connection::State::Closed));
     // No close() expected for closed connection.
     addConnectionToEstablishedQueue(std::move(closed_conn));
@@ -2902,7 +2933,7 @@ TEST_F(ReverseConnectionIOHandleTest, AcceptMethodSocketAndFdFailures) {
 
   // Test Case 1: Original socket not available or not open.
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket that returns isOpen() = false.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -2952,7 +2983,7 @@ TEST_F(ReverseConnectionIOHandleTest, AcceptMethodSocketAndFdFailures) {
 
   // Test Case 2: Failed to duplicate file descriptor.
   {
-    auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+    auto mock_connection = getDeletableConn();
 
     // Create a mock socket with IO handle that fails to duplicate.
     auto mock_socket_ptr = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -3151,6 +3182,51 @@ TEST_F(ReverseConnectionIOHandleTest, OnConnectionDoneTlsConnectionDynamicCastFa
   auto stat_map = extension_->getCrossWorkerStatMap();
   EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.connected"], 1);
   EXPECT_EQ(stat_map["test_scope.reverse_connections.cluster.test-cluster.connected"], 1);
+}
+
+// Verify ReverseConnectionIOHandle::close() doesn't double-close original_socket_fd_ when it equals
+// fd_.
+TEST_F(ReverseConnectionIOHandleTest, CloseNoDoubleCloseWhenOriginalEqualsFd) {
+  auto config = createDefaultTestConfig();
+  int test_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_GE(test_fd, 0);
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(test_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  auto handle = std::make_unique<ReverseConnectionIOHandle>(test_fd, config, cluster_manager_,
+                                                            extension_.get(), *stats_scope_);
+  handle->close();
+  handle.reset();
+}
+
+// Verify that after initializeFileEvent (pipe created), close+destructor closes each FD exactly
+// once. After initializeFileEvent: fd_ = pipe_read_fd, original_socket_fd_ = original_fd,
+// pipe_write_fd separate. close() should close original_fd once (manual) and pipe_read_fd once (via
+// IoSocketHandleImpl::close). cleanup() closes pipe_write_fd once.
+TEST_F(ReverseConnectionIOHandleTest, CloseNoDoubleCloseWithPipeFds) {
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+
+  NiceMock<Api::MockOsSysCalls> mock_os_syscalls;
+  TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> injector(&mock_os_syscalls);
+  EXPECT_CALL(mock_os_syscalls, close(io_handle_->fdDoNotUse()))
+      .WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  ASSERT_TRUE(isTriggerPipeReady());
+
+  os_fd_t pipe_read_fd = getTriggerPipeReadFd();
+  os_fd_t pipe_write_fd = getTriggerPipeWriteFd();
+  EXPECT_CALL(mock_os_syscalls, close(pipe_read_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+  EXPECT_CALL(mock_os_syscalls, close(pipe_write_fd)).WillOnce(Return(Api::SysCallIntResult{0, 0}));
+
+  io_handle_->close();
+  io_handle_.reset();
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -368,6 +368,23 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, UpdateConnectionStatsWithDetailedSta
   EXPECT_FALSE(found_detailed_stats);
 }
 
+// incrementHandshakeStats should no-op when detailed stats are disabled.
+TEST_F(ReverseTunnelInitiatorExtensionTest, IncrementHandshakeStatsWithDetailedStatsDisabled) {
+  envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+      DownstreamReverseConnectionSocketInterface no_stats_config;
+  no_stats_config.set_stat_prefix("reverse_connections");
+  no_stats_config.set_enable_detailed_stats(false);
+
+  auto no_stats_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, no_stats_config);
+
+  no_stats_extension->incrementHandshakeStats("cluster1", true, "");
+  no_stats_extension->incrementHandshakeStats("cluster2", false, "timeout");
+
+  auto cross_worker_stat_map = no_stats_extension->getCrossWorkerStatMap();
+  EXPECT_TRUE(cross_worker_stat_map.empty());
+}
+
 // Test per-worker stats aggregation for one thread only (test thread)
 TEST_F(ReverseTunnelInitiatorExtensionTest, GetPerWorkerStatMapSingleThread) {
   // Set up thread local slot first.


### PR DESCRIPTION
## Commit Message
Fix ReverseConnectionIOHandle cleanup/close

## Additional Description
We have some local load tests which failed when we tried using lds to remove a lot of listeners one of the possible reasons seems to be this -> double close of fds which causes issues like EBADF elsewhere removed the double closes in the reverseconnectioniohandle.
Minor: moved from ::close to the os sys calls singleton.

## Testing
Added unit tests and if it matters the local tests became more stable.