### PR TITLE
ci/sync: Disable envoy-filter-example

### DIFF
--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         downstream:
         - go-control-plane
-        - envoy-filter-example
         - data-plane-api
         - mobile-website
     steps:


### PR DESCRIPTION
due to brown out, probs best we leave disabled

