### PR TITLE
ci: use catch-errors to detect CI failures for Slack notifications

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -42,6 +42,7 @@ jobs:
         Error:
       rbe: true
       request: ${{ inputs.request }}
+      catch-errors: ${{ matrix.catch-errors || false }}
       skip: ${{ matrix.skip != false && true || false }}
       slack-channel: ${{ matrix.slack-channel || '' }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -394,6 +394,7 @@ jobs:
     # NOTE: This is where untrusted code can be run!!!
     #  Only post-failure notification steps (which don't use any repo code) should follow this step.
     - uses: envoyproxy/toolshed/actions/github/run@2ed4461f62fe3cf80196c05bea0d7dc39f15cf26  # actions-v0.4.12
+      id: ci-run
       name: Run CI ${{ inputs.command }} ${{ inputs.target }}
       with:
         args: ${{ inputs.args != '--' && inputs.args || inputs.target }}
@@ -450,7 +451,7 @@ jobs:
         ENVOY_PUBLISH_DRY_RUN: ${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}
 
     - name: Notify Slack on failure
-      if: ${{ failure() && inputs.slack-channel != '' }}
+      if: ${{ steps.ci-run.outputs.exit-code != 0 && inputs.slack-channel != '' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       env:
         JOB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Use the toolshed action's existing `catch-errors` input to suppress CI step failures without blocking the overall job. When enabled, the step exits successfully but the real exit code is still available via `steps.ci-run.outputs.exit-code`, allowing the Slack notification step to detect failures and notify the appropriate channel.
