### PR TITLE
ci: skip Docker Hub login on macOS

### DIFF
--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -390,6 +390,7 @@ jobs:
         BAZELRC_CONTENT: ${{ vars.ENVOY_CI_BAZELRC }}
 
     - id: dockerhub
+      if: runner.os == 'Linux'
       run: |
         if [[ -n "$DOCKERHUB_TOKEN" ]]; then
           echo "login=true" >> "$GITHUB_OUTPUT"
@@ -397,7 +398,7 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.dockerhub-token }}
     - name: Login to Docker Hub (read-only)
-      if: steps.dockerhub.outputs.login == 'true'
+      if: runner.os == 'Linux' && steps.dockerhub.outputs.login == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -390,7 +390,7 @@ jobs:
         BAZELRC_CONTENT: ${{ vars.ENVOY_CI_BAZELRC }}
 
     - id: dockerhub
-      if: runner.os == 'Linux'
+      if: inputs.container-command != ''
       run: |
         if [[ -n "$DOCKERHUB_TOKEN" ]]; then
           echo "login=true" >> "$GITHUB_OUTPUT"
@@ -398,7 +398,7 @@ jobs:
       env:
         DOCKERHUB_TOKEN: ${{ secrets.dockerhub-token }}
     - name: Login to Docker Hub (read-only)
-      if: runner.os == 'Linux' && steps.dockerhub.outputs.login == 'true'
+      if: inputs.container-command != '' && steps.dockerhub.outputs.login == 'true'
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
The docker/login-action requires Docker, which is not available on macOS runners. Gate both the token check and login steps on `runner.os == 'Linux'`.
