### PR TITLE
mobile: add new CRTP EngineBuilderBase and MobileEngineBuilder

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -168,7 +168,7 @@ build:mobile-cc --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 
 # CC with xDS
 build:mobile-cc-xds-enabled --config=mobile-cc
-test:mobile-cc-xds-enabled --define=envoy_mobile_xds=enabled
+build:mobile-cc-xds-enabled --define=envoy_mobile_xds=enabled
 
 # Coverage
 build:mobile-coverage --build_tests_only

--- a/mobile/bazel/envoy_mobile_cc_test.bzl
+++ b/mobile/bazel/envoy_mobile_cc_test.bzl
@@ -1,19 +1,36 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_cc_test_library")
 
+# List of intermediate test libraries that concretely depend on Platform::EngineBuilder.
+# Targets in this list will be double-compiled into 2 targets to support both Engine Builders
+# (the legacy pristine EngineBuilder and the new MobileEngineBuilder) cleanly.
+# Note: Any library depending on these targets is transitively forced to be double-compiled
+# as well due to ODR layout constraints. This cascading effect is a minor side-effect given
+# that these test libraries reside very close to the leaves/end of the test dependency tree.
 LEGACY_BUILDER_LIBRARIES = [
     "base_client_integration_test_lib",
     "engine_with_test_server",
     "xds_integration_test_lib",
-    "xds_test_server_lib",
 ]
 
 def envoy_cc_test_library_with_engine_builder(name, srcs, deps = [], copts = [], **kwargs):
     # 1. Legacy library using pristine EngineBuilder (suffixed)
+    overridden_deps = []
+    for dep in deps:
+        is_legacy = False
+        for suffix in LEGACY_BUILDER_LIBRARIES:
+            if dep.endswith(":" + suffix):
+                is_legacy = True
+                break
+        if is_legacy:
+            overridden_deps.append(dep + "_legacy_builder")
+        else:
+            overridden_deps.append(dep)
+
     envoy_cc_test_library(
         name = name + "_legacy_builder",
         srcs = srcs,
         copts = copts,
-        deps = deps + ["//test/cc:engine_builder_test_shim_lib"],
+        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_lib"],
         **kwargs
     )
 

--- a/mobile/bazel/envoy_mobile_cc_test.bzl
+++ b/mobile/bazel/envoy_mobile_cc_test.bzl
@@ -1,0 +1,64 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_cc_test_library")
+
+LEGACY_BUILDER_LIBRARIES = [
+    "base_client_integration_test_lib",
+    "engine_with_test_server",
+    "xds_integration_test_lib",
+    "xds_test_server_lib",
+]
+
+def envoy_cc_test_library_with_engine_builder(name, srcs, deps = [], copts = [], **kwargs):
+    # 1. Legacy library using pristine EngineBuilder (suffixed)
+    envoy_cc_test_library(
+        name = name + "_legacy_builder",
+        srcs = srcs,
+        copts = copts,
+        deps = deps + ["//test/cc:engine_builder_test_shim_lib"],
+        **kwargs
+    )
+
+    # 2. New library using MobileEngineBuilder under macro switch (default name)
+    envoy_cc_test_library(
+        name = name,
+        srcs = srcs,
+        copts = copts + ["-DUSE_MOBILE_ENGINE_BUILDER"],
+        deps = deps + [
+            "//test/cc:engine_builder_test_shim_lib",
+            "//library/cc:mobile_engine_builder_lib",
+        ],
+        **kwargs
+    )
+
+def envoy_cc_test_with_engine_builder(name, srcs, deps = [], copts = [], **kwargs):
+    # 1. Legacy test target (suffixed): rewrite deps to map to _legacy_builder libraries
+    overridden_deps = []
+    for dep in deps:
+        is_legacy = False
+        for suffix in LEGACY_BUILDER_LIBRARIES:
+            if dep.endswith(":" + suffix):
+                is_legacy = True
+                break
+        if is_legacy:
+            overridden_deps.append(dep + "_legacy_builder")
+        else:
+            overridden_deps.append(dep)
+
+    envoy_cc_test(
+        name = name + "_legacy_builder",
+        srcs = srcs,
+        copts = copts,
+        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_lib"],
+        **kwargs
+    )
+
+    # 2. Mobile test target (default name): uses default deps mapping directly
+    envoy_cc_test(
+        name = name,
+        srcs = srcs,
+        copts = copts + ["-DUSE_MOBILE_ENGINE_BUILDER"],
+        deps = deps + [
+            "//test/cc:engine_builder_test_shim_lib",
+            "//library/cc:mobile_engine_builder_lib",
+        ],
+        **kwargs
+    )

--- a/mobile/library/cc/BUILD
+++ b/mobile/library/cc/BUILD
@@ -9,6 +9,23 @@ licenses(["notice"])  # Apache 2
 envoy_mobile_package()
 
 envoy_cc_library(
+    name = "engine_builder_types_lib",
+    srcs = [
+        "engine_builder_types.cc",
+    ],
+    hdrs = [
+        "engine_builder_types.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@abseil-cpp//absl/strings",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "network_change_monitor_interface",
     srcs = [
         "network_change_monitor.h",
@@ -16,6 +33,30 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [],
+)
+
+envoy_cc_library(
+    name = "engine_builder_base_lib",
+    hdrs = [
+        "engine_builder_base.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":envoy_engine_cc_lib_no_stamp",
+        "//library/common:engine_types_lib",
+        "//library/common:internal_engine_lib_no_stamp",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:optional",
+        "@envoy//source/common/common:base_logger_lib",
+        "@envoy//source/common/runtime:runtime_features_lib",
+        "@envoy//source/server:options_base",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/type/matcher/v3:pkg_cc_proto",
+    ],
 )
 
 envoy_cc_library(
@@ -33,6 +74,61 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":engine_builder_base_lib",
+        ":engine_builder_types_lib",
+        ":envoy_engine_cc_lib_no_stamp",
+        "@abseil-cpp//absl/types:optional",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/protobuf",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/compression/brotli/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/compression/gzip/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/early_data/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/alternate_protocols_cache/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/decompressor/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/apple/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/network/dns_resolver/getaddrinfo/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/raw_buffer/v3:pkg_cc_proto",
+        "@envoy_mobile//library/common:engine_types_lib",
+        "@envoy_mobile//library/common/config:certificates_lib",
+        "@envoy_mobile//library/common/extensions/cert_validator/platform_bridge:platform_bridge_cc_proto",
+        "@envoy_mobile//library/common/extensions/filters/http/local_error:filter_cc_proto",
+        "@envoy_mobile//library/common/extensions/filters/http/network_configuration:filter_cc_proto",
+        "@envoy_mobile//library/common/extensions/filters/http/socket_tag:filter_cc_proto",
+        "@envoy_mobile//library/common/extensions/quic_packet_writer/platform:platform_packet_writer_proto_cc_proto",
+        "@envoy_mobile//library/common/types:matcher_data_lib",
+    ] + select({
+        "@envoy//bazel:apple": [
+            "@envoy_mobile//library/common/network:apple_proxy_resolution_lib",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+envoy_cc_library(
+    name = "mobile_engine_builder_lib",
+    srcs = [
+        "mobile_engine_builder.cc",
+    ],
+    hdrs = [
+        "mobile_engine_builder.h",
+    ],
+    copts = select({
+        "//bazel:exclude_certificates": ["-DEXCLUDE_CERTIFICATES"],
+        "//conditions:default": [],
+    }),
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":engine_builder_base_lib",
+        ":engine_builder_types_lib",
         ":envoy_engine_cc_lib_no_stamp",
         "@abseil-cpp//absl/types:optional",
         "@envoy//source/common/common:assert_lib",
@@ -111,6 +207,7 @@ envoy_cc_library(
     deps = [
         ":engine_builder_lib",
         ":envoy_engine_cc_lib_no_stamp",
+        ":mobile_engine_builder_lib",
         "//library/common:engine_common_lib_stamped",
     ],
 )

--- a/mobile/library/cc/engine.h
+++ b/mobile/library/cc/engine.h
@@ -47,6 +47,7 @@ private:
 
   // required to access private constructor
   friend class EngineBuilder;
+  template <typename T> friend class EngineBuilderBase;
   // required to use envoy_engine_t without exposing it publicly
   friend class StreamPrototype;
   // for testing only

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -481,91 +481,6 @@ EngineBuilder& EngineBuilder::setIosNetworkServiceType(int ios_network_service_t
 #endif
 
 #ifdef ENVOY_MOBILE_XDS
-XdsBuilder::XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port)
-    : xds_server_address_(std::move(xds_server_address)), xds_server_port_(xds_server_port) {}
-
-XdsBuilder& XdsBuilder::addInitialStreamHeader(std::string header, std::string value) {
-  envoy::config::core::v3::HeaderValue header_value;
-  header_value.set_key(std::move(header));
-  header_value.set_value(std::move(value));
-  xds_initial_grpc_metadata_.emplace_back(std::move(header_value));
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::setSslRootCerts(std::string root_certs) {
-  ssl_root_certs_ = std::move(root_certs);
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::addRuntimeDiscoveryService(std::string resource_name,
-                                                   const int timeout_in_seconds) {
-  rtds_resource_name_ = std::move(resource_name);
-  rtds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::addClusterDiscoveryService(std::string cds_resources_locator,
-                                                   const int timeout_in_seconds) {
-  enable_cds_ = true;
-  cds_resources_locator_ = std::move(cds_resources_locator);
-  cds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
-  return *this;
-}
-
-void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
-  auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
-  ads_config->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
-  ads_config->set_set_node_on_first_message_only(true);
-  ads_config->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-
-  auto& grpc_service = *ads_config->add_grpc_services();
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("base");
-  grpc_service.mutable_envoy_grpc()->set_authority(
-      absl::StrCat(xds_server_address_, ":", xds_server_port_));
-
-  if (!xds_initial_grpc_metadata_.empty()) {
-    grpc_service.mutable_initial_metadata()->Assign(xds_initial_grpc_metadata_.begin(),
-                                                    xds_initial_grpc_metadata_.end());
-  }
-
-  if (!rtds_resource_name_.empty()) {
-    auto* layered_runtime = bootstrap.mutable_layered_runtime();
-    auto* layer = layered_runtime->add_layers();
-    layer->set_name("rtds_layer");
-    auto* rtds_layer = layer->mutable_rtds_layer();
-    rtds_layer->set_name(rtds_resource_name_);
-    auto* rtds_config = rtds_layer->mutable_rtds_config();
-    rtds_config->mutable_ads();
-    rtds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-    rtds_config->mutable_initial_fetch_timeout()->set_seconds(rtds_timeout_in_seconds_);
-  }
-
-  if (enable_cds_) {
-    auto* cds_config = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
-    if (cds_resources_locator_.empty()) {
-      cds_config->mutable_ads();
-    } else {
-      bootstrap.mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
-      cds_config->mutable_api_config_source()->set_api_type(
-          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
-      cds_config->mutable_api_config_source()->set_transport_api_version(
-          envoy::config::core::v3::ApiVersion::V3);
-    }
-    cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_in_seconds_);
-    cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-    bootstrap.add_node_context_params("cluster");
-    // Stat prefixes that we use in tests.
-    auto* list =
-        bootstrap.mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
-    list->add_patterns()->set_exact("cluster_manager.active_clusters");
-    list->add_patterns()->set_exact("cluster_manager.cluster_added");
-    list->add_patterns()->set_exact("cluster_manager.cluster_updated");
-    list->add_patterns()->set_exact("cluster_manager.cluster_removed");
-    // Allow SDS related stats.
-    list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
-    list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");
-  }
-}
 
 EngineBuilder& EngineBuilder::setXds(XdsBuilder xds_builder) {
   xds_builder_ = std::move(xds_builder);
@@ -1180,8 +1095,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 EngineSharedPtr EngineBuilder::build() {
   InternalEngine* envoy_engine = absl::IgnoreLeak(new InternalEngine(
       std::move(callbacks_), std::move(logger_), std::move(event_tracker_),
-      network_thread_priority_, high_watermark_, disable_dns_refresh_on_network_change_,
-      enable_logger_, use_worker_thread_));
+      network_thread_priority_, high_watermark_, enable_logger_, use_worker_thread_));
+  envoy_engine->disableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change_);
 
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -18,102 +18,10 @@
 #include "library/cc/string_accessor.h"
 #include "library/common/engine_types.h"
 
+#include "library/cc/engine_builder_types.h"
+
 namespace Envoy {
 namespace Platform {
-
-// Represents the locality information in the Bootstrap's node, as defined in:
-// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-locality
-struct NodeLocality {
-  std::string region;
-  std::string zone;
-  std::string sub_zone;
-};
-
-#ifdef ENVOY_MOBILE_XDS
-constexpr int DefaultXdsTimeout = 5;
-
-// Forward declaration so it can be referenced by XdsBuilder.
-class EngineBuilder;
-
-// A class for building the xDS configuration for the Envoy Mobile engine.
-// xDS is a protocol for dynamic configuration of Envoy instances, more information can be found in:
-// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.
-//
-// This class is typically used as input to the EngineBuilder's setXds() method.
-class XdsBuilder final {
-public:
-  // `xds_server_address`: the host name or IP address of the xDS management server. The xDS server
-  //                       must support the ADS protocol
-  //                       (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#aggregated-xds-ads).
-  // `xds_server_port`: the port on which the xDS management server listens for ADS discovery
-  //                    requests.
-  XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port);
-
-  // Adds a header to the initial HTTP metadata headers sent on the gRPC stream.
-  //
-  // A common use for the initial metadata headers is for authentication to the xDS management
-  // server.
-  //
-  // For example, if using API keys to authenticate to Traffic Director on GCP (see
-  // https://cloud.google.com/docs/authentication/api-keys for details), invoke:
-  //   builder.addInitialStreamHeader("x-goog-api-key", api_key_token)
-  //          .addInitialStreamHeader("X-Android-Package", app_package_name)
-  //          .addInitialStreamHeader("X-Android-Cert", sha1_key_fingerprint);
-  XdsBuilder& addInitialStreamHeader(std::string header, std::string value);
-
-  // Sets the PEM-encoded server root certificates used to negotiate the TLS handshake for the gRPC
-  // connection. If no root certs are specified, the operating system defaults are used.
-  XdsBuilder& setSslRootCerts(std::string root_certs);
-
-  // Adds Runtime Discovery Service (RTDS) to the Runtime layers of the Bootstrap configuration,
-  // to retrieve dynamic runtime configuration via the xDS management server.
-  //
-  // `resource_name`: The runtime config resource to subscribe to.
-  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
-  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
-  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
-  //    parameter value may change through the course of experimentation and no assumptions should
-  //    be made of its exact value.
-  XdsBuilder& addRuntimeDiscoveryService(std::string resource_name,
-                                         int timeout_in_seconds = DefaultXdsTimeout);
-
-  // Adds the Cluster Discovery Service (CDS) configuration for retrieving dynamic cluster resources
-  // via the xDS management server.
-  //
-  // `cds_resources_locator`: <optional> the xdstp:// URI for subscribing to the cluster resources.
-  //    If not using xdstp, then `cds_resources_locator` should be set to the empty string.
-  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
-  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
-  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
-  //    parameter value may change through the course of experimentation and no assumptions should
-  //    be made of its exact value.
-  XdsBuilder& addClusterDiscoveryService(std::string cds_resources_locator = "",
-                                         int timeout_in_seconds = DefaultXdsTimeout);
-
-protected:
-  // Sets the xDS configuration specified on this XdsBuilder instance on the Bootstrap proto
-  // provided as an input parameter.
-  //
-  // This method takes in a modifiable Bootstrap proto pointer because returning a new Bootstrap
-  // proto would rely on proto's MergeFrom behavior, which can lead to unexpected results in the
-  // Bootstrap config.
-  void build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const;
-
-private:
-  // Required so that EngineBuilder can call the XdsBuilder's protected build() method.
-  friend class EngineBuilder;
-
-  std::string xds_server_address_;
-  uint32_t xds_server_port_;
-  std::vector<envoy::config::core::v3::HeaderValue> xds_initial_grpc_metadata_;
-  std::string ssl_root_certs_;
-  std::string rtds_resource_name_;
-  int rtds_timeout_in_seconds_ = DefaultXdsTimeout;
-  bool enable_cds_ = false;
-  std::string cds_resources_locator_;
-  int cds_timeout_in_seconds_ = DefaultXdsTimeout;
-};
-#endif // ENVOY_MOBILE_XDS
 
 // The C++ Engine builder creates a structured bootstrap proto and modifies it through parameters
 // set through the EngineBuilder API calls to produce the Bootstrap config that the Engine is

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -34,10 +34,10 @@ namespace Platform {
  *
  * Key CRTP Hooks the Derived Class SHOULD/MUST implement:
  * 1. Pre-run and Post-run Lifecycle Hooks:
- *    - `void PreRunSetup(InternalEngine* engine)`: Called inside build() on the engine thread
+ *    - `void preRunSetup(InternalEngine* engine)`: Called inside build() on the engine thread
  *      prior to starting the event loop. Derived builders should register dynamic key-value stores
  *      or string accessors here.
- *    - `void PostRunSetup(Engine* engine)`: Called inside build() immediately after starting
+ *    - `void postRunSetup(Engine* engine)`: Called inside build() immediately after starting
  *      the engine. Used to initialize platform monitors (e.g., NetworkChangeMonitor).
  *
  * 2. Bootstrap Configuration Hooks:
@@ -160,7 +160,7 @@ public:
         /*thread_priority=*/absl::nullopt, high_watermark_, enable_logger_, useWorkerThread());
 
     // Pre-run setup (to be implemented by derived classes if needed)
-    static_cast<T*>(this)->PreRunSetup(envoy_engine.get());
+    static_cast<T*>(this)->preRunSetup(envoy_engine.get());
 
     auto options = std::make_shared<Envoy::OptionsImplBase>();
     options->setConfigProto(std::move(bootstrap.value()));
@@ -172,7 +172,7 @@ public:
     auto engine_wrapper =
         std::shared_ptr<Engine>(new Engine(absl::IgnoreLeak(envoy_engine.release())));
 
-    static_cast<T*>(this)->PostRunSetup(engine_wrapper.get());
+    static_cast<T*>(this)->postRunSetup(engine_wrapper.get());
 
     return engine_wrapper;
   }

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -169,7 +169,8 @@ public:
 
     envoy_engine->run(options);
 
-    auto engine_wrapper = std::shared_ptr<Engine>(new Engine(absl::IgnoreLeak(envoy_engine.release())));
+    auto engine_wrapper =
+        std::shared_ptr<Engine>(new Engine(absl::IgnoreLeak(envoy_engine.release())));
 
     static_cast<T*>(this)->PostRunSetup(engine_wrapper.get());
 

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -1,0 +1,380 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "absl/types/optional.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "library/cc/engine.h"
+#include "library/common/engine_types.h"
+#include "library/common/internal_engine.h"
+#include "source/common/common/base_logger.h"
+#include "source/server/options_impl_base.h"
+#include "source/common/runtime/runtime_features.h"
+#include "envoy/type/matcher/v3/string.pb.h"
+
+namespace Envoy {
+namespace Platform {
+
+/**
+ * Base class template implementing the Curiously Recurring Template Pattern (CRTP)
+ * to share common bootstrap generation and lifecycle logic between Engine Builders.
+ *
+ * How to Subclass:
+ * Subclasses should derive from this base class passing themselves as the template parameter:
+ *   class MobileEngineBuilder : public Platform::EngineBuilderBase<MobileEngineBuilder> { ... };
+ *
+ * Key CRTP Hooks the Derived Class SHOULD/MUST implement:
+ * 1. Pre-run and Post-run Lifecycle Hooks:
+ *    - `void PreRunSetup(InternalEngine* engine)`: Called inside build() on the engine thread
+ *      prior to starting the event loop. Derived builders should register dynamic key-value stores
+ *      or string accessors here.
+ *    - `void PostRunSetup(Engine* engine)`: Called inside build() immediately after starting
+ *      the engine. Used to initialize platform monitors (e.g., NetworkChangeMonitor).
+ *
+ * 2. Bootstrap Configuration Hooks:
+ *    - `absl::Status configureNode(envoy::config::core::v3::Node* node)`:
+ *      Configures the Bootstrap's node metadata (e.g., setting app_id, app_version, device_os).
+ *    - `absl::Status configureRouteConfig(envoy::config::route::v3::RouteConfiguration*
+ * route_config)`: Configures virtual hosts, domains, routes, and early data policies.
+ *    - `absl::Status configureStaticClusters(
+ *          Protobuf::RepeatedPtrField<envoy::config::cluster::v3::Cluster>* clusters)`:
+ *      Defines and registers static upstream clusters (e.g., base DFP cluster or mock test
+ * clusters).
+ *    - `absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap* bootstrap)`:
+ *      Configures dynamic xDS RTDS/CDS layers on the bootstrap.
+ *
+ * 3. Optional HTTP Filter Config Overrides:
+ *    - `absl::Status configureHttpFilters(
+ *          std::function<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter*()>
+ * add_filter)`: Customizes the HttpFilter chain (e.g., AlternateProtocolsCache, Decompressors,
+ * SocketTagging).
+ *    - `void configureCustomRouterFilter(
+ *          envoy::extensions::filters::http::router::v3::Router& router_config)`:
+ *      Applies custom tweaks to the terminal HTTP router filter.
+ *    - `absl::Status configureTracing(...)`:
+ *      Configures custom tracing providers.
+ */
+template <typename T> class EngineBuilderBase {
+public:
+  EngineBuilderBase() : callbacks_(std::make_unique<::Envoy::EngineCallbacks>()) {}
+  virtual ~EngineBuilderBase() = default;
+  EngineBuilderBase(EngineBuilderBase&&) = default;
+
+  T& setLogLevel(Logger::Logger::Levels log_level) {
+    log_level_ = log_level;
+    return static_cast<T&>(*this);
+  }
+
+  T& setLogger(std::unique_ptr<EnvoyLogger> logger) {
+    logger_ = std::move(logger);
+    return static_cast<T&>(*this);
+  }
+
+  T& enableLogger(bool logger_on) {
+    enable_logger_ = logger_on;
+    return static_cast<T&>(*this);
+  }
+
+  T& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks) {
+    callbacks_ = std::move(callbacks);
+    return static_cast<T&>(*this);
+  }
+
+  T& setOnEngineRunning(absl::AnyInvocable<void()> closure) {
+    if (!callbacks_) {
+      callbacks_ = std::make_unique<EngineCallbacks>();
+    }
+    callbacks_->on_engine_running_ = std::move(closure);
+    return static_cast<T&>(*this);
+  }
+
+  T& setOnEngineExit(absl::AnyInvocable<void()> closure) {
+    if (!callbacks_) {
+      callbacks_ = std::make_unique<EngineCallbacks>();
+    }
+    callbacks_->on_exit_ = std::move(closure);
+    return static_cast<T&>(*this);
+  }
+
+  T& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker) {
+    event_tracker_ = std::move(event_tracker);
+    return static_cast<T&>(*this);
+  }
+
+  T& setBufferHighWatermark(size_t high_watermark) {
+    high_watermark_ = high_watermark;
+    return static_cast<T&>(*this);
+  }
+
+  T& enableStatsCollection(bool stats_collection_on) {
+    enable_stats_collection_ = stats_collection_on;
+    return static_cast<T&>(*this);
+  }
+
+  T& addReloadableRuntimeGuard(std::string guard, bool value) {
+    reloadable_runtime_guards_.emplace_back(std::move(guard), value);
+    return static_cast<T&>(*this);
+  }
+
+  T& addRestartRuntimeGuard(std::string guard, bool value) {
+    restart_runtime_guards_.emplace_back(std::move(guard), value);
+    return static_cast<T&>(*this);
+  }
+
+  T& setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds) {
+    stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
+    return static_cast<T&>(*this);
+  }
+
+  T& setPerConnectionBufferLimitBytes(uint32_t per_connection_buffer_limit_bytes) {
+    per_connection_buffer_limit_bytes_ = per_connection_buffer_limit_bytes;
+    return static_cast<T&>(*this);
+  }
+
+  // If true, all HTTP requests are handled on a dedicated worker thread instead of on the Envoy
+  // main thread which also handles all xDS requests.
+  // Note: Engine in worker thread model doesn't support platform certificate validation and system
+  // proxy settings. And these settings will be ignored if worker thread model is enabled.
+  T& enableWorkerThread(bool use_worker_thread) {
+    use_worker_thread_ = use_worker_thread;
+    return static_cast<T&>(*this);
+  }
+
+  absl::StatusOr<std::shared_ptr<Engine>> build() {
+    auto bootstrap = static_cast<T*>(this)->generateBootstrap();
+    if (!bootstrap.ok()) {
+      return bootstrap.status();
+    }
+
+    auto envoy_engine = std::make_unique<::Envoy::InternalEngine>(
+        std::move(callbacks_), std::move(logger_), std::move(event_tracker_),
+        /*thread_priority=*/absl::nullopt, high_watermark_, enable_logger_, useWorkerThread());
+
+    // Pre-run setup (to be implemented by derived classes if needed)
+    static_cast<T*>(this)->PreRunSetup(envoy_engine.get());
+
+    auto options = std::make_shared<Envoy::OptionsImplBase>();
+    options->setConfigProto(std::move(bootstrap.value()));
+    options->setLogLevel(static_cast<spdlog::level::level_enum>(log_level_));
+    options->setConcurrency(1);
+
+    envoy_engine->run(options);
+
+    auto engine_wrapper = std::shared_ptr<Engine>(new Engine(envoy_engine.release()));
+
+    static_cast<T*>(this)->PostRunSetup(engine_wrapper.get());
+
+    return engine_wrapper;
+  }
+
+  absl::StatusOr<std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap>> generateBootstrap() {
+    auto bootstrap = std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
+
+    // Set up the HCM, make sure a route config is provided.
+    ::envoy::extensions::filters::network::http_connection_manager::v3::
+        EnvoyMobileHttpConnectionManager api_listener_config;
+    auto* hcm = api_listener_config.mutable_config();
+    hcm->set_stat_prefix("hcm");
+    hcm->set_server_header_transformation(
+        ::envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+            PASS_THROUGH);
+    ::envoy::extensions::filters::network::http_connection_manager::v3::
+        HttpConnectionManager_Tracing tracing;
+    if (auto status = static_cast<T*>(this)->configureTracing(&tracing); !status.ok()) {
+      return status;
+    }
+    if (tracing.ByteSizeLong() > 0) {
+      *hcm->mutable_tracing() = std::move(tracing);
+    }
+    hcm->mutable_stream_idle_timeout()->set_seconds(stream_idle_timeout_seconds_);
+    if (auto status = static_cast<T*>(this)->configureRouteConfig(hcm->mutable_route_config());
+        !status.ok()) {
+      return status;
+    }
+
+    if (auto status = static_cast<T*>(this)->configureHttpFilters(
+            [hcm]() { return hcm->add_http_filters(); });
+        !status.ok()) {
+      return status;
+    }
+
+    // Add the router filter to the HCM last.
+    auto* router_filter = hcm->add_http_filters();
+    router_filter->set_name("envoy.router");
+    ::envoy::extensions::filters::http::router::v3::Router router_config;
+    static_cast<T*>(this)->configureCustomRouterFilter(router_config);
+    router_filter->mutable_typed_config()->PackFrom(router_config);
+
+    auto* static_resources = bootstrap->mutable_static_resources();
+
+    // Finally create the base API listener, and point it at the HCM.
+    auto* base_listener = static_resources->add_listeners();
+    base_listener->set_name("base_api_listener");
+    auto* base_address = base_listener->mutable_address();
+    base_address->mutable_socket_address()->set_protocol(
+        ::envoy::config::core::v3::SocketAddress::TCP);
+    base_address->mutable_socket_address()->set_address("0.0.0.0");
+    base_address->mutable_socket_address()->set_port_value(10000);
+    base_listener->mutable_per_connection_buffer_limit_bytes()->set_value(
+        per_connection_buffer_limit_bytes_);
+    base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
+
+    // Add all clusters to the bootstrap, there should be at least one.
+    if (auto status =
+            static_cast<T*>(this)->configureStaticClusters(static_resources->mutable_clusters());
+        !status.ok()) {
+      return status;
+    }
+
+    if (watchdog_.has_value()) {
+      *bootstrap->mutable_watchdogs() = std::move(watchdog_).value();
+    }
+
+    if (auto status = static_cast<T*>(this)->configureNode(bootstrap->mutable_node());
+        !status.ok()) {
+      return status;
+    }
+
+    configureStats(*bootstrap);
+    configureStaticLayeredRuntime(*bootstrap);
+    configureListenerManager(*bootstrap);
+
+    if (auto status = static_cast<T*>(this)->configXds(bootstrap.get()); !status.ok()) {
+      return status;
+    }
+
+    return bootstrap;
+  }
+
+protected:
+  // The default implementation if the derived class does not override it.
+  absl::Status configureTracing(::envoy::extensions::filters::network::http_connection_manager::v3::
+                                    HttpConnectionManager_Tracing* tracing_config) {
+    (void)tracing_config;
+    return absl::OkStatus();
+  }
+
+  absl::Status configureHttpFilters(
+      std::function<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter*()>
+          add_filter) {
+    (void)add_filter;
+    return absl::OkStatus();
+  }
+
+  absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap* bootstrap) {
+    (void)bootstrap;
+    return absl::OkStatus();
+  }
+
+protected:
+  bool useWorkerThread() const { return use_worker_thread_; }
+
+  void setWatchdog(envoy::config::bootstrap::v3::Watchdogs watchdog) {
+    watchdog_ = std::move(watchdog);
+  }
+
+  void addStatsInclusionPattern(envoy::type::matcher::v3::StringMatcher pattern) {
+    if (!stats_inclusion_list_.has_value()) {
+      stats_inclusion_list_.emplace();
+    }
+    *stats_inclusion_list_->add_patterns() = std::move(pattern);
+  }
+
+private:
+  void configureStats(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
+    if (enable_stats_collection_) {
+      if (stats_inclusion_list_.has_value()) {
+        auto* list =
+            bootstrap.mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
+        list->MergeFrom(stats_inclusion_list_.value());
+      }
+    } else {
+      bootstrap.mutable_stats_config()->mutable_stats_matcher()->set_reject_all(true);
+    }
+    bootstrap.mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+  }
+
+  void configureStaticLayeredRuntime(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
+    auto* runtime = bootstrap.mutable_layered_runtime()->add_layers();
+    runtime->set_name("static_layer_0");
+    Protobuf::Struct envoy_layer;
+    Protobuf::Struct& runtime_values =
+        *(*envoy_layer.mutable_fields())["envoy"].mutable_struct_value();
+
+    if (!reloadable_runtime_guards_.empty()) {
+      Protobuf::Struct& reloadable_features =
+          *(*runtime_values.mutable_fields())["reloadable_features"].mutable_struct_value();
+      for (const auto& guard_and_value : reloadable_runtime_guards_) {
+        if (Runtime::RuntimeFeaturesDefaults::get().getFlag(absl::StrJoin(
+                {"envoy", "reloadable_features", guard_and_value.first}, ".")) == nullptr) {
+          continue;
+        }
+        (*reloadable_features.mutable_fields())[guard_and_value.first].set_bool_value(
+            guard_and_value.second);
+      }
+    }
+
+    if (!restart_runtime_guards_.empty()) {
+      Protobuf::Struct& restart_features =
+          *(*runtime_values.mutable_fields())["restart_features"].mutable_struct_value();
+      for (const auto& guard_and_value : restart_runtime_guards_) {
+        if (Runtime::RuntimeFeaturesDefaults::get().getFlag(absl::StrJoin(
+                {"envoy", "restart_features", guard_and_value.first}, ".")) == nullptr) {
+          continue;
+        }
+        (*restart_features.mutable_fields())[guard_and_value.first].set_bool_value(
+            guard_and_value.second);
+      }
+    }
+
+    (*runtime_values.mutable_fields())["disallow_global_stats"].set_bool_value(true);
+
+    Protobuf::Struct& overload_values =
+        *(*envoy_layer.mutable_fields())["overload"].mutable_struct_value();
+    (*overload_values.mutable_fields())["global_downstream_max_connections"].set_string_value(
+        "4294967295");
+
+    runtime->mutable_static_layer()->MergeFrom(envoy_layer);
+  }
+
+  void configureListenerManager(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
+    envoy::config::bootstrap::v3::ApiListenerManager api;
+    if (!useWorkerThread()) {
+      api.set_threading_model(envoy::config::bootstrap::v3::ApiListenerManager::MAIN_THREAD_ONLY);
+    } else {
+      api.set_threading_model(
+          envoy::config::bootstrap::v3::ApiListenerManager::STANDALONE_WORKER_THREAD);
+    }
+    auto* listener_manager = bootstrap.mutable_listener_manager();
+    listener_manager->mutable_typed_config()->PackFrom(api);
+    listener_manager->set_name("envoy.listener_manager_impl.api");
+  }
+
+  absl::optional<envoy::config::bootstrap::v3::Watchdogs> watchdog_;
+  absl::optional<envoy::type::matcher::v3::ListStringMatcher> stats_inclusion_list_;
+  uint32_t per_connection_buffer_limit_bytes_ = 10485760;
+  int stream_idle_timeout_seconds_ = 15;
+  std::vector<std::pair<std::string, bool>> reloadable_runtime_guards_;
+  std::vector<std::pair<std::string, bool>> restart_runtime_guards_;
+
+  // Common fields for InternalEngine
+  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
+  std::unique_ptr<EnvoyLogger> logger_{nullptr};
+  bool enable_logger_{true};
+  std::unique_ptr<EngineCallbacks> callbacks_;
+  std::unique_ptr<EnvoyEventTracker> event_tracker_{nullptr};
+  absl::optional<size_t> high_watermark_ = absl::nullopt;
+  bool enable_stats_collection_ = true;
+  bool use_worker_thread_ = false;
+};
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/debugging/leak_check.h"
 #include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
@@ -168,7 +169,7 @@ public:
 
     envoy_engine->run(options);
 
-    auto engine_wrapper = std::shared_ptr<Engine>(new Engine(envoy_engine.release()));
+    auto engine_wrapper = std::shared_ptr<Engine>(new Engine(absl::IgnoreLeak(envoy_engine.release())));
 
     static_cast<T*>(this)->PostRunSetup(engine_wrapper.get());
 

--- a/mobile/library/cc/engine_builder_types.cc
+++ b/mobile/library/cc/engine_builder_types.cc
@@ -1,0 +1,99 @@
+#include "library/cc/engine_builder_types.h"
+
+#include "absl/strings/str_cat.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+
+namespace Envoy {
+namespace Platform {
+
+#ifdef ENVOY_MOBILE_XDS
+XdsBuilder::XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port)
+    : xds_server_address_(std::move(xds_server_address)), xds_server_port_(xds_server_port) {}
+
+XdsBuilder& XdsBuilder::addInitialStreamHeader(std::string header, std::string value) {
+  envoy::config::core::v3::HeaderValue header_value;
+  header_value.set_key(std::move(header));
+  header_value.set_value(std::move(value));
+  xds_initial_grpc_metadata_.emplace_back(std::move(header_value));
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::setSslRootCerts(std::string root_certs) {
+  ssl_root_certs_ = std::move(root_certs);
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::addRuntimeDiscoveryService(std::string resource_name,
+                                                   const int timeout_in_seconds) {
+  rtds_resource_name_ = std::move(resource_name);
+  rtds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::addClusterDiscoveryService(std::string cds_resources_locator,
+                                                   const int timeout_in_seconds) {
+  enable_cds_ = true;
+  cds_resources_locator_ = std::move(cds_resources_locator);
+  cds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
+  return *this;
+}
+
+void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
+  auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
+  ads_config->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
+  ads_config->set_set_node_on_first_message_only(true);
+  ads_config->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+
+  auto& grpc_service = *ads_config->add_grpc_services();
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("base");
+  grpc_service.mutable_envoy_grpc()->set_authority(
+      absl::StrCat(xds_server_address_, ":", xds_server_port_));
+
+  if (!xds_initial_grpc_metadata_.empty()) {
+    grpc_service.mutable_initial_metadata()->Assign(xds_initial_grpc_metadata_.begin(),
+                                                    xds_initial_grpc_metadata_.end());
+  }
+
+  if (!rtds_resource_name_.empty()) {
+    auto* layered_runtime = bootstrap.mutable_layered_runtime();
+    auto* layer = layered_runtime->add_layers();
+    layer->set_name("rtds_layer");
+    auto* rtds_layer = layer->mutable_rtds_layer();
+    rtds_layer->set_name(rtds_resource_name_);
+    auto* rtds_config = rtds_layer->mutable_rtds_config();
+    rtds_config->mutable_ads();
+    rtds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+    rtds_config->mutable_initial_fetch_timeout()->set_seconds(rtds_timeout_in_seconds_);
+  }
+
+  if (enable_cds_) {
+    auto* cds_config = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
+    if (cds_resources_locator_.empty()) {
+      cds_config->mutable_ads();
+    } else {
+      bootstrap.mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
+      cds_config->mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
+      cds_config->mutable_api_config_source()->set_transport_api_version(
+          envoy::config::core::v3::ApiVersion::V3);
+    }
+    cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_in_seconds_);
+    cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+    bootstrap.add_node_context_params("cluster");
+    // Stat prefixes that we use in tests.
+    auto* list =
+        bootstrap.mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
+    list->add_patterns()->set_exact("cluster_manager.active_clusters");
+    list->add_patterns()->set_exact("cluster_manager.cluster_added");
+    list->add_patterns()->set_exact("cluster_manager.cluster_updated");
+    list->add_patterns()->set_exact("cluster_manager.cluster_removed");
+    // Allow SDS related stats.
+    list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
+    list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");
+  }
+}
+#endif // ENVOY_MOBILE_XDS
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/library/cc/engine_builder_types.h
+++ b/mobile/library/cc/engine_builder_types.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+
+namespace Envoy {
+namespace Platform {
+
+// Represents the locality information in the Bootstrap's node, as defined in:
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-locality
+struct NodeLocality {
+  std::string region;
+  std::string zone;
+  std::string sub_zone;
+};
+
+#ifdef ENVOY_MOBILE_XDS
+constexpr int DefaultXdsTimeout = 5;
+
+// Forward declarations so they can be friended by XdsBuilder.
+class EngineBuilder;
+class MobileEngineBuilder;
+
+// A class for building the xDS configuration for the Envoy Mobile engine.
+// xDS is a protocol for dynamic configuration of Envoy instances, more information can be found in:
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.
+//
+// This class is typically used as input to the EngineBuilder's/MobileEngineBuilder's setXds()
+// method.
+class XdsBuilder final {
+public:
+  // `xds_server_address`: the host name or IP address of the xDS management server. The xDS server
+  //                       must support the ADS protocol
+  //                       (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#aggregated-xds-ads).
+  // `xds_server_port`: the port on which the xDS management server listens for ADS discovery
+  //                    requests.
+  XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port);
+
+  // Adds a header to the initial HTTP metadata headers sent on the gRPC stream.
+  //
+  // A common use for the initial metadata headers is for authentication to the xDS management
+  // server.
+  //
+  // For example, if using API keys to authenticate to Traffic Director on GCP (see
+  // https://cloud.google.com/docs/authentication/api-keys for details), invoke:
+  //   builder.addInitialStreamHeader("x-goog-api-key", api_key_token)
+  //          .addInitialStreamHeader("X-Android-Package", app_package_name)
+  //          .addInitialStreamHeader("X-Android-Cert", sha1_key_fingerprint);
+  XdsBuilder& addInitialStreamHeader(std::string header, std::string value);
+
+  // Sets the PEM-encoded server root certificates used to negotiate the TLS handshake for the gRPC
+  // connection. If no root certs are specified, the operating system defaults are used.
+  XdsBuilder& setSslRootCerts(std::string root_certs);
+
+  // Adds Runtime Discovery Service (RTDS) to the Runtime layers of the Bootstrap configuration,
+  // to retrieve dynamic runtime configuration via the xDS management server.
+  //
+  // `resource_name`: The runtime config resource to subscribe to.
+  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
+  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
+  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
+  //    parameter value may change through the course of experimentation and no assumptions should
+  //    be made of its exact value.
+  XdsBuilder& addRuntimeDiscoveryService(std::string resource_name,
+                                         int timeout_in_seconds = DefaultXdsTimeout);
+
+  // Adds the Cluster Discovery Service (CDS) configuration for retrieving dynamic cluster resources
+  // via the xDS management server.
+  //
+  // `cds_resources_locator`: <optional> the xdstp:// URI for subscribing to the cluster resources.
+  //    If not using xdstp, then `cds_resources_locator` should be set to the empty string.
+  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
+  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
+  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
+  //    parameter value may change through the course of experimentation and no assumptions should
+  //    be made of its exact value.
+  XdsBuilder& addClusterDiscoveryService(std::string cds_resources_locator = "",
+                                         int timeout_in_seconds = DefaultXdsTimeout);
+
+protected:
+  // Sets the xDS configuration specified on this XdsBuilder instance on the Bootstrap proto
+  // provided as an input parameter.
+  //
+  // This method takes in a modifiable Bootstrap proto pointer because returning a new Bootstrap
+  // proto would rely on proto's MergeFrom behavior, which can lead to unexpected results in the
+  // Bootstrap config.
+  void build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const;
+
+private:
+  // Required so that both Builders can call the XdsBuilder's protected build() method.
+  friend class EngineBuilder;
+  friend class MobileEngineBuilder;
+
+  std::string xds_server_address_;
+  uint32_t xds_server_port_;
+  std::vector<envoy::config::core::v3::HeaderValue> xds_initial_grpc_metadata_;
+  std::string ssl_root_certs_;
+  std::string rtds_resource_name_;
+  int rtds_timeout_in_seconds_ = DefaultXdsTimeout;
+  bool enable_cds_ = false;
+  std::string cds_resources_locator_;
+  int cds_timeout_in_seconds_ = DefaultXdsTimeout;
+};
+#endif // ENVOY_MOBILE_XDS
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -1,4 +1,4 @@
-#include "engine_builder.h"
+#include "library/cc/mobile_engine_builder.h"
 
 #include <stdint.h>
 #include <sys/socket.h>
@@ -27,6 +27,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "source/extensions/clusters/dynamic_forward_proxy/cluster.h"
 #include "source/common/runtime/runtime_features.h"
+#include "envoy/type/matcher/v3/string.pb.h"
 
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
@@ -48,103 +49,63 @@
 namespace Envoy {
 namespace Platform {
 
-EngineBuilder::EngineBuilder() : callbacks_(std::make_unique<EngineCallbacks>()) {}
+MobileEngineBuilder::MobileEngineBuilder() {}
 
-EngineBuilder& EngineBuilder::setNetworkThreadPriority(int thread_priority) {
+MobileEngineBuilder& MobileEngineBuilder::setNetworkThreadPriority(int thread_priority) {
   network_thread_priority_ = thread_priority;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setBufferHighWatermark(size_t high_watermark) {
-  high_watermark_ = high_watermark;
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setLogLevel(Logger::Logger::Levels log_level) {
-  log_level_ = log_level;
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setLogger(std::unique_ptr<EnvoyLogger> logger) {
-  logger_ = std::move(logger);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::enableLogger(bool logger_on) {
-  enable_logger_ = logger_on;
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks) {
-  callbacks_ = std::move(callbacks);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setOnEngineRunning(absl::AnyInvocable<void()> closure) {
-  callbacks_->on_engine_running_ = std::move(closure);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setOnEngineExit(absl::AnyInvocable<void()> closure) {
-  callbacks_->on_exit_ = std::move(closure);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker) {
-  event_tracker_ = std::move(event_tracker);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
   connect_timeout_seconds_ = connect_timeout_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addDnsRefreshSeconds(int dns_refresh_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::addDnsRefreshSeconds(int dns_refresh_seconds) {
   dns_refresh_seconds_ = dns_refresh_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addDnsMinRefreshSeconds(int dns_min_refresh_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::addDnsMinRefreshSeconds(int dns_min_refresh_seconds) {
   dns_min_refresh_seconds_ = dns_min_refresh_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addDnsFailureRefreshSeconds(int base, int max) {
+MobileEngineBuilder& MobileEngineBuilder::addDnsFailureRefreshSeconds(int base, int max) {
   dns_failure_refresh_seconds_base_ = base;
   dns_failure_refresh_seconds_max_ = max;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds) {
   dns_query_timeout_seconds_ = dns_query_timeout_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure) {
+MobileEngineBuilder&
+MobileEngineBuilder::setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure) {
   disable_dns_refresh_on_failure_ = disable_dns_refresh_on_failure;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change) {
+MobileEngineBuilder& MobileEngineBuilder::setDisableDnsRefreshOnNetworkChange(
+    bool disable_dns_refresh_on_network_change) {
   disable_dns_refresh_on_network_change_ = disable_dns_refresh_on_network_change;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setDnsNumRetries(uint32_t dns_num_retries) {
+MobileEngineBuilder& MobileEngineBuilder::setDnsNumRetries(uint32_t dns_num_retries) {
   dns_num_retries_ = dns_num_retries;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setGetaddrinfoNumThreads(uint32_t num_threads) {
+MobileEngineBuilder& MobileEngineBuilder::setGetaddrinfoNumThreads(uint32_t num_threads) {
   getaddrinfo_num_threads_ = num_threads;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addDnsPreresolveHostnames(const std::vector<std::string>& hostnames) {
-  // Add a default port of 443 for all hosts. We'll eventually change this API so it takes a single
-  // {host, pair} and it can be called multiple times.
+MobileEngineBuilder&
+MobileEngineBuilder::addDnsPreresolveHostnames(const std::vector<std::string>& hostnames) {
   dns_preresolve_hostnames_.clear();
   for (const std::string& hostname : hostnames) {
     dns_preresolve_hostnames_.push_back({hostname /* host */, 443 /* port */});
@@ -152,220 +113,220 @@ EngineBuilder& EngineBuilder::addDnsPreresolveHostnames(const std::vector<std::s
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setDnsResolver(
+MobileEngineBuilder& MobileEngineBuilder::setDnsResolver(
     const envoy::config::core::v3::TypedExtensionConfig& dns_resolver_config) {
   dns_resolver_config_ = dns_resolver_config;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setAdditionalSocketOptions(
+MobileEngineBuilder& MobileEngineBuilder::setAdditionalSocketOptions(
     const std::vector<envoy::config::core::v3::SocketOption>& socket_options) {
   socket_options_ = socket_options;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addMaxConnectionsPerHost(int max_connections_per_host) {
+MobileEngineBuilder& MobileEngineBuilder::addMaxConnectionsPerHost(int max_connections_per_host) {
   max_connections_per_host_ = max_connections_per_host;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+MobileEngineBuilder& MobileEngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
     int h2_connection_keepalive_idle_interval_milliseconds) {
   h2_connection_keepalive_idle_interval_milliseconds_ =
       h2_connection_keepalive_idle_interval_milliseconds;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(
+    int h2_connection_keepalive_timeout_seconds) {
   h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addKeyValueStore(std::string name,
-                                               KeyValueStoreSharedPtr key_value_store) {
+MobileEngineBuilder& MobileEngineBuilder::addKeyValueStore(std::string name,
+                                                           KeyValueStoreSharedPtr key_value_store) {
   key_value_stores_[std::move(name)] = std::move(key_value_store);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setAppVersion(std::string app_version) {
+MobileEngineBuilder& MobileEngineBuilder::setAppVersion(std::string app_version) {
   app_version_ = std::move(app_version);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setAppId(std::string app_id) {
+MobileEngineBuilder& MobileEngineBuilder::setAppId(std::string app_id) {
   app_id_ = std::move(app_id);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setDeviceOs(std::string device_os) {
+MobileEngineBuilder& MobileEngineBuilder::setDeviceOs(std::string device_os) {
   device_os_ = std::move(device_os);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds) {
-  stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds) {
+MobileEngineBuilder&
+MobileEngineBuilder::setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds) {
   per_try_idle_timeout_seconds_ = per_try_idle_timeout_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableGzipDecompression(bool gzip_decompression_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableGzipDecompression(bool gzip_decompression_on) {
   gzip_decompression_filter_ = gzip_decompression_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableBrotliDecompression(bool brotli_decompression_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableBrotliDecompression(bool brotli_decompression_on) {
   brotli_decompression_filter_ = brotli_decompression_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableSocketTagging(bool socket_tagging_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableSocketTagging(bool socket_tagging_on) {
   socket_tagging_filter_ = socket_tagging_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableHttp3(bool http3_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableHttp3(bool http3_on) {
   enable_http3_ = http3_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableEarlyData(bool early_data_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableEarlyData(bool early_data_on) {
   enable_early_data_ = early_data_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableScone(bool enable) {
+MobileEngineBuilder& MobileEngineBuilder::enableScone(bool enable) {
   scone_enabled_ = enable;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addQuicConnectionOption(std::string option) {
+MobileEngineBuilder& MobileEngineBuilder::addQuicConnectionOption(std::string option) {
   quic_connection_options_.push_back(std::move(option));
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addQuicClientConnectionOption(std::string option) {
+MobileEngineBuilder& MobileEngineBuilder::addQuicClientConnectionOption(std::string option) {
   quic_client_connection_options_.push_back(std::move(option));
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setHttp3ConnectionOptions(std::string options) {
+MobileEngineBuilder& MobileEngineBuilder::setHttp3ConnectionOptions(std::string options) {
   http3_connection_options_ = std::move(options);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setHttp3ClientConnectionOptions(std::string options) {
+MobileEngineBuilder& MobileEngineBuilder::setHttp3ClientConnectionOptions(std::string options) {
   http3_client_connection_options_ = std::move(options);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addQuicHint(std::string host, int port) {
+MobileEngineBuilder& MobileEngineBuilder::addQuicHint(std::string host, int port) {
   quic_hints_.emplace_back(std::move(host), port);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addQuicCanonicalSuffix(std::string suffix) {
+MobileEngineBuilder& MobileEngineBuilder::addQuicCanonicalSuffix(std::string suffix) {
   quic_suffixes_.emplace_back(std::move(suffix));
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setNumTimeoutsToTriggerPortMigration(int num_timeouts) {
+MobileEngineBuilder& MobileEngineBuilder::setNumTimeoutsToTriggerPortMigration(int num_timeouts) {
   num_timeouts_to_trigger_port_migration_ = num_timeouts;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableInterfaceBinding(bool interface_binding_on) {
+MobileEngineBuilder& MobileEngineBuilder::enableInterfaceBinding(bool interface_binding_on) {
   enable_interface_binding_ = interface_binding_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setUdpSocketReceiveBufferSize(int32_t size) {
+MobileEngineBuilder& MobileEngineBuilder::setUdpSocketReceiveBufferSize(int32_t size) {
   udp_socket_receive_buffer_size_ = size;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setUdpSocketSendBufferSize(int32_t size) {
+MobileEngineBuilder& MobileEngineBuilder::setUdpSocketSendBufferSize(int32_t size) {
   udp_socket_send_buffer_size_ = size;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on) {
+MobileEngineBuilder&
+MobileEngineBuilder::enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on) {
   enable_drain_post_dns_refresh_ = drain_post_dns_refresh_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enforceTrustChainVerification(bool trust_chain_verification_on) {
+MobileEngineBuilder&
+MobileEngineBuilder::enforceTrustChainVerification(bool trust_chain_verification_on) {
   enforce_trust_chain_verification_ = trust_chain_verification_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setUpstreamTlsSni(std::string sni) {
+MobileEngineBuilder& MobileEngineBuilder::setUpstreamTlsSni(std::string sni) {
   upstream_tls_sni_ = std::move(sni);
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds) {
+MobileEngineBuilder&
+MobileEngineBuilder::setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds) {
   quic_connection_idle_timeout_seconds_ = quic_connection_idle_timeout_seconds;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms) {
+MobileEngineBuilder&
+MobileEngineBuilder::setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms) {
   keepalive_initial_interval_ms_ = keepalive_initial_interval_ms;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setMaxConcurrentStreams(int max_concurrent_streams) {
+MobileEngineBuilder& MobileEngineBuilder::setMaxConcurrentStreams(int max_concurrent_streams) {
   max_concurrent_streams_ = max_concurrent_streams;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::enablePlatformCertificatesValidation(bool platform_certificates_validation_on) {
-  if (use_worker_thread_) {
-    // Platform certificate validation is not supported with worker thread.
+MobileEngineBuilder& MobileEngineBuilder::enablePlatformCertificatesValidation(
+    bool platform_certificates_validation_on) {
+  if (useWorkerThread()) {
     return *this;
   }
   platform_certificates_validation_on_ = platform_certificates_validation_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableDnsCache(bool dns_cache_on, int save_interval_seconds) {
+MobileEngineBuilder& MobileEngineBuilder::enableDnsCache(bool dns_cache_on,
+                                                         int save_interval_seconds) {
   dns_cache_on_ = dns_cache_on;
   dns_cache_save_interval_seconds_ = save_interval_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addStringAccessor(std::string name,
-                                                StringAccessorSharedPtr accessor) {
+MobileEngineBuilder& MobileEngineBuilder::addStringAccessor(std::string name,
+                                                            StringAccessorSharedPtr accessor) {
   string_accessors_[std::move(name)] = std::move(accessor);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addNativeFilter(std::string name, std::string typed_config) {
+MobileEngineBuilder& MobileEngineBuilder::addNativeFilter(std::string name,
+                                                          std::string typed_config) {
   native_filter_chain_.emplace_back(NativeFilterConfig(std::move(name), std::move(typed_config)));
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name,
-                                              const Protobuf::Any& typed_config) {
+MobileEngineBuilder& MobileEngineBuilder::addNativeFilter(const std::string& name,
+                                                          const Protobuf::Any& typed_config) {
   native_filter_chain_.push_back(NativeFilterConfig(name, typed_config));
   return *this;
 }
 
 #if defined(__APPLE__)
-EngineBuilder& EngineBuilder::enableNetworkChangeMonitor(bool network_change_monitor_on) {
+MobileEngineBuilder&
+MobileEngineBuilder::enableNetworkChangeMonitor(bool network_change_monitor_on) {
   enable_network_change_monitor_ = network_change_monitor_on;
   return *this;
 }
 #endif
 
-std::string EngineBuilder::nativeNameToConfig(absl::string_view name) {
+std::string MobileEngineBuilder::nativeNameToConfig(absl::string_view name) {
 #ifdef ENVOY_ENABLE_FULL_PROTOS
   return absl::StrCat("[type.googleapis.com/"
                       "envoymobile.extensions.filters.http.platform_bridge.PlatformBridge] {"
@@ -385,11 +346,14 @@ std::string EngineBuilder::nativeNameToConfig(absl::string_view name) {
 #endif
 }
 
-EngineBuilder& EngineBuilder::enableWorkerThread(bool use_worker_thread) {
-  use_worker_thread_ = use_worker_thread;
-  if (use_worker_thread_) {
-    // Platform certificate validation and system proxy settings are not supported with worker
-    // thread.
+MobileEngineBuilder& MobileEngineBuilder::addPlatformFilter(const std::string& name) {
+  addNativeFilter("envoy.filters.http.platform_bridge", nativeNameToConfig(name));
+  return *this;
+}
+
+MobileEngineBuilder& MobileEngineBuilder::enableWorkerThread(bool use_worker_thread) {
+  Platform::EngineBuilderBase<MobileEngineBuilder>::enableWorkerThread(use_worker_thread);
+  if (useWorkerThread()) {
     platform_certificates_validation_on_ = false;
 #ifdef __APPLE__
     respect_system_proxy_settings_ = false;
@@ -398,73 +362,61 @@ EngineBuilder& EngineBuilder::enableWorkerThread(bool use_worker_thread) {
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addPlatformFilter(const std::string& name) {
-  addNativeFilter("envoy.filters.http.platform_bridge", nativeNameToConfig(name));
+MobileEngineBuilder& MobileEngineBuilder::addRuntimeGuard(std::string guard, bool value) {
+  addReloadableRuntimeGuard(std::move(guard), value);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addRuntimeGuard(std::string guard, bool value) {
-  runtime_guards_.emplace_back(std::move(guard), value);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::addRestartRuntimeGuard(std::string guard, bool value) {
-  restart_runtime_guards_.emplace_back(std::move(guard), value);
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::enableStatsCollection(bool stats_collection_on) {
-  enable_stats_collection_ = stats_collection_on;
-  return *this;
-}
-
-EngineBuilder& EngineBuilder::setNodeId(std::string node_id) {
+MobileEngineBuilder& MobileEngineBuilder::setNodeId(std::string node_id) {
   node_id_ = std::move(node_id);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setNodeLocality(std::string region, std::string zone,
-                                              std::string sub_zone) {
+MobileEngineBuilder& MobileEngineBuilder::setNodeLocality(std::string region, std::string zone,
+                                                          std::string sub_zone) {
   node_locality_ = {std::move(region), std::move(zone), std::move(sub_zone)};
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setNodeMetadata(Protobuf::Struct node_metadata) {
+MobileEngineBuilder& MobileEngineBuilder::setNodeMetadata(Protobuf::Struct node_metadata) {
   node_metadata_ = std::move(node_metadata);
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer) {
+MobileEngineBuilder&
+MobileEngineBuilder::setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer) {
   use_quic_platform_packet_writer_ = use_quic_platform_packet_writer;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::enableQuicConnectionMigration(bool quic_connection_migration_on) {
+MobileEngineBuilder&
+MobileEngineBuilder::enableQuicConnectionMigration(bool quic_connection_migration_on) {
   enable_quic_connection_migration_ = quic_connection_migration_on;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setMigrateIdleQuicConnection(bool migrate_idle_quic_connection) {
+MobileEngineBuilder&
+MobileEngineBuilder::setMigrateIdleQuicConnection(bool migrate_idle_quic_connection) {
   migrate_idle_quic_connection_ = migrate_idle_quic_connection;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::setMaxIdleTimeBeforeQuicMigrationSeconds(int max_idle_time_before_quic_migration) {
+MobileEngineBuilder& MobileEngineBuilder::setMaxIdleTimeBeforeQuicMigrationSeconds(
+    int max_idle_time_before_quic_migration) {
   max_idle_time_before_quic_migration_seconds_ = max_idle_time_before_quic_migration;
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network) {
+MobileEngineBuilder&
+MobileEngineBuilder::setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network) {
   max_time_on_non_default_network_seconds_ = max_time_on_non_default_network;
   return *this;
 }
 
 #if defined(__APPLE__)
-EngineBuilder& EngineBuilder::respectSystemProxySettings(bool value, int refresh_interval_secs) {
-  if (use_worker_thread_) {
-    // System proxy settings are not supported with worker thread.
+MobileEngineBuilder& MobileEngineBuilder::respectSystemProxySettings(bool value,
+                                                                     int refresh_interval_secs) {
+  if (useWorkerThread()) {
     return *this;
   }
   respect_system_proxy_settings_ = value;
@@ -474,123 +426,24 @@ EngineBuilder& EngineBuilder::respectSystemProxySettings(bool value, int refresh
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setIosNetworkServiceType(int ios_network_service_type) {
+MobileEngineBuilder& MobileEngineBuilder::setIosNetworkServiceType(int ios_network_service_type) {
   ios_network_service_type_ = ios_network_service_type;
   return *this;
 }
 #endif
 
 #ifdef ENVOY_MOBILE_XDS
-XdsBuilder::XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port)
-    : xds_server_address_(std::move(xds_server_address)), xds_server_port_(xds_server_port) {}
 
-XdsBuilder& XdsBuilder::addInitialStreamHeader(std::string header, std::string value) {
-  envoy::config::core::v3::HeaderValue header_value;
-  header_value.set_key(std::move(header));
-  header_value.set_value(std::move(value));
-  xds_initial_grpc_metadata_.emplace_back(std::move(header_value));
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::setSslRootCerts(std::string root_certs) {
-  ssl_root_certs_ = std::move(root_certs);
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::addRuntimeDiscoveryService(std::string resource_name,
-                                                   const int timeout_in_seconds) {
-  rtds_resource_name_ = std::move(resource_name);
-  rtds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
-  return *this;
-}
-
-XdsBuilder& XdsBuilder::addClusterDiscoveryService(std::string cds_resources_locator,
-                                                   const int timeout_in_seconds) {
-  enable_cds_ = true;
-  cds_resources_locator_ = std::move(cds_resources_locator);
-  cds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
-  return *this;
-}
-
-void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
-  auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
-  ads_config->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
-  ads_config->set_set_node_on_first_message_only(true);
-  ads_config->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-
-  auto& grpc_service = *ads_config->add_grpc_services();
-  grpc_service.mutable_envoy_grpc()->set_cluster_name("base");
-  grpc_service.mutable_envoy_grpc()->set_authority(
-      absl::StrCat(xds_server_address_, ":", xds_server_port_));
-
-  if (!xds_initial_grpc_metadata_.empty()) {
-    grpc_service.mutable_initial_metadata()->Assign(xds_initial_grpc_metadata_.begin(),
-                                                    xds_initial_grpc_metadata_.end());
-  }
-
-  if (!rtds_resource_name_.empty()) {
-    auto* layered_runtime = bootstrap.mutable_layered_runtime();
-    auto* layer = layered_runtime->add_layers();
-    layer->set_name("rtds_layer");
-    auto* rtds_layer = layer->mutable_rtds_layer();
-    rtds_layer->set_name(rtds_resource_name_);
-    auto* rtds_config = rtds_layer->mutable_rtds_config();
-    rtds_config->mutable_ads();
-    rtds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-    rtds_config->mutable_initial_fetch_timeout()->set_seconds(rtds_timeout_in_seconds_);
-  }
-
-  if (enable_cds_) {
-    auto* cds_config = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
-    if (cds_resources_locator_.empty()) {
-      cds_config->mutable_ads();
-    } else {
-      bootstrap.mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
-      cds_config->mutable_api_config_source()->set_api_type(
-          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
-      cds_config->mutable_api_config_source()->set_transport_api_version(
-          envoy::config::core::v3::ApiVersion::V3);
-    }
-    cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_in_seconds_);
-    cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
-    bootstrap.add_node_context_params("cluster");
-    // Stat prefixes that we use in tests.
-    auto* list =
-        bootstrap.mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
-    list->add_patterns()->set_exact("cluster_manager.active_clusters");
-    list->add_patterns()->set_exact("cluster_manager.cluster_added");
-    list->add_patterns()->set_exact("cluster_manager.cluster_updated");
-    list->add_patterns()->set_exact("cluster_manager.cluster_removed");
-    // Allow SDS related stats.
-    list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
-    list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");
-  }
-}
-
-EngineBuilder& EngineBuilder::setXds(XdsBuilder xds_builder) {
+MobileEngineBuilder& MobileEngineBuilder::setXds(XdsBuilder xds_builder) {
   xds_builder_ = std::move(xds_builder);
-  // Add the XdsBuilder's xDS server hostname and port to the list of DNS addresses to preresolve in
-  // the `base` DFP cluster.
   dns_preresolve_hostnames_.push_back(
       {xds_builder_->xds_server_address_ /* host */, xds_builder_->xds_server_port_ /* port */});
   return *this;
 }
 #endif // ENVOY_MOBILE_XDS
 
-std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generateBootstrap() const {
-  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =
-      std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
-
-  // Set up the HCM
-  envoy::extensions::filters::network::http_connection_manager::v3::EnvoyMobileHttpConnectionManager
-      api_listener_config;
-  auto* hcm = api_listener_config.mutable_config();
-  hcm->set_stat_prefix("hcm");
-  hcm->set_server_header_transformation(
-      envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
-          PASS_THROUGH);
-  hcm->mutable_stream_idle_timeout()->set_seconds(stream_idle_timeout_seconds_);
-  auto* route_config = hcm->mutable_route_config();
+absl::Status MobileEngineBuilder::configureRouteConfig(
+    envoy::config::route::v3::RouteConfiguration* route_config) {
   route_config->set_name("api_router");
 
   auto* api_service = route_config->add_virtual_hosts();
@@ -618,13 +471,18 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     ::envoy::extensions::early_data::v3::DefaultEarlyDataPolicy config;
     early_data->mutable_typed_config()->PackFrom(config);
   }
+  return absl::OkStatus();
+}
 
+absl::Status MobileEngineBuilder::configureHttpFilters(
+    std::function<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter*()>
+        add_filter) {
   for (auto filter = native_filter_chain_.rbegin(); filter != native_filter_chain_.rend();
        ++filter) {
-    auto* native_filter = hcm->add_http_filters();
+    auto* native_filter = add_filter();
     native_filter->set_name(filter->name_);
     if (!filter->textproto_typed_config_.empty()) {
-#ifdef ENVOY_ENABLE_FULL_PROTOS
+#if ENVOY_ENABLE_FULL_PROTOS
       Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
                                             native_filter->mutable_typed_config());
       RELEASE_ASSERT(!native_filter->typed_config().DebugString().empty(),
@@ -639,10 +497,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     }
   }
 
-  // Set up the optional filters
   if (enable_http3_) {
     envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig cache_config;
-    auto* cache_filter = hcm->add_http_filters();
+    auto* cache_filter = add_filter();
     cache_filter->set_name("alternate_protocols_cache");
     cache_filter->mutable_typed_config()->PackFrom(cache_config);
   }
@@ -661,7 +518,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     decompressor_config.mutable_response_direction_config()
         ->mutable_common_config()
         ->set_ignore_no_transform_header(true);
-    auto* gzip_filter = hcm->add_http_filters();
+    auto* gzip_filter = add_filter();
     gzip_filter->set_name("envoy.filters.http.decompressor");
     gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
@@ -678,33 +535,40 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     decompressor_config.mutable_response_direction_config()
         ->mutable_common_config()
         ->set_ignore_no_transform_header(true);
-    auto* brotli_filter = hcm->add_http_filters();
+    auto* brotli_filter = add_filter();
     brotli_filter->set_name("envoy.filters.http.decompressor");
     brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
   if (socket_tagging_filter_) {
     envoymobile::extensions::filters::http::socket_tag::SocketTag tag_config;
-    auto* tag_filter = hcm->add_http_filters();
+    auto* tag_filter = add_filter();
     tag_filter->set_name("envoy.filters.http.socket_tag");
     tag_filter->mutable_typed_config()->PackFrom(tag_config);
   }
 
-  // Set up the always-present filters
   envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration
       network_config;
   network_config.set_enable_drain_post_dns_refresh(enable_drain_post_dns_refresh_);
   network_config.set_enable_interface_binding(enable_interface_binding_);
-  auto* network_filter = hcm->add_http_filters();
+  auto* network_filter = add_filter();
   network_filter->set_name("envoy.filters.http.network_configuration");
   network_filter->mutable_typed_config()->PackFrom(network_config);
 
   envoymobile::extensions::filters::http::local_error::LocalError local_config;
-  auto* local_filter = hcm->add_http_filters();
+  auto* local_filter = add_filter();
   local_filter->set_name("envoy.filters.http.local_error");
   local_filter->mutable_typed_config()->PackFrom(local_config);
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig dfp_config;
-  auto* dns_cache_config = dfp_config.mutable_dns_cache_config();
+  configureDnsCache(dfp_config.mutable_dns_cache_config());
+  auto* dfp_filter = add_filter();
+  dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
+  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
+  return absl::OkStatus();
+}
+
+void MobileEngineBuilder::configureDnsCache(
+    envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig* dns_cache_config) const {
   dns_cache_config->set_name("base_dns_cache");
   dns_cache_config->set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
   dns_cache_config->mutable_host_ttl()->set_seconds(86400);
@@ -757,29 +621,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     address->set_address(host);
     address->set_port_value(port);
   }
+}
 
-  auto* dfp_filter = hcm->add_http_filters();
-  dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
-  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
-
-  auto* router_filter = hcm->add_http_filters();
-  envoy::extensions::filters::http::router::v3::Router router_config;
-  router_filter->set_name("envoy.router");
-  router_filter->mutable_typed_config()->PackFrom(router_config);
-
-  auto* static_resources = bootstrap->mutable_static_resources();
-
-  // Finally create the base listener, and point it at the HCM.
-  auto* base_listener = static_resources->add_listeners();
-  base_listener->set_name("base_api_listener");
-  auto* base_address = base_listener->mutable_address();
-  base_address->mutable_socket_address()->set_protocol(envoy::config::core::v3::SocketAddress::TCP);
-  base_address->mutable_socket_address()->set_address("0.0.0.0");
-  base_address->mutable_socket_address()->set_port_value(10000);
-  base_listener->mutable_per_connection_buffer_limit_bytes()->set_value(10485760);
-  base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
-
-  // Basic TLS config.
+absl::Status MobileEngineBuilder::configureStaticClusters(
+    Protobuf::RepeatedPtrField<envoy::config::cluster::v3::Cluster>* clusters) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_socket;
   if (!upstream_tls_sni_.empty()) {
     tls_socket.set_sni(upstream_tls_sni_);
@@ -812,16 +657,12 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     }
 #endif // ENVOY_MOBILE_XDS
     if (certs.empty()) {
-      // The xDS builder doesn't supply root certs, so we'll use the certs packed with Envoy Mobile,
-      // if the build config allows it.
       const char* inline_certs = ""
 #ifndef EXCLUDE_CERTIFICATES
 #include "library/common/config/certificates.inc"
 #endif
                                  "";
       certs = inline_certs;
-      // The certificates in certificates.inc are prefixed with 2 spaces per
-      // line to be ingressed into YAML.
       absl::StrReplaceAll({{"\n  ", "\n"}}, &certs);
     }
     if (!certs.empty()) {
@@ -833,18 +674,13 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   ssl_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
   ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
 
-  envoy::config::core::v3::TransportSocket base_tls_socket;
-  base_tls_socket.set_name("envoy.transport_sockets.http_11_proxy");
-  base_tls_socket.mutable_typed_config()->PackFrom(ssl_proxy_socket);
-
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions h2_protocol_options;
   h2_protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
 
-  // Base cluster config (DFP cluster config)
-  auto* base_cluster = static_resources->add_clusters();
+  envoy::config::cluster::v3::Cluster* base_cluster = clusters->Add();
   envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig base_cluster_config;
   envoy::config::cluster::v3::Cluster::CustomClusterType base_cluster_type;
-  base_cluster_config.mutable_dns_cache_config()->CopyFrom(*dns_cache_config);
+  configureDnsCache(base_cluster_config.mutable_dns_cache_config());
   base_cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
   base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
 
@@ -919,7 +755,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       *alpn_options.mutable_auto_config()->mutable_http_protocol_options());
 
   // Base clear-text cluster.
-  auto* base_clear = static_resources->add_clusters();
+  envoy::config::cluster::v3::Cluster* base_clear = clusters->Add();
   base_clear->set_name("base_clear");
   base_clear->mutable_connect_timeout()->set_seconds(connect_timeout_seconds_);
   base_clear->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
@@ -1065,42 +901,48 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
       sock_opt->CopyFrom(socket_option);
     }
   }
+  return absl::OkStatus();
+}
 
-  // Set up stats.
-  if (enable_stats_collection_) {
-    auto* list =
-        bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
-    list->add_patterns()->set_prefix("cluster.base.upstream_rq_");
-    list->add_patterns()->set_prefix("cluster.stats.upstream_rq_");
-    list->add_patterns()->set_prefix("cluster.base.upstream_cx_");
-    list->add_patterns()->set_prefix("cluster.stats.upstream_cx_");
-    list->add_patterns()->set_exact("cluster.base.http2.keepalive_timeout");
-    list->add_patterns()->set_exact("cluster.base.upstream_http3_broken");
-    list->add_patterns()->set_exact("cluster.stats.http2.keepalive_timeout");
-    list->add_patterns()->set_prefix("http.hcm.downstream_rq_");
-    list->add_patterns()->set_prefix("http.hcm.decompressor.");
-    list->add_patterns()->set_prefix("pulse.");
-    list->add_patterns()->set_prefix("runtime.load_success");
-    list->add_patterns()->set_prefix("dns_cache");
-    list->add_patterns()->mutable_safe_regex()->set_regex(
-        "^vhost\\.[\\w]+\\.vcluster\\.[\\w]+?\\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry|"
-        "total)");
-    list->add_patterns()->set_contains("quic_connection_close_error_code");
-    list->add_patterns()->set_contains("quic_reset_stream_error_code");
-  } else {
-    bootstrap->mutable_stats_config()->mutable_stats_matcher()->set_reject_all(true);
-  }
-  bootstrap->mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+void MobileEngineBuilder::addStatsInclusionStringMatchers() {
+  auto add_prefix = [this](const std::string& prefix) {
+    envoy::type::matcher::v3::StringMatcher matcher;
+    matcher.set_prefix(prefix);
+    addStatsInclusionPattern(std::move(matcher));
+  };
+  auto add_regex = [this](const std::string& regex) {
+    envoy::type::matcher::v3::StringMatcher matcher;
+    matcher.mutable_safe_regex()->set_regex(regex);
+    addStatsInclusionPattern(std::move(matcher));
+  };
+  add_prefix("cluster.base.upstream_rq_");
+  add_prefix("cluster.stats.upstream_rq_");
+  add_prefix("cluster.base.upstream_cx_");
+  add_prefix("cluster.stats.upstream_cx_");
+  add_regex("^cluster\\.base\\.http2\\.keepalive_timeout$");
+  add_regex("^cluster\\.base\\.upstream_http3_broken$");
+  add_regex("^cluster\\.stats\\.http2\\.keepalive_timeout$");
+  add_prefix("http.hcm.downstream_rq_");
+  add_prefix("http.hcm.decompressor.");
+  add_prefix("pulse.");
+  add_prefix("runtime.load_success");
+  add_prefix("dns_cache");
+  add_regex("^vhost\\.[\\w]+\\.vcluster\\.[\\w]+?\\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry|"
+            "total)");
+  add_regex(".*quic_connection_close_error_code.*");
+  add_regex(".*quic_reset_stream_error_code.*");
+}
 
-  // Set up watchdog
-  auto* watchdog = bootstrap->mutable_watchdogs();
-  watchdog->mutable_main_thread_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
-  watchdog->mutable_main_thread_watchdog()->mutable_miss_timeout()->set_seconds(60);
-  watchdog->mutable_worker_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
-  watchdog->mutable_worker_watchdog()->mutable_miss_timeout()->set_seconds(60);
+void MobileEngineBuilder::addWatchdog() {
+  envoy::config::bootstrap::v3::Watchdogs watchdog;
+  watchdog.mutable_main_thread_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
+  watchdog.mutable_main_thread_watchdog()->mutable_miss_timeout()->set_seconds(60);
+  watchdog.mutable_worker_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
+  watchdog.mutable_worker_watchdog()->mutable_miss_timeout()->set_seconds(60);
+  setWatchdog(std::move(watchdog));
+}
 
-  // Set up node
-  auto* node = bootstrap->mutable_node();
+absl::Status MobileEngineBuilder::configureNode(envoy::config::core::v3::Node* node) {
   node->set_id(node_id_.empty() ? "envoy-mobile" : node_id_);
   node->set_cluster("envoy-mobile");
   if (node_locality_ && !node_locality_->region.empty()) {
@@ -1116,73 +958,25 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   (*metadata.mutable_fields())["app_version"].set_string_value(app_version_);
   (*metadata.mutable_fields())["device_os"].set_string_value(device_os_);
 
-  // Set up runtime.
-  auto* runtime = bootstrap->mutable_layered_runtime()->add_layers();
-  runtime->set_name("static_layer_0");
-  Protobuf::Struct envoy_layer;
-  Protobuf::Struct& runtime_values =
-      *(*envoy_layer.mutable_fields())["envoy"].mutable_struct_value();
-  Protobuf::Struct& reloadable_features =
-      *(*runtime_values.mutable_fields())["reloadable_features"].mutable_struct_value();
-  for (auto& guard_and_value : runtime_guards_) {
-    if (Runtime::RuntimeFeaturesDefaults::get().getFlag(absl::StrJoin(
-            {"envoy", "reloadable_features", guard_and_value.first}, ".")) == nullptr) {
-      // Not a registered runtime guard, skip it.
-      continue;
-    }
-    (*reloadable_features.mutable_fields())[guard_and_value.first].set_bool_value(
-        guard_and_value.second);
-  }
-  Protobuf::Struct& restart_features =
-      *(*runtime_values.mutable_fields())["restart_features"].mutable_struct_value();
-  for (auto& guard_and_value : restart_runtime_guards_) {
-    if (Runtime::RuntimeFeaturesDefaults::get().getFlag(
-            absl::StrJoin({"envoy", "restart_features", guard_and_value.first}, ".")) == nullptr) {
-      // Not a registered runtime guard, skip it.
-      continue;
-    }
-    (*restart_features.mutable_fields())[guard_and_value.first].set_bool_value(
-        guard_and_value.second);
-  }
-  (*runtime_values.mutable_fields())["disallow_global_stats"].set_bool_value(true);
-  (*runtime_values.mutable_fields())["enable_dfp_dns_trace"].set_bool_value(true);
-  Protobuf::Struct& overload_values =
-      *(*envoy_layer.mutable_fields())["overload"].mutable_struct_value();
-  (*overload_values.mutable_fields())["global_downstream_max_connections"].set_string_value(
-      "4294967295");
-  runtime->mutable_static_layer()->MergeFrom(envoy_layer);
+  return absl::OkStatus();
+}
 
-  bootstrap->mutable_typed_dns_resolver_config()->CopyFrom(
-      *dns_cache_config->mutable_typed_dns_resolver_config());
-
-  bootstrap->mutable_dynamic_resources();
-
+absl::Status MobileEngineBuilder::configXds(envoy::config::bootstrap::v3::Bootstrap* bootstrap) {
+  (void)bootstrap;
 #ifdef ENVOY_MOBILE_XDS
   if (xds_builder_) {
     xds_builder_->build(*bootstrap);
   }
 #endif // ENVOY_MOBILE_XDS
-
-  envoy::config::bootstrap::v3::ApiListenerManager api;
-  if (!use_worker_thread_) {
-    api.set_threading_model(envoy::config::bootstrap::v3::ApiListenerManager::MAIN_THREAD_ONLY);
-  } else {
-    api.set_threading_model(
-        envoy::config::bootstrap::v3::ApiListenerManager::STANDALONE_WORKER_THREAD);
-  }
-  auto* listener_manager = bootstrap->mutable_listener_manager();
-  listener_manager->mutable_typed_config()->PackFrom(api);
-  listener_manager->set_name("envoy.listener_manager_impl.api");
-
-  return bootstrap;
+  return absl::OkStatus();
 }
 
-EngineSharedPtr EngineBuilder::build() {
-  InternalEngine* envoy_engine = absl::IgnoreLeak(new InternalEngine(
-      std::move(callbacks_), std::move(logger_), std::move(event_tracker_),
-      network_thread_priority_, high_watermark_, disable_dns_refresh_on_network_change_,
-      enable_logger_, use_worker_thread_));
+EngineSharedPtr MobileEngineBuilder::build() {
+  return Platform::EngineBuilderBase<MobileEngineBuilder>::build().value();
+}
 
+void MobileEngineBuilder::PreRunSetup(InternalEngine* engine) {
+  engine->disableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change_);
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.
     if (!Api::External::retrieveApi(name, true)) {
@@ -1206,26 +1000,12 @@ EngineSharedPtr EngineBuilder::build() {
     registerAppleProxyResolver(proxy_settings_refresh_interval_secs_);
   }
 #endif
+}
 
-  Engine* engine = new Engine(envoy_engine);
-
-  auto options = std::make_shared<Envoy::OptionsImplBase>();
-  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = generateBootstrap();
-  if (bootstrap) {
-    options->setConfigProto(std::move(bootstrap));
-  }
-  options->setLogLevel(static_cast<spdlog::level::level_enum>(log_level_));
-  options->setConcurrency(1);
-  envoy_engine->run(options);
-
+void MobileEngineBuilder::PostRunSetup(Engine* engine) {
   if (enable_network_change_monitor_) {
     engine->initializeNetworkChangeMonitor();
   }
-
-  // we can't construct via std::make_shared
-  // because Engine is only constructible as a friend
-  auto engine_ptr = EngineSharedPtr(engine);
-  return engine_ptr;
 }
 
 } // namespace Platform

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -1,0 +1,1232 @@
+#include "engine_builder.h"
+
+#include <stdint.h>
+#include <sys/socket.h>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/core/v3/socket_option.pb.h"
+#include "envoy/config/metrics/v3/metrics_service.pb.h"
+#include "envoy/extensions/compression/brotli/decompressor/v3/brotli.pb.h"
+#include "envoy/extensions/compression/gzip/decompressor/v3/gzip.pb.h"
+#include "envoy/extensions/filters/http/alternate_protocols_cache/v3/alternate_protocols_cache.pb.h"
+#include "envoy/extensions/filters/http/decompressor/v3/decompressor.pb.h"
+#include "envoy/extensions/filters/http/dynamic_forward_proxy/v3/dynamic_forward_proxy.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
+#include "envoy/extensions/early_data/v3/default_early_data_policy.pb.h"
+
+#if defined(__APPLE__)
+#include "envoy/extensions/network/dns_resolver/apple/v3/apple_dns_resolver.pb.h"
+#endif
+#include "envoy/extensions/network/dns_resolver/getaddrinfo/v3/getaddrinfo_dns_resolver.pb.h"
+#include "envoy/extensions/transport_sockets/http_11_proxy/v3/upstream_http_11_connect.pb.h"
+#include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.pb.h"
+
+#include "source/common/http/matching/inputs.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "source/extensions/clusters/dynamic_forward_proxy/cluster.h"
+#include "source/common/runtime/runtime_features.h"
+
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
+#include "absl/debugging/leak_check.h"
+#include "fmt/core.h"
+#include "library/common/internal_engine.h"
+#include "library/common/extensions/cert_validator/platform_bridge/platform_bridge.pb.h"
+#include "library/common/extensions/filters/http/platform_bridge/filter.pb.h"
+#include "library/common/extensions/filters/http/local_error/filter.pb.h"
+#include "library/common/extensions/filters/http/network_configuration/filter.pb.h"
+#include "library/common/extensions/filters/http/socket_tag/filter.pb.h"
+#include "library/common/extensions/key_value/platform/platform.pb.h"
+#include "library/common/extensions/quic_packet_writer/platform/platform_packet_writer.pb.h"
+
+#if defined(__APPLE__)
+#include "library/common/network/apple_proxy_resolution.h"
+#endif
+
+namespace Envoy {
+namespace Platform {
+
+EngineBuilder::EngineBuilder() : callbacks_(std::make_unique<EngineCallbacks>()) {}
+
+EngineBuilder& EngineBuilder::setNetworkThreadPriority(int thread_priority) {
+  network_thread_priority_ = thread_priority;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setBufferHighWatermark(size_t high_watermark) {
+  high_watermark_ = high_watermark;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setLogLevel(Logger::Logger::Levels log_level) {
+  log_level_ = log_level;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setLogger(std::unique_ptr<EnvoyLogger> logger) {
+  logger_ = std::move(logger);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableLogger(bool logger_on) {
+  enable_logger_ = logger_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks) {
+  callbacks_ = std::move(callbacks);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setOnEngineRunning(absl::AnyInvocable<void()> closure) {
+  callbacks_->on_engine_running_ = std::move(closure);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setOnEngineExit(absl::AnyInvocable<void()> closure) {
+  callbacks_->on_exit_ = std::move(closure);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker) {
+  event_tracker_ = std::move(event_tracker);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
+  connect_timeout_seconds_ = connect_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addDnsRefreshSeconds(int dns_refresh_seconds) {
+  dns_refresh_seconds_ = dns_refresh_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addDnsMinRefreshSeconds(int dns_min_refresh_seconds) {
+  dns_min_refresh_seconds_ = dns_min_refresh_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addDnsFailureRefreshSeconds(int base, int max) {
+  dns_failure_refresh_seconds_base_ = base;
+  dns_failure_refresh_seconds_max_ = max;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds) {
+  dns_query_timeout_seconds_ = dns_query_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure) {
+  disable_dns_refresh_on_failure_ = disable_dns_refresh_on_failure;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change) {
+  disable_dns_refresh_on_network_change_ = disable_dns_refresh_on_network_change;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setDnsNumRetries(uint32_t dns_num_retries) {
+  dns_num_retries_ = dns_num_retries;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setGetaddrinfoNumThreads(uint32_t num_threads) {
+  getaddrinfo_num_threads_ = num_threads;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addDnsPreresolveHostnames(const std::vector<std::string>& hostnames) {
+  // Add a default port of 443 for all hosts. We'll eventually change this API so it takes a single
+  // {host, pair} and it can be called multiple times.
+  dns_preresolve_hostnames_.clear();
+  for (const std::string& hostname : hostnames) {
+    dns_preresolve_hostnames_.push_back({hostname /* host */, 443 /* port */});
+  }
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setDnsResolver(
+    const envoy::config::core::v3::TypedExtensionConfig& dns_resolver_config) {
+  dns_resolver_config_ = dns_resolver_config;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setAdditionalSocketOptions(
+    const std::vector<envoy::config::core::v3::SocketOption>& socket_options) {
+  socket_options_ = socket_options;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addMaxConnectionsPerHost(int max_connections_per_host) {
+  max_connections_per_host_ = max_connections_per_host;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+    int h2_connection_keepalive_idle_interval_milliseconds) {
+  h2_connection_keepalive_idle_interval_milliseconds_ =
+      h2_connection_keepalive_idle_interval_milliseconds;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
+  h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addKeyValueStore(std::string name,
+                                               KeyValueStoreSharedPtr key_value_store) {
+  key_value_stores_[std::move(name)] = std::move(key_value_store);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setAppVersion(std::string app_version) {
+  app_version_ = std::move(app_version);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setAppId(std::string app_id) {
+  app_id_ = std::move(app_id);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setDeviceOs(std::string device_os) {
+  device_os_ = std::move(device_os);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds) {
+  stream_idle_timeout_seconds_ = stream_idle_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds) {
+  per_try_idle_timeout_seconds_ = per_try_idle_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableGzipDecompression(bool gzip_decompression_on) {
+  gzip_decompression_filter_ = gzip_decompression_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableBrotliDecompression(bool brotli_decompression_on) {
+  brotli_decompression_filter_ = brotli_decompression_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableSocketTagging(bool socket_tagging_on) {
+  socket_tagging_filter_ = socket_tagging_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableHttp3(bool http3_on) {
+  enable_http3_ = http3_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableEarlyData(bool early_data_on) {
+  enable_early_data_ = early_data_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableScone(bool enable) {
+  scone_enabled_ = enable;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addQuicConnectionOption(std::string option) {
+  quic_connection_options_.push_back(std::move(option));
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addQuicClientConnectionOption(std::string option) {
+  quic_client_connection_options_.push_back(std::move(option));
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setHttp3ConnectionOptions(std::string options) {
+  http3_connection_options_ = std::move(options);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setHttp3ClientConnectionOptions(std::string options) {
+  http3_client_connection_options_ = std::move(options);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addQuicHint(std::string host, int port) {
+  quic_hints_.emplace_back(std::move(host), port);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addQuicCanonicalSuffix(std::string suffix) {
+  quic_suffixes_.emplace_back(std::move(suffix));
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setNumTimeoutsToTriggerPortMigration(int num_timeouts) {
+  num_timeouts_to_trigger_port_migration_ = num_timeouts;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableInterfaceBinding(bool interface_binding_on) {
+  enable_interface_binding_ = interface_binding_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setUdpSocketReceiveBufferSize(int32_t size) {
+  udp_socket_receive_buffer_size_ = size;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setUdpSocketSendBufferSize(int32_t size) {
+  udp_socket_send_buffer_size_ = size;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on) {
+  enable_drain_post_dns_refresh_ = drain_post_dns_refresh_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enforceTrustChainVerification(bool trust_chain_verification_on) {
+  enforce_trust_chain_verification_ = trust_chain_verification_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setUpstreamTlsSni(std::string sni) {
+  upstream_tls_sni_ = std::move(sni);
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds) {
+  quic_connection_idle_timeout_seconds_ = quic_connection_idle_timeout_seconds;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms) {
+  keepalive_initial_interval_ms_ = keepalive_initial_interval_ms;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setMaxConcurrentStreams(int max_concurrent_streams) {
+  max_concurrent_streams_ = max_concurrent_streams;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::enablePlatformCertificatesValidation(bool platform_certificates_validation_on) {
+  if (use_worker_thread_) {
+    // Platform certificate validation is not supported with worker thread.
+    return *this;
+  }
+  platform_certificates_validation_on_ = platform_certificates_validation_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableDnsCache(bool dns_cache_on, int save_interval_seconds) {
+  dns_cache_on_ = dns_cache_on;
+  dns_cache_save_interval_seconds_ = save_interval_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addStringAccessor(std::string name,
+                                                StringAccessorSharedPtr accessor) {
+  string_accessors_[std::move(name)] = std::move(accessor);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addNativeFilter(std::string name, std::string typed_config) {
+  native_filter_chain_.emplace_back(NativeFilterConfig(std::move(name), std::move(typed_config)));
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name,
+                                              const Protobuf::Any& typed_config) {
+  native_filter_chain_.push_back(NativeFilterConfig(name, typed_config));
+  return *this;
+}
+
+#if defined(__APPLE__)
+EngineBuilder& EngineBuilder::enableNetworkChangeMonitor(bool network_change_monitor_on) {
+  enable_network_change_monitor_ = network_change_monitor_on;
+  return *this;
+}
+#endif
+
+std::string EngineBuilder::nativeNameToConfig(absl::string_view name) {
+#ifdef ENVOY_ENABLE_FULL_PROTOS
+  return absl::StrCat("[type.googleapis.com/"
+                      "envoymobile.extensions.filters.http.platform_bridge.PlatformBridge] {"
+                      "platform_filter_name: \"",
+                      name, "\" }");
+#else
+  envoymobile::extensions::filters::http::platform_bridge::PlatformBridge proto_config;
+  proto_config.set_platform_filter_name(name);
+  std::string ret;
+  proto_config.SerializeToString(&ret);
+  Protobuf::Any any_config;
+  any_config.set_type_url(
+      "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge");
+  any_config.set_value(ret);
+  any_config.SerializeToString(&ret);
+  return ret;
+#endif
+}
+
+EngineBuilder& EngineBuilder::enableWorkerThread(bool use_worker_thread) {
+  use_worker_thread_ = use_worker_thread;
+  if (use_worker_thread_) {
+    // Platform certificate validation and system proxy settings are not supported with worker
+    // thread.
+    platform_certificates_validation_on_ = false;
+#ifdef __APPLE__
+    respect_system_proxy_settings_ = false;
+#endif
+  }
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addPlatformFilter(const std::string& name) {
+  addNativeFilter("envoy.filters.http.platform_bridge", nativeNameToConfig(name));
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addRuntimeGuard(std::string guard, bool value) {
+  runtime_guards_.emplace_back(std::move(guard), value);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addRestartRuntimeGuard(std::string guard, bool value) {
+  restart_runtime_guards_.emplace_back(std::move(guard), value);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableStatsCollection(bool stats_collection_on) {
+  enable_stats_collection_ = stats_collection_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setNodeId(std::string node_id) {
+  node_id_ = std::move(node_id);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setNodeLocality(std::string region, std::string zone,
+                                              std::string sub_zone) {
+  node_locality_ = {std::move(region), std::move(zone), std::move(sub_zone)};
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setNodeMetadata(Protobuf::Struct node_metadata) {
+  node_metadata_ = std::move(node_metadata);
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer) {
+  use_quic_platform_packet_writer_ = use_quic_platform_packet_writer;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::enableQuicConnectionMigration(bool quic_connection_migration_on) {
+  enable_quic_connection_migration_ = quic_connection_migration_on;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setMigrateIdleQuicConnection(bool migrate_idle_quic_connection) {
+  migrate_idle_quic_connection_ = migrate_idle_quic_connection;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::setMaxIdleTimeBeforeQuicMigrationSeconds(int max_idle_time_before_quic_migration) {
+  max_idle_time_before_quic_migration_seconds_ = max_idle_time_before_quic_migration;
+  return *this;
+}
+
+EngineBuilder&
+EngineBuilder::setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network) {
+  max_time_on_non_default_network_seconds_ = max_time_on_non_default_network;
+  return *this;
+}
+
+#if defined(__APPLE__)
+EngineBuilder& EngineBuilder::respectSystemProxySettings(bool value, int refresh_interval_secs) {
+  if (use_worker_thread_) {
+    // System proxy settings are not supported with worker thread.
+    return *this;
+  }
+  respect_system_proxy_settings_ = value;
+  if (refresh_interval_secs > 0) {
+    proxy_settings_refresh_interval_secs_ = refresh_interval_secs;
+  }
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::setIosNetworkServiceType(int ios_network_service_type) {
+  ios_network_service_type_ = ios_network_service_type;
+  return *this;
+}
+#endif
+
+#ifdef ENVOY_MOBILE_XDS
+XdsBuilder::XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port)
+    : xds_server_address_(std::move(xds_server_address)), xds_server_port_(xds_server_port) {}
+
+XdsBuilder& XdsBuilder::addInitialStreamHeader(std::string header, std::string value) {
+  envoy::config::core::v3::HeaderValue header_value;
+  header_value.set_key(std::move(header));
+  header_value.set_value(std::move(value));
+  xds_initial_grpc_metadata_.emplace_back(std::move(header_value));
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::setSslRootCerts(std::string root_certs) {
+  ssl_root_certs_ = std::move(root_certs);
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::addRuntimeDiscoveryService(std::string resource_name,
+                                                   const int timeout_in_seconds) {
+  rtds_resource_name_ = std::move(resource_name);
+  rtds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
+  return *this;
+}
+
+XdsBuilder& XdsBuilder::addClusterDiscoveryService(std::string cds_resources_locator,
+                                                   const int timeout_in_seconds) {
+  enable_cds_ = true;
+  cds_resources_locator_ = std::move(cds_resources_locator);
+  cds_timeout_in_seconds_ = timeout_in_seconds > 0 ? timeout_in_seconds : DefaultXdsTimeout;
+  return *this;
+}
+
+void XdsBuilder::build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const {
+  auto* ads_config = bootstrap.mutable_dynamic_resources()->mutable_ads_config();
+  ads_config->set_transport_api_version(envoy::config::core::v3::ApiVersion::V3);
+  ads_config->set_set_node_on_first_message_only(true);
+  ads_config->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+
+  auto& grpc_service = *ads_config->add_grpc_services();
+  grpc_service.mutable_envoy_grpc()->set_cluster_name("base");
+  grpc_service.mutable_envoy_grpc()->set_authority(
+      absl::StrCat(xds_server_address_, ":", xds_server_port_));
+
+  if (!xds_initial_grpc_metadata_.empty()) {
+    grpc_service.mutable_initial_metadata()->Assign(xds_initial_grpc_metadata_.begin(),
+                                                    xds_initial_grpc_metadata_.end());
+  }
+
+  if (!rtds_resource_name_.empty()) {
+    auto* layered_runtime = bootstrap.mutable_layered_runtime();
+    auto* layer = layered_runtime->add_layers();
+    layer->set_name("rtds_layer");
+    auto* rtds_layer = layer->mutable_rtds_layer();
+    rtds_layer->set_name(rtds_resource_name_);
+    auto* rtds_config = rtds_layer->mutable_rtds_config();
+    rtds_config->mutable_ads();
+    rtds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+    rtds_config->mutable_initial_fetch_timeout()->set_seconds(rtds_timeout_in_seconds_);
+  }
+
+  if (enable_cds_) {
+    auto* cds_config = bootstrap.mutable_dynamic_resources()->mutable_cds_config();
+    if (cds_resources_locator_.empty()) {
+      cds_config->mutable_ads();
+    } else {
+      bootstrap.mutable_dynamic_resources()->set_cds_resources_locator(cds_resources_locator_);
+      cds_config->mutable_api_config_source()->set_api_type(
+          envoy::config::core::v3::ApiConfigSource::AGGREGATED_GRPC);
+      cds_config->mutable_api_config_source()->set_transport_api_version(
+          envoy::config::core::v3::ApiVersion::V3);
+    }
+    cds_config->mutable_initial_fetch_timeout()->set_seconds(cds_timeout_in_seconds_);
+    cds_config->set_resource_api_version(envoy::config::core::v3::ApiVersion::V3);
+    bootstrap.add_node_context_params("cluster");
+    // Stat prefixes that we use in tests.
+    auto* list =
+        bootstrap.mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
+    list->add_patterns()->set_exact("cluster_manager.active_clusters");
+    list->add_patterns()->set_exact("cluster_manager.cluster_added");
+    list->add_patterns()->set_exact("cluster_manager.cluster_updated");
+    list->add_patterns()->set_exact("cluster_manager.cluster_removed");
+    // Allow SDS related stats.
+    list->add_patterns()->mutable_safe_regex()->set_regex("sds\\..*");
+    list->add_patterns()->mutable_safe_regex()->set_regex(".*\\.ssl_context_update_by_sds");
+  }
+}
+
+EngineBuilder& EngineBuilder::setXds(XdsBuilder xds_builder) {
+  xds_builder_ = std::move(xds_builder);
+  // Add the XdsBuilder's xDS server hostname and port to the list of DNS addresses to preresolve in
+  // the `base` DFP cluster.
+  dns_preresolve_hostnames_.push_back(
+      {xds_builder_->xds_server_address_ /* host */, xds_builder_->xds_server_port_ /* port */});
+  return *this;
+}
+#endif // ENVOY_MOBILE_XDS
+
+std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generateBootstrap() const {
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap =
+      std::make_unique<envoy::config::bootstrap::v3::Bootstrap>();
+
+  // Set up the HCM
+  envoy::extensions::filters::network::http_connection_manager::v3::EnvoyMobileHttpConnectionManager
+      api_listener_config;
+  auto* hcm = api_listener_config.mutable_config();
+  hcm->set_stat_prefix("hcm");
+  hcm->set_server_header_transformation(
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+          PASS_THROUGH);
+  hcm->mutable_stream_idle_timeout()->set_seconds(stream_idle_timeout_seconds_);
+  auto* route_config = hcm->mutable_route_config();
+  route_config->set_name("api_router");
+
+  auto* api_service = route_config->add_virtual_hosts();
+  api_service->set_name("api");
+  api_service->set_include_attempt_count_in_response(true);
+  api_service->add_domains("*");
+
+  auto* route = api_service->add_routes();
+  route->mutable_match()->set_prefix("/");
+  route->add_request_headers_to_remove("x-forwarded-proto");
+  route->add_request_headers_to_remove("x-envoy-mobile-cluster");
+  route->mutable_per_request_buffer_limit_bytes()->set_value(4096);
+  auto* route_to = route->mutable_route();
+  route_to->set_cluster_header("x-envoy-mobile-cluster");
+  route_to->mutable_timeout()->set_seconds(0);
+  route_to->mutable_retry_policy()->mutable_per_try_idle_timeout()->set_seconds(
+      per_try_idle_timeout_seconds_);
+  auto* backoff = route_to->mutable_retry_policy()->mutable_retry_back_off();
+  backoff->mutable_base_interval()->set_nanos(250000000);
+  backoff->mutable_max_interval()->set_seconds(60);
+
+  if (!enable_early_data_) {
+    auto* early_data = route_to->mutable_early_data_policy();
+    early_data->set_name("envoy.route.early_data_policy.default");
+    ::envoy::extensions::early_data::v3::DefaultEarlyDataPolicy config;
+    early_data->mutable_typed_config()->PackFrom(config);
+  }
+
+  for (auto filter = native_filter_chain_.rbegin(); filter != native_filter_chain_.rend();
+       ++filter) {
+    auto* native_filter = hcm->add_http_filters();
+    native_filter->set_name(filter->name_);
+    if (!filter->textproto_typed_config_.empty()) {
+#ifdef ENVOY_ENABLE_FULL_PROTOS
+      Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
+                                            native_filter->mutable_typed_config());
+      RELEASE_ASSERT(!native_filter->typed_config().DebugString().empty(),
+                     "Failed to parse: " + (*filter).textproto_typed_config_);
+#else
+      RELEASE_ASSERT(
+          native_filter->mutable_typed_config()->ParseFromString((*filter).textproto_typed_config_),
+          "Failed to parse binary proto: " + (*filter).textproto_typed_config_);
+#endif // !ENVOY_ENABLE_FULL_PROTOS
+    } else {
+      *native_filter->mutable_typed_config() = filter->typed_config_;
+    }
+  }
+
+  // Set up the optional filters
+  if (enable_http3_) {
+    envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig cache_config;
+    auto* cache_filter = hcm->add_http_filters();
+    cache_filter->set_name("alternate_protocols_cache");
+    cache_filter->mutable_typed_config()->PackFrom(cache_config);
+  }
+
+  if (gzip_decompression_filter_) {
+    envoy::extensions::compression::gzip::decompressor::v3::Gzip gzip_config;
+    gzip_config.mutable_window_bits()->set_value(15);
+    envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
+    decompressor_config.mutable_decompressor_library()->set_name("gzip");
+    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+        gzip_config);
+    auto* common_request =
+        decompressor_config.mutable_request_direction_config()->mutable_common_config();
+    common_request->mutable_enabled()->mutable_default_value();
+    common_request->mutable_enabled()->set_runtime_key("request_decompressor_enabled");
+    decompressor_config.mutable_response_direction_config()
+        ->mutable_common_config()
+        ->set_ignore_no_transform_header(true);
+    auto* gzip_filter = hcm->add_http_filters();
+    gzip_filter->set_name("envoy.filters.http.decompressor");
+    gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
+  }
+  if (brotli_decompression_filter_) {
+    envoy::extensions::compression::brotli::decompressor::v3::Brotli brotli_config;
+    envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
+    decompressor_config.mutable_decompressor_library()->set_name("text_optimized");
+    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+        brotli_config);
+    auto* common_request =
+        decompressor_config.mutable_request_direction_config()->mutable_common_config();
+    common_request->mutable_enabled()->mutable_default_value();
+    common_request->mutable_enabled()->set_runtime_key("request_decompressor_enabled");
+    decompressor_config.mutable_response_direction_config()
+        ->mutable_common_config()
+        ->set_ignore_no_transform_header(true);
+    auto* brotli_filter = hcm->add_http_filters();
+    brotli_filter->set_name("envoy.filters.http.decompressor");
+    brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
+  }
+  if (socket_tagging_filter_) {
+    envoymobile::extensions::filters::http::socket_tag::SocketTag tag_config;
+    auto* tag_filter = hcm->add_http_filters();
+    tag_filter->set_name("envoy.filters.http.socket_tag");
+    tag_filter->mutable_typed_config()->PackFrom(tag_config);
+  }
+
+  // Set up the always-present filters
+  envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration
+      network_config;
+  network_config.set_enable_drain_post_dns_refresh(enable_drain_post_dns_refresh_);
+  network_config.set_enable_interface_binding(enable_interface_binding_);
+  auto* network_filter = hcm->add_http_filters();
+  network_filter->set_name("envoy.filters.http.network_configuration");
+  network_filter->mutable_typed_config()->PackFrom(network_config);
+
+  envoymobile::extensions::filters::http::local_error::LocalError local_config;
+  auto* local_filter = hcm->add_http_filters();
+  local_filter->set_name("envoy.filters.http.local_error");
+  local_filter->mutable_typed_config()->PackFrom(local_config);
+
+  envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig dfp_config;
+  auto* dns_cache_config = dfp_config.mutable_dns_cache_config();
+  dns_cache_config->set_name("base_dns_cache");
+  dns_cache_config->set_dns_lookup_family(envoy::config::cluster::v3::Cluster::ALL);
+  dns_cache_config->mutable_host_ttl()->set_seconds(86400);
+  dns_cache_config->mutable_dns_min_refresh_rate()->set_seconds(dns_min_refresh_seconds_);
+  dns_cache_config->mutable_dns_refresh_rate()->set_seconds(dns_refresh_seconds_);
+  dns_cache_config->mutable_dns_failure_refresh_rate()->mutable_base_interval()->set_seconds(
+      dns_failure_refresh_seconds_base_);
+  dns_cache_config->mutable_dns_failure_refresh_rate()->mutable_max_interval()->set_seconds(
+      dns_failure_refresh_seconds_max_);
+  dns_cache_config->mutable_dns_query_timeout()->set_seconds(dns_query_timeout_seconds_);
+  dns_cache_config->set_disable_dns_refresh_on_failure(disable_dns_refresh_on_failure_);
+  if (dns_cache_on_) {
+    envoymobile::extensions::key_value::platform::PlatformKeyValueStoreConfig kv_config;
+    kv_config.set_key("dns_persistent_cache");
+    kv_config.mutable_save_interval()->set_seconds(dns_cache_save_interval_seconds_);
+    kv_config.set_max_entries(100);
+    dns_cache_config->mutable_key_value_config()->mutable_config()->set_name(
+        "envoy.key_value.platform");
+    dns_cache_config->mutable_key_value_config()
+        ->mutable_config()
+        ->mutable_typed_config()
+        ->PackFrom(kv_config);
+  }
+
+  if (dns_resolver_config_.has_value()) {
+    *dns_cache_config->mutable_typed_dns_resolver_config() = *dns_resolver_config_;
+  } else {
+#if defined(__APPLE__)
+    envoy::extensions::network::dns_resolver::apple::v3::AppleDnsResolverConfig resolver_config;
+    dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
+        "envoy.network.dns_resolver.apple");
+    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+        resolver_config);
+#else
+    envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig
+        resolver_config;
+    if (dns_num_retries_.has_value()) {
+      resolver_config.mutable_num_retries()->set_value(*dns_num_retries_);
+    }
+    resolver_config.mutable_num_resolver_threads()->set_value(getaddrinfo_num_threads_);
+    dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
+        "envoy.network.dns_resolver.getaddrinfo");
+    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+        resolver_config);
+#endif
+  }
+
+  for (const auto& [host, port] : dns_preresolve_hostnames_) {
+    envoy::config::core::v3::SocketAddress* address = dns_cache_config->add_preresolve_hostnames();
+    address->set_address(host);
+    address->set_port_value(port);
+  }
+
+  auto* dfp_filter = hcm->add_http_filters();
+  dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
+  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
+
+  auto* router_filter = hcm->add_http_filters();
+  envoy::extensions::filters::http::router::v3::Router router_config;
+  router_filter->set_name("envoy.router");
+  router_filter->mutable_typed_config()->PackFrom(router_config);
+
+  auto* static_resources = bootstrap->mutable_static_resources();
+
+  // Finally create the base listener, and point it at the HCM.
+  auto* base_listener = static_resources->add_listeners();
+  base_listener->set_name("base_api_listener");
+  auto* base_address = base_listener->mutable_address();
+  base_address->mutable_socket_address()->set_protocol(envoy::config::core::v3::SocketAddress::TCP);
+  base_address->mutable_socket_address()->set_address("0.0.0.0");
+  base_address->mutable_socket_address()->set_port_value(10000);
+  base_listener->mutable_per_connection_buffer_limit_bytes()->set_value(10485760);
+  base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
+
+  // Basic TLS config.
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_socket;
+  if (!upstream_tls_sni_.empty()) {
+    tls_socket.set_sni(upstream_tls_sni_);
+  }
+  tls_socket.mutable_common_tls_context()->mutable_tls_params()->set_tls_maximum_protocol_version(
+      envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3);
+  auto* validation = tls_socket.mutable_common_tls_context()->mutable_validation_context();
+  if (enforce_trust_chain_verification_) {
+    validation->set_trust_chain_verification(envoy::extensions::transport_sockets::tls::v3::
+                                                 CertificateValidationContext::VERIFY_TRUST_CHAIN);
+  } else {
+    validation->set_trust_chain_verification(envoy::extensions::transport_sockets::tls::v3::
+                                                 CertificateValidationContext::ACCEPT_UNTRUSTED);
+  }
+
+  if (platform_certificates_validation_on_) {
+    envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator
+        validator;
+    if (network_thread_priority_.has_value()) {
+      validator.mutable_thread_priority()->set_value(*network_thread_priority_);
+    }
+    validation->mutable_custom_validator_config()->set_name(
+        "envoy_mobile.cert_validator.platform_bridge_cert_validator");
+    validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);
+  } else {
+    std::string certs;
+#ifdef ENVOY_MOBILE_XDS
+    if (xds_builder_ && !xds_builder_->ssl_root_certs_.empty()) {
+      certs = xds_builder_->ssl_root_certs_;
+    }
+#endif // ENVOY_MOBILE_XDS
+    if (certs.empty()) {
+      // The xDS builder doesn't supply root certs, so we'll use the certs packed with Envoy Mobile,
+      // if the build config allows it.
+      const char* inline_certs = ""
+#ifndef EXCLUDE_CERTIFICATES
+#include "library/common/config/certificates.inc"
+#endif
+                                 "";
+      certs = inline_certs;
+      // The certificates in certificates.inc are prefixed with 2 spaces per
+      // line to be ingressed into YAML.
+      absl::StrReplaceAll({{"\n  ", "\n"}}, &certs);
+    }
+    if (!certs.empty()) {
+      validation->mutable_trusted_ca()->set_inline_string(certs);
+    }
+  }
+  envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+      ssl_proxy_socket;
+  ssl_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
+  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+
+  envoy::config::core::v3::TransportSocket base_tls_socket;
+  base_tls_socket.set_name("envoy.transport_sockets.http_11_proxy");
+  base_tls_socket.mutable_typed_config()->PackFrom(ssl_proxy_socket);
+
+  envoy::extensions::upstreams::http::v3::HttpProtocolOptions h2_protocol_options;
+  h2_protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+
+  // Base cluster config (DFP cluster config)
+  auto* base_cluster = static_resources->add_clusters();
+  envoy::extensions::clusters::dynamic_forward_proxy::v3::ClusterConfig base_cluster_config;
+  envoy::config::cluster::v3::Cluster::CustomClusterType base_cluster_type;
+  base_cluster_config.mutable_dns_cache_config()->CopyFrom(*dns_cache_config);
+  base_cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
+  base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
+
+  auto* upstream_opts = base_cluster->mutable_upstream_connection_options();
+  upstream_opts->set_set_local_interface_name_on_upstream_connections(true);
+  upstream_opts->mutable_tcp_keepalive()->mutable_keepalive_interval()->set_value(5);
+  upstream_opts->mutable_tcp_keepalive()->mutable_keepalive_probes()->set_value(1);
+  upstream_opts->mutable_tcp_keepalive()->mutable_keepalive_time()->set_value(10);
+
+  auto* circuit_breaker_settings = base_cluster->mutable_circuit_breakers();
+  auto* breaker1 = circuit_breaker_settings->add_thresholds();
+  breaker1->set_priority(envoy::config::core::v3::RoutingPriority::DEFAULT);
+  breaker1->mutable_retry_budget()->mutable_budget_percent()->set_value(100);
+  breaker1->mutable_retry_budget()->mutable_min_retry_concurrency()->set_value(0xffffffff);
+  auto* breaker2 = circuit_breaker_settings->add_per_host_thresholds();
+  breaker2->set_priority(envoy::config::core::v3::RoutingPriority::DEFAULT);
+  breaker2->mutable_max_connections()->set_value(max_connections_per_host_);
+
+  envoy::extensions::upstreams::http::v3::HttpProtocolOptions alpn_options;
+  alpn_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
+  alpn_options.mutable_upstream_http_protocol_options()->set_auto_san_validation(true);
+  auto* h2_options = alpn_options.mutable_auto_config()->mutable_http2_protocol_options();
+  if (h2_connection_keepalive_idle_interval_milliseconds_ > 1000) {
+    h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_seconds(
+        h2_connection_keepalive_idle_interval_milliseconds_ / 1000);
+  } else {
+    h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_nanos(
+        h2_connection_keepalive_idle_interval_milliseconds_ * 1000 * 1000);
+  }
+  h2_options->mutable_connection_keepalive()->mutable_timeout()->set_seconds(
+      h2_connection_keepalive_timeout_seconds_);
+  h2_options->mutable_max_concurrent_streams()->set_value(100);
+  h2_options->mutable_initial_stream_window_size()->set_value(initial_stream_window_size_);
+  h2_options->mutable_initial_connection_window_size()->set_value(initial_connection_window_size_);
+  if (max_concurrent_streams_ > 0) {
+    h2_options->mutable_max_concurrent_streams()->set_value(max_concurrent_streams_);
+  }
+
+  envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig
+      preserve_case_config;
+  preserve_case_config.set_forward_reason_phrase(false);
+  preserve_case_config.set_formatter_type_on_envoy_headers(
+      envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+          DEFAULT);
+
+  auto* h1_options = alpn_options.mutable_auto_config()->mutable_http_protocol_options();
+  auto* formatter = h1_options->mutable_header_key_format()->mutable_stateful_formatter();
+  formatter->set_name("preserve_case");
+  formatter->mutable_typed_config()->PackFrom(preserve_case_config);
+
+  // Base cluster
+  base_cluster->set_name("base");
+  base_cluster->mutable_connect_timeout()->set_seconds(connect_timeout_seconds_);
+  base_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+  (*base_cluster->mutable_typed_extension_protocol_options())
+      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+          .PackFrom(alpn_options);
+  base_cluster->mutable_cluster_type()->CopyFrom(base_cluster_type);
+  base_cluster->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
+  base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(ssl_proxy_socket);
+
+  // Base clear-text cluster set up
+  envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer raw_buffer;
+  envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+      cleartext_proxy_socket;
+  cleartext_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
+  cleartext_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
+  envoy::extensions::upstreams::http::v3::HttpProtocolOptions h1_protocol_options;
+  h1_protocol_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
+  h1_protocol_options.mutable_upstream_http_protocol_options()->set_auto_san_validation(true);
+  h1_protocol_options.mutable_explicit_http_config()->mutable_http_protocol_options()->CopyFrom(
+      *alpn_options.mutable_auto_config()->mutable_http_protocol_options());
+
+  // Base clear-text cluster.
+  auto* base_clear = static_resources->add_clusters();
+  base_clear->set_name("base_clear");
+  base_clear->mutable_connect_timeout()->set_seconds(connect_timeout_seconds_);
+  base_clear->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+  base_clear->mutable_cluster_type()->CopyFrom(base_cluster_type);
+  base_clear->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
+  base_clear->mutable_transport_socket()->mutable_typed_config()->PackFrom(cleartext_proxy_socket);
+  base_clear->mutable_upstream_connection_options()->CopyFrom(
+      *base_cluster->mutable_upstream_connection_options());
+  base_clear->mutable_circuit_breakers()->CopyFrom(*base_cluster->mutable_circuit_breakers());
+  (*base_clear->mutable_typed_extension_protocol_options())
+      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+          .PackFrom(h1_protocol_options);
+
+  // Edit and re-pack
+  tls_socket.mutable_common_tls_context()->add_alpn_protocols("h2");
+  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+
+  // Edit base cluster to be an HTTP/3 cluster.
+  if (enable_http3_) {
+    envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport h3_inner_socket;
+    tls_socket.mutable_common_tls_context()->mutable_alpn_protocols()->Clear();
+    h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_socket);
+    envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+        h3_proxy_socket;
+    h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+    h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
+
+    auto* quic_protocol_options = alpn_options.mutable_auto_config()
+                                      ->mutable_http3_protocol_options()
+                                      ->mutable_quic_protocol_options();
+    if (!quic_connection_options_.empty()) {
+      quic_protocol_options->set_connection_options(absl::StrJoin(quic_connection_options_, ","));
+    } else {
+      quic_protocol_options->set_connection_options(http3_connection_options_);
+    }
+    if (!quic_client_connection_options_.empty()) {
+      quic_protocol_options->set_client_connection_options(
+          absl::StrJoin(quic_client_connection_options_, ","));
+    } else {
+      quic_protocol_options->set_client_connection_options(http3_client_connection_options_);
+    }
+    quic_protocol_options->mutable_initial_stream_window_size()->set_value(
+        initial_stream_window_size_);
+    quic_protocol_options->mutable_initial_connection_window_size()->set_value(
+        initial_connection_window_size_);
+    quic_protocol_options->mutable_idle_network_timeout()->set_seconds(
+        quic_connection_idle_timeout_seconds_);
+    if (num_timeouts_to_trigger_port_migration_ > 0) {
+      quic_protocol_options->mutable_num_timeouts_to_trigger_port_migration()->set_value(
+          num_timeouts_to_trigger_port_migration_);
+    }
+    if (keepalive_initial_interval_ms_ > 0) {
+      quic_protocol_options->mutable_connection_keepalive()->mutable_initial_interval()->set_nanos(
+          keepalive_initial_interval_ms_ * 1000 * 1000);
+    }
+    if (max_concurrent_streams_ > 0) {
+      quic_protocol_options->mutable_max_concurrent_streams()->set_value(max_concurrent_streams_);
+    }
+    if (enable_quic_connection_migration_) {
+      auto* migration_setting = quic_protocol_options->mutable_connection_migration();
+      if (migrate_idle_quic_connection_) {
+        auto* migrate_idle_connections = migration_setting->mutable_migrate_idle_connections();
+        if (max_idle_time_before_quic_migration_seconds_ > 0) {
+          migrate_idle_connections->mutable_max_idle_time_before_migration()->set_seconds(
+              max_idle_time_before_quic_migration_seconds_);
+        }
+      }
+      if (max_time_on_non_default_network_seconds_ > 0) {
+        migration_setting->mutable_max_time_on_non_default_network()->set_seconds(
+            max_time_on_non_default_network_seconds_);
+      }
+    }
+
+    if (scone_enabled_) {
+      quic_protocol_options->mutable_enable_scone()->set_value(true);
+    }
+
+    if (use_quic_platform_packet_writer_ || enable_quic_connection_migration_) {
+      envoy_mobile::extensions::quic_packet_writer::platform::QuicPlatformPacketWriterConfig
+          writer_config;
+      quic_protocol_options->mutable_client_packet_writer()->mutable_typed_config()->PackFrom(
+          writer_config);
+      quic_protocol_options->mutable_client_packet_writer()->set_name(
+          "envoy.quic.packet_writer.platform");
+    }
+
+    alpn_options.mutable_auto_config()->mutable_alternate_protocols_cache_options()->set_name(
+        "default_alternate_protocols_cache");
+    for (const auto& [host, port] : quic_hints_) {
+      auto* entry = alpn_options.mutable_auto_config()
+                        ->mutable_alternate_protocols_cache_options()
+                        ->add_prepopulated_entries();
+      entry->set_hostname(host);
+      entry->set_port(port);
+    }
+    for (const auto& suffix : quic_suffixes_) {
+      alpn_options.mutable_auto_config()
+          ->mutable_alternate_protocols_cache_options()
+          ->add_canonical_suffixes(suffix);
+    }
+
+    base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+    (*base_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+            .PackFrom(alpn_options);
+
+    // Set the upstream connections UDP socket receive buffer size. The operating system defaults
+    // are usually too small for QUIC.
+    envoy::config::core::v3::SocketOption* udp_rcv_buf_sock_opt =
+        base_cluster->mutable_upstream_bind_config()->add_socket_options();
+    udp_rcv_buf_sock_opt->set_name(SO_RCVBUF);
+    udp_rcv_buf_sock_opt->set_level(SOL_SOCKET);
+    udp_rcv_buf_sock_opt->set_int_value(udp_socket_receive_buffer_size_);
+    // Only apply the socket option to the datagram socket.
+    udp_rcv_buf_sock_opt->mutable_type()->mutable_datagram();
+    udp_rcv_buf_sock_opt->set_description(
+        absl::StrCat("UDP SO_RCVBUF = ", udp_socket_receive_buffer_size_, " bytes"));
+
+    envoy::config::core::v3::SocketOption* udp_snd_buf_sock_opt =
+        base_cluster->mutable_upstream_bind_config()->add_socket_options();
+    udp_snd_buf_sock_opt->set_name(SO_SNDBUF);
+    udp_snd_buf_sock_opt->set_level(SOL_SOCKET);
+    udp_snd_buf_sock_opt->set_int_value(udp_socket_send_buffer_size_);
+    // Only apply the socket option to the datagram socket.
+    udp_snd_buf_sock_opt->mutable_type()->mutable_datagram();
+    udp_snd_buf_sock_opt->set_description(
+        absl::StrCat("UDP SO_SNDBUF = ", udp_socket_send_buffer_size_, " bytes"));
+    // Set the network service type on iOS, if supplied.
+#if defined(__APPLE__)
+    if (ios_network_service_type_ > 0) {
+      envoy::config::core::v3::SocketOption* net_svc_sock_opt =
+          base_cluster->mutable_upstream_bind_config()->add_socket_options();
+      net_svc_sock_opt->set_name(SO_NET_SERVICE_TYPE);
+      net_svc_sock_opt->set_level(SOL_SOCKET);
+      net_svc_sock_opt->set_int_value(ios_network_service_type_);
+      net_svc_sock_opt->set_description(
+          absl::StrCat("SO_NET_SERVICE_TYPE = ", ios_network_service_type_));
+    }
+#endif
+    for (const auto& socket_option : socket_options_) {
+      envoy::config::core::v3::SocketOption* sock_opt =
+          base_cluster->mutable_upstream_bind_config()->add_socket_options();
+      sock_opt->CopyFrom(socket_option);
+    }
+  }
+
+  // Set up stats.
+  if (enable_stats_collection_) {
+    auto* list =
+        bootstrap->mutable_stats_config()->mutable_stats_matcher()->mutable_inclusion_list();
+    list->add_patterns()->set_prefix("cluster.base.upstream_rq_");
+    list->add_patterns()->set_prefix("cluster.stats.upstream_rq_");
+    list->add_patterns()->set_prefix("cluster.base.upstream_cx_");
+    list->add_patterns()->set_prefix("cluster.stats.upstream_cx_");
+    list->add_patterns()->set_exact("cluster.base.http2.keepalive_timeout");
+    list->add_patterns()->set_exact("cluster.base.upstream_http3_broken");
+    list->add_patterns()->set_exact("cluster.stats.http2.keepalive_timeout");
+    list->add_patterns()->set_prefix("http.hcm.downstream_rq_");
+    list->add_patterns()->set_prefix("http.hcm.decompressor.");
+    list->add_patterns()->set_prefix("pulse.");
+    list->add_patterns()->set_prefix("runtime.load_success");
+    list->add_patterns()->set_prefix("dns_cache");
+    list->add_patterns()->mutable_safe_regex()->set_regex(
+        "^vhost\\.[\\w]+\\.vcluster\\.[\\w]+?\\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry|"
+        "total)");
+    list->add_patterns()->set_contains("quic_connection_close_error_code");
+    list->add_patterns()->set_contains("quic_reset_stream_error_code");
+  } else {
+    bootstrap->mutable_stats_config()->mutable_stats_matcher()->set_reject_all(true);
+  }
+  bootstrap->mutable_stats_config()->mutable_use_all_default_tags()->set_value(false);
+
+  // Set up watchdog
+  auto* watchdog = bootstrap->mutable_watchdogs();
+  watchdog->mutable_main_thread_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
+  watchdog->mutable_main_thread_watchdog()->mutable_miss_timeout()->set_seconds(60);
+  watchdog->mutable_worker_watchdog()->mutable_megamiss_timeout()->set_seconds(60);
+  watchdog->mutable_worker_watchdog()->mutable_miss_timeout()->set_seconds(60);
+
+  // Set up node
+  auto* node = bootstrap->mutable_node();
+  node->set_id(node_id_.empty() ? "envoy-mobile" : node_id_);
+  node->set_cluster("envoy-mobile");
+  if (node_locality_ && !node_locality_->region.empty()) {
+    node->mutable_locality()->set_region(node_locality_->region);
+    node->mutable_locality()->set_zone(node_locality_->zone);
+    node->mutable_locality()->set_sub_zone(node_locality_->sub_zone);
+  }
+  if (node_metadata_.has_value()) {
+    *node->mutable_metadata() = *node_metadata_;
+  }
+  Protobuf::Struct& metadata = *node->mutable_metadata();
+  (*metadata.mutable_fields())["app_id"].set_string_value(app_id_);
+  (*metadata.mutable_fields())["app_version"].set_string_value(app_version_);
+  (*metadata.mutable_fields())["device_os"].set_string_value(device_os_);
+
+  // Set up runtime.
+  auto* runtime = bootstrap->mutable_layered_runtime()->add_layers();
+  runtime->set_name("static_layer_0");
+  Protobuf::Struct envoy_layer;
+  Protobuf::Struct& runtime_values =
+      *(*envoy_layer.mutable_fields())["envoy"].mutable_struct_value();
+  Protobuf::Struct& reloadable_features =
+      *(*runtime_values.mutable_fields())["reloadable_features"].mutable_struct_value();
+  for (auto& guard_and_value : runtime_guards_) {
+    if (Runtime::RuntimeFeaturesDefaults::get().getFlag(absl::StrJoin(
+            {"envoy", "reloadable_features", guard_and_value.first}, ".")) == nullptr) {
+      // Not a registered runtime guard, skip it.
+      continue;
+    }
+    (*reloadable_features.mutable_fields())[guard_and_value.first].set_bool_value(
+        guard_and_value.second);
+  }
+  Protobuf::Struct& restart_features =
+      *(*runtime_values.mutable_fields())["restart_features"].mutable_struct_value();
+  for (auto& guard_and_value : restart_runtime_guards_) {
+    if (Runtime::RuntimeFeaturesDefaults::get().getFlag(
+            absl::StrJoin({"envoy", "restart_features", guard_and_value.first}, ".")) == nullptr) {
+      // Not a registered runtime guard, skip it.
+      continue;
+    }
+    (*restart_features.mutable_fields())[guard_and_value.first].set_bool_value(
+        guard_and_value.second);
+  }
+  (*runtime_values.mutable_fields())["disallow_global_stats"].set_bool_value(true);
+  (*runtime_values.mutable_fields())["enable_dfp_dns_trace"].set_bool_value(true);
+  Protobuf::Struct& overload_values =
+      *(*envoy_layer.mutable_fields())["overload"].mutable_struct_value();
+  (*overload_values.mutable_fields())["global_downstream_max_connections"].set_string_value(
+      "4294967295");
+  runtime->mutable_static_layer()->MergeFrom(envoy_layer);
+
+  bootstrap->mutable_typed_dns_resolver_config()->CopyFrom(
+      *dns_cache_config->mutable_typed_dns_resolver_config());
+
+  bootstrap->mutable_dynamic_resources();
+
+#ifdef ENVOY_MOBILE_XDS
+  if (xds_builder_) {
+    xds_builder_->build(*bootstrap);
+  }
+#endif // ENVOY_MOBILE_XDS
+
+  envoy::config::bootstrap::v3::ApiListenerManager api;
+  if (!use_worker_thread_) {
+    api.set_threading_model(envoy::config::bootstrap::v3::ApiListenerManager::MAIN_THREAD_ONLY);
+  } else {
+    api.set_threading_model(
+        envoy::config::bootstrap::v3::ApiListenerManager::STANDALONE_WORKER_THREAD);
+  }
+  auto* listener_manager = bootstrap->mutable_listener_manager();
+  listener_manager->mutable_typed_config()->PackFrom(api);
+  listener_manager->set_name("envoy.listener_manager_impl.api");
+
+  return bootstrap;
+}
+
+EngineSharedPtr EngineBuilder::build() {
+  InternalEngine* envoy_engine = absl::IgnoreLeak(new InternalEngine(
+      std::move(callbacks_), std::move(logger_), std::move(event_tracker_),
+      network_thread_priority_, high_watermark_, disable_dns_refresh_on_network_change_,
+      enable_logger_, use_worker_thread_));
+
+  for (const auto& [name, store] : key_value_stores_) {
+    // TODO(goaway): This leaks, but it's tied to the life of the engine.
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_kv_store();
+      *api = store->asEnvoyKeyValueStore();
+      Envoy::Api::External::registerApi(name.c_str(), api);
+    }
+  }
+
+  for (const auto& [name, accessor] : string_accessors_) {
+    // TODO(RyanTheOptimist): This leaks, but it's tied to the life of the engine.
+    if (!Api::External::retrieveApi(name, true)) {
+      auto* api = new envoy_string_accessor();
+      *api = StringAccessor::asEnvoyStringAccessor(accessor);
+      Envoy::Api::External::registerApi(name.c_str(), api);
+    }
+  }
+
+#if defined(__APPLE__)
+  if (respect_system_proxy_settings_) {
+    registerAppleProxyResolver(proxy_settings_refresh_interval_secs_);
+  }
+#endif
+
+  Engine* engine = new Engine(envoy_engine);
+
+  auto options = std::make_shared<Envoy::OptionsImplBase>();
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> bootstrap = generateBootstrap();
+  if (bootstrap) {
+    options->setConfigProto(std::move(bootstrap));
+  }
+  options->setLogLevel(static_cast<spdlog::level::level_enum>(log_level_));
+  options->setConcurrency(1);
+  envoy_engine->run(options);
+
+  if (enable_network_change_monitor_) {
+    engine->initializeNetworkChangeMonitor();
+  }
+
+  // we can't construct via std::make_shared
+  // because Engine is only constructible as a friend
+  auto engine_ptr = EngineSharedPtr(engine);
+  return engine_ptr;
+}
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -975,7 +975,7 @@ EngineSharedPtr MobileEngineBuilder::build() {
   return Platform::EngineBuilderBase<MobileEngineBuilder>::build().value();
 }
 
-void MobileEngineBuilder::PreRunSetup(InternalEngine* engine) {
+void MobileEngineBuilder::preRunSetup(InternalEngine* engine) {
   engine->disableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change_);
   for (const auto& [name, store] : key_value_stores_) {
     // TODO(goaway): This leaks, but it's tied to the life of the engine.
@@ -1002,7 +1002,7 @@ void MobileEngineBuilder::PreRunSetup(InternalEngine* engine) {
 #endif
 }
 
-void MobileEngineBuilder::PostRunSetup(Engine* engine) {
+void MobileEngineBuilder::postRunSetup(Engine* engine) {
   if (enable_network_change_monitor_) {
     engine->initializeNetworkChangeMonitor();
   }

--- a/mobile/library/cc/mobile_engine_builder.h
+++ b/mobile/library/cc/mobile_engine_builder.h
@@ -1,0 +1,396 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/core/v3/socket_option.pb.h"
+
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/types/optional.h"
+#include "library/cc/engine.h"
+#include "library/cc/key_value_store.h"
+#include "library/cc/string_accessor.h"
+#include "library/common/engine_types.h"
+
+namespace Envoy {
+namespace Platform {
+
+// Represents the locality information in the Bootstrap's node, as defined in:
+// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-locality
+struct NodeLocality {
+  std::string region;
+  std::string zone;
+  std::string sub_zone;
+};
+
+#ifdef ENVOY_MOBILE_XDS
+constexpr int DefaultXdsTimeout = 5;
+
+// Forward declaration so it can be referenced by XdsBuilder.
+class EngineBuilder;
+
+// A class for building the xDS configuration for the Envoy Mobile engine.
+// xDS is a protocol for dynamic configuration of Envoy instances, more information can be found in:
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.
+//
+// This class is typically used as input to the EngineBuilder's setXds() method.
+class XdsBuilder final {
+public:
+  // `xds_server_address`: the host name or IP address of the xDS management server. The xDS server
+  //                       must support the ADS protocol
+  //                       (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#aggregated-xds-ads).
+  // `xds_server_port`: the port on which the xDS management server listens for ADS discovery
+  //                    requests.
+  XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port);
+
+  // Adds a header to the initial HTTP metadata headers sent on the gRPC stream.
+  //
+  // A common use for the initial metadata headers is for authentication to the xDS management
+  // server.
+  //
+  // For example, if using API keys to authenticate to Traffic Director on GCP (see
+  // https://cloud.google.com/docs/authentication/api-keys for details), invoke:
+  //   builder.addInitialStreamHeader("x-goog-api-key", api_key_token)
+  //          .addInitialStreamHeader("X-Android-Package", app_package_name)
+  //          .addInitialStreamHeader("X-Android-Cert", sha1_key_fingerprint);
+  XdsBuilder& addInitialStreamHeader(std::string header, std::string value);
+
+  // Sets the PEM-encoded server root certificates used to negotiate the TLS handshake for the gRPC
+  // connection. If no root certs are specified, the operating system defaults are used.
+  XdsBuilder& setSslRootCerts(std::string root_certs);
+
+  // Adds Runtime Discovery Service (RTDS) to the Runtime layers of the Bootstrap configuration,
+  // to retrieve dynamic runtime configuration via the xDS management server.
+  //
+  // `resource_name`: The runtime config resource to subscribe to.
+  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
+  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
+  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
+  //    parameter value may change through the course of experimentation and no assumptions should
+  //    be made of its exact value.
+  XdsBuilder& addRuntimeDiscoveryService(std::string resource_name,
+                                         int timeout_in_seconds = DefaultXdsTimeout);
+
+  // Adds the Cluster Discovery Service (CDS) configuration for retrieving dynamic cluster resources
+  // via the xDS management server.
+  //
+  // `cds_resources_locator`: <optional> the xdstp:// URI for subscribing to the cluster resources.
+  //    If not using xdstp, then `cds_resources_locator` should be set to the empty string.
+  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
+  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
+  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
+  //    parameter value may change through the course of experimentation and no assumptions should
+  //    be made of its exact value.
+  XdsBuilder& addClusterDiscoveryService(std::string cds_resources_locator = "",
+                                         int timeout_in_seconds = DefaultXdsTimeout);
+
+protected:
+  // Sets the xDS configuration specified on this XdsBuilder instance on the Bootstrap proto
+  // provided as an input parameter.
+  //
+  // This method takes in a modifiable Bootstrap proto pointer because returning a new Bootstrap
+  // proto would rely on proto's MergeFrom behavior, which can lead to unexpected results in the
+  // Bootstrap config.
+  void build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const;
+
+private:
+  // Required so that EngineBuilder can call the XdsBuilder's protected build() method.
+  friend class EngineBuilder;
+
+  std::string xds_server_address_;
+  uint32_t xds_server_port_;
+  std::vector<envoy::config::core::v3::HeaderValue> xds_initial_grpc_metadata_;
+  std::string ssl_root_certs_;
+  std::string rtds_resource_name_;
+  int rtds_timeout_in_seconds_ = DefaultXdsTimeout;
+  bool enable_cds_ = false;
+  std::string cds_resources_locator_;
+  int cds_timeout_in_seconds_ = DefaultXdsTimeout;
+};
+#endif // ENVOY_MOBILE_XDS
+
+// The C++ Engine builder creates a structured bootstrap proto and modifies it through parameters
+// set through the EngineBuilder API calls to produce the Bootstrap config that the Engine is
+// created from.
+class EngineBuilder {
+public:
+  EngineBuilder();
+  EngineBuilder(EngineBuilder&&) = default;
+  virtual ~EngineBuilder() = default;
+  static std::string nativeNameToConfig(absl::string_view name);
+
+  EngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
+  EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
+  EngineBuilder& enableLogger(bool logger_on);
+  EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
+  EngineBuilder& setOnEngineRunning(absl::AnyInvocable<void()> closure);
+  EngineBuilder& setOnEngineExit(absl::AnyInvocable<void()> closure);
+  EngineBuilder& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker);
+  EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
+  EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
+  EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
+  EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
+  EngineBuilder& setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure);
+  EngineBuilder& setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change);
+  EngineBuilder& addDnsMinRefreshSeconds(int dns_min_refresh_seconds);
+  EngineBuilder& setDnsNumRetries(uint32_t dns_num_retries);
+  EngineBuilder& setGetaddrinfoNumThreads(uint32_t num_threads);
+  EngineBuilder& addMaxConnectionsPerHost(int max_connections_per_host);
+  EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+      int h2_connection_keepalive_idle_interval_milliseconds);
+  EngineBuilder&
+  addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
+  // Configures Envoy to use the PlatformBridge filter named `name`. An instance of
+  // envoy_http_filter must be registered as a platform API with the same name.
+  EngineBuilder& setAppVersion(std::string app_version);
+  EngineBuilder& setAppId(std::string app_id);
+  EngineBuilder& setDeviceOs(std::string app_id);
+  EngineBuilder& setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds);
+  EngineBuilder& setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds);
+  EngineBuilder& enableGzipDecompression(bool gzip_decompression_on);
+  EngineBuilder& enableBrotliDecompression(bool brotli_decompression_on);
+  EngineBuilder& enableSocketTagging(bool socket_tagging_on);
+  EngineBuilder& enableHttp3(bool http3_on);
+  // If true, all HTTP requests are handled on a dedicated worker thread instead of on the Envoy
+  // main thread which also handles all xDS requests.
+  // Note: Engine in worker thread model doesn't support platform certificate validation and system
+  // proxy settings. And these settings will be ignored if worker thread model is enabled.
+  EngineBuilder& enableWorkerThread(bool use_worker_thread);
+  EngineBuilder& enableEarlyData(bool early_data_on);
+  EngineBuilder& enableScone(bool enable);
+  EngineBuilder& addQuicConnectionOption(std::string option);
+  EngineBuilder& addQuicClientConnectionOption(std::string option);
+  // Deprecated, use addQuicConnectionOption() instead.
+  EngineBuilder& setHttp3ConnectionOptions(std::string options);
+  // Deprecated, use addQuicClientConnectionOption() instead.
+  EngineBuilder& setHttp3ClientConnectionOptions(std::string options);
+  EngineBuilder& addQuicHint(std::string host, int port);
+  EngineBuilder& addQuicCanonicalSuffix(std::string suffix);
+  // 0 means port migration is disabled.
+  EngineBuilder& setNumTimeoutsToTriggerPortMigration(int num_timeouts);
+  EngineBuilder& enableInterfaceBinding(bool interface_binding_on);
+  EngineBuilder& enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on);
+  EngineBuilder& setUdpSocketReceiveBufferSize(int32_t size);
+  EngineBuilder& setUdpSocketSendBufferSize(int32_t size);
+  EngineBuilder& enforceTrustChainVerification(bool trust_chain_verification_on);
+  EngineBuilder& setUpstreamTlsSni(std::string sni);
+  EngineBuilder& enablePlatformCertificatesValidation(bool platform_certificates_validation_on);
+  EngineBuilder& setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer);
+  // If called to enable QUIC connection migration, no need to call setUseQuicPlatformPacketWriter()
+  // separately.
+  EngineBuilder& enableQuicConnectionMigration(bool quic_connection_migration_on);
+  EngineBuilder& setMigrateIdleQuicConnection(bool migrate_idle_quic_connection);
+  // 0 means using the Envoy default 30s.
+  EngineBuilder& setMaxIdleTimeBeforeQuicMigrationSeconds(int max_idle_time_before_quic_migration);
+  // 0 means using the Envoy default 128s.
+  EngineBuilder& setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network);
+
+  EngineBuilder& enableDnsCache(bool dns_cache_on, int save_interval_seconds = 1);
+  // Set additional socket options on the upstream cluster outbound sockets.
+  EngineBuilder& setAdditionalSocketOptions(
+      const std::vector<envoy::config::core::v3::SocketOption>& socket_options);
+  // Adds the hostnames that should be pre-resolved by DNS prior to the first request issued for
+  // that host. When invoked, any previous preresolve hostname entries get cleared and only the ones
+  // provided in the hostnames argument get set.
+  // TODO(abeyad): change this method and the other language APIs to take a {host,port} pair.
+  // E.g. addDnsPreresolveHost(std::string host, uint32_t port);
+  EngineBuilder& addDnsPreresolveHostnames(const std::vector<std::string>& hostnames);
+  EngineBuilder&
+  setDnsResolver(const envoy::config::core::v3::TypedExtensionConfig& dns_resolver_config);
+  EngineBuilder& addNativeFilter(std::string name, std::string typed_config);
+  EngineBuilder& addNativeFilter(const std::string& name, const Protobuf::Any& typed_config);
+
+  EngineBuilder& addPlatformFilter(const std::string& name);
+  // Adds a runtime guard for the `envoy.reloadable_features.<guard>`.
+  // For example if the runtime guard is `envoy.reloadable_features.use_foo`, the guard name is
+  // `use_foo`.
+  EngineBuilder& addRuntimeGuard(std::string guard, bool value);
+  // Adds a runtime guard for the `envoy.restart_features.<guard>`. Restart features cannot be
+  // changed after the Envoy applicable has started and initialized.
+  // For example if the runtime guard is `envoy.restart_features.use_foo`, the guard name is
+  // `use_foo`.
+  EngineBuilder& addRestartRuntimeGuard(std::string guard, bool value);
+
+  // These functions don't affect the Bootstrap configuration but instead perform registrations.
+  EngineBuilder& addKeyValueStore(std::string name, KeyValueStoreSharedPtr key_value_store);
+  EngineBuilder& addStringAccessor(std::string name, StringAccessorSharedPtr accessor);
+
+  // Sets the thread priority of the Envoy main (network) thread.
+  // The value must be an integer between -20 (highest priority) and 19 (lowest priority). Values
+  // outside of this range will be ignored.
+  EngineBuilder& setNetworkThreadPriority(int thread_priority);
+  // Sets the high watermark for the response buffer. The low watermark is set to half of this
+  // value. Defaults to 2MB if not set.
+  EngineBuilder& setBufferHighWatermark(size_t high_watermark);
+
+  // Sets the QUIC connection idle timeout in seconds.
+  EngineBuilder& setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds);
+
+  // Sets the QUIC connection keepalive initial interval in nanoseconds
+  EngineBuilder& setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms);
+
+  // Sets the maximum number of concurrent streams on a multiplexed connection (HTTP/2 or HTTP/3).
+  EngineBuilder& setMaxConcurrentStreams(int max_concurrent_streams);
+
+  // Sets the node.id field in the Bootstrap configuration.
+  EngineBuilder& setNodeId(std::string node_id);
+  // Sets the node.locality field in the Bootstrap configuration.
+  EngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
+  // Sets the node.metadata field in the Bootstrap configuration.
+  EngineBuilder& setNodeMetadata(Protobuf::Struct node_metadata);
+  // Sets whether to collect Envoy's internal stats (counters & guages). Off by default.
+  EngineBuilder& enableStatsCollection(bool stats_collection_on);
+#if defined(__APPLE__)
+  // If true, initialize the platform network change monitor to listen for network change events.
+  // Only takes effect on iOS, where it is required in order to enable the network change monitor.
+  // Defaults to false.
+  EngineBuilder& enableNetworkChangeMonitor(bool network_change_monitor_on);
+#endif
+
+#ifdef ENVOY_MOBILE_XDS
+  // Sets the xDS configuration for the Envoy Mobile engine.
+  //
+  // `xds_builder`: the XdsBuilder instance used to specify the xDS configuration options.
+  EngineBuilder& setXds(XdsBuilder xds_builder);
+#endif // ENVOY_MOBILE_XDS
+
+#if defined(__APPLE__)
+  // Right now, this API is only used by Apple (iOS) to register the Apple proxy resolver API for
+  // use in reading and using the system proxy settings.
+  // If/when we move Android system proxy registration to the C++ Engine Builder, we will make this
+  // API available on all platforms.
+  // The optional `refresh_interval_secs` parameter determines how often the system proxy settings
+  // are polled by the operating system; defaults to 10 seconds. If the value is <= 0, the default
+  // value will be used.
+  EngineBuilder& respectSystemProxySettings(bool value, int refresh_interval_secs = 10);
+  EngineBuilder& setIosNetworkServiceType(int ios_network_service_type);
+#endif
+
+  // This is separated from build() for the sake of testability
+  virtual std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> generateBootstrap() const;
+
+  EngineSharedPtr build();
+
+private:
+  struct NativeFilterConfig {
+    NativeFilterConfig(std::string name, std::string typed_config)
+        : name_(std::move(name)), textproto_typed_config_(std::move(typed_config)) {}
+
+    NativeFilterConfig(const std::string& name, const Protobuf::Any& typed_config)
+        : name_(name), typed_config_(typed_config) {}
+
+    std::string name_;
+    std::string textproto_typed_config_{};
+    Protobuf::Any typed_config_{};
+  };
+
+  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
+  std::unique_ptr<EnvoyLogger> logger_{nullptr};
+  bool enable_logger_{true};
+  std::unique_ptr<EngineCallbacks> callbacks_;
+  std::unique_ptr<EnvoyEventTracker> event_tracker_{nullptr};
+
+  int connect_timeout_seconds_ = 10;
+  int dns_refresh_seconds_ = 60;
+  int dns_failure_refresh_seconds_base_ = 2;
+  int dns_failure_refresh_seconds_max_ = 10;
+  int dns_query_timeout_seconds_ = 120;
+  bool disable_dns_refresh_on_failure_{false};
+  bool disable_dns_refresh_on_network_change_{false};
+  absl::optional<uint32_t> dns_num_retries_ = 3;
+  uint32_t getaddrinfo_num_threads_ = 1;
+  int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
+  int h2_connection_keepalive_timeout_seconds_ = 15;
+  std::string app_version_ = "unspecified";
+  std::string app_id_ = "unspecified";
+  std::string device_os_ = "unspecified";
+  int stream_idle_timeout_seconds_ = 15;
+  int per_try_idle_timeout_seconds_ = 15;
+  bool gzip_decompression_filter_ = true;
+  bool brotli_decompression_filter_ = false;
+  bool socket_tagging_filter_ = false;
+  bool platform_certificates_validation_on_ = false;
+  bool dns_cache_on_ = false;
+  int dns_cache_save_interval_seconds_ = 1;
+  absl::optional<int> network_thread_priority_ = absl::nullopt;
+  absl::optional<size_t> high_watermark_ = absl::nullopt;
+
+  absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_{};
+
+  bool enable_interface_binding_ = false;
+  bool enable_drain_post_dns_refresh_ = false;
+  bool enforce_trust_chain_verification_ = true;
+  std::string upstream_tls_sni_;
+  bool enable_http3_ = true;
+  bool enable_early_data_{true};
+  bool scone_enabled_ = false;
+  std::string http3_connection_options_ = "";
+  std::string http3_client_connection_options_ = "";
+  // EVMB is to distinguish Envoy Mobile client connections.
+  std::vector<std::string> quic_connection_options_{"AKDU", "BWRS", "5RTO", "EVMB"};
+  std::vector<std::string> quic_client_connection_options_;
+  std::vector<std::pair<std::string, int>> quic_hints_;
+  std::vector<std::string> quic_suffixes_;
+  int num_timeouts_to_trigger_port_migration_ = 0;
+#if defined(__APPLE__)
+  bool respect_system_proxy_settings_ = true;
+  int proxy_settings_refresh_interval_secs_ = 10;
+  int ios_network_service_type_ = 0;
+#endif
+  int dns_min_refresh_seconds_ = 60;
+  int max_connections_per_host_ = 7;
+
+  std::vector<NativeFilterConfig> native_filter_chain_;
+  std::vector<std::pair<std::string /* host */, uint32_t /* port */>> dns_preresolve_hostnames_;
+  absl::optional<envoy::config::core::v3::TypedExtensionConfig> dns_resolver_config_;
+  std::vector<envoy::config::core::v3::SocketOption> socket_options_;
+
+  std::vector<std::pair<std::string, bool>> runtime_guards_;
+  std::vector<std::pair<std::string, bool>> restart_runtime_guards_;
+  absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;
+
+  // This is the same value Cronet uses for QUIC:
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.h;drc=ccfe61524368c94b138ddf96ae8121d7eb7096cf;l=87
+  int32_t udp_socket_receive_buffer_size_ = 1024 * 1024; // 1MB
+  // This is the same value Cronet uses for QUIC:
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_session_pool.cc;l=790-793;drc=7f04a8e033c23dede6beae129cd212e6d4473d72
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_constants.h;l=43-47;drc=34ad7f3844f882baf3d31a6bc6e300acaa0e3fc8
+  int32_t udp_socket_send_buffer_size_ = 1452 * 20;
+  // These are the same values Cronet uses for QUIC:
+  // https://source.chromium.org/chromium/chromium/src/+/main:net/quic/quic_context.cc;l=21-22;drc=6849bf6b37e96bd1c38a5f77f7deaa28b53779c4;bpv=1;bpt=1
+  const uint32_t initial_stream_window_size_ = 6 * 1024 * 1024;      // 6MB
+  const uint32_t initial_connection_window_size_ = 15 * 1024 * 1024; // 15MB
+  int quic_connection_idle_timeout_seconds_ = 60;
+
+  int keepalive_initial_interval_ms_ = 0;
+  int max_concurrent_streams_ = 0;
+  bool use_quic_platform_packet_writer_ = false;
+
+  // QUIC connection migration.
+  bool enable_quic_connection_migration_ = false;
+  bool migrate_idle_quic_connection_ = false;
+  int max_idle_time_before_quic_migration_seconds_ = 0;
+  int max_time_on_non_default_network_seconds_ = 0;
+
+  std::string node_id_;
+  absl::optional<NodeLocality> node_locality_ = absl::nullopt;
+  absl::optional<Protobuf::Struct> node_metadata_ = absl::nullopt;
+  bool enable_stats_collection_ = true;
+  bool use_worker_thread_{false};
+  bool enable_network_change_monitor_{false};
+
+#ifdef ENVOY_MOBILE_XDS
+  absl::optional<XdsBuilder> xds_builder_ = absl::nullopt;
+#endif // ENVOY_MOBILE_XDS
+};
+
+using EngineBuilderSharedPtr = std::shared_ptr<EngineBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/library/cc/mobile_engine_builder.h
+++ b/mobile/library/cc/mobile_engine_builder.h
@@ -14,250 +14,144 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
 #include "library/cc/engine.h"
+#include "library/cc/engine_builder_base.h"
 #include "library/cc/key_value_store.h"
 #include "library/cc/string_accessor.h"
 #include "library/common/engine_types.h"
 
+#include "library/cc/engine_builder_types.h"
+
 namespace Envoy {
 namespace Platform {
 
-// Represents the locality information in the Bootstrap's node, as defined in:
-// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-locality
-struct NodeLocality {
-  std::string region;
-  std::string zone;
-  std::string sub_zone;
-};
-
-#ifdef ENVOY_MOBILE_XDS
-constexpr int DefaultXdsTimeout = 5;
-
-// Forward declaration so it can be referenced by XdsBuilder.
-class EngineBuilder;
-
-// A class for building the xDS configuration for the Envoy Mobile engine.
-// xDS is a protocol for dynamic configuration of Envoy instances, more information can be found in:
-// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol.
-//
-// This class is typically used as input to the EngineBuilder's setXds() method.
-class XdsBuilder final {
-public:
-  // `xds_server_address`: the host name or IP address of the xDS management server. The xDS server
-  //                       must support the ADS protocol
-  //                       (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration#aggregated-xds-ads).
-  // `xds_server_port`: the port on which the xDS management server listens for ADS discovery
-  //                    requests.
-  XdsBuilder(std::string xds_server_address, const uint32_t xds_server_port);
-
-  // Adds a header to the initial HTTP metadata headers sent on the gRPC stream.
-  //
-  // A common use for the initial metadata headers is for authentication to the xDS management
-  // server.
-  //
-  // For example, if using API keys to authenticate to Traffic Director on GCP (see
-  // https://cloud.google.com/docs/authentication/api-keys for details), invoke:
-  //   builder.addInitialStreamHeader("x-goog-api-key", api_key_token)
-  //          .addInitialStreamHeader("X-Android-Package", app_package_name)
-  //          .addInitialStreamHeader("X-Android-Cert", sha1_key_fingerprint);
-  XdsBuilder& addInitialStreamHeader(std::string header, std::string value);
-
-  // Sets the PEM-encoded server root certificates used to negotiate the TLS handshake for the gRPC
-  // connection. If no root certs are specified, the operating system defaults are used.
-  XdsBuilder& setSslRootCerts(std::string root_certs);
-
-  // Adds Runtime Discovery Service (RTDS) to the Runtime layers of the Bootstrap configuration,
-  // to retrieve dynamic runtime configuration via the xDS management server.
-  //
-  // `resource_name`: The runtime config resource to subscribe to.
-  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
-  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
-  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
-  //    parameter value may change through the course of experimentation and no assumptions should
-  //    be made of its exact value.
-  XdsBuilder& addRuntimeDiscoveryService(std::string resource_name,
-                                         int timeout_in_seconds = DefaultXdsTimeout);
-
-  // Adds the Cluster Discovery Service (CDS) configuration for retrieving dynamic cluster resources
-  // via the xDS management server.
-  //
-  // `cds_resources_locator`: <optional> the xdstp:// URI for subscribing to the cluster resources.
-  //    If not using xdstp, then `cds_resources_locator` should be set to the empty string.
-  // `timeout_in_seconds`: <optional> specifies the `initial_fetch_timeout` field on the
-  //    api.v3.core.ConfigSource. Unlike the ConfigSource default of 15s, we set a default fetch
-  //    timeout value of 5s, to prevent mobile app initialization from stalling. The default
-  //    parameter value may change through the course of experimentation and no assumptions should
-  //    be made of its exact value.
-  XdsBuilder& addClusterDiscoveryService(std::string cds_resources_locator = "",
-                                         int timeout_in_seconds = DefaultXdsTimeout);
-
-protected:
-  // Sets the xDS configuration specified on this XdsBuilder instance on the Bootstrap proto
-  // provided as an input parameter.
-  //
-  // This method takes in a modifiable Bootstrap proto pointer because returning a new Bootstrap
-  // proto would rely on proto's MergeFrom behavior, which can lead to unexpected results in the
-  // Bootstrap config.
-  void build(envoy::config::bootstrap::v3::Bootstrap& bootstrap) const;
-
-private:
-  // Required so that EngineBuilder can call the XdsBuilder's protected build() method.
-  friend class EngineBuilder;
-
-  std::string xds_server_address_;
-  uint32_t xds_server_port_;
-  std::vector<envoy::config::core::v3::HeaderValue> xds_initial_grpc_metadata_;
-  std::string ssl_root_certs_;
-  std::string rtds_resource_name_;
-  int rtds_timeout_in_seconds_ = DefaultXdsTimeout;
-  bool enable_cds_ = false;
-  std::string cds_resources_locator_;
-  int cds_timeout_in_seconds_ = DefaultXdsTimeout;
-};
-#endif // ENVOY_MOBILE_XDS
-
 // The C++ Engine builder creates a structured bootstrap proto and modifies it through parameters
-// set through the EngineBuilder API calls to produce the Bootstrap config that the Engine is
+// set through the MobileEngineBuilder API calls to produce the Bootstrap config that the Engine is
 // created from.
-class EngineBuilder {
+class MobileEngineBuilder : public Platform::EngineBuilderBase<MobileEngineBuilder> {
 public:
-  EngineBuilder();
-  EngineBuilder(EngineBuilder&&) = default;
-  virtual ~EngineBuilder() = default;
+  MobileEngineBuilder();
+  MobileEngineBuilder(MobileEngineBuilder&&) = default;
+  virtual ~MobileEngineBuilder() = default;
   static std::string nativeNameToConfig(absl::string_view name);
 
-  EngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
-  EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
-  EngineBuilder& enableLogger(bool logger_on);
-  EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
-  EngineBuilder& setOnEngineRunning(absl::AnyInvocable<void()> closure);
-  EngineBuilder& setOnEngineExit(absl::AnyInvocable<void()> closure);
-  EngineBuilder& setEventTracker(std::unique_ptr<EnvoyEventTracker> event_tracker);
-  EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
-  EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
-  EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
-  EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
-  EngineBuilder& setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure);
-  EngineBuilder& setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change);
-  EngineBuilder& addDnsMinRefreshSeconds(int dns_min_refresh_seconds);
-  EngineBuilder& setDnsNumRetries(uint32_t dns_num_retries);
-  EngineBuilder& setGetaddrinfoNumThreads(uint32_t num_threads);
-  EngineBuilder& addMaxConnectionsPerHost(int max_connections_per_host);
-  EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+  MobileEngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
+  MobileEngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
+  MobileEngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
+  MobileEngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
+  MobileEngineBuilder& setDisableDnsRefreshOnFailure(bool disable_dns_refresh_on_failure);
+  MobileEngineBuilder&
+  setDisableDnsRefreshOnNetworkChange(bool disable_dns_refresh_on_network_change);
+
+  MobileEngineBuilder& addDnsMinRefreshSeconds(int dns_min_refresh_seconds);
+  MobileEngineBuilder& setDnsNumRetries(uint32_t dns_num_retries);
+  MobileEngineBuilder& setGetaddrinfoNumThreads(uint32_t num_threads);
+  MobileEngineBuilder& addMaxConnectionsPerHost(int max_connections_per_host);
+  MobileEngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
-  EngineBuilder&
+  MobileEngineBuilder&
   addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
-  // Configures Envoy to use the PlatformBridge filter named `name`. An instance of
-  // envoy_http_filter must be registered as a platform API with the same name.
-  EngineBuilder& setAppVersion(std::string app_version);
-  EngineBuilder& setAppId(std::string app_id);
-  EngineBuilder& setDeviceOs(std::string app_id);
-  EngineBuilder& setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds);
-  EngineBuilder& setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds);
-  EngineBuilder& enableGzipDecompression(bool gzip_decompression_on);
-  EngineBuilder& enableBrotliDecompression(bool brotli_decompression_on);
-  EngineBuilder& enableSocketTagging(bool socket_tagging_on);
-  EngineBuilder& enableHttp3(bool http3_on);
-  // If true, all HTTP requests are handled on a dedicated worker thread instead of on the Envoy
-  // main thread which also handles all xDS requests.
-  // Note: Engine in worker thread model doesn't support platform certificate validation and system
-  // proxy settings. And these settings will be ignored if worker thread model is enabled.
-  EngineBuilder& enableWorkerThread(bool use_worker_thread);
-  EngineBuilder& enableEarlyData(bool early_data_on);
-  EngineBuilder& enableScone(bool enable);
-  EngineBuilder& addQuicConnectionOption(std::string option);
-  EngineBuilder& addQuicClientConnectionOption(std::string option);
+  MobileEngineBuilder& setAppVersion(std::string app_version);
+  MobileEngineBuilder& setAppId(std::string app_id);
+  MobileEngineBuilder& setDeviceOs(std::string app_id);
+
+  MobileEngineBuilder& setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds);
+  MobileEngineBuilder& enableGzipDecompression(bool gzip_decompression_on);
+  MobileEngineBuilder& enableBrotliDecompression(bool brotli_decompression_on);
+  MobileEngineBuilder& enableSocketTagging(bool socket_tagging_on);
+  MobileEngineBuilder& enableHttp3(bool http3_on);
+  MobileEngineBuilder& enableEarlyData(bool early_data_on);
+  MobileEngineBuilder& enableScone(bool enable);
+  MobileEngineBuilder& addQuicConnectionOption(std::string option);
+  MobileEngineBuilder& addQuicClientConnectionOption(std::string option);
   // Deprecated, use addQuicConnectionOption() instead.
-  EngineBuilder& setHttp3ConnectionOptions(std::string options);
+  MobileEngineBuilder& setHttp3ConnectionOptions(std::string options);
   // Deprecated, use addQuicClientConnectionOption() instead.
-  EngineBuilder& setHttp3ClientConnectionOptions(std::string options);
-  EngineBuilder& addQuicHint(std::string host, int port);
-  EngineBuilder& addQuicCanonicalSuffix(std::string suffix);
+  MobileEngineBuilder& setHttp3ClientConnectionOptions(std::string options);
+  MobileEngineBuilder& addQuicHint(std::string host, int port);
+  MobileEngineBuilder& addQuicCanonicalSuffix(std::string suffix);
   // 0 means port migration is disabled.
-  EngineBuilder& setNumTimeoutsToTriggerPortMigration(int num_timeouts);
-  EngineBuilder& enableInterfaceBinding(bool interface_binding_on);
-  EngineBuilder& enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on);
-  EngineBuilder& setUdpSocketReceiveBufferSize(int32_t size);
-  EngineBuilder& setUdpSocketSendBufferSize(int32_t size);
-  EngineBuilder& enforceTrustChainVerification(bool trust_chain_verification_on);
-  EngineBuilder& setUpstreamTlsSni(std::string sni);
-  EngineBuilder& enablePlatformCertificatesValidation(bool platform_certificates_validation_on);
-  EngineBuilder& setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer);
+  MobileEngineBuilder& setNumTimeoutsToTriggerPortMigration(int num_timeouts);
+  MobileEngineBuilder& enableInterfaceBinding(bool interface_binding_on);
+  MobileEngineBuilder& enableDrainPostDnsRefresh(bool drain_post_dns_refresh_on);
+  MobileEngineBuilder& setUdpSocketReceiveBufferSize(int32_t size);
+  MobileEngineBuilder& setUdpSocketSendBufferSize(int32_t size);
+  MobileEngineBuilder& enforceTrustChainVerification(bool trust_chain_verification_on);
+  MobileEngineBuilder& setUpstreamTlsSni(std::string sni);
+  MobileEngineBuilder&
+  enablePlatformCertificatesValidation(bool platform_certificates_validation_on);
+  // Overridden to turn off system proxying and platform certs validation while enabling worker
+  // thread.
+  MobileEngineBuilder& enableWorkerThread(bool use_worker_thread);
+  MobileEngineBuilder& setUseQuicPlatformPacketWriter(bool use_quic_platform_packet_writer);
   // If called to enable QUIC connection migration, no need to call setUseQuicPlatformPacketWriter()
   // separately.
-  EngineBuilder& enableQuicConnectionMigration(bool quic_connection_migration_on);
-  EngineBuilder& setMigrateIdleQuicConnection(bool migrate_idle_quic_connection);
+  MobileEngineBuilder& enableQuicConnectionMigration(bool quic_connection_migration_on);
+  MobileEngineBuilder& setMigrateIdleQuicConnection(bool migrate_idle_quic_connection);
   // 0 means using the Envoy default 30s.
-  EngineBuilder& setMaxIdleTimeBeforeQuicMigrationSeconds(int max_idle_time_before_quic_migration);
+  MobileEngineBuilder&
+  setMaxIdleTimeBeforeQuicMigrationSeconds(int max_idle_time_before_quic_migration);
   // 0 means using the Envoy default 128s.
-  EngineBuilder& setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network);
+  MobileEngineBuilder& setMaxTimeOnNonDefaultNetworkSeconds(int max_time_on_non_default_network);
 
-  EngineBuilder& enableDnsCache(bool dns_cache_on, int save_interval_seconds = 1);
+  MobileEngineBuilder& enableDnsCache(bool dns_cache_on, int save_interval_seconds = 1);
   // Set additional socket options on the upstream cluster outbound sockets.
-  EngineBuilder& setAdditionalSocketOptions(
+  MobileEngineBuilder& setAdditionalSocketOptions(
       const std::vector<envoy::config::core::v3::SocketOption>& socket_options);
   // Adds the hostnames that should be pre-resolved by DNS prior to the first request issued for
   // that host. When invoked, any previous preresolve hostname entries get cleared and only the ones
   // provided in the hostnames argument get set.
   // TODO(abeyad): change this method and the other language APIs to take a {host,port} pair.
   // E.g. addDnsPreresolveHost(std::string host, uint32_t port);
-  EngineBuilder& addDnsPreresolveHostnames(const std::vector<std::string>& hostnames);
-  EngineBuilder&
+  MobileEngineBuilder& addDnsPreresolveHostnames(const std::vector<std::string>& hostnames);
+  MobileEngineBuilder&
   setDnsResolver(const envoy::config::core::v3::TypedExtensionConfig& dns_resolver_config);
-  EngineBuilder& addNativeFilter(std::string name, std::string typed_config);
-  EngineBuilder& addNativeFilter(const std::string& name, const Protobuf::Any& typed_config);
+  MobileEngineBuilder& addNativeFilter(std::string name, std::string typed_config);
+  MobileEngineBuilder& addNativeFilter(const std::string& name, const Protobuf::Any& typed_config);
 
-  EngineBuilder& addPlatformFilter(const std::string& name);
+  MobileEngineBuilder& addPlatformFilter(const std::string& name);
   // Adds a runtime guard for the `envoy.reloadable_features.<guard>`.
   // For example if the runtime guard is `envoy.reloadable_features.use_foo`, the guard name is
   // `use_foo`.
-  EngineBuilder& addRuntimeGuard(std::string guard, bool value);
-  // Adds a runtime guard for the `envoy.restart_features.<guard>`. Restart features cannot be
-  // changed after the Envoy applicable has started and initialized.
-  // For example if the runtime guard is `envoy.restart_features.use_foo`, the guard name is
-  // `use_foo`.
-  EngineBuilder& addRestartRuntimeGuard(std::string guard, bool value);
+  MobileEngineBuilder& addRuntimeGuard(std::string guard, bool value);
 
   // These functions don't affect the Bootstrap configuration but instead perform registrations.
-  EngineBuilder& addKeyValueStore(std::string name, KeyValueStoreSharedPtr key_value_store);
-  EngineBuilder& addStringAccessor(std::string name, StringAccessorSharedPtr accessor);
+  MobileEngineBuilder& addKeyValueStore(std::string name, KeyValueStoreSharedPtr key_value_store);
+  MobileEngineBuilder& addStringAccessor(std::string name, StringAccessorSharedPtr accessor);
 
   // Sets the thread priority of the Envoy main (network) thread.
   // The value must be an integer between -20 (highest priority) and 19 (lowest priority). Values
   // outside of this range will be ignored.
-  EngineBuilder& setNetworkThreadPriority(int thread_priority);
-  // Sets the high watermark for the response buffer. The low watermark is set to half of this
-  // value. Defaults to 2MB if not set.
-  EngineBuilder& setBufferHighWatermark(size_t high_watermark);
+  MobileEngineBuilder& setNetworkThreadPriority(int thread_priority);
 
   // Sets the QUIC connection idle timeout in seconds.
-  EngineBuilder& setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds);
+  MobileEngineBuilder&
+  setQuicConnectionIdleTimeoutSeconds(int quic_connection_idle_timeout_seconds);
 
   // Sets the QUIC connection keepalive initial interval in nanoseconds
-  EngineBuilder& setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms);
+  MobileEngineBuilder& setKeepAliveInitialIntervalMilliseconds(int keepalive_initial_interval_ms);
 
   // Sets the maximum number of concurrent streams on a multiplexed connection (HTTP/2 or HTTP/3).
-  EngineBuilder& setMaxConcurrentStreams(int max_concurrent_streams);
+  MobileEngineBuilder& setMaxConcurrentStreams(int max_concurrent_streams);
 
   // Sets the node.id field in the Bootstrap configuration.
-  EngineBuilder& setNodeId(std::string node_id);
+  MobileEngineBuilder& setNodeId(std::string node_id);
   // Sets the node.locality field in the Bootstrap configuration.
-  EngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
+  MobileEngineBuilder& setNodeLocality(std::string region, std::string zone, std::string sub_zone);
   // Sets the node.metadata field in the Bootstrap configuration.
-  EngineBuilder& setNodeMetadata(Protobuf::Struct node_metadata);
-  // Sets whether to collect Envoy's internal stats (counters & guages). Off by default.
-  EngineBuilder& enableStatsCollection(bool stats_collection_on);
+  MobileEngineBuilder& setNodeMetadata(Protobuf::Struct node_metadata);
+
 #if defined(__APPLE__)
   // If true, initialize the platform network change monitor to listen for network change events.
   // Only takes effect on iOS, where it is required in order to enable the network change monitor.
   // Defaults to false.
-  EngineBuilder& enableNetworkChangeMonitor(bool network_change_monitor_on);
+  MobileEngineBuilder& enableNetworkChangeMonitor(bool network_change_monitor_on);
 #endif
 
 #ifdef ENVOY_MOBILE_XDS
   // Sets the xDS configuration for the Envoy Mobile engine.
   //
   // `xds_builder`: the XdsBuilder instance used to specify the xDS configuration options.
-  EngineBuilder& setXds(XdsBuilder xds_builder);
+  MobileEngineBuilder& setXds(XdsBuilder xds_builder);
 #endif // ENVOY_MOBILE_XDS
 
 #if defined(__APPLE__)
@@ -268,16 +162,36 @@ public:
   // The optional `refresh_interval_secs` parameter determines how often the system proxy settings
   // are polled by the operating system; defaults to 10 seconds. If the value is <= 0, the default
   // value will be used.
-  EngineBuilder& respectSystemProxySettings(bool value, int refresh_interval_secs = 10);
-  EngineBuilder& setIosNetworkServiceType(int ios_network_service_type);
+  MobileEngineBuilder& respectSystemProxySettings(bool value, int refresh_interval_secs = 10);
+  MobileEngineBuilder& setIosNetworkServiceType(int ios_network_service_type);
 #endif
-
-  // This is separated from build() for the sake of testability
-  virtual std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> generateBootstrap() const;
-
+  // Overload to preserve the same return type as the EngineBuilder class.
   EngineSharedPtr build();
 
 private:
+  friend class Platform::EngineBuilderBase<MobileEngineBuilder>;
+
+  // base class hooks
+  void PreRunSetup(InternalEngine* engine);
+  void PostRunSetup(Engine* engine);
+  absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap* bootstrap);
+  void configureDnsCache(
+      envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig* dns_cache_config) const;
+  absl::Status configureNode(envoy::config::core::v3::Node* node);
+  absl::Status configureRouteConfig(envoy::config::route::v3::RouteConfiguration* route_config);
+  absl::Status configureStaticClusters(
+      Protobuf::RepeatedPtrField<envoy::config::cluster::v3::Cluster>* clusters);
+  absl::Status configureHttpFilters(
+      std::function<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter*()>
+          add_filter);
+  void configureCustomRouterFilter(
+      ::envoy::extensions::filters::http::router::v3::Router& router_config) {
+    (void)router_config;
+  }
+
+  void addWatchdog();
+  void addStatsInclusionStringMatchers();
+
   struct NativeFilterConfig {
     NativeFilterConfig(std::string name, std::string typed_config)
         : name_(std::move(name)), textproto_typed_config_(std::move(typed_config)) {}
@@ -289,12 +203,6 @@ private:
     std::string textproto_typed_config_{};
     Protobuf::Any typed_config_{};
   };
-
-  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
-  std::unique_ptr<EnvoyLogger> logger_{nullptr};
-  bool enable_logger_{true};
-  std::unique_ptr<EngineCallbacks> callbacks_;
-  std::unique_ptr<EnvoyEventTracker> event_tracker_{nullptr};
 
   int connect_timeout_seconds_ = 10;
   int dns_refresh_seconds_ = 60;
@@ -310,7 +218,6 @@ private:
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string device_os_ = "unspecified";
-  int stream_idle_timeout_seconds_ = 15;
   int per_try_idle_timeout_seconds_ = 15;
   bool gzip_decompression_filter_ = true;
   bool brotli_decompression_filter_ = false;
@@ -319,7 +226,6 @@ private:
   bool dns_cache_on_ = false;
   int dns_cache_save_interval_seconds_ = 1;
   absl::optional<int> network_thread_priority_ = absl::nullopt;
-  absl::optional<size_t> high_watermark_ = absl::nullopt;
 
   absl::flat_hash_map<std::string, KeyValueStoreSharedPtr> key_value_stores_{};
 
@@ -351,8 +257,6 @@ private:
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> dns_resolver_config_;
   std::vector<envoy::config::core::v3::SocketOption> socket_options_;
 
-  std::vector<std::pair<std::string, bool>> runtime_guards_;
-  std::vector<std::pair<std::string, bool>> restart_runtime_guards_;
   absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;
 
   // This is the same value Cronet uses for QUIC:
@@ -381,16 +285,14 @@ private:
   std::string node_id_;
   absl::optional<NodeLocality> node_locality_ = absl::nullopt;
   absl::optional<Protobuf::Struct> node_metadata_ = absl::nullopt;
-  bool enable_stats_collection_ = true;
-  bool use_worker_thread_{false};
-  bool enable_network_change_monitor_{false};
 
+  bool enable_network_change_monitor_ = false;
 #ifdef ENVOY_MOBILE_XDS
   absl::optional<XdsBuilder> xds_builder_ = absl::nullopt;
 #endif // ENVOY_MOBILE_XDS
 };
 
-using EngineBuilderSharedPtr = std::shared_ptr<EngineBuilder>;
+using MobileEngineBuilderSharedPtr = std::shared_ptr<MobileEngineBuilder>;
 
 } // namespace Platform
 } // namespace Envoy

--- a/mobile/library/cc/mobile_engine_builder.h
+++ b/mobile/library/cc/mobile_engine_builder.h
@@ -172,8 +172,8 @@ private:
   friend class Platform::EngineBuilderBase<MobileEngineBuilder>;
 
   // base class hooks
-  void PreRunSetup(InternalEngine* engine);
-  void PostRunSetup(Engine* engine);
+  void preRunSetup(InternalEngine* engine);
+  void postRunSetup(Engine* engine);
   absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap* bootstrap);
   void configureDnsCache(
       envoy::extensions::common::dynamic_forward_proxy::v3::DnsCacheConfig* dns_cache_config) const;

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -79,16 +79,17 @@ bool areIpAddressesDifferent(const Network::Address::InstanceConstSharedPtr& add
 
 static std::atomic<envoy_stream_t> current_stream_handle_{0};
 
-InternalEngine::InternalEngine(
-    std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
-    std::unique_ptr<EnvoyEventTracker> event_tracker, absl::optional<int> thread_priority,
-    absl::optional<size_t> high_watermark, bool disable_dns_refresh_on_network_change,
-    Thread::PosixThreadFactoryPtr thread_factory, bool enable_logger, bool use_worker_thread)
+InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks,
+                               std::unique_ptr<EnvoyLogger> logger,
+                               std::unique_ptr<EnvoyEventTracker> event_tracker,
+                               absl::optional<int> thread_priority,
+                               absl::optional<size_t> high_watermark,
+                               Thread::PosixThreadFactoryPtr thread_factory, bool enable_logger,
+                               bool use_worker_thread)
     : thread_factory_(std::move(thread_factory)), callbacks_(std::move(callbacks)),
       logger_(std::move(logger)), event_tracker_(std::move(event_tracker)),
       thread_priority_(thread_priority), high_watermark_(high_watermark),
       main_dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()),
-      disable_dns_refresh_on_network_change_(disable_dns_refresh_on_network_change),
       enable_logger_(enable_logger), use_worker_thread_(use_worker_thread),
       request_dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
   ExtensionRegistry::registerFactories();
@@ -100,12 +101,11 @@ InternalEngine::InternalEngine(std::unique_ptr<EngineCallbacks> callbacks,
                                std::unique_ptr<EnvoyLogger> logger,
                                std::unique_ptr<EnvoyEventTracker> event_tracker,
                                absl::optional<int> thread_priority,
-                               absl::optional<size_t> high_watermark,
-                               bool disable_dns_refresh_on_network_change, bool enable_logger,
+                               absl::optional<size_t> high_watermark, bool enable_logger,
                                bool use_worker_thread)
     : InternalEngine(std::move(callbacks), std::move(logger), std::move(event_tracker),
-                     thread_priority, high_watermark, disable_dns_refresh_on_network_change,
-                     Thread::PosixThreadFactory::create(), enable_logger, use_worker_thread) {}
+                     thread_priority, high_watermark, Thread::PosixThreadFactory::create(),
+                     enable_logger, use_worker_thread) {}
 
 envoy_stream_t InternalEngine::initStream() { return current_stream_handle_++; }
 

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -35,8 +35,7 @@ public:
   InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
                  std::unique_ptr<EnvoyEventTracker> event_tracker,
                  absl::optional<int> thread_priority = absl::nullopt,
-                 absl::optional<size_t> high_watermark = absl::nullopt,
-                 bool disable_dns_refresh_on_network_change = false, bool enable_logger = true,
+                 absl::optional<size_t> high_watermark = absl::nullopt, bool enable_logger = true,
                  bool use_worker_thread = false);
 
   /**
@@ -205,6 +204,13 @@ public:
    */
   Stats::Store& getStatsStore();
 
+  /**
+   * Set whether to disable DNS refresh on network change events.
+   */
+  void disableDnsRefreshOnNetworkChange(bool disable) {
+    disable_dns_refresh_on_network_change_ = disable;
+  }
+
 private:
   // Needs access to the private constructor.
   GTEST_FRIEND_CLASS(InternalEngineTest, ThreadCreationFailed);
@@ -212,7 +218,6 @@ private:
   InternalEngine(std::unique_ptr<EngineCallbacks> callbacks, std::unique_ptr<EnvoyLogger> logger,
                  std::unique_ptr<EnvoyEventTracker> event_tracker,
                  absl::optional<int> thread_priority, absl::optional<size_t> high_watermark,
-                 bool disable_dns_refresh_on_network_change,
                  Thread::PosixThreadFactoryPtr thread_factory, bool enable_logger = true,
                  bool use_worker_thread = false);
 
@@ -266,7 +271,7 @@ private:
   Thread::PosixThreadPtr main_thread_{nullptr}; // Empty placeholder to be populated later.
   bool terminated_{false};
   absl::Notification engine_running_;
-  bool disable_dns_refresh_on_network_change_;
+  bool disable_dns_refresh_on_network_change_{false};
   int prev_network_type_{0};
   Network::Address::InstanceConstSharedPtr prev_local_addr_{nullptr};
   bool enable_logger_{true};

--- a/mobile/library/jni/BUILD
+++ b/mobile/library/jni/BUILD
@@ -77,7 +77,7 @@ envoy_cc_library(
         ":android_network_utility_lib",
         ":jni_init_lib",
         ":jni_utility_lib",
-        "//library/cc:engine_builder_lib",
+        "//library/cc:mobile_engine_builder_lib",
         "//library/common:internal_engine_lib",
         "//library/common/api:c_types",
         "//library/common/bridge:utility_lib",

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -3,7 +3,7 @@
 
 #include "source/common/protobuf/protobuf.h"
 
-#include "library/cc/engine_builder.h"
+#include "library/cc/mobile_engine_builder.h"
 #include "library/common/api/c_types.h"
 #include "library/common/bridge/utility.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
@@ -16,7 +16,7 @@
 #include "library/jni/jni_init.h"
 #include "library/jni/jni_utility.h"
 
-using Envoy::Platform::EngineBuilder;
+using Envoy::Platform::MobileEngineBuilder;
 
 // NOLINT(namespace-envoy)
 
@@ -107,10 +107,11 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     };
   }
 
-  return reinterpret_cast<jlong>(
+  auto* engine =
       new Envoy::InternalEngine(std::move(callbacks), std::move(logger), std::move(event_tracker),
-                                /*network_thread_priority*/ absl::nullopt,
-                                (disable_dns_refresh_on_network_change == JNI_TRUE)));
+                                /*network_thread_priority*/ absl::nullopt);
+  engine->disableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change == JNI_TRUE);
+  return reinterpret_cast<jlong>(engine);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
@@ -1066,8 +1067,8 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerStringAccessor(JNIEnv* 
 
 // Takes a jstring from Java, converts it to a C++ string, calls the supplied
 // setter on it.
-void setString(Envoy::JNI::JniHelper& jni_helper, jstring java_string, EngineBuilder* builder,
-               EngineBuilder& (EngineBuilder::*setter)(std::string)) {
+void setString(Envoy::JNI::JniHelper& jni_helper, jstring java_string, MobileEngineBuilder* builder,
+               MobileEngineBuilder& (MobileEngineBuilder::*setter)(std::string)) {
   if (!java_string) {
     return;
   }
@@ -1155,7 +1156,7 @@ void configureBuilder(
     jobjectArray runtime_guards, jlong h3_connection_keepalive_initial_interval_milliseconds,
     jboolean use_quic_platform_packet_writer, jboolean enable_connection_migration,
     jboolean migrate_idle_connection, jlong max_idle_time_before_migration_seconds,
-    jlong max_time_on_non_default_network_seconds, Envoy::Platform::EngineBuilder& builder) {
+    jlong max_time_on_non_default_network_seconds, MobileEngineBuilder& builder) {
   builder.addConnectTimeoutSeconds((connect_timeout_seconds));
   builder.setDisableDnsRefreshOnFailure(disable_dns_refresh_on_failure);
   builder.setDisableDnsRefreshOnNetworkChange(disable_dns_refresh_on_network_change);
@@ -1173,8 +1174,8 @@ void configureBuilder(
       (h2_connection_keepalive_idle_interval_milliseconds));
   builder.addH2ConnectionKeepaliveTimeoutSeconds((h2_connection_keepalive_timeout_seconds));
 
-  setString(jni_helper, app_version, &builder, &EngineBuilder::setAppVersion);
-  setString(jni_helper, app_id, &builder, &EngineBuilder::setAppId);
+  setString(jni_helper, app_version, &builder, &MobileEngineBuilder::setAppVersion);
+  setString(jni_helper, app_id, &builder, &MobileEngineBuilder::setAppId);
   builder.setDeviceOs("Android");
 
   builder.setStreamIdleTimeoutSeconds((stream_idle_timeout_seconds));
@@ -1238,7 +1239,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_getNativeFilterConfig(JNIEnv* e
                                                                        jstring filter_name_jstr) {
   Envoy::JNI::JniHelper jni_helper(env);
   std::string filter_name = Envoy::JNI::javaStringToCppString(jni_helper, filter_name_jstr);
-  std::string filter_config = EngineBuilder::nativeNameToConfig(filter_name);
+  std::string filter_config = MobileEngineBuilder::nativeNameToConfig(filter_name);
 
   return jni_helper.newStringUtf(filter_config.c_str()).release();
 }
@@ -1265,7 +1266,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     jboolean migrate_idle_connection, jlong max_idle_time_before_migration_seconds,
     jlong max_time_on_non_default_network_seconds) {
   Envoy::JNI::JniHelper jni_helper(env);
-  Envoy::Platform::EngineBuilder builder;
+  MobileEngineBuilder builder;
 
   configureBuilder(
       jni_helper, connect_timeout_seconds, disable_dns_refresh_on_failure,
@@ -1283,7 +1284,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
       h3_connection_keepalive_initial_interval_milliseconds, use_quic_platform_packet_writer,
       enable_connection_migration, migrate_idle_connection, max_idle_time_before_migration_seconds,
       max_time_on_non_default_network_seconds, builder);
-  return reinterpret_cast<intptr_t>(builder.generateBootstrap().release());
+  return reinterpret_cast<intptr_t>(builder.generateBootstrap().value().release());
 }
 
 #if defined(__GNUC__)

--- a/mobile/library/objective-c/BUILD
+++ b/mobile/library/objective-c/BUILD
@@ -54,7 +54,7 @@ envoy_objc_library(
         ":envoy_key_value_store_bridge_impl_lib",
         ":envoy_key_value_store_lib",
         ":envoy_objc_bridge_lib",
-        "//library/cc:engine_builder_lib",
+        "//library/cc:mobile_engine_builder_lib",
         "//library/cc:network_change_monitor_interface",
         "//library/common:internal_engine_lib",
         "//library/common/api:c_types",

--- a/mobile/library/objective-c/EnvoyConfiguration.mm
+++ b/mobile/library/objective-c/EnvoyConfiguration.mm
@@ -1,8 +1,10 @@
 #import "library/objective-c/EnvoyEngine.h"
 
-#import "library/cc/engine_builder.h"
+#import "library/cc/mobile_engine_builder.h"
 #import "library/cc/direct_response_testing.h"
 #include "source/common/protobuf/utility.h"
+
+using Envoy::Platform::MobileEngineBuilder;
 
 @implementation NSString (CXX)
 - (std::string)toCXXString {
@@ -154,8 +156,8 @@
   return self;
 }
 
-- (Envoy::Platform::EngineBuilder)applyToCXXBuilder {
-  Envoy::Platform::EngineBuilder builder;
+- (MobileEngineBuilder)applyToCXXBuilder {
+  MobileEngineBuilder builder;
 
   for (EnvoyNativeFilterConfig *nativeFilterConfig in
        [self.nativeFilterChain reverseObjectEnumerator]) {
@@ -228,8 +230,8 @@
 
 - (std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap>)generateBootstrap {
   try {
-    Envoy::Platform::EngineBuilder builder = [self applyToCXXBuilder];
-    return builder.generateBootstrap();
+    MobileEngineBuilder builder = [self applyToCXXBuilder];
+    return std::move(builder.generateBootstrap().value());
   } catch (const std::exception &e) {
     NSLog(@"[Envoy] error generating bootstrap: %@", @(e.what()));
     return nullptr;

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -8,7 +8,7 @@
 
 #import "library/common/types/c_types.h"
 #import "library/common/extensions/key_value/platform/c_types.h"
-#import "library/cc/engine_builder.h"
+#import "library/cc/mobile_engine_builder.h"
 #import "library/cc/network_change_monitor.h"
 #import "library/common/internal_engine.h"
 #include "library/common/system/system_helper.h"

--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -1,16 +1,26 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_mobile_package")
+load("//bazel:envoy_mobile_cc_test.bzl", "envoy_cc_test_with_engine_builder")
 
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-envoy_cc_test(
+envoy_cc_library(
+    name = "engine_builder_test_shim_lib",
+    hdrs = ["engine_builder_test_shim.h"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//library/cc:engine_builder_lib",
+    ],
+)
+
+envoy_cc_test_with_engine_builder(
     name = "engine_test",
     srcs = ["engine_test.cc"],
     env = {"ENVOY_NO_LOG_SINK": ""},
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",

--- a/mobile/test/cc/engine_builder_test_shim.h
+++ b/mobile/test/cc/engine_builder_test_shim.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#if defined(USE_MOBILE_ENGINE_BUILDER)
+
+#include "library/cc/mobile_engine_builder.h"
+
+namespace Envoy {
+namespace Platform {
+class EngineBuilder : public MobileEngineBuilder {
+public:
+  using MobileEngineBuilder::MobileEngineBuilder;
+
+  std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> generateBootstrap() const {
+    auto* mutable_this = const_cast<EngineBuilder*>(this);
+    return mutable_this->Platform::EngineBuilderBase<MobileEngineBuilder>::generateBootstrap()
+        .value();
+  }
+};
+using EngineBuilderSharedPtr = std::shared_ptr<EngineBuilder>;
+} // namespace Platform
+} // namespace Envoy
+
+#else
+
+#include "library/cc/engine_builder.h"
+
+#endif

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -5,7 +5,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -1,15 +1,15 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_cc_test_library", "envoy_mobile_package")
+load("//bazel:envoy_mobile_cc_test.bzl", "envoy_cc_test_with_engine_builder")
 
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "send_headers_test",
     srcs = ["send_headers_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/http/filters/assertion:filter_cc_proto",
@@ -19,12 +19,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "send_trailers_test",
     srcs = ["send_trailers_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/http/filters/assertion:filter_cc_proto",
@@ -34,12 +33,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "send_data_test",
     srcs = ["send_data_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/http/filters/assertion:filter_cc_proto",
@@ -49,12 +47,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "receive_headers_test",
     srcs = ["receive_headers_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
@@ -63,12 +60,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "receive_data_test",
     srcs = ["receive_data_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
@@ -77,12 +73,11 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "receive_trailers_test",
     srcs = ["receive_trailers_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
@@ -91,16 +86,48 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "lifetimes_test",
     srcs = ["lifetimes_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_types_lib",
         "//library/common/http:header_utility_lib",
         "//test/common/integration:engine_with_test_server",
         "//test/common/integration:test_server_lib",
         "@envoy_build_config//:test_extensions",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "test_base_lib",
+    srcs = [
+        "base/test_engine_and_server.cc",
+    ],
+    hdrs = [
+        "base/test_engine_and_server.h",
+        "base/test_engine_builder.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:engine_builder_base_lib",
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "//test/common/integration:test_server_lib",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/strings",
+        "@envoy//source/extensions/clusters/static:static_cluster_lib",
+        "@envoy//source/extensions/load_balancing_policies/round_robin:config",
+    ],
+)
+
+envoy_cc_test(
+    name = "integration_test",
+    srcs = ["base/integration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":test_base_lib",
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "//test/common/http/filters/assertion:filter_cc_proto",
+        "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/mobile/test/cc/integration/BUILD
+++ b/mobile/test/cc/integration/BUILD
@@ -117,6 +117,15 @@ envoy_cc_test_library(
         "@abseil-cpp//absl/strings",
         "@envoy//source/extensions/clusters/static:static_cluster_lib",
         "@envoy//source/extensions/load_balancing_policies/round_robin:config",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/http_11_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/quic/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/raw_buffer/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/upstreams/http/v3:pkg_cc_proto",
     ],
 )
 
@@ -129,5 +138,6 @@ envoy_cc_test(
         "//library/cc:envoy_engine_cc_lib_no_stamp",
         "//test/common/http/filters/assertion:filter_cc_proto",
         "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )

--- a/mobile/test/cc/integration/base/integration_test.cc
+++ b/mobile/test/cc/integration/base/integration_test.cc
@@ -1,0 +1,177 @@
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "test/cc/integration/base/test_engine_builder.h"
+#include "test/cc/integration/base/test_engine_and_server.h"
+#include "test/test_common/utility.h"
+#include "library/cc/stream_prototype.h"
+#include "gtest/gtest.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/notification.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/buffer/buffer.h"
+#include "envoy/http/header_map.h"
+#include "library/cc/stream.h"
+#include "library/common/engine_types.h"
+#include "library/common/http/header_utility.h"
+#include "library/common/types/c_types.h"
+#include "test/common/http/filters/assertion/filter.pb.h"
+#include "test/common/integration/test_server.h"
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/base_logger.h"
+
+namespace Envoy {
+namespace {
+
+class BaseEngineBuilderTest : public testing::TestWithParam<TestServerType> {
+protected:
+  BaseEngineBuilderTest() : server_type_(GetParam()) {}
+
+  void
+  SetUpEngineAndServer(absl::optional<envoymobile::extensions::filters::http::assertion::Assertion>
+                           assertion_config = std::nullopt,
+                       const absl::flat_hash_map<std::string, std::string>& headers = {},
+                       absl::string_view body = "",
+                       const absl::flat_hash_map<std::string, std::string>& trailers = {}) {
+    absl::Notification engine_running;
+    Platform::TestEngineBuilder engine_builder;
+
+    if (assertion_config.has_value()) {
+      ::envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter
+          assertion_filter;
+      assertion_filter.set_name("envoy.filters.http.assertion");
+      assertion_filter.mutable_typed_config()->PackFrom(assertion_config.value());
+      engine_builder.addHcmHttpFilter(std::move(assertion_filter));
+    }
+
+    engine_builder.enableLogger(false).setLogLevel(Logger::Logger::debug).setOnEngineRunning([&]() {
+      engine_running.Notify();
+    });
+    client_engine_with_test_server_ = std::make_unique<TestEngineAndServer>(
+        engine_builder, server_type_, headers, body, trailers);
+    engine_running.WaitForNotification();
+  }
+
+  std::shared_ptr<Platform::Stream> StartStream(Platform::StreamPrototypeSharedPtr stream_prototype,
+                                                bool end_stream = true) {
+    on_data_was_called_ = false;
+    on_headers_was_called_ = false;
+    on_trailers_was_called_ = false;
+    actual_status_code_ = "";
+    actual_response_body_ = "";
+    actual_trailer_value_ = "";
+    actual_end_stream_ = false;
+
+    EnvoyStreamCallbacks callbacks;
+    callbacks.on_headers_ = [this](const Http::ResponseHeaderMap& headers, bool end_stream,
+                                   envoy_stream_intel) {
+      on_headers_was_called_ = true;
+      actual_end_stream_ = end_stream;
+      auto status = headers.get(Http::LowerCaseString(":status"));
+      if (!status.empty()) {
+        actual_status_code_ = std::string(status[0]->value().getStringView());
+      }
+    };
+    callbacks.on_data_ = [this](const Buffer::Instance& data, uint64_t, bool end_stream,
+                                envoy_stream_intel) {
+      on_data_was_called_ = true;
+      actual_end_stream_ = end_stream;
+      actual_response_body_ += data.toString();
+    };
+    callbacks.on_trailers_ = [this](const Http::ResponseTrailerMap& trailers, envoy_stream_intel) {
+      on_trailers_was_called_ = true;
+      actual_end_stream_ = true;
+      auto trailer = trailers.get(Http::LowerCaseString("test-trailer"));
+      if (!trailer.empty()) {
+        actual_trailer_value_ = std::string(trailer[0]->value().getStringView());
+      }
+    };
+    callbacks.on_complete_ = [this](envoy_stream_intel, envoy_final_stream_intel) {
+      stream_completed_.Notify();
+    };
+
+    auto stream = stream_prototype->start(std::move(callbacks));
+
+    auto headers = std::make_unique<Http::TestRequestHeaderMapImpl>();
+    headers->addCopy(Http::LowerCaseString(":method"), "GET");
+    headers->addCopy(Http::LowerCaseString(":scheme"), "http");
+    headers->addCopy(Http::LowerCaseString(":authority"),
+                     client_engine_with_test_server_->test_server().getAddress());
+    headers->addCopy(Http::LowerCaseString(":path"), "/");
+    stream->sendHeaders(std::move(headers), end_stream);
+    return stream;
+  }
+
+  TestServerType server_type_;
+  std::unique_ptr<TestEngineAndServer> client_engine_with_test_server_;
+  absl::Notification stream_completed_;
+  bool on_data_was_called_ = false;
+  bool on_headers_was_called_ = false;
+  bool on_trailers_was_called_ = false;
+  bool actual_end_stream_ = false;
+  std::string actual_status_code_;
+  std::string actual_trailer_value_;
+  std::string actual_response_body_;
+};
+
+INSTANTIATE_TEST_SUITE_P(BaseEngineBuilderTest, BaseEngineBuilderTest,
+                         testing::Values(TestServerType::HTTP1_WITHOUT_TLS,
+                                         TestServerType::HTTP1_WITH_TLS,
+                                         TestServerType::HTTP2_WITH_TLS, TestServerType::HTTP3));
+
+TEST_P(BaseEngineBuilderTest, GetRequest) {
+  SetUpEngineAndServer(/*assertion_config=*/std::nullopt,
+                       /*headers=*/{{"test-header", "test-value"}},
+                       /*body=*/"test body");
+  auto engine = client_engine_with_test_server_->engine();
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  StartStream(stream_prototype);
+  stream_completed_.WaitForNotification();
+
+  EXPECT_TRUE(on_headers_was_called_);
+  EXPECT_TRUE(on_data_was_called_);
+  EXPECT_TRUE(actual_end_stream_);
+  EXPECT_EQ(actual_status_code_, "200");
+  EXPECT_EQ(actual_response_body_, "test body");
+}
+
+TEST_P(BaseEngineBuilderTest, GetRequestWithTrailers) {
+  SetUpEngineAndServer(/*assertion_config=*/std::nullopt,
+                       /*headers=*/{{"test-header", "test-value"}},
+                       /*body=*/"test body",
+                       /*trailers=*/{{"test-trailer", "test-trailer-value"}});
+  auto engine = client_engine_with_test_server_->engine();
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  StartStream(stream_prototype);
+  stream_completed_.WaitForNotification();
+
+  EXPECT_TRUE(on_headers_was_called_);
+  EXPECT_TRUE(on_data_was_called_);
+  EXPECT_TRUE(on_trailers_was_called_);
+  EXPECT_TRUE(actual_end_stream_);
+  EXPECT_EQ(actual_status_code_, "200");
+  EXPECT_EQ(actual_response_body_, "test body");
+  EXPECT_EQ(actual_trailer_value_, "test-trailer-value");
+}
+
+TEST_P(BaseEngineBuilderTest, PostRequestWithBody) {
+  SetUpEngineAndServer();
+  auto engine = client_engine_with_test_server_->engine();
+  auto stream_prototype = engine->streamClient()->newStreamPrototype();
+  auto stream = StartStream(stream_prototype, /*end_stream=*/false);
+
+  auto buffer = std::make_unique<Buffer::OwnedImpl>("post body");
+  stream->close(std::move(buffer));
+  stream_completed_.WaitForNotification();
+
+  EXPECT_TRUE(on_headers_was_called_);
+  EXPECT_TRUE(on_data_was_called_);
+  EXPECT_TRUE(actual_end_stream_);
+  EXPECT_EQ(actual_status_code_, "200");
+}
+
+} // namespace
+} // namespace Envoy

--- a/mobile/test/cc/integration/base/test_engine_and_server.cc
+++ b/mobile/test/cc/integration/base/test_engine_and_server.cc
@@ -1,0 +1,121 @@
+#include "test/cc/integration/base/test_engine_and_server.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "test/cc/integration/base/test_engine_builder.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/str_cat.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/endpoint/v3/endpoint_components.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/route_components.pb.h"
+#include "envoy/extensions/transport_sockets/http_11_proxy/v3/upstream_http_11_connect.pb.h"
+#include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
+#include "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.pb.h"
+#include "envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
+#include "test/common/integration/test_server.h"
+#include "source/common/common/assert.h"
+
+namespace Envoy {
+
+TestEngineAndServer::TestEngineAndServer(
+    Platform::TestEngineBuilder& engine_builder, TestServerType type,
+    const absl::flat_hash_map<std::string, std::string>& headers, absl::string_view body,
+    const absl::flat_hash_map<std::string, std::string>& trailers) {
+  test_server_.start(type);
+  test_server_.setResponse(headers, body, trailers);
+
+  // Set up route configuration and cluster for ClientEngineBuilder to route
+  // requests to test_server_.
+  ::envoy::config::route::v3::RouteConfiguration route_configuration;
+  route_configuration.set_name("route_config");
+  auto* virtual_host = route_configuration.add_virtual_hosts();
+  virtual_host->set_name("test_virtual_host");
+  virtual_host->add_domains("*");
+  auto* route = virtual_host->add_routes();
+  route->mutable_match()->set_prefix("/");
+  route->mutable_route()->set_cluster("test_cluster");
+  engine_builder.setHcmRouteConfiguration(std::move(route_configuration));
+
+  ::envoy::config::cluster::v3::Cluster cluster;
+  cluster.set_name("test_cluster");
+  cluster.mutable_connect_timeout()->set_seconds(5);
+  auto* endpoint =
+      cluster.mutable_load_assignment()->add_endpoints()->add_lb_endpoints()->mutable_endpoint();
+  endpoint->mutable_address()->mutable_socket_address()->set_address(test_server_.getIpAddress());
+  endpoint->mutable_address()->mutable_socket_address()->set_port_value(test_server_.getPort());
+  cluster.mutable_load_assignment()->set_cluster_name("test_cluster");
+  cluster.set_type(::envoy::config::cluster::v3::Cluster::STATIC);
+
+  bool use_tls = type == TestServerType::HTTP1_WITH_TLS || type == TestServerType::HTTP2_WITH_TLS ||
+                 type == TestServerType::HTTP3;
+
+  ::envoy::extensions::upstreams::http::v3::HttpProtocolOptions protocol_options;
+
+  if (use_tls) {
+    ::envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+    tls_context.mutable_common_tls_context()
+        ->mutable_validation_context()
+        ->set_trust_chain_verification(::envoy::extensions::transport_sockets::tls::v3::
+                                           CertificateValidationContext::ACCEPT_UNTRUSTED);
+    tls_context.set_sni("www.lyft.com");
+
+    if (type == TestServerType::HTTP2_WITH_TLS) {
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
+      protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+    } else if (type == TestServerType::HTTP1_WITH_TLS) {
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("http/1.1");
+      protocol_options.mutable_explicit_http_config()
+          ->mutable_http_protocol_options()
+          ->set_enable_trailers(true);
+    }
+    cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
+    cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
+
+    if (type == TestServerType::HTTP3) {
+      protocol_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
+      ::envoy::extensions::transport_sockets::quic::v3::QuicUpstreamTransport h3_inner_socket;
+      h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_context);
+      ::envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
+          h3_proxy_socket;
+      h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+      h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
+      cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
+      cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+    }
+  } else {
+    cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
+    ::envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer raw_buffer;
+    cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
+    protocol_options.mutable_explicit_http_config()
+        ->mutable_http_protocol_options()
+        ->set_enable_trailers(true);
+  }
+
+  (*cluster.mutable_typed_extension_protocol_options())
+      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+          .PackFrom(protocol_options);
+
+  engine_builder.addCluster(std::move(cluster));
+
+  auto engine = engine_builder.build();
+  RELEASE_ASSERT(engine.ok(), absl::StrCat("Failed to build engine: ", engine.status().message()));
+  engine_ = *std::move(engine);
+}
+
+TestEngineAndServer::~TestEngineAndServer() {
+  test_server_.shutdown();
+  if (engine_ != nullptr) {
+    engine_->terminate();
+  }
+}
+
+std::shared_ptr<Platform::Engine> TestEngineAndServer::engine() { return engine_; }
+
+TestServer& TestEngineAndServer::test_server() { return test_server_; }
+
+} // namespace Envoy

--- a/mobile/test/cc/integration/base/test_engine_and_server.h
+++ b/mobile/test/cc/integration/base/test_engine_and_server.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifndef TEST_CC_INTEGRATION_BASE_TEST_ENGINE_AND_SERVER_H_
+#define TEST_CC_INTEGRATION_BASE_TEST_ENGINE_AND_SERVER_H_
+
+#include <memory>
+#include <string>
+
+#include "test/cc/integration/base/test_engine_builder.h"
+#include "library/cc/engine.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+#include "test/common/integration/test_server.h"
+
+namespace Envoy {
+
+// Test only class.
+class TestEngineAndServer {
+public:
+  TestEngineAndServer(Platform::TestEngineBuilder& engine_builder, TestServerType type,
+                      const absl::flat_hash_map<std::string, std::string>& headers = {},
+                      absl::string_view body = "",
+                      const absl::flat_hash_map<std::string, std::string>& trailers = {});
+  ~TestEngineAndServer();
+
+  std::shared_ptr<Platform::Engine> engine();
+
+  TestServer& test_server();
+
+private:
+  std::shared_ptr<Platform::Engine> engine_;
+  TestServer test_server_;
+};
+
+} // namespace Envoy
+
+#endif // TEST_CC_INTEGRATION_BASE_TEST_ENGINE_AND_SERVER_H_

--- a/mobile/test/cc/integration/base/test_engine_builder.h
+++ b/mobile/test/cc/integration/base/test_engine_builder.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "library/cc/engine_builder_base.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+
+#include "source/extensions/clusters/static/static_cluster.h"
+#include "source/extensions/load_balancing_policies/round_robin/config.h"
+
+namespace Envoy {
+namespace Platform {
+
+class TestEngineBuilder : public EngineBuilderBase<TestEngineBuilder> {
+  friend class EngineBuilderBase<TestEngineBuilder>;
+
+public:
+  TestEngineBuilder() = default;
+
+  TestEngineBuilder& addHcmHttpFilter(
+      ::envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter filter) {
+    hcm_http_filters_.push_back(std::move(filter));
+    return *this;
+  }
+
+  TestEngineBuilder&
+  setHcmRouteConfiguration(::envoy::config::route::v3::RouteConfiguration route_configuration) {
+    route_configuration_ = std::move(route_configuration);
+    return *this;
+  }
+
+  TestEngineBuilder& addCluster(::envoy::config::cluster::v3::Cluster cluster) {
+    clusters_.push_back(std::move(cluster));
+    return *this;
+  }
+
+private:
+  // Hooks required by EngineBuilderBase
+  void PreRunSetup(InternalEngine* engine) {
+    (void)engine;
+    Envoy::Upstream::forceRegisterStaticClusterFactory();
+    Envoy::Extensions::LoadBalancingPolicies::RoundRobin::forceRegisterFactory();
+  }
+  void PostRunSetup(Engine*) {}
+
+  absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap*) { return absl::OkStatus(); }
+  absl::Status configureNode(envoy::config::core::v3::Node* node) {
+    node->set_id("envoy-test-client");
+    node->set_cluster("envoy-test-client");
+    return absl::OkStatus();
+  }
+
+  absl::Status configureRouteConfig(envoy::config::route::v3::RouteConfiguration* route_config) {
+    if (route_configuration_.has_value()) {
+      route_config->Swap(&route_configuration_.value());
+    }
+    return absl::OkStatus();
+  }
+
+  absl::Status configureStaticClusters(
+      Protobuf::RepeatedPtrField<envoy::config::cluster::v3::Cluster>* clusters) {
+    for (auto& cluster : clusters_) {
+      *clusters->Add() = std::move(cluster);
+    }
+    clusters_.clear();
+    return absl::OkStatus();
+  }
+
+  absl::Status configureHttpFilters(
+      std::function<envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter*()>
+          add_filter) {
+    for (auto& filter : hcm_http_filters_) {
+      *add_filter() = std::move(filter);
+    }
+    hcm_http_filters_.clear();
+    return absl::OkStatus();
+  }
+
+  void configureCustomRouterFilter(::envoy::extensions::filters::http::router::v3::Router&) {}
+
+  std::vector<::envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter>
+      hcm_http_filters_;
+  absl::optional<::envoy::config::route::v3::RouteConfiguration> route_configuration_;
+  std::vector<::envoy::config::cluster::v3::Cluster> clusters_;
+};
+
+} // namespace Platform
+} // namespace Envoy

--- a/mobile/test/cc/integration/base/test_engine_builder.h
+++ b/mobile/test/cc/integration/base/test_engine_builder.h
@@ -34,12 +34,12 @@ public:
 
 private:
   // Hooks required by EngineBuilderBase
-  void PreRunSetup(InternalEngine* engine) {
+  void preRunSetup(InternalEngine* engine) {
     (void)engine;
     Envoy::Upstream::forceRegisterStaticClusterFactory();
     Envoy::Extensions::LoadBalancingPolicies::RoundRobin::forceRegisterFactory();
   }
-  void PostRunSetup(Engine*) {}
+  void postRunSetup(Engine*) {}
 
   absl::Status configXds(envoy::config::bootstrap::v3::Bootstrap*) { return absl::OkStatus(); }
   absl::Status configureNode(envoy::config::core::v3::Node* node) {

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -3,7 +3,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/receive_data_test.cc
+++ b/mobile/test/cc/integration/receive_data_test.cc
@@ -3,7 +3,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/receive_headers_test.cc
+++ b/mobile/test/cc/integration/receive_headers_test.cc
@@ -3,7 +3,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/receive_trailers_test.cc
+++ b/mobile/test/cc/integration/receive_trailers_test.cc
@@ -3,7 +3,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/send_data_test.cc
+++ b/mobile/test/cc/integration/send_data_test.cc
@@ -4,7 +4,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -4,7 +4,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/integration/send_trailers_test.cc
+++ b/mobile/test/cc/integration/send_trailers_test.cc
@@ -4,7 +4,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_types.h"
 #include "library/common/http/header_utility.h"
 

--- a/mobile/test/cc/unit/BUILD
+++ b/mobile/test/cc/unit/BUILD
@@ -1,10 +1,11 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("//bazel:envoy_mobile_cc_test.bzl", "envoy_cc_test_with_engine_builder")
 
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "envoy_config_test",
     srcs = ["envoy_config_test.cc"],
     linkopts = select({
@@ -17,7 +18,6 @@ envoy_cc_test(
     }),
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/cc:envoy_engine_cc_lib_no_stamp",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
@@ -28,7 +28,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "fetch_client_test",
     srcs = ["fetch_client_test.cc"],
     exec_properties = {
@@ -36,18 +36,16 @@ envoy_cc_test(
     },
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "@envoy_build_config//:extension_registry",
         "@envoy_build_config//:test_extensions",
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "engine_handle_test",
     srcs = ["engine_handle_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:internal_engine_lib_no_stamp",
         "@envoy_build_config//:extension_registry",
         "@envoy_build_config//:test_extensions",

--- a/mobile/test/cc/unit/engine_handle_test.cc
+++ b/mobile/test/cc/unit/engine_handle_test.cc
@@ -1,6 +1,6 @@
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/internal_engine.h"
 
 namespace Envoy {

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -14,7 +14,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/api/external.h"
 #include "library/common/bridge//utility.h"
 

--- a/mobile/test/cc/unit/fetch_client_test.cc
+++ b/mobile/test/cc/unit/fetch_client_test.cc
@@ -8,7 +8,7 @@
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 #include "library/cc/engine.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/cc/stream.h"
 #include "library/cc/stream_client.h"
 #include "library/cc/stream_prototype.h"

--- a/mobile/test/common/BUILD
+++ b/mobile/test/common/BUILD
@@ -1,26 +1,25 @@
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_mobile_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_mobile_package")
+load("//bazel:envoy_mobile_cc_test.bzl", "envoy_cc_test_with_engine_builder")
 
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "engine_common_test",
     srcs = ["engine_common_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:engine_common_lib",
         "@envoy_build_config//:extension_registry",
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "internal_engine_test",
     srcs = ["internal_engine_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common:internal_engine_lib_no_stamp",
         "//library/common/bridge:utility_lib",
         "//library/common/http:header_utility_lib",

--- a/mobile/test/common/engine_common_test.cc
+++ b/mobile/test/common/engine_common_test.cc
@@ -1,6 +1,6 @@
 #include "extension_registry.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/engine_common.h"
 
 namespace Envoy {

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -1,17 +1,21 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_mobile_package",
     "envoy_select_envoy_mobile_xds",
     "envoy_select_signal_trace",
+)
+load(
+    "//bazel:envoy_mobile_cc_test.bzl",
+    "envoy_cc_test_library_with_engine_builder",
+    "envoy_cc_test_with_engine_builder",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_package()
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "client_integration_test",
     srcs = ["client_integration_test.cc"],
     linkopts = select({
@@ -45,7 +49,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_library(
+envoy_cc_test_library_with_engine_builder(
     name = "base_client_integration_test_lib",
     srcs = [
         "base_client_integration_test.cc",
@@ -55,7 +59,6 @@ envoy_cc_test_library(
     ],
     repository = "@envoy",
     deps = [
-        "//library/cc:engine_builder_lib",
         "//library/common/http:client_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/network:network_types_lib",
@@ -109,7 +112,7 @@ envoy_cc_test_library(
     ],
 )
 
-envoy_cc_test_library(
+envoy_cc_test_library_with_engine_builder(
     name = "engine_with_test_server",
     srcs = [
         "engine_with_test_server.cc",
@@ -120,11 +123,10 @@ envoy_cc_test_library(
     repository = "@envoy",
     deps = [
         ":test_server_lib",
-        "//library/cc:engine_builder_lib",
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "rtds_integration_test",
     srcs = envoy_select_envoy_mobile_xds(
         ["rtds_integration_test.cc"],
@@ -147,7 +149,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "cds_integration_test",
     srcs = envoy_select_envoy_mobile_xds(
         ["cds_integration_test.cc"],
@@ -169,7 +171,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_test_with_engine_builder(
     name = "sds_integration_test",
     srcs = envoy_select_envoy_mobile_xds(
         ["sds_integration_test.cc"],
@@ -194,7 +196,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test_library(
+envoy_cc_test_library_with_engine_builder(
     name = "xds_integration_test_lib",
     srcs = [
         "xds_integration_test.cc",
@@ -215,7 +217,7 @@ envoy_cc_test_library(
     ],
 )
 
-envoy_cc_test_library(
+envoy_cc_test_library_with_engine_builder(
     name = "xds_test_server_lib",
     srcs = [
         "xds_test_server.cc",

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -217,7 +217,7 @@ envoy_cc_test_library_with_engine_builder(
     ],
 )
 
-envoy_cc_test_library_with_engine_builder(
+envoy_cc_test_library(
     name = "xds_test_server_lib",
     srcs = [
         "xds_test_server.cc",
@@ -227,7 +227,6 @@ envoy_cc_test_library_with_engine_builder(
     ],
     repository = "@envoy",
     deps = [
-        ":base_client_integration_test_lib",
         "@envoy//source/common/event:libevent_lib",
         "@envoy//source/common/tls:context_config_lib",
         "@envoy//source/common/tls:context_lib",

--- a/mobile/test/common/integration/base_client_integration_test.h
+++ b/mobile/test/common/integration/base_client_integration_test.h
@@ -2,7 +2,7 @@
 
 #include "test/integration/integration.h"
 
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/cc/stream.h"
 #include "library/cc/stream_prototype.h"
 #include "library/common/http/client.h"

--- a/mobile/test/common/integration/engine_with_test_server.h
+++ b/mobile/test/common/integration/engine_with_test_server.h
@@ -2,7 +2,7 @@
 
 #include "test/common/integration/test_server.h"
 
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 
 namespace Envoy {
 

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -14,7 +14,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/cc/engine_builder.h"
+#include "test/cc/engine_builder_test_shim.h"
 #include "library/common/api/external.h"
 #include "library/common/bridge//utility.h"
 #include "library/common/http/header_utility.h"
@@ -445,9 +445,9 @@ TEST_F(InternalEngineTest, ThreadCreationFailed) {
   EngineTestContext test_context{};
   auto thread_factory = std::make_unique<Thread::MockPosixThreadFactory>();
   EXPECT_CALL(*thread_factory, createThread(_, _, false)).WillOnce(Return(ByMove(nullptr)));
-  std::unique_ptr<InternalEngine> engine(
-      new InternalEngine(createDefaultEngineCallbacks(test_context), {}, {}, {}, {}, false,
-                         std::move(thread_factory)));
+  std::unique_ptr<InternalEngine> engine(new InternalEngine(
+      createDefaultEngineCallbacks(test_context), {}, {}, {}, {}, std::move(thread_factory)));
+  engine->disableDnsRefreshOnNetworkChange(false);
   Platform::EngineBuilder builder;
   envoy_status_t status = runEngine(engine, builder, LOG_LEVEL);
   EXPECT_EQ(status, ENVOY_FAILURE);


### PR DESCRIPTION
Commit Message: extract all common bootstrap generation and engine creation pipelines from  the C++ `EngineBuilder`  into a unified CRTP template base class (`EngineBuilderBase<T>`). And add a new `MobileEngineBuilder` which is branched from the existing `EngineBuilder` but inherits from`EngineBuilderBase`. `MobileEngineBuilder` shares identical C++ API, Envoy configuration and engine setup as the`EngineBuilder`. And the latter will be deprecated in preference of `MobileEngineBuilder`.

Setup all the existing C++ tests to run against both EngineBuilder and MobileEngineBuilder. The same test targets are double-compiled into 2 test targets: one for legacy `EngineBuilder` and is renamed to `foo_test_legacy_builder`; and one for `MobileEngineBuilder` with test target name as is. 

Swift and Python APIs directly switch to use the new `MobileEngineBuilder` in this PR. Java APIs directly interacts with InternalEngine, so it's irrelevant to this change.

`Platform::XdsBuilder` & `Platform::NodeLocality` are extracted into a standalone file for sharing between 2 engine builders.

For better feature isolation, this PR also refactors `InternalEngine` by removing  disable_dns_refresh_on_network_change from the constructor and add a setter for it. So that the EngineBuilderBase doesn't need to be aware of this mobile-specific feature.

Additional Description: also fixes an JNI bug in Envoy::InternalEngine() construction where `disable_dns_refresh_on_network_change` is passed in as the wrong parameter.

Notes to reviewers: due to GitHub's unified diff limitation, the main "Files changed" tab shows the newly added `mobile_engine_builder.h/cc` as 100% new green lines. But these files are actually modified based on engine_builder.h/cc. A better diff can viewed at commit https://github.com/envoyproxy/envoy/pull/44865/changes/7357c340acff893bfbf85b16c3b25e1b52ca9afc.

Risk Level: low, new class not in use
Testing: existing tests with new test combination
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

