### PR TITLE
deps: bump dd-trace-cpp to v2.1.0

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -163,7 +163,7 @@ dd_trace_cpp:
   project_name: "Datadog C++ Tracing Library"
   project_desc: "Datadog distributed tracing for C++"
   project_url: "https://github.com/DataDog/dd-trace-cpp"
-  release_date: "2025-10-14"
+  release_date: "2026-05-06"
   use_category:
   - observability_ext
   extensions:

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -290,8 +290,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/SkyAPM/cpp2sky/archive/v{version}.tar.gz"],
     ),
     dd_trace_cpp = dict(
-        version = "2.0.0",
-        sha256 = "e4a0dabc3e186ce99c71685178448f93c501577102cdc50ddbf12cbaaba54713",
+        version = "2.1.0",
+        sha256 = "8152fb69e61518a5b55ecb96edcbb19585f8950b6f070ac98ebd0b6dd6177492",
         strip_prefix = "dd-trace-cpp-{version}",
         urls = ["https://github.com/DataDog/dd-trace-cpp/archive/v{version}.tar.gz"],
     ),


### PR DESCRIPTION
This PR bumps up the version of `dd_trace_cpp` to v2.1.0.

This adds new capabilities and bug fixes without any updates to the tracing APIs.

**Reference:**
For complete details on the v2.1.0 release: https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.1.0

---

Commit Message: deps: bump `dd_trace_cpp` to v2.1.0
Additional Description: Bump the version of `dd_trace_cpp` to v2.1.0
Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes:N/A
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
