### PR TITLE
Added coverage for the uninitialized gauge

### DIFF
--- a/test/common/stats/allocator_test.cc
+++ b/test/common/stats/allocator_test.cc
@@ -138,6 +138,11 @@ TEST_F(AllocatorTest, RefCountDecAllocRaceSynchronized) {
 }
 
 TEST_F(AllocatorTest, HiddenGauge) {
+  GaugeSharedPtr uninitialized_gauge =
+      alloc_.makeGauge(makeStat("uninitialized"), StatName(), {}, Gauge::ImportMode::Uninitialized);
+  EXPECT_EQ(uninitialized_gauge->importMode(), Gauge::ImportMode::Uninitialized);
+  EXPECT_FALSE(uninitialized_gauge->hidden());
+
   GaugeSharedPtr hidden_gauge =
       alloc_.makeGauge(makeStat("hidden"), StatName(), {}, Gauge::ImportMode::HiddenAccumulate);
   EXPECT_EQ(hidden_gauge->importMode(), Gauge::ImportMode::HiddenAccumulate);


### PR DESCRIPTION
Commit Message: test: adds coverage for uninitialized gauge import mode behavior
Additional Description: Adds code in a unit test that ensures Gauge::ImportMode::Uninitialized correctly reports its import mode and is not hidden.
Risk Level: Low
Testing: All existing tests pass locally.
Docs Changes: None
Release Notes: Test only change.
Platform Specific Features: None