### PR TITLE
Migrates thread local free slot storage from `std::list` to `std::vector`.

### DIFF
--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -33,9 +33,8 @@ SlotPtr InstanceImpl::allocateSlot() {
     slots_.push_back(slot.get());
     return slot;
   }
-  auto it = free_slot_indexes_.begin();
-  const uint32_t idx = *it;
-  free_slot_indexes_.erase(it);
+  const uint32_t idx = free_slot_indexes_.back();
+  free_slot_indexes_.pop_back();
   ASSERT(idx < slots_.size());
   SlotPtr slot = std::make_unique<SlotImpl>(*this, idx);
   slots_[idx] = slot.get();
@@ -162,9 +161,10 @@ void InstanceImpl::removeSlot(uint32_t slot) {
   }
 
   slots_[slot] = nullptr;
-  ASSERT(!free_slot_indexes_.contains(slot),
+  ASSERT(std::find(free_slot_indexes_.begin(), free_slot_indexes_.end(), slot) ==
+             free_slot_indexes_.end(),
          fmt::format("slot index {} already in free slot set!", slot));
-  free_slot_indexes_.insert(slot);
+  free_slot_indexes_.push_back(slot);
   runOnAllThreads([slot]() -> void {
     // This runs on each thread and clears the slot, making it available for a new allocations.
     // This is safe even if a new allocation comes in, because everything happens with post() and

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -33,8 +33,9 @@ SlotPtr InstanceImpl::allocateSlot() {
     slots_.push_back(slot.get());
     return slot;
   }
-  const uint32_t idx = free_slot_indexes_.front();
-  free_slot_indexes_.pop_front();
+  auto it = free_slot_indexes_.begin();
+  const uint32_t idx = *it;
+  free_slot_indexes_.erase(it);
   ASSERT(idx < slots_.size());
   SlotPtr slot = std::make_unique<SlotImpl>(*this, idx);
   slots_[idx] = slot.get();
@@ -161,10 +162,9 @@ void InstanceImpl::removeSlot(uint32_t slot) {
   }
 
   slots_[slot] = nullptr;
-  ASSERT(std::find(free_slot_indexes_.begin(), free_slot_indexes_.end(), slot) ==
-             free_slot_indexes_.end(),
+  ASSERT(!free_slot_indexes_.contains(slot),
          fmt::format("slot index {} already in free slot set!", slot));
-  free_slot_indexes_.push_back(slot);
+  free_slot_indexes_.insert(slot);
   runOnAllThreads([slot]() -> void {
     // This runs on each thread and clears the slot, making it available for a new allocations.
     // This is safe even if a new allocation comes in, because everything happens with post() and

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -11,6 +11,8 @@
 #include "source/common/common/logger.h"
 #include "source/common/common/non_copyable.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace ThreadLocal {
 
@@ -83,8 +85,8 @@ private:
 
   Thread::MainThread main_thread_;
   std::vector<Slot*> slots_;
-  // A list of index of freed slots.
-  std::list<uint32_t> free_slot_indexes_;
+  // A collection of indices of freed slots.
+  absl::flat_hash_set<uint32_t> free_slot_indexes_;
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   Event::Dispatcher* main_thread_dispatcher_{};
   std::atomic<bool> shutdown_{};

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -11,8 +11,6 @@
 #include "source/common/common/logger.h"
 #include "source/common/common/non_copyable.h"
 
-#include "absl/container/flat_hash_set.h"
-
 namespace Envoy {
 namespace ThreadLocal {
 
@@ -86,7 +84,7 @@ private:
   Thread::MainThread main_thread_;
   std::vector<Slot*> slots_;
   // A collection of indices of freed slots.
-  absl::flat_hash_set<uint32_t> free_slot_indexes_;
+  std::vector<uint32_t> free_slot_indexes_;
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   Event::Dispatcher* main_thread_dispatcher_{};
   std::atomic<bool> shutdown_{};


### PR DESCRIPTION
`std::list` is not a great choice for a performance critical utility, as it requires a heap operation on every mutation.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
