### PR TITLE
golang: always post continueStatus/sendLocalReply to the dispatcher

### DIFF
--- a/changelogs/current/bug_fixes/golang__fixed-a-crash-in-the-golang-http.rst
+++ b/changelogs/current/bug_fixes/golang__fixed-a-crash-in-the-golang-http.rst
@@ -1,0 +1,7 @@
+Fixed a crash in the Golang HTTP filter introduced by #44503 where ``continueStatus`` or
+``sendLocalReply`` invoked synchronously from inside a Go ``OnHttpHeader``/``OnHttpData``
+cgo callback would re-enter the C++ state machine while the cgo frame was still on the
+stack, tripping the ``ASSERT(filterState() == Processing*)`` at the top of
+``handle*GolangStatus`` once the cgo call returned. The inline-on-worker-thread
+optimization from #44503 is reverted for these two CAPI methods; both now always
+post to the dispatcher, matching the pre-#44503 behavior.

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -479,7 +479,6 @@ CAPIStatus
 Filter::sendLocalReply(ProcessorState& state, Http::Code response_code, std::string body_text,
                        std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                        Grpc::Status::GrpcStatus grpc_status, std::string details) {
-  bool on_worker_thread = state.isThreadSafe();
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -490,11 +489,9 @@ Filter::sendLocalReply(ProcessorState& state, Http::Code response_code, std::str
   }
   ENVOY_LOG(debug, "sendLocalReply, response code: {}", int(response_code));
 
-  if (on_worker_thread) {
-    sendLocalReplyInternal(state, response_code, body_text, modify_headers, grpc_status, details);
-    return CAPIStatus::CAPIOK;
-  }
-
+  // Always post to the dispatcher: inline execution from inside a Go cgo callback
+  // would re-enter the C++ state machine before handle*GolangStatus consumes the
+  // returned status, tripping its ASSERT (see #44704).
   auto weak_ptr = weak_from_this();
   state.getDispatcher().post([this, &state, weak_ptr, response_code, body_text, modify_headers,
                               grpc_status, details] {
@@ -520,7 +517,6 @@ CAPIStatus Filter::sendPanicReply(ProcessorState& state, absl::string_view detai
 }
 
 CAPIStatus Filter::continueStatus(ProcessorState& state, GolangStatus status) {
-  bool on_worker_thread = state.isThreadSafe();
   if (hasDestroyed()) {
     ENVOY_LOG(debug, "golang filter has been destroyed");
     return CAPIStatus::CAPIFilterIsDestroy;
@@ -532,15 +528,9 @@ CAPIStatus Filter::continueStatus(ProcessorState& state, GolangStatus status) {
   ENVOY_LOG(debug, "golang filter continue from Go, status: {}, state: {}", int(status),
             state.stateStr());
 
-  // When on the worker thread, continueStatusInternal re-enters the filter chain
-  // (continueProcessing / continueDoData / sendLocalReply) while the cgo call is still on the
-  // stack. This synchronous reentrancy is intentional and is the same model used by the addData
-  // inline path below; callers must not hold any state-mutating locks across this call.
-  if (on_worker_thread) {
-    continueStatusInternal(state, status);
-    return CAPIStatus::CAPIOK;
-  }
-
+  // Always post to the dispatcher: inline execution from inside a Go cgo callback
+  // would re-enter the C++ state machine before handle*GolangStatus consumes the
+  // returned status, tripping its ASSERT (see #44704).
   auto weak_ptr = weak_from_this();
   state.getDispatcher().post([this, &state, weak_ptr, status] {
     if (!weak_ptr.expired() && !hasDestroyed()) {

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -42,7 +42,6 @@ public:
   using Filter::continueStatus;
   using Filter::continueStatusInternal;
   using Filter::Filter;
-  using Filter::sendLocalReply;
   DecodingProcessorState& testDecodingState() { return decoding_state_; }
   HttpRequestInternal* testReq() { return req_; }
 };
@@ -266,112 +265,67 @@ TEST_F(GolangHttpFilterTest, BufferedDataAfterDestroyDuringContinue) {
   delete filter->testReq();
 }
 
-// Helper to set up a mock-based filter for dispatcher post tests.
-struct MockFilterContext {
-  std::shared_ptr<NiceMock<Dso::MockHttpFilterDsoImpl>> dso_lib;
-  std::shared_ptr<FilterConfig> config;
+// Regression test for #44704: when the Go plugin calls continueStatus() from inside
+// the OnHttpHeader cgo callback, the call must post to the dispatcher rather than
+// transition the C++ state machine inline; otherwise handleHeaderGolangStatus trips
+// its ASSERT(filterState == ProcessingHeader) once the cgo call returns.
+TEST_F(GolangHttpFilterTest, ContinueStatusFromInsideHeaderCgoCallbackPostsToDispatcher) {
+  auto dso_lib = std::make_shared<NiceMock<Dso::MockHttpFilterDsoImpl>>();
+  ON_CALL(*dso_lib, envoyGoFilterNewHttpPluginConfig(_)).WillByDefault(Return(1));
+
+  const auto yaml = R"EOF(
+    library_id: test
+    library_path: test
+    plugin_name: test
+    )EOF";
+  envoy::extensions::filters::http::golang::v3alpha::Config proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> mock_context;
-  Network::Address::InstanceConstSharedPtr addr;
+  auto config = std::make_shared<FilterConfig>(proto_config, dso_lib, "", mock_context);
+  config->newGoPluginConfig();
+
   NiceMock<Http::MockStreamDecoderFilterCallbacks> mock_callbacks;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> mock_enc_callbacks;
   NiceMock<Envoy::Network::MockConnection> mock_connection;
-  std::shared_ptr<TestFilter> filter;
+  auto addr = (*Network::Address::PipeInstance::create("/test/test.sock")).release();
+  Network::Address::InstanceConstSharedPtr addr_ptr(addr);
+  ON_CALL(mock_callbacks, connection())
+      .WillByDefault(Return(OptRef<const Network::Connection>{mock_connection}));
+  mock_connection.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr_ptr);
+  mock_connection.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr_ptr);
 
-  void setup(bool thread_safe) {
-    dso_lib = std::make_shared<NiceMock<Dso::MockHttpFilterDsoImpl>>();
-    ON_CALL(*dso_lib, envoyGoFilterNewHttpPluginConfig(_)).WillByDefault(Return(1));
-    ON_CALL(*dso_lib, envoyGoFilterOnHttpHeader(_, _, _, _))
-        .WillByDefault(Return(static_cast<uint64_t>(GolangStatus::Running)));
+  EXPECT_CALL(mock_callbacks.dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
 
-    const auto yaml = R"EOF(
-      library_id: test
-      library_path: test
-      plugin_name: test
-      )EOF";
-    envoy::extensions::filters::http::golang::v3alpha::Config proto_config;
-    TestUtility::loadFromYaml(yaml, proto_config);
-    config = std::make_shared<FilterConfig>(proto_config, dso_lib, "", mock_context);
-    config->newGoPluginConfig();
+  // Capture the posted closure instead of running it inline (the default
+  // MockDispatcher::post() ON_CALL invokes the callback synchronously, which would
+  // defeat the point of the regression test).
+  Event::PostCb captured_post;
+  EXPECT_CALL(mock_callbacks.dispatcher_, post(_)).WillOnce([&captured_post](Event::PostCb cb) {
+    captured_post = std::move(cb);
+  });
 
-    addr.reset((*Network::Address::PipeInstance::create("/test/test.sock")).release());
-    ON_CALL(mock_callbacks, connection())
-        .WillByDefault(Return(OptRef<const Network::Connection>{mock_connection}));
-    mock_connection.stream_info_.downstream_connection_info_provider_->setRemoteAddress(addr);
-    mock_connection.stream_info_.downstream_connection_info_provider_->setLocalAddress(addr);
-    EXPECT_CALL(mock_callbacks.dispatcher_, isThreadSafe()).WillRepeatedly(Return(thread_safe));
+  auto filter = std::make_shared<TestFilter>(config, dso_lib, 0);
+  filter->setDecoderFilterCallbacks(mock_callbacks);
+  filter->setEncoderFilterCallbacks(mock_enc_callbacks);
 
-    filter = std::make_shared<TestFilter>(config, dso_lib, 0);
-    filter->setDecoderFilterCallbacks(mock_callbacks);
-    filter->setEncoderFilterCallbacks(mock_enc_callbacks);
+  EXPECT_CALL(*dso_lib, envoyGoFilterOnHttpHeader(_, _, _, _))
+      .WillOnce(Invoke([&filter](processState*, int, int, uint64_t) -> uint64_t {
+        auto status = filter->continueStatus(filter->testDecodingState(), GolangStatus::Continue);
+        EXPECT_EQ(CAPIStatus::CAPIOK, status);
+        return static_cast<uint64_t>(GolangStatus::Running);
+      }));
 
-    Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
-    EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-              filter->decodeHeaders(request_headers, false));
-  }
+  // No inline continueDecoding while the cgo frame is on the stack: state must still
+  // be ProcessingHeader when handleHeaderGolangStatus runs.
+  EXPECT_CALL(mock_callbacks, continueDecoding()).Times(0);
 
-  void teardown() {
-    filter->onDestroy();
-    delete filter->testReq();
-  }
-};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter->decodeHeaders(request_headers, false));
+  EXPECT_TRUE(captured_post != nullptr) << "continueStatus must defer via dispatcher.post()";
 
-// Verify that continueStatus executes inline when already on the worker thread,
-// bypassing dispatcher.post for lower latency.
-TEST_F(GolangHttpFilterTest, ContinueStatusSkipsPostOnWorkerThread) {
-  MockFilterContext ctx;
-  ctx.setup(true);
-
-  EXPECT_CALL(ctx.mock_callbacks.dispatcher_, post(_)).Times(0);
-  EXPECT_CALL(ctx.mock_callbacks, continueDecoding());
-
-  auto status = ctx.filter->continueStatus(ctx.filter->testDecodingState(), GolangStatus::Continue);
-  EXPECT_EQ(CAPIStatus::CAPIOK, status);
-
-  ctx.teardown();
-}
-
-// Verify that continueStatus posts to the dispatcher when not on the worker thread.
-TEST_F(GolangHttpFilterTest, ContinueStatusPostsOffWorkerThread) {
-  MockFilterContext ctx;
-  ctx.setup(false);
-
-  EXPECT_CALL(ctx.mock_callbacks.dispatcher_, post(_));
-
-  auto status = ctx.filter->continueStatus(ctx.filter->testDecodingState(), GolangStatus::Continue);
-  EXPECT_EQ(CAPIStatus::CAPIOK, status);
-
-  ctx.teardown();
-}
-
-// Verify that sendLocalReply executes inline when already on the worker thread.
-TEST_F(GolangHttpFilterTest, SendLocalReplySkipsPostOnWorkerThread) {
-  MockFilterContext ctx;
-  ctx.setup(true);
-
-  EXPECT_CALL(ctx.mock_callbacks.dispatcher_, post(_)).Times(0);
-  EXPECT_CALL(ctx.mock_callbacks, sendLocalReply(Http::Code::BadRequest, "bad request", _, _, _));
-
-  auto status =
-      ctx.filter->sendLocalReply(ctx.filter->testDecodingState(), Http::Code::BadRequest,
-                                 "bad request", nullptr, Grpc::Status::WellKnownGrpcStatus::Ok, "");
-  EXPECT_EQ(CAPIStatus::CAPIOK, status);
-
-  ctx.teardown();
-}
-
-// Verify that sendLocalReply posts to the dispatcher when not on the worker thread.
-TEST_F(GolangHttpFilterTest, SendLocalReplyPostsOffWorkerThread) {
-  MockFilterContext ctx;
-  ctx.setup(false);
-
-  EXPECT_CALL(ctx.mock_callbacks.dispatcher_, post(_));
-
-  auto status =
-      ctx.filter->sendLocalReply(ctx.filter->testDecodingState(), Http::Code::BadRequest,
-                                 "bad request", nullptr, Grpc::Status::WellKnownGrpcStatus::Ok, "");
-  EXPECT_EQ(CAPIStatus::CAPIOK, status);
-
-  ctx.teardown();
+  filter->onDestroy();
+  delete filter->testReq();
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message:
#44503 made `continueStatus()` and `sendLocalReply()` run inline when already on the worker thread. When invoked synchronously from inside a Go `OnHttpHeader`/`OnHttpData` cgo callback this re-entered the C++ state machine before `handle*GolangStatus()` consumed the returned `GolangStatus`, tripping its `ASSERT(filterState() == Processing*)` and aborting the worker. There is no realistic call path that is both off the cgo callback stack and on the worker thread (a goroutine calling back into C++ runs on a Go runtime M, not the dispatcher thread), so the inline optimization had no remaining beneficiary. Revert the inline branch from both methods so they always post.

Additional Description:
Also removes the four #44503 unit tests for the inline/post branch selection (now testing dead behavior) and their `MockFilterContext` helper.

Risk Level:
Low. Matches pre-#44503 behavior for both methods.

Testing:
New `ContinueStatusFromInsideHeaderCgoCallbackPostsToDispatcher` reproduces #44704: dso mock calls `continueStatus(Continue)` from inside `envoyGoFilterOnHttpHeader`, asserts no `processor_state.cc:54` abort, exactly one `dispatcher.post()`, no inline `continueDecoding`.

Docs Changes:
N/A

Release Notes:
`bug_fixes` entry in `changelogs/current.yaml`.

Platform Specific Features:
N/A

Fixes #44704
Fixes commit #44503