### PR TITLE
docs: fix duplicated words in comments

### DIFF
--- a/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
+++ b/docs/root/intro/arch_overview/advanced/matching/matching_api.rst
@@ -322,7 +322,7 @@ at the current time, it is not used for all filters.
 For HTTP filters, the restrictions are specified by the filter implementation, so consult the individual
 filter documentation to understand whether there are restrictions in place.
 
-For example, in the example below, the match tree could not be used with a filter that restricts the the
+For example, in the example below, the match tree could not be used with a filter that restricts the
 match tree to only use
 :ref:`HttpRequestHeaderMatchInput <envoy_v3_api_msg_type.matcher.v3.HttpRequestHeaderMatchInput>`.
 

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -368,7 +368,7 @@ class CodecEventCallbacks {
 public:
   virtual ~CodecEventCallbacks() = default;
   /**
-   * Called when the the underlying codec finishes encoding.
+   * Called when the underlying codec finishes encoding.
    */
   virtual void onCodecEncodeComplete() PURE;
 


### PR DESCRIPTION
Fixes two duplicated `the` words in docs/comments:

- `docs/root/intro/arch_overview/advanced/matching/matching_api.rst`
- `envoy/http/codec.h`

Text-only cleanup; no behavior change.

AI tool use: Kimi was used to make the text-only edit; I reviewed the diff.

Verification:
- `git diff --check`