### PR TITLE
fix: rebuilding devcontainer causes duplicate lines in user.bazelrc

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-echo "build --config=clang" >> user.bazelrc
+if [[ ! -f user.bazelrc ]] || ! grep -Fxq 'build --config=clang' user.bazelrc; then
+  echo -e "build --config=clang" >> user.bazelrc
+fi
 
 # Ideally we want this line so bazel doesn't pollute things outside of the devcontainer, but some of
 # API tooling (proto_sync) depends on symlink like bazel-bin.


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: fix: rebuilding devcontainer causes duplicate lines in user.bazelrc
Additional Description: Currently each time you open the project in a devcontainer the setup script will re-run and add a copy of the `build --config=clang` to user.bazelrc
Risk Level: Low
Testing: Manually tested the following cases:
- existing file with `build --config=clang`
- empty file
- no file exists
- file with existing contents `build --config=asan`

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A
[Optional Fixes commit #PR or SHA] N/A
[Optional Deprecated:] N/A
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] N/A
