### PR TITLE
docs: fix load balancer comment typo

### DIFF
--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -117,7 +117,7 @@ public:
    * priority. Implementations may return the provided original reference to make no changes, or
    * return a reference to alternative PriorityLoad held internally.
    *
-   * @param priority_state current priority state of the cluster being being load balanced.
+   * @param priority_state current priority state of the cluster being load balanced.
    * @param original_priority_load the cached priority load for the cluster being load balanced.
    * @param priority_mapping_func see @Upstream::RetryPriority::PriorityMappingFunc.
    * @return a reference to the priority load data that should be used to select a priority.


### PR DESCRIPTION
Fixes a duplicated word in a load balancer comment:

- `being being load balanced` -> `being load balanced`

Text-only comment cleanup; no behavior change.

AI tool use: Kimi was used to make the text-only edit; I reviewed the diff.

Verification:
- `git diff --check`