### PR TITLE
otel: implement network.protocol.name and network.protocol.version span attributes

### DIFF
--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -376,6 +376,13 @@ public:
   } ProtocolStrings;
 
   struct {
+    const std::string Http10String{"1.0"};
+    const std::string Http11String{"1.1"};
+    const std::string Http2String{"2"};
+    const std::string Http3String{"3"};
+  } ProtocolVersionStrings;
+
+  struct {
     const std::string ContentLengthTooSmall{"ContentLengthTooSmall"};
     const std::string ContentTypeNotAllowed{"ContentTypeNotAllowed"};
     const std::string EtagNotAllowed{"EtagNotAllowed"};

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1069,6 +1069,21 @@ const std::string& Utility::getProtocolString(const Protocol protocol) {
   return EMPTY_STRING;
 }
 
+const std::string& Utility::getProtocolVersionString(const Protocol protocol) {
+  switch (protocol) {
+  case Protocol::Http10:
+    return Headers::get().ProtocolVersionStrings.Http10String;
+  case Protocol::Http11:
+    return Headers::get().ProtocolVersionStrings.Http11String;
+  case Protocol::Http2:
+    return Headers::get().ProtocolVersionStrings.Http2String;
+  case Protocol::Http3:
+    return Headers::get().ProtocolVersionStrings.Http3String;
+  }
+
+  return EMPTY_STRING;
+}
+
 std::string Utility::buildOriginalUri(const Http::RequestHeaderMap& request_headers,
                                       const absl::optional<uint32_t> max_path_length) {
   if (!request_headers.Path()) {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -462,6 +462,13 @@ bool sanitizeConnectionHeader(Http::RequestHeaderMap& headers);
 const std::string& getProtocolString(const Protocol p);
 
 /**
+ * Get the version string for the given http protocol.
+ * @param protocol for which to return the version string representation.
+ * @return string representation of the protocol version.
+ */
+const std::string& getProtocolVersionString(const Protocol p);
+
+/**
  * Constructs the original URI sent from the client from
  * the request headers.
  * @param request headers from the original request

--- a/source/common/tracing/common_values.h
+++ b/source/common/tracing/common_values.h
@@ -32,6 +32,8 @@ public:
   const std::string PeerPort = "peer.port";
   const std::string PeerService = "peer.service";
   const std::string SpanKind = "span.kind";
+  const std::string NetworkProtocolName = "network.protocol.name";
+  const std::string NetworkProtocolVersion = "network.protocol.version";
 
   // Non-standard tag names.
   const std::string DownstreamCluster = "downstream_cluster";
@@ -59,6 +61,7 @@ public:
 
   // Tag values.
   const std::string Canceled = "canceled";
+  const std::string Http = "http";
   const std::string Proxy = "proxy";
   const std::string True = "true";
 };

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -242,10 +242,12 @@ void HttpTracerUtility::setCommonTags(Span& span, const StreamInfo::StreamInfo& 
   span.setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
   span.setTag(Tracing::Tags::get().NetworkProtocolName, Tracing::Tags::get().Http);
   if (stream_info.protocol().has_value()) {
-    span.setTag(Tracing::Tags::get().NetworkProtocolVersion,
-                Http::Utility::getProtocolVersionString(stream_info.protocol().value()));
+    const std::string& version =
+        Http::Utility::getProtocolVersionString(stream_info.protocol().value());
+    if (!version.empty()) {
+      span.setTag(Tracing::Tags::get().NetworkProtocolVersion, version);
+    }
   }
-
   // Cluster info.
   if (const auto cluster_info = stream_info.upstreamClusterInfo()) {
     span.setTag(Tracing::Tags::get().UpstreamCluster, cluster_info->name());

--- a/source/common/tracing/http_tracer_impl.cc
+++ b/source/common/tracing/http_tracer_impl.cc
@@ -240,6 +240,11 @@ void HttpTracerUtility::setCommonTags(Span& span, const StreamInfo::StreamInfo& 
                                       const Config& tracing_config, bool upstream_span) {
 
   span.setTag(Tracing::Tags::get().Component, Tracing::Tags::get().Proxy);
+  span.setTag(Tracing::Tags::get().NetworkProtocolName, Tracing::Tags::get().Http);
+  if (stream_info.protocol().has_value()) {
+    span.setTag(Tracing::Tags::get().NetworkProtocolVersion,
+                Http::Utility::getProtocolVersionString(stream_info.protocol().value()));
+  }
 
   // Cluster info.
   if (const auto cluster_info = stream_info.upstreamClusterInfo()) {

--- a/test/common/http/async_client_impl_test.cc
+++ b/test/common/http/async_client_impl_test.cc
@@ -652,6 +652,9 @@ TEST_F(AsyncClientImplTracingTest, Basic) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -706,6 +709,9 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpan) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -758,6 +764,9 @@ TEST_F(AsyncClientImplTracingTest, BasicNamedChildSpanKeepParentSampling) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -1906,6 +1915,9 @@ TEST_F(AsyncClientImplTracingTest, CancelRequest) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
 
@@ -1951,6 +1963,9 @@ TEST_F(AsyncClientImplTracingTest, CancelRequestAfterComplete) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
 
@@ -2042,6 +2057,9 @@ TEST_F(AsyncClientImplTracingTest, DestroyWithActiveRequest) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -2237,6 +2255,9 @@ TEST_F(AsyncClientImplTracingTest, RequestTimeout) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.1")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.1")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.1:443")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -458,6 +458,9 @@ TEST_F(RouterTestChildSpan, BasicFlow) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -516,6 +519,9 @@ TEST_F(RouterTestChildSpan, ResetFlow) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -566,6 +572,9 @@ TEST_F(RouterTestChildSpan, CancelFlow) {
   EXPECT_CALL(*child_span,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(*child_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -618,6 +627,9 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
   EXPECT_CALL(*child_span_1,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(*child_span_1,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_1, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));
@@ -666,6 +678,9 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
   EXPECT_CALL(*child_span_2,
               setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(*child_span_2,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq("10.0.0.5:9211")));
   EXPECT_CALL(*child_span_2, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake_cluster")));

--- a/test/common/tracing/http_tracer_impl_test.cc
+++ b/test/common/tracing/http_tracer_impl_test.cc
@@ -199,6 +199,8 @@ TEST_F(HttpConnManFinalizerImplTest, NullRequestHeadersAndNullRouteEntry) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamAddress), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
@@ -280,6 +282,8 @@ TEST_F(HttpConnManFinalizerImplTest, UpstreamClusterTagSetAlthoughNoUpstreamInfo
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("my_upstream_cluster")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName),
                            Eq("my_upstream_cluster_observable")));
@@ -303,6 +307,8 @@ TEST_F(HttpConnManFinalizerImplTest, NoUpstreamClusterTagSetWhenNoClusterInfo) {
   EXPECT_CALL(stream_info, responseCode()).WillRepeatedly(ReturnPointee(&response_code));
 
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().Component), Eq(Tracing::Tags::get().Proxy)));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UpstreamClusterName), _)).Times(0);
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("0")));
@@ -334,6 +340,9 @@ TEST_F(HttpConnManFinalizerImplTest, SpanOptionalHeaders) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UserAgent), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().DownstreamCluster), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip)));
@@ -523,6 +532,9 @@ TEST_F(HttpConnManFinalizerImplTest, SpanPopulatedFailureResponse) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("GET")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().UserAgent), Eq("agent")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/1.0")));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("1.0")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().DownstreamCluster), Eq("downstream_cluster")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().RequestSize), Eq("10")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GuidXClientTraceId), Eq("client_trace_id")));
@@ -586,6 +598,9 @@ TEST_F(HttpConnManFinalizerImplTest, GrpcOkStatus) {
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().ResponseFlags), Eq("-")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpMethod), Eq("POST")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
+  EXPECT_CALL(span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("2")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().HttpStatusCode), Eq("200")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcPath), Eq("/pb.Foo/Bar")));
   EXPECT_CALL(span, setTag(Eq(Tracing::Tags::get().GrpcAuthority), Eq("example.com:80")));

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -455,6 +455,9 @@ TEST_F(TracerImplTest, ChildGrpcUpstreamSpanTest) {
   EXPECT_CALL(*second_span, setTag(_, _)).Times(testing::AnyNumber());
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().HttpProtocol), Eq("HTTP/2")));
   EXPECT_CALL(*second_span,
+              setTag(Eq(Tracing::Tags::get().NetworkProtocolName), Eq(Tracing::Tags::get().Http)));
+  EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().NetworkProtocolVersion), Eq("2")));
+  EXPECT_CALL(*second_span,
               setTag(Eq(Tracing::Tags::get().UpstreamAddress), Eq(expected_ip + ":0")));
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().PeerAddress), Eq(expected_ip + ":0")));
   EXPECT_CALL(*second_span, setTag(Eq(Tracing::Tags::get().UpstreamCluster), Eq("fake cluster")));


### PR DESCRIPTION
Commit Message: otel: implement network.protocol.name span attribute

Additional Description:

This change implements the `network.protocol.name` and `network.protocol.version` semantic convention attributes as outlined in the OpenTelemetry specification.

Per the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-protocol-name), `network.protocol.name` captures the high-level application layer protocol name.

Currently, for Envoy's core HTTP ecosystem, `"http"` is the canonical normalized value for this attribute. This applies even when serving logical RPC protocols such as gRPC, as the underlying application-layer transport remains HTTP (e.g., HTTP/2).

`network.protocol.version` is populated dynamically based on the negotiated protocol version available in `StreamInfo` (e.g., `"1.1"`, `"2"`, `"3"`).

Relevant Specification Links:
- [[HTTP client span](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span)]
- [[HTTP server span](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span)]
- [[Network Attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-attributes)]

Risk Level: Low (Adds a standardized instrumentation tag to emitted spans)
Testing:

- Enhanced core tracing utility unit tests in `http_tracer_impl_test.cc` to validate mandatory propagation for downstream spans.
- Expanded core tracer implementation tests in `tracer_impl_test.cc` to verify corresponding propagation for upstream legs.

Docs Changes: None.
Release Notes: Added the `network.protocol.name` semantic attribute to core HTTP tracing spans.
Platform Specific Features: None.
Runtime guard: None.

[Disclosed usage of generative AI: Yes, used to assist in code modifications.]