### PR TITLE
docs: fix rate limit stat prefix for network local ratelimit filter

### DIFF
--- a/docs/root/configuration/listeners/network_filters/local_rate_limit_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/local_rate_limit_filter.rst
@@ -35,7 +35,7 @@ be immediately closed without further filter iteration.
 Statistics
 ----------
 
-Every configured local rate limit filter has statistics rooted at *local_ratelimit.<stat_prefix>.*
+Every configured local rate limit filter has statistics rooted at *local_rate_limit.<stat_prefix>.*
 with the following statistics:
 
 .. csv-table::


### PR DESCRIPTION
Risk Level: low
Testing: n/a
Docs Changes: yes
Release Notes: n/a
Platform Specific Features: n/a
Fixes #44895
