### PR TITLE
Replace strict-aliasing UB in BSON double serialization

### DIFF
--- a/source/extensions/filters/network/mongo_proxy/BUILD
+++ b/source/extensions/filters/network/mongo_proxy/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         "//source/common/common:byte_order_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/common:safe_memcpy_lib",
         "//source/common/common:utility_lib",
     ],
 )

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -133,9 +133,10 @@ void BufferHelper::writeCString(Buffer::Instance& data, const std::string& value
 }
 
 void BufferHelper::writeDouble(Buffer::Instance& data, double value) {
-  // We need to hack converting a double into little endian.
-  int64_t* to_write = reinterpret_cast<int64_t*>(&value);
-  writeInt64(data, *to_write);
+  static_assert(sizeof(double) == sizeof(int64_t), "invalid type size");
+  int64_t to_write;
+  std::memcpy(&to_write, &value, sizeof(to_write));
+  writeInt64(data, to_write);
 }
 
 void BufferHelper::writeInt32(Buffer::Instance& data, int32_t value) {

--- a/source/extensions/filters/network/mongo_proxy/bson_impl.cc
+++ b/source/extensions/filters/network/mongo_proxy/bson_impl.cc
@@ -8,6 +8,7 @@
 #include "source/common/common/byte_order.h"
 #include "source/common/common/fmt.h"
 #include "source/common/common/hex.h"
+#include "source/common/common/safe_memcpy.h"
 #include "source/common/common/utility.h"
 
 namespace Envoy {
@@ -133,9 +134,8 @@ void BufferHelper::writeCString(Buffer::Instance& data, const std::string& value
 }
 
 void BufferHelper::writeDouble(Buffer::Instance& data, double value) {
-  static_assert(sizeof(double) == sizeof(int64_t), "invalid type size");
   int64_t to_write;
-  std::memcpy(&to_write, &value, sizeof(to_write));
+  safeMemcpy(&to_write, &value);
   writeInt64(data, to_write);
 }
 


### PR DESCRIPTION
Replace reinterpret_cast-based type punning in `BufferHelper::writeDouble` with a standards-compliant `std::memcpy` bit copy.

The previous implementation reinterpreted a double as an `int64_t` through a pointer cast, which violates C++ strict-aliasing rules and may result in undefined behavior under compiler optimization.

This change preserves the exact serialized bit pattern while removing UB from the BSON double serialization path. A static_assert was also added to verify size compatibility between double and int64_t.
 
#### Risk Level:
Low

#### Testing:
- Verified bit-pattern equivalence for representative edge cases:
  zero, signed zero, ±1, π, ±∞, NaN, denormals, and ±DBL_MAX
- Verified round-trip correctness through writeDouble/removeDouble

#### Docs Changes:
None