### PR TITLE
[test/integration] Defer fake upstream read enable until initialize

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -437,6 +437,16 @@ FakeHttpConnection::FakeHttpConnection(
       Network::ReadFilterSharedPtr{new ReadFilter(*this)});
 }
 
+void FakeHttpConnection::initialize() {
+  FakeConnectionBase::initialize();
+  if (shared_connection_.connected() && !shared_connection_.connection().readEnabled()) {
+    // FakeUpstream::consumeConnection() may hand HTTP connections off before the codec/filter
+    // stack is initialized. Re-enable reads only after initialize() has attached the HTTP read
+    // filter, or early request bytes can be consumed without ever creating a FakeStream.
+    shared_connection_.connection().readDisable(false);
+  }
+}
+
 AssertionResult FakeConnectionBase::close(std::chrono::milliseconds timeout) {
   ENVOY_LOG(trace, "FakeConnectionBase close");
   if (!shared_connection_.connected()) {
@@ -750,7 +760,8 @@ bool FakeUpstream::createNetworkFilterChain(Network::Connection& connection,
   // not lazily create for HTTP/3
   if (http_type_ == Http::CodecType::HTTP3) {
     quic_connections_.push_back(std::make_unique<FakeHttpConnection>(
-        *this, consumeConnection(), http_type_, time_system_, config_.max_request_headers_kb_,
+        *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
+        config_.max_request_headers_kb_,
         config_.max_request_headers_count_, config_.headers_with_underscores_action_));
     quic_connections_.back()->initialize();
   }
@@ -821,7 +832,8 @@ AssertionResult FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_di
   return runOnDispatcherThreadAndWait([&]() {
     absl::MutexLock lock(lock_);
     connection = std::make_unique<FakeHttpConnection>(
-        *this, consumeConnection(), http_type_, time_system_, config_.max_request_headers_kb_,
+        *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
+        config_.max_request_headers_kb_,
         config_.max_request_headers_count_, config_.headers_with_underscores_action_);
     connection->initialize();
     return AssertionSuccess();
@@ -858,7 +870,8 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
       EXPECT_TRUE(upstream.runOnDispatcherThreadAndWait([&]() {
         absl::MutexLock lock(upstream.lock_);
         connection = std::make_unique<FakeHttpConnection>(
-            upstream, upstream.consumeConnection(), upstream.http_type_, upstream.timeSystem(),
+            upstream, upstream.consumeConnection(/*defer_read_enable=*/true),
+            upstream.http_type_, upstream.timeSystem(),
             Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
             envoy::config::core::v3::HttpProtocolOptions::ALLOW);
         connection->initialize();
@@ -929,7 +942,7 @@ void FakeUpstream::convertFromRawToHttp(FakeRawConnectionPtr& raw_connection,
   raw_connection.release();
 }
 
-SharedConnectionWrapper& FakeUpstream::consumeConnection() {
+SharedConnectionWrapper& FakeUpstream::consumeConnection(bool defer_read_enable) {
   ASSERT(!new_connections_.empty());
   auto* const connection_wrapper = new_connections_.front().get();
   // Skip the thread safety check if the network connection has already been freed since there's no
@@ -939,10 +952,11 @@ SharedConnectionWrapper& FakeUpstream::consumeConnection() {
   connection_wrapper->moveBetweenLists(new_connections_, consumed_connections_);
   if (read_disable_on_new_connection_ && connection_wrapper->connected() &&
       http_type_ != Http::CodecType::HTTP3 && !disable_and_do_not_enable_) {
-    // Re-enable read and early close detection.
     auto& connection = connection_wrapper->connection();
     connection.detectEarlyCloseWhenReadDisabled(true);
-    connection.readDisable(false);
+    if (!defer_read_enable) {
+      connection.readDisable(false);
+    }
   }
   return *connection_wrapper;
 }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -761,8 +761,8 @@ bool FakeUpstream::createNetworkFilterChain(Network::Connection& connection,
   if (http_type_ == Http::CodecType::HTTP3) {
     quic_connections_.push_back(std::make_unique<FakeHttpConnection>(
         *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
-        config_.max_request_headers_kb_,
-        config_.max_request_headers_count_, config_.headers_with_underscores_action_));
+        config_.max_request_headers_kb_, config_.max_request_headers_count_,
+        config_.headers_with_underscores_action_));
     quic_connections_.back()->initialize();
   }
   return true;
@@ -833,8 +833,8 @@ AssertionResult FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_di
     absl::MutexLock lock(lock_);
     connection = std::make_unique<FakeHttpConnection>(
         *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
-        config_.max_request_headers_kb_,
-        config_.max_request_headers_count_, config_.headers_with_underscores_action_);
+        config_.max_request_headers_kb_, config_.max_request_headers_count_,
+        config_.headers_with_underscores_action_);
     connection->initialize();
     return AssertionSuccess();
   });
@@ -870,10 +870,9 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
       EXPECT_TRUE(upstream.runOnDispatcherThreadAndWait([&]() {
         absl::MutexLock lock(upstream.lock_);
         connection = std::make_unique<FakeHttpConnection>(
-            upstream, upstream.consumeConnection(/*defer_read_enable=*/true),
-            upstream.http_type_, upstream.timeSystem(),
-            Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
-            envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+            upstream, upstream.consumeConnection(/*defer_read_enable=*/true), upstream.http_type_,
+            upstream.timeSystem(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
+            Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
         connection->initialize();
         return AssertionSuccess();
       }));

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -401,8 +401,10 @@ FakeHttpConnection::FakeHttpConnection(
     Event::TestTimeSystem& time_system, uint32_t max_request_headers_kb,
     uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-        headers_with_underscores_action)
+        headers_with_underscores_action,
+    bool deferred_read_enable)
     : FakeConnectionBase(shared_connection, time_system), type_(type),
+      deferred_read_enable_(deferred_read_enable),
       header_validator_factory_(
           IntegrationUtil::makeHeaderValidationFactory(fakeUpstreamHeaderValidatorConfig())) {
   ASSERT(max_request_headers_count != 0);
@@ -439,10 +441,11 @@ FakeHttpConnection::FakeHttpConnection(
 
 void FakeHttpConnection::initialize() {
   FakeConnectionBase::initialize();
-  if (shared_connection_.connected() && !shared_connection_.connection().readEnabled()) {
-    // FakeUpstream::consumeConnection() may hand HTTP connections off before the codec/filter
-    // stack is initialized. Re-enable reads only after initialize() has attached the HTTP read
-    // filter, or early request bytes can be consumed without ever creating a FakeStream.
+  if (deferred_read_enable_ && shared_connection_.connected() &&
+      !shared_connection_.connection().readEnabled()) {
+    // Re-enable reads that were explicitly deferred by consumeConnection(defer_read_enable=true)
+    // to ensure the HTTP codec and read filter are fully initialized before processing request
+    // bytes. This must not re-enable reads when disable_and_do_not_enable_ is active.
     shared_connection_.connection().readDisable(false);
   }
 }
@@ -760,9 +763,8 @@ bool FakeUpstream::createNetworkFilterChain(Network::Connection& connection,
   // not lazily create for HTTP/3
   if (http_type_ == Http::CodecType::HTTP3) {
     quic_connections_.push_back(std::make_unique<FakeHttpConnection>(
-        *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
-        config_.max_request_headers_kb_, config_.max_request_headers_count_,
-        config_.headers_with_underscores_action_));
+        *this, consumeConnection(), http_type_, time_system_, config_.max_request_headers_kb_,
+        config_.max_request_headers_count_, config_.headers_with_underscores_action_));
     quic_connections_.back()->initialize();
   }
   return true;
@@ -834,7 +836,8 @@ AssertionResult FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_di
     connection = std::make_unique<FakeHttpConnection>(
         *this, consumeConnection(/*defer_read_enable=*/true), http_type_, time_system_,
         config_.max_request_headers_kb_, config_.max_request_headers_count_,
-        config_.headers_with_underscores_action_);
+        config_.headers_with_underscores_action_,
+        /*deferred_read_enable=*/read_disable_on_new_connection_ && !disable_and_do_not_enable_);
     connection->initialize();
     return AssertionSuccess();
   });
@@ -872,7 +875,9 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
         connection = std::make_unique<FakeHttpConnection>(
             upstream, upstream.consumeConnection(/*defer_read_enable=*/true), upstream.http_type_,
             upstream.timeSystem(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-            Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
+            Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW,
+            /*deferred_read_enable=*/upstream.read_disable_on_new_connection_ &&
+                !upstream.disable_and_do_not_enable_);
         connection->initialize();
         return AssertionSuccess();
       }));

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -547,6 +547,8 @@ public:
                      envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                          headers_with_underscores_action);
 
+  void initialize() override;
+
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
   waitForNewStream(Event::Dispatcher& client_dispatcher, FakeStreamPtr& stream,
@@ -1002,7 +1004,8 @@ private:
   };
 
   void threadRoutine();
-  SharedConnectionWrapper& consumeConnection() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  SharedConnectionWrapper& consumeConnection(bool defer_read_enable = false)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
   Network::FilterStatus onRecvDatagram(Network::UdpRecvData& data);
   AssertionResult
   runOnDispatcherThreadAndWait(std::function<AssertionResult()> cb,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -545,7 +545,8 @@ public:
                      Http::CodecType type, Event::TestTimeSystem& time_system,
                      uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
                      envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-                         headers_with_underscores_action);
+                         headers_with_underscores_action,
+                     bool deferred_read_enable = false);
 
   void initialize() override;
 
@@ -609,6 +610,7 @@ private:
   };
 
   const Http::CodecType type_;
+  bool deferred_read_enable_;
   Http::ServerConnectionPtr codec_;
   std::list<FakeStreamPtr> new_streams_ ABSL_GUARDED_BY(lock_);
   testing::NiceMock<Server::MockOverloadManager> overload_manager_;


### PR DESCRIPTION
When FakeUpstream hands off HTTP connections via consumeConnection(), reads were re-enabled before the codec/filter stack was initialized. This could cause early request bytes to be consumed without creating a FakeStream. Defer read re-enable until FakeHttpConnection::initialize() attaches the HTTP read filter.

Commit Message: [test/integration] Defer fake upstream read enable until initialize
Additional Description:
Risk Level: Low (test code)
Testing:
Docs Changes: NA
Release Notes:
Platform Specific Features:

