### PR TITLE
clang tidy: fix naming/enum cast and so on of source

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -83,6 +83,7 @@ enum class MatchResult {
 };
 
 // Prints a human-readable string representing the MatchResult.
+// NOLINTNEXTLINE(readability-identifier-naming)
 inline static std::string MatchResultToString(MatchResult match_result) {
   switch (match_result) {
   case MatchResult::Matched:
@@ -337,6 +338,7 @@ public:
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   NoData(DataAvailability data_availability = DataAvailability::AllDataAvailable) {
     return DataInputGetResult(absl::monostate(), data_availability);
   }
@@ -346,18 +348,21 @@ public:
    *duration of matching. Use CreateString when a string must be constructed.
    **/
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateStringView(absl::string_view data,
                    DataAvailability data_availability = DataAvailability::AllDataAvailable) {
     return DataInputGetResult(data, data_availability);
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateString(std::string&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
     return DataInputGetResult(std::move(data), data_availability);
   }
 
   static DataInputGetResult
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateCustom(std::shared_ptr<CustomMatchData>&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
     return DataInputGetResult(std::move(data), data_availability);

--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -323,6 +323,8 @@ public:
 // combination of flags, such as listeners(ListenerState::WARMING|ListenerState::ACTIVE)
 constexpr ListenerManager::ListenerState operator|(const ListenerManager::ListenerState lhs,
                                                    const ListenerManager::ListenerState rhs) {
+  // Bitmask combinations intentionally produce intermediate values that are not named enumerators.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   return static_cast<ListenerManager::ListenerState>(static_cast<uint8_t>(lhs) |
                                                      static_cast<uint8_t>(rhs));
 }

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -213,7 +213,7 @@ using OnHeaderResult = http2::adapter::Http2VisitorInterface::OnHeaderResult;
 enum Settings {
   // SETTINGS_HEADER_TABLE_SIZE = 0x01,
   // SETTINGS_ENABLE_PUSH = 0x02,
-  SETTINGS_MAX_CONCURRENT_STREAMS = 0x03,
+  SETTINGS_MAX_CONCURRENT_STREAMS = 0x03, // NOLINT(readability-identifier-naming)
   // SETTINGS_INITIAL_WINDOW_SIZE = 0x04,
   // SETTINGS_MAX_FRAME_SIZE = 0x05,
   // SETTINGS_MAX_HEADER_LIST_SIZE = 0x06,
@@ -223,9 +223,9 @@ enum Settings {
 
 enum Flags {
   // FLAG_NONE = 0,
-  FLAG_END_STREAM = 0x01,
+  FLAG_END_STREAM = 0x01, // NOLINT(readability-identifier-naming)
   // FLAG_END_HEADERS = 0x04,
-  FLAG_ACK = 0x01,
+  FLAG_ACK = 0x01, // NOLINT(readability-identifier-naming)
   // FLAG_PADDED = 0x08,
   // FLAG_PRIORITY = 0x20
 };

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -44,6 +44,7 @@ namespace Http {
 namespace Http2 {
 
 // Types inherited from nghttp2 and preserved in oghttp2
+// NOLINTBEGIN(readability-identifier-naming)
 enum ErrorType {
   OGHTTP2_NO_ERROR,
   OGHTTP2_PROTOCOL_ERROR,
@@ -60,6 +61,7 @@ enum ErrorType {
   OGHTTP2_INADEQUATE_SECURITY,
   OGHTTP2_HTTP_1_1_REQUIRED,
 };
+// NOLINTEND(readability-identifier-naming)
 
 class Http2CodecImplTestFixture;
 

--- a/source/common/http/http2/protocol_constraints.h
+++ b/source/common/http/http2/protocol_constraints.h
@@ -18,6 +18,7 @@ namespace Http {
 namespace Http2 {
 
 // Frame types as inherited from nghttp2 and preserved for oghttp2
+// NOLINTBEGIN(readability-identifier-naming)
 enum FrameType {
   OGHTTP2_DATA_FRAME_TYPE,
   OGHTTP2_HEADERS_FRAME_TYPE,
@@ -30,6 +31,7 @@ enum FrameType {
   OGHTTP2_WINDOW_UPDATE_FRAME_TYPE,
   OGHTTP2_CONTINUATION_FRAME_TYPE,
 };
+// NOLINTEND(readability-identifier-naming)
 
 //  Class for detecting abusive peers and validating additional constraints imposed by Envoy.
 //  This class does not check protocol compliance with the H/2 standard, as this is checked by

--- a/source/common/http/muxdemux.h
+++ b/source/common/http/muxdemux.h
@@ -50,10 +50,11 @@ public:
 
   // Iterator over streams. Allows sending different headers, body or trailers to different streams.
   struct StreamIterator {
-    using difference_type = std::ptrdiff_t;
-    using element_type = AsyncClient::Stream*;
-    using pointer = element_type*;
-    using reference = element_type&;
+    // Standard iterator aliases intentionally use STL-prescribed snake_case names.
+    using difference_type = std::ptrdiff_t;    // NOLINT(readability-identifier-naming)
+    using element_type = AsyncClient::Stream*; // NOLINT(readability-identifier-naming)
+    using pointer = element_type*;             // NOLINT(readability-identifier-naming)
+    using reference = element_type&;           // NOLINT(readability-identifier-naming)
     explicit StreamIterator(std::vector<CallbacksFacade>::iterator it) : it(it) {}
     StreamIterator() = default;
 

--- a/source/common/http/session_idle_list.h
+++ b/source/common/http/session_idle_list.h
@@ -30,24 +30,30 @@ public:
   ~SessionIdleList() override = default;
 
   // Adds a session to the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void AddSession(IdleSessionInterface& session) override;
 
   // Removes a session from the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void RemoveSession(IdleSessionInterface& session) override;
 
   // Terminates idle sessions if they are eligible for termination. This is
   // called by the worker thread when the system is overloaded.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeTerminateIdleSessions(bool is_saturated) override;
 
   // Sets the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_min_time_before_termination_allowed(absl::Duration min_time_before_termination_allowed) {
     min_time_before_termination_allowed_ = min_time_before_termination_allowed;
   };
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_max_sessions_to_terminate_in_one_round(int max_sessions_to_terminate_in_one_round) {
     max_sessions_to_terminate_in_one_round_ = max_sessions_to_terminate_in_one_round;
   }
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_max_sessions_to_terminate_in_one_round_when_saturated(
       int max_sessions_to_terminate_in_one_round_when_saturated) {
     max_sessions_to_terminate_in_one_round_when_saturated_ =
@@ -55,6 +61,7 @@ public:
   }
 
   // Sets whether to ignore the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_ignore_min_time_before_termination_allowed(bool ignore) {
     ignore_min_time_before_termination_allowed_ = ignore;
   };
@@ -88,16 +95,21 @@ private:
     IdleSessions(const IdleSessions&) = delete;
     IdleSessions& operator=(const IdleSessions&) = delete;
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     IdleSessionInterface& next_session_to_terminate() { return *set_.begin()->session; }
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     void AddSessionToList(MonotonicTime enqueue_time, IdleSessionInterface& session);
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
     void RemoveSessionFromList(IdleSessionInterface& session);
 
     // Get the time at which the session was added to the idle list.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     MonotonicTime GetEnqueueTime(IdleSessionInterface& session) const;
 
     // Returns true if the session is in the map. For testing only.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     bool ContainsForTest(IdleSessionInterface& session) const { return map_.contains(&session); }
 
     size_t size() const { return set_.size(); }
@@ -111,14 +123,17 @@ private:
     IdleSessionMap map_;
   };
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const IdleSessions* idle_sessions() const { return &idle_sessions_; }
 
   // If this is > 0 then we do not terminate more than that many
   // sessions in a single attempt. This prevents us from doing too
   // much work in a single round. We want a small constant for this.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   size_t MaxSessionsToTerminateInOneRound(bool is_saturated) const;
 
   // Returns the minimum time before a session can be terminated.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::Duration MinTimeBeforeTerminationAllowed() const;
 
   Event::Dispatcher& dispatcher_;

--- a/source/common/http/session_idle_list_interface.h
+++ b/source/common/http/session_idle_list_interface.h
@@ -10,6 +10,7 @@ public:
 
   // Terminates the idle session. This is called by the SessionIdleList when
   // the system is overloaded and the session is eligible for termination.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void TerminateIdleSession() = 0;
 };
 
@@ -19,13 +20,16 @@ public:
   virtual ~SessionIdleListInterface() = default;
 
   // Adds a session to the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void AddSession(IdleSessionInterface& session) = 0;
 
   // Removes a session from the idle list.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void RemoveSession(IdleSessionInterface& session) = 0;
 
   // Terminates idle sessions if they are eligible for termination. This is
   // called by the worker thread when the system is overloaded.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void MaybeTerminateIdleSessions(bool is_saturated) = 0;
 };
 

--- a/source/common/json/json_rpc_field_extractor.h
+++ b/source/common/json/json_rpc_field_extractor.h
@@ -82,6 +82,7 @@ protected:
   virtual absl::string_view jsonRpcVersion() const = 0;
   virtual absl::string_view jsonRpcField() const = 0;
   virtual absl::string_view methodField() const = 0;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual bool lists_supported() const = 0;
 
   Protobuf::Struct temp_storage_;   // Store all fields temporarily
@@ -92,7 +93,8 @@ protected:
   struct NestedContext {
     Protobuf::Struct* struct_ptr{nullptr};
     Protobuf::ListValue* list_ptr{nullptr};
-    std::string field_name{};
+    std::string field_name;
+    // NOLINTNEXTLINE(readability-identifier-naming)
     bool is_list() const { return list_ptr != nullptr; }
   };
   std::stack<NestedContext> context_stack_;

--- a/source/common/jwt/check_audience.h
+++ b/source/common/jwt/check_audience.h
@@ -39,7 +39,7 @@ private:
   std::set<std::string> config_audiences_;
 };
 
-typedef std::unique_ptr<CheckAudience> CheckAudiencePtr;
+using CheckAudiencePtr = std::unique_ptr<CheckAudience>;
 
 } // namespace JwtVerify
 } // namespace Envoy

--- a/source/common/jwt/jwks.cc
+++ b/source/common/jwt/jwks.cc
@@ -4,8 +4,7 @@
 
 #include "source/common/jwt/jwks.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <iostream>
 
 #include "source/common/jwt/struct_utils.h"
@@ -133,7 +132,7 @@ private:
     if (!absl::WebSafeBase64Unescape(s, &s_decoded)) {
       return nullptr;
     }
-    return bssl::UniquePtr<BIGNUM>(BN_bin2bn(castToUChar(s_decoded), s_decoded.length(), NULL));
+    return bssl::UniquePtr<BIGNUM>(BN_bin2bn(castToUChar(s_decoded), s_decoded.length(), nullptr));
   };
 };
 

--- a/source/common/jwt/jwks.h
+++ b/source/common/jwt/jwks.h
@@ -53,7 +53,7 @@ public:
     bssl::UniquePtr<BIO> bio_;
     bssl::UniquePtr<X509> x509_;
   };
-  typedef std::unique_ptr<Pubkey> PubkeyPtr;
+  using PubkeyPtr = std::unique_ptr<Pubkey>;
 
   // Access to list of Jwks
   const std::vector<PubkeyPtr>& keys() const { return keys_; }
@@ -68,7 +68,7 @@ private:
   std::vector<PubkeyPtr> keys_;
 };
 
-typedef std::unique_ptr<Jwks> JwksPtr;
+using JwksPtr = std::unique_ptr<Jwks>;
 
 } // namespace JwtVerify
 } // namespace Envoy

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -106,10 +106,12 @@ template <class Key, class Value, class MapType>
 class SimpleLRUCacheConstIterator
     : public std::iterator<std::input_iterator_tag, const std::pair<Key, Value*>> {
 public:
-  typedef typename MapType::const_iterator HashMapConstIterator;
+  using HashMapConstIterator = typename MapType::const_iterator;
   // Allow parent template's types to be referenced without qualification.
-  typedef typename SimpleLRUCacheConstIterator::reference reference;
-  typedef typename SimpleLRUCacheConstIterator::pointer pointer;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using reference = typename SimpleLRUCacheConstIterator::reference;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using pointer = typename SimpleLRUCacheConstIterator::pointer;
 
   // This default constructed Iterator can only be assigned to or destroyed.
   // All other operations give undefined behaviour.
@@ -122,10 +124,12 @@ public:
 
   // For LRU mode, last_use_time() returns elements last use time.
   // See getLastUseTime() description for more information.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int64_t last_use_time() const { return last_use_; }
 
   // For age-based mode, insertion_time() returns elements insertion time.
   // See getInsertionTime() description for more information.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   int64_t insertion_time() const { return last_use_; }
 
   friend bool operator==(const SimpleLRUCacheConstIterator& a,
@@ -196,7 +200,9 @@ public:
   // the element ordering (for LRU eviction) will be updated.
   // This value must be the same for both lookup and release.
   // The default is true.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool update_eviction_order() const { return update_eviction_order_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void set_update_eviction_order(bool v) { update_eviction_order_ = v; }
 
 private:
@@ -449,7 +455,8 @@ public:
   }
 
   // STL style const_iterator support
-  typedef SimpleLRUCacheConstIterator<Key, Value, MapType> const_iterator;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  using const_iterator = SimpleLRUCacheConstIterator<Key, Value, MapType>;
   friend class SimpleLRUCacheConstIterator<Key, Value, MapType>;
   const_iterator begin() const { return const_iterator(table_.begin(), table_.end()); }
   const_iterator end() const { return const_iterator(table_.end(), table_.end()); }
@@ -490,13 +497,13 @@ protected:
   virtual bool isOverfull() const { return units_ > max_units_; }
 
 private:
-  typedef SimpleLRUCacheElem<Key, Value> Elem;
-  typedef MapType Table;
-  typedef typename Table::iterator TableIterator;
-  typedef typename Table::const_iterator TableConstIterator;
-  typedef MapType DeferredTable;
-  typedef typename DeferredTable::iterator DeferredTableIterator;
-  typedef typename DeferredTable::const_iterator DeferredTableConstIterator;
+  using Elem = SimpleLRUCacheElem<Key, Value>;
+  using Table = MapType;
+  using TableIterator = typename Table::iterator;
+  using TableConstIterator = typename Table::const_iterator;
+  using DeferredTable = MapType;
+  using DeferredTableIterator = typename DeferredTable::iterator;
+  using DeferredTableConstIterator = typename DeferredTable::const_iterator;
 
   Table table_; // Main table
   // Pinned entries awaiting to be released before they can be discarded.
@@ -1028,8 +1035,8 @@ template <class Key, class Value, class Deleter, class H, class EQ>
 class SimpleLRUCacheWithDeleter
     : public SimpleLRUCacheBase<
           Key, Value, absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ>, EQ> {
-  typedef absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ> HashMap;
-  typedef SimpleLRUCacheBase<Key, Value, HashMap, EQ> Base;
+  using HashMap = absl::flat_hash_map<Key, SimpleLRUCacheElem<Key, Value>*, H, EQ>;
+  using Base = SimpleLRUCacheBase<Key, Value, HashMap, EQ>;
 
 public:
   explicit SimpleLRUCacheWithDeleter(int64_t total_units) : Base(total_units), deleter_() {}

--- a/source/common/jwt/struct_utils.h
+++ b/source/common/jwt/struct_utils.h
@@ -15,29 +15,37 @@ class StructUtils {
 public:
   StructUtils(const Protobuf::Struct& struct_pb);
 
+  // NOLINTBEGIN(readability-identifier-naming)
   enum FindResult {
     OK = 0,
     MISSING,
     WRONG_TYPE,
     OUT_OF_RANGE,
   };
+  // NOLINTEND(readability-identifier-naming)
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetString(const std::string& name, std::string* str_value);
 
   // Return error if the JSON value is not within a positive 64 bit integer
   // range. The decimals in the JSON value are dropped.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetUInt64(const std::string& name, uint64_t* int_value);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetDouble(const std::string& name, double* double_value);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetBoolean(const std::string& name, bool* bool_value);
 
   // Get string or list of string, designed to get "aud" field
   // "aud" can be either string array or string.
   // Try as string array, read it as empty array if doesn't exist.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetStringList(const std::string& name, std::vector<std::string>* list);
 
   // Find the value with nested names.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   FindResult GetValue(const std::string& nested_names, const Protobuf::Value*& found);
 
 private:

--- a/source/common/matcher/map_matcher.h
+++ b/source/common/matcher/map_matcher.h
@@ -17,6 +17,9 @@ public:
   virtual void addChild(std::string value, OnMatch<DataType>&& on_match) PURE;
 
   ActionMatchResult doNoMatch(const DataType& data, SkippedMatchCb skipped_match_cb) {
+    // This is not true redundant-smartptr-get but we still add a NOLINT to make the
+    // clang-tidy check happy.
+    // NOLINTNEXTLINE(readability-redundant-smartptr-get)
     if (data_input_->get(data).availability() == DataAvailability::MoreDataMightBeAvailable) {
       return ActionMatchResult::insufficientData();
     }

--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -20,13 +20,14 @@ public:
   static_assert((Alignment % sizeof(void*)) == 0,
                 "Alignment must be a multiple of sizeof(void*) when using posix_memalign");
 #endif
-  using value_type = T;
+  using value_type = T; // NOLINT(readability-identifier-naming)
 
   AlignedAllocator() noexcept = default;
 
   // Copy constructor for rebind compatibility.
   template <typename U> explicit AlignedAllocator(const AlignedAllocator<U, Alignment>&) noexcept {}
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static std::size_t round_up_to_alignment(std::size_t bytes) {
     return (bytes + Alignment - 1) & ~(Alignment - 1);
   }
@@ -72,8 +73,8 @@ public:
   }
 
   // Satisfy libc++ requirement.
-  template <typename U> struct rebind {
-    using other = AlignedAllocator<U, Alignment>;
+  template <typename U> struct rebind {           // NOLINT(readability-identifier-naming)
+    using other = AlignedAllocator<U, Alignment>; // NOLINT(readability-identifier-naming)
   };
 };
 

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -105,12 +105,15 @@ public:
   // Register this session to the given registry for receiving network change events.
   void registerNetworkObserver(EnvoyQuicNetworkObserverRegistry& registry);
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const quic::TransportParameters::ParameterMap& received_custom_transport_parameters() {
     return received_custom_transport_parameters_;
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const absl::optional<quic::QuicSocketAddress>& received_ipv6_alternate_server_address() {
     return received_ipv6_alternate_server_address_;
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const absl::optional<quic::QuicSocketAddress>& received_ipv4_alternate_server_address() {
     return received_ipv4_alternate_server_address_;
   }

--- a/source/common/quic/envoy_quic_dispatcher.h
+++ b/source/common/quic/envoy_quic_dispatcher.h
@@ -103,6 +103,7 @@ protected:
 
 private:
   friend class EnvoyQuicDispatcherTest;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   Http::SessionIdleListInterface* idle_session_list() { return session_idle_list_.get(); }
 
   Network::ConnectionHandler& connection_handler_;

--- a/source/common/quic/envoy_quic_server_connection.cc
+++ b/source/common/quic/envoy_quic_server_connection.cc
@@ -66,6 +66,7 @@ bool EnvoyQuicServerConnection::OnPacketHeader(const quic::QuicPacketHeader& hea
   return true;
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerConnection::OnWritePacketDone(size_t packet_size,
                                                   const quic::WriteResult& /*result*/) {
   if (hasConnectionStats()) {

--- a/source/common/quic/envoy_quic_server_connection.h
+++ b/source/common/quic/envoy_quic_server_connection.h
@@ -160,6 +160,7 @@ protected:
 
 private:
   // Called when a packet is written to the packet writer.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void OnWritePacketDone(size_t packet_size, const quic::WriteResult& result);
   std::unique_ptr<QuicListenerFilterManagerImpl> listener_filter_manager_;
   bool first_packet_received_ = false;

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -312,6 +312,7 @@ void EnvoyQuicServerSession::OnStreamClosed(quic::QuicStreamId id) {
   }
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::TerminateIdleSession() {
   ENVOY_BUG(!on_connection_closed_called_,
             "TerminateIdleSession called after session on close called.");
@@ -319,8 +320,10 @@ void EnvoyQuicServerSession::TerminateIdleSession() {
                                 quic::ConnectionCloseBehavior::SEND_CONNECTION_CLOSE_PACKET);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::OnLastActiveStreamClosed() { MaybeAddSessionToIdleList(); }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::MaybeAddSessionToIdleList() {
   if (session_idle_list_ == nullptr || is_in_idle_list_) {
     return;
@@ -329,6 +332,7 @@ void EnvoyQuicServerSession::MaybeAddSessionToIdleList() {
   session_idle_list_->AddSession(*this);
 }
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void EnvoyQuicServerSession::MaybeRemoveSessionFromIdleList() {
   if (session_idle_list_ == nullptr || !is_in_idle_list_) {
     return;

--- a/source/common/quic/envoy_quic_server_session.h
+++ b/source/common/quic/envoy_quic_server_session.h
@@ -126,6 +126,7 @@ public:
   void OnStreamClosed(quic::QuicStreamId id) override;
 
   // IdleSessionInterface
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void TerminateIdleSession() override;
 
   using quic::QuicSession::PerformActionOnActiveStreams;
@@ -149,12 +150,15 @@ protected:
   // Used by base class to access quic connection after initialization.
   const quic::QuicConnection* quicConnection() const override;
   quic::QuicConnection* quicConnection() override;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeAddSessionToIdleList();
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeRemoveSessionFromIdleList();
 
 private:
   void setUpRequestDecoder(EnvoyQuicServerStream& stream);
   void ActivateStream(std::unique_ptr<quic::QuicStream> stream) override;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void OnLastActiveStreamClosed();
 
   std::unique_ptr<EnvoyQuicServerConnection> quic_connection_;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -245,6 +245,7 @@ protected:
 
   std::string quicStreamState();
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   http2::adapter::HeaderValidator& header_validator() { return header_validator_; }
 
 #ifdef ENVOY_ENABLE_HTTP_DATAGRAMS

--- a/source/common/quic/quic_stats_gatherer.h
+++ b/source/common/quic/quic_stats_gatherer.h
@@ -59,6 +59,7 @@ public:
   }
   bool loggingDone() { return logging_done_; }
   uint64_t bytesOutstanding() { return bytes_outstanding_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool notify_ack_listener_before_soon_to_be_destroyed() const {
     return notify_ack_listener_before_soon_to_be_destroyed_;
   }

--- a/source/common/router/retry_state_impl.cc
+++ b/source/common/router/retry_state_impl.cc
@@ -368,6 +368,7 @@ RetryStateImpl::wouldRetryFromHeaders(const Http::ResponseHeaderMap& response_he
   }
 
   if ((retry_on_ & RetryPolicy::RETRY_ON_RETRIABLE_4XX)) {
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     Http::Code code = static_cast<Http::Code>(response_status);
     if (code == Http::Code::Conflict) {
       return RetryDecision::RetryWithBackoff;

--- a/source/common/upstream/load_stats_reporter_impl.cc
+++ b/source/common/upstream/load_stats_reporter_impl.cc
@@ -12,6 +12,7 @@ namespace Upstream {
 namespace {
 
 envoy::service::load_stats::v3::LoadStatsRequest
+// NOLINTNEXTLINE(readability-identifier-naming)
 MakeRequestTemplate(const LocalInfo::LocalInfo& local_info) {
   envoy::service::load_stats::v3::LoadStatsRequest request;
   request.mutable_node()->MergeFrom(local_info.node());

--- a/source/common/version/BUILD
+++ b/source/common/version/BUILD
@@ -67,6 +67,7 @@ envoy_cc_library(
         "//bazel:using_openssl": ["-DENVOY_SSL_VERSION=\\\"OpenSSL\\\""],
         "//conditions:default": ["-DENVOY_SSL_VERSION=\\\"BoringSSL\\\""],
     }),
+    tags = ["notidy"],
     deps = [
         ":version_string_interface_lib",
         ":version_suffix_default",

--- a/source/extensions/access_loggers/stats/stats.h
+++ b/source/extensions/access_loggers/stats/stats.h
@@ -145,8 +145,8 @@ private:
   struct Gauge {
     enum class OperationType {
       SET,
-      PAIRED_ADD,
-      PAIRED_SUBTRACT,
+      PAIRED_ADD,      // NOLINT(readability-identifier-naming)
+      PAIRED_SUBTRACT, // NOLINT(readability-identifier-naming)
     };
 
     NameAndTags stat_;

--- a/source/extensions/common/dubbo/codec.cc
+++ b/source/extensions/common/dubbo/codec.cc
@@ -121,6 +121,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, Context& context) {
 
 void parseResponseInfoFromBuffer(Buffer::Instance& buffer, Context& context) {
   ASSERT(buffer.length() >= DubboCodec::HeadersSize);
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ResponseStatus status = static_cast<ResponseStatus>(buffer.peekInt<uint8_t>(StatusOffset));
   if (!isValidResponseStatus(status)) {
     throw EnvoyException(

--- a/source/extensions/filters/common/expr/evaluator.h
+++ b/source/extensions/filters/common/expr/evaluator.h
@@ -59,7 +59,9 @@ public:
   FindFunctionOverloads(absl::string_view) const override {
     return {};
   }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool needs_response_path_data() const { return needs_response_path_data_; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool has_response_data() const {
     return activation_response_headers_ != nullptr || activation_response_trailers_ != nullptr;
   }

--- a/source/extensions/filters/http/cache_v2/cache_sessions.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.h
@@ -21,8 +21,8 @@ public:
       const Http::RequestHeaderMap& request_headers,
       UpstreamRequestFactoryPtr upstream_request_factory, absl::string_view cluster_name,
       Event::Dispatcher& dispatcher, SystemTime timestamp,
-      const std::shared_ptr<const CacheableResponseChecker> cacheable_response_checker_,
-      const std::shared_ptr<const CacheFilterStatsProvider> stats_provider_,
+      const std::shared_ptr<const CacheableResponseChecker> cacheable_response_checker,
+      const std::shared_ptr<const CacheFilterStatsProvider> stats_provider,
       bool ignore_request_cache_control_header);
 
   // Caches may modify the key according to local needs, though care must be

--- a/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
+++ b/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
@@ -184,15 +184,15 @@ void UpstreamRequestImpl::sendHeaders(Http::RequestHeaderMapPtr request_headers)
   }
 }
 
-template <class... Ts> struct overloaded : Ts... {
+template <class... Ts> struct Overloaded : Ts... {
   using Ts::operator()...;
 };
-template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+template <class... Ts> Overloaded(Ts...) -> Overloaded<Ts...>;
 
 void UpstreamRequestImpl::onReset() {
   ASSERT(dispatcher_.isThreadSafe());
   stream_ = nullptr;
-  absl::visit(overloaded{
+  absl::visit(Overloaded{
                   [](absl::monostate&&) {},
                   [](GetHeadersCallback&& cb) { cb(nullptr, EndStream::Reset); },
                   [](GetBodyCallback&& cb) { cb(nullptr, EndStream::Reset); },

--- a/source/extensions/filters/http/ext_proc/processing_request_modifier.h
+++ b/source/extensions/filters/http/ext_proc/processing_request_modifier.h
@@ -35,7 +35,7 @@ public:
   // Implementations may modify the request and must return true if any modifications were made.
   virtual bool
   modifyRequest(const Params& params,
-                envoy::service::ext_proc::v3::ProcessingRequest& processingRequest) PURE;
+                envoy::service::ext_proc::v3::ProcessingRequest& processing_request) PURE;
 };
 
 class ProcessingRequestModifierFactory : public Config::TypedFactory {

--- a/source/extensions/filters/http/file_server/absl_status_to_http_status.cc
+++ b/source/extensions/filters/http/file_server/absl_status_to_http_status.cc
@@ -10,6 +10,7 @@ Http::Code abslStatusToHttpStatus(absl::StatusCode code) {
   case absl::StatusCode::kOk:
     return Http::Code::OK;
   case absl::StatusCode::kCancelled:
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     return static_cast<Http::Code>(499);
   case absl::StatusCode::kUnknown:
     return Http::Code::InternalServerError;

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter.cc
@@ -61,6 +61,7 @@ absl::StatusOr<StreamMessagePtr> MessageConverter::accumulateMessage(Envoy::Buff
 
   ENVOY_LOG_MISC(info, "len(parsing_buffer_)={}", parsing_buffer_.length());
   if (parsed_output->owned_bytes != nullptr) {
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     ABSL_DCHECK(!parsed_output->needs_more_data);
     ENVOY_LOG_MISC(info, "len(parsed owned_bytes)={}", parsed_output->owned_bytes->length());
   }
@@ -87,6 +88,7 @@ MessageConverter::accumulateMessages(Envoy::Buffer::Instance& data, bool end_str
 
 absl::StatusOr<Envoy::Buffer::InstancePtr>
 MessageConverter::convertBackToBuffer(StreamMessagePtr message) {
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ABSL_DCHECK(message != nullptr);
   conversions_to_envoy_buffer_++;
   if (conversions_to_envoy_buffer_ > conversions_to_message_data_) {

--- a/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/message_converter/message_converter_utility.cc
@@ -78,6 +78,7 @@ absl::StatusOr<ParsedGrpcMessage> parseGrpcMessage(CreateMessageDataFunc& factor
     bytes_needed -= slice_length;
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ABSL_DCHECK(bytes_needed == 0) << "Tried reading past the array of slices during "
                                     "parsing. This should never happen as "
                                     "caller already did size checks.";

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
@@ -64,9 +64,9 @@ namespace GrpcJsonReverseTranscoder {
 
 namespace {
 
-// AppendHttpBodyEnvelope wraps the response returned from the upstream server
+// appendHttpBodyEnvelope wraps the response returned from the upstream server
 // in a google.api.HttpBody message.
-void AppendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
+void appendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
                             uint64_t content_length) {
   // Manually encode the protobuf envelope for the body.
   // See https://developers.google.com/protocol-buffers/docs/encoding#embedded
@@ -101,7 +101,7 @@ void AppendHttpBodyEnvelope(Buffer::Instance& output, std::string content_type,
   output.add(proto_envelope);
 }
 
-bool ReadToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& buffer) {
+bool readToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& buffer) {
   const void* out;
   int size;
   while (stream.Next(&out, &size)) {
@@ -258,7 +258,7 @@ void GrpcJsonReverseTranscoderFilter::SendHttpBodyResponse(Buffer::Instance* dat
     return;
   }
   Buffer::OwnedImpl message_payload;
-  AppendHttpBodyEnvelope(message_payload, response_content_type_, response_data_.length());
+  appendHttpBodyEnvelope(message_payload, response_content_type_, response_data_.length());
   response_content_type_.clear();
   message_payload.move(response_data_);
   Grpc::Encoder().prependFrameHeader(Grpc::GRPC_FH_DEFAULT, message_payload);
@@ -493,7 +493,7 @@ FilterDataStatus GrpcJsonReverseTranscoderFilter::decodeData(Buffer::Instance& d
     return FilterDataStatus::StopIterationNoBuffer;
   }
 
-  ReadToBuffer(*transcoder_->RequestOutput(), request_buffer_);
+  readToBuffer(*transcoder_->RequestOutput(), request_buffer_);
 
   if (!end_stream) {
     return FilterDataStatus::StopIterationNoBuffer;
@@ -603,7 +603,7 @@ FilterDataStatus GrpcJsonReverseTranscoderFilter::encodeData(Buffer::Instance& d
       return FilterDataStatus::StopIterationNoBuffer;
     }
 
-    ReadToBuffer(*transcoder_->ResponseOutput(), response_buffer_);
+    readToBuffer(*transcoder_->ResponseOutput(), response_buffer_);
 
     if (CheckAndRejectIfResponseTranscoderFailed()) {
       return FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.h
@@ -82,21 +82,33 @@ private:
   // MaybeExpandBufferLimits expands the buffer limits for the request and
   // response if the limits are set in the reverse transcoder config and are
   // greater than the default limits.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void MaybeExpandBufferLimits() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool DecoderBufferLimitReached(uint64_t buffer_length) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool EncoderBufferLimitReached(uint64_t buffer_length) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CheckAndRejectIfRequestTranscoderFailed() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CheckAndRejectIfResponseTranscoderFailed() const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   Grpc::Status::GrpcStatus GrpcStatusFromHeaders(Http::ResponseHeaderMap& headers);
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void InitPerRouteConfig();
   // BuildRequestFromHttpBody reads the contents of the data field of the
   // google.api.HttpBody message and builds the request body out of it.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool BuildRequestFromHttpBody(Buffer::Instance& data);
   // SendHttpBodyResponse sends the response returned from the upstream server
   // as a google.api.HttpBody message.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void SendHttpBodyResponse(Buffer::Instance* data);
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void ReplaceAPIVersionInPath();
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool CreateDataBuffer(const nlohmann::json& payload, Buffer::OwnedImpl& buffer) const;
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::Status ExtractHttpAnnotationValues(const Protobuf::MethodDescriptor* method_descriptor);
 
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_;

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.h
@@ -73,19 +73,23 @@ public:
       Api::Api& api);
 
   // Takes the value of the path header of a gRPC request and returns its path descriptor.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const Protobuf::MethodDescriptor* GetMethodDescriptor(absl::string_view path) const;
 
   // Checks if the request body field is of type `google.api.HttpBody`.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool IsRequestNestedHttpBody(const Protobuf::MethodDescriptor* method_descriptor,
                                const std::string& request_body_field) const;
 
   absl::StatusOr<std::unique_ptr<Transcoder>>
+  // NOLINTNEXTLINE(readability-identifier-naming)
   CreateTranscoder(const Protobuf::MethodDescriptor* method_descriptor,
                    TranscoderInputStream& request_input,
                    TranscoderInputStream& response_input) const;
 
   // Changes the body field to its `json_name` value or to camelCase if the filter
   // is not configured to preserve the proto field names.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   absl::StatusOr<std::string> ChangeBodyFieldName(absl::string_view path,
                                                   absl::string_view body_field) const;
 

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.cc
@@ -25,7 +25,7 @@ namespace GrpcJsonReverseTranscoder {
 
 namespace {
 
-absl::Status BuildReplacementVector(nlohmann::json& request, std::string http_rule_path,
+absl::Status buildReplacementVector(nlohmann::json& request, std::string http_rule_path,
                                     std::vector<std::pair<std::string, std::string>>& replacements,
                                     absl::flat_hash_set<std::string>& param_set) {
   size_t end = 0;
@@ -139,7 +139,8 @@ absl::StatusOr<std::string> BuildPath(nlohmann::json& request, std::string http_
                                       std::string http_body_field) {
   std::vector<std::pair<std::string, std::string>> replacements;
   absl::flat_hash_set<std::string> param_set;
-  absl::Status status = BuildReplacementVector(request, http_rule_path, replacements, param_set);
+  const absl::Status status =
+      buildReplacementVector(request, http_rule_path, replacements, param_set);
   if (!status.ok()) {
     return status;
   }

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/utils.h
@@ -17,6 +17,7 @@ namespace GrpcJsonReverseTranscoder {
 inline constexpr char reserved_chars[] = " %:?#[]@!$&'()*+,;=";
 
 // This builds grpc-message header value from body data.
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string BuildGrpcMessage(Envoy::Buffer::Instance& body_data);
 
 // Takes the json object and a path and returns the value of the json object at
@@ -28,6 +29,7 @@ std::string BuildGrpcMessage(Envoy::Buffer::Instance& body_data);
 // [-_./0-9a-zA-Z].
 // TODO(numanelahi): Add `~` to the list of characters that are not percent
 // encoded.
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::optional<std::string> GetNestedJsonValueAsString(const nlohmann::json& object,
                                                        const std::string& key,
                                                        bool has_one_path_segment);
@@ -62,6 +64,7 @@ absl::optional<std::string> GetNestedJsonValueAsString(const nlohmann::json& obj
 // param_set = {"a", "e"}, and
 // key_prefix = "prefix"
 // then query_string = "prefix.f=hello%20world&prefix.g=1.234"
+// NOLINTNEXTLINE(readability-identifier-naming)
 void BuildQueryParamString(const nlohmann::json& object,
                            const absl::flat_hash_set<std::string>& ignore_list,
                            std::string* query_string, std::string key_prefix = "");
@@ -86,6 +89,7 @@ void BuildQueryParamString(const nlohmann::json& object,
 // `/v1/projects/123456789/shelves/fiction?description=This%20is%20a%20test%20description&theme=Kids`,
 // when the http_body_field is "shelf", adding `theme` and `description` as
 // query parameters to the http path.
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::StatusOr<std::string> BuildPath(nlohmann::json& request, std::string http_rule_path,
                                       std::string http_body_field);
 

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.cc
@@ -126,6 +126,7 @@ void GetMonitoredResourceLabels(absl::string_view label_extractor,
 
 WireFormatLite::WireType getWireType(const Field& field_desc) {
   static WireFormatLite::WireType field_kind_to_wire_type[] = {
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       static_cast<WireFormatLite::WireType>(-1), // TYPE_UNKNOWN
       WireFormatLite::WIRETYPE_FIXED64,          // TYPE_DOUBLE
       WireFormatLite::WIRETYPE_FIXED32,          // TYPE_FLOAT
@@ -172,6 +173,7 @@ ExtractRepeatedFieldSizeHelper(const FieldExtractor& field_extractor, const std:
         if (field->number() != WireFormatLite::GetTagFieldNumber(tag)) {
           WireFormatLite::SkipField(input_stream, tag);
         } else {
+          // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
           DCHECK_EQ(WireFormatLite::WIRETYPE_LENGTH_DELIMITED, WireFormatLite::GetTagWireType(tag));
 
           uint32_t length;
@@ -224,6 +226,7 @@ int64_t ExtractRepeatedFieldSize(const Type& type,
 
   // SCRUB directive should only be applied to one field. Tools
   // framework validation should check this case.
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   DCHECK_EQ(1, field_mask->paths_size());
 
   FieldExtractor field_extractor(&type, std::move(type_finder));
@@ -269,6 +272,7 @@ void RedactPath(std::vector<std::string>::const_iterator path_begin,
     auto* repeated_values = field_value.mutable_list_value()->mutable_values();
     for (int i = 0; i < repeated_values->size(); ++i) {
       Value* value = repeated_values->Mutable(i);
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       CHECK(value->has_struct_value()) << "Cannot redact non-message-type field " << field;
       RedactPath(path_begin, path_end, value->mutable_struct_value());
     }
@@ -281,6 +285,7 @@ void RedactPath(std::vector<std::string>::const_iterator path_begin,
 void RedactPaths(absl::Span<const std::string> paths_to_redact, Struct* proto_struct) {
   for (const std::string& path : paths_to_redact) {
     std::vector<std::string> path_pieces = absl::StrSplit(path, '.', absl::SkipEmpty());
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
     CHECK(path_pieces.size() < kMaxRedactedPathDepth)
         << "Attempting to redact path with depth >= " << kMaxRedactedPathDepth << ": " << path;
     RedactPath(path_pieces.begin(), path_pieces.end(), proto_struct);

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/extraction_util.h
@@ -44,22 +44,28 @@ constexpr int kProtoTranslationMaxRecursionDepth = 64;
 
 ABSL_CONST_INIT const char* const kStructTypeUrl = "type.googleapis.com/google.protobuf.Struct";
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool IsEmptyStruct(const Protobuf::Struct& message_struct);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool IsLabelName(absl::string_view value);
 
 // Monitored resource label names are captured within curly brackets ("{", "}").
 // The format is verified by the service config validator, so to extract label
 // name, we just remove the brackets.
+// NOLINTNEXTLINE(readability-identifier-naming)
 std::string GetLabelName(absl::string_view value);
 
 // Singleton mapping of string to ExtractedMessageDirective.
+// NOLINTNEXTLINE(readability-identifier-naming)
 const absl::flat_hash_map<std::string, ExtractedMessageDirective>& StringToDirectiveMap();
 
 absl::optional<ExtractedMessageDirective>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractedMessageDirectiveFromString(absl::string_view directive);
 
 // Returns a mapping of monitored resource label keys to their values.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void GetMonitoredResourceLabels(absl::string_view label_extractor,
                                 absl::string_view resource_string,
                                 Protobuf::Map<std::string, std::string>* labels);
@@ -70,6 +76,7 @@ void GetMonitoredResourceLabels(absl::string_view label_extractor,
 // In case of error or nullptr/empty field_mask, it returns a negative value and
 // logs the error.
 int64_t
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractRepeatedFieldSize(const Protobuf::Type& type,
                          std::function<const Protobuf::Type*(const std::string&)> type_finder,
                          const Protobuf::FieldMask* field_mask,
@@ -78,22 +85,27 @@ ExtractRepeatedFieldSize(const Protobuf::Type& type,
 // Extract the size of the repeated field represented by given field mask
 // path from given proto message. `path` must represent a repeated field.
 absl::StatusOr<int64_t>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractRepeatedFieldSizeHelper(const Protobuf::field_extraction::FieldExtractor& field_extractor,
                                const std::string& path,
                                const Protobuf::field_extraction::MessageData& message);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::string_view ExtractLocationIdFromResourceName(absl::string_view resource_name);
 
 // Recursively redacts the path_pieces in the enclosing proto_struct.
+// NOLINTNEXTLINE(readability-identifier-naming)
 void RedactPath(std::vector<std::string>::const_iterator path_begin,
                 std::vector<std::string>::const_iterator path_end, Protobuf::Struct* proto_struct);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 void RedactPaths(absl::Span<const std::string> paths_to_redact, Protobuf::Struct* proto_struct);
 
 // Finds the last value of the non-repeated string field after the first
 // value. Returns an empty string if there is only one string field. Returns
 // an error if the resource is malformed in case that the search goes forever.
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 FindSingularLastValue(const Protobuf::Field* field,
                       Envoy::Protobuf::io::CodedInputStream* input_stream);
 
@@ -104,15 +116,18 @@ FindSingularLastValue(const Protobuf::Field* field,
 // non-repeated field. However, parsers are expected to handle the case in
 // which they do."
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 SingularFieldUseLastValue(const std::string first_value, const Protobuf::Field* field,
                           Envoy::Protobuf::io::CodedInputStream* input_stream);
 
 absl::StatusOr<std::string>
+// NOLINTNEXTLINE(readability-identifier-naming)
 ExtractStringFieldValue(const Protobuf::Type& type,
                         std::function<const Protobuf::Type*(const std::string&)> type_finder,
                         const std::string& path,
                         const Protobuf::field_extraction::MessageData& message);
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator path_pieces_begin,
                                      std::vector<std::string>::const_iterator path_pieces_end,
                                      Protobuf::Struct* message_struct);
@@ -120,6 +135,7 @@ absl::Status RedactStructRecursively(std::vector<std::string>::const_iterator pa
 // Converts given proto message to Struct. It also adds
 // a "@type" property with proto type url to the generated Struct. Expects the
 // TypeResolver to handle types prefixed with "type.googleapis.com/".
+// NOLINTNEXTLINE(readability-identifier-naming)
 absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& message,
                              const Envoy::Protobuf::Type& type,
                              ::Envoy::Protobuf::util::TypeResolver* type_resolver,
@@ -131,6 +147,7 @@ absl::Status ConvertToStruct(const Protobuf::field_extraction::MessageData& mess
 //  (1) `scrubber` is nullptr;
 //  (2) error during scrubbing/converting;
 //  (3) the message is empty after scrubbing;
+// NOLINTNEXTLINE(readability-identifier-naming)
 bool ScrubToStruct(const proto_processing_lib::proto_scrubber::ProtoScrubber* scrubber,
                    const Envoy::Protobuf::Type& type,
                    const ::google::grpc::transcoding::TypeHelper& type_helper,

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.h
@@ -42,11 +42,13 @@ private:
 
   // Populate the target resource or the target resource callback in the extracted message
   // metadata.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void GetTargetResourceOrTargetResourceCallback(
       const Protobuf::FieldMask& field_mask, const Protobuf::field_extraction::MessageData& message,
       bool callback, ExtractedMessageMetadata* extracted_message_metadata) const;
 
   // Function to get the value associated with a key
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const Protobuf::FieldMask& FindWithDefault(ExtractedMessageDirective directive);
 
   const google::grpc::transcoding::TypeHelper* type_helper_;

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
@@ -16,9 +16,9 @@ namespace ProtoMessageExtraction {
 
 // All valid field extraction directives.
 enum class ExtractedMessageDirective {
-  EXTRACT_REDACT,
+  EXTRACT_REDACT, // NOLINT(readability-identifier-naming)
   EXTRACT,
-  EXTRACT_REPEATED_CARDINALITY,
+  EXTRACT_REPEATED_CARDINALITY, // NOLINT(readability-identifier-naming)
 };
 
 using FieldPathToExtractType =
@@ -41,6 +41,7 @@ public:
   // that contains the extracted message and other extracted message metadata obtained during
   // extraction.
   virtual ExtractedMessageMetadata
+  // NOLINTNEXTLINE(readability-identifier-naming)
   ExtractMessage(const Protobuf::field_extraction::MessageData& message) const = 0;
 
   virtual ~ProtoExtractorInterface() = default;

--- a/source/extensions/filters/http/proto_message_extraction/extractor.h
+++ b/source/extensions/filters/http/proto_message_extraction/extractor.h
@@ -57,8 +57,10 @@ public:
   // is the last message. It only keeps the result from the first one the last.
   virtual void processResponse(Protobuf::field_extraction::MessageData& message) = 0;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual const ExtractedMessageResult& GetResult() const = 0;
 
+  // NOLINTNEXTLINE(readability-identifier-naming)
   virtual void ClearResult() = 0;
 };
 

--- a/source/extensions/filters/http/proto_message_extraction/filter.cc
+++ b/source/extensions/filters/http/proto_message_extraction/filter.cc
@@ -321,9 +321,12 @@ Filter::HandleDataStatus Filter::handleEncodeData(Envoy::Buffer::Instance& data,
     // The converter returns an empty stream_message for the last empty
     // buffer.
     if (stream_message->message() == nullptr) {
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(end_stream);
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(stream_message->isFinalMessage());
       // This is the last one in the vector.
+      // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
       DCHECK(msg_idx == buffering->size() - 1);
       continue;
     }

--- a/source/extensions/filters/http/rate_limit_quota/client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/client_impl.h
@@ -56,8 +56,8 @@ private:
 
 inline std::unique_ptr<RateLimitClient>
 createLocalRateLimitClient(GlobalRateLimitClientImpl* global_client,
-                           ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_cache_tls_) {
-  return std::make_unique<LocalRateLimitClientImpl>(global_client, buckets_cache_tls_);
+                           ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_cache_tls) {
+  return std::make_unique<LocalRateLimitClientImpl>(global_client, buckets_cache_tls);
 }
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
+++ b/source/extensions/filters/http/set_metadata/set_metadata_filter.cc
@@ -15,7 +15,7 @@ namespace SetMetadataFilter {
 
 namespace {
 
-void ApplyConfigToMetadata(const Config& config,
+void applyConfigToMetadata(const Config& config,
                            envoy::config::core::v3::Metadata& dynamic_metadata) {
 
   // Add configured untyped metadata.
@@ -97,13 +97,13 @@ SetMetadataFilter::~SetMetadataFilter() = default;
 
 Http::FilterHeadersStatus SetMetadataFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
   // Apply global config first.
-  ApplyConfigToMetadata(*config_, decoder_callbacks_->streamInfo().dynamicMetadata());
+  applyConfigToMetadata(*config_, decoder_callbacks_->streamInfo().dynamicMetadata());
 
   // Apply route-specific config if present.
   const Config* route_specific_cfg =
       dynamic_cast<const Config*>(decoder_callbacks_->mostSpecificPerFilterConfig());
   if (route_specific_cfg) {
-    ApplyConfigToMetadata(*route_specific_cfg, decoder_callbacks_->streamInfo().dynamicMetadata());
+    applyConfigToMetadata(*route_specific_cfg, decoder_callbacks_->streamInfo().dynamicMetadata());
   }
 
   return Http::FilterHeadersStatus::Continue;

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -81,6 +81,7 @@ struct SupportedCommands {
    * @return commands without keys which are sent to all redis shards and the responses are handled
    * using special response handler according  to its response type
    */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   static const absl::flat_hash_set<std::string>& ClusterScopeCommands() {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb",
                            "slowlog", "config", "info", "keys", "select", "role", "hello");

--- a/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
+++ b/source/extensions/filters/network/dubbo_proxy/dubbo_protocol_impl.cc
@@ -56,6 +56,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
   ASSERT(data.length() >= DubboProtocolImpl::MessageSize);
   uint8_t flag = data.peekInt<uint8_t>(FlagOffset);
   bool is_two_way = (flag & TwoWayMask) == TwoWayMask ? true : false;
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   SerializationType type = static_cast<SerializationType>(flag & SerializationTypeMask);
   if (!isValidSerializationType(type)) {
     throw EnvoyException(
@@ -72,6 +73,7 @@ void parseRequestInfoFromBuffer(Buffer::Instance& data, MessageMetadataSharedPtr
 
 void parseResponseInfoFromBuffer(Buffer::Instance& buffer, MessageMetadataSharedPtr metadata) {
   ASSERT(buffer.length() >= DubboProtocolImpl::MessageSize);
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   ResponseStatus status = static_cast<ResponseStatus>(buffer.peekInt<uint8_t>(StatusOffset));
   if (!isValidResponseStatus(status)) {
     throw EnvoyException(

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -20,9 +20,9 @@ class ClusterScopeCmdRequest;
  * Enum defining the different response handler types for cluster scope commands
  */
 enum class ClusterScopeResponseHandlerType {
-  allresponses_mustbe_same,
-  aggregate_all_responses,
-  response_handler_none
+  allresponses_mustbe_same, // NOLINT(readability-identifier-naming)
+  aggregate_all_responses,  // NOLINT(readability-identifier-naming)
+  response_handler_none     // NOLINT(readability-identifier-naming)
 };
 
 /**

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -30,6 +30,7 @@ bool BinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMetad
 
   // The byte at offset 2 is unused and ignored.
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(3));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(
@@ -392,6 +393,7 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
     return false;
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
   MessageType type = static_cast<MessageType>(buffer.peekInt<int8_t>(name_len + 4));
   if (type < MessageType::Call || type > MessageType::LastMessageType) {
     throw EnvoyException(

--- a/source/extensions/matching/http/cel_input/cel_input.h
+++ b/source/extensions/matching/http/cel_input/cel_input.h
@@ -28,7 +28,9 @@ using StreamActivationPtr = std::unique_ptr<Filters::Common::Expr::StreamActivat
 class CelMatchData : public ::Envoy::Matcher::CustomMatchData {
 public:
   explicit CelMatchData(StreamActivationPtr activation) : activation_(std::move(activation)) {}
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool needs_response() const { return activation_->needs_response_path_data(); }
+  // NOLINTNEXTLINE(readability-identifier-naming)
   bool has_response_data() const { return activation_->has_response_data(); }
   StreamActivationPtr activation_;
 };

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h
@@ -77,8 +77,8 @@ public:
 
   class MetricKey {
   public:
-    MetricKey(std::string&& name, SortedAttributesVector&& sortedAttributes)
-        : name_(std::move(name)), sorted_attributes_(std::move(sortedAttributes)) {}
+    MetricKey(std::string&& name, SortedAttributesVector&& sorted_attributes)
+        : name_(std::move(name)), sorted_attributes_(std::move(sorted_attributes)) {}
 
     bool operator==(const MetricKey& other) const {
       return name_ == other.name_ && sorted_attributes_ == other.sorted_attributes_;
@@ -227,6 +227,7 @@ public:
   bool useTagExtractedName() { return use_tag_extracted_name_; }
   absl::string_view statPrefix() { return stat_prefix_; }
   const Protobuf::RepeatedPtrField<opentelemetry::proto::common::v1::KeyValue>&
+  // NOLINTNEXTLINE(readability-identifier-naming)
   resource_attributes() const {
     return resource_attributes_;
   }

--- a/source/extensions/tracers/datadog/agent_http_client.h
+++ b/source/extensions/tracers/datadog/agent_http_client.h
@@ -92,6 +92,7 @@ public:
    * Return a JSON representation of this object's configuration. This function
    * is used in the startup banner logged by \c dd-trace-cpp.
    */
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const nlohmann::json& config_json() const;
 
   // Http::AsyncClient::Callbacks

--- a/source/extensions/tracers/datadog/event_scheduler.h
+++ b/source/extensions/tracers/datadog/event_scheduler.h
@@ -40,6 +40,7 @@ public:
   std::string config() const override;
 
   // Provides JSON configuration for debug logging.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   const nlohmann::json& config_json() const;
 
 private:

--- a/source/extensions/transport_sockets/tap/tap_config_impl.cc
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.cc
@@ -30,7 +30,7 @@ PerSocketTapperImpl::PerSocketTapperImpl(
     sink_handle_->submitTrace(std::move(trace));
     pegSubmitCounter(true);
   }
-  seq_num++;
+  seq_num_++;
 }
 
 void PerSocketTapperImpl::fillConnectionInfo(envoy::data::tap::v3::Connection& connection) {
@@ -49,19 +49,19 @@ void PerSocketTapperImpl::closeSocket(Network::ConnectionEvent) {
   }
 
   if (config_->streaming()) {
-    seq_num++;
+    seq_num_++;
     if (shouldSendStreamedMsgByConfiguredSize()) {
       makeStreamedTraceIfNeeded();
       auto& event =
           *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       event.mutable_closed();
       // submit directly and don't check current_streamed_rx_tx_bytes_ any more
       submitStreamedDataPerConfiguredSize();
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       event.mutable_closed();
       sink_handle_->submitTrace(std::move(trace));
     }
@@ -140,7 +140,7 @@ void PerSocketTapperImpl::handleSendingStreamTappedMsgPerConfigSize(const Buffer
   makeStreamedTraceIfNeeded();
   auto& event =
       *streamed_trace_->mutable_socket_streamed_trace_segment()->mutable_events()->add_events();
-  initStreamingEvent(event, seq_num);
+  initStreamingEvent(event, seq_num_);
   uint32_t buffer_start_offset = 0;
   if (is_read) {
     buffer_start_offset = data.length() - total_bytes;
@@ -171,14 +171,14 @@ void PerSocketTapperImpl::onRead(const Buffer::Instance& data, uint32_t bytes_re
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       TapCommon::Utility::addBufferToProtoBytes(*event.mutable_read()->mutable_data(),
                                                 config_->maxBufferedRxBytes(), data,
                                                 data.length() - bytes_read, bytes_read);
       sink_handle_->submitTrace(std::move(trace));
       pegSubmitCounter(true);
     }
-    seq_num = seq_num + bytes_read;
+    seq_num_ = seq_num_ + bytes_read;
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().read_truncated()) {
       return;
@@ -209,7 +209,7 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
     } else {
       TapCommon::TraceWrapperPtr trace = makeTraceSegment();
       auto& event = *trace->mutable_socket_streamed_trace_segment()->mutable_event();
-      initStreamingEvent(event, seq_num);
+      initStreamingEvent(event, seq_num_);
       TapCommon::Utility::addBufferToProtoBytes(*event.mutable_write()->mutable_data(),
                                                 config_->maxBufferedTxBytes(), data, 0,
                                                 bytes_written);
@@ -217,7 +217,7 @@ void PerSocketTapperImpl::onWrite(const Buffer::Instance& data, uint32_t bytes_w
       sink_handle_->submitTrace(std::move(trace));
       pegSubmitCounter(true);
     }
-    seq_num = seq_num + bytes_written;
+    seq_num_ = seq_num_ + bytes_written;
   } else {
     if (buffered_trace_ != nullptr && buffered_trace_->socket_buffered_trace().write_truncated()) {
       return;

--- a/source/extensions/transport_sockets/tap/tap_config_impl.h
+++ b/source/extensions/transport_sockets/tap/tap_config_impl.h
@@ -65,7 +65,7 @@ private:
   // for some protocols (e.g., HTTP/2 frames may span multiple reads/writes).
   // Add sequence number to allow the receiver to reconstruct byte order and
   // determine completeness, similar to TCP sequence numbers.
-  uint64_t seq_num{};
+  uint64_t seq_num_ = 0;
   SocketTapConfigSharedPtr config_;
   Extensions::Common::Tap::PerTapSinkHandleManagerPtr sink_handle_;
   const Network::Connection& connection_;

--- a/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
+++ b/source/extensions/transport_sockets/tcp_stats/tcp_stats.h
@@ -13,6 +13,7 @@
 #include "source/extensions/transport_sockets/common/passthrough.h"
 
 // Defined in /usr/include/linux/tcp.h.
+// NOLINTNEXTLINE(readability-identifier-naming)
 struct tcp_info;
 
 namespace Envoy {

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1711,3 +1711,4 @@ bitrate
 kbps
 dataset
 datasets
+smartptr


### PR DESCRIPTION
## Summary

Apply clang-tidy fixes for naming conventions and enum-cast issues across `source/`.


**This PR only fix naming of inner function/local variable. For any method/function that exposed in the header file, I didn’t actually resolve the problem but only suppress the issue to make clang tidy CI happy because naming change may break our forks.**

In the future, we can use the `NOLINTNEXTLINE(readability-identifier-naming)` as tag to figure out the unexpected naming easily from the code base and resolve them one by one.

## Risk Level

Low — mechanical clang-tidy refactor; no behavior changes intended.

## Testing

CI.

## Docs Changes

None.

## Release Notes

None.

Signed-off-by: wbpcode/wangbaiping <wbphub@gmail.com>
