### PR TITLE
perf: convert StrSplit result from container of std::string to container of absl::string_view

### DIFF
--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -650,7 +650,7 @@ void McpFieldExtractor::copySelectedFields() {
 }
 
 void McpFieldExtractor::copyFieldByPath(const std::string& path) {
-  std::vector<std::string> segments = absl::StrSplit(path, '.');
+  std::vector<absl::string_view> segments = absl::StrSplit(path, '.');
 
   // Navigate source to find value
   const Protobuf::Struct* current_source = &temp_storage_;
@@ -753,7 +753,7 @@ const Protobuf::Value* McpJsonParser::getNestedValue(const std::string& dotted_p
     return nullptr;
   }
 
-  std::vector<std::string> path = absl::StrSplit(dotted_path, '.');
+  std::vector<absl::string_view> path = absl::StrSplit(dotted_path, '.');
   const Protobuf::Struct* current = &metadata_;
 
   for (size_t i = 0; i < path.size(); ++i) {

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
@@ -17,7 +17,7 @@ namespace {
 using ::nlohmann::json;
 
 absl::StatusOr<json> getJsonValue(const json& data, absl::string_view path) {
-  std::vector<std::string> parts = absl::StrSplit(path, '.');
+  std::vector<absl::string_view> parts = absl::StrSplit(path, '.');
   json current = data;
   for (const auto& part : parts) {
     if (!current.contains(part)) {
@@ -97,11 +97,11 @@ void appendQueryParamsToBaseUrl(std::string& url, absl::Span<const QueryParam> q
 
 // Recursively removes a path from a JSON object.
 // Returns true if `data` becomes empty after removal, false otherwise.
-bool recursiveRemoveJsonPath(json& data, absl::Span<const std::string> parts) {
+bool recursiveRemoveJsonPath(json& data, absl::Span<const absl::string_view> parts) {
   if (parts.empty()) {
     return false;
   }
-  const std::string& key = parts[0];
+  absl::string_view key = parts[0];
   if (!data.is_object() || !data.contains(key)) {
     return false;
   }
@@ -120,7 +120,7 @@ void removeJsonPath(json& data, absl::string_view path) {
   if (path.empty()) {
     return;
   }
-  std::vector<std::string> parts = absl::StrSplit(path, '.');
+  std::vector<absl::string_view> parts = absl::StrSplit(path, '.');
   recursiveRemoveJsonPath(data, parts);
 }
 

--- a/source/extensions/filters/http/mcp_router/session_codec.cc
+++ b/source/extensions/filters/http/mcp_router/session_codec.cc
@@ -36,7 +36,7 @@ std::string SessionCodec::buildCompositeSessionId(
 
 absl::StatusOr<SessionCodec::ParsedSession>
 SessionCodec::parseCompositeSessionId(const std::string& composite) {
-  std::vector<std::string> parts = absl::StrSplit(composite, '@');
+  std::vector<absl::string_view> parts = absl::StrSplit(composite, '@');
   if (parts.size() != 3) {
     return absl::InvalidArgumentError("Invalid session format");
   }
@@ -50,14 +50,14 @@ SessionCodec::parseCompositeSessionId(const std::string& composite) {
     return result;
   }
 
-  std::vector<std::string> backend_parts = absl::StrSplit(parts[2], ',');
+  std::vector<absl::string_view> backend_parts = absl::StrSplit(parts[2], ',');
   for (const auto& bp : backend_parts) {
     size_t colon = bp.find(':');
     if (colon == std::string::npos || colon == 0) {
       return absl::InvalidArgumentError("Invalid backend session format");
     }
-    std::string backend = bp.substr(0, colon);
-    std::string encoded_session = bp.substr(colon + 1);
+    absl::string_view backend = bp.substr(0, colon);
+    absl::string_view encoded_session = bp.substr(colon + 1);
     result.backend_sessions[backend] = Base64::decode(encoded_session);
   }
 

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -75,7 +75,7 @@ absl::optional<uint32_t> CgroupCpuUtil::getCpuLimit(Filesystem::Instance& fs) {
 // Returns string_view without trailing newline on success, absl::nullopt on validation failure.
 absl::optional<absl::string_view>
 CgroupCpuUtil::validateCgroupFileContent(const std::string& content, const std::string& file_path) {
-  // ✅ Newline Validation: Require trailing newline
+  // Newline Validation: Require trailing newline
   if (content.empty() || content.back() != '\n') {
     ENVOY_LOG_MISC(warn, "Malformed `cgroup` file {}: missing trailing newline", file_path);
     return absl::nullopt;
@@ -108,13 +108,13 @@ absl::optional<CgroupPathInfo> CgroupCpuUtil::getCurrentCgroupPath(Filesystem::I
   }
 
   const std::string content = result.value();
-  const std::vector<std::string> lines = absl::StrSplit(content, '\n');
+  const std::vector<absl::string_view> lines = absl::StrSplit(content, '\n');
 
   std::string v2_path;   // Save v2 path in case no v1 found
   bool found_v2 = false; // Track if we found any v2 hierarchy
 
   // Parse /proc/self/cgroup line by line
-  for (const std::string& line : lines) {
+  for (absl::string_view line : lines) {
     if (line.empty()) {
       continue;
     }
@@ -302,7 +302,7 @@ absl::optional<double> CgroupCpuUtil::readActualLimitsV2(const CpuFiles& cpu_fil
   const std::string content = std::string(absl::StripAsciiWhitespace(cpu_files.quota_content));
 
   // Parse "quota period" format
-  const std::vector<std::string> parts = absl::StrSplit(content, ' ');
+  const std::vector<absl::string_view> parts = absl::StrSplit(content, ' ');
 
   if (parts.size() != 2) {
     ENVOY_LOG_MISC(warn, "Malformed cgroup v2 cpu.max: expected 'quota period', got '{}'", content);
@@ -382,17 +382,15 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
   }
 
   const std::string content = result.value();
-  const std::vector<std::string> lines = absl::StrSplit(content, '\n');
+  const std::vector<absl::string_view> lines = absl::StrSplit(content, '\n');
 
   std::string v2_mount_point; // Save v2 mount in case no v1 found
 
-  for (const std::string& line_str : lines) {
-    if (line_str.empty()) {
+  for (absl::string_view line : lines) {
+    if (line.empty()) {
       continue;
     }
 
-    // Work with string_view for efficient parsing
-    absl::string_view line = line_str;
     bool line_valid = true;
 
     // Skip first four fields
@@ -507,7 +505,7 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
 //
 // This matches the Go runtime implementation:
 // https://github.com/golang/go/blob/master/src/internal/runtime/cgroup/cgroup_linux.go
-std::string CgroupCpuUtil::unescapePath(const std::string& path) {
+std::string CgroupCpuUtil::unescapePath(absl::string_view path) {
   std::string result;
   result.reserve(path.length()); // Pre-allocate to avoid `reallocations`
 
@@ -538,7 +536,7 @@ std::string CgroupCpuUtil::unescapePath(const std::string& path) {
       continue;
     }
 
-    std::string octal_str = path.substr(i + 1, 3);
+    absl::string_view octal_str = path.substr(i + 1, 3);
 
     // Validate all characters are valid octal digits (0-7)
     bool valid = std::all_of(octal_str.begin(), octal_str.end(),
@@ -553,10 +551,10 @@ std::string CgroupCpuUtil::unescapePath(const std::string& path) {
 
     // Convert octal string to integer
     char* end;
-    long decoded = std::strtol(octal_str.c_str(), &end, 8);
+    long decoded = std::strtol(octal_str.data(), &end, 8);
 
     // Verify conversion was successful and complete
-    if (end != octal_str.c_str() + 3 || decoded > 255) {
+    if (end != octal_str.data() + 3 || decoded > 255) {
       ENVOY_LOG_MISC(warn, "Invalid octal escape sequence in path '{}' at position {}", path, i);
       result += c; // Keep the backslash as-is
       continue;
@@ -582,7 +580,7 @@ std::string CgroupCpuUtil::unescapePath(const std::string& path) {
 // NOTE: Mount points may contain escaped characters (\040 for space, \134 for backslash, etc.)
 // and must be unescaped before use.
 absl::optional<std::string> CgroupCpuUtil::parseMountInfoLine(const std::string& line) {
-  const std::vector<std::string> fields = absl::StrSplit(line, ' ');
+  const std::vector<absl::string_view> fields = absl::StrSplit(line, ' ');
 
   // Find the separator "-" to locate filesystem type field
   size_t separator_pos = 0;
@@ -609,8 +607,8 @@ absl::optional<std::string> CgroupCpuUtil::parseMountInfoLine(const std::string&
     return absl::nullopt;
   }
 
-  const std::string& mount_point_escaped = fields[4];
-  const std::string& fs_type = fields[separator_pos + 1];
+  absl::string_view mount_point_escaped = fields[4];
+  absl::string_view fs_type = fields[separator_pos + 1];
 
   // Check if this is a cgroup filesystem
   if (fs_type != "cgroup" && fs_type != "cgroup2") {

--- a/source/server/cgroup_cpu_util.h
+++ b/source/server/cgroup_cpu_util.h
@@ -141,7 +141,7 @@ private:
    * @param path The escaped path string from `mountinfo`.
    * @return The unescaped path string.
    */
-  static std::string unescapePath(const std::string& path);
+  static std::string unescapePath(absl::string_view path);
 
   /**
    * Constructs complete `cgroup` path by combining mount point and process assignment.


### PR DESCRIPTION
Commit Message: perf: convert StrSplit result from container of std::string to container of absl::string_view
Additional Description:
Minor perf change. Modify the return type of some StrSplit operations, so it uses `absl::string_view` instead of `std::string`.

Risk Level: low - internal refactor
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
