### PR TITLE
srds: reduce memory by using string_view as a key instead of string

### DIFF
--- a/source/common/router/scoped_config_impl.cc
+++ b/source/common/router/scoped_config_impl.cc
@@ -129,8 +129,10 @@ void ScopedConfigImpl::addOrUpdateRoutingScopes(
     if (iter != scoped_route_info_by_name_.end()) {
       ASSERT(scoped_route_info_by_key_.contains(iter->second->scopeKey().hash()));
       scoped_route_info_by_key_.erase(iter->second->scopeKey().hash());
+      // Explicitly erase from _name_ map to avoid dangling string_view on overwrite.
+      scoped_route_info_by_name_.erase(iter);
     }
-    scoped_route_info_by_name_[scoped_route_info->scopeName()] = scoped_route_info;
+    scoped_route_info_by_name_.emplace(scoped_route_info->scopeName(), scoped_route_info);
     scoped_route_info_by_key_[scoped_route_info->scopeKey().hash()] = scoped_route_info;
   }
 }

--- a/source/common/router/scoped_config_impl.h
+++ b/source/common/router/scoped_config_impl.h
@@ -123,7 +123,10 @@ public:
 
 private:
   // From scope name to cached ScopedRouteInfo.
-  absl::flat_hash_map<std::string, ScopedRouteInfoConstSharedPtr> scoped_route_info_by_name_;
+  // WARNING: The absl::string_view keys point to strings owned by the ScopedRouteInfo
+  // objects stored as values. To avoid dangling pointers, any update to this map MUST
+  // first erase the old entry before inserting a new one.
+  absl::flat_hash_map<absl::string_view, ScopedRouteInfoConstSharedPtr> scoped_route_info_by_name_;
   // Hash by ScopeKey hash to lookup in constant time.
   absl::flat_hash_map<uint64_t, ScopedRouteInfoConstSharedPtr> scoped_route_info_by_key_;
 };


### PR DESCRIPTION
Commit Message: srds: reduce memory by using string_view as a key instead of string
Additional Description:
Minor refactor to the SRDS data-structure: converting the map key from `std::string` to `absl::string_view`.
This is valid because the string always appear in the key's value, and that is a shared-pointer, which will always be alive as long as `operator[]` isn't used (but erase/emplace is used instead).

Risk Level: low - internal refactor
Testing: N/A - internal refactor
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A