### PR TITLE
reverse tunnels: allow connection upgrades

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -27,6 +27,12 @@ message DownstreamReverseConnectionSocketInterface {
 
     // Additional headers to include in the HTTP handshake request.
     repeated config.core.v3.HeaderValueOption additional_headers = 2;
+
+    // Perform the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: reverse-tunnel``,
+    // success on ``101``) so HTTP proxies can route the handshake and splice the tunnel
+    // afterward. The responder must set this flag to the same value.
+    // Defaults to ``false``.
+    bool use_http_upgrade = 3;
   }
 
   // Stat prefix to be used for downstream reverse connection socket interface stats.

--- a/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
+++ b/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
@@ -96,7 +96,7 @@ message Validation {
 // Configuration for the reverse tunnel network filter.
 // This filter handles reverse tunnel connection acceptance and rejection by processing
 // HTTP requests where required identification values are provided via HTTP headers.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message ReverseTunnel {
   // Ping interval for health checks on established reverse tunnel connections.
   // If not specified, defaults to ``2 seconds``.
@@ -133,4 +133,11 @@ message ReverseTunnel {
   // via ``x-envoy-reverse-tunnel-upstream-cluster-name`` header. Connections with mismatched or missing
   // cluster names are rejected with HTTP ``400 Bad Request``. When empty, no cluster name validation is performed.
   string required_cluster_name = 6 [(validate.rules).string = {max_len: 255 ignore_empty: true}];
+
+  // Accept the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: reverse-tunnel``,
+  // reply ``101``) so HTTP proxies can route the handshake and splice the tunnel
+  // afterward. Non-upgrade requests are rejected with ``426``. The initiator must set this
+  // flag to the same value.
+  // Defaults to ``false``.
+  bool use_http_upgrade = 7;
 }

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
@@ -26,6 +26,10 @@ public:
       "/reverse_connections/request";
   static constexpr absl::string_view TENANT_SCOPE_DELIMITER = ":";
 
+  // Upgrade token advertised when the handshake is negotiated as an HTTP/1.1 Upgrade.
+  // Used by both the initiator (request `Upgrade:` header) and responder (`101` response).
+  static constexpr absl::string_view REVERSE_TUNNEL_UPGRADE_PROTOCOL = "reverse-tunnel";
+
   struct TenantScopedIdentifierView {
     absl::string_view tenant;
     absl::string_view identifier;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -135,6 +135,15 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
       {{Http::Headers::get().Method, Http::Headers::get().MethodValues.Get},
        {Http::Headers::get().Path, parent_.requestPath()},
        {Http::Headers::get().Host, host_value}});
+  if (parent_.useHttpUpgrade()) {
+    // Negotiate the handshake as an HTTP/1.1 Upgrade so HCM `upgrade_configs` can splice
+    // the connection raw after `101 Switching Protocols`. Both ends must agree.
+    headers->setReferenceKey(Http::Headers::get().Connection,
+                             Http::Headers::get().ConnectionValues.Upgrade);
+    headers->setReferenceKey(Http::Headers::get().Upgrade,
+                             ::Envoy::Extensions::Bootstrap::ReverseConnection::
+                                 ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+  }
   headers->addCopy(node_hdr, std::string(node_id));
   headers->addCopy(cluster_hdr, std::string(cluster_id));
   headers->addCopy(tenant_hdr, std::string(tenant_id));
@@ -178,11 +187,12 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
 
 void RCConnectionWrapper::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool) {
   const uint64_t status = Http::Utility::getResponseStatus(*headers);
-  if (status == 200) {
-    ENVOY_LOG(debug, "Received HTTP 200 OK response");
+  const uint64_t expected = parent_.useHttpUpgrade() ? 101 : 200;
+  if (status == expected) {
+    ENVOY_LOG(debug, "Received HTTP {} response", status);
     onHandshakeSuccess();
   } else {
-    ENVOY_LOG(error, "Received non-200 HTTP response: {}", status);
+    ENVOY_LOG(error, "Received unexpected HTTP response: {} (expected {})", status, expected);
     onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)));
   }
 }

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -85,7 +85,8 @@ struct ReverseConnectionSocketConfig {
   std::string request_path{
       std::string(ReverseConnectionUtility::DEFAULT_REVERSE_TUNNEL_REQUEST_PATH)};
   std::vector<envoy::config::core::v3::HeaderValueOption>
-      additional_headers; // Additional headers for the handshake request.
+      additional_headers;       // Additional headers for the handshake request.
+  bool use_http_upgrade{false}; // Negotiate handshake as HTTP/1.1 Upgrade -> 101.
   // TODO(basundhara-c): Add support for multiple remote clusters using the same
   // ReverseConnectionIOHandle. Currently, each ReverseConnectionIOHandle handles
   // reverse connections for a single upstream cluster since a different ReverseConnectionAddress
@@ -314,6 +315,11 @@ public:
   const std::vector<envoy::config::core::v3::HeaderValueOption>& additionalHeaders() const {
     return config_.additional_headers;
   }
+
+  /**
+   * @return whether the handshake is negotiated as an HTTP/1.1 Upgrade exchange.
+   */
+  bool useHttpUpgrade() const { return config_.use_http_upgrade; }
 
 private:
   /**

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
@@ -128,6 +128,7 @@ ReverseTunnelInitiator::socket(Envoy::Network::Socket::Type socket_type,
     if (extension_ != nullptr) {
       socket_config.request_path = extension_->handshakeRequestPath();
       socket_config.additional_headers = extension_->handshakeAdditionalHeaders();
+      socket_config.use_http_upgrade = extension_->handshakeUsesHttpUpgrade();
     }
 
     // Pass config directly to helper method.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -47,6 +47,7 @@ public:
     if (config.has_http_handshake()) {
       additional_headers_ = {config.http_handshake().additional_headers().begin(),
                              config.http_handshake().additional_headers().end()};
+      use_http_upgrade_ = config.http_handshake().use_http_upgrade();
     }
     ENVOY_LOG(debug,
               "ReverseTunnelInitiatorExtension: creating downstream reverse connection "
@@ -118,6 +119,11 @@ public:
   }
 
   /**
+   * @return whether the handshake is negotiated as an HTTP/1.1 Upgrade exchange.
+   */
+  bool handshakeUsesHttpUpgrade() const { return use_http_upgrade_; }
+
+  /**
    * Increment handshake stats for reverse tunnel connections (per-worker only).
    * Only tracks stats if enable_detailed_stats flag is true.
    * @param cluster_id the cluster identifier for the connection
@@ -147,6 +153,7 @@ private:
   bool enable_detailed_stats_{false};
   std::string handshake_request_path_;
   std::vector<envoy::config::core::v3::HeaderValueOption> additional_headers_;
+  bool use_http_upgrade_{false};
 
   /**
    * Update per-worker connection stats for debugging purposes.

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -13,6 +13,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/http1/codec_impl.h"
+#include "source/common/http/utility.h"
 #include "source/common/network/connection_socket_impl.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
@@ -156,7 +157,8 @@ ReverseTunnelFilterConfig::ReverseTunnelFilterConfig(
                   !proto_config.validation().dynamic_metadata_namespace().empty()
               ? proto_config.validation().dynamic_metadata_namespace()
               : "envoy.filters.network.reverse_tunnel"),
-      required_cluster_name_(proto_config.required_cluster_name()) {}
+      required_cluster_name_(proto_config.required_cluster_name()),
+      use_http_upgrade_(proto_config.use_http_upgrade()) {}
 
 bool ReverseTunnelFilterConfig::validateIdentifiers(
     absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
@@ -281,7 +283,11 @@ Http::RequestDecoder& ReverseTunnelFilter::newStream(Http::ResponseEncoder& resp
 void ReverseTunnelFilter::RequestDecoderImpl::decodeHeaders(
     Http::RequestHeaderMapSharedPtr&& headers, bool end_stream) {
   headers_ = std::move(headers);
-  if (end_stream) {
+  // For an Upgrade request, the HTTP/1 server codec calls decodeHeaders with
+  // end_stream=false because it now considers the connection a tunnel awaiting
+  // more bytes. The handshake has no body, so process the headers immediately
+  // rather than waiting for an end-of-stream that never comes.
+  if (end_stream || Http::Utility::isUpgrade(*headers_)) {
     processIfComplete(true);
   }
 }
@@ -348,6 +354,31 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
     // Close the connection after sending the response.
     parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
     return;
+  }
+
+  // When upgrade negotiation is enabled, require the request to advertise the
+  // `reverse-tunnel` upgrade. The HTTP/1 server codec already validates the
+  // `Connection: Upgrade` paired token, so we only re-check the `Upgrade` value here.
+  if (parent_.config_->useHttpUpgrade()) {
+    const auto upgrade = headers_->getUpgradeValue();
+    if (!absl::EqualsIgnoreCase(upgrade, Bootstrap::ReverseConnection::ReverseConnectionUtility::
+                                             REVERSE_TUNNEL_UPGRADE_PROTOCOL)) {
+      parent_.stats_.parse_error_.inc();
+      ENVOY_CONN_LOG(debug,
+                     "reverse_tunnel: upgrade negotiation enabled but Upgrade header missing or "
+                     "unexpected (got '{}')",
+                     parent_.read_callbacks_->connection(), upgrade);
+      sendLocalReply(
+          Http::Code::UpgradeRequired, "Upgrade: reverse-tunnel required",
+          [](Http::ResponseHeaderMap& h) {
+            h.setReferenceKey(Http::Headers::get().Upgrade,
+                              Bootstrap::ReverseConnection::ReverseConnectionUtility::
+                                  REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+          },
+          absl::nullopt, "reverse_tunnel_upgrade_required");
+      parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
+      return;
+    }
   }
 
   // Extract node/cluster/tenant identifiers from HTTP headers.
@@ -453,16 +484,28 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
     return;
   }
 
-  // Respond with 200 OK.
+  // Respond. In upgrade mode we send `101 Switching Protocols` with the upgrade headers
+  // echoed; the HTTP/1 server codec (created with allow_upgrade) flushes them and stops
+  // parsing further bytes as HTTP, leaving the spliced connection for the tunnel.
   auto resp_headers = Http::ResponseHeaderMapImpl::create();
-  resp_headers->setStatus(200);
+  if (parent_.config_->useHttpUpgrade()) {
+    resp_headers->setStatus(101);
+    resp_headers->setReferenceKey(Http::Headers::get().Connection,
+                                  Http::Headers::get().ConnectionValues.Upgrade);
+    resp_headers->setReferenceKey(
+        Http::Headers::get().Upgrade,
+        Bootstrap::ReverseConnection::ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+  } else {
+    resp_headers->setStatus(200);
+  }
   encoder_.encodeHeaders(*resp_headers, true);
 
   parent_.processAcceptedConnection(node_id, cluster_id, tenant_id);
   parent_.stats_.accepted_.inc();
 
-  // Close the connection if configured to do so after handling the request.
-  if (parent_.config_->autoCloseConnections()) {
+  // Close the listener-side connection so tunnel bytes go to the duped fd, not back into
+  // this filter's codec. Required in upgrade mode; opt-in otherwise.
+  if (parent_.config_->useHttpUpgrade() || parent_.config_->autoCloseConnections()) {
     auto& connection = parent_.read_callbacks_->connection();
     Bootstrap::ReverseConnection::ReverseConnectionUtility::applySslQuietClose(connection);
     connection.close(Network::ConnectionCloseType::FlushWrite);

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -62,6 +62,9 @@ public:
   // Returns the required cluster name for validation.
   const std::string& requiredClusterName() const { return required_cluster_name_; }
 
+  // Returns whether the handshake is negotiated as an HTTP/1.1 Upgrade exchange.
+  bool useHttpUpgrade() const { return use_http_upgrade_; }
+
 private:
   ReverseTunnelFilterConfig(
       const envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel& proto_config,
@@ -83,6 +86,9 @@ private:
 
   // Required cluster name for validation (empty means no validation).
   const std::string required_cluster_name_;
+
+  // When true, expect `Connection: Upgrade` + `Upgrade: reverse-tunnel` and respond `101`.
+  const bool use_http_upgrade_{false};
 };
 
 using ReverseTunnelFilterConfigSharedPtr = std::shared_ptr<ReverseTunnelFilterConfig>;

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1062,6 +1062,73 @@ TEST_F(RCConnectionWrapperTest, DecodeHeadersNonOk) {
   wrapper.decodeHeaders(std::move(headers), true);
 }
 
+// In upgrade mode, a 101 Switching Protocols response is treated as handshake success
+// and a 200 response is treated as a protocol mismatch.
+TEST_F(RCConnectionWrapperTest, DecodeHeadersUpgradeMode) {
+  ReverseConnectionSocketConfig upgrade_config = createDefaultTestConfig();
+  upgrade_config.use_http_upgrade = true;
+  auto upgrade_io_handle = createTestIOHandle(upgrade_config);
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  // 101 -> success path.
+  {
+    auto mock_connection = setupMockConnection();
+    RCConnectionWrapper wrapper(*upgrade_io_handle, std::move(mock_connection), mock_host,
+                                "test-cluster");
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->setStatus(101);
+    wrapper.decodeHeaders(std::move(headers), true);
+  }
+  // 200 in upgrade mode -> failure path (server didn't switch protocols).
+  {
+    auto mock_connection = setupMockConnection();
+    RCConnectionWrapper wrapper(*upgrade_io_handle, std::move(mock_connection), mock_host,
+                                "test-cluster");
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->setStatus(200);
+    wrapper.decodeHeaders(std::move(headers), true);
+  }
+}
+
+// In upgrade mode, connect() emits `Connection: Upgrade` + `Upgrade: reverse-tunnel`
+// in the handshake request. Verifies by capturing the bytes written by the encoder.
+TEST_F(RCConnectionWrapperTest, ConnectEmitsUpgradeHeaders) {
+  ReverseConnectionSocketConfig upgrade_config = createDefaultTestConfig();
+  upgrade_config.use_http_upgrade = true;
+  auto upgrade_io_handle = createTestIOHandle(upgrade_config);
+
+  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  std::string written;
+  EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, addReadFilter(_));
+  EXPECT_CALL(*mock_connection, connect());
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(43));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+  EXPECT_CALL(*mock_connection, write(_, _))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& buffer, bool) {
+        written.append(buffer.toString());
+        buffer.drain(buffer.length());
+      }));
+
+  auto mock_remote = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1", 80);
+  auto mock_local = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 10001);
+  EXPECT_CALL(*mock_connection, connectionInfoProvider())
+      .WillRepeatedly(Invoke([mock_remote, mock_local]() -> const Network::ConnectionInfoProvider& {
+        static auto provider =
+            std::make_unique<Network::ConnectionInfoSetterImpl>(mock_local, mock_remote);
+        return *provider;
+      }));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  RCConnectionWrapper wrapper(*upgrade_io_handle, std::move(mock_connection), mock_host,
+                              "test-cluster");
+  (void)wrapper.connect("tenant", "cluster", "node");
+
+  EXPECT_THAT(written, testing::HasSubstr("upgrade: reverse-tunnel"));
+  EXPECT_THAT(written, testing::HasSubstr("connection: upgrade"));
+}
+
 // Test dispatchHttp1 error path by initializing codec via connect() and
 // then feeding invalid bytes to the parser.
 TEST_F(RCConnectionWrapperTest, DispatchHttp1ErrorPath) {

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -2094,6 +2094,94 @@ TEST_F(ReverseTunnelFilterWithTenantIsolationTest, FilterReadsTenantIsolationFro
   EXPECT_EQ(1, parse_error->value());
 }
 
+// Upgrade-mode handshake: `Upgrade: reverse-tunnel` request -> `101` with echoed headers.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, UpgradeMode_RespondsWith101) {
+  // Reconfigure filter with upgrade enabled.
+  proto_config_.set_use_http_upgrade(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  config_ = config_or_error.value();
+  filter_ =
+      std::make_unique<ReverseTunnelFilter>(config_, *stats_store_.rootScope(), overload_manager_);
+  filter_->initializeReadFilterCallbacks(callbacks_);
+
+  // Build a socket whose io_handle.duplicate() returns a valid duped handle, since the
+  // success path in `processAcceptedConnection` registers the duped fd with the upstream
+  // socket manager. Pattern mirrors `SuccessfulSocketDuplication` above.
+  auto mock_socket = std::make_unique<Network::MockConnectionSocket>();
+  auto mock_io_handle = std::make_unique<Network::MockIoHandle>();
+  auto dup_handle = std::make_unique<Network::MockIoHandle>();
+  EXPECT_CALL(*dup_handle, isOpen()).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*dup_handle, resetFileEvents());
+  EXPECT_CALL(*dup_handle, fdDoNotUse()).WillRepeatedly(testing::Return(123));
+  EXPECT_CALL(*mock_io_handle, duplicate())
+      .WillOnce(testing::Return(testing::ByMove(std::move(dup_handle))));
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(testing::ReturnRef(*mock_io_handle));
+  EXPECT_CALL(*mock_socket, isOpen()).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*mock_io_handle, fdDoNotUse()).WillRepeatedly(testing::Return(122));
+  static Network::ConnectionSocketPtr stored_socket;
+  static std::unique_ptr<Network::MockIoHandle> stored_handle;
+  stored_handle = std::move(mock_io_handle);
+  stored_socket = std::move(mock_socket);
+  EXPECT_CALL(callbacks_.connection_, getSocket())
+      .WillRepeatedly(testing::ReturnRef(stored_socket));
+
+  std::string written;
+  EXPECT_CALL(callbacks_.connection_, write(testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke([&](Buffer::Instance& data, bool) {
+        written.append(data.toString());
+        data.drain(data.length());
+      }));
+  // Upgrade mode forces the original connection to close after handshake.
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "Connection: Upgrade\r\n"
+                    "Upgrade: reverse-tunnel\r\n"
+                    "x-envoy-reverse-tunnel-node-id: n\r\n"
+                    "x-envoy-reverse-tunnel-cluster-id: c\r\n"
+                    "x-envoy-reverse-tunnel-tenant-id: t\r\n"
+                    "Content-Length: 0\r\n\r\n";
+  Buffer::OwnedImpl request(req);
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+  EXPECT_THAT(written, testing::HasSubstr("101 Switching Protocols"));
+  EXPECT_THAT(written, testing::HasSubstr("upgrade: reverse-tunnel"));
+
+  auto accepted = TestUtility::findCounter(stats_store_, "reverse_tunnel.handshake.accepted");
+  ASSERT_NE(nullptr, accepted);
+  EXPECT_EQ(1, accepted->value());
+}
+
+// When `use_http_upgrade=true` but the request does not advertise the upgrade,
+// the filter rejects with `426 Upgrade Required` and closes the connection.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, UpgradeMode_MissingUpgradeRejected) {
+  proto_config_.set_use_http_upgrade(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  config_ = config_or_error.value();
+  filter_ =
+      std::make_unique<ReverseTunnelFilter>(config_, *stats_store_.rootScope(), overload_manager_);
+  filter_->initializeReadFilterCallbacks(callbacks_);
+
+  std::string written;
+  EXPECT_CALL(callbacks_.connection_, write(testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke([&](Buffer::Instance& data, bool) {
+        written.append(data.toString());
+        data.drain(data.length());
+      }));
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  Buffer::OwnedImpl request(
+      makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request", "n", "c", "t"));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+  EXPECT_THAT(written, testing::HasSubstr("426 Upgrade Required"));
+
+  auto parse_error = TestUtility::findCounter(stats_store_, "reverse_tunnel.handshake.parse_error");
+  ASSERT_NE(nullptr, parse_error);
+  EXPECT_EQ(1, parse_error->value());
+}
+
 } // namespace
 } // namespace ReverseTunnel
 } // namespace NetworkFilters


### PR DESCRIPTION
When reverse tunnels are used with L7 middle proxies (envoy HCM in our case) there are codec issues after the 200 OK, where the responder's sent data gets parsed as malformed requests.

Allowing connection upgrades so that L7 proxying can be supported.

Adds use_http_upgrade flag (default off) that negotiates the reverse-tunnel handshake as `HTTP/1.1 Upgrade: reverse-tunnel -> 101 Switching Protocols`. This lets HCM (or any L7 proxy) splice the connection after the 101 (same as websockets) and act as a pipe.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
