### PR TITLE
stateful_session/cookie: use systemTime instead of monotonicTime for cross-instance compatibility

### DIFF
--- a/source/extensions/http/stateful_session/cookie/cookie.cc
+++ b/source/extensions/http/stateful_session/cookie/cookie.cc
@@ -19,7 +19,7 @@ bool CookieBasedSessionStateFactory::SessionStateImpl::onUpdate(
     cookie.set_address(std::string(host_address));
     if (factory_.ttl_ != std::chrono::seconds::zero()) {
       const auto expiry_time = std::chrono::duration_cast<std::chrono::seconds>(
-          (time_source_.monotonicTime() + std::chrono::seconds(factory_.ttl_)).time_since_epoch());
+          (time_source_.systemTime() + std::chrono::seconds(factory_.ttl_)).time_since_epoch());
       cookie.set_expires(expiry_time.count());
     }
     std::string proto_string;

--- a/source/extensions/http/stateful_session/cookie/cookie.h
+++ b/source/extensions/http/stateful_session/cookie/cookie.h
@@ -75,7 +75,7 @@ private:
       if (cookie.expires() != 0) {
         const std::chrono::seconds expiry_time(cookie.expires());
         const auto now = std::chrono::duration_cast<std::chrono::seconds>(
-            (time_source_.monotonicTime()).time_since_epoch());
+            (time_source_.systemTime()).time_since_epoch());
         if (now > expiry_time) {
           // Ignore the address extracted from the cookie. This will cause
           // upstream cluster to select a new host and new cookie will be generated.

--- a/test/extensions/filters/http/stateful_session/stateful_session_integration_test.cc
+++ b/test/extensions/filters/http/stateful_session/stateful_session_integration_test.cc
@@ -434,7 +434,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -476,7 +476,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -516,7 +516,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     envoy::Cookie cookie;
     cookie.set_address(std::string("127.0.0.1:50000"));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -599,7 +599,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&cookie_string);
@@ -640,7 +640,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&cookie_string);
@@ -681,7 +681,7 @@ TEST_F(StatefulSessionIntegrationTest, DownstreamRequestWithStatefulSessionCooki
     std::string cookie_string;
     cookie.set_address(std::string("127.0.0.7:50000"));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&cookie_string);
@@ -928,7 +928,7 @@ TEST_F(StatefulSessionIntegrationTest, StatefulSessionDisabledByRoute) {
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -1066,7 +1066,7 @@ TEST_F(StatefulSessionIntegrationTest, CookieStatefulSessionOverriddenByRoute) {
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -1114,7 +1114,7 @@ TEST_F(StatefulSessionIntegrationTest, CookieStatefulSessionOverriddenByRoute) {
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -1243,7 +1243,7 @@ TEST_F(StatefulSessionIntegrationTest, CookieBasedStatefulSessionDisabledByReque
     cookie.set_address(std::string(
         fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
     cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                           std::chrono::steady_clock::now().time_since_epoch())
+                           std::chrono::system_clock::now().time_since_epoch())
                            .count() +
                        120);
     cookie.SerializeToString(&address_string);
@@ -1425,7 +1425,7 @@ TEST_F(StatefulSessionIntegrationTest, CookieBasedStatefulSessionRejectExpiredCo
   cookie.set_address(std::string(
       fmt::format("127.0.0.1:{}", endpoint.endpoint().address().socket_address().port_value())));
   cookie.set_expires(std::chrono::duration_cast<std::chrono::seconds>(
-                         std::chrono::steady_clock::now().time_since_epoch())
+                         std::chrono::system_clock::now().time_since_epoch())
                          .count() -
                      10);
   std::string address_string;

--- a/test/extensions/http/stateful_session/cookie/cookie_test.cc
+++ b/test/extensions/http/stateful_session/cookie/cookie_test.cc
@@ -28,7 +28,7 @@ TEST(CookieBasedSessionStateFactoryTest, EmptyCookieName) {
 
 TEST(CookieBasedSessionStateFactoryTest, SessionStateTest) {
   Event::SimulatedTimeSystem time_simulator;
-  time_simulator.setMonotonicTime(std::chrono::seconds(1000));
+  time_simulator.setSystemTime(std::chrono::seconds(1000));
 
   {
     CookieBasedSessionStateProto config;
@@ -122,7 +122,7 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateProtoCookie) {
   config.mutable_cookie()->set_path("/path");
   config.mutable_cookie()->mutable_ttl()->set_seconds(5);
   Event::SimulatedTimeSystem time_simulator;
-  time_simulator.setMonotonicTime(std::chrono::seconds(1000));
+  time_simulator.setSystemTime(std::chrono::seconds(1000));
   CookieBasedSessionStateFactory factory(config, time_simulator);
 
   std::string cookie_content;
@@ -131,7 +131,7 @@ TEST(CookieBasedSessionStateFactoryTest, SessionStateProtoCookie) {
   cookie.set_expires(1005);
   cookie.SerializeToString(&cookie_content);
   // PROTO format - expired cookie
-  time_simulator.setMonotonicTime(std::chrono::seconds(1006));
+  time_simulator.setSystemTime(std::chrono::seconds(1006));
   Envoy::Http::TestRequestHeaderMapImpl request_headers = {
       {":path", "/path"},
       {"cookie",


### PR DESCRIPTION
## Summary

Stateful session cookies created by one Envoy instance could appear expired when validated by another because `monotonicTime()` is process-specific. Different instances have different monotonic clock baselines, causing premature cookie expiry behind a load balancer.

Switches from `monotonicTime()` to `systemTime()` in both cookie creation and validation so all instances share a consistent time reference.

## Test plan
- [ ] Deploy multiple Envoy instances behind a load balancer with stateful session cookies
- [ ] Verify cookies created by one instance are accepted by another
- [ ] Verify cookie expiry works correctly with wall-clock time

Fixes #44111