### PR TITLE
test: Narrow config_test server mock deps and includes

### DIFF
--- a/contrib/rocketmq_proxy/filters/network/test/BUILD
+++ b/contrib/rocketmq_proxy/filters/network/test/BUILD
@@ -102,7 +102,6 @@ envoy_cc_test(
         "//contrib/rocketmq_proxy/filters/network/source:config",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:registry_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/rocketmq_proxy/v3:pkg_cc_proto",
     ],

--- a/contrib/rocketmq_proxy/filters/network/test/config_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/config_test.cc
@@ -1,6 +1,5 @@
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/registry.h"
 
 #include "contrib/envoy/extensions/filters/network/rocketmq_proxy/v3/rocketmq_proxy.pb.h"

--- a/test/extensions/filters/common/ratelimit_config/BUILD
+++ b/test/extensions/filters/common/ratelimit_config/BUILD
@@ -31,7 +31,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/ratelimit:ratelimit_mocks",
         "//test/mocks/router:router_mocks",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
+++ b/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
@@ -16,7 +16,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/ratelimit/mocks.h"
 #include "test/mocks/router/mocks.h"
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/test_runtime.h"

--- a/test/extensions/filters/http/aws_lambda/BUILD
+++ b/test/extensions/filters/http/aws_lambda/BUILD
@@ -59,7 +59,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/aws_lambda:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "@envoy_api//envoy/extensions/filters/http/aws_lambda/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -5,7 +5,6 @@
 #include "source/extensions/filters/http/aws_lambda/config.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 

--- a/test/extensions/filters/http/buffer/BUILD
+++ b/test/extensions/filters/http/buffer/BUILD
@@ -53,7 +53,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/buffer:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/buffer/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -5,7 +5,6 @@
 #include "source/extensions/filters/http/buffer/config.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -20,8 +20,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
-        "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
@@ -4,8 +4,7 @@
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 #include "source/extensions/filters/http/dynamic_forward_proxy/config.h"
 
-#include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/BUILD
@@ -51,7 +51,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/grpc_http1_reverse_bridge:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/grpc_http1_reverse_bridge/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -4,7 +4,6 @@
 #include "source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/header_to_metadata/BUILD
+++ b/test/extensions/filters/http/header_to_metadata/BUILD
@@ -32,7 +32,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/header_to_metadata:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/header_to_metadata/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -7,7 +7,6 @@
 #include "source/extensions/filters/http/header_to_metadata/header_to_metadata_filter.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/jwt_authn/BUILD
+++ b/test/extensions/filters/http/jwt_authn/BUILD
@@ -69,7 +69,6 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/jwt_authn:config",
         "//test/extensions/filters/http/jwt_authn:test_common_lib",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/jwt_authn/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -6,7 +6,6 @@
 
 #include "test/extensions/filters/http/jwt_authn/test_common.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/rbac/BUILD
+++ b/test/extensions/filters/http/rbac/BUILD
@@ -23,7 +23,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/rbac:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "@envoy_api//envoy/config/rbac/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/rbac/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -7,7 +7,6 @@
 #include "source/extensions/filters/http/rbac/rbac_filter.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/set_metadata/BUILD
+++ b/test/extensions/filters/http/set_metadata/BUILD
@@ -33,7 +33,6 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/set_metadata:config",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/set_metadata/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -7,7 +7,6 @@
 #include "source/extensions/filters/http/set_metadata/set_metadata_filter.h"
 
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/http/stateful_session/BUILD
+++ b/test/extensions/filters/http/stateful_session/BUILD
@@ -58,7 +58,6 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/stateful_session:config",
         "//test/mocks/http:stateful_session_mock",
         "//test/mocks/server:factory_context_mocks",
-        "//test/mocks/server:instance_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
     ],

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -2,7 +2,6 @@
 
 #include "test/mocks/http/stateful_session.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
 

--- a/test/extensions/filters/network/thrift_proxy/filters/header_to_metadata/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/filters/header_to_metadata/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/thrift_proxy/filters/header_to_metadata:config",
         "//source/extensions/filters/network/thrift_proxy/filters/header_to_metadata:header_to_metadata_filter_lib",
         "//test/extensions/filters/network/thrift_proxy:mocks",
-        "//test/mocks/server:server_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/filters/header_to_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/network/thrift_proxy/filters/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/header_to_metadata/config_test.cc
@@ -8,7 +8,6 @@
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/BUILD
+++ b/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata:config",
         "//source/extensions/filters/network/thrift_proxy/filters/payload_to_metadata:payload_to_metadata_filter_lib",
         "//test/extensions/filters/network/thrift_proxy:mocks",
-        "//test/mocks/server:server_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "@envoy_api//envoy/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/config_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/filters/payload_to_metadata/config_test.cc
@@ -8,7 +8,6 @@
 
 #include "test/extensions/filters/network/thrift_proxy/mocks.h"
 #include "test/mocks/server/factory_context.h"
-#include "test/mocks/server/instance.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/http/header_validators/envoy_default/BUILD
+++ b/test/extensions/http/header_validators/envoy_default/BUILD
@@ -141,7 +141,7 @@ envoy_extension_cc_test(
     deps = [
         "//envoy/registry",
         "//source/extensions/http/header_validators/envoy_default:config",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",
     ],

--- a/test/extensions/http/header_validators/envoy_default/config_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/config_test.cc
@@ -4,7 +4,7 @@
 #include "source/extensions/http/header_validators/envoy_default/config.h"
 #include "source/extensions/http/header_validators/envoy_default/header_validator_factory.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"

--- a/test/extensions/matching/actions/format_string/BUILD
+++ b/test/extensions/matching/actions/format_string/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//source/common/formatter:formatter_extension_lib",
         "//source/extensions/matching/actions/format_string:config",
         "//test/mocks/network:network_mocks",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
     ],
 )

--- a/test/extensions/matching/actions/format_string/config_test.cc
+++ b/test/extensions/matching/actions/format_string/config_test.cc
@@ -1,7 +1,7 @@
 #include "source/extensions/matching/actions/format_string/config.h"
 
 #include "test/mocks/network/mocks.h"
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
 
 #include "gtest/gtest.h"

--- a/test/extensions/stats_sinks/dog_statsd/BUILD
+++ b/test/extensions/stats_sinks/dog_statsd/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//envoy/registry",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/stat_sinks/dog_statsd:config",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -7,7 +7,7 @@
 #include "source/extensions/stat_sinks/common/statsd/statsd.h"
 #include "source/extensions/stat_sinks/dog_statsd/config.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"

--- a/test/extensions/stats_sinks/graphite_statsd/BUILD
+++ b/test/extensions/stats_sinks/graphite_statsd/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//envoy/registry",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/stat_sinks/graphite_statsd:config",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/stats_sinks/graphite_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/graphite_statsd/config_test.cc
@@ -8,7 +8,7 @@
 #include "source/extensions/stat_sinks/common/statsd/statsd.h"
 #include "source/extensions/stat_sinks/graphite_statsd/config.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"

--- a/test/extensions/stats_sinks/hystrix/BUILD
+++ b/test/extensions/stats_sinks/hystrix/BUILD
@@ -21,7 +21,7 @@ envoy_extension_cc_test(
         "//envoy/registry",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/stat_sinks/hystrix:config",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/stats_sinks/hystrix/config_test.cc
+++ b/test/extensions/stats_sinks/hystrix/config_test.cc
@@ -5,7 +5,7 @@
 #include "source/extensions/stat_sinks/hystrix/config.h"
 #include "source/extensions/stat_sinks/hystrix/hystrix.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"

--- a/test/extensions/stats_sinks/open_telemetry/BUILD
+++ b/test/extensions/stats_sinks/open_telemetry/BUILD
@@ -19,7 +19,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.stat_sinks.open_telemetry"],
     deps = [
         "//source/extensions/stat_sinks/open_telemetry:config",
-        "//test/mocks/server:server_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/stat_sinks/open_telemetry/v3:pkg_cc_proto",
     ],

--- a/test/extensions/stats_sinks/open_telemetry/config_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/config_test.cc
@@ -3,7 +3,7 @@
 #include "source/extensions/stat_sinks/open_telemetry/config.h"
 #include "source/extensions/stat_sinks/open_telemetry/open_telemetry_impl.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/stats_sinks/statsd/BUILD
+++ b/test/extensions/stats_sinks/statsd/BUILD
@@ -20,7 +20,7 @@ envoy_extension_cc_test(
         "//envoy/registry",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/stat_sinks/statsd:config",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -8,7 +8,7 @@
 #include "source/extensions/stat_sinks/common/statsd/statsd.h"
 #include "source/extensions/stat_sinks/statsd/config.h"
 
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"

--- a/test/extensions/upstreams/http/BUILD
+++ b/test/extensions/upstreams/http/BUILD
@@ -26,7 +26,7 @@ envoy_cc_test(
         "//source/common/upstream:upstream_lib",
         "//source/extensions/upstreams/http:config",
         "//test/mocks/http:header_validator_mocks",
-        "//test/mocks/server:instance_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",

--- a/test/extensions/upstreams/http/config_test.cc
+++ b/test/extensions/upstreams/http/config_test.cc
@@ -8,7 +8,7 @@
 #include "test/extensions/upstreams/http/config.pb.h"
 #include "test/extensions/upstreams/http/config.pb.validate.h"
 #include "test/mocks/http/header_validator.h"
-#include "test/mocks/server/instance.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"


### PR DESCRIPTION
these tests tend to timeout on build (oom suspected) reducing their includes should help

