### PR TITLE
docs: clarify security implications of clear_route_cache

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -88,6 +88,17 @@ message ExtAuthz {
   //   alter another client request header.
   //
   // Defaults to ``false``.
+  //
+  // .. attention::
+  //
+  //   Enabling this option can cause Envoy to recompute route matching after earlier HTTP filters
+  //   have already processed the request. This can be security-sensitive when route-dependent
+  //   authorization filters, such as the RBAC filter, run before ext_authz.
+  //
+  //   Operators should avoid enabling this option for authorization services that are not fully
+  //   trusted to influence routing. When possible, filters that mutate route-matching inputs and
+  //   clear the route cache should run before route-dependent authorization filters. Operators can
+  //   also use decoder_header_mutation_rules to restrict sensitive request header mutations.
   bool clear_route_cache = 6;
 
   // Sets the HTTP status that is returned to the client when the authorization server returns an error

--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -299,6 +299,17 @@ message ExternalProcessor {
   // received in response to request headers. It is recommended to set this field rather than set
   // :ref:`disable_clear_route_cache <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.disable_clear_route_cache>`.
   // Only one of ``disable_clear_route_cache`` or ``route_cache_action`` can be set.
+  //
+  // .. attention::
+  //
+  //   Clearing the route cache can cause Envoy to recompute route matching after earlier HTTP
+  //   filters have already processed the request. This can be security-sensitive when filters
+  //   that make route-dependent authorization decisions, such as the RBAC filter, run before
+  //   ext_proc and ext_proc mutates route-matching inputs.
+  //
+  //   Operators should only enable route cache clearing for trusted external processors, should
+  //   carefully order route-dependent authorization filters, and should use mutation_rules to
+  //   restrict sensitive mutations when appropriate.
   RouteCacheAction route_cache_action = 18
       [(udpa.annotations.field_migrate).oneof_promotion = "clear_route_cache_type"];
 

--- a/docs/root/intro/arch_overview/http/http_filters.rst
+++ b/docs/root/intro/arch_overview/http/http_filters.rst
@@ -114,17 +114,17 @@ Security Considerations
 
 .. attention::
 
-   **Route Cache Clearing and Authorization Bypass Risk**: When using per-route authorization filters
-   (such as :ref:`ExtAuthZ <config_http_filters_ext_authz>`, :ref:`RBAC <config_http_filters_rbac>`,
-   or :ref:`JWT <config_http_filters_jwt_authn>`), be aware that subsequent filters in the filter
-   chain may clear the route cache, potentially leading to privilege escalation vulnerabilities.
+   **Route cache clearing and route-dependent authorization**: Clearing the route cache can cause
+   Envoy to recompute route matching after earlier HTTP filters have already processed the request.
+   This can be security-sensitive when filters that make route-dependent authorization decisions
+   run before filters that mutate route-matching inputs.
 
-   **The Problem**: If a request initially matches **Route A** with certain authorization settings,
-   gets authorized, but then a subsequent filter clears the route cache causing the request
-   to match **Route B** with different authorization requirements, the request will bypass Route B's
-   authorization since the authorization filter has already executed.
+   Route matching may depend on request headers, dynamic metadata, filter state, the request path,
+   or other request attributes. If one of these inputs is modified by a later filter and that filter
+   clears the route cache, subsequent filters and the router may observe a different route than the
+   one seen by earlier filters.
 
-   **Filters That Can Clear Route Cache**:
+   Filters that may clear the route cache include:
 
    * :ref:`Lua filter <config_http_filters_lua>` - via ``clearRouteCache()`` method
    * :ref:`ext_proc filter <config_http_filters_ext_proc>` - when configured with ``CLEAR`` route cache action or when response contains ``clear_route_cache`` directive
@@ -134,12 +134,11 @@ Security Considerations
    * :ref:`IP tagging filter <config_http_filters_ip_tagging>` - when sanitizing headers
    * Custom filters that call ``clearRouteCache()`` on the decoder callbacks
 
-   **Mitigation Strategies**:
-
-   * Carefully review the order of filters in your HTTP filter chain when using per-route authorization filters.
-   * Avoid placing filters that clear route cache after authorization filters unless absolutely necessary.
-   * Consider using global authorization configuration at the HTTP connection manager level instead of per-route configs whenever possible.
-   * If route cache clearing is required after authorization, consider re-running authorization checks or using alternative authorization mechanisms.
+   Operators should carefully review HTTP filter ordering when using route-dependent authorization
+   filters such as :ref:`RBAC <config_http_filters_rbac>`, :ref:`ExtAuthZ <config_http_filters_ext_authz>`,
+   or :ref:`JWT <config_http_filters_jwt_authn>`. Avoid enabling route cache clearing for untrusted
+   mutation sources, and consider placing route-dependent authorization filters after filters that
+   mutate route-matching inputs when possible.
 
 .. _arch_overview_http_filters_per_filter_config:
 


### PR DESCRIPTION
Commit Message:
docs: clarify security implications of clear_route_cache

Additional Description:
This PR clarifies the security-sensitive behavior of clear_route_cache when route matching is recomputed after earlier HTTP filters have already processed the request.

Route matching may depend on request headers, dynamic metadata, filter state, the request path, or other request attributes. If one of these inputs is modified by a later filter and that filter clears the route cache, subsequent filters and the router may observe a different route than the one seen by earlier filters.

This can be security-sensitive when route-dependent authorization filters, such as RBAC, ExtAuthZ, or JWT, run before filters that mutate route-matching inputs and clear the route cache.

The PR also adds more specific guidance to the ext_authz and ext_proc API documentation.

This change follows maintainer feedback from a private security discussion where the behavior was classified as intended clear_route_cache behavior, with a recommendation to improve public documentation.

Generative AI disclosure:
I used generative AI assistance to help draft and refine the documentation wording. I reviewed and understand the final changes.

Risk Level:
Low. Documentation-only change.

Testing:
Not run. Documentation-only change.

Docs Changes:
Yes. Updates HTTP filter security considerations and API comments for ext_authz / ext_proc route cache clearing behavior.

Release Notes:
N/A

Platform Specific Features:
N/A

[Optional Runtime guard:]
N/A

[Optional Fixes #Issue]
N/A

[Optional Fixes commit #PR or SHA]
N/A

[Optional Deprecated:]
N/A

[Optional API Considerations]:
N/A. Documentation-only update to API comments; no API behavior change.
