### PR TITLE
san_matcher: correctly propagate creation errors to callers

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -51,6 +51,16 @@ bug_fixes:
     Fixed a bug in load stats reporting where reports were dropped if only custom metrics or completed
     requests were present in a reporting interval. This behavioral change can be reverted by setting
     the runtime guard ``envoy.reloadable_features.report_load_for_non_zero_stats`` to ``false``.
+- area: spiffe_validator
+  change: |
+    Fixed a bug where if an invalid custom SAN matcher was configured it would later lead to a crash
+    when validating a certificate.
+- area: rbac
+  change: |
+    Fixed a bug in the :ref:`mTLS Authenticated <envoy_v3_api_msg_extensions.rbac.principals.mtls_authenticated.v3.Config>`
+    principal extension where if an invalid SAN matcher was configured, it would incorrectly match any
+    certificate in the allowed trust chain. Known bad configurations are an invalid ``OID`` when using
+    an ``OTHER_NAME``, or specifying a ``StringMatcher`` with an invalid configuration.
 - area: build
   change: |
     Fixed ``Illegal ambiguous match`` error when building contrib targets with ``--config=aws-lc-fips``

--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -162,12 +162,9 @@ absl::StatusOr<int> DefaultCertValidator::initializeSslContexts(std::vector<SSL_
     if (!cert_validation_config->subjectAltNameMatchers().empty()) {
       for (const envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher& matcher :
            cert_validation_config->subjectAltNameMatchers()) {
-        auto san_matcher = createStringSanMatcher(matcher, context_);
-        if (san_matcher == nullptr) {
-          return absl::InvalidArgumentError(
-              absl::StrCat("Failed to create string SAN matcher of type ", matcher.san_type()));
-        }
-        subject_alt_name_matchers_.emplace_back(std::move(san_matcher));
+        auto status_or_san_matcher = createStringSanMatcher(matcher, context_);
+        RETURN_IF_NOT_OK_REF(status_or_san_matcher.status());
+        subject_alt_name_matchers_.emplace_back(std::move(*status_or_san_matcher));
       }
       verify_mode = verify_mode_validation_context;
     }

--- a/source/common/tls/cert_validator/san_matcher.cc
+++ b/source/common/tls/cert_validator/san_matcher.cc
@@ -52,7 +52,7 @@ bool DnsExactStringSanMatcher::match(GENERAL_NAME const* general_name) const {
   return Utility::dnsNameMatch(dns_exact_match_, Utility::generalNameAsString(general_name));
 }
 
-SanMatcherPtr createStringSanMatcher(
+absl::StatusOr<SanMatcherPtr> createStringSanMatcher(
     envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher const& matcher,
     Server::Configuration::CommonFactoryContext& context) {
   // Verify that a new san type has not been added.
@@ -79,7 +79,8 @@ SanMatcherPtr createStringSanMatcher(
     // Invalid/Empty OID returns a nullptr from OBJ_txt2obj
     bssl::UniquePtr<ASN1_OBJECT> oid(OBJ_txt2obj(matcher.oid().c_str(), 0));
     if (oid == nullptr) {
-      return nullptr;
+      return absl::InvalidArgumentError(
+          absl::StrCat("Failed to create SAN matcher for OTHER_NAME with OID: ", matcher.oid()));
     }
     return SanMatcherPtr{std::make_unique<StringSanMatcher>(GEN_OTHERNAME, matcher.matcher(),
                                                             context, std::move(oid))};
@@ -87,7 +88,8 @@ SanMatcherPtr createStringSanMatcher(
   case envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::SAN_TYPE_UNSPECIFIED:
     PANIC("unhandled value");
   }
-  return nullptr;
+  return absl::InternalError(
+      "Unhandled case in createStringSanMatcher; this should be unreachable");
 }
 
 } // namespace Tls

--- a/source/common/tls/cert_validator/san_matcher.h
+++ b/source/common/tls/cert_validator/san_matcher.h
@@ -84,7 +84,9 @@ private:
   const std::string dns_exact_match_;
 };
 
-SanMatcherPtr createStringSanMatcher(
+// Returns either a non-null SanMatcherPtr, or an error why it couldn't be
+// created.
+absl::StatusOr<SanMatcherPtr> createStringSanMatcher(
     const envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher& matcher,
     Server::Configuration::CommonFactoryContext& context);
 

--- a/source/extensions/filters/common/rbac/principals/mtls_authenticated/mtls_authenticated.cc
+++ b/source/extensions/filters/common/rbac/principals/mtls_authenticated/mtls_authenticated.cc
@@ -12,8 +12,12 @@ namespace Principals {
 MtlsAuthenticatedMatcher::MtlsAuthenticatedMatcher(
     const envoy::extensions::rbac::principals::mtls_authenticated::v3::Config& auth,
     Server::Configuration::CommonFactoryContext& context)
-    : matcher_(auth.has_san_matcher() ? Extensions::TransportSockets::Tls::createStringSanMatcher(
-                                            auth.san_matcher(), context)
+    : matcher_(auth.has_san_matcher() ? [&]() {
+        auto status_or_matcher =
+            Extensions::TransportSockets::Tls::createStringSanMatcher(auth.san_matcher(), context);
+        THROW_IF_NOT_OK_REF(status_or_matcher.status());
+        return std::move(*status_or_matcher);
+      }()
                                       : nullptr) {
   if (!auth.has_san_matcher() && !auth.any_validated_client_certificate()) {
     throw EnvoyException("envoy.rbac.principals.mtls_authenticated did not have any configured "

--- a/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator.cc
@@ -162,7 +162,10 @@ SPIFFEValidator::SPIFFEValidator(const Envoy::Ssl::CertificateValidationContextC
         // SAN types. See the discussion: https://github.com/envoyproxy/envoy/issues/15392
         // TODO(pradeepcrao): Throw an exception when a non-URI matcher is encountered after the
         // deprecated field match_subject_alt_names is removed
-        subject_alt_name_matchers_.emplace_back(createStringSanMatcher(matcher, context));
+        auto status_or_matcher = createStringSanMatcher(matcher, context);
+        SET_AND_RETURN_IF_NOT_OK(status_or_matcher.status(), creation_status);
+
+        subject_alt_name_matchers_.emplace_back(std::move(*status_or_matcher));
       }
     }
   }

--- a/test/common/tls/cert_validator/BUILD
+++ b/test/common/tls/cert_validator/BUILD
@@ -61,6 +61,7 @@ envoy_cc_test(
         "//source/common/protobuf:utility_lib",
         "//source/common/tls/cert_validator:cert_validator_lib",
         "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -734,7 +734,7 @@ TEST(DefaultCertValidatorTest, TestUnexpectedSanMatcherType) {
       std::make_unique<DefaultCertValidator>(mock_context_config.get(), ssl_stats, context);
   auto ctx = std::vector<SSL_CTX*>();
   EXPECT_THAT(validator->initializeSslContexts(ctx, false, *store.rootScope()).status().message(),
-              testing::ContainsRegex("Failed to create string SAN matcher of type.*"));
+              testing::ContainsRegex("Unhandled case in createStringSanMatcher.*"));
 }
 
 TEST(DefaultCertValidatorTest, TestInitializeSslContextFailure) {

--- a/test/common/tls/cert_validator/san_matcher_test.cc
+++ b/test/common/tls/cert_validator/san_matcher_test.cc
@@ -5,6 +5,7 @@
 #include "source/common/tls/cert_validator/san_matcher.h"
 
 #include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -14,6 +15,8 @@ namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
+
+using ::Envoy::StatusHelpers::HasStatusCode;
 
 // Verify that we get a valid string san matcher for all valid san types.
 TEST(SanMatcherConfigTest, TestValidSanType) {
@@ -36,17 +39,22 @@ TEST(SanMatcherConfigTest, TestValidSanType) {
     }
     if (san_type == envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::
                         SAN_TYPE_UNSPECIFIED) {
-      EXPECT_DEATH(createStringSanMatcher(san_matcher, context), "unhandled value");
+      EXPECT_DEATH(
+          {
+            auto result = createStringSanMatcher(san_matcher, context);
+            UNREFERENCED_PARAMETER(result);
+          },
+          "unhandled value");
     } else {
-      const SanMatcherPtr matcher = createStringSanMatcher(san_matcher, context);
-      EXPECT_NE(matcher.get(), nullptr);
+      auto result = createStringSanMatcher(san_matcher, context);
+      ASSERT_OK(result);
+      EXPECT_NE(result.value().get(), nullptr);
       // Verify that the message is valid.
       TestUtility::validate(san_matcher);
     }
   }
 }
 
-// Verify that setting Invalid OID for OtherName SAN results in a panic.
 TEST(SanMatcherConfigTest, TestInvalidOidOtherNameSanType) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher san_matcher;
@@ -54,7 +62,8 @@ TEST(SanMatcherConfigTest, TestInvalidOidOtherNameSanType) {
   san_matcher.set_oid("1.3.6.1.4.1.311.20.2.ffff");
   san_matcher.set_san_type(
       envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::OTHER_NAME);
-  EXPECT_EQ(createStringSanMatcher(san_matcher, context), nullptr);
+  EXPECT_THAT(createStringSanMatcher(san_matcher, context),
+              HasStatusCode(absl::StatusCode::kInvalidArgument));
 }
 
 TEST(SanMatcherConfigTest, UnspecifiedSanType) {
@@ -73,7 +82,8 @@ TEST(SanMatcherConfigTest, UnspecifiedSanType) {
       static_cast<envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::SanType>(
           static_cast<int>(123));
   san_matcher.set_san_type(san_type);
-  EXPECT_EQ(createStringSanMatcher(san_matcher, context), nullptr);
+  EXPECT_THAT(createStringSanMatcher(san_matcher, context),
+              HasStatusCode(absl::StatusCode::kInternal));
 }
 
 } // namespace Tls

--- a/test/extensions/filters/common/rbac/matchers_test.cc
+++ b/test/extensions/filters/common/rbac/matchers_test.cc
@@ -628,6 +628,21 @@ TEST(MtlsAuthenticatedMatcher, SanMatcher) {
   checkMatcher(Principals::MtlsAuthenticatedMatcher(auth, factory_context), false, conn);
 }
 
+TEST(MtlsAuthenticatedMatcher, InvalidOid) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+
+  envoy::extensions::rbac::principals::mtls_authenticated::v3::Config auth;
+  auto* matcher = auth.mutable_san_matcher();
+  matcher->set_san_type(
+      envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::OTHER_NAME);
+  matcher->mutable_matcher()->set_exact("test_value");
+  matcher->set_oid("not_a_valid_oid");
+
+  EXPECT_THROW_WITH_MESSAGE(
+      { Principals::MtlsAuthenticatedMatcher m(auth, factory_context); }, EnvoyException,
+      "Failed to create SAN matcher for OTHER_NAME with OID: not_a_valid_oid");
+}
+
 TEST(MetadataMatcher, MetadataMatcher) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Envoy::Network::MockConnection conn;

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -163,6 +163,10 @@ public:
     }
   };
 
+  void addSanMatcher(envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher matcher) {
+    san_matchers_.push_back(std::move(matcher));
+  }
+
   Api::ApiPtr api_;
   NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   NiceMock<Envoy::Event::MockDispatcher> dispatcher_;
@@ -1242,6 +1246,29 @@ typed_config:
   auto gauge_opt = store().findGaugeByString(expected_metric_name);
   EXPECT_TRUE(gauge_opt.has_value());
   EXPECT_EQ(gauge_opt->get().value(), 1787339642);
+}
+
+// Verify that a URI SAN matcher with an unregistered custom string matcher extension
+// fails during SPIFFE validator construction.
+TEST_F(TestSPIFFEValidator, InvalidCustomMatcherInSanMatcher) {
+  envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher san_matcher;
+  san_matcher.set_san_type(
+      envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::URI);
+  auto* custom = san_matcher.mutable_matcher()->mutable_custom();
+  custom->set_name("unregistered_custom_matcher");
+  custom->mutable_typed_config()->set_type_url("type.googleapis.com/nonexistent.Type");
+  addSanMatcher(san_matcher);
+
+  EXPECT_THROW_WITH_REGEX((void)initialize(TestEnvironment::substitute(R"EOF(
+name: envoy.tls.cert_validator.spiffe
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.SPIFFECertValidatorConfig
+  trust_domains:
+    - name: hello.com
+      trust_bundle:
+        filename: "{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"
+  )EOF")),
+                          EnvoyException, "Didn't find a registered implementation");
 }
 
 } // namespace Tls


### PR DESCRIPTION
Thanks to @omkhar for reporting this issue.

Risk Level: low
Testing: added tests
Docs Changes: not needed
Release Notes: added
