### PR TITLE
docs: clarify HTTP/1 header casing directions

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -445,8 +445,8 @@ message Http1ProtocolOptions {
   // This is a no-op if ``accept_http_10`` is not true.
   string default_host_for_http_10 = 3;
 
-  // Describes how the keys for response headers should be formatted. By default, all header keys
-  // are lower cased.
+  // Describes how the keys for headers encoded by the HTTP/1 codec should be formatted. By
+  // default, all header keys are lower cased.
   HeaderKeyFormat header_key_format = 4;
 
   // Enables trailers for HTTP/1. By default the HTTP/1 codec drops proxied trailers.

--- a/docs/root/configuration/http/http_conn_man/header_casing.rst
+++ b/docs/root/configuration/http/http_conn_man/header_casing.rst
@@ -11,10 +11,10 @@ To support these use cases, Envoy allows :ref:`configuring a formatting scheme f
 <envoy_v3_api_field_config.core.v3.Http1ProtocolOptions.header_key_format>`, which will have Envoy
 transform the header keys during serialization.
 
-To configure this formatting on response headers, specify the format in the
+To configure this formatting on upstream request headers, specify the format in the
 :ref:`http_protocol_options
 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.http_protocol_options>`.
-To configure this for upstream request headers, specify the formatting in
+To configure this for downstream response headers, specify the formatting in
 :ref:`http_protocol_options <envoy_v3_api_msg_extensions.upstreams.http.v3.HttpProtocolOptions>` in
 the cluster's
 :ref:`extension_protocol_options<envoy_v3_api_field_config.cluster.v3.Cluster.typed_extension_protocol_options>`.


### PR DESCRIPTION
Commit Message: docs: clarify HTTP/1 header casing directions

Additional Description:
Fix the header casing guide to describe the correct directions for HTTP/1 header_key_format configuration. For more details, please see #44924.

HttpConnectionManager http_protocol_options controls formatting for upstream request headers, while cluster HttpProtocolOptions controls formatting for downstream response headers. Also update the API comments to describe header_key_format as applying to headers encoded by the HTTP/1 codec rather than only response headers.

Fixes #44924