### PR TITLE
clang tidy: fix readability issues of source

### DIFF
--- a/envoy/matcher/matcher.h
+++ b/envoy/matcher/matcher.h
@@ -338,7 +338,7 @@ public:
 
   static DataInputGetResult
   NoData(DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(absl::monostate(), data_availability);
+    return {absl::monostate(), data_availability};
   }
 
   /**
@@ -348,19 +348,19 @@ public:
   static DataInputGetResult
   CreateStringView(absl::string_view data,
                    DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(data, data_availability);
+    return {data, data_availability};
   }
 
   static DataInputGetResult
   CreateString(std::string&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(std::move(data), data_availability);
+    return {std::move(data), data_availability};
   }
 
   static DataInputGetResult
   CreateCustom(std::shared_ptr<CustomMatchData>&& data,
                DataAvailability data_availability = DataAvailability::AllDataAvailable) {
-    return DataInputGetResult(std::move(data), data_availability);
+    return {std::move(data), data_availability};
   }
 
 private:

--- a/source/common/buffer/buffer_impl.cc
+++ b/source/common/buffer/buffer_impl.cc
@@ -590,7 +590,7 @@ bool OwnedImpl::startsWith(absl::string_view data) const {
     return false;
   }
 
-  if (data.length() == 0) {
+  if (data.empty()) {
     return true;
   }
 

--- a/source/common/common/scope_tracked_object_stack.h
+++ b/source/common/common/scope_tracked_object_stack.h
@@ -24,6 +24,7 @@ public:
   void add(const ScopeTrackedObject& object) { tracked_objects_.push_back(object); }
 
   OptRef<const StreamInfo::StreamInfo> trackedStream() const override {
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
       OptRef<const StreamInfo::StreamInfo> stream = iter->get().trackedStream();
       if (stream.has_value()) {
@@ -34,6 +35,7 @@ public:
   }
 
   void dumpState(std::ostream& os, int indent_level) const override {
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto iter = tracked_objects_.rbegin(); iter != tracked_objects_.rend(); ++iter) {
       iter->get().dumpState(os, indent_level);
     }

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -386,6 +386,7 @@ void DispatcherImpl::onFatalError(std::ostream& os) const {
   // Dump the state of the tracked objects in the dispatcher if thread safe. This generally
   // results in dumping the active state only for the thread which caused the fatal error.
   if (isThreadSafe()) {
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto iter = tracked_object_stack_.rbegin(); iter != tracked_object_stack_.rend(); ++iter) {
       (*iter)->dumpState(os);
     }

--- a/source/common/formatter/substitution_format_utility.cc
+++ b/source/common/formatter/substitution_format_utility.cc
@@ -18,12 +18,12 @@ absl::Status CommandSyntaxChecker::verifySyntax(CommandSyntaxChecker::CommandSyn
                                                 absl::string_view command,
                                                 absl::string_view subcommand,
                                                 absl::optional<size_t> length) {
-  if ((flags == COMMAND_ONLY) && ((subcommand.length() != 0) || length.has_value())) {
+  if ((flags == COMMAND_ONLY) && ((!subcommand.empty()) || length.has_value())) {
     return absl::InvalidArgumentError(
         fmt::format("{} does not take any parameters or length", command));
   }
 
-  if ((flags & PARAMS_REQUIRED).any() && (subcommand.length() == 0)) {
+  if ((flags & PARAMS_REQUIRED).any() && (subcommand.empty())) {
     return absl::InvalidArgumentError(fmt::format("{} requires parameters", command));
   }
 

--- a/source/common/http/header_map_impl.cc
+++ b/source/common/http/header_map_impl.cc
@@ -394,6 +394,7 @@ void HeaderMapImpl::iterate(HeaderMap::ConstIterateCb cb) const {
 }
 
 void HeaderMapImpl::iterateReverse(HeaderMap::ConstIterateCb cb) const {
+  // NOLINTNEXTLINE(modernize-loop-convert)
   for (auto it = headers_.rbegin(); it != headers_.rend(); it++) {
     if (cb(*it) == HeaderMap::Iterate::Break) {
       break;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1818,6 +1818,7 @@ void ConnectionImpl::onProtocolConstraintViolation() {
 
 void ConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWatermark() {
   // Notify the streams based on least recently encoding to the connection.
+  // NOLINTNEXTLINE(modernize-loop-convert)
   for (auto it = active_streams_.rbegin(); it != active_streams_.rend(); ++it) {
     (*it)->runLowWatermarkCallbacks();
   }

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -34,7 +34,7 @@ HttpServerPropertiesCacheImpl::stringToOrigin(const std::string& str) {
   std::string scheme;
   std::string hostname;
   int port = 0;
-  if (re2::RE2::FullMatch(str.c_str(), origin_regex, &scheme, &hostname, &port)) {
+  if (re2::RE2::FullMatch(str, origin_regex, &scheme, &hostname, &port)) {
     return HttpServerPropertiesCache::Origin(scheme, hostname, port);
   }
   return {};

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -37,8 +37,6 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -167,8 +165,9 @@ template <typename Key, typename Value> struct SimpleLRUCacheElem {
   }
 
   void unlink() {
-    if (!isLinked())
+    if (!isLinked()) {
       return;
+    }
     prev->next = next;
     next->prev = prev;
     prev = nullptr;
@@ -248,8 +247,9 @@ public:
           value_(cache_->lookupWithOptions(key_, options_)) {}
 
     ~ScopedLookup() {
-      if (value_ != nullptr)
+      if (value_ != nullptr) {
         cache_->releaseWithOptions(key_, value_, options_);
+      }
     }
     const Key& key() const { return key_; }
     Value* value() const { return value_; }
@@ -391,8 +391,9 @@ public:
   // Remove all entries which have exceeded their max idle time or age
   // set using setMaxIdleSeconds() or setAgeBasedEviction() respectively.
   void removeExpiredEntries() {
-    if (max_idle_ >= 0)
+    if (max_idle_ >= 0) {
       discardIdle(max_idle_);
+    }
   }
 
   // Return current size of cache
@@ -608,8 +609,9 @@ template <class Key, class Value, class MapType, class EQ>
 void SimpleLRUCacheBase<Key, Value, MapType, EQ>::removeUnpinned() {
   for (Elem* e = head_.next; e != &head_;) {
     Elem* next = e->next;
-    if (e->pin == 0)
+    if (e->pin == 0) {
       remove(e->key);
+    }
     e = next;
   }
 }
@@ -650,8 +652,9 @@ Value* SimpleLRUCacheBase<Key, Value, MapType, EQ>::lookupWithOptions(
       pinned_units_ += e->units;
       // We are pinning this entry, take it off the LRU list if we are in LRU
       // mode. In strict age-based mode entries stay on the list while pinned.
-      if (lru_ && options.update_eviction_order())
+      if (lru_ && options.update_eviction_order()) {
         e->unlink();
+      }
     }
     e->pin++;
     return e->value;
@@ -707,8 +710,9 @@ void SimpleLRUCacheBase<Key, Value, MapType, EQ>::releaseWithOptions(
     e->pin--;
 
     if (e->pin == 0) {
-      if (lru_ && options.update_eviction_order())
+      if (lru_ && options.update_eviction_order()) {
         e->link(&head_);
+      }
       pinned_units_ -= e->units;
       if (isOverfullInternal()) {
         // This element is no longer needed, and we are full. So kick it out.
@@ -735,8 +739,9 @@ void SimpleLRUCacheBase<Key, Value, MapType, EQ>::insertPinned(const Key& k, Val
   // If we are in the strict age-based eviction mode, the entry goes on the LRU
   // list now and is never removed. In the LRU mode, the list will only contain
   // unpinned entries.
-  if (!lru_)
+  if (!lru_) {
     e->link(&head_);
+  }
   garbageCollect();
 }
 
@@ -793,8 +798,9 @@ bool SimpleLRUCacheBase<Key, Value, MapType, EQ>::inDeferredTable(const Key& k,
     const Elem* const head = iter->second;
     const Elem* e = head;
     do {
-      if (e->value == value || value == nullptr)
+      if (e->value == value || value == nullptr) {
         return true;
+      }
       e = e->prev;
     } while (e != head);
   }
@@ -858,8 +864,9 @@ static const int kAcceptableClockSynchronizationDriftCycles = 1;
 
 template <class Key, class Value, class MapType, class EQ>
 void SimpleLRUCacheBase<Key, Value, MapType, EQ>::discardIdle(int64_t max_idle) {
-  if (max_idle < 0)
+  if (max_idle < 0) {
     return;
+  }
 
   Elem* e = head_.prev;
   const int64_t threshold = SimpleCycleTimer::now() - max_idle;
@@ -928,8 +935,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::deferredEntries() const {
 
 template <class Key, class Value, class MapType, class EQ>
 int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::ageOfLRUItemInMicroseconds() const {
-  if (head_.prev == &head_)
+  if (head_.prev == &head_) {
     return 0;
+  }
   return kSecToUsec * (SimpleCycleTimer::now() - head_.prev->last_use_) /
          SimpleCycleTimer::frequency();
 }
@@ -939,8 +947,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::getLastUseTime(const Key& k
   // getLastUseTime works only in LRU mode
   assert(lru_);
   TableConstIterator iter = table_.find(k);
-  if (iter == table_.end())
+  if (iter == table_.end()) {
     return -1;
+  }
   const Elem* e = iter->second;
   return e->last_use_;
 }
@@ -950,8 +959,9 @@ int64_t SimpleLRUCacheBase<Key, Value, MapType, EQ>::getInsertionTime(const Key&
   // getInsertionTime works only in age-based mode
   assert(!lru_);
   TableConstIterator iter = table_.find(k);
-  if (iter == table_.end())
+  if (iter == table_.end()) {
     return -1;
+  }
   const Elem* e = iter->second;
   return e->last_use_;
 }

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1369,12 +1369,16 @@ RouteEntryImplBase::perFilterConfigs(absl::string_view filter_name) const {
 }
 
 const envoy::config::core::v3::Metadata& RouteEntryImplBase::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& RouteEntryImplBase::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 UriTemplateMatcherRouteEntryImpl::UriTemplateMatcherRouteEntryImpl(
@@ -1728,12 +1732,16 @@ CommonVirtualHostImpl::perFilterConfigs(absl::string_view filter_name) const {
 }
 
 const envoy::config::core::v3::Metadata& CommonVirtualHostImpl::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& CommonVirtualHostImpl::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 absl::StatusOr<std::shared_ptr<CommonVirtualHostImpl>>
@@ -2136,12 +2144,16 @@ CommonConfigImpl::clusterSpecifierPlugin(absl::string_view provider) const {
 }
 
 const envoy::config::core::v3::Metadata& CommonConfigImpl::metadata() const {
-  return metadata_ != nullptr ? metadata_->proto_metadata_
-                              : DefaultRouteMetadataPack::get().proto_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->proto_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().proto_metadata_;
 }
 const Envoy::Config::TypedMetadata& CommonConfigImpl::typedMetadata() const {
-  return metadata_ != nullptr ? metadata_->typed_metadata_
-                              : DefaultRouteMetadataPack::get().typed_metadata_;
+  if (metadata_ != nullptr) {
+    return metadata_->typed_metadata_;
+  }
+  return DefaultRouteMetadataPack::get().typed_metadata_;
 }
 
 absl::StatusOr<std::shared_ptr<CommonConfigImpl>>

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1982,7 +1982,7 @@ void Filter::onUpstreamData(Buffer::Instance& data, UpstreamRequest& upstream_re
   // When route retry policy is configured and an upstream filter is returning StopIteration
   // in it's encodeHeaders() method, upstream_requests_.size() is equal to 0 in this case,
   // and we should just return.
-  if (upstream_requests_.size() == 0) {
+  if (upstream_requests_.empty()) {
     return;
   }
 
@@ -2006,7 +2006,7 @@ void Filter::onUpstreamTrailers(Http::ResponseTrailerMapPtr&& trailers,
   // When route retry policy is configured and an upstream filter is returning StopIteration
   // in it's encodeHeaders() method, upstream_requests_.size() is equal to 0 in this case,
   // and we should just return.
-  if (upstream_requests_.size() == 0) {
+  if (upstream_requests_.empty()) {
     return;
   }
 

--- a/source/common/router/scoped_config_impl.cc
+++ b/source/common/router/scoped_config_impl.cc
@@ -51,7 +51,7 @@ HeaderValueExtractorImpl::computeFragment(const Http::HeaderMap& headers) const 
   // This is an implicitly untrusted header, so per the API documentation only the first
   // value is used.
   std::vector<absl::string_view> elements{header_entry[0]->value().getStringView()};
-  if (header_value_extractor_config_.element_separator().length() > 0) {
+  if (!header_value_extractor_config_.element_separator().empty()) {
     elements = absl::StrSplit(header_entry[0]->value().getStringView(),
                               header_value_extractor_config_.element_separator());
   }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -387,7 +387,7 @@ Config::SharedConfig::parseTLVs(absl::Span<const envoy::config::core::v3::TlvEnt
 
     if (has_value) {
       // Static TLV value must be at least one byte long.
-      if (tlv->value().size() < 1) {
+      if (tlv->value().empty()) {
         throw EnvoyException("Invalid TLV configuration: 'value' must be at least one byte long.");
       }
       tlv_vector.push_back(

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -248,6 +248,7 @@ void InstanceImpl::shutdownThread() {
   //                     number than the first. This is an edge case that does not exist anywhere
   //                     in the code today, but we can keep this in mind if things become more
   //                     complicated in the future.
+  // NOLINTNEXTLINE(modernize-loop-convert)
   for (auto it = thread_local_data_.data_.rbegin(); it != thread_local_data_.data_.rend(); ++it) {
     it->reset();
   }

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -396,7 +396,7 @@ bool DefaultCertValidator::verifySubjectAltName(X509* cert,
   for (const GENERAL_NAME* general_name : san_names.get()) {
     const std::string san = Utility::generalNameAsString(general_name);
     for (auto& config_san : subject_alt_names) {
-      if (general_name->type == GEN_DNS ? Utility::dnsNameMatch(config_san, san.c_str())
+      if (general_name->type == GEN_DNS ? Utility::dnsNameMatch(config_san, san)
                                         : config_san == san) {
         return true;
       }

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -33,6 +33,7 @@ std::string certToPem(X509& cert) {
   const uint8_t* output;
   size_t length;
   RELEASE_ASSERT(BIO_mem_contents(buf.get(), &output, &length) == 1, "");
+  // NOLINTNEXTLINE(modernize-return-braced-init-list)
   return std::string(reinterpret_cast<const char*>(output), length);
 }
 

--- a/source/common/tls/ocsp/asn1_utility.cc
+++ b/source/common/tls/ocsp/asn1_utility.cc
@@ -63,7 +63,7 @@ absl::StatusOr<Envoy::SystemTime> Asn1Utility::parseGeneralizedTime(CBS& cbs) {
   // Local time or time differential, though a part of the `ASN.1`
   // `GENERALIZEDTIME` spec, are not supported.
   // Reference: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.2
-  if (time_str.length() > 0 && absl::ascii_toupper(time_str.at(time_str.length() - 1)) != 'Z') {
+  if (!time_str.empty() && absl::ascii_toupper(time_str.at(time_str.length() - 1)) != 'Z') {
     return absl::InvalidArgumentError("GENERALIZEDTIME must be in UTC");
   }
 

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1553,9 +1553,9 @@ ClusterInfoImpl::processHttpForOutlierDetection(Http::ResponseHeaderMap& headers
   // Run matchers.
   http_protocol_options_->outlier_detection_http_error_matcher_[0]->onHttpResponseHeaders(headers,
                                                                                           statuses);
-  return absl::optional<bool>(http_protocol_options_->outlier_detection_http_error_matcher_[0]
-                                  ->matchStatus(statuses)
-                                  .matches_);
+  return http_protocol_options_->outlier_detection_http_error_matcher_[0]
+      ->matchStatus(statuses)
+      .matches_;
 }
 
 absl::StatusOr<bool> validateTransportSocketSupportsQuic(

--- a/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
+++ b/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
@@ -106,6 +106,7 @@ uint64_t getBufferSizeBytes(
 std::vector<std::string> getFilterStateObjectsToLog(
     const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&
         config) {
+  // NOLINTNEXTLINE(modernize-return-braced-init-list)
   return std::vector<std::string>(config.filter_state_objects_to_log().begin(),
                                   config.filter_state_objects_to_log().end());
 }

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -342,7 +342,7 @@ void UpstreamSocketManager::markSocketDead(const int fd) {
 void UpstreamSocketManager::cleanStaleNodeEntry(const std::string& node_id) {
   // Clean the given node ID if there are no active sockets.
   if (accepted_reverse_connections_.find(node_id) != accepted_reverse_connections_.end() &&
-      accepted_reverse_connections_[node_id].size() > 0) {
+      !accepted_reverse_connections_[node_id].empty()) {
     ENVOY_LOG(trace, "reverse_tunnel: found {} active sockets for node {}.",
               accepted_reverse_connections_[node_id].size(), node_id);
     return;

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -474,7 +474,7 @@ size_t DynamicModuleCluster::removeHosts(const std::vector<Upstream::HostSharedP
   }
 
   // Build the remaining host list and update the priority set once.
-  ASSERT(priority_set_.hostSetsPerPriority().size() >= 1);
+  ASSERT(!priority_set_.hostSetsPerPriority().empty());
   const auto& first_host_set = priority_set_.getOrCreateHostSet(0);
 
   // Build a set of removed host pointers for O(1) lookup.

--- a/source/extensions/clusters/reverse_connection/reverse_connection.cc
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.cc
@@ -284,8 +284,8 @@ RevConClusterFactory::createClusterWithConfig(
   }
 
   absl::Status creation_status = absl::OkStatus();
-  auto new_cluster = std::shared_ptr<RevConCluster>(
-      new RevConCluster(cluster, context, creation_status, proto_config));
+  auto new_cluster =
+      std::make_shared<RevConCluster>(cluster, context, creation_status, proto_config);
   RETURN_IF_NOT_OK(creation_status);
   auto lb = std::make_unique<RevConCluster::ThreadAwareLoadBalancer>(new_cluster);
   return std::make_pair(new_cluster, std::move(lb));

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.h
@@ -104,7 +104,7 @@ public:
                  grpc_stream_.get())
           ->currentStreamForTest();
     }
-    return *grpc_stream_.get();
+    return *grpc_stream_;
   }
 
 private:

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
@@ -99,7 +99,7 @@ public:
                  grpc_stream_.get())
           ->currentStreamForTest();
     }
-    return *grpc_stream_.get();
+    return *grpc_stream_;
   }
 
   struct SubscriptionStuff {

--- a/source/extensions/content_parsers/json/json_content_parser_impl.cc
+++ b/source/extensions/content_parsers/json/json_content_parser_impl.cc
@@ -47,8 +47,7 @@ ContentParser::ParseResult JsonContentParserImpl::parse(absl::string_view data) 
   bool all_rules_have_limits = true;
   bool all_limited_rules_satisfied = true;
 
-  for (size_t i = 0; i < rules_.size(); ++i) {
-    auto& rule = rules_[i];
+  for (auto& rule : rules_) {
 
     // Track if any rule has no limit
     if (rule.stop_processing_after_matches_ == 0) {

--- a/source/extensions/filters/http/a2a/a2a_filter.cc
+++ b/source/extensions/filters/http/a2a/a2a_filter.cc
@@ -144,8 +144,9 @@ Http::FilterDataStatus A2aFilter::decodeData(Buffer::Instance& data, bool end_st
       }
     }
 
-    if (max_size > 0 && bytes_parsed_ == max_size)
+    if (max_size > 0 && bytes_parsed_ == max_size) {
       break;
+    }
   }
 
   // If we are here, we haven't collected all fields yet.

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -15,8 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CacheV2 {
 
-using CancelWrapper::cancelWrapped;
-
 class UpstreamRequestWithCacheabilityReset : public HttpSource {
 public:
   UpstreamRequestWithCacheabilityReset(
@@ -248,7 +246,7 @@ void CacheSession::sendLookupResponsesAndMaybeValidationRequest(CacheEntryStatus
   lookup_subscribers_.erase(it, lookup_subscribers_.end());
   if (!lookup_subscribers_.empty()) {
     // At least one subscriber required validation.
-    return performValidation();
+    performValidation();
   }
 }
 
@@ -586,7 +584,8 @@ void CacheSession::getLookupResult(ActiveLookupRequestPtr lookup, ActiveLookupRe
       } else {
         sub.context_->lookup().stats().incCacheSessionsSubscribers();
         lookup_subscribers_.push_back(std::move(sub));
-        return performValidation();
+        performValidation();
+        return;
       }
     }
     auto result = std::make_unique<ActiveLookupResult>();
@@ -771,7 +770,6 @@ void CacheSession::onUncacheable(Http::ResponseHeaderMapPtr headers, EndStream e
     cache_sessions->stats().subCacheSessionsSubscribers(lookup_subscribers_.size());
   }
   lookup_subscribers_.clear();
-  return;
 }
 
 void CacheSession::onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStream end_stream,

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter.cc
@@ -105,8 +105,9 @@ bool ReadToBuffer(Protobuf::io::ZeroCopyInputStream& stream, Buffer::Instance& b
   const void* out;
   int size;
   while (stream.Next(&out, &size)) {
-    if (size == 0)
+    if (size == 0) {
       return true;
+    }
     buffer.add(out, size);
   }
   return false;
@@ -192,8 +193,9 @@ bool GrpcJsonReverseTranscoderFilter::EncoderBufferLimitReached(uint64_t buffer_
 
 bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfRequestTranscoderFailed() const {
   const auto& status = transcoder_->RequestStatus();
-  if (status.ok())
+  if (status.ok()) {
     return false;
+  }
   decoder_callbacks_->sendLocalReply(
       Code::BadRequest, status.message(), nullptr, Status::WellKnownGrpcStatus::InvalidArgument,
       absl::StrCat(RcDetails::get().grpc_transcode_failed, "{",
@@ -204,8 +206,9 @@ bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfRequestTranscoderFailed() 
 
 bool GrpcJsonReverseTranscoderFilter::CheckAndRejectIfResponseTranscoderFailed() const {
   const auto& status = transcoder_->ResponseStatus();
-  if (status.ok())
+  if (status.ok()) {
     return false;
+  }
   ENVOY_STREAM_LOG(error, "Response transcoding failed: {}", *encoder_callbacks_, status.message());
   encoder_callbacks_->sendLocalReply(
       Code::InternalServerError, status.message(), nullptr, Status::WellKnownGrpcStatus::Internal,

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
@@ -40,7 +40,6 @@ using ResponseTranslator = ::google::grpc::transcoding::JsonRequestTranslator;
 using ResponseInfo = ::google::grpc::transcoding::RequestInfo;
 using ::envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
     GrpcJsonReverseTranscoder;
-using ::google::api::HttpRule;
 using ::google::grpc::transcoding::Transcoder;
 using ::google::grpc::transcoding::TranscoderInputStream;
 using ::google::grpc::transcoding::TypeHelper;

--- a/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/http_body_utils.cc
@@ -87,6 +87,7 @@ void HttpBodyUtils::appendHttpBodyEnvelope(
                              CodedOutputStream::VarintSize64(content_length);
     std::vector<uint32_t> message_sizes;
     message_sizes.reserve(request_body_field_path.size());
+    // NOLINTNEXTLINE(modernize-loop-convert)
     for (auto it = request_body_field_path.rbegin(); it != request_body_field_path.rend(); ++it) {
       const Protobuf::Field* field = *it;
       const uint64_t message_size = envelope_size + content_length;

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -310,8 +310,9 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
       }
     }
 
-    if (max_size > 0 && bytes_parsed_ == max_size)
+    if (max_size > 0 && bytes_parsed_ == max_size) {
       break;
+    }
   }
 
   // If we are here, we haven't collected all fields yet.

--- a/source/extensions/filters/http/mcp_router/mcp_router.cc
+++ b/source/extensions/filters/http/mcp_router/mcp_router.cc
@@ -677,8 +677,9 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
   // stores a pointer to the headers.
   auto stream_it = multistream_->begin();
   for (const auto& backend : config_->backends()) {
-    if (stream_it == multistream_->end())
+    if (stream_it == multistream_->end()) {
       break;
+    }
 
     auto headers = createUpstreamHeaders(backend, backend_sessions_[backend.name]);
     upstream_headers_.push_back(std::move(headers));

--- a/source/extensions/filters/http/transform/transform.cc
+++ b/source/extensions/filters/http/transform/transform.cc
@@ -101,7 +101,7 @@ Transformation::Transformation(const ProtoTransformation& config,
     }
   }
 
-  if (config.headers_mutations().size() > 0) {
+  if (!config.headers_mutations().empty()) {
     auto mutations_or =
         Http::HeaderMutations::create(config.headers_mutations(), context, bodyCommandParsers());
     SET_AND_RETURN_IF_NOT_OK(mutations_or.status(), creation_status);

--- a/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
+++ b/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
@@ -176,6 +176,7 @@ std::string JA4Fingerprinter::getJA4CipherHash(const SSL_CLIENT_HELLO* ssl_clien
   }
 
   if (ciphers.empty()) {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
     return std::string(JA4_HASH_LENGTH, '0');
   }
 
@@ -239,6 +240,7 @@ std::string JA4Fingerprinter::getJA4ExtensionHash(const SSL_CLIENT_HELLO* ssl_cl
   }
 
   if (extensions.empty()) {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
     return std::string(JA4_HASH_LENGTH, '0');
   }
 

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -243,7 +243,7 @@ bool AllshardSameResponseHandler::areAllResponsesSame() const {
 
   const Common::Redis::RespValue* first_response = pending_responses_.front().get();
   for (const auto& response : pending_responses_) {
-    if (!response || !first_response || *(response.get()) != *first_response) {
+    if (!response || !first_response || *response != *first_response) {
       return false;
     }
   }
@@ -354,12 +354,15 @@ void ArrayAppendAggregateResponseHandler::processAggregatedResponses(
 void HelloResponseHandler::processAggregatedResponses(ClusterScopeCmdRequest& request) {
   // Helper to check if two RespValues are equal
   auto valuesEqual = [](const Common::Redis::RespValue& v1, const Common::Redis::RespValue& v2) {
-    if (v1.type() != v2.type())
+    if (v1.type() != v2.type()) {
       return false;
-    if (v1.type() == Common::Redis::RespType::BulkString)
+    }
+    if (v1.type() == Common::Redis::RespType::BulkString) {
       return v1.asString() == v2.asString();
-    if (v1.type() == Common::Redis::RespType::Integer)
+    }
+    if (v1.type() == Common::Redis::RespType::Integer) {
       return v1.asInteger() == v2.asInteger();
+    }
     return true;
   };
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -1163,7 +1163,7 @@ SplitRequestPtr InstanceImpl::makeRequest(Common::Redis::RespValuePtr&& request,
   }
 
   // Get the handler for the downstream request
-  auto handler = handler_lookup_table_.find(command_name.c_str());
+  auto handler = handler_lookup_table_.find(command_name);
   ASSERT(handler != nullptr);
 
   // If we are within a transaction, forward all requests to the transaction handler (i.e. handler
@@ -1227,7 +1227,7 @@ void InstanceImpl::addHandler(Stats::Scope& scope, const std::string& stat_prefi
   Stats::StatNameManagedStorage storage{command_stat_prefix + std::string("latency"),
                                         scope.symbolTable()};
   handler_lookup_table_.add(
-      to_lower_name.c_str(),
+      to_lower_name,
       std::make_shared<HandlerData>(HandlerData{
           CommandStats{ALL_COMMAND_STATS(POOL_COUNTER_PREFIX(scope, command_stat_prefix))
                            scope.histogramFromStatName(storage.statName(),

--- a/source/extensions/filters/network/redis_proxy/info_command_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/info_command_handler.cc
@@ -444,6 +444,7 @@ std::string InfoCmdAggregateResponseHandler::bytesToHuman(uint64_t bytes) {
     snprintf(buffer, sizeof(buffer), "%" PRIu64 "B", bytes);
   }
 
+  // NOLINTNEXTLINE(modernize-return-braced-init-list)
   return std::string(buffer);
 }
 

--- a/source/extensions/filters/network/redis_proxy/router_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/router_impl.cc
@@ -85,8 +85,8 @@ PrefixRoutes::PrefixRoutes(
       absl::AsciiStrToLower(&copy);
     }
 
-    auto success = prefix_lookup_table_.add(
-        copy.c_str(), std::make_shared<Prefix>(route, upstreams_, runtime), false);
+    auto success =
+        prefix_lookup_table_.add(copy, std::make_shared<Prefix>(route, upstreams_, runtime), false);
     if (!success) {
       throw EnvoyException(fmt::format("prefix `{}` already exists.", route.prefix()));
     }

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.cc
@@ -208,7 +208,7 @@ void OverrideHostLoadBalancer::LoadBalancerImpl::addSelectedHostKey(
 
   const std::string selected_endpoint = response.host->address()->asString();
   const Config::MetadataKey& metadata_key = config_.selectedHostKey().value();
-  if (metadata_key.path_.size() < 1) {
+  if (metadata_key.path_.empty()) {
     // Should not be possible based on proto validation, catching anyways.
     ENVOY_LOG(trace, "Path was not provided in selected_host_key.");
     return;

--- a/source/extensions/tracers/dynamic_modules/tracer_config.cc
+++ b/source/extensions/tracers/dynamic_modules/tracer_config.cc
@@ -186,6 +186,7 @@ std::string DynamicModuleSpan::getBaggage(absl::string_view key) {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_baggage_(in_module_span_, key_buf, &value_out) &&
       value_out.ptr != nullptr) {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
     return std::string(value_out.ptr, value_out.length);
   }
   return {};
@@ -202,6 +203,7 @@ void DynamicModuleSpan::setBaggage(absl::string_view key, absl::string_view valu
 std::string DynamicModuleSpan::getTraceId() const {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_trace_id_(in_module_span_, &value_out) && value_out.ptr != nullptr) {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
     return std::string(value_out.ptr, value_out.length);
   }
   return {};
@@ -210,6 +212,7 @@ std::string DynamicModuleSpan::getTraceId() const {
 std::string DynamicModuleSpan::getSpanId() const {
   envoy_dynamic_module_type_module_buffer value_out = {.ptr = nullptr, .length = 0};
   if (config_->on_span_get_span_id_(in_module_span_, &value_out) && value_out.ptr != nullptr) {
+    // NOLINTNEXTLINE(modernize-return-braced-init-list)
     return std::string(value_out.ptr, value_out.length);
   }
   return {};

--- a/source/extensions/tracers/zipkin/span_context_extractor.cc
+++ b/source/extensions/tracers/zipkin/span_context_extractor.cc
@@ -171,7 +171,7 @@ SpanContextExtractor::extractSpanContextFromB3SingleFormat(bool is_sampled) {
   ASSERT(b3_head_entry.has_value());
   // This is an implicitly untrusted header, so only the first value is used.
   const std::string b3(b3_head_entry.value());
-  if (!b3.length()) {
+  if (b3.empty()) {
     throw ExtractorException("Invalid input: empty");
   }
 

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -92,7 +92,7 @@ parseTrustBundles(absl::string_view trust_bundle_mapping_str) {
                 return false;
               }
               const auto& certs = key->getStringArray("x5c");
-              if (!certs.ok() || (*certs).size() == 0) {
+              if (!certs.ok() || (*certs).empty()) {
                 parsing_status = absl::InvalidArgumentError(fmt::format(
                     "missing or empty 'x5c' field found in keys for domain: '{}'", domain_name));
                 return false;

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -405,8 +405,9 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
       }
       line = line.substr(space_pos + 1);
     }
-    if (!line_valid)
+    if (!line_valid) {
       continue;
+    }
 
     // (5) mount point: extract mount point
     size_t mount_end = line.find(' ');
@@ -441,8 +442,9 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
       }
       line = line.substr(space_pos + 1);
     }
-    if (!line_valid || !separator_found)
+    if (!line_valid || !separator_found) {
       continue;
+    }
 
     // (9) filesystem type: extract filesystem type
     size_t fs_type_end = line.find(' ');


### PR DESCRIPTION
## Summary

Apply clang-tidy fixes for readability issues across `source/`.

Part of a series of small, focused clang-tidy cleanup PRs split out from a larger branch.

## Risk Level

Low — mechanical clang-tidy refactor; no behavior changes intended.

## Testing

CI.

## Docs Changes

None.

## Release Notes

None.

Signed-off-by: wbpcode/wangbaiping <wbphub@gmail.com>
