### PR TITLE
clang-tidy: fix naming and enum-cast issues in source

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -83,6 +83,7 @@ enum class MatchResult {
 };
 
 // Prints a human-readable string representing the MatchResult.
+// NOLINTNEXTLINE(readability-identifier-naming)
 inline static std::string MatchResultToString(MatchResult match_result) {
   switch (match_result) {
   case MatchResult::Matched:

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -44,6 +44,7 @@ namespace Http {
 namespace Http2 {
 
 // Types inherited from nghttp2 and preserved in oghttp2
+// NOLINTBEGIN(readability-identifier-naming)
 enum ErrorType {
   OGHTTP2_NO_ERROR,
   OGHTTP2_PROTOCOL_ERROR,
@@ -60,6 +61,7 @@ enum ErrorType {
   OGHTTP2_INADEQUATE_SECURITY,
   OGHTTP2_HTTP_1_1_REQUIRED,
 };
+// NOLINTEND(readability-identifier-naming)
 
 class Http2CodecImplTestFixture;
 

--- a/source/common/http/http2/protocol_constraints.h
+++ b/source/common/http/http2/protocol_constraints.h
@@ -18,6 +18,7 @@ namespace Http {
 namespace Http2 {
 
 // Frame types as inherited from nghttp2 and preserved for oghttp2
+// NOLINTBEGIN(readability-identifier-naming)
 enum FrameType {
   OGHTTP2_DATA_FRAME_TYPE,
   OGHTTP2_HEADERS_FRAME_TYPE,
@@ -30,6 +31,7 @@ enum FrameType {
   OGHTTP2_WINDOW_UPDATE_FRAME_TYPE,
   OGHTTP2_CONTINUATION_FRAME_TYPE,
 };
+// NOLINTEND(readability-identifier-naming)
 
 //  Class for detecting abusive peers and validating additional constraints imposed by Envoy.
 //  This class does not check protocol compliance with the H/2 standard, as this is checked by

--- a/source/common/http/session_idle_list.h
+++ b/source/common/http/session_idle_list.h
@@ -30,24 +30,30 @@ public:
   ~SessionIdleList() override = default;
 
   // Adds a session to the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void AddSession(IdleSessionInterface& session) override;
 
   // Removes a session from the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void RemoveSession(IdleSessionInterface& session) override;
 
   // Terminates idle sessions if they are eligible for termination. This is
   // called by the worker thread when the system is overloaded.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeTerminateIdleSessions(bool is_saturated) override;
 
   // Sets the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_min_time_before_termination_allowed(absl::Duration min_time_before_termination_allowed) {
     min_time_before_termination_allowed_ = min_time_before_termination_allowed;
   };
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_max_sessions_to_terminate_in_one_round(int max_sessions_to_terminate_in_one_round) {
     max_sessions_to_terminate_in_one_round_ = max_sessions_to_terminate_in_one_round;
   }
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_max_sessions_to_terminate_in_one_round_when_saturated(
       int max_sessions_to_terminate_in_one_round_when_saturated) {
     max_sessions_to_terminate_in_one_round_when_saturated_ =
@@ -55,6 +61,7 @@ public:
   }
 
   // Sets whether to ignore the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_ignore_min_time_before_termination_allowed(bool ignore) {
     ignore_min_time_before_termination_allowed_ = ignore;
   };
@@ -88,16 +95,21 @@ private:
     IdleSessions(const IdleSessions&) = delete;
     IdleSessions& operator=(const IdleSessions&) = delete;
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     IdleSessionInterface& next_session_to_terminate() { return *set_.begin()->session; }
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     void AddSessionToList(MonotonicTime enqueue_time, IdleSessionInterface& session);
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     void RemoveSessionFromList(IdleSessionInterface& session);
 
     // Get the time at which the session was added to the idle list.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     MonotonicTime GetEnqueueTime(IdleSessionInterface& session) const;
 
     // Returns true if the session is in the map. For testing only.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     bool ContainsForTest(IdleSessionInterface& session) const { return map_.contains(&session); }
 
     size_t size() const { return set_.size(); }
@@ -111,14 +123,17 @@ private:
     IdleSessionMap map_;
   };
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const IdleSessions* idle_sessions() const { return &idle_sessions_; }
 
   // If this is > 0 then we do not terminate more than that many
   // sessions in a single attempt. This prevents us from doing too
   // much work in a single round. We want a small constant for this.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   size_t MaxSessionsToTerminateInOneRound(bool is_saturated) const;
 
   // Returns the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::Duration MinTimeBeforeTerminationAllowed() const;
 
   Event::Dispatcher& dispatcher_;

--- a/source/common/http/session_idle_list_interface.h
+++ b/source/common/http/session_idle_list_interface.h
@@ -10,6 +10,7 @@ public:
 
   // Terminates the idle session. This is called by the SessionIdleList when
   // the system is overloaded and the session is eligible for termination.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void TerminateIdleSession() = 0;
 };
 
@@ -19,13 +20,16 @@ public:
   virtual ~SessionIdleListInterface() = default;
 
   // Adds a session to the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void AddSession(IdleSessionInterface& session) = 0;
 
   // Removes a session from the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void RemoveSession(IdleSessionInterface& session) = 0;
 
   // Terminates idle sessions if they are eligible for termination. This is
   // called by the worker thread when the system is overloaded.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void MaybeTerminateIdleSessions(bool is_saturated) = 0;
 };
 

--- a/source/common/json/json_rpc_field_extractor.h
+++ b/source/common/json/json_rpc_field_extractor.h
@@ -82,6 +82,7 @@ protected:
   virtual absl::string_view jsonRpcVersion() const = 0;
   virtual absl::string_view jsonRpcField() const = 0;
   virtual absl::string_view methodField() const = 0;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual bool lists_supported() const = 0;
 
   Protobuf::Struct temp_storage_;   // Store all fields temporarily

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -122,10 +122,12 @@ public:
 
   // For LRU mode, last_use_time() returns elements last use time.
   // See getLastUseTime() description for more information.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int64_t last_use_time() const { return last_use_; }
 
   // For age-based mode, insertion_time() returns elements insertion time.
   // See getInsertionTime() description for more information.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int64_t insertion_time() const { return last_use_; }
 
   friend bool operator==(const SimpleLRUCacheConstIterator& a,

--- a/source/common/jwt/struct_utils.h
+++ b/source/common/jwt/struct_utils.h
@@ -15,29 +15,37 @@ class StructUtils {
 public:
   StructUtils(const Protobuf::Struct& struct_pb);
 
+  // NOLINTBEGIN(readability-identifier-naming)
   enum FindResult {
     OK = 0,
     MISSING,
     WRONG_TYPE,
     OUT_OF_RANGE,
   };
+  // NOLINTEND(readability-identifier-naming)
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetString(const std::string& name, std::string* str_value);
 
   // Return error if the JSON value is not within a positive 64 bit integer
   // range. The decimals in the JSON value are dropped.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetUInt64(const std::string& name, uint64_t* int_value);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetDouble(const std::string& name, double* double_value);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetBoolean(const std::string& name, bool* bool_value);
 
   // Get string or list of string, designed to get "aud" field
   // "aud" can be either string array or string.
   // Try as string array, read it as empty array if doesn't exist.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetStringList(const std::string& name, std::vector<std::string>* list);
 
   // Find the value with nested names.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetValue(const std::string& nested_names, const Protobuf::Value*& found);
 
 private:

--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -47,6 +47,7 @@ public:
     return static_cast<T*>(ptr);
 #else
     // Ensure bytes is a multiple of Alignment, which is required by std::aligned_alloc.
+    // NOLINTBEGIN(readability-identifier-naming)
     bytes = round_up_to_alignment(bytes);
     return static_cast<T*>(std::aligned_alloc(Alignment, bytes));
 #endif

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -105,12 +105,15 @@ public:
   // Register this session to the given registry for receiving network change events.
   void registerNetworkObserver(EnvoyQuicNetworkObserverRegistry& registry);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const quic::TransportParameters::ParameterMap& received_custom_transport_parameters() {
     return received_custom_transport_parameters_;
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const absl::optional<quic::QuicSocketAddress>& received_ipv6_alternate_server_address() {
     return received_ipv6_alternate_server_address_;
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const absl::optional<quic::QuicSocketAddress>& received_ipv4_alternate_server_address() {
     return received_ipv4_alternate_server_address_;
   }

--- a/source/common/quic/envoy_quic_dispatcher.h
+++ b/source/common/quic/envoy_quic_dispatcher.h
@@ -103,6 +103,7 @@ protected:
 
 private:
   friend class EnvoyQuicDispatcherTest;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   Http::SessionIdleListInterface* idle_session_list() { return session_idle_list_.get(); }
 
   Network::ConnectionHandler& connection_handler_;

--- a/source/common/quic/envoy_quic_server_connection.cc
+++ b/source/common/quic/envoy_quic_server_connection.cc
@@ -66,6 +66,7 @@ bool EnvoyQuicServerConnection::OnPacketHeader(const quic::QuicPacketHeader& hea
   return true;
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerConnection::OnWritePacketDone(size_t packet_size,
                                                   const quic::WriteResult& /*result*/) {
   if (hasConnectionStats()) {

--- a/source/common/quic/envoy_quic_server_connection.h
+++ b/source/common/quic/envoy_quic_server_connection.h
@@ -160,6 +160,7 @@ protected:
 
 private:
   // Called when a packet is written to the packet writer.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void OnWritePacketDone(size_t packet_size, const quic::WriteResult& result);
   std::unique_ptr<QuicListenerFilterManagerImpl> listener_filter_manager_;
   bool first_packet_received_ = false;

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -312,6 +312,7 @@ void EnvoyQuicServerSession::OnStreamClosed(quic::QuicStreamId id) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::TerminateIdleSession() {
   ENVOY_BUG(!on_connection_closed_called_,
             "TerminateIdleSession called after session on close called.");
@@ -319,8 +320,10 @@ void EnvoyQuicServerSession::TerminateIdleSession() {
                                 quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::OnLastActiveStreamClosed() { MaybeAddSessionToIdleList(); }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::MaybeAddSessionToIdleList() {
   if (session_idle_list_ == nullptr || is_in_idle_list_) {
     return;
@@ -329,6 +332,7 @@ void EnvoyQuicServerSession::MaybeAddSessionToIdleList() {
   session_idle_list_->AddSession(*this);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::MaybeRemoveSessionFromIdleList() {
   if (session_idle_list_ == nullptr || !is_in_idle_list_) {
     return;

--- a/source/common/quic/envoy_quic_server_session.h
+++ b/source/common/quic/envoy_quic_server_session.h
@@ -126,6 +126,7 @@ public:
   void OnStreamClosed(quic::QuicStreamId id) override;
 
   // IdleSessionInterface
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void TerminateIdleSession() override;
 
   using quic::QuicSession::PerformActionOnActiveStreams;
@@ -149,12 +150,15 @@ protected:
   // Used by base class to access quic connection after initialization.
   const quic::QuicConnection* quicConnection() const override;
   quic::QuicConnection* quicConnection() override;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeAddSessionToIdleList();
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeRemoveSessionFromIdleList();
 
 private:
   void setUpRequestDecoder(EnvoyQuicServerStream& stream);
   void ActivateStream(std::unique_ptr<quic::QuicStream> stream) override;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void OnLastActiveStreamClosed();
 
   std::unique_ptr<EnvoyQuicServerConnection> quic_connection_;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -245,6 +245,7 @@ protected:
 
   std::string quicStreamState();
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   http2::adapter::HeaderValidator& header_validator() { return header_validator_; }
 
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -59,6 +59,7 @@ public:
   }
   bool loggingDone() { return logging_done_; }
   uint64_t bytesOutstanding() { return bytes_outstanding_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool notify_ack_listener_before_soon_to_be_destroyed() const {
     return notify_ack_listener_before_soon_to_be_destroyed_;
   }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -368,6 +368,7 @@ RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_he
   }
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     Http::Code code = static_cast<Http::Code>(response_status);
     if (code == Http::Code::Conflict) {
       return RetryDecision::RetryWithBackoff;

--- a/source/common/upstream/load_stats_reporter_impl.cc
+++ b/source/common/upstream/load_stats_reporter_impl.cc
@@ -12,6 +12,7 @@ namespace Upstream {
 namespace {
 
 envoy::service::load_stats::v3::LoadStatsRequest
+// NOLINTNEXTLINE(readability-identifier-naming)
 MakeRequestTemplate(const LocalInfo::LocalInfo& local_info) {
   envoy::service::load_stats::v3::LoadStatsRequest request;
   request.mutable_node()->MergeFrom(local_info.node());

--- a/source/extensions/common/dubbo/codec.cc
+++ b/source/extensions/common/dubbo/codec.cc
@@ -121,6 +121,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, Context& context) {
 
 void parseResponseInfoFromBuffer(Buffer::Instance& buffer, Context& context) {
   ASSERT(buffer.length() >= DubboCodec::HeadersSize);
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ResponseStatus status = static_cast<ResponseStatus>(buffer.peekInt<uint8_t>(StatusOffset));
   if (!isValidResponseStatus(status)) {
     throw EnvoyException(

--- a/source/extensions/filters/common/expr/evaluator.h
+++ b/source/extensions/filters/common/expr/evaluator.h
@@ -59,7 +59,9 @@ public:
   FindFunctionOverloads(absl::string_view) const override {
     return {};
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool needs_response_path_data() const { return needs_response_path_data_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool has_response_data() const {
     return activation_response_headers_ != nullptr || activation_response_trailers_ != nullptr;
   }

--- a/source/extensions/filters/http/file_server/absl_status_to_http_status.cc
+++ b/source/extensions/filters/http/file_server/absl_status_to_http_status.cc
@@ -10,6 +10,7 @@ Http::Code abslStatusToHttpStatus(absl::StatusCode code) {
   case absl::StatusCode::kOk:
     return Http::Code::OK;
   case absl::StatusCode::kCancelled:
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     return static_cast<Http::Code>(499);
   case absl::StatusCode::kUnknown:
     return Http::Code::InternalServerError;

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter.cc
@@ -61,6 +61,7 @@ absl::StatusOr<StreamMessagePtr> MessageConverter::accumulateMessage(Envoy::Buff
 
   ENVOY_LOG_MISC(info, "len(parsing_buffer_)={}", parsing_buffer_.length());
   if (parsed_output->owned_bytes != nullptr) {
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     ABSL_DCHECK(!parsed_output->needs_more_data);
     ENVOY_LOG_MISC(info, "len(parsed owned_bytes)={}", parsed_output->owned_bytes->length());
   }
@@ -87,6 +88,7 @@ MessageConverter::accumulateMessages(Envoy::Buffer::Instance& data, bool end_str
 
 absl::StatusOr<Envoy::Buffer::InstancePtr>
 MessageConverter::convertBackToBuffer(StreamMessagePtr message) {
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ABSL_DCHECK(message != nullptr);
   conversions_to_envoy_buffer_++;
   if (conversions_to_envoy_buffer_ > conversions_to_message_data_) {

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.cc
@@ -78,6 +78,7 @@ absl::StatusOr<ParsedGrpcMessage> parseGrpcMessage(CreateMessageDataFunc& factor
     bytes_needed -= slice_length;
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ABSL_DCHECK(bytes_needed == 0) << "Tried reading past the array of slices during "
                                     "parsing. This should never happen as "
                                     "caller already did size checks.";

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.h
@@ -82,21 +82,33 @@ private:
   // MaybeExpandBufferLimits expands the buffer limits for the request and
   // response if the limits are set in the reverse transcoder config and are
   // greater than the default limits.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeExpandBufferLimits() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool DecoderBufferLimitReached(uint64_t buffer_length) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool EncoderBufferLimitReached(uint64_t buffer_length) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CheckAndRejectIfRequestTranscoderFailed() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CheckAndRejectIfResponseTranscoderFailed() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   Grpc::Status::GrpcStatus GrpcStatusFromHeaders(Http::ResponseHeaderMap& headers);
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void InitPerRouteConfig();
   // BuildRequestFromHttpBody reads the contents of the data field of the
   // google.api.HttpBody message and builds the request body out of it.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool BuildRequestFromHttpBody(Buffer::Instance& data);
   // SendHttpBodyResponse sends the response returned from the upstream server
   // as a google.api.HttpBody message.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SendHttpBodyResponse(Buffer::Instance* data);
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void ReplaceAPIVersionInPath();
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CreateDataBuffer(const nlohmann::json& payload, Buffer::OwnedImpl& buffer) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::Status ExtractHttpAnnotationValues(const Protobuf::MethodDescriptor* method_descriptor);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_;

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
@@ -73,19 +73,23 @@ public:
       Api::Api& api);
 
   // Takes the value of the path header of a gRPC request and returns its path descriptor.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const Protobuf::MethodDescriptor* GetMethodDescriptor(absl::string_view path) const;
 
   // Checks if the request body field is of type `google.api.HttpBody`.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool IsRequestNestedHttpBody(const Protobuf::MethodDescriptor* method_descriptor,
                                const std::string& request_body_field) const;
 
   absl::StatusOr<std::unique_ptr<Transcoder>>
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateTranscoder(const Protobuf::MethodDescriptor* method_descriptor,
                    TranscoderInputStream& request_input,
                    TranscoderInputStream& response_input) const;
 
   // Changes the body field to its `json_name` value or to camelCase if the filter
   // is not configured to preserve the proto field names.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::StatusOr<std::string> ChangeBodyFieldName(absl::string_view path,
                                                   absl::string_view body_field) const;
 

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.h
@@ -17,6 +17,7 @@ namespace GrpcJsonReverseTranscoder {
 inline constexpr char reserved_chars[] = " %:?#[]@!$&'()*+,;=";
 
 // This builds grpc-message header value from body data.
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string BuildGrpcMessage(Envoy::Buffer::Instance& body_data);
 
 // Takes the json object and a path and returns the value of the json object at
@@ -28,6 +29,7 @@ std::string BuildGrpcMessage(Envoy::Buffer::Instance& body_data);
 // [-_./0-9a-zA-Z].
 // TODO(numanelahi): Add `~` to the list of characters that are not percent
 // encoded.
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::optional<std::string> GetNestedJsonValueAsString(const nlohmann::json& object,
                                                        const std::string& key,
                                                        bool has_one_path_segment);
@@ -62,6 +64,7 @@ absl::optional<std::string> GetNestedJsonValueAsString(const nlohmann::json& obj
 // param_set = {"a", "e"}, and
 // key_prefix = "prefix"
 // then query_string = "prefix.f=hello%20world&prefix.g=1.234"
+// NOLINTNEXTLINE(readability-identifier-naming)
 void BuildQueryParamString(const nlohmann::json& object,
                            const absl::flat_hash_set<std::string>& ignore_list,
                            std::string* query_string, std::string key_prefix = "");
@@ -86,6 +89,7 @@ void BuildQueryParamString(const nlohmann::json& object,
 // `/v1/projects/123456789/shelves/fiction?description=This%20is%20a%20test%20description&theme=Kids`,
 // when the http_body_field is "shelf", adding `theme` and `description` as
 // query parameters to the http path.
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::StatusOr<std::string> BuildPath(nlohmann::json& request, std::string http_rule_path,
                                       std::string http_body_field);
 

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
@@ -126,6 +126,7 @@ void GetMonitoredResourceLabels(absl::string_view label_extractor,
 
 WireFormatLite::WireType getWireType(const Field& field_desc) {
   static WireFormatLite::WireType field_kind_to_wire_type[] = {
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       static_cast<WireFormatLite::WireType>(-1), // TYPE_UNKNOWN
       WireFormatLite::WIRETYPE_FIXED64,          // TYPE_DOUBLE
       WireFormatLite::WIRETYPE_FIXED32,          // TYPE_FLOAT
@@ -172,6 +173,7 @@ ExtractRepeatedFieldSizeHelper(const FieldExtractor& field_extractor, const std:
         if (field->number() != WireFormatLite::GetTagFieldNumber(tag)) {
           WireFormatLite::SkipField(input_stream, tag);
         } else {
+          // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
           DCHECK_EQ(WireFormatLite::WIRETYPE_LENGTH_DELIMITED, WireFormatLite::GetTagWireType(tag));
 
           uint32_t length;
@@ -224,6 +226,7 @@ int64_t ExtractRepeatedFieldSize(const Type& type,
 
   // SCRUB directive should only be applied to one field. Tools
   // framework validation should check this case.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   DCHECK_EQ(1, field_mask->paths_size());
 
   FieldExtractor field_extractor(&type, std::move(type_finder));
@@ -269,6 +272,7 @@ void RedactPath(std::vector<std::string>::const_iterator path_begin,
     auto* repeated_values = field_value.mutable_list_value()->mutable_values();
     for (int i = 0; i < repeated_values->size(); ++i) {
       Value* value = repeated_values->Mutable(i);
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       CHECK(value->has_struct_value()) << "Cannot redact non-message-type field " << field;
       RedactPath(path_begin, path_end, value->mutable_struct_value());
     }
@@ -281,6 +285,7 @@ void RedactPath(std::vector<std::string>::const_iterator path_begin,
 void RedactPaths(absl::Span<const std::string> paths_to_redact, Struct* proto_struct) {
   for (const std::string& path : paths_to_redact) {
     std::vector<std::string> path_pieces = absl::StrSplit(path, '.', absl::SkipEmpty());
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     CHECK(path_pieces.size() < kMaxRedactedPathDepth)
         << "Attempting to redact path with depth >= " << kMaxRedactedPathDepth << ": " << path;
     RedactPath(path_pieces.begin(), path_pieces.end(), proto_struct);

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
@@ -44,22 +44,28 @@ constexpr int kProtoTranslationMaxRecursionDepth = 64;
 
 ABSL_CONST_INIT const char* const kStructTypeUrl = "type.googleapis.com/google.protobuf.Struct";
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool IsEmptyStruct(const Protobuf::Struct& message_struct);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool IsLabelName(absl::string_view value);
 
 // Monitored resource label names are captured within curly brackets ("{", "}").
 // The format is verified by the service config validator, so to extract label
 // name, we just remove the brackets.
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string GetLabelName(absl::string_view value);
 
 // Singleton mapping of string to ExtractedMessageDirective.
+// NOLINTNEXTLINE(readability-identifier-naming)
 const absl::flat_hash_map<std::string, ExtractedMessageDirective>& StringToDirectiveMap();
 
 absl::optional<ExtractedMessageDirective>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractedMessageDirectiveFromString(absl::string_view directive);
 
 // Returns a mapping of monitored resource label keys to their values.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void GetMonitoredResourceLabels(absl::string_view label_extractor,
                                 absl::string_view resource_string,
                                 Protobuf::Map<std::string, std::string>* labels);
@@ -70,6 +76,7 @@ void GetMonitoredResourceLabels(absl::string_view label_extractor,
 // In case of error or nullptr/empty field_mask, it returns a negative value and
 // logs the error.
 int64_t
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractRepeatedFieldSize(const Protobuf::Type& type,
                          std::function<const Protobuf::Type*(const std::string&)> type_finder,
                          const Protobuf::FieldMask* field_mask,
@@ -78,22 +85,27 @@ ExtractRepeatedFieldSize(const Protobuf::Type& type,
 // Extract the size of the repeated field represented by given field mask
 // path from given proto message. `path` must represent a repeated field.
 absl::StatusOr<int64_t>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractRepeatedFieldSizeHelper(const Protobuf::field_extraction::FieldExtractor& field_extractor,
                                const std::string& path,
                                const Protobuf::field_extraction::MessageData& message);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::string_view ExtractLocationIdFromResourceName(absl::string_view resource_name);
 
 // Recursively redacts the path_pieces in the enclosing proto_struct.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void RedactPath(std::vector<std::string>::const_iterator path_begin,
                 std::vector<std::string>::const_iterator path_end, Protobuf::Struct* proto_struct);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void RedactPaths(absl::Span<const std::string> paths_to_redact, Protobuf::Struct* proto_struct);
 
 // Finds the last value of the non-repeated string field after the first
 // value. Returns an empty string if there is only one string field. Returns
 // an error if the resource is malformed in case that the search goes forever.
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 FindSingularLastValue(const Protobuf::Field* field,
                       Envoy::Protobuf::io::CodedInputStream* input_stream);
 
@@ -104,15 +116,18 @@ FindSingularLastValue(const Protobuf::Field* field,
 // non-repeated field. However, parsers are expected to handle the case in
 // which they do."
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 SingularFieldUseLastValue(const std::string first_value, const Protobuf::Field* field,
                           Envoy::Protobuf::io::CodedInputStream* input_stream);
 
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractStringFieldValue(const Protobuf::Type& type,
                         std::function<const Protobuf::Type*(const std::string&)> type_finder,
                         const std::string& path,
                         const Protobuf::field_extraction::MessageData& message);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator path_pieces_begin,
                                      std::vector<std::string>::const_iterator path_pieces_end,
                                      Protobuf::Struct* message_struct);
@@ -120,6 +135,7 @@ absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator pa
 // Converts given proto message to Struct. It also adds
 // a "@type" property with proto type url to the generated Struct. Expects the
 // TypeResolver to handle types prefixed with "type.googleapis.com/".
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& message,
                              const Envoy::Protobuf::Type& type,
                              ::Envoy::Protobuf::util::TypeResolver* type_resolver,
@@ -131,6 +147,7 @@ absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& mess
 //  (1) `scrubber` is nullptr;
 //  (2) error during scrubbing/converting;
 //  (3) the message is empty after scrubbing;
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool ScrubToStruct(const proto_processing_lib::proto_scrubber::ProtoScrubber* scrubber,
                    const Envoy::Protobuf::Type& type,
                    const ::google::grpc::transcoding::TypeHelper& type_helper,

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
@@ -42,11 +42,13 @@ private:
 
   // Populate the target resource or the target resource callback in the extracted message
   // metadata.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void GetTargetResourceOrTargetResourceCallback(
       const Protobuf::FieldMask& field_mask, const Protobuf::field_extraction::MessageData& message,
       bool callback, ExtractedMessageMetadata* extracted_message_metadata) const;
 
   // Function to get the value associated with a key
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const Protobuf::FieldMask& FindWithDefault(ExtractedMessageDirective directive);
 
   const google::grpc::transcoding::TypeHelper* type_helper_;

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
@@ -41,6 +41,7 @@ public:
   // that contains the extracted message and other extracted message metadata obtained during
   // extraction.
   virtual ExtractedMessageMetadata
+  // NOLINTNEXTLINE(readability-identifier-naming)
   ExtractMessage(const Protobuf::field_extraction::MessageData& message) const = 0;
 
   virtual ~ProtoExtractorInterface() = default;

--- a/source/extensions/filters/http/proto_message_extraction/extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor.h
@@ -57,8 +57,10 @@ public:
   // is the last message. It only keeps the result from the first one the last.
   virtual void processResponse(Protobuf::field_extraction::MessageData& message) = 0;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual const ExtractedMessageResult& GetResult() const = 0;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void ClearResult() = 0;
 };
 

--- a/source/extensions/filters/http/proto_message_extraction/filter.cc
+++ b/source/extensions/filters/http/proto_message_extraction/filter.cc
@@ -321,9 +321,12 @@ Filter::HandleDataStatus Filter::handleEncodeData(Envoy::Buffer::Instance& data,
     // The converter returns an empty stream_message for the last empty
     // buffer.
     if (stream_message->message() == nullptr) {
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(end_stream);
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(stream_message->isFinalMessage());
       // This is the last one in the vector.
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(msg_idx == buffering->size() - 1);
       continue;
     }

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -81,6 +81,7 @@ struct SupportedCommands {
    * @return commands without keys which are sent to all redis shards and the responses are handled
    * using special response handler according  to its response type
    */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static const absl::flat_hash_set<std::string>& ClusterScopeCommands() {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb",
                            "slowlog", "config", "info", "keys", "select", "role", "hello");

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -56,6 +56,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
   ASSERT(data.length() >= DubboProtocolImpl::MessageSize);
   uint8_t flag = data.peekInt<uint8_t>(FlagOffset);
   bool is_two_way = (flag & TwoWayMask) == TwoWayMask ? true : false;
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   SerializationType type = static_cast<SerializationType>(flag & SerializationTypeMask);
   if (!isValidSerializationType(type)) {
     throw EnvoyException(
@@ -72,6 +73,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
 
 void parseResponseInfoFromBuffer(Buffer::Instance& buffer, MessageMetadataSharedPtr metadata) {
   ASSERT(buffer.length() >= DubboProtocolImpl::MessageSize);
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ResponseStatus status = static_cast<ResponseStatus>(buffer.peekInt<uint8_t>(StatusOffset));
   if (!isValidResponseStatus(status)) {
     throw EnvoyException(

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -30,6 +30,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
 
   // The byte at offset 2 is unused and ignored.
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(3));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
@@ -392,6 +393,7 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
     return false;
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(name_len + 4));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(

--- a/source/extensions/matching/http/cel_input/cel_input.h
+++ b/source/extensions/matching/http/cel_input/cel_input.h
@@ -28,7 +28,9 @@ using StreamActivationPtr = std::unique_ptr<Filters::Common::Expr::StreamActivat
 class CelMatchData : public ::Envoy::Matcher::CustomMatchData {
 public:
   explicit CelMatchData(StreamActivationPtr activation) : activation_(std::move(activation)) {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool needs_response() const { return activation_->needs_response_path_data(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool has_response_data() const { return activation_->has_response_data(); }
   StreamActivationPtr activation_;
 };

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
@@ -227,6 +227,7 @@ public:
   bool useTagExtractedName() { return use_tag_extracted_name_; }
   absl::string_view statPrefix() { return stat_prefix_; }
   const Protobuf::RepeatedPtrField<opentelemetry::proto::common::v1::KeyValue>&
+  // NOLINTNEXTLINE(readability-identifier-naming)
   resource_attributes() const {
     return resource_attributes_;
   }

--- a/source/extensions/tracers/datadog/agent_http_client.h
+++ b/source/extensions/tracers/datadog/agent_http_client.h
@@ -92,6 +92,7 @@ public:
    * Return a JSON representation of this object's configuration. This function
    * is used in the startup banner logged by \c dd-trace-cpp.
    */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const nlohmann::json& config_json() const;
 
   // Http::AsyncClient::Callbacks

--- a/source/extensions/tracers/datadog/event_scheduler.h
+++ b/source/extensions/tracers/datadog/event_scheduler.h
@@ -40,6 +40,7 @@ public:
   std::string config() const override;
 
   // Provides JSON configuration for debug logging.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const nlohmann::json& config_json() const;
 
 private:

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -13,6 +13,7 @@
 #include "source/extensions/transport_sockets/common/passthrough.h"
 
 // Defined in /usr/include/linux/tcp.h.
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct tcp_info;
 
 namespace Envoy {


### PR DESCRIPTION
## Summary
Adds targeted clang-tidy fixes for naming and enum-cast-related findings across `source/`, mostly small declaration updates and annotation cleanups with no intended behavior changes.

**This PR not actually fix the naming problem but suppress the errors to make clang-tidy ci happy**. This is because the naming change may affects our forks and I inclined to do it in the future gradually one by one.
