### PR TITLE
mobile: update python integration tests to fallback to IPv6 loopback

### DIFF
--- a/mobile/test/python/async_client/async_client_fetch_test.py
+++ b/mobile/test/python/async_client/async_client_fetch_test.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import random
 import unittest
 from test.python.echo_test_server import EchoTestServer
 
@@ -16,10 +15,9 @@ class TestAsyncClientFetch(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up an echo test server for the tests to hit."""
-        port = random.randint(2**14, 2**16)
-        cls._echo_server = EchoTestServer("127.0.0.1", port)
+        cls._echo_server = EchoTestServer()
         cls._echo_server.start()
-        cls._echo_server_url = f"http://127.0.0.1:{port}"
+        cls._echo_server_url = f"http://{cls._echo_server.url}"
 
     @classmethod
     def tearDownClass(cls):

--- a/mobile/test/python/async_client/async_client_fetch_test.py
+++ b/mobile/test/python/async_client/async_client_fetch_test.py
@@ -26,7 +26,11 @@ class TestAsyncClientFetch(unittest.TestCase):
 
     def _make_client_builder(self):
         # factory to keep constructor logic consistent without sharing instances
-        builder = EngineBuilder().set_log_level(LogLevel.trace)
+        builder = (
+            EngineBuilder()
+            .set_log_level(LogLevel.trace)
+            .add_runtime_guard("getaddrinfo_no_ai_flags", True)
+        )
         return builder
 
     def test_simple_get_request(self):

--- a/mobile/test/python/echo_test_server.py
+++ b/mobile/test/python/echo_test_server.py
@@ -75,20 +75,17 @@ class HTTPServerV6(HTTPServer):
 
 def is_ipv4_supported():
     try:
-        socket.getaddrinfo("127.0.0.1", None, family=socket.AF_INET, flags=socket.AI_ADDRCONFIG)
+        socket.getaddrinfo("127.0.0.1", None, family=socket.AF_INET)
         return True
-    except socket.gaierror as e:
-        print(f"Error: {e}, errno {e.errno}, details {e.strerror}")
-    except OSError as e:
-        print(f"Error: {e}")
-    return False
+    except socket.gaierror:
+        return False
 
 
 def is_ipv6_supported():
     try:
-        socket.getaddrinfo("::1", None, family=socket.AF_INET6, flags=socket.AI_ADDRCONFIG)
+        socket.getaddrinfo("::1", None, family=socket.AF_INET6)
         return True
-    except Exception:
+    except socket.gaierror:
         return False
 
 

--- a/mobile/test/python/echo_test_server.py
+++ b/mobile/test/python/echo_test_server.py
@@ -92,23 +92,18 @@ def is_ipv6_supported():
 class EchoTestServer:
 
     def __init__(self):
+        use_v4 = is_ipv4_supported()
+        if not (use_v4 or is_ipv6_supported()):
+            raise RuntimeError("Neither IPv4 nor IPv6 is supported by the environment")
+
         port = random.randint(2**14, 2**16)
-        v4_supported = is_ipv4_supported()
-
         server = None
-        if v4_supported:
-            try:
-                server = HTTPServer(("127.0.0.1", port), EchoServerHandler)
-                self.url = f"127.0.0.1:{port}"
-            except Exception:
-                v4_supported = False
-
-        if not v4_supported:
-            if is_ipv6_supported():
-                server = HTTPServerV6(("::1", port), EchoServerHandler)
-                self.url = f"[::1]:{port}"
-            else:
-                raise RuntimeError("Neither IPv4 nor IPv6 is supported by the environment")
+        if use_v4:
+            server = HTTPServer(("127.0.0.1", port), EchoServerHandler)
+            self.url = f"127.0.0.1:{port}"
+        else:
+            server = HTTPServerV6(("::1", port), EchoServerHandler)
+            self.url = f"[::1]:{port}"
 
         self._server = server
         assert self._server is not None

--- a/mobile/test/python/echo_test_server.py
+++ b/mobile/test/python/echo_test_server.py
@@ -3,6 +3,8 @@ from http.server import HTTPServer
 from threading import Event
 from threading import Thread
 import json
+import random
+import socket
 
 
 class EchoServerHandler(BaseHTTPRequestHandler):
@@ -67,15 +69,55 @@ class EchoServerHandler(BaseHTTPRequestHandler):
         pass
 
 
+class HTTPServerV6(HTTPServer):
+    address_family = socket.AF_INET6
+
+
+def is_ipv4_supported():
+    try:
+        socket.getaddrinfo("127.0.0.1", None, family=socket.AF_INET, flags=socket.AI_ADDRCONFIG)
+        return True
+    except Exception:
+        return False
+
+
+def is_ipv6_supported():
+    try:
+        socket.getaddrinfo("::1", None, family=socket.AF_INET6, flags=socket.AI_ADDRCONFIG)
+        return True
+    except Exception:
+        return False
+
+
 class EchoTestServer:
 
-    def __init__(self, ip, port):
-        self._server = HTTPServer((ip, port), EchoServerHandler)
+    def __init__(self):
+        port = random.randint(2**14, 2**16)
+        v4_supported = is_ipv4_supported()
+
+        server = None
+        if v4_supported:
+            try:
+                server = HTTPServer(("127.0.0.1", port), EchoServerHandler)
+                self.url = f"127.0.0.1:{port}"
+            except Exception:
+                v4_supported = False
+
+        if not v4_supported:
+            if is_ipv6_supported():
+                server = HTTPServerV6(("::1", port), EchoServerHandler)
+                self.url = f"[::1]:{port}"
+            else:
+                raise RuntimeError("Neither IPv4 nor IPv6 is supported by the environment")
+
+        self._server = server
+        assert self._server is not None
         self._server_thread = Thread(target=self._server.serve_forever, daemon=True)
 
     def start(self):
         self._server_thread.start()
 
     def stop(self):
+        assert self._server is not None
         self._server.shutdown()
         self._server_thread.join()

--- a/mobile/test/python/echo_test_server.py
+++ b/mobile/test/python/echo_test_server.py
@@ -77,8 +77,11 @@ def is_ipv4_supported():
     try:
         socket.getaddrinfo("127.0.0.1", None, family=socket.AF_INET, flags=socket.AI_ADDRCONFIG)
         return True
-    except Exception:
-        return False
+    except socket.gaierror as e:
+        print(f"Error: {e}, errno {e.errno}, details {e.strerror}")
+    except OSError as e:
+        print(f"Error: {e}")
+    return False
 
 
 def is_ipv6_supported():

--- a/mobile/test/python/fetch_test.py
+++ b/mobile/test/python/fetch_test.py
@@ -36,6 +36,7 @@ class TestFetchRequest(unittest.TestCase):
             EngineBuilder()
             .set_log_level(LogLevel.trace)
             .add_runtime_guard("dns_cache_set_ip_version_to_remove", True)
+            .add_runtime_guard("getaddrinfo_no_ai_flags", True)
             .set_on_engine_running(lambda: engine_running.set())
             .enable_worker_thread(True)
             .build()

--- a/mobile/test/python/fetch_test.py
+++ b/mobile/test/python/fetch_test.py
@@ -1,6 +1,5 @@
 """Integration tests for the Envoy Mobile Python bindings."""
 
-import random
 import threading
 import unittest
 from test.python.echo_test_server import EchoTestServer
@@ -21,10 +20,9 @@ class TestFetchRequest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Set up an echo test server for the tests to hit."""
-        port = random.randint(2**14, 2**16)
-        cls._echo_server = EchoTestServer("127.0.0.1", port)
+        cls._echo_server = EchoTestServer()
         cls._echo_server.start()
-        cls._echo_server_url = f"127.0.0.1:{port}"
+        cls._echo_server_url = cls._echo_server.url
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Commit Message: change the test to run under IPv6 if the environment doesn't support IPv4.


Risk Level: low
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
