### PR TITLE
build: fix build for contrib arm boring ssl fips

### DIFF
--- a/bazel/SSL.md
+++ b/bazel/SSL.md
@@ -33,7 +33,7 @@ not be changed on the release branch unless a bug or security vulnerability whic
 bazel build --config=boringssl-fips //source/exe:envoy-static
 ```
 
-- **Supported architectures:** Linux x86_64 only
+- **Supported architectures:** Linux x86_64, aarch64
 - **Version string:** `BoringSSL-FIPS` (visible in `envoy --version`)
 
 ### AWS-LC FIPS

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -86,6 +86,11 @@ bug_fixes:
     resulting binary "plaintext" was written back into the ``Cookie:`` request header and tripped a
     ``HeaderString`` validation assert. Such plaintexts are now rejected and the original cookie value
     is preserved, matching the behavior already documented for the explicit decryption-failure case.
+- area: build
+  change: |
+    Fixed ``Illegal ambiguous match`` error when building contrib targets with ``--config=boringssl-fips``
+    on aarch64 by restricting the ``using_boringssl_fips`` branch of ``SELECTED_CONTRIB_EXTENSIONS`` to
+    ``linux_x86_64``. Mirrors the approach taken by #44661 for ``aws-lc``.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -23,6 +23,20 @@ selects.config_setting_group(
     visibility = ["//visibility:public"],
 )
 
+# Disambiguation for SELECTED_CONTRIB_EXTENSIONS' select, where both
+# "//bazel:linux_aarch64" and "//bazel:using_boringssl_fips" otherwise match for an
+# arm64 boringssl fips build. Restricting the boringssl fips branch to x86_64 lets the
+# aarch64 branch win on arm64; arm64 + boringssl fips builds then fall through
+# to their platform skip lists, which already exclude the Intel-specific contribs.
+selects.config_setting_group(
+    name = "using_boringssl_fips_on_linux_x86_64",
+    match_all = [
+        "//bazel:using_boringssl_fips",
+        "//bazel:linux_x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 exports_files([
     "extensions_metadata.yaml",
     "contrib_build_config.bzl",

--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -56,6 +56,6 @@ SELECTED_CONTRIB_EXTENSIONS = select({
     "//bazel:linux_aarch64": envoy_all_contrib_extensions(ARM64_SKIP_CONTRIB_TARGETS),
     "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
     "//contrib:using_aws_lc_on_linux_x86_64": envoy_all_contrib_extensions(AWS_LC_SKIP_CONTRIB_TARGETS),
-    "//bazel:using_boringssl_fips": envoy_all_contrib_extensions(BORINGSSL_FIPS_SKIP_CONTRIB_TARGETS),
+    "//contrib:using_boringssl_fips_on_linux_x86_64": envoy_all_contrib_extensions(BORINGSSL_FIPS_SKIP_CONTRIB_TARGETS),
     "//conditions:default": envoy_all_contrib_extensions(X86_SKIP_CONTRIB_TARGETS),
 })


### PR DESCRIPTION
## Commit Message 
build: fix build for contrib arm boring ssl fips

## Additional Description
Building envoy on arm with boring ssl fips fails due to the following:
```
envoybuild@ip-10-92-23-225:/workspaces/envoy$ bazel cquery //contrib/exe:envoy-static --config=boringssl-fips --platforms=//bazel/platforms:linux_arm64
ERROR: /workspaces/envoy/contrib/exe/BUILD:25:16: Illegal ambiguous match on configurable attribute "deps" in //contrib/exe:envoy-static:
//bazel:linux_aarch64
//bazel:using_boringssl_fips
Multiple matches are not allowed unless one is unambiguously more specialized or they resolve to the same value. See https://bazel.build/reference/be/functions#select.
ERROR: Analysis of target '//contrib/exe:envoy-static' failed; build aborted
INFO: Elapsed time: 0.883s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
```

Fix is exactly the same as the aws lc one: #44661

After the change it seems to work

```
envoybuild@ip-10-92-23-225:/workspaces/envoy$ bazel cquery //contrib/exe:envoy-static --config=boringssl-fips --platforms=//bazel/platforms:linux_arm64
INFO: Analyzed target //contrib/exe:envoy-static (1463 packages loaded, 81211 targets configured).
INFO: Found 1 target...
//contrib/exe:envoy-static (39afe8a)
INFO: Elapsed time: 2.313s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```

## Risk level
Low existing builds should not be affected due to the change.