### PR TITLE
ci: fix Docker Hub login missing username

### DIFF
--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -400,7 +400,7 @@ jobs:
       if: steps.dockerhub.outputs.login == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
       with:
-        username: ${{ inputs.dockerhub-username }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.dockerhub-token }}
 
     # NOTE: This is where untrusted code can be run!!!


### PR DESCRIPTION
The dockerhub-username input was removed from _run.yml in #44927, but the Docker Hub read-only login step still referenced it, causing all CI jobs to fail with "Username required".
