### PR TITLE
build: use local llvm-objcopy when use_local_llvm is true

### DIFF
--- a/source/extensions/dynamic_modules/dynamic_modules.bzl
+++ b/source/extensions/dynamic_modules/dynamic_modules.bzl
@@ -1,5 +1,6 @@
 """Bazel rules for building Envoy dynamic modules."""
 
+load("@envoy_repo//:compiler.bzl", "LLVM_PATH")
 load("@rules_cc//cc:defs.bzl", "cc_import")
 
 def envoy_dynamic_module_prefix_symbols(name, module_name, archive, tags = [], **kwargs):
@@ -61,19 +62,30 @@ def envoy_dynamic_module_prefix_symbols(name, module_name, archive, tags = [], *
     # NOTE: The case statement is kept outside $() command substitution for
     # compatibility with bash 3.2 (macOS default), which cannot parse case
     # pattern delimiters inside $().
+    archive_select_cmd = (
+        "ARCH=\"\"; " +
+        "for f in $(SRCS); do case $$f in *.pic.a) continue;; *.a) ARCH=$$f; break;; esac; done; " +
+        "[ -z \"$$ARCH\" ] && " +
+        "for f in $(SRCS); do case $$f in *.a) ARCH=$$f; break;; esac; done; "
+    )
     native.genrule(
         name = renamed_name,
         srcs = [archive, ":" + redefine_syms_name],
         outs = [name + "_renamed.a"],
-        cmd = (
-            "ARCH=\"\"; " +
-            "for f in $(SRCS); do case $$f in *.pic.a) continue;; *.a) ARCH=$$f; break;; esac; done; " +
-            "[ -z \"$$ARCH\" ] && " +
-            "for f in $(SRCS); do case $$f in *.a) ARCH=$$f; break;; esac; done; " +
-            "$(location @llvm_toolchain_llvm//:objcopy) " +
-            "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
-        ),
-        tools = ["@llvm_toolchain_llvm//:objcopy"],
+        cmd = archive_select_cmd + select({
+            "@envoy_repo//:use_local_llvm": (
+                "%s/bin/llvm-objcopy " % LLVM_PATH +
+                "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
+            ),
+            "//conditions:default": (
+                "$(location @llvm_toolchain_llvm//:objcopy) " +
+                "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
+            ),
+        }),
+        tools = select({
+            "@envoy_repo//:use_local_llvm": [],
+            "//conditions:default": ["@llvm_toolchain_llvm//:objcopy"],
+        }),
         tags = tags,
     )
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: build: use local llvm-objcopy when use_local_llvm is true
Additional Description: Fixing a location where the hermetic toolchain objcopy is still used when use_local_llvm is true.
Risk Level: Low
Testing: Manual testing
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
AI Disclosure: Used Copilot CLI with Opus 4.7 for feedback/iteration