### PR TITLE
clang tidy: fix virtual method specifier of source

### DIFF
--- a/source/common/http/route_config_update_requster.h
+++ b/source/common/http/route_config_update_requster.h
@@ -45,9 +45,7 @@ private:
 class RdsRouteConfigUpdateRequesterFactory : public RouteConfigUpdateRequesterFactory {
 public:
   // UntypedFactory
-  virtual std::string name() const override {
-    return "envoy.route_config_update_requester.default";
-  }
+  std::string name() const override { return "envoy.route_config_update_requester.default"; }
 
   std::unique_ptr<RouteConfigUpdateRequester>
   createRouteConfigUpdateRequester(Router::RouteConfigProvider* route_config_provider) override {

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -1018,7 +1018,7 @@ public:
             total_units) {}
 
 protected:
-  virtual void removeElement(Value* value) { delete value; }
+  void removeElement(Value* value) override { delete value; }
 
 private:
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(SimpleLRUCache);
@@ -1038,7 +1038,7 @@ public:
       : Base(total_units), deleter_(deleter) {}
 
 protected:
-  virtual void removeElement(Value* value) { deleter_(value); }
+  void removeElement(Value* value) override { deleter_(value); }
 
 private:
   Deleter deleter_;

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -148,7 +148,7 @@ public:
       : SdsApi(sds_config, sds_config_name, subscription_factory, time_source, validation_visitor,
                stats, std::move(destructor_cb), dispatcher, api, warm) {}
 
-  virtual const SecretType* secret() const override PURE;
+  const SecretType* secret() const override PURE;
 
   ABSL_MUST_USE_RESULT Common::CallbackHandlePtr
   addValidationCallback(std::function<absl::Status(const SecretType&)> callback) override {

--- a/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.h
+++ b/source/extensions/access_loggers/fluentd/fluentd_access_log_impl.h
@@ -26,7 +26,7 @@ public:
                           Event::Dispatcher& dispatcher, const FluentdAccessLogConfig& config,
                           BackOffStrategyPtr backoff_strategy, Stats::Scope& parent_scope);
 
-  void packMessage(MessagePackPacker& packer);
+  void packMessage(MessagePackPacker& packer) override;
 };
 
 using FluentdAccessLoggerWeakPtr = std::weak_ptr<FluentdService>;

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -93,7 +93,7 @@ public:
                                         Server::Configuration::ServerFactoryContext& context,
                                         Stats::Store& stats_store);
 
-  ~DynamicModuleBootstrapExtensionConfig();
+  ~DynamicModuleBootstrapExtensionConfig() override;
 
   /**
    * This is called when an event is scheduled via

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
@@ -38,7 +38,7 @@ public:
   UpstreamSocketManager(Event::Dispatcher& dispatcher,
                         ReverseTunnelAcceptorExtension* extension = nullptr);
 
-  ~UpstreamSocketManager();
+  ~UpstreamSocketManager() override;
 
   /**
    * Add accepted connection to socket manager.

--- a/source/extensions/clusters/dns/dns_cluster.cc
+++ b/source/extensions/clusters/dns/dns_cluster.cc
@@ -53,7 +53,7 @@ public:
   LegacyDnsClusterFactory(const std::string& name, bool set_all_addresses_in_single_endpoint)
       : ClusterFactoryImplBase(name),
         set_all_addresses_in_single_endpoint_(set_all_addresses_in_single_endpoint) {}
-  virtual absl::StatusOr<std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>>
+  absl::StatusOr<std::pair<ClusterImplBaseSharedPtr, ThreadAwareLoadBalancerPtr>>
   createClusterImpl(const envoy::config::cluster::v3::Cluster& cluster,
                     ClusterFactoryContext& context) override {
     absl::StatusOr<Network::DnsResolverSharedPtr> dns_resolver_or_error =

--- a/source/extensions/clusters/redis/redis_cluster.h
+++ b/source/extensions/clusters/redis/redis_cluster.h
@@ -90,7 +90,7 @@ namespace Redis {
 
 class RedisCluster : public Upstream::BaseDynamicClusterImpl {
 public:
-  ~RedisCluster();
+  ~RedisCluster() override;
   static absl::StatusOr<std::unique_ptr<RedisCluster>>
   create(const envoy::config::cluster::v3::Cluster& cluster,
          const envoy::extensions::clusters::redis::v3::RedisClusterConfig& redis_cluster,

--- a/source/extensions/common/fluentd/fluentd_base.h
+++ b/source/extensions/common/fluentd/fluentd_base.h
@@ -78,7 +78,7 @@ public:
               const std::string& stat_prefix, BackOffStrategyPtr backoff_strategy,
               uint64_t buffer_flush_interval, uint64_t max_buffer_size);
 
-  virtual ~FluentdBase() = default;
+  ~FluentdBase() override = default;
 
   // Tcp::AsyncTcpClientCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -138,7 +138,7 @@ public:
     });
   }
 
-  virtual ~FluentdCacheBase() = default;
+  ~FluentdCacheBase() override = default;
 
   SharedPtrType getOrCreate(const std::shared_ptr<ConfigType>& config,
                             Random::RandomGenerator& random,

--- a/source/extensions/config_subscription/grpc/grpc_mux_failover.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_failover.h
@@ -85,7 +85,7 @@ public:
     }
   }
 
-  virtual ~GrpcMuxFailover() = default;
+  ~GrpcMuxFailover() override = default;
 
   // Attempts to establish a new stream to the either the primary or failover source.
   void establishNewStream() override {

--- a/source/extensions/filters/common/ext_proc/grpc_client.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client.h
@@ -16,7 +16,7 @@ namespace ExternalProcessing {
  */
 template <typename ResponseType> class ProcessorCallbacks : public RequestCallbacks<ResponseType> {
 public:
-  virtual ~ProcessorCallbacks() = default;
+  ~ProcessorCallbacks() override = default;
   virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& response) PURE;
   virtual void onGrpcError(Grpc::Status::GrpcStatus error, const std::string& message) PURE;
   virtual void onGrpcClose() PURE;
@@ -48,7 +48,7 @@ using ProcessorStreamPtr = std::unique_ptr<ProcessorStream<RequestType, Response
 template <typename RequestType, typename ResponseType>
 class ProcessorClient : public ClientBase<RequestType, ResponseType> {
 public:
-  virtual ~ProcessorClient() = default;
+  ~ProcessorClient() override = default;
   virtual ProcessorStreamPtr<RequestType, ResponseType>
   start(ProcessorCallbacks<ResponseType>& callbacks,
         const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -66,7 +66,7 @@ public:
       ABSL_LOCKS_EXCLUDED(mu_);
   void clearUncacheableState() ABSL_LOCKS_EXCLUDED(mu_);
 
-  ~CacheSession();
+  ~CacheSession() override;
 
   class Subscriber {
   public:

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -109,23 +109,25 @@ public:
       const std::string& stats_prefix, Stats::Scope& scope,
       Server::Configuration::FactoryContext& context);
 
-  const std::vector<McpBackendConfig>& backends() const { return backends_; }
-  bool isMultiplexing() const { return backends_.size() > 1; }
-  const std::string& defaultBackendName() const { return default_backend_name_; }
-  Server::Configuration::FactoryContext& factoryContext() const { return factory_context_; }
-  const McpBackendConfig* findBackend(const std::string& name) const;
+  const std::vector<McpBackendConfig>& backends() const override { return backends_; }
+  bool isMultiplexing() const override { return backends_.size() > 1; }
+  const std::string& defaultBackendName() const override { return default_backend_name_; }
+  Server::Configuration::FactoryContext& factoryContext() const override {
+    return factory_context_;
+  }
+  const McpBackendConfig* findBackend(const std::string& name) const override;
 
-  bool hasSessionIdentity() const {
+  bool hasSessionIdentity() const override {
     return !absl::holds_alternative<absl::monostate>(session_identity_.subject_source);
   }
-  const SubjectSource& subjectSource() const { return session_identity_.subject_source; }
-  ValidationMode validationMode() const { return session_identity_.validation_mode; }
-  bool shouldEnforceValidation() const {
+  const SubjectSource& subjectSource() const override { return session_identity_.subject_source; }
+  ValidationMode validationMode() const override { return session_identity_.validation_mode; }
+  bool shouldEnforceValidation() const override {
     return session_identity_.validation_mode == ValidationMode::Enforce;
   }
-  const std::string& metadataNamespace() const { return metadata_namespace_; }
+  const std::string& metadataNamespace() const override { return metadata_namespace_; }
 
-  McpRouterStats& stats() { return stats_; }
+  McpRouterStats& stats() override { return stats_; }
 
 private:
   std::vector<McpBackendConfig> backends_;

--- a/source/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/mapped_attribute_builder.cc
+++ b/source/extensions/http/ext_proc/processing_request_modifiers/mapped_attribute_builder/mapped_attribute_builder.cc
@@ -11,8 +11,6 @@ namespace Envoy {
 namespace Http {
 namespace ExternalProcessing {
 
-using envoy::service::ext_proc::v3::ProcessingRequest;
-
 // Helper function to convert proto map values to a unique vector of strings.
 // The order of elements in the returned vector is not guaranteed.
 Protobuf::RepeatedPtrField<std::string>

--- a/source/extensions/local_address_selectors/filter_state_override/config.cc
+++ b/source/extensions/local_address_selectors/filter_state_override/config.cc
@@ -31,7 +31,7 @@ public:
   Upstream::UpstreamLocalAddress getUpstreamLocalAddress(
       const Network::Address::InstanceConstSharedPtr& endpoint_address,
       const Network::ConnectionSocket::OptionsSharedPtr& socket_options,
-      OptRef<const Network::TransportSocketOptions> transport_socket_options) const {
+      OptRef<const Network::TransportSocketOptions> transport_socket_options) const override {
     const auto upstream_address =
         inner_->getUpstreamLocalAddress(endpoint_address, socket_options, transport_socket_options);
     if (transport_socket_options && upstream_address.address_) {

--- a/source/extensions/matching/input_matchers/cel_matcher/matcher.cc
+++ b/source/extensions/matching/input_matchers/cel_matcher/matcher.cc
@@ -9,8 +9,6 @@ namespace InputMatchers {
 namespace CelMatcher {
 
 using ::Envoy::Extensions::Matching::Http::CelInput::CelMatchData;
-using ::xds::type::v3::CelExpression;
-
 CelInputMatcher::CelInputMatcher(CelMatcherSharedPtr cel_matcher,
                                  Filters::Common::Expr::BuilderInstanceSharedConstPtr builder)
     : compiled_expr_([&]() {

--- a/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
+++ b/source/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader.h
@@ -55,7 +55,7 @@ class LinuxContainerCpuStatsReader : public CpuStatsReader {
 public:
   using ContainerStatsReaderPtr = std::unique_ptr<LinuxContainerCpuStatsReader>;
 
-  virtual ~LinuxContainerCpuStatsReader() = default;
+  ~LinuxContainerCpuStatsReader() override = default;
 
   /**
    * Create the appropriate cgroup stats reader.

--- a/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
+++ b/source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.cc
@@ -10,9 +10,7 @@ namespace OpenTelemetry {
 
 using ::opentelemetry::proto::metrics::v1::AggregationTemporality;
 using ::opentelemetry::proto::metrics::v1::HistogramDataPoint;
-using ::opentelemetry::proto::metrics::v1::Metric;
 using ::opentelemetry::proto::metrics::v1::NumberDataPoint;
-using ::opentelemetry::proto::metrics::v1::ResourceMetrics;
 
 using MetricsExportRequest =
     opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest;

--- a/source/extensions/transport_sockets/tls/cert_mappers/filter_state_override/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/filter_state_override/config.cc
@@ -15,8 +15,9 @@ namespace {
 class Mapper : public Ssl::UpstreamTlsCertificateMapper {
 public:
   explicit Mapper(const std::string& default_value) : default_value_(default_value) {}
-  std::string deriveFromServerHello(const SSL&,
-                                    const Network::TransportSocketOptionsConstSharedPtr& options) {
+  std::string
+  deriveFromServerHello(const SSL&,
+                        const Network::TransportSocketOptionsConstSharedPtr& options) override {
     if (options) {
       for (const auto& obj : options->downstreamSharedFilterStateObjects()) {
         if (obj.name_ == "envoy.tls.certificate_mappers.on_demand_secret") {

--- a/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/sni/config.cc
@@ -13,7 +13,7 @@ namespace {
 class SNIMapper : public Ssl::TlsCertificateMapper {
 public:
   explicit SNIMapper(const std::string& default_value) : default_value_(default_value) {}
-  std::string deriveFromClientHello(const SSL_CLIENT_HELLO& ssl_client_hello) {
+  std::string deriveFromClientHello(const SSL_CLIENT_HELLO& ssl_client_hello) override {
     absl::string_view sni = absl::NullSafeStringView(
         SSL_get_servername(ssl_client_hello.ssl, TLSEXT_NAMETYPE_host_name));
     return sni.empty() ? default_value_ : std::string(sni);

--- a/source/extensions/transport_sockets/tls/cert_mappers/static_name/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_mappers/static_name/config.cc
@@ -12,9 +12,9 @@ class StaticNameMapper : public Ssl::TlsCertificateMapper,
                          public Ssl::UpstreamTlsCertificateMapper {
 public:
   explicit StaticNameMapper(const std::string& name) : name_(name) {}
-  std::string deriveFromClientHello(const SSL_CLIENT_HELLO&) { return name_; }
+  std::string deriveFromClientHello(const SSL_CLIENT_HELLO&) override { return name_; }
   std::string deriveFromServerHello(const SSL&,
-                                    const Network::TransportSocketOptionsConstSharedPtr&) {
+                                    const Network::TransportSocketOptionsConstSharedPtr&) override {
     return name_;
   }
 


### PR DESCRIPTION
## Summary

Apply clang-tidy fixes for virtual method specifier issues (e.g. `override`/`final` placement) across `source/`.

Part of a series of small, focused clang-tidy cleanup PRs split out from a larger branch.

## Risk Level

Low — mechanical clang-tidy refactor; no behavior changes intended.

## Testing

CI.

## Docs Changes

None.

## Release Notes

None.

Signed-off-by: wbpcode/wangbaiping <wbphub@gmail.com>
