### PR TITLE
lb: fix segfault in validateEndpoints with non-contiguous priorities

### DIFF
--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
@@ -379,6 +379,10 @@ TypedHashLbConfigBase::TypedHashLbConfigBase(absl::Span<const HashPolicyProto* c
 absl::Status TypedHashLbConfigBase::validateEndpoints(const PriorityState& priorities) const {
 
   for (const auto& [hosts, locality_weights_map] : priorities) {
+    // Non-contiguous priorities can leave null entries in the priority vector.
+    if (hosts == nullptr) {
+      continue;
+    }
     // Sum should be at most uint32_t max value, so we can validate it by accumulating into uint64_t
     // and making sure there was no overflow.
     uint64_t host_sum = 0;

--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
@@ -380,18 +380,18 @@ absl::Status TypedHashLbConfigBase::validateEndpoints(const PriorityState& prior
 
   for (const auto& [hosts, locality_weights_map] : priorities) {
     // Non-contiguous priorities can leave null entries in the priority vector.
-    if (hosts == nullptr) {
-      continue;
-    }
-    // Sum should be at most uint32_t max value, so we can validate it by accumulating into uint64_t
-    // and making sure there was no overflow.
-    uint64_t host_sum = 0;
-    for (const auto& host : *hosts) {
-      host_sum += host->weight();
-      if (host_sum > std::numeric_limits<uint32_t>::max()) {
-        return absl::InvalidArgumentError(
-            fmt::format("The sum of weights of all upstream hosts in a locality exceeds {}",
-                        std::numeric_limits<uint32_t>::max()));
+    // Only skip the host-weight check; locality weights are still validated.
+    if (hosts != nullptr) {
+      // Sum should be at most uint32_t max value, so we can validate it by accumulating into
+      // uint64_t and making sure there was no overflow.
+      uint64_t host_sum = 0;
+      for (const auto& host : *hosts) {
+        host_sum += host->weight();
+        if (host_sum > std::numeric_limits<uint32_t>::max()) {
+          return absl::InvalidArgumentError(
+              fmt::format("The sum of weights of all upstream hosts in a locality exceeds {}",
+                          std::numeric_limits<uint32_t>::max()));
+        }
       }
     }
 

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -1252,31 +1252,27 @@ TEST(RingHashMidBatchInitializeCrashTest, NoOobOnNewPriority) {
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/44349.
-// Non-contiguous EDS priorities leave null entries in the PriorityState vector.
-// validateEndpoints must skip them instead of crashing.
-TEST_P(RingHashLoadBalancerTest, ValidateEndpointsWithNonContiguousPriorities) {
-  // Build a PriorityState with a null entry at index 1 (simulates gap between
-  // priority 0 and priority 2).
+// Null entries in PriorityState (from non-contiguous priority levels) must not segfault.
+TEST_P(RingHashLoadBalancerTest, ValidateEndpointsSkipsNullPriorityEntries) {
   PriorityState priorities;
 
-  // Priority 0: one host.
   auto hosts_p0 = std::make_unique<HostVector>();
   hosts_p0->push_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
   priorities.emplace_back(std::move(hosts_p0), LocalityWeightsMap{});
 
-  // Priority 1: null (gap).
-  priorities.emplace_back(nullptr, LocalityWeightsMap{});
+  // Gaps at priorities 1-4 (null host lists, as produced by non-contiguous EDS assignments).
+  for (int i = 0; i < 4; ++i) {
+    priorities.emplace_back(nullptr, LocalityWeightsMap{});
+  }
 
-  // Priority 2: one host.
-  auto hosts_p2 = std::make_unique<HostVector>();
-  hosts_p2->push_back(makeTestHost(info_, "tcp://127.0.0.1:81"));
-  priorities.emplace_back(std::move(hosts_p2), LocalityWeightsMap{});
+  auto hosts_p5 = std::make_unique<HostVector>();
+  hosts_p5->push_back(makeTestHost(info_, "tcp://127.0.0.1:81"));
+  priorities.emplace_back(std::move(hosts_p5), LocalityWeightsMap{});
 
   absl::Status creation_status;
   TypedRingHashLbConfig typed_config(config_, context_.regex_engine_, creation_status);
   ASSERT_TRUE(creation_status.ok());
 
-  // This must not crash (was a segfault before the fix).
   EXPECT_TRUE(typed_config.validateEndpoints(priorities).ok());
 }
 

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -1251,6 +1251,35 @@ TEST(RingHashMidBatchInitializeCrashTest, NoOobOnNewPriority) {
   EXPECT_NE(nullptr, worker_lb);
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/44349.
+// Non-contiguous EDS priorities leave null entries in the PriorityState vector.
+// validateEndpoints must skip them instead of crashing.
+TEST_P(RingHashLoadBalancerTest, ValidateEndpointsWithNonContiguousPriorities) {
+  // Build a PriorityState with a null entry at index 1 (simulates gap between
+  // priority 0 and priority 2).
+  PriorityState priorities;
+
+  // Priority 0: one host.
+  auto hosts_p0 = std::make_unique<HostVector>();
+  hosts_p0->push_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
+  priorities.emplace_back(std::move(hosts_p0), LocalityWeightsMap{});
+
+  // Priority 1: null (gap).
+  priorities.emplace_back(nullptr, LocalityWeightsMap{});
+
+  // Priority 2: one host.
+  auto hosts_p2 = std::make_unique<HostVector>();
+  hosts_p2->push_back(makeTestHost(info_, "tcp://127.0.0.1:81"));
+  priorities.emplace_back(std::move(hosts_p2), LocalityWeightsMap{});
+
+  absl::Status creation_status;
+  TypedRingHashLbConfig typed_config(config_, context_.regex_engine_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  // This must not crash (was a segfault before the fix).
+  EXPECT_TRUE(typed_config.validateEndpoints(priorities).ok());
+}
+
 } // namespace
 } // namespace Upstream
 } // namespace Envoy


### PR DESCRIPTION
## Summary
- Fix null pointer dereference in `validateEndpoints` when EDS priority levels are non-contiguous (e.g., priorities 0 and 2 are present but priority 1 is absent)
- Add null check before accessing per-priority host sets to prevent crash
- Add ring hash load balancer test exercising non-contiguous priority levels

Fixes #44349

## Test plan
- New test `RingHashNonContiguousPriorityCrash` reproduces the crash scenario
- Existing ring hash tests continue to pass