### PR TITLE
scoped-routes: remove unused data-member form StringKeyFragment

### DIFF
--- a/envoy/router/scopes.h
+++ b/envoy/router/scopes.h
@@ -70,12 +70,11 @@ using ScopeKeyPtr = std::unique_ptr<ScopeKey>;
 class StringKeyFragment : public ScopeKeyFragmentBase {
 public:
   explicit StringKeyFragment(absl::string_view value)
-      : value_(value), hash_(HashUtil::xxHash64(value_)) {}
+      : hash_(HashUtil::xxHash64(value)) {}
 
   uint64_t hash() const override { return hash_; }
 
 private:
-  const std::string value_;
   const uint64_t hash_;
 };
 

--- a/envoy/router/scopes.h
+++ b/envoy/router/scopes.h
@@ -69,8 +69,7 @@ using ScopeKeyPtr = std::unique_ptr<ScopeKey>;
 // String fragment.
 class StringKeyFragment : public ScopeKeyFragmentBase {
 public:
-  explicit StringKeyFragment(absl::string_view value)
-      : hash_(HashUtil::xxHash64(value)) {}
+  explicit StringKeyFragment(absl::string_view value) : hash_(HashUtil::xxHash64(value)) {}
 
   uint64_t hash() const override { return hash_; }
 


### PR DESCRIPTION
Commit Message: scoped-routes: remove unused data-member form StringKeyFragment
Additional Description:
Removing an unused data-member.

Risk Level: low - internal modification.
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
