### PR TITLE
test: fix build break from BufferStringEqual rename merge skew

### DIFF
--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -4512,7 +4512,7 @@ TEST_F(Http1ClientConnectionImplTest, DecoderDestroyedBeforeMessageComplete) {
   EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
 
   EXPECT_CALL(*response_decoder, decodeHeaders_(_, false));
-  EXPECT_CALL(*response_decoder, decodeData(BufferStringEqual("hello"), false));
+  EXPECT_CALL(*response_decoder, decodeData(BufferString("hello"), false));
 
   Buffer::OwnedImpl response("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
                              "5\r\nhello\r\n");


### PR DESCRIPTION
BufferStringEqual was renamed to BufferString in #44817, but #44676 merged after with a new use of the old name, causing a build break.
