### PR TITLE
Update QUICHE from 13384c955 to 5320187c1

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-04-30"
+  release_date: "2026-05-13"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "13384c955f76e3a2b157f7b613ce6c02d594770f",
-        sha256 = "a2310cab30a46e9ccf533cd10632d44852d46784f4192e202cc53b6e353d5876",
+        version = "5320187c10ba1958720a811e635eae77203c3330",
+        sha256 = "8db5bf0bb8a908de2240a6e00824e119b0836a7626667d86bdf592e48f51dd6d",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/13384c955..5320187c1

```
$ git log 13384c955..5320187c1 --date=short --no-merges --format="%ad %al %s"

2026-05-13 quiche-dev Enabling rolled out flags.
2026-05-13 quiche-dev Add support for handling client certificate requests in QUIC TLS.
2026-05-13 martinduke Fix an issue from AI review of cl/914368728.
2026-05-13 martinduke Fix ASAN/MSAN errors in MoqtSessionTest and MoqtTrackTest.
2026-05-13 ianswett Deflake BBR3SimulatorTest
2026-05-13 asedeno Fix OSS QUICHE build.
2026-05-13 vasilvv Use new MOQT control message parser API directly.
2026-05-12 ripere Add support for chunked response decompression.
2026-05-12 ripere Refactor gzip decompression to share common code for chunked support.
2026-05-12 martinduke Allow fragmented MOQT object payloads.
2026-05-12 haoyuewang Maybe copy datagram frames in QuicUnackedPacketMap.
2026-05-12 martinduke Remove PUBLISH_OK message.
2026-05-07 ianswett Update CWND calculations to match the latest BBR draft. https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html
2026-05-07 rch No public description
2026-05-06 ricea Temporarily add a dummy definition of CreateIncomingStream() to quic::QuicSession
2026-05-06 haoyuewang Increase the QUIC_BUG threshold.
2026-05-06 vasilvv Add functions to interop between absl::Cord and QuicheMemSlice.
2026-05-05 rch No public description
2026-05-04 rch Deprecate QUIC reloadable flag quic_close_connection_on_underflow.
2026-05-04 vasilvv Rewrite MOQT control message parser.
2026-05-02 ianswett Update BBR3 to more closely align with the BBRv3 draft.
2026-05-01 ianswett Remove tests for the deprecated kB201 connection option from BBR2 and BBR3 simulator tests.
```

Risk Level: Low
Testing: Existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
