### PR TITLE
ci: enable catch-errors and Slack notification for OpenSSL check

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -62,4 +62,5 @@ jobs:
         - target: openssl
           name: OpenSSL
           skip: ${{ ! fromJSON(inputs.request).run.check-build-openssl }}
+          catch-errors: true
           slack-channel: '#envoy-openssl'

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -822,15 +822,7 @@ case $CI_TARGET in
         ;;
 
     openssl)
-        # This whole boilerplate is to not fail the entire CI if there is an issue with the OpenSSL build or tests,
-        # as this is not a blocker for other work.
-        set +e
-        (set -e; build_openssl)
-        rc=$?
-        set -e
-        if [[ $rc -ne 0 ]]; then
-            echo "ERROR: OpenSSL build or test failed" >&2
-        fi
+        build_openssl
         ;;
 
     publish)


### PR DESCRIPTION
Enable `catch-errors` for the OpenSSL CI target so that failures are captured without blocking the overall job. Remove the error masking in do_ci.sh — failures now propagate naturally and are handled at the workflow level, where the Slack notification step detects them via the exit code and notifies `#envoy-openssl`.
