### PR TITLE
clang-tidy: fix member initializer issues in source

### DIFF
--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -192,23 +192,23 @@ private:
   std::vector<std::vector<SipHeader>> headers_{HeaderType::HeaderMaxNum};
 
   std::vector<Operation> operation_list_;
-  absl::optional<absl::string_view> ep_{};
-  absl::optional<absl::string_view> opaque_{};
+  absl::optional<absl::string_view> ep_;
+  absl::optional<absl::string_view> opaque_;
 
-  absl::optional<std::pair<std::string, std::string>> p_cookie_ip_map_{};
+  absl::optional<std::pair<std::string, std::string>> p_cookie_ip_map_;
 
-  absl::optional<absl::string_view> transaction_id_{};
+  absl::optional<absl::string_view> transaction_id_;
 
-  std::string destination_{};
+  std::string destination_;
 
-  std::vector<AffinityEntry> affinity_{};
+  std::vector<AffinityEntry> affinity_;
   std::vector<AffinityEntry>::iterator affinity_iteration_{affinity_.begin()};
 
-  std::string raw_msg_{};
+  std::string raw_msg_;
   State state_{State::TransportBegin};
   bool stop_load_balance_{};
 
-  TraContextMap tra_context_map_{};
+  TraContextMap tra_context_map_;
 
   bool isDomainMatched(
       HeaderType type,

--- a/envoy/network/proxy_protocol.h
+++ b/envoy/network/proxy_protocol.h
@@ -21,7 +21,7 @@ using ProxyProtocolTLVVector = std::vector<ProxyProtocolTLV>;
 struct ProxyProtocolData {
   const Network::Address::InstanceConstSharedPtr src_addr_;
   const Network::Address::InstanceConstSharedPtr dst_addr_;
-  const ProxyProtocolTLVVector tlv_vector_{};
+  const ProxyProtocolTLVVector tlv_vector_;
   std::string asStringForHash() const {
     return std::string(src_addr_ ? src_addr_->asString() : "null") +
            (dst_addr_ ? dst_addr_->asString() : "null");

--- a/envoy/server/admin.h
+++ b/envoy/server/admin.h
@@ -111,7 +111,7 @@ public:
     Type type_;
     std::string id_;   // HTML form ID and query-param name (JS var name rules).
     std::string help_; // Rendered into home-page HTML and /help text.
-    std::vector<absl::string_view> enum_choices_{};
+    std::vector<absl::string_view> enum_choices_;
   };
   using ParamDescriptorVec = std::vector<ParamDescriptor>;
 
@@ -163,7 +163,7 @@ public:
     const GenRequestFn handler_;
     const bool removable_;
     const bool mutates_server_state_;
-    const ParamDescriptorVec params_{};
+    const ParamDescriptorVec params_;
   };
 
   /**

--- a/source/common/access_log/access_log_impl.h
+++ b/source/common/access_log/access_log_impl.h
@@ -188,7 +188,7 @@ public:
                 const StreamInfo::StreamInfo& info) const override;
 
 private:
-  std::vector<bool> configured_flags_{};
+  std::vector<bool> configured_flags_;
 };
 
 /**

--- a/source/common/buffer/buffer_impl.h
+++ b/source/common/buffer/buffer_impl.h
@@ -40,7 +40,7 @@ public:
   using StoragePtr = std::unique_ptr<uint8_t[]>;
 
   struct SizedStorage {
-    StoragePtr mem_{};
+    StoragePtr mem_;
     size_t len_{};
   };
 

--- a/source/common/buffer/watermark_buffer.h
+++ b/source/common/buffer/watermark_buffer.h
@@ -144,7 +144,7 @@ private:
 
   uint64_t buffer_memory_allocated_ = 0;
   // Current bucket index where the account is being tracked in.
-  absl::optional<uint32_t> current_bucket_idx_{};
+  absl::optional<uint32_t> current_bucket_idx_;
 
   WatermarkBufferFactory* factory_ = nullptr;
 

--- a/source/common/common/basic_resource_impl.h
+++ b/source/common/common/basic_resource_impl.h
@@ -49,7 +49,7 @@ public:
   void resetMax() { max_ = std::numeric_limits<uint64_t>::max(); }
 
 protected:
-  std::atomic<uint64_t> current_{};
+  std::atomic<uint64_t> current_{0};
 
 private:
   uint64_t max_;

--- a/source/common/common/thread.cc
+++ b/source/common/common/thread.cc
@@ -67,7 +67,7 @@ struct ThreadIds {
 
 private:
   mutable absl::Mutex mutex_;
-  std::atomic<uint32_t> skip_asserts_{};
+  std::atomic<uint32_t> skip_asserts_{0};
   absl::flat_hash_map<std::thread::id, uint32_t>
       main_threads_to_usage_count_ ABSL_GUARDED_BY(mutex_);
 };

--- a/source/common/event/timer_impl.h
+++ b/source/common/event/timer_impl.h
@@ -71,7 +71,7 @@ private:
   // This has to be atomic for alarms which are handled out of thread, for
   // example if the DispatcherImpl::post is called by two threads, they race to
   // both set this to null.
-  std::atomic<const ScopeTrackedObject*> object_{};
+  std::atomic<const ScopeTrackedObject*> object_{nullptr};
 };
 
 } // namespace Event

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -139,7 +139,7 @@ public:
   void reset() { client_.reset(); }
 
 private:
-  RawAsyncClientSharedPtr client_{};
+  RawAsyncClientSharedPtr client_;
 };
 
 } // namespace Grpc

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -104,9 +104,7 @@ static constexpr absl::string_view COLON_SPACE = ": ";
 
 StreamEncoderImpl::StreamEncoderImpl(ConnectionImpl& connection,
                                      StreamInfo::BytesMeterSharedPtr&& bytes_meter)
-    : connection_(connection), disable_chunk_encoding_(false), chunk_encoding_(true),
-      connect_request_(false), is_tcp_tunneling_(false), is_response_to_head_request_(false),
-      is_response_to_connect_request_(false), bytes_meter_(std::move(bytes_meter)) {
+    : connection_(connection), bytes_meter_(std::move(bytes_meter)) {
   if (!bytes_meter_) {
     bytes_meter_ = std::make_shared<StreamInfo::BytesMeter>();
   }
@@ -535,9 +533,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
                                uint32_t max_headers_kb, const uint32_t max_headers_count)
     : connection_(connection), stats_(stats), codec_settings_(settings),
       encode_only_header_key_formatter_(encodeOnlyFormatterFromSettings(settings)),
-      processing_trailers_(false), handling_upgrade_(false), reset_stream_called_(false),
-      deferred_end_stream_headers_(false), dispatching_(false), max_headers_kb_(max_headers_kb),
-      max_headers_count_(max_headers_count) {
+      max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count) {
   parser_ = std::make_unique<BalsaParser>(type, this, max_headers_kb_ * 1024, enableTrailers(),
                                           codec_settings_.allow_custom_methods_);
 }

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -102,12 +102,12 @@ protected:
   Buffer::BufferMemoryAccountSharedPtr buffer_memory_account_;
   ConnectionImpl& connection_;
   uint32_t read_disable_calls_{};
-  bool disable_chunk_encoding_ : 1;
-  bool chunk_encoding_ : 1;
-  bool connect_request_ : 1;
-  bool is_tcp_tunneling_ : 1;
-  bool is_response_to_head_request_ : 1;
-  bool is_response_to_connect_request_ : 1;
+  bool disable_chunk_encoding_ : 1 = false;
+  bool chunk_encoding_ : 1 = true;
+  bool connect_request_ : 1 = false;
+  bool is_tcp_tunneling_ : 1 = false;
+  bool is_response_to_head_request_ : 1 = false;
+  bool is_response_to_connect_request_ : 1 = false;
 
 private:
   /**
@@ -311,14 +311,14 @@ protected:
   const HeaderKeyFormatterConstPtr encode_only_header_key_formatter_;
   HeaderString current_header_field_;
   HeaderString current_header_value_;
-  bool processing_trailers_ : 1;
-  bool handling_upgrade_ : 1;
-  bool reset_stream_called_ : 1;
+  bool processing_trailers_ : 1 = false;
+  bool handling_upgrade_ : 1 = false;
+  bool reset_stream_called_ : 1 = false;
   // Deferred end stream headers indicate that we are not going to raise headers until the full
   // HTTP/1 message has been flushed from the parser. This allows raising an HTTP/2 style headers
   // block with end stream set to true with no further protocol data remaining.
-  bool deferred_end_stream_headers_ : 1;
-  bool dispatching_ : 1;
+  bool deferred_end_stream_headers_ : 1 = false;
+  bool dispatching_ : 1 = false;
   bool dispatching_slice_already_drained_ : 1;
   StreamInfo::BytesMeterSharedPtr bytes_meter_before_stream_;
   const uint32_t max_headers_kb_;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -301,12 +301,7 @@ ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_l
       pending_send_data_(parent_.connection_.dispatcher().getWatermarkFactory().createBuffer(
           [this]() -> void { this->pendingSendBufferLowWatermark(); },
           [this]() -> void { this->pendingSendBufferHighWatermark(); },
-          []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),
-      local_end_stream_sent_(false), remote_end_stream_(false), remote_rst_(false),
-      data_deferred_(false), received_noninformational_headers_(false),
-      pending_receive_buffer_high_watermark_called_(false),
-      pending_send_buffer_high_watermark_called_(false), reset_due_to_messaging_error_(false),
-      extend_stream_lifetime_flag_(false) {
+          []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })) {
   parent_.stats_.streams_active_.inc();
   if (buffer_limit > 0) {
     setWriteBufferWatermarks(buffer_limit);
@@ -983,8 +978,7 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
       per_stream_buffer_limit_(http2_options.initial_stream_window_size().value()),
       stream_error_on_invalid_http_messaging_(
           http2_options.override_stream_error_on_invalid_http_message().value()),
-      protocol_constraints_(stats, http2_options), dispatching_(false), raised_goaway_(false),
-      random_(random_generator),
+      protocol_constraints_(stats, http2_options), random_(random_generator),
       last_received_data_time_(connection_.dispatcher().timeSource().monotonicTime()) {
   if (http2_options.has_use_oghttp2_codec()) {
     use_oghttp2_library_ = http2_options.use_oghttp2_codec().value();

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -78,7 +78,7 @@ public:
   }
 
 private:
-  absl::optional<uint32_t> concurrent_stream_limit_{};
+  absl::optional<uint32_t> concurrent_stream_limit_;
 };
 
 class Utility {
@@ -439,16 +439,16 @@ protected:
     // to determine whether we should continue processing that data.
     absl::optional<StreamResetReason> reset_reason_;
     HeaderString cookies_;
-    bool local_end_stream_sent_ : 1;
-    bool remote_end_stream_ : 1;
-    bool remote_rst_ : 1;
-    bool data_deferred_ : 1;
-    bool received_noninformational_headers_ : 1;
-    bool pending_receive_buffer_high_watermark_called_ : 1;
-    bool pending_send_buffer_high_watermark_called_ : 1;
-    bool reset_due_to_messaging_error_ : 1;
+    bool local_end_stream_sent_ : 1 = false;
+    bool remote_end_stream_ : 1 = false;
+    bool remote_rst_ : 1 = false;
+    bool data_deferred_ : 1 = false;
+    bool received_noninformational_headers_ : 1 = false;
+    bool pending_receive_buffer_high_watermark_called_ : 1 = false;
+    bool pending_send_buffer_high_watermark_called_ : 1 = false;
+    bool reset_due_to_messaging_error_ : 1 = false;
     // Latch whether this stream is operating with this flag.
-    bool extend_stream_lifetime_flag_ : 1;
+    bool extend_stream_lifetime_flag_ : 1 = false;
     absl::string_view details_;
 
     /**
@@ -808,8 +808,8 @@ private:
   // remove streams from the map when they are closed in order to avoid calls to resetStreamWorker
   // after the stream has been removed from the active list.
   std::map<int32_t, StreamImpl*> pending_deferred_reset_streams_;
-  bool dispatching_ : 1;
-  bool raised_goaway_ : 1;
+  bool dispatching_ : 1 = false;
+  bool raised_goaway_ : 1 = false;
   Event::SchedulableCallbackPtr protocol_constraint_violation_callback_;
   Random::RandomGenerator& random_;
   MonotonicTime last_received_data_time_;

--- a/source/common/io/io_uring_worker_impl.h
+++ b/source/common/io/io_uring_worker_impl.h
@@ -227,7 +227,7 @@ protected:
   // shutdown_ has 3 states. A absl::nullopt indicates the socket has not been shutdown, a false
   // value represents the socket wants to be shutdown but the shutdown has not been performed or
   // completed, and a true value means the socket has been shutdown.
-  absl::optional<bool> shutdown_{};
+  absl::optional<bool> shutdown_;
   // If there is in progress write_or_shutdown_req_ during closing, a write timeout timer may be
   // setup to cancel the write_or_shutdown_req_, either a write request or a shutdown request. So
   // we can make sure all SQEs bounding to the iouring socket is completed and the socket can be

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -190,17 +190,19 @@ template <typename Key, typename Value> const int64_t SimpleLRUCacheElem<Key, Va
 // behavior for that single call.
 class SimpleLRUCacheOptions {
 public:
-  SimpleLRUCacheOptions() : update_eviction_order_(true) {}
+  SimpleLRUCacheOptions() = default;
 
   // If false neither the last modified time (for based age eviction) nor
   // the element ordering (for LRU eviction) will be updated.
   // This value must be the same for both lookup and release.
   // The default is true.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool update_eviction_order() const { return update_eviction_order_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_update_eviction_order(bool v) { update_eviction_order_ = v; }
 
 private:
-  bool update_eviction_order_;
+  bool update_eviction_order_ = true;
 };
 
 // The MapType's value_type must be pair<const Key, Elem*>

--- a/source/common/listener_manager/active_tcp_listener.h
+++ b/source/common/listener_manager/active_tcp_listener.h
@@ -94,7 +94,7 @@ public:
   Network::TcpConnectionHandler& tcp_conn_handler_;
   // The number of connections currently active on this listener. This is typically used for
   // connection balancing across per-handler listeners.
-  std::atomic<uint64_t> num_listener_connections_{};
+  std::atomic<uint64_t> num_listener_connections_{0};
 
   Network::ConnectionBalancer& connection_balancer_;
   // This is the address this listener is listening on. It's used to get the correct listener

--- a/source/common/listener_manager/connection_handler_impl.h
+++ b/source/common/listener_manager/connection_handler_impl.h
@@ -158,7 +158,7 @@ private:
   OptRef<OverloadManager> null_overload_manager_;
   const std::string per_handler_stat_prefix_;
   // Declare before its users ActiveListenerDetails.
-  std::atomic<uint64_t> num_handler_connections_{};
+  std::atomic<uint64_t> num_handler_connections_{0};
   absl::flat_hash_map<uint64_t, std::unique_ptr<ActiveListenerDetails>> listener_map_by_tag_;
   absl::flat_hash_map<std::string, std::shared_ptr<PerAddressActiveListenerDetails>>
       tcp_listener_map_by_address_;

--- a/source/common/matcher/regex_replace.h
+++ b/source/common/matcher/regex_replace.h
@@ -24,8 +24,8 @@ public:
   std::string apply(absl::string_view in) const;
 
 private:
-  Regex::CompiledMatcherPtr regex_{};
-  const std::string substitution_{};
+  Regex::CompiledMatcherPtr regex_;
+  const std::string substitution_;
 };
 
 } // namespace Matcher

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -80,9 +80,6 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
           [this]() -> void { this->onReadBufferLowWatermark(); },
           [this]() -> void { this->onReadBufferHighWatermark(); },
           []() -> void { /* TODO(adisuissa): Handle overflow watermark */ })),
-      detect_early_close_(true), enable_half_close_(false), read_end_stream_raised_(false),
-      read_end_stream_(false), write_end_stream_(false), current_write_end_stream_(false),
-      dispatch_buffered_data_(false), transport_wants_read_(false),
       enable_close_through_filter_manager_(Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.connection_close_through_filter_manager")) {
 

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -264,19 +264,19 @@ private:
   StreamInfo::DetectedCloseType detected_close_type_{StreamInfo::DetectedCloseType::Normal};
   std::chrono::milliseconds buffer_high_watermark_timeout_{};
   Event::TimerPtr buffer_high_watermark_timer_{nullptr};
-  bool detect_early_close_ : 1;
-  bool enable_half_close_ : 1;
-  bool read_end_stream_raised_ : 1;
-  bool read_end_stream_ : 1;
-  bool write_end_stream_ : 1;
-  bool current_write_end_stream_ : 1;
-  bool dispatch_buffered_data_ : 1;
+  bool detect_early_close_ : 1 = true;
+  bool enable_half_close_ : 1 = false;
+  bool read_end_stream_raised_ : 1 = false;
+  bool read_end_stream_ : 1 = false;
+  bool write_end_stream_ : 1 = false;
+  bool current_write_end_stream_ : 1 = false;
+  bool dispatch_buffered_data_ : 1 = false;
   // True if the most recent call to the transport socket's doRead method invoked
   // setTransportSocketIsReadable to schedule read resumption after yielding due to
   // shouldDrainReadBuffer(). When true, readDisable must schedule read resumption when
   // read_disable_count_ == 0 to ensure that read resumption happens when remaining bytes are held
   // in transport socket internal buffers.
-  bool transport_wants_read_ : 1;
+  bool transport_wants_read_ : 1 = false;
   bool enable_close_through_filter_manager_ : 1;
 };
 

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -89,7 +89,7 @@ private:
   quic::QuicVersionManager version_manager_;
   std::unique_ptr<EnvoyQuicDispatcher> quic_dispatcher_;
   const bool kernel_worker_routing_;
-  absl::optional<Runtime::FeatureFlag> enabled_{};
+  absl::optional<Runtime::FeatureFlag> enabled_;
   Network::UdpPacketWriter* udp_packet_writer_;
 
   // The number of runs of the event loop in which at least one CHLO was buffered.

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -66,7 +66,7 @@ public:
 private:
   uint64_t bytes_outstanding_ = 0;
   bool fin_sent_ = false;
-  AccessLog::InstanceSharedPtrVector access_log_handlers_{};
+  AccessLog::InstanceSharedPtrVector access_log_handlers_;
   Http::RequestHeaderMapConstSharedPtr request_header_map_;
   Http::ResponseHeaderMapConstSharedPtr response_header_map_;
   Http::ResponseTrailerMapConstSharedPtr response_trailer_map_;

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -88,14 +88,8 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
                        : nullptr,
                    StreamInfo::FilterState::LifeSpan::FilterChain),
       start_time_(parent_.callbacks()->dispatcher().timeSource().monotonicTime()),
-      upstream_canary_(false), router_sent_end_stream_(false), encode_trailers_(false),
-      retried_(false), awaiting_headers_(true), outlier_detection_timeout_recorded_(false),
-      create_per_try_timeout_on_request_complete_(false), paused_for_connect_(false),
-      paused_for_websocket_(false), reset_stream_(false),
       record_timeout_budget_(parent_.cluster()->timeoutBudgetStats().has_value()),
-      cleaned_up_(false), had_upstream_(false),
-      stream_options_({can_send_early_data, can_use_http3}), grpc_rq_success_deferred_(false),
-      enable_half_close_(enable_half_close) {
+      stream_options_({can_send_early_data, can_use_http3}), enable_half_close_(enable_half_close) {
   // Get tracing config once and reuse it.
   auto tracing_config = parent_.callbacks()->tracingConfig();
 

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -238,29 +238,29 @@ private:
   // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
   // Tracks the number of times the flow of data from downstream has been disabled.
   uint32_t downstream_data_disabled_{};
-  bool upstream_canary_ : 1;
-  bool router_sent_end_stream_ : 1;
-  bool encode_trailers_ : 1;
-  bool retried_ : 1;
-  bool awaiting_headers_ : 1;
-  bool outlier_detection_timeout_recorded_ : 1;
+  bool upstream_canary_ : 1 = false;
+  bool router_sent_end_stream_ : 1 = false;
+  bool encode_trailers_ : 1 = false;
+  bool retried_ : 1 = false;
+  bool awaiting_headers_ : 1 = true;
+  bool outlier_detection_timeout_recorded_ : 1 = false;
   // Tracks whether we deferred a per try timeout because the downstream request
   // had not been completed yet.
-  bool create_per_try_timeout_on_request_complete_ : 1;
+  bool create_per_try_timeout_on_request_complete_ : 1 = false;
   // True if the CONNECT headers have been sent but proxying payload is paused
   // waiting for response headers.
-  bool paused_for_connect_ : 1;
-  bool paused_for_websocket_ : 1;
-  bool reset_stream_ : 1;
+  bool paused_for_connect_ : 1 = false;
+  bool paused_for_websocket_ : 1 = false;
+  bool reset_stream_ : 1 = false;
 
   // Sentinel to indicate if timeout budget tracking is configured for the cluster,
   // and if so, if the per-try histogram should record a value.
   bool record_timeout_budget_ : 1;
   // Track if one time clean up has been performed.
-  bool cleaned_up_ : 1;
-  bool had_upstream_ : 1;
+  bool cleaned_up_ : 1 = false;
+  bool had_upstream_ : 1 = false;
   Http::ConnectionPool::Instance::StreamOptions stream_options_;
-  bool grpc_rq_success_deferred_ : 1;
+  bool grpc_rq_success_deferred_ : 1 = false;
   bool enable_half_close_ : 1;
 };
 

--- a/source/common/ssl/tls_certificate_config_impl.h
+++ b/source/common/ssl/tls_certificate_config_impl.h
@@ -51,7 +51,7 @@ private:
   const std::string password_path_;
   const std::vector<uint8_t> ocsp_staple_;
   const std::string ocsp_staple_path_;
-  Envoy::Ssl::PrivateKeyMethodProviderSharedPtr private_key_method_{};
+  Envoy::Ssl::PrivateKeyMethodProviderSharedPtr private_key_method_;
 };
 
 } // namespace Ssl

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -35,7 +35,7 @@ private:
     absl::optional<ConstSupportedBuckets> buckets_;
     absl::optional<uint32_t> bins_;
   };
-  const std::vector<Config> configs_{};
+  const std::vector<Config> configs_;
 };
 
 /**

--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -586,7 +586,7 @@ private:
   bool should_scheme_match_upstream_{false};
   bool should_drain_connection_{false};
   bool is_shadow_{false};
-  absl::optional<uint32_t> codec_stream_id_{};
+  absl::optional<uint32_t> codec_stream_id_;
 };
 
 } // namespace StreamInfo

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -757,7 +757,7 @@ protected:
   // the upstream connection is established.
   bool receive_before_connect_{false};
   bool early_data_end_stream_{false};
-  Buffer::OwnedImpl early_data_buffer_{};
+  Buffer::OwnedImpl early_data_buffer_;
   HttpStreamDecoderFilterCallbacks upstream_decoder_filter_callbacks_;
 
   // Connection establishment mode configuration.

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -50,7 +50,7 @@ public:
                    Upstream::HostDescriptionConstSharedPtr host) override;
 
 private:
-  absl::optional<Upstream::TcpPoolData> conn_pool_data_{};
+  absl::optional<Upstream::TcpPoolData> conn_pool_data_;
   Tcp::ConnectionPool::Cancellable* upstream_handle_{};
   GenericConnectionPoolCallbacks* callbacks_{};
   Tcp::ConnectionPool::UpstreamCallbacks& upstream_callbacks_;
@@ -155,7 +155,7 @@ private:
                           Ssl::ConnectionInfoConstSharedPtr ssl_info);
   const TunnelingConfigHelper& config_;
   Http::CodecType type_;
-  absl::optional<Upstream::HttpPoolData> conn_pool_data_{};
+  absl::optional<Upstream::HttpPoolData> conn_pool_data_;
   Http::ConnectionPool::Cancellable* upstream_handle_{};
   GenericConnectionPoolCallbacks* callbacks_{};
   Http::StreamDecoderFilterCallbacks* decoder_filter_callbacks_;

--- a/source/common/tls/context_impl.h
+++ b/source/common/tls/context_impl.h
@@ -53,7 +53,7 @@ struct TlsContext {
   // for "not an ECDSA context".
   CurveNID ec_group_curve_name_ = EC_CURVE_INVALID_NID;
   bool is_must_staple_{};
-  Ssl::PrivateKeyMethodProviderSharedPtr private_key_method_provider_{};
+  Ssl::PrivateKeyMethodProviderSharedPtr private_key_method_provider_;
 
 #ifdef ENVOY_ENABLE_QUIC
   quiche::QuicheReferenceCountedPointer<quic::ProofSource::Chain> quic_cert_;

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -816,7 +816,7 @@ private:
     // Keep smaller fields near the end to reduce padding
     const bool added_via_api_ : 1;
     const bool avoid_cds_removal_ : 1;
-    bool added_or_updated_ : 1;
+    bool added_or_updated_ : 1 = false;
     const bool required_for_ads_ : 1;
   };
 

--- a/source/common/upstream/load_stats_reporter_impl.h
+++ b/source/common/upstream/load_stats_reporter_impl.h
@@ -75,7 +75,7 @@ private:
   Grpc::AsyncClient<envoy::service::load_stats::v3::LoadStatsRequest,
                     envoy::service::load_stats::v3::LoadStatsResponse>
       async_client_;
-  Grpc::AsyncStream<envoy::service::load_stats::v3::LoadStatsRequest> stream_{};
+  Grpc::AsyncStream<envoy::service::load_stats::v3::LoadStatsRequest> stream_;
   const Protobuf::MethodDescriptor& service_method_;
   Event::TimerPtr retry_timer_;
   Event::TimerPtr response_timer_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -138,7 +138,7 @@ public:
   double successRate(SuccessRateMonitorType) const override { return -1; }
 
 private:
-  const absl::optional<MonotonicTime> time_{};
+  const absl::optional<MonotonicTime> time_;
 };
 
 /**
@@ -479,13 +479,14 @@ private:
 
   void setEdsHealthFlag(envoy::config::core::v3::HealthStatus health_status);
 
-  std::atomic<uint32_t> health_flags_{};
+  std::atomic<uint32_t> health_flags_{0};
   std::atomic<uint32_t> weight_;
   bool disable_active_health_check_;
   // TODO(wbpcode): should we store the EDS health status to health_flags_ to get unified status or
   // flag access? May be we could refactor HealthFlag to contain all these statuses and flags in the
   // future.
-  std::atomic<Host::HealthStatus> eds_health_status_{};
+  std::atomic<Host::HealthStatus> eds_health_status_{
+      envoy::config::core::v3::HealthStatus::UNKNOWN};
   // 0 indicates no status has been set.
   std::atomic<uint64_t> last_hc_http_status_{0};
 
@@ -501,7 +502,7 @@ private:
     }
     const std::weak_ptr<const HostImplBase> parent_;
   };
-  mutable std::atomic<uint32_t> handle_count_{};
+  mutable std::atomic<uint32_t> handle_count_{0};
 };
 
 class HostImpl : public HostImplBase, public HostDescriptionImpl {
@@ -685,7 +686,7 @@ using HostSetImplPtr = std::unique_ptr<HostSetImpl>;
  */
 class PrioritySetImpl : public PrioritySet {
 public:
-  PrioritySetImpl() : batch_update_(false) {}
+  PrioritySetImpl() = default;
   // From PrioritySet
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addMemberUpdateCb(MemberUpdateCb callback) const override {
@@ -750,7 +751,7 @@ private:
       member_update_cb_helper_;
   mutable Common::CallbackManager<void, uint32_t, const HostVector&, const HostVector&>
       priority_update_cb_helper_;
-  bool batch_update_ : 1;
+  bool batch_update_ : 1 = false;
 
   // Helper class to maintain state as we perform multiple host updates. Keeps track of all hosts
   // that have been added/removed throughout the batch update, and ensures that we properly manage
@@ -1251,7 +1252,7 @@ protected:
   Outlier::DetectorSharedPtr outlier_detector_;
   const bool wait_for_warm_on_init_;
 
-  Server::Configuration::TransportSocketFactoryContextImplPtr transport_factory_context_{};
+  Server::Configuration::TransportSocketFactoryContextImplPtr transport_factory_context_;
 
 protected:
   Random::RandomGenerator& random_;

--- a/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
+++ b/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
@@ -115,8 +115,7 @@ RateLimiterProviderSingleton::TokenBucketSubscription::getLimiter() {
 RateLimiterProviderSingleton::TokenBucketSubscription::TokenBucketSubscription(
     RateLimiterProviderSingleton& parent, absl::string_view resource_name)
     : parent_(parent), resource_name_(resource_name),
-      resource_type_helper_(parent.factory_context_.messageValidationVisitor(), ""),
-      token_bucket_config_hash_(0) {
+      resource_type_helper_(parent.factory_context_.messageValidationVisitor(), "") {
   subscription_ =
       THROW_OR_RETURN_VALUE(parent.factory_context_.xdsManager().subscribeToSingletonResource(
                                 resource_name, parent.config_source_,

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.cc
@@ -17,7 +17,7 @@ namespace ReverseConnection {
 
 // ReverseTunnelAcceptor implementation
 ReverseTunnelAcceptor::ReverseTunnelAcceptor(Server::Configuration::ServerFactoryContext& context)
-    : extension_(nullptr), context_(&context) {
+    : context_(&context) {
   ENVOY_LOG(debug, "reverse_tunnel: created acceptor");
 }
 

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor.h
@@ -43,7 +43,7 @@ public:
    */
   ReverseTunnelAcceptor(Server::Configuration::ServerFactoryContext& context);
 
-  ReverseTunnelAcceptor() : extension_(nullptr), context_(nullptr) {}
+  ReverseTunnelAcceptor() = default;
 
   // SocketInterface overrides
   /**

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -190,7 +190,6 @@ DynamicModuleCluster::DynamicModuleCluster(const envoy::config::cluster::v3::Clu
                                            Upstream::ClusterFactoryContext& context,
                                            absl::Status& creation_status)
     : ClusterImplBase(cluster, context, creation_status), config_(std::move(config)),
-      in_module_cluster_(nullptr),
       dispatcher_(context.serverFactoryContext().mainThreadDispatcher()),
       server_context_(context.serverFactoryContext()) {
 
@@ -642,7 +641,7 @@ bool DynamicModuleLoadBalancer::withActiveInstance(
 
 DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(
     const DynamicModuleClusterHandleSharedPtr& handle, const Upstream::PrioritySet& priority_set)
-    : handle_(handle), priority_set_(priority_set), in_module_lb_(nullptr) {
+    : handle_(handle), priority_set_(priority_set) {
   // Register before invoking any module hook so a concurrent async host selection completion can
   // validate its raw pointer against a live instance.
   registerActiveDynamicModuleLoadBalancer(this);

--- a/source/extensions/common/dubbo/codec.h
+++ b/source/extensions/common/dubbo/codec.h
@@ -40,7 +40,7 @@ public:
   static constexpr int32_t MaxBodySize = 16 * 1024 * 1024;
 
 private:
-  SerializerPtr serializer_{};
+  SerializerPtr serializer_;
 };
 
 class DirectResponseUtil {

--- a/source/extensions/common/dubbo/message.h
+++ b/source/extensions/common/dubbo/message.h
@@ -252,7 +252,7 @@ public:
   ResponseContent& content() const { return content_; }
 
 private:
-  absl::optional<RpcResponseType> response_type_{};
+  absl::optional<RpcResponseType> response_type_;
   mutable ResponseContent content_;
 };
 

--- a/source/extensions/common/dubbo/metadata.h
+++ b/source/extensions/common/dubbo/metadata.h
@@ -46,7 +46,7 @@ public:
 
 private:
   MessageType message_type_{MessageType::Request};
-  absl::optional<ResponseStatus> response_status_{};
+  absl::optional<ResponseStatus> response_status_;
 
   int64_t request_id_{};
   size_t body_size_{};

--- a/source/extensions/common/matcher/matcher.h
+++ b/source/extensions/common/matcher/matcher.h
@@ -53,7 +53,7 @@ public:
 
     bool matches_{false};            // Does the matcher currently match?
     bool might_change_status_{true}; // Is it possible for matches_ to change in subsequent updates?
-    std::unique_ptr<MatcherCtx> ctx_{}; // Context used by matchers to save interim context.
+    std::unique_ptr<MatcherCtx> ctx_; // Context used by matchers to save interim context.
   };
 
   using MatchStatusVector = std::vector<MatchStatus>;

--- a/source/extensions/common/redis/cluster_refresh_manager_impl.h
+++ b/source/extensions/common/redis/cluster_refresh_manager_impl.h
@@ -35,10 +35,10 @@ public:
           redirects_threshold_(redirects_threshold), failure_threshold_(failure_threshold),
           host_degraded_threshold_(host_degraded_threshold), cb_(std::move(cb)) {}
     std::string cluster_name_;
-    std::atomic<uint64_t> last_callback_time_ms_{};
-    std::atomic<uint32_t> redirects_count_{};
-    std::atomic<uint32_t> failures_count_{};
-    std::atomic<uint32_t> host_degraded_count_{};
+    std::atomic<uint64_t> last_callback_time_ms_{0};
+    std::atomic<uint32_t> redirects_count_{0};
+    std::atomic<uint32_t> failures_count_{0};
+    std::atomic<uint32_t> host_degraded_count_{0};
     std::chrono::milliseconds min_time_between_triggering_;
     const uint32_t redirects_threshold_;
     const uint32_t failure_threshold_;

--- a/source/extensions/common/wasm/foreign.cc
+++ b/source/extensions/common/wasm/foreign.cc
@@ -262,7 +262,7 @@ protected:
     const Filters::Common::Expr::Builder* builder() const { return builder_.get(); }
 
   private:
-    const Filters::Common::Expr::BuilderConstPtr builder_{};
+    const Filters::Common::Expr::BuilderConstPtr builder_;
     uint32_t next_expr_token_ = 0;
     absl::flat_hash_map<uint32_t, ExpressionData> expr_;
   };

--- a/source/extensions/common/wasm/plugin.h
+++ b/source/extensions/common/wasm/plugin.h
@@ -29,7 +29,7 @@ public:
 
 private:
   const envoy::extensions::wasm::v3::PluginConfig config_;
-  proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_{};
+  proxy_wasm::AllowedCapabilitiesMap allowed_capabilities_;
   EnvironmentVariableMap envs_;
 };
 

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -224,7 +224,7 @@ private:
   PluginSharedPtr plugin_;
   RemoteAsyncDataProviderPtr remote_data_provider_;
   const bool is_singleton_handle_{};
-  WasmHandleSharedPtr base_wasm_{};
+  WasmHandleSharedPtr base_wasm_;
   absl::variant<absl::monostate, SinglePluginHandle, ThreadLocalPluginHandle> plugin_handle_;
 };
 

--- a/source/extensions/config_subscription/grpc/grpc_mux_failover.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_failover.h
@@ -70,8 +70,7 @@ public:
                   Event::Dispatcher& dispatcher)
       : grpc_mux_callbacks_(grpc_mux_callbacks), primary_callbacks_(*this),
         primary_grpc_stream_(std::move(primary_stream_creator(&primary_callbacks_))),
-        connection_state_(ConnectionState::None), ever_connected_to_primary_(false),
-        previously_connected_to_(ConnectedTo::None) {
+        connection_state_(ConnectionState::None), previously_connected_to_(ConnectedTo::None) {
     ASSERT(primary_grpc_stream_ != nullptr);
     if (failover_stream_creator.has_value()) {
       ENVOY_LOG(warn, "Using xDS-Failover. Note that the implementation is currently considered "

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.h
@@ -261,7 +261,7 @@ private:
     TtlManager ttl_;
     // The identifier for the server that sent the most recent response, or
     // empty if there is none.
-    std::string control_plane_identifier_{};
+    std::string control_plane_identifier_;
     // If true, xDS resources were previously fetched from an xDS source or an xDS delegate.
     bool previously_fetched_data_{false};
   };

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
@@ -117,7 +117,7 @@ public:
 
     WatchMap watch_map_;
     DeltaSubscriptionState sub_state_;
-    std::string control_plane_identifier_{};
+    std::string control_plane_identifier_;
 
     SubscriptionStuff(const SubscriptionStuff&) = delete;
     SubscriptionStuff& operator=(const SubscriptionStuff&) = delete;

--- a/source/extensions/config_subscription/grpc/xds_mux/subscription_state.h
+++ b/source/extensions/config_subscription/grpc/xds_mux/subscription_state.h
@@ -130,7 +130,7 @@ protected:
   UntypedConfigUpdateCallbacks& callbacks_;
   Event::Dispatcher& dispatcher_;
   bool dynamic_context_changed_{};
-  std::string control_plane_identifier_{};
+  std::string control_plane_identifier_;
   XdsConfigTrackerOptRef xds_config_tracker_;
   XdsResourcesDelegateOptRef xds_resources_delegate_;
   const std::string target_xds_authority_;

--- a/source/extensions/filters/common/expr/cel_state.h
+++ b/source/extensions/filters/common/expr/cel_state.h
@@ -82,7 +82,7 @@ private:
   const bool readonly_;
   const CelStateType type_;
   absl::string_view schema_;
-  std::string value_{};
+  std::string value_;
   bool initialized_{false};
 };
 

--- a/source/extensions/filters/http/decompressor/decompressor_filter.h
+++ b/source/extensions/filters/http/decompressor/decompressor_filter.h
@@ -238,8 +238,8 @@ private:
   }
 
   DecompressorFilterConfigSharedPtr config_;
-  Compression::Decompressor::DecompressorPtr request_decompressor_{};
-  Compression::Decompressor::DecompressorPtr response_decompressor_{};
+  Compression::Decompressor::DecompressorPtr request_decompressor_;
+  Compression::Decompressor::DecompressorPtr response_decompressor_;
   ByteTracker request_byte_tracker_;
   ByteTracker response_byte_tracker_;
 };

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -561,10 +561,10 @@ private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   Http::RequestHeaderMap* request_headers_;
-  Http::HeaderVector response_headers_to_add_{};
-  Http::HeaderVector response_headers_to_set_{};
-  Http::HeaderVector response_headers_to_add_if_absent_{};
-  Http::HeaderVector response_headers_to_overwrite_if_exists_{};
+  Http::HeaderVector response_headers_to_add_;
+  Http::HeaderVector response_headers_to_set_;
+  Http::HeaderVector response_headers_to_add_if_absent_;
+  Http::HeaderVector response_headers_to_overwrite_if_exists_;
   State state_{State::NotStarted};
   FilterReturn filter_return_{FilterReturn::ContinueDecoding};
   Upstream::ClusterInfoConstSharedPtr cluster_;
@@ -580,7 +580,7 @@ private:
   bool initiating_call_{};
   bool buffer_data_{};
   bool skip_check_{false};
-  envoy::service::auth::v3::CheckRequest check_request_{};
+  envoy::service::auth::v3::CheckRequest check_request_;
 };
 
 } // namespace ExtAuthz

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -681,11 +681,11 @@ private:
   DecodingProcessorState decoding_state_;
   EncodingProcessorState encoding_state_;
 
-  std::vector<std::string> untyped_forwarding_namespaces_{};
-  std::vector<std::string> typed_forwarding_namespaces_{};
-  std::vector<std::string> untyped_receiving_namespaces_{};
-  std::vector<std::string> untyped_cluster_metadata_forwarding_namespaces_{};
-  std::vector<std::string> typed_cluster_metadata_forwarding_namespaces_{};
+  std::vector<std::string> untyped_forwarding_namespaces_;
+  std::vector<std::string> typed_forwarding_namespaces_;
+  std::vector<std::string> untyped_receiving_namespaces_;
+  std::vector<std::string> untyped_cluster_metadata_forwarding_namespaces_;
+  std::vector<std::string> typed_cluster_metadata_forwarding_namespaces_;
   Http::StreamFilterCallbacks* filter_callbacks_;
   Http::StreamFilterSidestreamWatermarkCallbacks watermark_callbacks_;
 

--- a/source/extensions/filters/http/fault/fault_filter.h
+++ b/source/extensions/filters/http/fault/fault_filter.h
@@ -98,7 +98,7 @@ private:
   Filters::Common::Fault::FaultAbortConfigPtr request_abort_config_;
   std::string upstream_cluster_; // restrict faults to specific upstream cluster
   const std::vector<Http::HeaderUtility::HeaderDataPtr> fault_filter_headers_;
-  absl::flat_hash_set<std::string> downstream_nodes_{}; // Inject failures for specific downstream
+  absl::flat_hash_set<std::string> downstream_nodes_; // Inject failures for specific downstream
   absl::optional<uint64_t> max_active_faults_;
 
   Filters::Common::Fault::FaultRateLimitConfigPtr response_rate_limit_;
@@ -223,16 +223,16 @@ private:
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   Http::StreamEncoderFilterCallbacks* encoder_callbacks_{};
   Event::TimerPtr delay_timer_;
-  std::string downstream_cluster_{};
+  std::string downstream_cluster_;
   std::unique_ptr<Stats::StatNameDynamicStorage> downstream_cluster_storage_;
   const FaultSettings* fault_settings_;
   bool fault_active_{};
   std::unique_ptr<Envoy::Extensions::HttpFilters::Common::StreamRateLimiter> response_limiter_;
-  std::string downstream_cluster_delay_percent_key_{};
-  std::string downstream_cluster_abort_percent_key_{};
-  std::string downstream_cluster_delay_duration_key_{};
-  std::string downstream_cluster_abort_http_status_key_{};
-  std::string downstream_cluster_abort_grpc_status_key_{};
+  std::string downstream_cluster_delay_percent_key_;
+  std::string downstream_cluster_abort_percent_key_;
+  std::string downstream_cluster_delay_duration_key_;
+  std::string downstream_cluster_abort_http_status_key_;
+  std::string downstream_cluster_abort_grpc_status_key_;
 };
 
 } // namespace Fault

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
@@ -57,11 +57,11 @@ private:
   // The actual size of the response returned by the upstream so far.
   uint32_t upstream_response_bytes_{};
 
-  std::string content_type_{};
+  std::string content_type_;
   Grpc::Status::GrpcStatus grpc_status_{};
   // Normally we'd use the encoding buffer, but since we need to mutate the
   // buffer we instead maintain our own.
-  Buffer::OwnedImpl buffer_{};
+  Buffer::OwnedImpl buffer_;
 };
 
 using FilterPtr = std::unique_ptr<Filter>;

--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.h
@@ -101,7 +101,7 @@ public:
   }
 
   envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder::
-      RequestValidationOptions request_validation_options_{};
+      RequestValidationOptions request_validation_options_;
 
   absl::optional<uint32_t> max_request_body_size_;
   absl::optional<uint32_t> max_response_body_size_;

--- a/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/scrubbing_util_lib/field_checker.cc
@@ -107,7 +107,7 @@ FieldChecker::FieldChecker(const ScrubberContext scrubber_context,
                            const std::string& method_name,
                            const ProtoApiScrubberFilterConfig* filter_config)
     : scrubber_context_(scrubber_context), matching_data_(*stream_info), method_name_(method_name),
-      filter_config_ptr_(filter_config), root_descriptor_(nullptr) {
+      filter_config_ptr_(filter_config) {
 
   if (request_headers.has_value()) {
     matching_data_.onRequestHeaders(request_headers.ref());

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -164,7 +164,7 @@ private:
   // Client is stored as the bare object since GrpcAsyncClient already takes ownership of the given
   // raw AsyncClientPtr.
   GrpcAsyncClient async_client_;
-  Grpc::AsyncStream<RateLimitQuotaUsageReports> stream_{};
+  Grpc::AsyncStream<RateLimitQuotaUsageReports> stream_;
 
   // Reference to TLS slot for the global quota bucket cache. It outlives
   // the filter.

--- a/source/extensions/filters/http/thrift_to_metadata/filter.h
+++ b/source/extensions/filters/http/thrift_to_metadata/filter.h
@@ -74,8 +74,8 @@ public:
 private:
   const ProtoRule rule_;
   const uint16_t rule_id_;
-  std::string method_name_{};
-  ThriftMetadataToProtobufValue protobuf_value_extracter_{};
+  std::string method_name_;
+  ThriftMetadataToProtobufValue protobuf_value_extracter_;
 };
 
 using Rules = std::vector<Rule>;

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.h
@@ -151,7 +151,7 @@ private:
   absl::flat_hash_map<uint8_t, KeyValuePair> tlv_types_;
   const bool allow_requests_without_proxy_protocol_;
   const bool pass_all_tlvs_;
-  absl::flat_hash_set<uint8_t> pass_through_tlvs_{};
+  absl::flat_hash_set<uint8_t> pass_through_tlvs_;
   bool allow_v1_{true};
   bool allow_v2_{true};
   const envoy::extensions::filters::listener::proxy_protocol::v3::ProxyProtocol::TlvLocation

--- a/source/extensions/filters/network/dubbo_proxy/active_message.cc
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.cc
@@ -15,7 +15,7 @@ ActiveResponseDecoder::ActiveResponseDecoder(ActiveMessage& parent, DubboFilterS
                                              ProtocolPtr&& protocol)
     : parent_(parent), stats_(stats), response_connection_(connection),
       protocol_(std::move(protocol)),
-      decoder_(std::make_unique<ResponseDecoder>(*protocol_, *this)), complete_(false) {}
+      decoder_(std::make_unique<ResponseDecoder>(*protocol_, *this)) {}
 
 DubboFilters::UpstreamResponseStatus ActiveResponseDecoder::onData(Buffer::Instance& data) {
   ENVOY_LOG(debug, "dubbo response: the received reply data length is {}", data.length());
@@ -180,8 +180,7 @@ ActiveMessage::ActiveMessage(ConnectionManager& parent)
                            parent_.stats().request_time_ms_, parent.timeSystem())),
       stream_id_(parent.randomGenerator().random()),
       stream_info_(parent.timeSystem(), parent_.connection().connectionInfoProviderSharedPtr(),
-                   StreamInfo::FilterState::LifeSpan::FilterChain),
-      pending_stream_decoded_(false), local_response_sent_(false) {
+                   StreamInfo::FilterState::LifeSpan::FilterChain) {
   parent_.stats().request_active_.inc();
 }
 

--- a/source/extensions/filters/network/dubbo_proxy/active_message.h
+++ b/source/extensions/filters/network/dubbo_proxy/active_message.h
@@ -54,7 +54,7 @@ private:
   ProtocolPtr protocol_;
   ResponseDecoderPtr decoder_;
   MessageMetadataSharedPtr metadata_;
-  bool complete_ : 1;
+  bool complete_ : 1 = false;
   DubboFilters::UpstreamResponseStatus response_status_{
       DubboFilters::UpstreamResponseStatus::MoreData};
 };
@@ -209,8 +209,8 @@ private:
 
   Buffer::OwnedImpl response_buffer_;
 
-  bool pending_stream_decoded_ : 1;
-  bool local_response_sent_ : 1;
+  bool pending_stream_decoded_ : 1 = false;
+  bool local_response_sent_ : 1 = false;
 
   friend class ActiveResponseDecoder;
 };

--- a/source/extensions/filters/network/dubbo_proxy/message_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/message_impl.h
@@ -123,8 +123,8 @@ private:
   AttachmentLazyCallback attachment_lazy_callback_;
   ParametersLazyCallback parameters_lazy_callback_;
 
-  mutable ParametersPtr parameters_{};
-  mutable AttachmentPtr attachment_{};
+  mutable ParametersPtr parameters_;
+  mutable AttachmentPtr attachment_;
 };
 
 class RpcResultImpl : public RpcResult {

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.cc
@@ -267,10 +267,8 @@ Router::UpstreamRequest::UpstreamRequest(Router& parent, Upstream::TcpPoolData& 
                                          SerializationType serialization_type,
                                          ProtocolType protocol_type)
     : parent_(parent), conn_pool_data_(pool_data), metadata_(metadata),
-      protocol_(
-          NamedProtocolConfigFactory::getFactory(protocol_type).createProtocol(serialization_type)),
-      request_complete_(false), response_started_(false), response_complete_(false),
-      stream_reset_(false) {}
+      protocol_(NamedProtocolConfigFactory::getFactory(protocol_type)
+                    .createProtocol(serialization_type)) {}
 
 Router::UpstreamRequest::~UpstreamRequest() = default;
 

--- a/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/dubbo_proxy/router/router_impl.h
@@ -84,10 +84,10 @@ private:
     SerializerPtr serializer_;
     ProtocolPtr protocol_;
 
-    bool request_complete_ : 1;
-    bool response_started_ : 1;
-    bool response_complete_ : 1;
-    bool stream_reset_ : 1;
+    bool request_complete_ : 1 = false;
+    bool response_started_ : 1 = false;
+    bool response_complete_ : 1 = false;
+    bool stream_reset_ : 1 = false;
   };
 
   void cleanup();
@@ -97,7 +97,7 @@ private:
 
   DubboFilters::DecoderFilterCallbacks* callbacks_{};
   DubboFilters::EncoderFilterCallbacks* encoder_callbacks_{};
-  RouteConstSharedPtr route_{};
+  RouteConstSharedPtr route_;
   const RouteEntry* route_entry_{};
   Upstream::ClusterInfoConstSharedPtr cluster_;
 

--- a/source/extensions/filters/network/ext_authz/ext_authz.h
+++ b/source/extensions/filters/network/ext_authz/ext_authz.h
@@ -162,7 +162,7 @@ private:
   FilterReturn filter_return_{FilterReturn::Stop};
   // Used to identify if the callback to onComplete() is synchronous (on the stack) or asynchronous.
   bool calling_check_{};
-  envoy::service::auth::v3::CheckRequest check_request_{};
+  envoy::service::auth::v3::CheckRequest check_request_;
 };
 } // namespace ExtAuthz
 } // namespace NetworkFilters

--- a/source/extensions/filters/network/generic_proxy/stats.h
+++ b/source/extensions/filters/network/generic_proxy/stats.h
@@ -102,8 +102,8 @@ private:
   // Even in the worst case where the status code and response flag are different for every
   // request, we will only do some additional integer comparisons and local variable
   // assignments which should be very cheap.
-  std::pair<uint32_t, OptRef<Stats::Counter>> last_code_counter_{};
-  std::pair<StreamInfo::ResponseFlag, OptRef<Stats::Counter>> last_flag_counter_{};
+  std::pair<uint32_t, OptRef<Stats::Counter>> last_code_counter_;
+  std::pair<StreamInfo::ResponseFlag, OptRef<Stats::Counter>> last_flag_counter_;
 };
 
 } // namespace GenericProxy

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -50,7 +50,7 @@ protected:
   std::vector<Common::Redis::RespValuePtr> pending_responses_;
 
   explicit BaseClusterScopeResponseHandler(uint32_t shard_count)
-      : num_pending_responses_(shard_count), error_count_(0) {
+      : num_pending_responses_(shard_count) {
     pending_responses_.reserve(shard_count);
   }
 

--- a/source/extensions/filters/network/thrift_proxy/auto_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/auto_protocol_impl.h
@@ -157,7 +157,7 @@ public:
   }
 
 private:
-  ProtocolPtr protocol_{};
+  ProtocolPtr protocol_;
   std::string name_;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/auto_transport_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/auto_transport_impl.h
@@ -44,7 +44,7 @@ public:
   }
 
 private:
-  TransportPtr transport_{};
+  TransportPtr transport_;
   std::string name_;
 };
 

--- a/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/compact_protocol_impl.h
@@ -98,15 +98,15 @@ private:
   void writeFieldBeginInternal(Buffer::Instance& buffer, FieldType field_type, int16_t field_id,
                                absl::optional<CompactFieldType> field_type_override);
 
-  std::stack<int16_t> last_field_id_stack_{};
+  std::stack<int16_t> last_field_id_stack_;
   int16_t last_field_id_{0};
 
   // Compact protocol encodes boolean struct fields as true/false *types* with no data.
   // This tracks the last boolean struct field's value for readBool.
-  absl::optional<bool> bool_value_{};
+  absl::optional<bool> bool_value_;
 
   // Similarly, track the field id for writeBool.
-  absl::optional<int16_t> bool_field_id_{};
+  absl::optional<int16_t> bool_field_id_;
 
   const static uint16_t Magic;
   const static uint16_t MagicMask;

--- a/source/extensions/filters/network/thrift_proxy/conn_manager.h
+++ b/source/extensions/filters/network/thrift_proxy/conn_manager.h
@@ -135,9 +135,9 @@ private:
     MessageMetadataSharedPtr metadata_;
     ProtocolConverterSharedPtr protocol_converter_;
     absl::optional<bool> success_;
-    bool complete_ : 1;
-    bool passthrough_ : 1;
-    bool pending_transport_end_ : 1;
+    bool complete_ : 1 = false;
+    bool passthrough_ : 1 = false;
+    bool pending_transport_end_ : 1 = false;
   };
   using ResponseDecoderPtr = std::unique_ptr<ResponseDecoder>;
 
@@ -370,10 +370,10 @@ private:
     int32_t original_sequence_id_{0};
     MessageType original_msg_type_{MessageType::Call};
     std::function<FilterStatus(DecoderEventHandler*)> filter_action_;
-    bool local_response_sent_ : 1;
-    bool pending_transport_end_ : 1;
-    bool passthrough_ : 1;
-    bool under_on_local_reply_ : 1;
+    bool local_response_sent_ : 1 = false;
+    bool pending_transport_end_ : 1 = false;
+    bool passthrough_ : 1 = false;
+    bool under_on_local_reply_ : 1 = false;
   };
 
   using ActiveRpcPtr = std::unique_ptr<ActiveRpc>;

--- a/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
+++ b/source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/payload_to_metadata_filter.h
@@ -45,7 +45,7 @@ private:
   };
   const ProtoRule rule_;
   absl::optional<Matcher::RegexReplace> regex_replace_;
-  std::string method_or_service_name_{};
+  std::string method_or_service_name_;
   MatchType match_type_;
   uint16_t rule_id_;
 };

--- a/source/extensions/filters/network/thrift_proxy/metadata.h
+++ b/source/extensions/filters/network/thrift_proxy/metadata.h
@@ -256,13 +256,13 @@ private:
       copy->setSampled(sampled_opt.value());
     }
   }
-  absl::optional<uint32_t> frame_size_{};
-  absl::optional<ProtocolType> proto_{};
-  absl::optional<std::string> method_name_{};
-  absl::optional<int16_t> header_flags_{};
-  absl::optional<int32_t> seq_id_{};
-  absl::optional<MessageType> msg_type_{};
-  absl::optional<ReplyType> reply_type_{};
+  absl::optional<uint32_t> frame_size_;
+  absl::optional<ProtocolType> proto_;
+  absl::optional<std::string> method_name_;
+  absl::optional<int16_t> header_flags_;
+  absl::optional<int32_t> seq_id_;
+  absl::optional<MessageType> msg_type_;
+  absl::optional<ReplyType> reply_type_;
   Http::RequestHeaderMapPtr request_headers_{nullptr};
   Http::ResponseHeaderMapPtr response_headers_{nullptr};
   absl::optional<AppExceptionType> app_ex_type_;

--- a/source/extensions/filters/network/thrift_proxy/router/router_impl.h
+++ b/source/extensions/filters/network/thrift_proxy/router/router_impl.h
@@ -231,8 +231,8 @@ class Router : public Tcp::ConnectionPool::UpstreamCallbacks,
 public:
   Router(Upstream::ClusterManager& cluster_manager, const RouterStats& stats,
          Runtime::Loader& runtime, ShadowWriter& shadow_writer, bool close_downstream_on_error)
-      : RequestOwner(cluster_manager, stats), passthrough_supported_(false), runtime_(runtime),
-        shadow_writer_(shadow_writer), close_downstream_on_error_(close_downstream_on_error) {}
+      : RequestOwner(cluster_manager, stats), runtime_(runtime), shadow_writer_(shadow_writer),
+        close_downstream_on_error_(close_downstream_on_error) {}
 
   ~Router() override = default;
 
@@ -321,19 +321,19 @@ private:
   void cleanup();
 
   ThriftFilters::DecoderFilterCallbacks* callbacks_{};
-  std::unique_ptr<UpstreamResponseCallbacksImpl> upstream_response_callbacks_{};
-  RouteConstSharedPtr route_{};
+  std::unique_ptr<UpstreamResponseCallbacksImpl> upstream_response_callbacks_;
+  RouteConstSharedPtr route_;
   const RouteEntry* route_entry_{};
   Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_criteria_;
 
   std::unique_ptr<UpstreamRequest> upstream_request_;
   Buffer::OwnedImpl upstream_request_buffer_;
 
-  bool passthrough_supported_ : 1;
+  bool passthrough_supported_ : 1 = false;
   uint64_t request_size_{};
   Runtime::Loader& runtime_;
   ShadowWriter& shadow_writer_;
-  std::vector<std::reference_wrapper<ShadowRouterHandle>> shadow_routers_{};
+  std::vector<std::reference_wrapper<ShadowRouterHandle>> shadow_routers_;
 
   bool close_downstream_on_error_;
 };

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.cc
@@ -14,7 +14,6 @@ UpstreamRequest::UpstreamRequest(RequestOwner& parent, Upstream::TcpPoolData& po
     : parent_(parent), stats_(parent.stats()), conn_pool_data_(pool_data), metadata_(metadata),
       transport_(NamedTransportConfigFactory::getFactory(transport_type).createTransport()),
       protocol_(NamedProtocolConfigFactory::getFactory(protocol_type).createProtocol()),
-      request_complete_(false), response_underflow_(false), charged_response_timing_(false),
       close_downstream_on_error_(close_downstream_on_error) {}
 
 UpstreamRequest::~UpstreamRequest() {

--- a/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
+++ b/source/extensions/filters/network/thrift_proxy/router/upstream_request.h
@@ -79,9 +79,9 @@ struct UpstreamRequest : public Tcp::ConnectionPool::Callbacks,
   };
 
   ResponseState response_state_{ResponseState::None};
-  bool request_complete_ : 1;
-  bool response_underflow_ : 1;
-  bool charged_response_timing_ : 1;
+  bool request_complete_ : 1 = false;
+  bool response_underflow_ : 1 = false;
+  bool charged_response_timing_ : 1 = false;
   bool close_downstream_on_error_ : 1;
 
   absl::optional<MonotonicTime> downstream_request_complete_time_;

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -444,7 +444,7 @@ public:
                    StreamInfo::StreamInfo& upstream_info, absl::optional<Http::Protocol>) override;
 
 private:
-  absl::optional<Upstream::HttpPoolData> conn_pool_data_{};
+  absl::optional<Upstream::HttpPoolData> conn_pool_data_;
   HttpStreamCallbacks* callbacks_{};
   UpstreamTunnelCallbacks& upstream_callbacks_;
   std::unique_ptr<HttpUpstreamImpl> upstream_;

--- a/source/extensions/health_checkers/http/health_checker_impl.cc
+++ b/source/extensions/health_checkers/http/health_checker_impl.cc
@@ -213,8 +213,7 @@ HttpHealthCheckerImpl::HttpActiveHealthCheckSession::HttpActiveHealthCheckSessio
       local_connection_info_provider_(std::make_shared<Network::ConnectionInfoSetterImpl>(
           Network::Utility::getCanonicalIpv4LoopbackAddress(),
           Network::Utility::getCanonicalIpv4LoopbackAddress())),
-      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)), expect_reset_(false),
-      reuse_connection_(false), request_in_flight_(false) {}
+      protocol_(codecClientTypeToProtocol(parent_.codec_client_type_)) {}
 
 HttpHealthCheckerImpl::HttpActiveHealthCheckSession::~HttpActiveHealthCheckSession() {
   ASSERT(client_ == nullptr);

--- a/source/extensions/health_checkers/http/health_checker_impl.h
+++ b/source/extensions/health_checkers/http/health_checker_impl.h
@@ -146,9 +146,9 @@ private:
     Network::ConnectionInfoProviderSharedPtr local_connection_info_provider_;
     // Keep small members (bools and enums) at the end of class, to reduce alignment overhead.
     const Http::Protocol protocol_;
-    bool expect_reset_ : 1;
-    bool reuse_connection_ : 1;
-    bool request_in_flight_ : 1;
+    bool expect_reset_ : 1 = false;
+    bool reuse_connection_ : 1 = false;
+    bool request_in_flight_ : 1 = false;
   };
 
   using HttpActiveHealthCheckSessionPtr = std::unique_ptr<HttpActiveHealthCheckSession>;

--- a/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/lb_config.cc
@@ -57,8 +57,7 @@ DynamicModuleLbConfig::DynamicModuleLbConfig(
     const std::string& lb_policy_name, const std::string& lb_config,
     const std::string& metrics_namespace,
     Envoy::Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope)
-    : in_module_config_(nullptr),
-      stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
+    : stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
       stat_name_pool_(stats_scope_->symbolTable()), lb_policy_name_(lb_policy_name),
       lb_config_(lb_config), dynamic_module_(std::move(dynamic_module)) {}
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
@@ -8,8 +8,7 @@ namespace DynamicModules {
 DynamicModuleLoadBalancer::DynamicModuleLoadBalancer(DynamicModuleLbConfigSharedPtr config,
                                                      const Upstream::PrioritySet& priority_set,
                                                      const std::string& cluster_name)
-    : config_(std::move(config)), priority_set_(priority_set), cluster_name_(cluster_name),
-      in_module_lb_(nullptr) {
+    : config_(std::move(config)), priority_set_(priority_set), cluster_name_(cluster_name) {
   // Create the in-module load balancer instance.
   in_module_lb_ = config_->on_lb_new_(config_->in_module_config_, this);
   if (in_module_lb_ == nullptr) {

--- a/source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/resource_detector.h
@@ -26,7 +26,7 @@ using ResourceAttributes = absl::flat_hash_map<std::string, std::string>;
  */
 struct Resource {
   std::string schema_url_{""};
-  ResourceAttributes attributes_{};
+  ResourceAttributes attributes_;
 
   virtual ~Resource() = default;
 };

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/sampling_controller.h
@@ -109,11 +109,11 @@ public:
 private:
   using SamplingExponentsT = absl::flat_hash_map<std::string, SamplingState>;
   SamplingExponentsT sampling_exponents_;
-  mutable absl::Mutex sampling_exponents_mutex_{};
-  std::string rest_bucket_key_{};
+  mutable absl::Mutex sampling_exponents_mutex_;
+  std::string rest_bucket_key_;
   std::unique_ptr<StreamSummaryT> stream_summary_;
   uint64_t last_effective_count_{};
-  mutable absl::Mutex stream_summary_mutex_{};
+  mutable absl::Mutex stream_summary_mutex_;
   SamplerConfigProviderPtr sampler_config_provider_;
 
   void logSamplingInfo(const TopKListT& top_k, const SamplingExponentsT& new_sampling_exponents,

--- a/source/extensions/transport_sockets/alts/tsi_socket.h
+++ b/source/extensions/transport_sockets/alts/tsi_socket.h
@@ -99,7 +99,7 @@ private:
 
   HandshakerFactory handshaker_factory_;
   HandshakeValidator handshake_validator_;
-  TsiHandshakerPtr handshaker_{};
+  TsiHandshakerPtr handshaker_;
   bool handshaker_next_calling_{};
 
   TsiFrameProtectorPtr frame_protector_;

--- a/source/extensions/transport_sockets/http_11_proxy/connect.h
+++ b/source/extensions/transport_sockets/http_11_proxy/connect.h
@@ -52,7 +52,7 @@ private:
 
   Network::TransportSocketOptionsConstSharedPtr options_;
   Network::TransportSocketCallbacks* callbacks_{};
-  Buffer::OwnedImpl header_buffer_{};
+  Buffer::OwnedImpl header_buffer_;
   bool need_to_strip_connect_response_{};
 };
 

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.h
@@ -51,12 +51,12 @@ private:
 
   Network::TransportSocketOptionsConstSharedPtr options_;
   Network::TransportSocketCallbacks* callbacks_{};
-  Buffer::OwnedImpl header_buffer_{};
+  Buffer::OwnedImpl header_buffer_;
   ProxyProtocolConfig_Version version_{ProxyProtocolConfig_Version::ProxyProtocolConfig_Version_V1};
   const UpstreamProxyProtocolStats& stats_;
   const bool pass_all_tlvs_;
-  absl::flat_hash_set<uint8_t> pass_through_tlvs_{};
-  std::vector<Envoy::Network::ProxyProtocolTLV> added_tlvs_{};
+  absl::flat_hash_set<uint8_t> pass_through_tlvs_;
+  std::vector<Envoy::Network::ProxyProtocolTLV> added_tlvs_;
 };
 
 class UpstreamProxyProtocolSocketFactory : public PassthroughFactory {

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.h
@@ -97,7 +97,7 @@ private:
 
   std::string ca_file_name_;
   std::shared_ptr<SpiffeData> spiffe_data_;
-  std::vector<SanMatcherPtr> subject_alt_name_matchers_{};
+  std::vector<SanMatcherPtr> subject_alt_name_matchers_;
   SslStats& stats_;
   TimeSource& time_source_;
   using SpiffeTrustBundles = Config::DataSource::ProviderSingleton<SpiffeData>;

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -73,7 +73,7 @@ public:
 
   const Envoy::Http::Http1Settings http1_settings_;
   const envoy::config::core::v3::Http2ProtocolOptions http2_options_;
-  const envoy::config::core::v3::Http3ProtocolOptions http3_options_{};
+  const envoy::config::core::v3::Http3ProtocolOptions http3_options_;
   const envoy::config::core::v3::HttpProtocolOptions common_http_protocol_options_;
   const absl::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions>
       upstream_http_protocol_options_;

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -48,7 +48,7 @@ public:
 
 protected:
   // Points to the actual connection pool to create streams from.
-  absl::optional<Envoy::Upstream::HttpPoolData> pool_data_{};
+  absl::optional<Envoy::Upstream::HttpPoolData> pool_data_;
   Envoy::Http::ConnectionPool::Cancellable* conn_pool_stream_handle_{};
   Router::GenericConnectionPoolCallbacks* callbacks_{};
 };

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -81,7 +81,7 @@ private:
   const bool skip_parent_stats_;
   sockaddr_un parent_address_;
   sockaddr_un parent_address_udp_forwarding_;
-  std::unique_ptr<Stats::StatMerger> stat_merger_{};
+  std::unique_ptr<Stats::StatMerger> stat_merger_;
   Stats::StatName hot_restart_generation_stat_name_;
   // There are multiple listener instances per address that must all be reactivated
   // when the parent is drained, so a multimap is used to contain them.


### PR DESCRIPTION
## Summary
Aligns constructor member initialization with declaration order and removes related clang-tidy findings across the touched `source/` files, without intended behavior changes.