### PR TITLE
modify UdpPacketWriterFactory to accept ListenerFactoryContext 

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -86,6 +86,17 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "udp_packet_writer_factory_factory_interface",
+    hdrs = ["udp_packet_writer_factory_factory.h"],
+    deps = [
+        ":udp_packet_writer_handler_interface",
+        "//envoy/config:typed_config_interface",
+        "//envoy/server:factory_context_interface",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "dns_interface",
     hdrs = ["dns.h"],
     deps = [

--- a/envoy/network/udp_packet_writer_factory_factory.h
+++ b/envoy/network/udp_packet_writer_factory_factory.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "envoy/config/core/v3/extension.pb.h"
+#include "envoy/config/typed_config.h"
+#include "envoy/network/udp_packet_writer_handler.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Network {
+
+/**
+ * UdpPacketWriterFactoryFactory adds an extra layer of indirection In order to
+ * support a UdpPacketWriterFactory whose behavior depends on the
+ * TypedConfig for that factory. The UdpPacketWriterFactoryFactory is created
+ * with a no-arg constructor based on the type of the config. Then this
+ * `createUdpPacketWriterFactory` can be called with the config to
+ * create an actual UdpPacketWriterFactory.
+ */
+class UdpPacketWriterFactoryFactory : public Envoy::Config::TypedFactory {
+public:
+  ~UdpPacketWriterFactoryFactory() override = default;
+
+  /**
+   * Creates an UdpPacketWriterFactory based on the specified config.
+   * @return the UdpPacketWriterFactory created.
+   */
+  virtual UdpPacketWriterFactoryPtr
+  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig& config,
+                               Server::Configuration::ListenerFactoryContext& context) PURE;
+
+  std::string category() const override { return "envoy.udp_packet_writer"; }
+};
+
+} // namespace Network
+} // namespace Envoy

--- a/envoy/network/udp_packet_writer_handler.h
+++ b/envoy/network/udp_packet_writer_handler.h
@@ -125,27 +125,5 @@ public:
 
 using UdpPacketWriterFactoryPtr = std::unique_ptr<UdpPacketWriterFactory>;
 
-/**
- * UdpPacketWriterFactoryFactory adds an extra layer of indirection In order to
- * support a UdpPacketWriterFactory whose behavior depends on the
- * TypedConfig for that factory. The UdpPacketWriterFactoryFactory is created
- * with a no-arg constructor based on the type of the config. Then this
- * `createUdpPacketWriterFactory1 can be called with the config to
- * create an actual UdpPacketWriterFactory.
- */
-class UdpPacketWriterFactoryFactory : public Envoy::Config::TypedFactory {
-public:
-  ~UdpPacketWriterFactoryFactory() override = default;
-
-  /**
-   * Creates an UdpPacketWriterFactory based on the specified config.
-   * @return the UdpPacketWriterFactory created.
-   */
-  virtual UdpPacketWriterFactoryPtr
-  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig& config) PURE;
-
-  std::string category() const override { return "envoy.udp_packet_writer"; }
-};
-
 } // namespace Network
 } // namespace Envoy

--- a/source/common/listener_manager/BUILD
+++ b/source/common/listener_manager/BUILD
@@ -30,6 +30,7 @@ envoy_cc_library(
         "//envoy/config:typed_metadata_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:listener_interface",
+        "//envoy/network:udp_packet_writer_factory_factory_interface",
         "//envoy/server:api_listener_interface",
         "//envoy/server:filter_config_interface",
         "//envoy/server:listener_manager_interface",

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -10,6 +10,7 @@
 #include "envoy/extensions/filters/listener/proxy_protocol/v3/proxy_protocol.pb.h"
 #include "envoy/extensions/udp_packet_writer/v3/udp_default_writer_factory.pb.h"
 #include "envoy/network/exception.h"
+#include "envoy/network/udp_packet_writer_factory_factory.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/options.h"
 #include "envoy/server/transport_socket_config.h"
@@ -701,7 +702,7 @@ ListenerImpl::buildUdpListenerFactory(const envoy::config::listener::v3::Listene
     auto* factory_factory = Config::Utility::getFactory<Network::UdpPacketWriterFactoryFactory>(
         config.udp_listener_config().udp_packet_packet_writer_config());
     udp_listener_config_->writer_factory_ = factory_factory->createUdpPacketWriterFactory(
-        config.udp_listener_config().udp_packet_packet_writer_config());
+        config.udp_listener_config().udp_packet_packet_writer_config(), *listener_factory_context_);
   }
   if (config.udp_listener_config().has_quic_options()) {
 #ifdef ENVOY_ENABLE_QUIC

--- a/source/extensions/udp_packet_writer/default/BUILD
+++ b/source/extensions/udp_packet_writer/default/BUILD
@@ -22,6 +22,7 @@ envoy_cc_extension(
     ],
     deps = [
         "//envoy/config:typed_config_interface",
+        "//envoy/network:udp_packet_writer_factory_factory_interface",
         "//envoy/registry",
         "//source/common/network:udp_packet_writer_handler_lib",
         "@envoy_api//envoy/extensions/udp_packet_writer/v3:pkg_cc_proto",

--- a/source/extensions/udp_packet_writer/default/config.h
+++ b/source/extensions/udp_packet_writer/default/config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/extensions/udp_packet_writer/v3/udp_default_writer_factory.pb.h"
-#include "envoy/network/udp_packet_writer_handler.h"
+#include "envoy/network/udp_packet_writer_factory_factory.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/network/udp_packet_writer_handler_impl.h"
@@ -13,7 +13,8 @@ class UdpDefaultWriterFactoryFactory : public Network::UdpPacketWriterFactoryFac
 public:
   std::string name() const override { return "envoy.udp_packet_writer.default"; }
   UdpPacketWriterFactoryPtr
-  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig&) override {
+  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig&,
+                               Server::Configuration::ListenerFactoryContext&) override {
     return std::make_unique<UdpDefaultWriterFactory>();
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/udp_packet_writer/gso/BUILD
+++ b/source/extensions/udp_packet_writer/gso/BUILD
@@ -23,7 +23,7 @@ envoy_cc_extension(
     ],
     deps = [
         "//envoy/config:typed_config_interface",
-        "//envoy/network:udp_packet_writer_handler_interface",
+        "//envoy/network:udp_packet_writer_factory_factory_interface",
         "//envoy/registry",
         "@envoy_api//envoy/extensions/udp_packet_writer/v3:pkg_cc_proto",
     ] + envoy_select_enable_http3([

--- a/source/extensions/udp_packet_writer/gso/config.h
+++ b/source/extensions/udp_packet_writer/gso/config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "envoy/extensions/udp_packet_writer/v3/udp_gso_batch_writer_factory.pb.h"
-#include "envoy/network/udp_packet_writer_handler.h"
+#include "envoy/network/udp_packet_writer_factory_factory.h"
 #include "envoy/registry/registry.h"
 
 #ifdef ENVOY_ENABLE_QUIC
@@ -17,7 +17,8 @@ class UdpGsoBatchWriterFactoryFactory : public Network::UdpPacketWriterFactoryFa
 public:
   std::string name() const override { return "envoy.udp_packet_writer.gso"; }
   Network::UdpPacketWriterFactoryPtr
-  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig&) override {
+  createUdpPacketWriterFactory(const envoy::config::core::v3::TypedExtensionConfig&,
+                               Server::Configuration::ListenerFactoryContext&) override {
 #ifdef ENVOY_ENABLE_QUIC
     return std::make_unique<UdpGsoBatchWriterFactory>();
 #else

--- a/test/extensions/udp_packet_writer/default/BUILD
+++ b/test/extensions/udp_packet_writer/default/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/udp_packet_writer/default:config",
+        "//test/mocks/server:listener_factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/udp_packet_writer/v3:pkg_cc_proto",
     ],

--- a/test/extensions/udp_packet_writer/default/config_test.cc
+++ b/test/extensions/udp_packet_writer/default/config_test.cc
@@ -2,6 +2,9 @@
 
 #include "source/extensions/udp_packet_writer/default/config.h"
 
+#include "test/mocks/server/listener_factory_context.h"
+
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -22,7 +25,8 @@ TEST(FactoryTest, CreateUdpPacketWriterFactory) {
   envoy::extensions::udp_packet_writer::v3::UdpDefaultWriterFactory writer_config;
   envoy::config::core::v3::TypedExtensionConfig config;
   config.mutable_typed_config()->PackFrom(writer_config);
-  EXPECT_TRUE(factory.createUdpPacketWriterFactory(config) != nullptr);
+  testing::NiceMock<Server::Configuration::MockListenerFactoryContext> listener_context;
+  EXPECT_TRUE(factory.createUdpPacketWriterFactory(config, listener_context) != nullptr);
 }
 
 } // namespace Quic

--- a/test/extensions/udp_packet_writer/gso/BUILD
+++ b/test/extensions/udp_packet_writer/gso/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     srcs = ["config_test.cc"],
     rbe_pool = "6gig",
     deps = [
+        "//test/mocks/server:listener_factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/udp_packet_writer/v3:pkg_cc_proto",
     ] + envoy_select_enable_http3([

--- a/test/extensions/udp_packet_writer/gso/config_test.cc
+++ b/test/extensions/udp_packet_writer/gso/config_test.cc
@@ -4,6 +4,10 @@
 
 #include "source/extensions/udp_packet_writer/gso/config.h"
 
+#include "test/mocks/server/listener_factory_context.h"
+
+#include "gmock/gmock.h"
+
 #if UDP_GSO_BATCH_WRITER_COMPILETIME_SUPPORT
 
 #include "gtest/gtest.h"
@@ -26,7 +30,8 @@ TEST(FactoryTest, CreateUdpPacketWriterFactory) {
   envoy::extensions::udp_packet_writer::v3::UdpGsoBatchWriterFactory writer_config;
   envoy::config::core::v3::TypedExtensionConfig config;
   config.mutable_typed_config()->PackFrom(writer_config);
-  EXPECT_TRUE(factory.createUdpPacketWriterFactory(config) != nullptr);
+  testing::NiceMock<Server::Configuration::MockListenerFactoryContext> listener_context;
+  EXPECT_TRUE(factory.createUdpPacketWriterFactory(config, listener_context) != nullptr);
 }
 
 } // namespace Quic


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: modify UdpPacketWriterFactory to accept ListenerFactoryContext 
Additional Description: This change modifies the UdpPacketWriterFactoryFactory interface to pass a ListenerFactoryContext to the createUdpPacketWriterFactory method. This enables UDP packet writer factories to access listener-scoped resources such as stats, runtime, and singletons.
Risk Level: low
Testing: n/a
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
