### PR TITLE
clang-tidy: fix misc source cleanups

### DIFF
--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -323,6 +323,8 @@ public:
 // combination of flags, such as listeners(ListenerState::WARMING|ListenerState::ACTIVE)
 constexpr ListenerManager::ListenerState operator|(const ListenerManager::ListenerState lhs,
                                                    const ListenerManager::ListenerState rhs) {
+  // Bitmask combinations intentionally produce intermediate values that are not named enumerators.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   return static_cast<ListenerManager::ListenerState>(static_cast<uint8_t>(lhs) |
                                                      static_cast<uint8_t>(rhs));
 }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -213,7 +213,7 @@ using OnHeaderResult = http2::adapter::Http2VisitorInterface::OnHeaderResult;
 enum Settings {
   // SETTINGS_HEADER_TABLE_SIZE = 0x01,
   // SETTINGS_ENABLE_PUSH = 0x02,
-  SETTINGS_MAX_CONCURRENT_STREAMS = 0x03,
+  SETTINGS_MAX_CONCURRENT_STREAMS = 0x03, // NOLINT(readability-identifier-naming)
   // SETTINGS_INITIAL_WINDOW_SIZE = 0x04,
   // SETTINGS_MAX_FRAME_SIZE = 0x05,
   // SETTINGS_MAX_HEADER_LIST_SIZE = 0x06,
@@ -223,9 +223,9 @@ enum Settings {
 
 enum Flags {
   // FLAG_NONE = 0,
-  FLAG_END_STREAM = 0x01,
+  FLAG_END_STREAM = 0x01, // NOLINT(readability-identifier-naming)
   // FLAG_END_HEADERS = 0x04,
-  FLAG_ACK = 0x01,
+  FLAG_ACK = 0x01, // NOLINT(readability-identifier-naming)
   // FLAG_PADDED = 0x08,
   // FLAG_PRIORITY = 0x20
 };

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -34,7 +34,7 @@ HttpServerPropertiesCacheImpl::stringToOrigin(const std::string& str) {
   std::string scheme;
   std::string hostname;
   int port = 0;
-  if (re2::RE2::FullMatch(str.c_str(), origin_regex, &scheme, &hostname, &port)) {
+  if (re2::RE2::FullMatch(str, origin_regex, &scheme, &hostname, &port)) {
     return HttpServerPropertiesCache::Origin(scheme, hostname, port);
   }
   return {};

--- a/source/common/http/muxdemux.cc
+++ b/source/common/http/muxdemux.cc
@@ -148,7 +148,7 @@ void MultiStream::maybeSwitchToIdle() {
 
 MuxDemux::MuxDemux(Server::Configuration::FactoryContext& context) : factory_context_(context) {}
 
-MuxDemux::~MuxDemux() {}
+MuxDemux::~MuxDemux() = default;
 
 absl::StatusOr<std::unique_ptr<MultiStream>>
 MuxDemux::multicast(const AsyncClient::StreamOptions& options,

--- a/source/common/http/muxdemux.h
+++ b/source/common/http/muxdemux.h
@@ -50,10 +50,11 @@ public:
 
   // Iterator over streams. Allows sending different headers, body or trailers to different streams.
   struct StreamIterator {
-    using difference_type = std::ptrdiff_t;
-    using element_type = AsyncClient::Stream*;
-    using pointer = element_type*;
-    using reference = element_type&;
+    // Standard iterator aliases intentionally use STL-prescribed snake_case names.
+    using difference_type = std::ptrdiff_t;    // NOLINT(readability-identifier-naming)
+    using element_type = AsyncClient::Stream*; // NOLINT(readability-identifier-naming)
+    using pointer = element_type*;             // NOLINT(readability-identifier-naming)
+    using reference = element_type&;           // NOLINT(readability-identifier-naming)
     explicit StreamIterator(std::vector<CallbacksFacade>::iterator it) : it(it) {}
     StreamIterator() = default;
 

--- a/source/common/json/json_rpc_field_extractor.h
+++ b/source/common/json/json_rpc_field_extractor.h
@@ -92,7 +92,8 @@ protected:
   struct NestedContext {
     Protobuf::Struct* struct_ptr{nullptr};
     Protobuf::ListValue* list_ptr{nullptr};
-    std::string field_name{};
+    std::string field_name;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     bool is_list() const { return list_ptr != nullptr; }
   };
   std::stack<NestedContext> context_stack_;

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -167,8 +167,9 @@ template <typename Key, typename Value> struct SimpleLRUCacheElem {
   }
 
   void unlink() {
-    if (!isLinked())
+    if (!isLinked()) {
       return;
+    }
     prev->next = next;
     next->prev = prev;
     prev = nullptr;
@@ -248,8 +249,9 @@ public:
           value_(cache_->lookupWithOptions(key_, options_)) {}
 
     ~ScopedLookup() {
-      if (value_ != nullptr)
+      if (value_ != nullptr) {
         cache_->releaseWithOptions(key_, value_, options_);
+      }
     }
     const Key& key() const { return key_; }
     Value* value() const { return value_; }
@@ -391,8 +393,9 @@ public:
   // Remove all entries which have exceeded their max idle time or age
   // set using setMaxIdleSeconds() or setAgeBasedEviction() respectively.
   void removeExpiredEntries() {
-    if (max_idle_ >= 0)
+    if (max_idle_ >= 0) {
       discardIdle(max_idle_);
+    }
   }
 
   // Return current size of cache
@@ -608,8 +611,9 @@ template <class Key, class Value, class MapType, class EQ>
 void SimpleLRUCacheBase<Key, Value, MapType, EQ>::removeUnpinned() {
   for (Elem* e = head_.next; e != &head_;) {
     Elem* next = e->next;
-    if (e->pin == 0)
+    if (e->pin == 0) {
       remove(e->key);
+    }
     e = next;
   }
 }
@@ -650,8 +654,9 @@ Value* SimpleLRUCacheBase<Key, Value, MapType, EQ>::lookupWithOptions(
       pinned_units_ += e->units;
       // We are pinning this entry, take it off the LRU list if we are in LRU
       // mode. In strict age-based mode entries stay on the list while pinned.
-      if (lru_ && options.update_eviction_order())
+      if (lru_ && options.update_eviction_order()) {
         e->unlink();
+      }
     }
     e->pin++;
     return e->value;
@@ -707,8 +712,9 @@ void SimpleLRUCacheBase<Key, Value, MapType, EQ>::releaseWithOptions(
     e->pin--;
 
     if (e->pin == 0) {
-      if (lru_ && options.update_eviction_order())
+      if (lru_ && options.update_eviction_order()) {
         e->link(&head_);
+      }
       pinned_units_ -= e->units;
       if (isOverfullInternal()) {
         // This element is no longer needed, and we are full. So kick it out.
@@ -735,8 +741,9 @@ void SimpleLRUCacheBase<Key, Value, MapType, EQ>::insertPinned(const Key& k, Val
   // If we are in the strict age-based eviction mode, the entry goes on the LRU
   // list now and is never removed. In the LRU mode, the list will only contain
   // unpinned entries.
-  if (!lru_)
+  if (!lru_) {
     e->link(&head_);
+  }
   garbageCollect();
 }
 
@@ -793,8 +800,9 @@ bool SimpleLRUCacheBase<Key, Value, MapType, EQ>::inDeferredTable(const Key& k,
     const Elem* const head = iter->second;
     const Elem* e = head;
     do {
-      if (e->value == value || value == nullptr)
+      if (e->value == value || value == nullptr) {
         return true;
+      }
       e = e->prev;
     } while (e != head);
   }
@@ -858,8 +866,9 @@ static const int kAcceptableClockSynchronizationDriftCycles = 1;
 
 template <class Key, class Value, class MapType, class EQ>
 void SimpleLRUCacheBase<Key, Value, MapType, EQ>::discardIdle(int64_t max_idle) {
-  if (max_idle < 0)
+  if (max_idle < 0) {
     return;
+  }
 
   Elem* e = head_.prev;
   const int64_t threshold = SimpleCycleTimer::now() - max_idle;
@@ -928,8 +937,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::deferredEntries() const {
 
 template <class Key, class Value, class MapType, class EQ>
 int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::ageOfLRUItemInMicroseconds() const {
-  if (head_.prev == &head_)
+  if (head_.prev == &head_) {
     return 0;
+  }
   return kSecToUsec * (SimpleCycleTimer::now() - head_.prev->last_use_) /
          SimpleCycleTimer::frequency();
 }
@@ -939,8 +949,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::getLastUseTime(const Key& k
   // getLastUseTime works only in LRU mode
   assert(lru_);
   TableConstIterator iter = table_.find(k);
-  if (iter == table_.end())
+  if (iter == table_.end()) {
     return -1;
+  }
   const Elem* e = iter->second;
   return e->last_use_;
 }
@@ -950,8 +961,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::getInsertionTime(const Key&
   // getInsertionTime works only in age-based mode
   assert(!lru_);
   TableConstIterator iter = table_.find(k);
-  if (iter == table_.end())
+  if (iter == table_.end()) {
     return -1;
+  }
   const Elem* e = iter->second;
   return e->last_use_;
 }

--- a/source/common/jwt/status.h
+++ b/source/common/jwt/status.h
@@ -245,7 +245,7 @@ protected:
 
 private:
   // The internal status.
-  Status status_;
+  Status status_{Status::Ok};
 };
 
 } // namespace JwtVerify

--- a/source/common/matcher/map_matcher.h
+++ b/source/common/matcher/map_matcher.h
@@ -17,6 +17,9 @@ public:
   virtual void addChild(std::string value, OnMatch<DataType>&& on_match) PURE;
 
   ActionMatchResult doNoMatch(const DataType& data, SkippedMatchCb skipped_match_cb) {
+    // This is not true redundant-smartptr-get but we still add a NOLINT to make the
+    // clang-tidy check happy.
+    // NOLINTNEXTLINE(readability-redundant-smartptr-get)
     if (data_input_->get(data).availability() == DataAvailability::MoreDataMightBeAvailable) {
       return ActionMatchResult::insufficientData();
     }

--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -294,7 +294,7 @@ private:
     return [match_children, data_input, on_no_match, creation_function]() {
       auto matcher_or_error = creation_function(
           data_input(), on_no_match ? absl::make_optional((*on_no_match)()) : absl::nullopt);
-      THROW_IF_NOT_OK(matcher_or_error.status());
+      THROW_IF_NOT_OK_REF(matcher_or_error.status());
       auto multimap_matcher = std::move(*matcher_or_error);
       for (const auto& children : match_children) {
         multimap_matcher->addChild(children.first, children.second());

--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -20,13 +20,14 @@ public:
   static_assert((Alignment % sizeof(void*)) == 0,
                 "Alignment must be a multiple of sizeof(void*) when using posix_memalign");
 #endif
-  using value_type = T;
+  using value_type = T; // NOLINT(readability-identifier-naming)
 
   AlignedAllocator() noexcept = default;
 
   // Copy constructor for rebind compatibility.
   template <typename U> explicit AlignedAllocator(const AlignedAllocator<U, Alignment>&) noexcept {}
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static std::size_t round_up_to_alignment(std::size_t bytes) {
     return (bytes + Alignment - 1) & ~(Alignment - 1);
   }
@@ -72,8 +73,8 @@ public:
   }
 
   // Satisfy libc++ requirement.
-  template <typename U> struct rebind {
-    using other = AlignedAllocator<U, Alignment>;
+  template <typename U> struct rebind {           // NOLINT(readability-identifier-naming)
+    using other = AlignedAllocator<U, Alignment>; // NOLINT(readability-identifier-naming)
   };
 };
 

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1369,12 +1369,16 @@ RouteEntryImplBase::perFilterConfigs(absl::string_view filter_name) const {
 }
 
 const envoy::config::core::v3::Metadata& RouteEntryImplBase::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& RouteEntryImplBase::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 UriTemplateMatcherRouteEntryImpl::UriTemplateMatcherRouteEntryImpl(
@@ -1728,12 +1732,16 @@ CommonVirtualHostImpl::perFilterConfigs(absl::string_view filter_name) const {
 }
 
 const envoy::config::core::v3::Metadata& CommonVirtualHostImpl::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& CommonVirtualHostImpl::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 absl::StatusOr<std::shared_ptr<CommonVirtualHostImpl>>
@@ -2136,12 +2144,16 @@ CommonConfigImpl::clusterSpecifierPlugin(absl::string_view provider) const {
 }
 
 const envoy::config::core::v3::Metadata& CommonConfigImpl::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& CommonConfigImpl::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 absl::StatusOr<std::shared_ptr<CommonConfigImpl>>

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -903,7 +903,10 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
       // For the last shadow policy, we can reuse the original headers to save a copy because
       // copy whole headers map is not cheap.
       shadow_headers = std::move(original_shadow_headers);
+      original_shadow_headers = nullptr;
     } else {
+      ASSERT(original_shadow_headers != nullptr);
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       shadow_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(*original_shadow_headers);
     }
     applyShadowPolicyHeaders(shadow_policy, *shadow_headers);
@@ -1180,7 +1183,10 @@ Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap& trail
       // For the last shadow stream, we can reuse the original trailers to save a copy because
       // copy whole trailers map is not cheap.
       shadow_trailer = std::move(original_shadow_trailer);
+      original_shadow_trailer = nullptr;
     } else {
+      ASSERT(original_shadow_trailer != nullptr);
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       shadow_trailer = Http::createHeaderMap<Http::RequestTrailerMapImpl>(*original_shadow_trailer);
     }
     ASSERT(shadow_trailer != nullptr);

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -519,6 +519,7 @@ public:
   const uint8_t* bytes() const { return bytes_.get(); }
 
 protected:
+  SymbolTable::StoragePtr releaseBytes() { return std::move(bytes_); }
   void setBytes(SymbolTable::StoragePtr&& bytes) { bytes_ = std::move(bytes); }
   void clear() { bytes_.reset(); }
 
@@ -567,6 +568,9 @@ public:
    * @param table the symbol table.
    */
   void free(SymbolTable& table);
+
+protected:
+  StatNameStorage() = default;
 };
 
 /**
@@ -733,8 +737,9 @@ public:
   // generate symbols for it.
   StatNameManagedStorage(absl::string_view name, SymbolTable& table)
       : StatNameStorage(name, table), symbol_table_(table) {}
-  StatNameManagedStorage(StatNameManagedStorage&& src) noexcept
-      : StatNameStorage(std::move(src)), symbol_table_(src.symbol_table_) {}
+  StatNameManagedStorage(StatNameManagedStorage&& src) noexcept : symbol_table_(src.symbol_table_) {
+    setBytes(src.releaseBytes());
+  }
   StatNameManagedStorage(StatName src, SymbolTable& table) noexcept
       : StatNameStorage(src, table), symbol_table_(table) {}
 

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -87,7 +87,7 @@ private:
   std::vector<uint32_t> free_slot_indexes_;
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
   Event::Dispatcher* main_thread_dispatcher_{};
-  std::atomic<bool> shutdown_{};
+  std::atomic<bool> shutdown_{false};
 
   // Test only.
   friend class ThreadLocalInstanceImplTest;

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -396,7 +396,7 @@ bool DefaultCertValidator::verifySubjectAltName(X509* cert,
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = Utility::generalNameAsString(general_name);
     for (auto& config_san : subject_alt_names) {
-      if (general_name->type == GEN_DNS ? Utility::dnsNameMatch(config_san, san.c_str())
+      if (general_name->type == GEN_DNS ? Utility::dnsNameMatch(config_san, san)
                                         : config_san == san) {
         return true;
       }

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -136,7 +136,7 @@ getCertificateValidationContextConfigProvider(
       const std::string hash_id =
           generateCertificateHash(validation_context.trusted_ca().inline_bytes());
       if (!hash_id.empty()) {
-        ca_cert_id = absl::StrCat(ca_cert_id, "_", hash_id);
+        absl::StrAppend(&ca_cert_id, "_", hash_id);
       }
     }
     return CertificateValidationContextConfigProviderSharedPtrWithName{

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -325,14 +325,13 @@ ContextImpl::ContextImpl(
       }
 
       if (additional_init != nullptr) {
-        absl::Status init_status = additional_init(ctx, tls_certificate);
-        SET_AND_RETURN_IF_NOT_OK(creation_status, init_status);
+        SET_AND_RETURN_IF_NOT_OK(additional_init(ctx, tls_certificate), creation_status);
       }
     }
   }
 
   parsed_alpn_protocols_ = parseAlpnProtocols(config.alpnProtocols(), creation_status);
-  SET_AND_RETURN_IF_NOT_OK(creation_status, creation_status);
+  RETURN_ONLY_IF_NOT_OK_REF(creation_status);
 
   // Register stat names based on lists reported by BoringSSL.
   std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -781,8 +781,7 @@ private:
         : cluster_config_(cluster_config), config_hash_(cluster_config_hash),
           version_info_(version_info), cluster_(std::move(cluster)),
           last_updated_(time_source.systemTime()), added_via_api_(added_via_api),
-          avoid_cds_removal_(avoid_cds_removal), added_or_updated_{},
-          required_for_ads_(required_for_ads) {}
+          avoid_cds_removal_(avoid_cds_removal), required_for_ads_(required_for_ads) {}
 
     bool blockUpdate(uint64_t hash) { return !added_via_api_ || config_hash_ == hash; }
 

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -174,8 +174,7 @@ private:
   Grpc::AsyncClient<envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse,
                     envoy::service::health::v3::HealthCheckSpecifier>
       async_client_;
-  Grpc::AsyncStream<envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse>
-      stream_{};
+  Grpc::AsyncStream<envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse> stream_;
   Event::Dispatcher& dispatcher_;
   Server::Configuration::ServerFactoryContext& server_context_;
   Envoy::Stats::Store& store_stats_;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -514,6 +514,8 @@ HostDescriptionImplBase::HostDescriptionImplBase(
       locality_metadata_(locality_metadata), locality_(std::move(locality)),
       locality_zone_stat_name_(locality_->zone(), cluster->statsScope().symbolTable()),
       priority_(priority),
+      // TODO(wbpcode): This should be resolved.
+      // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
       socket_factory_(resolveTransportSocketFactory(dest_address, endpoint_metadata_.get())) {
   if (health_check_config.port_value() != 0 && dest_address->type() != Network::Address::Type::Ip) {
     // Setting the health check port to non-0 only works for IP-type addresses. Setting the port

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
         "//bazel:using_openssl": ["-DENVOY_SSL_VERSION=\\\"OpenSSL\\\""],
         "//conditions:default": ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     }),
+    tags = ["notidy"],
     deps = [
         ":version_string_interface_lib",
         ":version_suffix_default",

--- a/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.h
+++ b/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.h
@@ -160,7 +160,7 @@ public:
     absl::optional<envoy::type::v3::TokenBucket> config_;
     std::weak_ptr<LocalRateLimiterImpl> limiter_;
     const Config::ResourceTypeHelper<envoy::type::v3::TokenBucket> resource_type_helper_;
-    size_t token_bucket_config_hash_;
+    size_t token_bucket_config_hash_{0};
   };
 
   Server::Configuration::ServerFactoryContext& factory_context_;

--- a/source/extensions/access_loggers/stats/stats.h
+++ b/source/extensions/access_loggers/stats/stats.h
@@ -145,8 +145,8 @@ private:
   struct Gauge {
     enum class OperationType {
       SET,
-      PAIRED_ADD,
-      PAIRED_SUBTRACT,
+      PAIRED_ADD,      // NOLINT(readability-identifier-naming)
+      PAIRED_SUBTRACT, // NOLINT(readability-identifier-naming)
     };
 
     NameAndTags stat_;

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
@@ -113,7 +113,7 @@ public:
   ReverseTunnelAcceptorExtension* extension_{nullptr};
 
 private:
-  Server::Configuration::ServerFactoryContext* context_;
+  Server::Configuration::ServerFactoryContext* context_{nullptr};
 };
 
 DECLARE_FACTORY(ReverseTunnelAcceptor);

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
@@ -56,16 +56,19 @@ void ReverseTunnelAcceptorExtension::onServerInitialized(Server::Instance&) {
   // Create thread-local slot for the dispatcher and socket manager.
   tls_slot_ = ThreadLocal::TypedSlot<UpstreamSocketThreadLocal>::makeUnique(context_.threadLocal());
 
+  const bool ping_failure_threshold = ping_failure_threshold_;
+  const bool enable_tenant_isolation = enable_tenant_isolation_;
   // Set up the thread-local dispatcher and socket manager.
-  tls_slot_->set([this](Event::Dispatcher& dispatcher) {
-    auto tls = std::make_shared<UpstreamSocketThreadLocal>(dispatcher, this);
-    // Propagate configured miss threshold and tenant isolation into the socket manager.
-    if (tls->socketManager()) {
-      tls->socketManager()->setMissThreshold(ping_failure_threshold_);
-      tls->socketManager()->setTenantIsolationEnabled(enable_tenant_isolation_);
-    }
-    return tls;
-  });
+  tls_slot_->set(
+      [this, ping_failure_threshold, enable_tenant_isolation](Event::Dispatcher& dispatcher) {
+        auto tls = std::make_shared<UpstreamSocketThreadLocal>(dispatcher, this);
+        // Propagate configured miss threshold and tenant isolation into the socket manager.
+        if (auto* socket_manager = tls->socketManager(); socket_manager != nullptr) {
+          socket_manager->setMissThreshold(ping_failure_threshold);
+          socket_manager->setTenantIsolationEnabled(enable_tenant_isolation);
+        }
+        return tls;
+      });
 }
 
 // Get thread-local registry for the current thread.

--- a/source/extensions/clusters/dns/dns_cluster.cc
+++ b/source/extensions/clusters/dns/dns_cluster.cc
@@ -53,7 +53,7 @@ public:
   LegacyDnsClusterFactory(const std::string& name, bool set_all_addresses_in_single_endpoint)
       : ClusterFactoryImplBase(name),
         set_all_addresses_in_single_endpoint_(set_all_addresses_in_single_endpoint) {}
-  virtual absl::StatusOr<std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>>
+  absl::StatusOr<std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>>
   createClusterImpl(const envoy::config::cluster::v3::Cluster& cluster,
                     ClusterFactoryContext& context) override {
     absl::StatusOr<Network::DnsResolverSharedPtr> dns_resolver_or_error =

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -474,7 +474,7 @@ size_t DynamicModuleCluster::removeHosts(const std::vector<Upstream::HostSharedP
   }
 
   // Build the remaining host list and update the priority set once.
-  ASSERT(priority_set_.hostSetsPerPriority().size() >= 1);
+  ASSERT(!priority_set_.hostSetsPerPriority().empty());
   const auto& first_host_set = priority_set_.getOrCreateHostSet(0);
 
   // Build a set of removed host pointers for O(1) lookup.

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -406,7 +406,7 @@ private:
   uint64_t getNextCalloutId() { return next_callout_id_++; }
 
   DynamicModuleClusterConfigSharedPtr config_;
-  envoy_dynamic_module_type_cluster_module_ptr in_module_cluster_;
+  envoy_dynamic_module_type_cluster_module_ptr in_module_cluster_{nullptr};
   Event::Dispatcher& dispatcher_;
   Server::Configuration::ServerFactoryContext& server_context_;
 
@@ -484,7 +484,7 @@ public:
 
 private:
   envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle_;
-  envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
+  envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_{nullptr};
   OnClusterLbCancelHostSelectionType cancel_fn_;
   std::shared_ptr<std::atomic<bool>> cancelled_;
 };

--- a/source/extensions/clusters/reverse_connection/reverse_connection.cc
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.cc
@@ -284,8 +284,8 @@ RevConClusterFactory::createClusterWithConfig(
   }
 
   absl::Status creation_status = absl::OkStatus();
-  auto new_cluster = std::shared_ptr<RevConCluster>(
-      new RevConCluster(cluster, context, creation_status, proto_config));
+  auto new_cluster =
+      std::make_shared<RevConCluster>(cluster, context, creation_status, proto_config);
   RETURN_IF_NOT_OK(creation_status);
   auto lb = std::make_unique<RevConCluster::ThreadAwareLoadBalancer>(new_cluster);
   return std::make_pair(new_cluster, std::move(lb));

--- a/source/extensions/common/async_files/async_file_manager_thread_pool.cc
+++ b/source/extensions/common/async_files/async_file_manager_thread_pool.cc
@@ -161,7 +161,6 @@ void AsyncFileManagerThreadPool::worker() {
     }
     if (action.action_ != nullptr) {
       executeAction(std::move(action));
-      action.action_ = nullptr;
     }
     if (cleanup_action != nullptr) {
       std::move(cleanup_action)->onCancelledBeforeCallback();

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -443,12 +443,17 @@ void DnsCacheImpl::finishResolve(const std::string& host,
 
   // Functions like this one that modify primary_hosts_ are only called in the main thread so we
   // know it is safe to use the PrimaryHostInfo pointers outside of the lock.
-  auto* primary_host_info = [&]() {
+  auto* primary_host_info = [this, &host]() {
     absl::ReaderMutexLock reader_lock{primary_hosts_lock_};
     const auto primary_host_it = primary_hosts_.find(host);
     ASSERT(primary_host_it != primary_hosts_.end());
     return primary_host_it->second.get();
   }();
+
+  if (primary_host_info == nullptr) {
+    ENVOY_LOG(warn, "host '{}' was removed during resolution, skipping update", host);
+    return;
+  }
 
   std::string details_with_maybe_trace = std::string(details);
   if (primary_host_info != nullptr && primary_host_info->active_query_ != nullptr) {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -154,8 +154,8 @@ using PluginHandleSharedPtr = std::shared_ptr<PluginHandle>;
 
 class PluginHandleSharedPtrThreadLocal : public ThreadLocal::ThreadLocalObject {
 public:
-  PluginHandleSharedPtr handle{};
-  MonotonicTime last_load{};
+  PluginHandleSharedPtr handle;
+  MonotonicTime last_load;
 
   PluginHandleSharedPtrThreadLocal(PluginHandleSharedPtr h, MonotonicTime t = {})
       : handle(std::move(h)), last_load(t) {}

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.h
@@ -104,7 +104,7 @@ public:
                  grpc_stream_.get())
           ->currentStreamForTest();
     }
-    return *grpc_stream_.get();
+    return *grpc_stream_;
   }
 
 private:

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
@@ -99,7 +99,7 @@ public:
                  grpc_stream_.get())
           ->currentStreamForTest();
     }
-    return *grpc_stream_.get();
+    return *grpc_stream_;
   }
 
   struct SubscriptionStuff {

--- a/source/extensions/content_parsers/json/json_content_parser_impl.cc
+++ b/source/extensions/content_parsers/json/json_content_parser_impl.cc
@@ -47,8 +47,7 @@ ContentParser::ParseResult JsonContentParserImpl::parse(absl::string_view data) 
   bool all_rules_have_limits = true;
   bool all_limited_rules_satisfied = true;
 
-  for (size_t i = 0; i < rules_.size(); ++i) {
-    auto& rule = rules_[i];
+  for (auto& rule : rules_) {
 
     // Track if any rule has no limit
     if (rule.stop_processing_after_matches_ == 0) {

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -234,7 +234,7 @@ public:
       : host_plugin_ptr_(host_plugin_ptr), child_span_ptr_(child_span_ptr),
         span_ptr_(reinterpret_cast<envoy_dynamic_module_type_span_envoy_ptr>(child_span_ptr)) {}
 
-  ~ChildSpanImpl() override { finish(); }
+  ~ChildSpanImpl() override { finishImpl(); }
 
   void setTag(std::string_view key, std::string_view value) override {
     envoy_dynamic_module_callback_http_span_set_tag(
@@ -298,7 +298,10 @@ public:
     return std::make_unique<ChildSpanImpl>(host_plugin_ptr_, child);
   }
 
-  void finish() override {
+  void finish() override { finishImpl(); }
+
+private:
+  void finishImpl() {
     if (child_span_ptr_ == nullptr) {
       return;
     }
@@ -306,8 +309,6 @@ public:
     child_span_ptr_ = nullptr;
     span_ptr_ = nullptr;
   }
-
-private:
   const envoy_dynamic_module_type_http_filter_envoy_ptr host_plugin_ptr_;
   envoy_dynamic_module_type_child_span_module_ptr child_span_ptr_;
   envoy_dynamic_module_type_span_envoy_ptr span_ptr_;

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -85,50 +85,72 @@ using UnsafeHeaderVector = std::vector<UnsafeHeader>;
  * client before packing them into this struct (hence they are "unsafe").
  */
 struct Response {
+  Response() = default;
+  Response(CheckStatus status, UnsafeHeaderVector headers_to_append,
+           UnsafeHeaderVector headers_to_set, UnsafeHeaderVector headers_to_add,
+           UnsafeHeaderVector response_headers_to_add, UnsafeHeaderVector response_headers_to_set,
+           UnsafeHeaderVector response_headers_to_add_if_absent,
+           UnsafeHeaderVector response_headers_to_overwrite_if_exists,
+           bool saw_invalid_append_actions, std::vector<std::string> headers_to_remove,
+           Http::Utility::QueryParamsVector query_parameters_to_set,
+           std::vector<std::string> query_parameters_to_remove, std::string body,
+           Http::Code status_code, Protobuf::Struct dynamic_metadata)
+      : status(status), headers_to_append(std::move(headers_to_append)),
+        headers_to_set(std::move(headers_to_set)), headers_to_add(std::move(headers_to_add)),
+        response_headers_to_add(std::move(response_headers_to_add)),
+        response_headers_to_set(std::move(response_headers_to_set)),
+        response_headers_to_add_if_absent(std::move(response_headers_to_add_if_absent)),
+        response_headers_to_overwrite_if_exists(std::move(response_headers_to_overwrite_if_exists)),
+        saw_invalid_append_actions(saw_invalid_append_actions),
+        headers_to_remove(std::move(headers_to_remove)),
+        query_parameters_to_set(std::move(query_parameters_to_set)),
+        query_parameters_to_remove(std::move(query_parameters_to_remove)), body(std::move(body)),
+        status_code(status_code), dynamic_metadata(std::move(dynamic_metadata)) {}
+
   // Call status.
-  CheckStatus status;
+  CheckStatus status = CheckStatus::OK;
   // A set of HTTP headers returned by the authorization server, that will be optionally appended
   // to the request to the upstream server.
-  UnsafeHeaderVector headers_to_append{};
+  UnsafeHeaderVector headers_to_append;
   // A set of HTTP headers returned by the authorization server, will be optionally set
   // (using "setCopy") to the request to the upstream server.
-  UnsafeHeaderVector headers_to_set{};
+  UnsafeHeaderVector headers_to_set;
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the request to the upstream server.
-  UnsafeHeaderVector headers_to_add{};
+  UnsafeHeaderVector headers_to_add;
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the response sent back to the downstream client on OK auth
   // responses.
-  UnsafeHeaderVector response_headers_to_add{};
+  UnsafeHeaderVector response_headers_to_add;
   // A set of HTTP headers returned by the authorization server, will be optionally set (using
   // "setCopy") to the response sent back to the downstream client on OK auth responses.
-  UnsafeHeaderVector response_headers_to_set{};
+  UnsafeHeaderVector response_headers_to_set;
   // A set of HTTP headers returned by the authorization server, will be optionally added
   // (using "addCopy") to the response sent back to the downstream client on OK auth
   // responses only if the headers were not returned from the authz server.
-  UnsafeHeaderVector response_headers_to_add_if_absent{};
+  UnsafeHeaderVector response_headers_to_add_if_absent;
   // A set of HTTP headers returned by the authorization server, will be optionally set (using
   // "setCopy") to the response sent back to the downstream client on OK auth responses
   // only if the headers were returned from the authz server.
-  UnsafeHeaderVector response_headers_to_overwrite_if_exists{};
+  UnsafeHeaderVector response_headers_to_overwrite_if_exists;
   // Whether the authorization server returned any headers with an invalid append action type.
-  bool saw_invalid_append_actions{false};
+  bool saw_invalid_append_actions = false;
   // A set of HTTP headers consumed by the authorization server, will be removed
   // from the request to the upstream server.
-  std::vector<std::string> headers_to_remove{};
+  std::vector<std::string> headers_to_remove;
   // A set of query string parameters to be set (possibly overwritten) on the
   // request to the upstream server.
-  Http::Utility::QueryParamsVector query_parameters_to_set{};
+  Http::Utility::QueryParamsVector query_parameters_to_set;
   // A set of query string parameters to remove from the request to the upstream server.
-  std::vector<std::string> query_parameters_to_remove{};
+  std::vector<std::string> query_parameters_to_remove;
   // Optional http body used only on denied response.
-  std::string body{};
+  std::string body;
   // Optional http status used only on denied response.
   Http::Code status_code{};
 
   // A set of metadata returned by the authorization server, that will be emitted as filter's
   // dynamic metadata that other filters can leverage.
-  Protobuf::Struct dynamic_metadata{};
+  Protobuf::Struct dynamic_metadata;
 
   // The gRPC status returned by the authorization server when it is making a
   // gRPC call.

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -33,6 +33,11 @@ const Http::HeaderMap& lengthZeroHeader() {
   return *headers;
 }
 
+Http::Code zeroHttpCode() {
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
+  return static_cast<Http::Code>(0);
+}
+
 // Static response used for creating authorization ERROR responses.
 // Note: status_code is left unset so the filter can use the configured status_on_error
 // configuration.
@@ -50,7 +55,7 @@ const Response& errorResponse() {
                                             Http::Utility::QueryParamsVector{},
                                             {},
                                             EMPTY_STRING,
-                                            static_cast<Http::Code>(0),
+                                            zeroHttpCode(),
                                             Protobuf::Struct{}});
 }
 
@@ -70,7 +75,7 @@ struct SuccessResponse {
       : headers_(headers), matchers_(matchers), append_matchers_(append_matchers),
         response_matchers_(response_matchers),
         to_dynamic_metadata_matchers_(dynamic_metadata_matchers),
-        response_(std::make_unique<Response>(response)) {
+        response_(std::make_unique<Response>(std::move(response))) {
     headers_.iterate([this](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
       // UpstreamHeaderMatcher
       if (matchers_->matches(header.key().getStringView())) {

--- a/source/extensions/filters/http/a2a/a2a_filter.cc
+++ b/source/extensions/filters/http/a2a/a2a_filter.cc
@@ -144,8 +144,9 @@ Http::FilterDataStatus A2aFilter::decodeData(Buffer::Instance& data, bool end_st
       }
     }
 
-    if (max_size > 0 && bytes_parsed_ == max_size)
+    if (max_size > 0 && bytes_parsed_ == max_size) {
       break;
+    }
   }
 
   // If we are here, we haven't collected all fields yet.

--- a/source/extensions/filters/http/api_key_auth/api_key_auth.h
+++ b/source/extensions/filters/http/api_key_auth/api_key_auth.h
@@ -189,7 +189,7 @@ private:
 struct AuthResult {
   bool authenticated{};
   bool authorized{};
-  absl::string_view response_code_details{};
+  absl::string_view response_code_details;
 };
 
 class FilterConfig {

--- a/source/extensions/filters/http/bandwidth_share/fair_token_bucket_impl.h
+++ b/source/extensions/filters/http/bandwidth_share/fair_token_bucket_impl.h
@@ -158,7 +158,7 @@ private:
   // The empty_at_ value is used to store how many tokens are in the bucket,
   // for example if empty_at_ is 100ms in the past, then there is 1/10 of
   // max_tokens_, or if 1000ms or more, then there is max_tokens_.
-  MonotonicTime empty_at_ ABSL_GUARDED_BY(mutex_){};
+  MonotonicTime empty_at_ ABSL_GUARDED_BY(mutex_);
   absl::flat_hash_set<Tenant, TenantHash, TenantHashEq> active_tenants_ ABSL_GUARDED_BY(mutex_);
   std::vector<std::pair<MonotonicTime, std::string>> draining_tenants_ ABSL_GUARDED_BY(mutex_);
   uint64_t active_tenants_total_weight_ = 0;

--- a/source/extensions/filters/http/cache/upstream_request.cc
+++ b/source/extensions/filters/http/cache/upstream_request.cc
@@ -205,23 +205,23 @@ void UpstreamRequest::onHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_s
     if (filter_) {
       ENVOY_STREAM_LOG(debug, "UpstreamRequest::onHeaders inserting headers",
                        *filter_->decoder_callbacks_);
-    }
-    auto insert_context =
-        cache_->makeInsertContext(std::move(lookup_), *filter_->encoder_callbacks_);
-    lookup_ = nullptr;
-    if (insert_context != nullptr) {
-      // The callbacks passed to CacheInsertQueue are all called through the dispatcher,
-      // so they're thread-safe. During CacheFilter::onDestroy the queue is given ownership
-      // of itself and all the callbacks are cancelled, so they are also filter-destruction-safe.
-      insert_queue_ = std::make_unique<CacheInsertQueue>(cache_, *filter_->encoder_callbacks_,
-                                                         std::move(insert_context), *this);
-      // Add metadata associated with the cached response. Right now this is only response_time;
-      const ResponseMetadata metadata = {config_->timeSource().systemTime()};
-      insert_queue_->insertHeaders(*headers, metadata, end_stream);
-      // insert_status_ remains absl::nullopt if end_stream == false, as we have not completed the
-      // insertion yet.
-      if (end_stream) {
-        setInsertStatus(InsertStatus::InsertSucceeded);
+      auto insert_context =
+          cache_->makeInsertContext(std::move(lookup_), *filter_->encoder_callbacks_);
+      lookup_ = nullptr;
+      if (insert_context != nullptr) {
+        // The callbacks passed to CacheInsertQueue are all called through the dispatcher,
+        // so they're thread-safe. During CacheFilter::onDestroy the queue is given ownership
+        // of itself and all the callbacks are cancelled, so they are also filter-destruction-safe.
+        insert_queue_ = std::make_unique<CacheInsertQueue>(cache_, *filter_->encoder_callbacks_,
+                                                           std::move(insert_context), *this);
+        // Add metadata associated with the cached response. Right now this is only response_time;
+        const ResponseMetadata metadata = {config_->timeSource().systemTime()};
+        insert_queue_->insertHeaders(*headers, metadata, end_stream);
+        // insert_status_ remains absl::nullopt if end_stream == false, as we have not completed the
+        // insertion yet.
+        if (end_stream) {
+          setInsertStatus(InsertStatus::InsertSucceeded);
+        }
       }
     }
   } else {

--- a/source/extensions/filters/http/cache_v2/cache_sessions.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.h
@@ -21,8 +21,8 @@ public:
       const Http::RequestHeaderMap& request_headers,
       UpstreamRequestFactoryPtr upstream_request_factory, absl::string_view cluster_name,
       Event::Dispatcher& dispatcher, SystemTime timestamp,
-      const std::shared_ptr<const CacheableResponseChecker> cacheable_response_checker_,
-      const std::shared_ptr<const CacheFilterStatsProvider> stats_provider_,
+      const std::shared_ptr<const CacheableResponseChecker> cacheable_response_checker,
+      const std::shared_ptr<const CacheFilterStatsProvider> stats_provider,
       bool ignore_request_cache_control_header);
 
   // Caches may modify the key according to local needs, though care must be

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -15,8 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CacheV2 {
 
-using CancelWrapper::cancelWrapped;
-
 class UpstreamRequestWithCacheabilityReset : public HttpSource {
 public:
   UpstreamRequestWithCacheabilityReset(
@@ -248,7 +246,7 @@ void CacheSession::sendLookupResponsesAndMaybeValidationRequest(CacheEntryStatus
   lookup_subscribers_.erase(it, lookup_subscribers_.end());
   if (!lookup_subscribers_.empty()) {
     // At least one subscriber required validation.
-    return performValidation();
+    performValidation();
   }
 }
 
@@ -586,7 +584,8 @@ void CacheSession::getLookupResult(ActiveLookupRequestPtr lookup, ActiveLookupRe
       } else {
         sub.context_->lookup().stats().incCacheSessionsSubscribers();
         lookup_subscribers_.push_back(std::move(sub));
-        return performValidation();
+        performValidation();
+        return;
       }
     }
     auto result = std::make_unique<ActiveLookupResult>();
@@ -771,7 +770,6 @@ void CacheSession::onUncacheable(Http::ResponseHeaderMapPtr headers, EndStream e
     cache_sessions->stats().subCacheSessionsSubscribers(lookup_subscribers_.size());
   }
   lookup_subscribers_.clear();
-  return;
 }
 
 void CacheSession::onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStream end_stream,

--- a/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
+++ b/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
@@ -184,15 +184,15 @@ void UpstreamRequestImpl::sendHeaders(Http::RequestHeaderMapPtr request_headers)
   }
 }
 
-template <class... Ts> struct overloaded : Ts... {
+template <class... Ts> struct Overloaded : Ts... {
   using Ts::operator()...;
 };
-template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 
 void UpstreamRequestImpl::onReset() {
   ASSERT(dispatcher_.isThreadSafe());
   stream_ = nullptr;
-  absl::visit(overloaded{
+  absl::visit(Overloaded{
                   [](absl::monostate&&) {},
                   [](GetHeadersCallback&& cb) { cb(nullptr, EndStream::Reset); },
                   [](GetBodyCallback&& cb) { cb(nullptr, EndStream::Reset); },

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -188,10 +188,6 @@ DynamicModuleConfigFactory::createFilterFactoryFromRemoteSource(
   };
   auto async_state = std::make_shared<AsyncState>();
 
-  // Copies for use in the callback — the originals may not outlive the async fetch.
-  const FilterConfig proto_config_copy = proto_config;
-  const auto module_config_copy = module_config;
-
   // Use a weak_ptr in the callback to break the reference cycle:
   // async_state -> remote_provider -> callback -> async_state.
   std::weak_ptr<AsyncState> weak_state = async_state;
@@ -200,7 +196,7 @@ DynamicModuleConfigFactory::createFilterFactoryFromRemoteSource(
       context.clusterManager(), init_manager, module_config.module().remote(),
       context.mainThreadDispatcher(), context.api().randomGenerator(),
       /*allow_empty=*/true,
-      [weak_state, proto_config_copy, module_config_copy, &context,
+      [weak_state, proto_config_copy = proto_config, module_config_copy = module_config, &context,
        &scope](const std::string& data) {
         auto state = weak_state.lock();
         if (!state) {

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -75,6 +75,11 @@ bool headersWithinLimits(const Http::HeaderMap& headers) {
          headers.byteSize() <= headers.maxHeadersKb() * 1024;
 }
 
+Http::Code zeroHttpCode() {
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
+  return static_cast<Http::Code>(0);
+}
+
 } // namespace
 
 FilterConfig::FilterConfig(const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& config,
@@ -1111,7 +1116,7 @@ void Filter::onComplete(Filters::Common::ExtAuthz::ResponsePtr&& response) {
     } else {
       // Use custom status code from error_response if provided, otherwise use status_on_error.
       // Status code 0 means not set.
-      const Http::Code status_code = response->status_code != static_cast<Http::Code>(0)
+      const Http::Code status_code = response->status_code != zeroHttpCode()
                                          ? response->status_code
                                          : config_->statusOnError();
       ENVOY_STREAM_LOG(
@@ -1222,7 +1227,7 @@ bool Filter::validateAndClearInvalidErrorResponseAttributes(
       response->headers_to_set.clear();
       response->headers_to_append.clear();
       response->body.clear();
-      response->status_code = static_cast<Http::Code>(0); // Clear custom status.
+      response->status_code = zeroHttpCode(); // Clear custom status.
       return false;
     }
   }
@@ -1241,7 +1246,7 @@ bool Filter::validateAndClearInvalidErrorResponseAttributes(
       response->headers_to_set.clear();
       response->headers_to_append.clear();
       response->body.clear();
-      response->status_code = static_cast<Http::Code>(0); // Clear custom status.
+      response->status_code = zeroHttpCode(); // Clear custom status.
       return false;
     }
   }
@@ -1291,7 +1296,7 @@ void Filter::addErrorResponseHeaders(
 
 void ShadowDecisionObject::populateProto(ShadowDecisionProto& msg) const {
   msg.set_check_result(check_result_);
-  if (status_code_ != static_cast<Http::Code>(0)) {
+  if (status_code_ != zeroHttpCode()) {
     msg.set_status_code(static_cast<uint32_t>(status_code_));
   }
   for (const auto& [key, value] : response_headers_) {
@@ -1318,7 +1323,7 @@ void Filter::setShadowFilterState(Filters::Common::ExtAuthz::Response& response)
   using ShadowDecisionProto = envoy::extensions::filters::http::ext_authz::v3::ShadowDecision;
 
   ShadowDecisionProto::CheckResult check_result = ShadowDecisionProto::UNSPECIFIED;
-  Http::Code status_code = static_cast<Http::Code>(0);
+  Http::Code status_code{};
   Filters::Common::ExtAuthz::UnsafeHeaderVector response_headers;
 
   switch (response.status) {
@@ -1334,8 +1339,8 @@ void Filter::setShadowFilterState(Filters::Common::ExtAuthz::Response& response)
     break;
   case CheckStatus::Error:
     check_result = ShadowDecisionProto::ERROR;
-    status_code = response.status_code != static_cast<Http::Code>(0) ? response.status_code
-                                                                     : config_->statusOnError();
+    status_code =
+        response.status_code != zeroHttpCode() ? response.status_code : config_->statusOnError();
     stats_.shadow_error_.inc();
     break;
   default:

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -27,7 +27,6 @@ namespace HttpFilters {
 namespace ExternalProcessing {
 namespace {
 
-using envoy::config::common::mutation_rules::v3::HeaderMutationRules;
 using envoy::config::core::v3::TrafficDirection;
 using envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor;
 using envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute;
@@ -38,7 +37,6 @@ using envoy::service::ext_proc::v3::ImmediateResponse;
 using envoy::service::ext_proc::v3::ProcessingRequest;
 using envoy::service::ext_proc::v3::ProcessingResponse;
 
-using Filters::Common::MutationRules::Checker;
 using Filters::Common::ProcessingEffect::Effect;
 using Http::FilterDataStatus;
 using Http::FilterHeadersStatus;
@@ -261,25 +259,7 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
                            const std::string& stats_prefix, bool is_upstream,
                            Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder,
                            Server::Configuration::CommonFactoryContext& context)
-    : failure_mode_allow_(config.failure_mode_allow()),
-      observability_mode_(config.observability_mode()),
-      route_cache_action_(config.route_cache_action()),
-      deferred_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, deferred_close_timeout,
-                                                         DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS)),
-      message_timeout_(message_timeout), max_message_timeout_ms_(max_message_timeout_ms),
-      grpc_service_(getFilterGrpcService(config)),
-      send_body_without_waiting_for_header_response_(
-          config.send_body_without_waiting_for_header_response()),
-      stats_(generateStats(stats_prefix, config.stat_prefix(), scope)),
-      processing_mode_(config.processing_mode()),
-      mutation_checker_(config.mutation_rules(), context.regexEngine()),
-      filter_metadata_(config.filter_metadata()),
-      allow_mode_override_(config.allow_mode_override()),
-      disable_immediate_response_(config.disable_immediate_response()),
-      allowed_headers_(initHeaderMatchers(config.forward_rules().allowed_headers(), context)),
-      disallowed_headers_(initHeaderMatchers(config.forward_rules().disallowed_headers(), context)),
-      is_upstream_(is_upstream), graceful_grpc_close_(Runtime::runtimeFeatureEnabled(
-                                     "envoy.reloadable_features.ext_proc_graceful_grpc_close")),
+    : stats_(generateStats(stats_prefix, config.stat_prefix(), scope)),
       untyped_forwarding_namespaces_(
           config.metadata_options().forwarding_namespaces().untyped().begin(),
           config.metadata_options().forwarding_namespaces().untyped().end()),
@@ -295,7 +275,12 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
       typed_cluster_metadata_forwarding_namespaces_(
           config.metadata_options().cluster_metadata_forwarding_namespaces().typed().begin(),
           config.metadata_options().cluster_metadata_forwarding_namespaces().typed().end()),
+      allowed_headers_(initHeaderMatchers(config.forward_rules().allowed_headers(), context)),
+      disallowed_headers_(initHeaderMatchers(config.forward_rules().disallowed_headers(), context)),
       allowed_override_modes_(config.allowed_override_modes()),
+      grpc_service_(getFilterGrpcService(config)),
+      mutation_checker_(config.mutation_rules(), context.regexEngine()),
+      filter_metadata_(config.filter_metadata()),
       expression_manager_(builder, context.localInfo(), config.request_attributes(),
                           config.response_attributes()),
       processing_request_modifier_factory_cb_(
@@ -303,9 +288,22 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
       on_processing_response_factory_cb_(
           createOnProcessingResponseCb(config, context, stats_prefix)),
       thread_local_stream_manager_slot_(context.threadLocal().allocateSlot()),
+      route_cache_action_(config.route_cache_action()), processing_mode_(config.processing_mode()),
+      deferred_close_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, deferred_close_timeout,
+                                                         DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS)),
+      message_timeout_(message_timeout),
       remote_close_timeout_(context.runtime().snapshot().getInteger(
           RemoteCloseTimeout, DefaultRemoteCloseTimeoutMilliseconds)),
+      max_message_timeout_ms_(max_message_timeout_ms),
       status_on_error_(toErrorCode(config.status_on_error().code())),
+      failure_mode_allow_(config.failure_mode_allow()),
+      observability_mode_(config.observability_mode()),
+      send_body_without_waiting_for_header_response_(
+          config.send_body_without_waiting_for_header_response()),
+      allow_mode_override_(config.allow_mode_override()),
+      disable_immediate_response_(config.disable_immediate_response()), is_upstream_(is_upstream),
+      graceful_grpc_close_(
+          Runtime::runtimeFeatureEnabled("envoy.reloadable_features.ext_proc_graceful_grpc_close")),
       allow_content_length_header_(config.allow_content_length_header()) {
   if (config.disable_clear_route_cache()) {
     route_cache_action_ = ExternalProcessor::RETAIN;

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -365,38 +365,24 @@ private:
       const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& config,
       Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder,
       Server::Configuration::CommonFactoryContext& context);
-  const bool failure_mode_allow_;
-  const bool observability_mode_;
-  envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor::RouteCacheAction
-      route_cache_action_;
-  const std::chrono::milliseconds deferred_close_timeout_;
-  const std::chrono::milliseconds message_timeout_;
-  const uint32_t max_message_timeout_ms_;
-  const absl::optional<const envoy::config::core::v3::GrpcService> grpc_service_;
-  const bool send_body_without_waiting_for_header_response_;
 
   ExtProcFilterStats stats_;
-  const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode processing_mode_;
-  const Filters::Common::MutationRules::Checker mutation_checker_;
-  const Protobuf::Struct filter_metadata_;
-  // If set to true, allow the processing mode to be modified by the ext_proc response.
-  const bool allow_mode_override_;
-  // If set to true, disable the immediate response from the ext_proc server, which means
-  // closing the stream to the ext_proc server, and no more external processing.
-  const bool disable_immediate_response_;
-  // Empty allowed_header_ means allow all.
-  const std::vector<Matchers::StringMatcherPtr> allowed_headers_;
-  // Empty disallowed_header_ means disallow nothing, i.e, allow all.
-  const std::vector<Matchers::StringMatcherPtr> disallowed_headers_;
-  // is_upstream_ is true if ext_proc filter is in the upstream filter chain.
-  const bool is_upstream_;
-  const bool graceful_grpc_close_;
+
   const std::vector<std::string> untyped_forwarding_namespaces_;
   const std::vector<std::string> typed_forwarding_namespaces_;
   const std::vector<std::string> untyped_receiving_namespaces_;
   const std::vector<std::string> untyped_cluster_metadata_forwarding_namespaces_;
   const std::vector<std::string> typed_cluster_metadata_forwarding_namespaces_;
+  // Empty allowed_header_ means allow all.
+  const std::vector<Matchers::StringMatcherPtr> allowed_headers_;
+  // Empty disallowed_header_ means disallow nothing, i.e, allow all.
+  const std::vector<Matchers::StringMatcherPtr> disallowed_headers_;
+
   const AllowedOverrideModesSet allowed_override_modes_;
+
+  const absl::optional<const envoy::config::core::v3::GrpcService> grpc_service_;
+  const Filters::Common::MutationRules::Checker mutation_checker_;
+  const Protobuf::Struct filter_metadata_;
   const ExpressionManager expression_manager_;
 
   const std::function<std::unique_ptr<ProcessingRequestModifier>()>
@@ -404,9 +390,29 @@ private:
   const std::function<std::unique_ptr<OnProcessingResponse>()> on_processing_response_factory_cb_;
 
   ThreadLocal::SlotPtr thread_local_stream_manager_slot_;
+  envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor::RouteCacheAction
+      route_cache_action_;
+  const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode processing_mode_;
+  const std::chrono::milliseconds deferred_close_timeout_;
+  const std::chrono::milliseconds message_timeout_;
   const std::chrono::milliseconds remote_close_timeout_;
-  const Http::Code status_on_error_;
-  const bool allow_content_length_header_;
+  const uint32_t max_message_timeout_ms_ = 0;
+
+  const Http::Code status_on_error_{};
+
+  const bool failure_mode_allow_ = false;
+  const bool observability_mode_ = false;
+  const bool send_body_without_waiting_for_header_response_ = false;
+  // If set to true, allow the processing mode to be modified by the ext_proc response.
+  const bool allow_mode_override_ = false;
+  // If set to true, disable the immediate response from the ext_proc server, which means
+  // closing the stream to the ext_proc server, and no more external processing.
+  const bool disable_immediate_response_ = false;
+  // is_upstream_ is true if ext_proc filter is in the upstream filter chain.
+  const bool is_upstream_ = false;
+  const bool graceful_grpc_close_ = false;
+
+  const bool allow_content_length_header_ = false;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;

--- a/source/extensions/filters/http/ext_proc/processing_request_modifier.h
+++ b/source/extensions/filters/http/ext_proc/processing_request_modifier.h
@@ -35,7 +35,7 @@ public:
   // Implementations may modify the request and must return true if any modifications were made.
   virtual bool
   modifyRequest(const Params& params,
-                envoy::service::ext_proc::v3::ProcessingRequest& processingRequest) PURE;
+                envoy::service::ext_proc::v3::ProcessingRequest& processing_request) PURE;
 };
 
 class ProcessingRequestModifierFactory : public Config::TypedFactory {

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
@@ -64,9 +64,9 @@ namespace GrpcJsonReverseTranscoder {
 
 namespace {
 
-// AppendHttpBodyEnvelope wraps the response returned from the upstream server
+// appendHttpBodyEnvelope wraps the response returned from the upstream server
 // in a google.api.HttpBody message.
-void AppendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
+void appendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
                             uint64_t content_length) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded
@@ -101,12 +101,13 @@ void AppendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
   output.add(proto_envelope);
 }
 
-bool ReadToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& buffer) {
+bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& buffer) {
   const void* out;
   int size;
   while (stream.Next(&out, &size)) {
-    if (size == 0)
+    if (size == 0) {
       return true;
+    }
     buffer.add(out, size);
   }
   return false;
@@ -192,8 +193,9 @@ bool GrpcJsonReverseTranscoderFilter::EncoderBufferLimitReached(uint64_t buffer_
 
 bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfRequestTranscoderFailed() const {
   const auto& status = transcoder_->RequestStatus();
-  if (status.ok())
+  if (status.ok()) {
     return false;
+  }
   decoder_callbacks_->sendLocalReply(
       Code::BadRequest, status.message(), nullptr, Status::WellKnownGrpcStatus::InvalidArgument,
       absl::StrCat(RcDetails::get().grpc_transcode_failed, "{",
@@ -204,8 +206,9 @@ bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfRequestTranscoderFailed() 
 
 bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfResponseTranscoderFailed() const {
   const auto& status = transcoder_->ResponseStatus();
-  if (status.ok())
+  if (status.ok()) {
     return false;
+  }
   ENVOY_STREAM_LOG(error, "Response transcoding failed: {}", *encoder_callbacks_, status.message());
   encoder_callbacks_->sendLocalReply(
       Code::InternalServerError, status.message(), nullptr, Status::WellKnownGrpcStatus::Internal,
@@ -258,7 +261,7 @@ void GrpcJsonReverseTranscoderFilter::SendHttpBodyResponse(Buffer::Instance* dat
     return;
   }
   Buffer::OwnedImpl message_payload;
-  AppendHttpBodyEnvelope(message_payload, response_content_type_, response_data_.length());
+  appendHttpBodyEnvelope(message_payload, response_content_type_, response_data_.length());
   response_content_type_.clear();
   message_payload.move(response_data_);
   Grpc::Encoder().prependFrameHeader(Grpc::GRPC_FH_DEFAULT, message_payload);
@@ -493,7 +496,7 @@ FilterDataStatus GrpcJsonReverseTranscoderFilter::decodeData(Buffer::Instance& d
     return FilterDataStatus::StopIterationNoBuffer;
   }
 
-  ReadToBuffer(*transcoder_->RequestOutput(), request_buffer_);
+  readToBuffer(*transcoder_->RequestOutput(), request_buffer_);
 
   if (!end_stream) {
     return FilterDataStatus::StopIterationNoBuffer;
@@ -603,7 +606,7 @@ FilterDataStatus GrpcJsonReverseTranscoderFilter::encodeData(Buffer::Instance& d
       return FilterDataStatus::StopIterationNoBuffer;
     }
 
-    ReadToBuffer(*transcoder_->ResponseOutput(), response_buffer_);
+    readToBuffer(*transcoder_->ResponseOutput(), response_buffer_);
 
     if (CheckAndRejectIfResponseTranscoderFailed()) {
       return FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
@@ -40,7 +40,6 @@ using ResponseTranslator = ::google::grpc::transcoding::JsonRequestTranslator;
 using ResponseInfo = ::google::grpc::transcoding::RequestInfo;
 using ::envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
     GrpcJsonReverseTranscoder;
-using ::google::api::HttpRule;
 using ::google::grpc::transcoding::Transcoder;
 using ::google::grpc::transcoding::TranscoderInputStream;
 using ::google::grpc::transcoding::TypeHelper;
@@ -50,7 +49,7 @@ GrpcJsonReverseTranscoderConfig::GrpcJsonReverseTranscoderConfig(
   Protobuf::FileDescriptorSet descriptor_set;
   if (!transcoder_config.descriptor_path().empty()) {
     auto file_or_error = api.fileSystem().fileReadToEnd(transcoder_config.descriptor_path());
-    THROW_IF_NOT_OK(file_or_error.status());
+    THROW_IF_NOT_OK_REF(file_or_error.status());
     if (!descriptor_set.ParseFromString(file_or_error.value())) {
       throw EnvoyException("Unable to parse proto descriptor");
     }

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
@@ -25,7 +25,7 @@ namespace GrpcJsonReverseTranscoder {
 
 namespace {
 
-absl::Status BuildReplacementVector(nlohmann::json& request, std::string http_rule_path,
+absl::Status buildReplacementVector(nlohmann::json& request, std::string http_rule_path,
                                     std::vector<std::pair<std::string, std::string>>& replacements,
                                     absl::flat_hash_set<std::string>& param_set) {
   size_t end = 0;
@@ -139,7 +139,8 @@ absl::StatusOr<std::string> BuildPath(nlohmann::json& request, std::string http_
                                       std::string http_body_field) {
   std::vector<std::pair<std::string, std::string>> replacements;
   absl::flat_hash_set<std::string> param_set;
-  absl::Status status = BuildReplacementVector(request, http_rule_path, replacements, param_set);
+  const absl::Status status =
+      buildReplacementVector(request, http_rule_path, replacements, param_set);
   if (!status.ok()) {
     return status;
   }

--- a/source/extensions/filters/http/health_check/health_check.h
+++ b/source/extensions/filters/http/health_check/health_check.h
@@ -72,9 +72,9 @@ private:
 
   Event::TimerPtr clear_cache_timer_;
   const std::chrono::milliseconds timeout_;
-  std::atomic<bool> use_cached_response_{};
-  std::atomic<Http::Code> last_response_code_{};
-  std::atomic<bool> last_response_degraded_{};
+  std::atomic<bool> use_cached_response_{false};
+  std::atomic<Http::Code> last_response_code_{static_cast<Http::Code>(0)};
+  std::atomic<bool> last_response_degraded_{false};
 };
 
 using HealthCheckCacheManagerSharedPtr = std::shared_ptr<HealthCheckCacheManager>;

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -310,8 +310,9 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
       }
     }
 
-    if (max_size > 0 && bytes_parsed_ == max_size)
+    if (max_size > 0 && bytes_parsed_ == max_size) {
       break;
+    }
   }
 
   // If we are here, we haven't collected all fields yet.

--- a/source/extensions/filters/http/mcp_router/mcp_router.cc
+++ b/source/extensions/filters/http/mcp_router/mcp_router.cc
@@ -677,8 +677,9 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
   // stores a pointer to the headers.
   auto stream_it = multistream_->begin();
   for (const auto& backend : config_->backends()) {
-    if (stream_it == multistream_->end())
+    if (stream_it == multistream_->end()) {
       break;
+    }
 
     auto headers = createUpstreamHeaders(backend, backend_sessions_[backend.name]);
     upstream_headers_.push_back(std::move(headers));

--- a/source/extensions/filters/http/proto_api_scrubber/filter_config.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/filter_config.cc
@@ -416,7 +416,7 @@ ProtoApiScrubberFilterConfig::getParentType(const Envoy::Protobuf::Field* field)
 void ProtoApiScrubberFilterConfig::buildFieldParentMap(
     const Envoy::Protobuf::FileDescriptorSet& descriptor_set) {
   for (const auto& file : descriptor_set.file()) {
-    std::string package_prefix = file.package();
+    const auto& package_prefix = file.package();
     for (const auto& msg : file.message_type()) {
       populateMapForMessage(msg, package_prefix);
     }

--- a/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
@@ -24,10 +24,9 @@ namespace {
 struct TraversalState {
   const Protobuf::Descriptor* current_desc;
   std::vector<std::string> normalized_path;
-  bool is_map_entry;
+  bool is_map_entry{false};
 
-  TraversalState(const Protobuf::Descriptor* root, size_t capacity)
-      : current_desc(root), is_map_entry(false) {
+  TraversalState(const Protobuf::Descriptor* root, size_t capacity) : current_desc(root) {
     normalized_path.reserve(capacity);
   }
 };

--- a/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h
+++ b/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.h
@@ -43,7 +43,7 @@ public:
   // This type is neither copyable nor movable.
   FieldChecker(const FieldChecker&) = delete;
   FieldChecker& operator=(const FieldChecker&) = delete;
-  ~FieldChecker() override {}
+  ~FieldChecker() override = default;
 
   // Make all the overloads from the base class visible here so the one explicit
   // override doesn't hide the other signatures.
@@ -111,7 +111,7 @@ private:
   std::string method_name_;
   const ProtoApiScrubberFilterConfig* filter_config_ptr_;
 
-  const Protobuf::Descriptor* root_descriptor_;
+  const Protobuf::Descriptor* root_descriptor_{nullptr};
 
   // Cache normalized results.
   mutable absl::flat_hash_map<std::vector<std::string>, NormalizationResult> path_cache_;

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
@@ -16,9 +16,9 @@ namespace ProtoMessageExtraction {
 
 // All valid field extraction directives.
 enum class ExtractedMessageDirective {
-  EXTRACT_REDACT,
+  EXTRACT_REDACT, // NOLINT(readability-identifier-naming)
   EXTRACT,
-  EXTRACT_REPEATED_CARDINALITY,
+  EXTRACT_REPEATED_CARDINALITY, // NOLINT(readability-identifier-naming)
 };
 
 using FieldPathToExtractType =

--- a/source/extensions/filters/http/proto_message_extraction/filter.h
+++ b/source/extensions/filters/http/proto_message_extraction/filter.h
@@ -40,11 +40,10 @@ public:
 
 private:
   struct HandleDataStatus {
-    explicit HandleDataStatus(Envoy::Http::FilterDataStatus status)
-        : got_messages(false), filter_status(status) {}
+    explicit HandleDataStatus(Envoy::Http::FilterDataStatus status) : filter_status(status) {}
 
     // If true, the function has processed at least one message.
-    bool got_messages;
+    bool got_messages{false};
 
     // If "got_message" is false, return this filter_status.
     Envoy::Http::FilterDataStatus filter_status;

--- a/source/extensions/filters/http/rate_limit_quota/client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.h
@@ -56,8 +56,8 @@ private:
 
 inline std::unique_ptr<RateLimitClient>
 createLocalRateLimitClient(GlobalRateLimitClientImpl* global_client,
-                           ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_cache_tls_) {
-  return std::make_unique<LocalRateLimitClientImpl>(global_client, buckets_cache_tls_);
+                           ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_cache_tls) {
+  return std::make_unique<LocalRateLimitClientImpl>(global_client, buckets_cache_tls);
 }
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
+++ b/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
@@ -15,7 +15,7 @@ namespace SetMetadataFilter {
 
 namespace {
 
-void ApplyConfigToMetadata(const Config& config,
+void applyConfigToMetadata(const Config& config,
                            envoy::config::core::v3::Metadata& dynamic_metadata) {
 
   // Add configured untyped metadata.
@@ -97,13 +97,13 @@ SetMetadataFilter::~SetMetadataFilter() = default;
 
 Http::FilterHeadersStatus SetMetadataFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
   // Apply global config first.
-  ApplyConfigToMetadata(*config_, decoder_callbacks_->streamInfo().dynamicMetadata());
+  applyConfigToMetadata(*config_, decoder_callbacks_->streamInfo().dynamicMetadata());
 
   // Apply route-specific config if present.
   const Config* route_specific_cfg =
       dynamic_cast<const Config*>(decoder_callbacks_->mostSpecificPerFilterConfig());
   if (route_specific_cfg) {
-    ApplyConfigToMetadata(*route_specific_cfg, decoder_callbacks_->streamInfo().dynamicMetadata());
+    applyConfigToMetadata(*route_specific_cfg, decoder_callbacks_->streamInfo().dynamicMetadata());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -243,7 +243,7 @@ bool AllshardSameResponseHandler::areAllResponsesSame() const {
 
   const Common::Redis::RespValue* first_response = pending_responses_.front().get();
   for (const auto& response : pending_responses_) {
-    if (!response || !first_response || *(response.get()) != *first_response) {
+    if (!response || !first_response || *response != *first_response) {
       return false;
     }
   }
@@ -354,12 +354,15 @@ void ArrayAppendAggregateResponseHandler::processAggregatedResponses(
 void HelloResponseHandler::processAggregatedResponses(ClusterScopeCmdRequest& request) {
   // Helper to check if two RespValues are equal
   auto valuesEqual = [](const Common::Redis::RespValue& v1, const Common::Redis::RespValue& v2) {
-    if (v1.type() != v2.type())
+    if (v1.type() != v2.type()) {
       return false;
-    if (v1.type() == Common::Redis::RespType::BulkString)
+    }
+    if (v1.type() == Common::Redis::RespType::BulkString) {
       return v1.asString() == v2.asString();
-    if (v1.type() == Common::Redis::RespType::Integer)
+    }
+    if (v1.type() == Common::Redis::RespType::Integer) {
       return v1.asInteger() == v2.asInteger();
+    }
     return true;
   };
 

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -20,9 +20,9 @@ class ClusterScopeCmdRequest;
  * Enum defining the different response handler types for cluster scope commands
  */
 enum class ClusterScopeResponseHandlerType {
-  allresponses_mustbe_same,
-  aggregate_all_responses,
-  response_handler_none
+  allresponses_mustbe_same, // NOLINT(readability-identifier-naming)
+  aggregate_all_responses,  // NOLINT(readability-identifier-naming)
+  response_handler_none     // NOLINT(readability-identifier-naming)
 };
 
 /**

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -1163,7 +1163,7 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
   }
 
   // Get the handler for the downstream request
-  auto handler = handler_lookup_table_.find(command_name.c_str());
+  auto handler = handler_lookup_table_.find(command_name);
   ASSERT(handler != nullptr);
 
   // If we are within a transaction, forward all requests to the transaction handler (i.e. handler
@@ -1227,7 +1227,7 @@ void InstanceImpl::addHandler(Stats::Scope& scope, const std::string& stat_prefi
   Stats::StatNameManagedStorage storage{command_stat_prefix + std::string("latency"),
                                         scope.symbolTable()};
   handler_lookup_table_.add(
-      to_lower_name.c_str(),
+      to_lower_name,
       std::make_shared<HandlerData>(HandlerData{
           CommandStats{ALL_COMMAND_STATS(POOL_COUNTER_PREFIX(scope, command_stat_prefix))
                            scope.histogramFromStatName(storage.statName(),

--- a/source/extensions/filters/network/redis_proxy/info_command_handler.h
+++ b/source/extensions/filters/network/redis_proxy/info_command_handler.h
@@ -46,15 +46,15 @@ private:
     std::string key;                     // Metric key name
     AggregationType agg_type;            // How to aggregate
     std::string str_value;               // String value storage
-    int64_t int_value;                   // Integer value storage
+    int64_t int_value{0};                // Integer value storage
     CustomAggregatorFunc custom_handler; // Custom aggregation function
     std::string source_metric_for_human; // If set, convert this metric to human-readable format
 
     MetricConfig(const std::string& sec, const std::string& k, AggregationType type,
                  const std::string& default_val = "", CustomAggregatorFunc handler = nullptr,
                  const std::string& human_source = "")
-        : section(sec), key(k), agg_type(type), str_value(default_val), int_value(0),
-          custom_handler(handler), source_metric_for_human(human_source) {}
+        : section(sec), key(k), agg_type(type), str_value(default_val), custom_handler(handler),
+          source_metric_for_human(human_source) {}
   };
 
   // Initialize the metric template

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -85,8 +85,8 @@ PrefixRoutes::PrefixRoutes(
       absl::AsciiStrToLower(&copy);
     }
 
-    auto success = prefix_lookup_table_.add(
-        copy.c_str(), std::make_shared<Prefix>(route, upstreams_, runtime), false);
+    auto success =
+        prefix_lookup_table_.add(copy, std::make_shared<Prefix>(route, upstreams_, runtime), false);
     if (!success) {
       throw EnvoyException(fmt::format("prefix `{}` already exists.", route.prefix()));
     }

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -88,8 +88,7 @@ private:
   struct ResponseDecoder : public DecoderCallbacks, public DecoderEventHandler {
     ResponseDecoder(ActiveRpc& parent, Transport& transport, Protocol& protocol)
         : parent_(parent), decoder_(std::make_unique<Decoder>(transport, protocol, *this)),
-          protocol_converter_(std::make_shared<ProtocolConverter>()), complete_{false},
-          passthrough_{false}, pending_transport_end_{false} {
+          protocol_converter_(std::make_shared<ProtocolConverter>()) {
       protocol_converter_->initProtocolConverter(*parent_.parent_.protocol_,
                                                  parent_.response_buffer_);
     }
@@ -218,9 +217,7 @@ private:
           stream_id_(parent_.random_generator_.random()),
           stream_info_(parent_.time_source_,
                        parent_.read_callbacks_->connection().connectionInfoProviderSharedPtr(),
-                       StreamInfo::FilterState::LifeSpan::FilterChain),
-          local_response_sent_{false}, pending_transport_end_{false}, passthrough_{false},
-          under_on_local_reply_{false} {
+                       StreamInfo::FilterState::LifeSpan::FilterChain) {
       parent_.stats_.request_active_.inc();
     }
     ~ActiveRpc() override {

--- a/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
@@ -85,7 +85,7 @@ void InsertContext::onBody(AdjustedByteRange range, Buffer::InstancePtr buffer,
   } else {
     range = AdjustedByteRange(0, entry_->bodySize());
   }
-  progress_receiver_->onBodyInserted(std::move(range), end_stream == EndStream::End);
+  progress_receiver_->onBodyInserted(range, end_stream == EndStream::End);
   if (end_stream != EndStream::End) {
     AdjustedByteRange next_range(range.end(), range.end() + InsertReadChunkSize);
     return source_->getBody(next_range,

--- a/source/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/mapped_attribute_builder.cc
+++ b/source/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/mapped_attribute_builder.cc
@@ -11,8 +11,6 @@ namespace Envoy {
 namespace Http {
 namespace ExternalProcessing {
 
-using envoy::service::ext_proc::v3::ProcessingRequest;
-
 // Helper function to convert proto map values to a unique vector of strings.
 // The order of elements in the returned vector is not guaranteed.
 Protobuf::RepeatedPtrField<std::string>

--- a/source/extensions/matching/input_matchers/cel_matcher/matcher.cc
+++ b/source/extensions/matching/input_matchers/cel_matcher/matcher.cc
@@ -9,8 +9,6 @@ namespace InputMatchers {
 namespace CelMatcher {
 
 using ::Envoy::Extensions::Matching::Http::CelInput::CelMatchData;
-using ::xds::type::v3::CelExpression;
-
 CelInputMatcher::CelInputMatcher(CelMatcherSharedPtr cel_matcher,
                                  Filters::Common::Expr::BuilderInstanceSharedConstPtr builder)
     : compiled_expr_([&]() {

--- a/source/extensions/quic/connection_id_generator/quic_lb/config.cc
+++ b/source/extensions/quic/connection_id_generator/quic_lb/config.cc
@@ -23,7 +23,7 @@ EnvoyQuicConnectionIdGeneratorFactoryPtr ConfigFactory::createQuicConnectionIdGe
           const envoy::extensions::quic::connection_id_generator::quic_lb::v3::Config&>(
           config, validation_visitor),
       context);
-  THROW_IF_NOT_OK(factory_or_status.status());
+  THROW_IF_NOT_OK_REF(factory_or_status.status());
   return std::move(factory_or_status.value());
 }
 

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
@@ -10,9 +10,7 @@ namespace OpenTelemetry {
 
 using ::opentelemetry::proto::metrics::v1::AggregationTemporality;
 using ::opentelemetry::proto::metrics::v1::HistogramDataPoint;
-using ::opentelemetry::proto::metrics::v1::Metric;
 using ::opentelemetry::proto::metrics::v1::NumberDataPoint;
-using ::opentelemetry::proto::metrics::v1::ResourceMetrics;
 
 using MetricsExportRequest =
     opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
@@ -77,8 +77,8 @@ public:
 
   class MetricKey {
   public:
-    MetricKey(std::string&& name, SortedAttributesVector&& sortedAttributes)
-        : name_(std::move(name)), sorted_attributes_(std::move(sortedAttributes)) {}
+    MetricKey(std::string&& name, SortedAttributesVector&& sorted_attributes)
+        : name_(std::move(name)), sorted_attributes_(std::move(sorted_attributes)) {}
 
     bool operator==(const MetricKey& other) const {
       return name_ == other.name_ && sorted_attributes_ == other.sorted_attributes_;

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -30,7 +30,7 @@ PerSocketTapperImpl::PerSocketTapperImpl(
     sink_handle_->submitTrace(std::move(trace));
     pegSubmitCounter(true);
   }
-  seq_num++;
+  seq_num_++;
 }
 
 void PerSocketTapperImpl::fillConnectionInfo(envoy::data::tap::v3::Connection& connection) {
@@ -49,19 +49,19 @@ void PerSocketTapperImpl::closeSocket(Network::ConnectionEvent) {
   }
 
   if (config_->streaming()) {
-    seq_num++;
+    seq_num_++;
     if (shouldSendStreamedMsgByConfiguredSize()) {
       makeStreamedTraceIfNeeded();
       auto& event =
           *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       event.mutable_closed();
       // submit directly and don't check current_streamed_rx_tx_bytes_ any more
       submitStreamedDataPerConfiguredSize();
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       event.mutable_closed();
       sink_handle_->submitTrace(std::move(trace));
     }
@@ -140,7 +140,7 @@ void PerSocketTapperImpl::handleSendingStreamTappedMsgPerConfigSize(const Buffer
   makeStreamedTraceIfNeeded();
   auto& event =
       *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
-  initStreamingEvent(event, seq_num);
+  initStreamingEvent(event, seq_num_);
   uint32_t buffer_start_offset = 0;
   if (is_read) {
     buffer_start_offset = data.length() - total_bytes;
@@ -171,14 +171,14 @@ void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_re
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       TapCommon::Utility::addBufferToProtoBytes(*event.mutable_read()->mutable_data(),
                                                 config_->maxBufferedRxBytes(), data,
                                                 data.length() - bytes_read, bytes_read);
       sink_handle_->submitTrace(std::move(trace));
       pegSubmitCounter(true);
     }
-    seq_num = seq_num + bytes_read;
+    seq_num_ = seq_num_ + bytes_read;
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().read_truncated()) {
       return;
@@ -209,7 +209,7 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       TapCommon::Utility::addBufferToProtoBytes(*event.mutable_write()->mutable_data(),
                                                 config_->maxBufferedTxBytes(), data, 0,
                                                 bytes_written);
@@ -217,7 +217,7 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
       sink_handle_->submitTrace(std::move(trace));
       pegSubmitCounter(true);
     }
-    seq_num = seq_num + bytes_written;
+    seq_num_ = seq_num_ + bytes_written;
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().write_truncated()) {
       return;

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -65,7 +65,7 @@ private:
   // for some protocols (e.g., HTTP/2 frames may span multiple reads/writes).
   // Add sequence number to allow the receiver to reconstruct byte order and
   // determine completeness, similar to TCP sequence numbers.
-  uint64_t seq_num{};
+  uint64_t seq_num_ = 0;
   SocketTapConfigSharedPtr config_;
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;
   const Network::Connection& connection_;

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -405,8 +405,9 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
       }
       line = line.substr(space_pos + 1);
     }
-    if (!line_valid)
+    if (!line_valid) {
       continue;
+    }
 
     // (5) mount point: extract mount point
     size_t mount_end = line.find(' ');
@@ -441,8 +442,9 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
       }
       line = line.substr(space_pos + 1);
     }
-    if (!line_valid || !separator_found)
+    if (!line_valid || !separator_found) {
       continue;
+    }
 
     // (9) filesystem type: extract filesystem type
     size_t fs_type_end = line.find(' ');

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -103,8 +103,7 @@ InstanceBase::InstanceBase(Init::Manager& init_manager, const Options& options,
                                                   : nullptr),
       grpc_context_(store.symbolTable()), http_context_(store.symbolTable()),
       router_context_(store.symbolTable()), process_context_(std::move(process_context)),
-      hooks_(hooks), quic_stat_names_(store.symbolTable()), server_contexts_(*this),
-      enable_reuse_port_default_(true), stats_flush_in_progress_(false) {
+      hooks_(hooks), quic_stat_names_(store.symbolTable()), server_contexts_(*this) {
   // Register the server factory context on the main thread.
   Configuration::ServerFactoryContextInstance::initialize(&server_contexts_);
 }
@@ -235,7 +234,8 @@ void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, S
   }
 }
 
-void InstanceBase::flushStats() {
+void InstanceBase::flushStats() { flushStatsImpl(); }
+void InstanceBase::flushStatsImpl() {
   if (stats_flush_in_progress_) {
     ENVOY_LOG(debug, "skipping stats flush as flush is already in progress");
     server_stats_->dropped_stat_flushes_.inc();
@@ -248,7 +248,7 @@ void InstanceBase::flushStats() {
   // completion callback is not called immediately. As a result of this server stats will
   // not be updated and flushed to stat sinks. So skip mergeHistograms call if workers are
   // not started yet.
-  if (initManager().state() == Init::Manager::State::Initialized) {
+  if (init_manager_.state() == Init::Manager::State::Initialized) {
     // A shutdown initiated before this callback may prevent this from being called as per
     // the semantics documented in ThreadLocal's runOnAllThreads method.
     stats_store_.mergeHistograms([this]() -> void { flushStatsInternal(); });
@@ -267,22 +267,21 @@ void InstanceBase::updateServerStats() {
                                        parent_stats.parent_memory_allocated_);
   server_stats_->memory_heap_size_.set(Memory::Stats::totalCurrentlyReserved());
   server_stats_->memory_physical_size_.set(Memory::Stats::totalPhysicalBytes());
-  if (!options().hotRestartDisabled()) {
+  if (!options_.hotRestartDisabled()) {
     server_stats_->parent_connections_.set(parent_stats.parent_connections_);
   }
   server_stats_->total_connections_.set(listener_manager_->numConnections() +
                                         parent_stats.parent_connections_);
   server_stats_->days_until_first_cert_expiring_.set(
-      sslContextManager().daysUntilFirstCertExpires().value_or(0));
+      ssl_context_manager_->daysUntilFirstCertExpires().value_or(0));
 
   auto secs_until_ocsp_response_expires =
-      sslContextManager().secondsUntilFirstOcspResponseExpires();
+      ssl_context_manager_->secondsUntilFirstOcspResponseExpires();
   if (secs_until_ocsp_response_expires) {
     server_stats_->seconds_until_first_ocsp_response_expiring_.set(
         secs_until_ocsp_response_expires.value());
   }
-  server_stats_->state_.set(
-      enumToInt(Utility::serverState(initManager().state(), healthCheckFailed())));
+  server_stats_->state_.set(enumToInt(Utility::serverState(init_manager_.state(), !live_.load())));
   server_stats_->stats_recent_lookups_.set(
       stats_store_.symbolTable().getRecentLookups([](absl::string_view, uint64_t) {}));
 }
@@ -290,8 +289,9 @@ void InstanceBase::updateServerStats() {
 void InstanceBase::flushStatsInternal() {
   updateServerStats();
   auto& stats_config = config_.statsConfig();
-  InstanceUtil::flushMetricsToSinks(stats_config.sinks(), stats_store_, clusterManager(),
-                                    timeSource());
+  ASSERT(config_.clusterManager() != nullptr);
+  InstanceUtil::flushMetricsToSinks(stats_config.sinks(), stats_store_, *config_.clusterManager(),
+                                    time_source_);
   if (const auto evict_on_flush = stats_config.evictOnFlush(); evict_on_flush > 0) {
     stats_eviction_counter_ = (stats_eviction_counter_ + 1) % evict_on_flush;
     if (stats_eviction_counter_ == 0) {
@@ -1128,7 +1128,7 @@ void InstanceBase::terminate() {
 
   // Only flush if we have not been hot restarted.
   if (stat_flush_timer_) {
-    flushStats();
+    flushStatsImpl();
   }
 
   if (config_.clusterManager() != nullptr) {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -348,6 +348,7 @@ private:
   Network::DnsResolverSharedPtr getOrCreateDnsResolver();
 
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
+  void flushStatsImpl();
   void flushStatsInternal();
   void updateServerStats();
   // This does most of the work of initialization, but can throw or return errors caught
@@ -439,9 +440,9 @@ private:
   ListenerHooks& hooks_;
   Quic::QuicStatNames quic_stat_names_;
   ServerFactoryContextImpl server_contexts_;
-  bool enable_reuse_port_default_{false};
+  bool enable_reuse_port_default_ = true;
   Regex::EnginePtr regex_engine_;
-  bool stats_flush_in_progress_ : 1;
+  bool stats_flush_in_progress_ = false;
   std::unique_ptr<Memory::AllocatorManager> memory_allocator_manager_;
 
   template <class T>


### PR DESCRIPTION
## Summary
Applies a broad batch of clang-tidy-driven cleanups across `source/`, including const-correctness, control-flow simplifications, and small readability fixes without intended behavior changes.