### PR TITLE
clang tidy: fix misc issues of source

### DIFF
--- a/source/common/matcher/matcher.h
+++ b/source/common/matcher/matcher.h
@@ -294,7 +294,7 @@ private:
     return [match_children, data_input, on_no_match, creation_function]() {
       auto matcher_or_error = creation_function(
           data_input(), on_no_match ? absl::make_optional((*on_no_match)()) : absl::nullopt);
-      THROW_IF_NOT_OK(matcher_or_error.status());
+      THROW_IF_NOT_OK_REF(matcher_or_error.status());
       auto multimap_matcher = std::move(*matcher_or_error);
       for (const auto& children : match_children) {
         multimap_matcher->addChild(children.first, children.second());

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -903,7 +903,10 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
       // For the last shadow policy, we can reuse the original headers to save a copy because
       // copy whole headers map is not cheap.
       shadow_headers = std::move(original_shadow_headers);
+      original_shadow_headers = nullptr;
     } else {
+      ASSERT(original_shadow_headers != nullptr);
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       shadow_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(*original_shadow_headers);
     }
     applyShadowPolicyHeaders(shadow_policy, *shadow_headers);
@@ -1180,7 +1183,10 @@ Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap& trail
       // For the last shadow stream, we can reuse the original trailers to save a copy because
       // copy whole trailers map is not cheap.
       shadow_trailer = std::move(original_shadow_trailer);
+      original_shadow_trailer = nullptr;
     } else {
+      ASSERT(original_shadow_trailer != nullptr);
+      // NOLINTNEXTLINE(bugprone-use-after-move)
       shadow_trailer = Http::createHeaderMap<Http::RequestTrailerMapImpl>(*original_shadow_trailer);
     }
     ASSERT(shadow_trailer != nullptr);

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -903,7 +903,6 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
       // For the last shadow policy, we can reuse the original headers to save a copy because
       // copy whole headers map is not cheap.
       shadow_headers = std::move(original_shadow_headers);
-      original_shadow_headers = nullptr;
     } else {
       ASSERT(original_shadow_headers != nullptr);
       // NOLINTNEXTLINE(bugprone-use-after-move)
@@ -1183,7 +1182,6 @@ Http::FilterTrailersStatus Filter::decodeTrailers(Http::RequestTrailerMap& trail
       // For the last shadow stream, we can reuse the original trailers to save a copy because
       // copy whole trailers map is not cheap.
       shadow_trailer = std::move(original_shadow_trailer);
-      original_shadow_trailer = nullptr;
     } else {
       ASSERT(original_shadow_trailer != nullptr);
       // NOLINTNEXTLINE(bugprone-use-after-move)

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -136,7 +136,7 @@ getCertificateValidationContextConfigProvider(
       const std::string hash_id =
           generateCertificateHash(validation_context.trusted_ca().inline_bytes());
       if (!hash_id.empty()) {
-        ca_cert_id = absl::StrCat(ca_cert_id, "_", hash_id);
+        absl::StrAppend(&ca_cert_id, "_", hash_id);
       }
     }
     return CertificateValidationContextConfigProviderSharedPtrWithName{

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -325,14 +325,13 @@ ContextImpl::ContextImpl(
       }
 
       if (additional_init != nullptr) {
-        absl::Status init_status = additional_init(ctx, tls_certificate);
-        SET_AND_RETURN_IF_NOT_OK(creation_status, init_status);
+        SET_AND_RETURN_IF_NOT_OK(additional_init(ctx, tls_certificate), creation_status);
       }
     }
   }
 
   parsed_alpn_protocols_ = parseAlpnProtocols(config.alpnProtocols(), creation_status);
-  SET_AND_RETURN_IF_NOT_OK(creation_status, creation_status);
+  RETURN_ONLY_IF_NOT_OK_REF(creation_status);
 
   // Register stat names based on lists reported by BoringSSL.
   std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));

--- a/source/common/upstream/transport_socket_match_impl.cc
+++ b/source/common/upstream/transport_socket_match_impl.cc
@@ -154,7 +154,7 @@ TransportSocketMatcher::MatchData TransportSocketMatcherImpl::resolveUsingMatche
                                              filter_state.get());
   auto on_match = Matcher::evaluateMatch(*matcher_, data);
   if (on_match.isMatch()) {
-    const auto action = on_match.action();
+    const auto& action = on_match.action();
     if (action) {
       const auto& name_action = action->getTyped<TransportSocketNameAction>();
       const std::string& transport_socket_name = name_action.name();

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -514,6 +514,8 @@ HostDescriptionImplBase::HostDescriptionImplBase(
       locality_metadata_(locality_metadata), locality_(std::move(locality)),
       locality_zone_stat_name_(locality_->zone(), cluster->statsScope().symbolTable()),
       priority_(priority),
+      // TODO(wbpcode): This should be resolved.
+      // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
       socket_factory_(resolveTransportSocketFactory(dest_address, endpoint_metadata_.get())) {
   if (health_check_config.port_value() != 0 && dest_address->type() != Network::Address::Type::Ip) {
     // Setting the health check port to non-0 only works for IP-type addresses. Setting the port

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -31,7 +31,7 @@ HttpGrpcAccessLog::HttpGrpcAccessLog(AccessLog::FilterPtr&& filter,
                                      GrpcCommon::GrpcAccessLoggerCacheSharedPtr access_logger_cache,
                                      const Formatter::CommandParserPtrVector& command_parsers)
     : Common::ImplBase(std::move(filter)),
-      config_(std::make_shared<const HttpGrpcAccessLogConfig>(std::move(config))),
+      config_(std::make_shared<const HttpGrpcAccessLogConfig>(config)),
       tls_slot_(tls.allocateSlot()), access_logger_cache_(std::move(access_logger_cache)),
       common_properties_config_(config.common_config(), command_parsers) {
   for (const auto& header : config_->additional_request_headers_to_log()) {

--- a/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/tcp_grpc_access_log_impl.cc
@@ -24,7 +24,7 @@ TcpGrpcAccessLog::TcpGrpcAccessLog(AccessLog::FilterPtr&& filter,
                                    GrpcCommon::GrpcAccessLoggerCacheSharedPtr access_logger_cache,
                                    const Formatter::CommandParserPtrVector& command_parsers)
     : Common::ImplBase(std::move(filter)),
-      config_(std::make_shared<const TcpGrpcAccessLogConfig>(std::move(config))),
+      config_(std::make_shared<const TcpGrpcAccessLogConfig>(config)),
       tls_slot_(tls.allocateSlot()), access_logger_cache_(std::move(access_logger_cache)),
       common_properties_config_(config.common_config(), command_parsers) {
   THROW_IF_NOT_OK(Config::Utility::checkTransportVersion(config_->common_config()));

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
@@ -56,7 +56,7 @@ void ReverseTunnelAcceptorExtension::onServerInitialized(Server::Instance&) {
   // Create thread-local slot for the dispatcher and socket manager.
   tls_slot_ = ThreadLocal::TypedSlot<UpstreamSocketThreadLocal>::makeUnique(context_.threadLocal());
 
-  const bool ping_failure_threshold = ping_failure_threshold_;
+  const uint32_t ping_failure_threshold = ping_failure_threshold_;
   const bool enable_tenant_isolation = enable_tenant_isolation_;
   // Set up the thread-local dispatcher and socket manager.
   tls_slot_->set(

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
@@ -56,16 +56,19 @@ void ReverseTunnelAcceptorExtension::onServerInitialized(Server::Instance&) {
   // Create thread-local slot for the dispatcher and socket manager.
   tls_slot_ = ThreadLocal::TypedSlot<UpstreamSocketThreadLocal>::makeUnique(context_.threadLocal());
 
+  const bool ping_failure_threshold = ping_failure_threshold_;
+  const bool enable_tenant_isolation = enable_tenant_isolation_;
   // Set up the thread-local dispatcher and socket manager.
-  tls_slot_->set([this](Event::Dispatcher& dispatcher) {
-    auto tls = std::make_shared<UpstreamSocketThreadLocal>(dispatcher, this);
-    // Propagate configured miss threshold and tenant isolation into the socket manager.
-    if (tls->socketManager()) {
-      tls->socketManager()->setMissThreshold(ping_failure_threshold_);
-      tls->socketManager()->setTenantIsolationEnabled(enable_tenant_isolation_);
-    }
-    return tls;
-  });
+  tls_slot_->set(
+      [this, ping_failure_threshold, enable_tenant_isolation](Event::Dispatcher& dispatcher) {
+        auto tls = std::make_shared<UpstreamSocketThreadLocal>(dispatcher, this);
+        // Propagate configured miss threshold and tenant isolation into the socket manager.
+        if (auto* socket_manager = tls->socketManager(); socket_manager != nullptr) {
+          socket_manager->setMissThreshold(ping_failure_threshold);
+          socket_manager->setTenantIsolationEnabled(enable_tenant_isolation);
+        }
+        return tls;
+      });
 }
 
 // Get thread-local registry for the current thread.

--- a/source/extensions/common/async_files/async_file_manager_thread_pool.cc
+++ b/source/extensions/common/async_files/async_file_manager_thread_pool.cc
@@ -161,7 +161,6 @@ void AsyncFileManagerThreadPool::worker() {
     }
     if (action.action_ != nullptr) {
       executeAction(std::move(action));
-      action.action_ = nullptr;
     }
     if (cleanup_action != nullptr) {
       std::move(cleanup_action)->onCancelledBeforeCallback();

--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -443,12 +443,17 @@ void DnsCacheImpl::finishResolve(const std::string& host,
 
   // Functions like this one that modify primary_hosts_ are only called in the main thread so we
   // know it is safe to use the PrimaryHostInfo pointers outside of the lock.
-  auto* primary_host_info = [&]() {
+  auto* primary_host_info = [this, &host]() {
     absl::ReaderMutexLock reader_lock{primary_hosts_lock_};
     const auto primary_host_it = primary_hosts_.find(host);
     ASSERT(primary_host_it != primary_hosts_.end());
     return primary_host_it->second.get();
   }();
+
+  if (primary_host_info == nullptr) {
+    ENVOY_LOG(warn, "host '{}' was removed during resolution, skipping update", host);
+    return;
+  }
 
   std::string details_with_maybe_trace = std::string(details);
   if (primary_host_info != nullptr && primary_host_info->active_query_ != nullptr) {

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -234,7 +234,7 @@ public:
       : host_plugin_ptr_(host_plugin_ptr), child_span_ptr_(child_span_ptr),
         span_ptr_(reinterpret_cast<envoy_dynamic_module_type_span_envoy_ptr>(child_span_ptr)) {}
 
-  ~ChildSpanImpl() override { finish(); }
+  ~ChildSpanImpl() override { finishImpl(); }
 
   void setTag(std::string_view key, std::string_view value) override {
     envoy_dynamic_module_callback_http_span_set_tag(
@@ -298,7 +298,10 @@ public:
     return std::make_unique<ChildSpanImpl>(host_plugin_ptr_, child);
   }
 
-  void finish() override {
+  void finish() override { finishImpl(); }
+
+private:
+  void finishImpl() {
     if (child_span_ptr_ == nullptr) {
       return;
     }
@@ -306,8 +309,6 @@ public:
     child_span_ptr_ = nullptr;
     span_ptr_ = nullptr;
   }
-
-private:
   const envoy_dynamic_module_type_http_filter_envoy_ptr host_plugin_ptr_;
   envoy_dynamic_module_type_child_span_module_ptr child_span_ptr_;
   envoy_dynamic_module_type_span_envoy_ptr span_ptr_;

--- a/source/extensions/filters/http/cache/upstream_request.cc
+++ b/source/extensions/filters/http/cache/upstream_request.cc
@@ -205,23 +205,23 @@ void UpstreamRequest::onHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_s
     if (filter_) {
       ENVOY_STREAM_LOG(debug, "UpstreamRequest::onHeaders inserting headers",
                        *filter_->decoder_callbacks_);
-    }
-    auto insert_context =
-        cache_->makeInsertContext(std::move(lookup_), *filter_->encoder_callbacks_);
-    lookup_ = nullptr;
-    if (insert_context != nullptr) {
-      // The callbacks passed to CacheInsertQueue are all called through the dispatcher,
-      // so they're thread-safe. During CacheFilter::onDestroy the queue is given ownership
-      // of itself and all the callbacks are cancelled, so they are also filter-destruction-safe.
-      insert_queue_ = std::make_unique<CacheInsertQueue>(cache_, *filter_->encoder_callbacks_,
-                                                         std::move(insert_context), *this);
-      // Add metadata associated with the cached response. Right now this is only response_time;
-      const ResponseMetadata metadata = {config_->timeSource().systemTime()};
-      insert_queue_->insertHeaders(*headers, metadata, end_stream);
-      // insert_status_ remains absl::nullopt if end_stream == false, as we have not completed the
-      // insertion yet.
-      if (end_stream) {
-        setInsertStatus(InsertStatus::InsertSucceeded);
+      auto insert_context =
+          cache_->makeInsertContext(std::move(lookup_), *filter_->encoder_callbacks_);
+      lookup_ = nullptr;
+      if (insert_context != nullptr) {
+        // The callbacks passed to CacheInsertQueue are all called through the dispatcher,
+        // so they're thread-safe. During CacheFilter::onDestroy the queue is given ownership
+        // of itself and all the callbacks are cancelled, so they are also filter-destruction-safe.
+        insert_queue_ = std::make_unique<CacheInsertQueue>(cache_, *filter_->encoder_callbacks_,
+                                                           std::move(insert_context), *this);
+        // Add metadata associated with the cached response. Right now this is only response_time;
+        const ResponseMetadata metadata = {config_->timeSource().systemTime()};
+        insert_queue_->insertHeaders(*headers, metadata, end_stream);
+        // insert_status_ remains absl::nullopt if end_stream == false, as we have not completed the
+        // insertion yet.
+        if (end_stream) {
+          setInsertStatus(InsertStatus::InsertSucceeded);
+        }
       }
     }
   } else {

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -188,10 +188,6 @@ DynamicModuleConfigFactory::createFilterFactoryFromRemoteSource(
   };
   auto async_state = std::make_shared<AsyncState>();
 
-  // Copies for use in the callback — the originals may not outlive the async fetch.
-  const FilterConfig proto_config_copy = proto_config;
-  const auto module_config_copy = module_config;
-
   // Use a weak_ptr in the callback to break the reference cycle:
   // async_state -> remote_provider -> callback -> async_state.
   std::weak_ptr<AsyncState> weak_state = async_state;
@@ -200,7 +196,7 @@ DynamicModuleConfigFactory::createFilterFactoryFromRemoteSource(
       context.clusterManager(), init_manager, module_config.module().remote(),
       context.mainThreadDispatcher(), context.api().randomGenerator(),
       /*allow_empty=*/true,
-      [weak_state, proto_config_copy, module_config_copy, &context,
+      [weak_state, proto_config_copy = proto_config, module_config_copy = module_config, &context,
        &scope](const std::string& data) {
         auto state = weak_state.lock();
         if (!state) {

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/filter_config.cc
@@ -50,7 +50,7 @@ GrpcJsonReverseTranscoderConfig::GrpcJsonReverseTranscoderConfig(
   Protobuf::FileDescriptorSet descriptor_set;
   if (!transcoder_config.descriptor_path().empty()) {
     auto file_or_error = api.fileSystem().fileReadToEnd(transcoder_config.descriptor_path());
-    THROW_IF_NOT_OK(file_or_error.status());
+    THROW_IF_NOT_OK_REF(file_or_error.status());
     if (!descriptor_set.ParseFromString(file_or_error.value())) {
       throw EnvoyException("Unable to parse proto descriptor");
     }

--- a/source/extensions/filters/http/proto_api_scrubber/filter_config.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/filter_config.cc
@@ -416,7 +416,7 @@ ProtoApiScrubberFilterConfig::getParentType(const Envoy::Protobuf::Field* field)
 void ProtoApiScrubberFilterConfig::buildFieldParentMap(
     const Envoy::Protobuf::FileDescriptorSet& descriptor_set) {
   for (const auto& file : descriptor_set.file()) {
-    std::string package_prefix = file.package();
+    const auto& package_prefix = file.package();
     for (const auto& msg : file.message_type()) {
       populateMapForMessage(msg, package_prefix);
     }

--- a/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
@@ -85,7 +85,7 @@ void InsertContext::onBody(AdjustedByteRange range, Buffer::InstancePtr buffer,
   } else {
     range = AdjustedByteRange(0, entry_->bodySize());
   }
-  progress_receiver_->onBodyInserted(std::move(range), end_stream == EndStream::End);
+  progress_receiver_->onBodyInserted(range, end_stream == EndStream::End);
   if (end_stream != EndStream::End) {
     AdjustedByteRange next_range(range.end(), range.end() + InsertReadChunkSize);
     return source_->getBody(next_range,

--- a/source/extensions/quic/connection_id_generator/quic_lb/config.cc
+++ b/source/extensions/quic/connection_id_generator/quic_lb/config.cc
@@ -23,7 +23,7 @@ EnvoyQuicConnectionIdGeneratorFactoryPtr ConfigFactory::createQuicConnectionIdGe
           const envoy::extensions::quic::connection_id_generator::quic_lb::v3::Config&>(
           config, validation_visitor),
       context);
-  THROW_IF_NOT_OK(factory_or_status.status());
+  THROW_IF_NOT_OK_REF(factory_or_status.status());
   return std::move(factory_or_status.value());
 }
 

--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
@@ -120,7 +120,7 @@ absl::Status SecretManager::updateCertificate(absl::string_view secret_name,
   CacheEntry& entry = cache_[secret_name];
   entry.cert_context_ = cert_context;
   size_t notify_count = 0;
-  for (auto fetch_handle : entry.callbacks_) {
+  for (const auto& fetch_handle : entry.callbacks_) {
     if (auto handle = fetch_handle.lock(); handle) {
       handle->notify(cert_context);
       notify_count++;
@@ -168,7 +168,7 @@ void SecretManager::doRemoveCertificateConfig(absl::string_view secret_name) {
     return;
   }
   size_t notify_count = 0;
-  for (auto fetch_handle : it->second.callbacks_) {
+  for (const auto& fetch_handle : it->second.callbacks_) {
     if (auto handle = fetch_handle.lock(); handle) {
       handle->notify(nullptr);
       notify_count++;

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -107,7 +107,7 @@ absl::optional<CgroupPathInfo> CgroupCpuUtil::getCurrentCgroupPath(Filesystem::I
     return absl::nullopt;
   }
 
-  const std::string content = result.value();
+  const std::string& content = result.value();
   const std::vector<std::string> lines = absl::StrSplit(content, '\n');
 
   std::string v2_path;   // Save v2 path in case no v1 found
@@ -381,7 +381,7 @@ absl::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Insta
     return absl::nullopt;
   }
 
-  const std::string content = result.value();
+  const std::string& content = result.value();
   const std::vector<std::string> lines = absl::StrSplit(content, '\n');
 
   std::string v2_mount_point; // Save v2 mount in case no v1 found

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -235,7 +235,8 @@ void InstanceUtil::flushMetricsToSinks(const std::list<Stats::SinkPtr>& sinks, S
   }
 }
 
-void InstanceBase::flushStats() {
+void InstanceBase::flushStats() { flushStatsImpl(); }
+void InstanceBase::flushStatsImpl() {
   if (stats_flush_in_progress_) {
     ENVOY_LOG(debug, "skipping stats flush as flush is already in progress");
     server_stats_->dropped_stat_flushes_.inc();
@@ -248,7 +249,7 @@ void InstanceBase::flushStats() {
   // completion callback is not called immediately. As a result of this server stats will
   // not be updated and flushed to stat sinks. So skip mergeHistograms call if workers are
   // not started yet.
-  if (initManager().state() == Init::Manager::State::Initialized) {
+  if (init_manager_.state() == Init::Manager::State::Initialized) {
     // A shutdown initiated before this callback may prevent this from being called as per
     // the semantics documented in ThreadLocal's runOnAllThreads method.
     stats_store_.mergeHistograms([this]() -> void { flushStatsInternal(); });
@@ -267,22 +268,21 @@ void InstanceBase::updateServerStats() {
                                        parent_stats.parent_memory_allocated_);
   server_stats_->memory_heap_size_.set(Memory::Stats::totalCurrentlyReserved());
   server_stats_->memory_physical_size_.set(Memory::Stats::totalPhysicalBytes());
-  if (!options().hotRestartDisabled()) {
+  if (!options_.hotRestartDisabled()) {
     server_stats_->parent_connections_.set(parent_stats.parent_connections_);
   }
   server_stats_->total_connections_.set(listener_manager_->numConnections() +
                                         parent_stats.parent_connections_);
   server_stats_->days_until_first_cert_expiring_.set(
-      sslContextManager().daysUntilFirstCertExpires().value_or(0));
+      ssl_context_manager_->daysUntilFirstCertExpires().value_or(0));
 
   auto secs_until_ocsp_response_expires =
-      sslContextManager().secondsUntilFirstOcspResponseExpires();
+      ssl_context_manager_->secondsUntilFirstOcspResponseExpires();
   if (secs_until_ocsp_response_expires) {
     server_stats_->seconds_until_first_ocsp_response_expiring_.set(
         secs_until_ocsp_response_expires.value());
   }
-  server_stats_->state_.set(
-      enumToInt(Utility::serverState(initManager().state(), healthCheckFailed())));
+  server_stats_->state_.set(enumToInt(Utility::serverState(init_manager_.state(), !live_.load())));
   server_stats_->stats_recent_lookups_.set(
       stats_store_.symbolTable().getRecentLookups([](absl::string_view, uint64_t) {}));
 }
@@ -290,8 +290,9 @@ void InstanceBase::updateServerStats() {
 void InstanceBase::flushStatsInternal() {
   updateServerStats();
   auto& stats_config = config_.statsConfig();
-  InstanceUtil::flushMetricsToSinks(stats_config.sinks(), stats_store_, clusterManager(),
-                                    timeSource());
+  ASSERT(config_.clusterManager() != nullptr);
+  InstanceUtil::flushMetricsToSinks(stats_config.sinks(), stats_store_, *config_.clusterManager(),
+                                    time_source_);
   if (const auto evict_on_flush = stats_config.evictOnFlush(); evict_on_flush > 0) {
     stats_eviction_counter_ = (stats_eviction_counter_ + 1) % evict_on_flush;
     if (stats_eviction_counter_ == 0) {
@@ -1128,7 +1129,7 @@ void InstanceBase::terminate() {
 
   // Only flush if we have not been hot restarted.
   if (stat_flush_timer_) {
-    flushStats();
+    flushStatsImpl();
   }
 
   if (config_.clusterManager() != nullptr) {

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -348,6 +348,7 @@ private:
   Network::DnsResolverSharedPtr getOrCreateDnsResolver();
 
   ProtobufTypes::MessagePtr dumpBootstrapConfig();
+  void flushStatsImpl();
   void flushStatsInternal();
   void updateServerStats();
   // This does most of the work of initialization, but can throw or return errors caught


### PR DESCRIPTION
## Summary

Apply miscellaneous clang-tidy fixes across `source/`.

Part of a series of small, focused clang-tidy cleanup PRs split out from a larger branch.

## Risk Level

Low — mechanical clang-tidy refactor; no behavior changes intended.

## Testing

CI.

## Docs Changes

None.

## Release Notes

None.

Signed-off-by: wbpcode/wangbaiping <wbphub@gmail.com>
