### PR TITLE
lua test: ensure markDead be called before destory it by lua close

### DIFF
--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -31,6 +31,13 @@ public:
     Filters::Common::Lua::LuaWrappersTestBase<HeaderMapWrapper>::setup(script);
     state_->registerType<HeaderMapIterator>();
   }
+
+protected:
+  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper>
+  createWrapperRef(Http::HeaderMap& headers, HeaderMapWrapper::CheckModifiableCb cb) {
+    return Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper>(
+        HeaderMapWrapper::create(coroutine_->luaState(), headers, cb), true);
+  }
 };
 
 // Basic methods test for the header wrapper.
@@ -62,7 +69,7 @@ TEST_F(LuaHeaderMapWrapperTest, Methods) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers;
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_CALL(printer_, testPrint("WORLD"));
   EXPECT_CALL(printer_, testPrint("'hello' 'WORLD'"));
   EXPECT_CALL(printer_, testPrint("'header1' ''"));
@@ -71,6 +78,7 @@ TEST_F(LuaHeaderMapWrapperTest, Methods) {
   EXPECT_CALL(printer_, testPrint("'header2' 'foo'"));
   EXPECT_CALL(printer_, testPrint("foo,bar"));
   start("callMe");
+  wrapper.reset();
 }
 
 // Get the total number of values for a certain header with multiple values.
@@ -87,11 +95,12 @@ TEST_F(LuaHeaderMapWrapperTest, GetNumValues) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"x-test", "foo"}, {"x-test", "bar"}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_CALL(printer_, testPrint("2"));
   EXPECT_CALL(printer_, testPrint("1"));
   EXPECT_CALL(printer_, testPrint("0"));
   start("callMe");
+  wrapper.reset();
 }
 
 // Get the value on a certain index for a header with multiple values.
@@ -115,13 +124,14 @@ TEST_F(LuaHeaderMapWrapperTest, GetAtIndex) {
 
   Http::TestRequestHeaderMapImpl headers{
       {":path", "/"}, {"x-test", "foo"}, {"x-test", "bar"}, {"x-test", ""}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_CALL(printer_, testPrint("invalid_negative_index"));
   EXPECT_CALL(printer_, testPrint("foo"));
   EXPECT_CALL(printer_, testPrint("bar"));
   EXPECT_CALL(printer_, testPrint(""));
   EXPECT_CALL(printer_, testPrint("nil_value"));
   start("callMe");
+  wrapper.reset();
 }
 
 // Test modifiable methods.
@@ -150,23 +160,27 @@ TEST_F(LuaHeaderMapWrapperTest, ModifiableMethods) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers;
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return false; });
+  auto should_be_ok_wrapper = createWrapperRef(headers, []() { return false; });
   start("shouldBeOk");
+  should_be_ok_wrapper.reset();
 
   setup(SCRIPT);
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return false; });
+  auto should_fail_remove_wrapper = createWrapperRef(headers, []() { return false; });
   EXPECT_THROW_WITH_MESSAGE(start("shouldFailRemove"), Filters::Common::Lua::LuaException,
                             "[string \"...\"]:9: header map can no longer be modified");
+  should_fail_remove_wrapper.reset();
 
   setup(SCRIPT);
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return false; });
+  auto should_fail_add_wrapper = createWrapperRef(headers, []() { return false; });
   EXPECT_THROW_WITH_MESSAGE(start("shouldFailAdd"), Filters::Common::Lua::LuaException,
                             "[string \"...\"]:13: header map can no longer be modified");
+  should_fail_add_wrapper.reset();
 
   setup(SCRIPT);
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return false; });
+  auto should_fail_replace_wrapper = createWrapperRef(headers, []() { return false; });
   EXPECT_THROW_WITH_MESSAGE(start("shouldFailReplace"), Filters::Common::Lua::LuaException,
                             "[string \"...\"]:17: header map can no longer be modified");
+  should_fail_replace_wrapper.reset();
 }
 
 // Verify that replace works correctly with both inline and normal headers.
@@ -183,8 +197,9 @@ TEST_F(LuaHeaderMapWrapperTest, Replace) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"other_header", "hello"}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   start("callMe");
+  wrapper.reset();
 
   EXPECT_EQ((Http::TestRequestHeaderMapImpl{{":path", "/new_path"},
                                             {"other_header", "other_header_value"},
@@ -206,9 +221,10 @@ TEST_F(LuaHeaderMapWrapperTest, ModifyDuringIteration) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_THROW_WITH_MESSAGE(start("callMe"), Filters::Common::Lua::LuaException,
                             "[string \"...\"]:4: header map cannot be modified while iterating");
+  wrapper.reset();
 }
 
 // Modify after iteration.
@@ -231,11 +247,12 @@ TEST_F(LuaHeaderMapWrapperTest, ModifyAfterIteration) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_CALL(printer_, testPrint("'foo' 'bar'"));
   EXPECT_CALL(printer_, testPrint("'foo' 'bar'"));
   EXPECT_CALL(printer_, testPrint("'hello' 'world'"));
   start("callMe");
+  wrapper.reset();
 }
 
 // Don't finish iteration.
@@ -252,10 +269,11 @@ TEST_F(LuaHeaderMapWrapperTest, DontFinishIteration) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
-  HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; });
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   EXPECT_THROW_WITH_MESSAGE(
       start("callMe"), Filters::Common::Lua::LuaException,
       "[string \"...\"]:5: cannot create a second iterator before completing the first");
+  wrapper.reset();
 }
 
 // Use iterator across yield.
@@ -272,8 +290,7 @@ TEST_F(LuaHeaderMapWrapperTest, IteratorAcrossYield) {
   setup(SCRIPT);
 
   Http::TestRequestHeaderMapImpl headers{{"foo", "bar"}, {"hello", "world"}};
-  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> wrapper(
-      HeaderMapWrapper::create(coroutine_->luaState(), headers, []() { return true; }), true);
+  auto wrapper = createWrapperRef(headers, []() { return true; });
   yield_callback_ = [] {};
   start("callMe");
   wrapper.reset();
@@ -293,8 +310,9 @@ TEST_F(LuaHeaderMapWrapperTest, SetHttp1ReasonPhrase) {
   setup(SCRIPT);
 
   auto headers = Http::ResponseHeaderMapImpl::create();
-  HeaderMapWrapper::create(coroutine_->luaState(), *headers, []() { return true; });
+  auto wrapper = createWrapperRef(*headers, []() { return true; });
   start("callMe");
+  wrapper.reset();
 
   Http::StatefulHeaderKeyFormatterOptRef formatter(headers->formatter());
   EXPECT_EQ(true, formatter.has_value());


### PR DESCRIPTION
Commit Message:
Additional Description:

Try to address problem that referred at https://github.com/envoyproxy/envoy/pull/43204

Risk Level: low. test only change.
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
