### PR TITLE
clang-tidy: fix modernize and readability issues in source

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -337,8 +337,9 @@ public:
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   NoData(DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(absl::monostate(), data_availability);
+    return {absl::monostate(), data_availability};
   }
 
   /**
@@ -346,21 +347,24 @@ public:
    *duration of matching. Use CreateString when a string must be constructed.
    **/
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateStringView(absl::string_view data,
                    DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(data, data_availability);
+    return {data, data_availability};
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateString(std::string&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(std::move(data), data_availability);
+    return {std::move(data), data_availability};
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateCustom(std::shared_ptr<CustomMatchData>&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(std::move(data), data_availability);
+    return {std::move(data), data_availability};
   }
 
 private:

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -590,7 +590,7 @@ bool OwnedImpl::startsWith(absl::string_view data) const {
     return false;
   }
 
-  if (data.length() == 0) {
+  if (data.empty()) {
     return true;
   }
 

--- a/source/common/common/scope_tracked_object_stack.h
+++ b/source/common/common/scope_tracked_object_stack.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <ranges>
 #include <vector>
 
 #include "envoy/common/execution_context.h"
@@ -24,8 +25,8 @@ public:
   void add(const ScopeTrackedObject& object) { tracked_objects_.push_back(object); }
 
   OptRef<const StreamInfo::StreamInfo> trackedStream() const override {
-    for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
-      OptRef<const StreamInfo::StreamInfo> stream = iter->get().trackedStream();
+    for (const auto& tracked_object : std::ranges::reverse_view(tracked_objects_)) {
+      OptRef<const StreamInfo::StreamInfo> stream = tracked_object.get().trackedStream();
       if (stream.has_value()) {
         return stream;
       }
@@ -34,8 +35,8 @@ public:
   }
 
   void dumpState(std::ostream& os, int indent_level) const override {
-    for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
-      iter->get().dumpState(os, indent_level);
+    for (const auto& tracked_object : std::ranges::reverse_view(tracked_objects_)) {
+      tracked_object.get().dumpState(os, indent_level);
     }
   }
 

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -386,8 +387,8 @@ void DispatcherImpl::onFatalError(std::ostream& os) const {
   // Dump the state of the tracked objects in the dispatcher if thread safe. This generally
   // results in dumping the active state only for the thread which caused the fatal error.
   if (isThreadSafe()) {
-    for (auto iter = tracked_object_stack_.rbegin(); iter != tracked_object_stack_.rend(); ++iter) {
-      (*iter)->dumpState(os);
+    for (auto iter : std::ranges::reverse_view(tracked_object_stack_)) {
+      iter->dumpState(os);
     }
   }
 }

--- a/source/common/formatter/substitution_format_utility.cc
+++ b/source/common/formatter/substitution_format_utility.cc
@@ -18,12 +18,12 @@ absl::Status CommandSyntaxChecker::verifySyntax(CommandSyntaxChecker::CommandSyn
                                                 absl::string_view command,
                                                 absl::string_view subcommand,
                                                 absl::optional<size_t> length) {
-  if ((flags == COMMAND_ONLY) && ((subcommand.length() != 0) || length.has_value())) {
+  if ((flags == COMMAND_ONLY) && ((!subcommand.empty()) || length.has_value())) {
     return absl::InvalidArgumentError(
         fmt::format("{} does not take any parameters or length", command));
   }
 
-  if ((flags & PARAMS_REQUIRED).any() && (subcommand.length() == 0)) {
+  if ((flags & PARAMS_REQUIRED).any() && (subcommand.empty())) {
     return absl::InvalidArgumentError(fmt::format("{} requires parameters", command));
   }
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <ranges>
 #include <string>
 
 #include "envoy/http/header_map.h"
@@ -394,8 +395,8 @@ void HeaderMapImpl::iterate(HeaderMap::ConstIterateCb cb) const {
 }
 
 void HeaderMapImpl::iterateReverse(HeaderMap::ConstIterateCb cb) const {
-  for (auto it = headers_.rbegin(); it != headers_.rend(); it++) {
-    if (cb(*it) == HeaderMap::Iterate::Break) {
+  for (const auto& header : std::ranges::reverse_view(headers_)) {
+    if (cb(header) == HeaderMap::Iterate::Break) {
       break;
     }
   }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <ostream>
+#include <ranges>
 #include <vector>
 
 #include "envoy/event/dispatcher.h"
@@ -1818,8 +1819,8 @@ void ConnectionImpl::onProtocolConstraintViolation() {
 
 void ConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWatermark() {
   // Notify the streams based on least recently encoding to the connection.
-  for (auto it = active_streams_.rbegin(); it != active_streams_.rend(); ++it) {
-    (*it)->runLowWatermarkCallbacks();
+  for (auto& active_stream : std::ranges::reverse_view(active_streams_)) {
+    active_stream->runLowWatermarkCallbacks();
   }
 }
 

--- a/source/common/http/route_config_update_requster.h
+++ b/source/common/http/route_config_update_requster.h
@@ -45,9 +45,7 @@ private:
 class RdsRouteConfigUpdateRequesterFactory : public RouteConfigUpdateRequesterFactory {
 public:
   // UntypedFactory
-  virtual std::string name() const override {
-    return "envoy.route_config_update_requester.default";
-  }
+  std::string name() const override { return "envoy.route_config_update_requester.default"; }
 
   std::unique_ptr<RouteConfigUpdateRequester>
   createRouteConfigUpdateRequester(Router::RouteConfigProvider* route_config_provider) override {

--- a/source/common/jwt/check_audience.h
+++ b/source/common/jwt/check_audience.h
@@ -39,7 +39,7 @@ private:
   std::set<std::string> config_audiences_;
 };
 
-typedef std::unique_ptr<CheckAudience> CheckAudiencePtr;
+using CheckAudiencePtr = std::unique_ptr<CheckAudience>;
 
 } // namespace JwtVerify
 } // namespace Envoy

--- a/source/common/jwt/jwks.cc
+++ b/source/common/jwt/jwks.cc
@@ -4,8 +4,7 @@
 
 #include "source/common/jwt/jwks.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <iostream>
 
 #include "source/common/jwt/struct_utils.h"
@@ -133,7 +132,7 @@ private:
     if (!absl::WebSafeBase64Unescape(s, &s_decoded)) {
       return nullptr;
     }
-    return bssl::UniquePtr<BIGNUM>(BN_bin2bn(castToUChar(s_decoded), s_decoded.length(), NULL));
+    return bssl::UniquePtr<BIGNUM>(BN_bin2bn(castToUChar(s_decoded), s_decoded.length(), nullptr));
   };
 };
 

--- a/source/common/jwt/jwks.h
+++ b/source/common/jwt/jwks.h
@@ -53,7 +53,7 @@ public:
     bssl::UniquePtr<BIO> bio_;
     bssl::UniquePtr<X509> x509_;
   };
-  typedef std::unique_ptr<Pubkey> PubkeyPtr;
+  using PubkeyPtr = std::unique_ptr<Pubkey>;
 
   // Access to list of Jwks
   const std::vector<PubkeyPtr>& keys() const { return keys_; }
@@ -68,7 +68,7 @@ private:
   std::vector<PubkeyPtr> keys_;
 };
 
-typedef std::unique_ptr<Jwks> JwksPtr;
+using JwksPtr = std::unique_ptr<Jwks>;
 
 } // namespace JwtVerify
 } // namespace Envoy

--- a/source/common/jwt/jwt.h
+++ b/source/common/jwt/jwt.h
@@ -62,7 +62,7 @@ struct Jwt {
   /**
    * Standard constructor.
    */
-  Jwt() {}
+  Jwt() = default;
   /**
    * Copy constructor. The copy constructor is marked as explicit as the caller
    * should understand the copy operation is non-trivial as a complete

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -37,8 +37,6 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -106,14 +104,16 @@ template <class Key, class Value, class MapType>
 class SimpleLRUCacheConstIterator
     : public std::iterator<std::input_iterator_tag, const std::pair<Key, Value*>> {
 public:
-  typedef typename MapType::const_iterator HashMapConstIterator;
+  using HashMapConstIterator = typename MapType::const_iterator;
   // Allow parent template's types to be referenced without qualification.
-  typedef typename SimpleLRUCacheConstIterator::reference reference;
-  typedef typename SimpleLRUCacheConstIterator::pointer pointer;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using reference = typename SimpleLRUCacheConstIterator::reference;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using pointer = typename SimpleLRUCacheConstIterator::pointer;
 
   // This default constructed Iterator can only be assigned to or destroyed.
   // All other operations give undefined behaviour.
-  SimpleLRUCacheConstIterator() {}
+  SimpleLRUCacheConstIterator() = default;
   SimpleLRUCacheConstIterator(HashMapConstIterator it, HashMapConstIterator end);
   SimpleLRUCacheConstIterator& operator++();
 
@@ -449,7 +449,8 @@ public:
   }
 
   // STL style const_iterator support
-  typedef SimpleLRUCacheConstIterator<Key, Value, MapType> const_iterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using const_iterator = SimpleLRUCacheConstIterator<Key, Value, MapType>;
   friend class SimpleLRUCacheConstIterator<Key, Value, MapType>;
   const_iterator begin() const { return const_iterator(table_.begin(), table_.end()); }
   const_iterator end() const { return const_iterator(table_.end(), table_.end()); }
@@ -490,13 +491,13 @@ protected:
   virtual bool isOverfull() const { return units_ > max_units_; }
 
 private:
-  typedef SimpleLRUCacheElem<Key, Value> Elem;
-  typedef MapType Table;
-  typedef typename Table::iterator TableIterator;
-  typedef typename Table::const_iterator TableConstIterator;
-  typedef MapType DeferredTable;
-  typedef typename DeferredTable::iterator DeferredTableIterator;
-  typedef typename DeferredTable::const_iterator DeferredTableConstIterator;
+  using Elem = SimpleLRUCacheElem<Key, Value>;
+  using Table = MapType;
+  using TableIterator = typename Table::iterator;
+  using TableConstIterator = typename Table::const_iterator;
+  using DeferredTable = MapType;
+  using DeferredTableIterator = typename DeferredTable::iterator;
+  using DeferredTableConstIterator = typename DeferredTable::const_iterator;
 
   Table table_; // Main table
   // Pinned entries awaiting to be released before they can be discarded.
@@ -1018,7 +1019,7 @@ public:
             total_units) {}
 
 protected:
-  virtual void removeElement(Value* value) { delete value; }
+  void removeElement(Value* value) override { delete value; }
 
 private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(SimpleLRUCache);
@@ -1028,8 +1029,8 @@ template <class Key, class Value, class Deleter, class H, class EQ>
 class SimpleLRUCacheWithDeleter
     : public SimpleLRUCacheBase<
           Key, Value, absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ>, EQ> {
-  typedef absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ> HashMap;
-  typedef SimpleLRUCacheBase<Key, Value, HashMap, EQ> Base;
+  using HashMap = absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ>;
+  using Base = SimpleLRUCacheBase<Key, Value, HashMap, EQ>;
 
 public:
   explicit SimpleLRUCacheWithDeleter(int64_t total_units) : Base(total_units), deleter_() {}
@@ -1038,7 +1039,7 @@ public:
       : Base(total_units), deleter_(deleter) {}
 
 protected:
-  virtual void removeElement(Value* value) { deleter_(value); }
+  void removeElement(Value* value) override { deleter_(value); }
 
 private:
   Deleter deleter_;

--- a/source/common/jwt/status.h
+++ b/source/common/jwt/status.h
@@ -225,7 +225,7 @@ std::string getStatusString(Status status);
  */
 class WithStatus {
 public:
-  WithStatus() : status_(Status::Ok) {}
+  WithStatus() = default;
 
   /**
    * Get the current status.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1982,7 +1982,7 @@ void Filter::onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_re
   // When route retry policy is configured and an upstream filter is returning StopIteration
   // in it's encodeHeaders() method, upstream_requests_.size() is equal to 0 in this case,
   // and we should just return.
-  if (upstream_requests_.size() == 0) {
+  if (upstream_requests_.empty()) {
     return;
   }
 
@@ -2006,7 +2006,7 @@ void Filter::onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
   // When route retry policy is configured and an upstream filter is returning StopIteration
   // in it's encodeHeaders() method, upstream_requests_.size() is equal to 0 in this case,
   // and we should just return.
-  if (upstream_requests_.size() == 0) {
+  if (upstream_requests_.empty()) {
     return;
   }
 

--- a/source/common/router/scoped_config_impl.cc
+++ b/source/common/router/scoped_config_impl.cc
@@ -51,7 +51,7 @@ HeaderValueExtractorImpl::computeFragment(const Http::HeaderMap& headers) const 
   // This is an implicitly untrusted header, so per the API documentation only the first
   // value is used.
   std::vector<absl::string_view> elements{header_entry[0]->value().getStringView()};
-  if (header_value_extractor_config_.element_separator().length() > 0) {
+  if (!header_value_extractor_config_.element_separator().empty()) {
     elements = absl::StrSplit(header_entry[0]->value().getStringView(),
                               header_value_extractor_config_.element_separator());
   }

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -148,7 +148,7 @@ public:
       : SdsApi(sds_config, sds_config_name, subscription_factory, time_source, validation_visitor,
                stats, std::move(destructor_cb), dispatcher, api, warm) {}
 
-  virtual const SecretType* secret() const override PURE;
+  const SecretType* secret() const override PURE;
 
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addValidationCallback(std::function<absl::Status(const SecretType&)> callback) override {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -387,7 +387,7 @@ Config::SharedConfig::parseTLVs(absl::Span<const envoy::config::core::v3::TlvEnt
 
     if (has_value) {
       // Static TLV value must be at least one byte long.
-      if (tlv->value().size() < 1) {
+      if (tlv->value().empty()) {
         throw EnvoyException("Invalid TLV configuration: 'value' must be at least one byte long.");
       }
       tlv_vector.push_back(

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstdint>
 #include <list>
+#include <ranges>
 
 #include "envoy/event/dispatcher.h"
 
@@ -248,8 +249,8 @@ void InstanceImpl::shutdownThread() {
   //                     number than the first. This is an edge case that does not exist anywhere
   //                     in the code today, but we can keep this in mind if things become more
   //                     complicated in the future.
-  for (auto it = thread_local_data_.data_.rbegin(); it != thread_local_data_.data_.rend(); ++it) {
-    it->reset();
+  for (auto& it : std::ranges::reverse_view(thread_local_data_.data_)) {
+    it.reset();
   }
   thread_local_data_.data_.clear();
 }

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -33,7 +33,7 @@ std::string certToPem(X509& cert) {
   const uint8_t* output;
   size_t length;
   RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
-  return std::string(reinterpret_cast<const char*>(output), length);
+  return {reinterpret_cast<const char*>(output), length};
 }
 
 // Iterate the peer certificate chain, converting each certificate to PEM and calling the provided

--- a/source/common/tls/ocsp/asn1_utility.cc
+++ b/source/common/tls/ocsp/asn1_utility.cc
@@ -63,7 +63,7 @@ absl::StatusOr<Envoy::SystemTime> Asn1Utility::parseGeneralizedTime(CBS& cbs) {
   // Local time or time differential, though a part of the `ASN.1`
   // `GENERALIZEDTIME` spec, are not supported.
   // Reference: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.2
-  if (time_str.length() > 0 && absl::ascii_toupper(time_str.at(time_str.length() - 1)) != 'Z') {
+  if (!time_str.empty() && absl::ascii_toupper(time_str.at(time_str.length() - 1)) != 'Z') {
     return absl::InvalidArgumentError("GENERALIZEDTIME must be in UTC");
   }
 

--- a/source/common/upstream/transport_socket_match_impl.cc
+++ b/source/common/upstream/transport_socket_match_impl.cc
@@ -154,7 +154,7 @@ TransportSocketMatcher::MatchData TransportSocketMatcherImpl::resolveUsingMatche
                                              filter_state.get());
   auto on_match = Matcher::evaluateMatch(*matcher_, data);
   if (on_match.isMatch()) {
-    const auto action = on_match.action();
+    const auto& action = on_match.action();
     if (action) {
       const auto& name_action = action->getTyped<TransportSocketNameAction>();
       const std::string& transport_socket_name = name_action.name();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1553,9 +1553,9 @@ ClusterInfoImpl::processHttpForOutlierDetection(Http::ResponseHeaderMap& headers
   // Run matchers.
   http_protocol_options_->outlier_detection_http_error_matcher_[0]->onHttpResponseHeaders(headers,
                                                                                           statuses);
-  return absl::optional<bool>(http_protocol_options_->outlier_detection_http_error_matcher_[0]
-                                  ->matchStatus(statuses)
-                                  .matches_);
+  return {http_protocol_options_->outlier_detection_http_error_matcher_[0]
+              ->matchStatus(statuses)
+              .matches_};
 }
 
 absl::StatusOr<bool> validateTransportSocketSupportsQuic(

--- a/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.h
+++ b/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.h
@@ -26,7 +26,7 @@ public:
                           Event::Dispatcher& dispatcher, const FluentdAccessLogConfig& config,
                           BackOffStrategyPtr backoff_strategy, Stats::Scope& parent_scope);
 
-  void packMessage(MessagePackPacker& packer);
+  void packMessage(MessagePackPacker& packer) override;
 };
 
 using FluentdAccessLoggerWeakPtr = std::weak_ptr<FluentdService>;

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -31,7 +31,7 @@ HttpGrpcAccessLog::HttpGrpcAccessLog(AccessLog::FilterPtr&& filter,
                                      GrpcCommon::GrpcAccessLoggerCacheSharedPtr access_logger_cache,
                                      const Formatter::CommandParserPtrVector& command_parsers)
     : Common::ImplBase(std::move(filter)),
-      config_(std::make_shared<const HttpGrpcAccessLogConfig>(std::move(config))),
+      config_(std::make_shared<const HttpGrpcAccessLogConfig>(config)),
       tls_slot_(tls.allocateSlot()), access_logger_cache_(std::move(access_logger_cache)),
       common_properties_config_(config.common_config(), command_parsers) {
   for (const auto& header : config_->additional_request_headers_to_log()) {

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
@@ -24,7 +24,7 @@ TcpGrpcAccessLog::TcpGrpcAccessLog(AccessLog::FilterPtr&& filter,
                                    GrpcCommon::GrpcAccessLoggerCacheSharedPtr access_logger_cache,
                                    const Formatter::CommandParserPtrVector& command_parsers)
     : Common::ImplBase(std::move(filter)),
-      config_(std::make_shared<const TcpGrpcAccessLogConfig>(std::move(config))),
+      config_(std::make_shared<const TcpGrpcAccessLogConfig>(config)),
       tls_slot_(tls.allocateSlot()), access_logger_cache_(std::move(access_logger_cache)),
       common_properties_config_(config.common_config(), command_parsers) {
   THROW_IF_NOT_OK(Config::Utility::checkTransportVersion(config_->common_config()));

--- a/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
+++ b/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
@@ -106,8 +106,7 @@ uint64_t getBufferSizeBytes(
 std::vector<std::string> getFilterStateObjectsToLog(
     const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&
         config) {
-  return std::vector<std::string>(config.filter_state_objects_to_log().begin(),
-                                  config.filter_state_objects_to_log().end());
+  return {config.filter_state_objects_to_log().begin(), config.filter_state_objects_to_log().end()};
 }
 
 std::vector<Tracing::CustomTagConstSharedPtr> getCustomTags(

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -93,7 +93,7 @@ public:
                                         Server::Configuration::ServerFactoryContext& context,
                                         Stats::Store& stats_store);
 
-  ~DynamicModuleBootstrapExtensionConfig();
+  ~DynamicModuleBootstrapExtensionConfig() override;
 
   /**
    * This is called when an event is scheduled via

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -94,10 +94,10 @@ struct ReverseConnectionSocketConfig {
   // multiple remote clusters in the same ReverseConnectionAddress and therefore should be able
   // to use a single ReverseConnectionIOHandle for multiple remote clusters.
   std::vector<RemoteClusterConnectionConfig>
-      remote_clusters;         // List of remote cluster configurations.
-  bool enable_circuit_breaker; // Whether to place a cluster in backoff when reverse connection
-                               // attempts fail.
-  ReverseConnectionSocketConfig() : enable_circuit_breaker(true) {}
+      remote_clusters;               // List of remote cluster configurations.
+  bool enable_circuit_breaker{true}; // Whether to place a cluster in backoff when reverse
+                                     // connection attempts fail.
+  ReverseConnectionSocketConfig() = default;
 };
 
 /**

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -342,7 +342,7 @@ void UpstreamSocketManager::markSocketDead(const int fd) {
 void UpstreamSocketManager::cleanStaleNodeEntry(const std::string& node_id) {
   // Clean the given node ID if there are no active sockets.
   if (accepted_reverse_connections_.find(node_id) != accepted_reverse_connections_.end() &&
-      accepted_reverse_connections_[node_id].size() > 0) {
+      !accepted_reverse_connections_[node_id].empty()) {
     ENVOY_LOG(trace, "reverse_tunnel: found {} active sockets for node {}.",
               accepted_reverse_connections_[node_id].size(), node_id);
     return;

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
@@ -38,7 +38,7 @@ public:
   UpstreamSocketManager(Event::Dispatcher& dispatcher,
                         ReverseTunnelAcceptorExtension* extension = nullptr);
 
-  ~UpstreamSocketManager();
+  ~UpstreamSocketManager() override;
 
   /**
    * Add accepted connection to socket manager.

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -90,7 +90,7 @@ namespace Redis {
 
 class RedisCluster : public Upstream::BaseDynamicClusterImpl {
 public:
-  ~RedisCluster();
+  ~RedisCluster() override;
   static absl::StatusOr<std::unique_ptr<RedisCluster>>
   create(const envoy::config::cluster::v3::Cluster& cluster,
          const envoy::extensions::clusters::redis::v3::RedisClusterConfig& redis_cluster,

--- a/source/extensions/common/fluentd/fluentd_base.h
+++ b/source/extensions/common/fluentd/fluentd_base.h
@@ -78,7 +78,7 @@ public:
               const std::string& stat_prefix, BackOffStrategyPtr backoff_strategy,
               uint64_t buffer_flush_interval, uint64_t max_buffer_size);
 
-  virtual ~FluentdBase() = default;
+  ~FluentdBase() override = default;
 
   // Tcp::AsyncTcpClientCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -138,7 +138,7 @@ public:
     });
   }
 
-  virtual ~FluentdCacheBase() = default;
+  ~FluentdCacheBase() override = default;
 
   SharedPtrType getOrCreate(const std::shared_ptr<ConfigType>& config,
                             Random::RandomGenerator& random,

--- a/source/extensions/config_subscription/grpc/grpc_mux_failover.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_failover.h
@@ -85,7 +85,7 @@ public:
     }
   }
 
-  virtual ~GrpcMuxFailover() = default;
+  ~GrpcMuxFailover() override = default;
 
   // Attempts to establish a new stream to the either the primary or failover source.
   void establishNewStream() override {

--- a/source/extensions/filters/common/ext_proc/grpc_client.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client.h
@@ -16,7 +16,7 @@ namespace ExternalProcessing {
  */
 template <typename ResponseType> class ProcessorCallbacks : public RequestCallbacks<ResponseType> {
 public:
-  virtual ~ProcessorCallbacks() = default;
+  ~ProcessorCallbacks() override = default;
   virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& response) PURE;
   virtual void onGrpcError(Grpc::Status::GrpcStatus error, const std::string& message) PURE;
   virtual void onGrpcClose() PURE;
@@ -48,7 +48,7 @@ using ProcessorStreamPtr = std::unique_ptr<ProcessorStream<RequestType, Response
 template <typename RequestType, typename ResponseType>
 class ProcessorClient : public ClientBase<RequestType, ResponseType> {
 public:
-  virtual ~ProcessorClient() = default;
+  ~ProcessorClient() override = default;
   virtual ProcessorStreamPtr<RequestType, ResponseType>
   start(ProcessorCallbacks<ResponseType>& callbacks,
         const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -66,7 +66,7 @@ public:
       ABSL_LOCKS_EXCLUDED(mu_);
   void clearUncacheableState() ABSL_LOCKS_EXCLUDED(mu_);
 
-  ~CacheSession();
+  ~CacheSession() override;
 
   class Subscriber {
   public:

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/http/grpc_json_transcoder/http_body_utils.h"
 
+#include <ranges>
+
 #include "envoy/extensions/filters/http/grpc_json_transcoder/v3/transcoder.pb.h"
 
 #include "google/api/httpbody.pb.h"
@@ -87,8 +89,7 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
                              CodedOutputStream::VarintSize64(content_length);
     std::vector<uint32_t> message_sizes;
     message_sizes.reserve(request_body_field_path.size());
-    for (auto it = request_body_field_path.rbegin(); it != request_body_field_path.rend(); ++it) {
-      const Protobuf::Field* field = *it;
+    for (auto field : std::ranges::reverse_view(request_body_field_path)) {
       const uint64_t message_size = envelope_size + content_length;
       const uint32_t field_number = (field->number() << 3) | ProtobufLengthDelimitedField;
       const uint64_t field_size = CodedOutputStream::VarintSize32(field_number) +

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -109,23 +109,25 @@ public:
       const std::string& stats_prefix, Stats::Scope& scope,
       Server::Configuration::FactoryContext& context);
 
-  const std::vector<McpBackendConfig>& backends() const { return backends_; }
-  bool isMultiplexing() const { return backends_.size() > 1; }
-  const std::string& defaultBackendName() const { return default_backend_name_; }
-  Server::Configuration::FactoryContext& factoryContext() const { return factory_context_; }
-  const McpBackendConfig* findBackend(const std::string& name) const;
+  const std::vector<McpBackendConfig>& backends() const override { return backends_; }
+  bool isMultiplexing() const override { return backends_.size() > 1; }
+  const std::string& defaultBackendName() const override { return default_backend_name_; }
+  Server::Configuration::FactoryContext& factoryContext() const override {
+    return factory_context_;
+  }
+  const McpBackendConfig* findBackend(const std::string& name) const override;
 
-  bool hasSessionIdentity() const {
+  bool hasSessionIdentity() const override {
     return !absl::holds_alternative<absl::monostate>(session_identity_.subject_source);
   }
-  const SubjectSource& subjectSource() const { return session_identity_.subject_source; }
-  ValidationMode validationMode() const { return session_identity_.validation_mode; }
-  bool shouldEnforceValidation() const {
+  const SubjectSource& subjectSource() const override { return session_identity_.subject_source; }
+  ValidationMode validationMode() const override { return session_identity_.validation_mode; }
+  bool shouldEnforceValidation() const override {
     return session_identity_.validation_mode == ValidationMode::Enforce;
   }
-  const std::string& metadataNamespace() const { return metadata_namespace_; }
+  const std::string& metadataNamespace() const override { return metadata_namespace_; }
 
-  McpRouterStats& stats() { return stats_; }
+  McpRouterStats& stats() override { return stats_; }
 
 private:
   std::vector<McpBackendConfig> backends_;

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -68,7 +68,7 @@ public:
                             std::chrono::milliseconds send_reports_interval,
                             ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls,
                             Envoy::Event::Dispatcher& main_dispatcher);
-  ~GlobalRateLimitClientImpl() = default;
+  ~GlobalRateLimitClientImpl() override = default;
 
   void onReceiveMessage(RateLimitQuotaResponsePtr&& response) override;
 

--- a/source/extensions/filters/http/transform/transform.cc
+++ b/source/extensions/filters/http/transform/transform.cc
@@ -101,7 +101,7 @@ Transformation::Transformation(const ProtoTransformation& config,
     }
   }
 
-  if (config.headers_mutations().size() > 0) {
+  if (!config.headers_mutations().empty()) {
     auto mutations_or =
         Http::HeaderMutations::create(config.headers_mutations(), context, bodyCommandParsers());
     SET_AND_RETURN_IF_NOT_OK(mutations_or.status(), creation_status);

--- a/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
+++ b/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
@@ -176,7 +176,7 @@ std::string JA4Fingerprinter::getJA4CipherHash(const SSL_CLIENT_HELLO* ssl_clien
   }
 
   if (ciphers.empty()) {
-    return std::string(JA4_HASH_LENGTH, '0');
+    return {JA4_HASH_LENGTH, '0'};
   }
 
   std::sort(ciphers.begin(), ciphers.end());
@@ -239,7 +239,7 @@ std::string JA4Fingerprinter::getJA4ExtensionHash(const SSL_CLIENT_HELLO* ssl_cl
   }
 
   if (extensions.empty()) {
-    return std::string(JA4_HASH_LENGTH, '0');
+    return {JA4_HASH_LENGTH, '0'};
   }
 
   std::sort(extensions.begin(), extensions.end());

--- a/source/extensions/filters/network/ext_proc/ext_proc.h
+++ b/source/extensions/filters/network/ext_proc/ext_proc.h
@@ -48,7 +48,7 @@ struct NetworkExtProcStats {
  */
 class NetworkExtProcLoggingInfo : public Envoy::StreamInfo::FilterState::Object {
 public:
-  explicit NetworkExtProcLoggingInfo() {}
+  explicit NetworkExtProcLoggingInfo() = default;
 
   // Direction-specific aggregated statistics.
   struct DirectionalStats {

--- a/source/extensions/filters/network/redis_proxy/info_command_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/info_command_handler.cc
@@ -444,7 +444,7 @@ std::string InfoCmdAggregateResponseHandler::bytesToHuman(uint64_t bytes) {
     snprintf(buffer, sizeof(buffer), "%" PRIu64 "B", bytes);
   }
 
-  return std::string(buffer);
+  return {buffer};
 }
 
 bool InfoCmdAggregateResponseHandler::shouldIncludeSection(absl::string_view section) const {

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -208,7 +208,7 @@ void OverrideHostLoadBalancer::LoadBalancerImpl::addSelectedHostKey(
 
   const std::string selected_endpoint = response.host->address()->asString();
   const Config::MetadataKey& metadata_key = config_.selectedHostKey().value();
-  if (metadata_key.path_.size() < 1) {
+  if (metadata_key.path_.empty()) {
     // Should not be possible based on proto validation, catching anyways.
     ENVOY_LOG(trace, "Path was not provided in selected_host_key.");
     return;

--- a/source/extensions/local_address_selectors/filter_state_override/config.cc
+++ b/source/extensions/local_address_selectors/filter_state_override/config.cc
@@ -31,7 +31,7 @@ public:
   Upstream::UpstreamLocalAddress getUpstreamLocalAddress(
       const Network::Address::InstanceConstSharedPtr& endpoint_address,
       const Network::ConnectionSocket::OptionsSharedPtr& socket_options,
-      OptRef<const Network::TransportSocketOptions> transport_socket_options) const {
+      OptRef<const Network::TransportSocketOptions> transport_socket_options) const override {
     const auto upstream_address =
         inner_->getUpstreamLocalAddress(endpoint_address, socket_options, transport_socket_options);
     if (transport_socket_options && upstream_address.address_) {

--- a/source/extensions/matching/actions/transform_stat/transform_stat.h
+++ b/source/extensions/matching/actions/transform_stat/transform_stat.h
@@ -70,7 +70,7 @@ public:
 
 class NoOpAction : public Matcher::ActionBase<ProtoTransformStat>, public TransformStatAction {
 public:
-  explicit NoOpAction() {}
+  explicit NoOpAction() = default;
   Result apply(std::string&) const override;
 };
 

--- a/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
+++ b/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
@@ -55,7 +55,7 @@ class LinuxContainerCpuStatsReader : public CpuStatsReader {
 public:
   using ContainerStatsReaderPtr = std::unique_ptr<LinuxContainerCpuStatsReader>;
 
-  virtual ~LinuxContainerCpuStatsReader() = default;
+  ~LinuxContainerCpuStatsReader() override = default;
 
   /**
    * Create the appropriate cgroup stats reader.

--- a/source/extensions/tracers/dynamic_modules/tracer_config.cc
+++ b/source/extensions/tracers/dynamic_modules/tracer_config.cc
@@ -186,7 +186,7 @@ std::string DynamicModuleSpan::getBaggage(absl::string_view key) {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_baggage_(in_module_span_, key_buf, &value_out) &&
       value_out.ptr != nullptr) {
-    return std::string(value_out.ptr, value_out.length);
+    return {value_out.ptr, value_out.length};
   }
   return {};
 }
@@ -202,7 +202,7 @@ void DynamicModuleSpan::setBaggage(absl::string_view key, absl::string_view valu
 std::string DynamicModuleSpan::getTraceId() const {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_trace_id_(in_module_span_, &value_out) && value_out.ptr != nullptr) {
-    return std::string(value_out.ptr, value_out.length);
+    return {value_out.ptr, value_out.length};
   }
   return {};
 }
@@ -210,7 +210,7 @@ std::string DynamicModuleSpan::getTraceId() const {
 std::string DynamicModuleSpan::getSpanId() const {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_span_id_(in_module_span_, &value_out) && value_out.ptr != nullptr) {
-    return std::string(value_out.ptr, value_out.length);
+    return {value_out.ptr, value_out.length};
   }
   return {};
 }

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -171,7 +171,7 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
   ASSERT(b3_head_entry.has_value());
   // This is an implicitly untrusted header, so only the first value is used.
   const std::string b3(b3_head_entry.value());
-  if (!b3.length()) {
+  if (b3.empty()) {
     throw ExtractorException("Invalid input: empty");
   }
 

--- a/source/extensions/transport_sockets/tls/cert_mappers/filter_state_override/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/filter_state_override/config.cc
@@ -15,8 +15,9 @@ namespace {
 class Mapper : public Ssl::UpstreamTlsCertificateMapper {
 public:
   explicit Mapper(const std::string& default_value) : default_value_(default_value) {}
-  std::string deriveFromServerHello(const SSL&,
-                                    const Network::TransportSocketOptionsConstSharedPtr& options) {
+  std::string
+  deriveFromServerHello(const SSL&,
+                        const Network::TransportSocketOptionsConstSharedPtr& options) override {
     if (options) {
       for (const auto& obj : options->downstreamSharedFilterStateObjects()) {
         if (obj.name_ == "envoy.tls.certificate_mappers.on_demand_secret") {

--- a/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
@@ -13,7 +13,7 @@ namespace {
 class SNIMapper : public Ssl::TlsCertificateMapper {
 public:
   explicit SNIMapper(const std::string& default_value) : default_value_(default_value) {}
-  std::string deriveFromClientHello(const SSL_CLIENT_HELLO& ssl_client_hello) {
+  std::string deriveFromClientHello(const SSL_CLIENT_HELLO& ssl_client_hello) override {
     absl::string_view sni = absl::NullSafeStringView(
         SSL_get_servername(ssl_client_hello.ssl, TLSEXT_NAMETYPE_host_name));
     return sni.empty() ? default_value_ : std::string(sni);

--- a/source/extensions/transport_sockets/tls/cert_mappers/static_name/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/static_name/config.cc
@@ -12,9 +12,9 @@ class StaticNameMapper : public Ssl::TlsCertificateMapper,
                          public Ssl::UpstreamTlsCertificateMapper {
 public:
   explicit StaticNameMapper(const std::string& name) : name_(name) {}
-  std::string deriveFromClientHello(const SSL_CLIENT_HELLO&) { return name_; }
+  std::string deriveFromClientHello(const SSL_CLIENT_HELLO&) override { return name_; }
   std::string deriveFromServerHello(const SSL&,
-                                    const Network::TransportSocketOptionsConstSharedPtr&) {
+                                    const Network::TransportSocketOptionsConstSharedPtr&) override {
     return name_;
   }
 

--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
@@ -120,7 +120,7 @@ absl::Status SecretManager::updateCertificate(absl::string_view secret_name,
   CacheEntry& entry = cache_[secret_name];
   entry.cert_context_ = cert_context;
   size_t notify_count = 0;
-  for (auto fetch_handle : entry.callbacks_) {
+  for (const auto& fetch_handle : entry.callbacks_) {
     if (auto handle = fetch_handle.lock(); handle) {
       handle->notify(cert_context);
       notify_count++;
@@ -168,7 +168,7 @@ void SecretManager::doRemoveCertificateConfig(absl::string_view secret_name) {
     return;
   }
   size_t notify_count = 0;
-  for (auto fetch_handle : it->second.callbacks_) {
+  for (const auto& fetch_handle : it->second.callbacks_) {
     if (auto handle = fetch_handle.lock(); handle) {
       handle->notify(nullptr);
       notify_count++;

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -92,7 +92,7 @@ parseTrustBundles(absl::string_view trust_bundle_mapping_str) {
                 return false;
               }
               const auto& certs = key->getStringArray("x5c");
-              if (!certs.ok() || (*certs).size() == 0) {
+              if (!certs.ok() || (*certs).empty()) {
                 parsing_status = absl::InvalidArgumentError(fmt::format(
                     "missing or empty 'x5c' field found in keys for domain: '{}'", domain_name));
                 return false;

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -107,7 +107,7 @@ absl::optional<CgroupPathInfo> CgroupCpuUtil::getCurrentCgroupPath(Filesystem::I
     return absl::nullopt;
   }
 
-  const std::string content = result.value();
+  const std::string& content = result.value();
   const std::vector<std::string> lines = absl::StrSplit(content, '\n');
 
   std::string v2_path;   // Save v2 path in case no v1 found
@@ -381,7 +381,7 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
     return absl::nullopt;
   }
 
-  const std::string content = result.value();
+  const std::string& content = result.value();
   const std::vector<std::string> lines = absl::StrSplit(content, '\n');
 
   std::string v2_mount_point; // Save v2 mount in case no v1 found


### PR DESCRIPTION
## Summary
Updates affected `source/` files with modernize and readability cleanups such as clearer declarations, simplified conditionals, and minor refactors that preserve behavior.