### PR TITLE
config: introduce GrpcMuxCache component & tests

### DIFF
--- a/source/common/config/BUILD
+++ b/source/common/config/BUILD
@@ -303,10 +303,31 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "grpc_mux_cache_lib",
+    srcs = ["grpc_mux_cache.cc"],
+    hdrs = ["grpc_mux_cache.h"],
+    deps = [
+        "//envoy/config:grpc_mux_interface",
+        "//envoy/config:subscription_factory_interface",
+        "//envoy/config:subscription_interface",
+        "//envoy/grpc:async_client_interface",
+        "//envoy/local_info:local_info_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/protobuf",
+        "//source/common/protobuf:utility_lib",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/strings",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "xds_manager_lib",
     srcs = ["xds_manager_impl.cc"],
     hdrs = ["xds_manager_impl.h"],
     deps = [
+        ":grpc_mux_cache_lib",
         ":null_grpc_mux_lib",
         ":subscription_factory_lib",
         ":utility_lib",

--- a/source/common/config/grpc_mux_cache.cc
+++ b/source/common/config/grpc_mux_cache.cc
@@ -5,9 +5,10 @@
 namespace Envoy {
 namespace Config {
 
-std::shared_ptr<GrpcMux> GrpcMuxCache::getOrCreateMux(
-    const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
-    std::function<std::shared_ptr<GrpcMux>()> mux_creator) {
+std::shared_ptr<GrpcMux>
+GrpcMuxCache::getOrCreateMux(const envoy::config::core::v3::ConfigSource& config,
+                             absl::string_view type_url,
+                             std::function<std::shared_ptr<GrpcMux>()> mux_creator) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   GrpcMuxKey key(config, type_url);
   auto it = cache_.find(key);

--- a/source/common/config/grpc_mux_cache.cc
+++ b/source/common/config/grpc_mux_cache.cc
@@ -1,0 +1,30 @@
+#include "source/common/config/grpc_mux_cache.h"
+
+#include "source/common/common/assert.h"
+
+namespace Envoy {
+namespace Config {
+
+std::shared_ptr<GrpcMux> GrpcMuxCache::getOrCreateMux(
+    const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
+    std::function<std::shared_ptr<GrpcMux>()> mux_creator) {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  GrpcMuxKey key(config, type_url);
+  auto it = cache_.find(key);
+  if (it != cache_.end()) {
+    if (auto mux = it->second.lock()) {
+      return mux;
+    }
+  }
+  auto mux = mux_creator();
+  cache_[key] = mux;
+  return mux;
+}
+
+void GrpcMuxCache::clear() {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  cache_.clear();
+}
+
+} // namespace Config
+} // namespace Envoy

--- a/source/common/config/grpc_mux_cache.h
+++ b/source/common/config/grpc_mux_cache.h
@@ -45,9 +45,9 @@ class GrpcMuxCache {
 public:
   GrpcMuxCache() = default;
 
-  std::shared_ptr<GrpcMux> getOrCreateMux(
-      const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
-      std::function<std::shared_ptr<GrpcMux>()> mux_creator);
+  std::shared_ptr<GrpcMux> getOrCreateMux(const envoy::config::core::v3::ConfigSource& config,
+                                          absl::string_view type_url,
+                                          std::function<std::shared_ptr<GrpcMux>()> mux_creator);
 
   void clear();
 

--- a/source/common/config/grpc_mux_cache.h
+++ b/source/common/config/grpc_mux_cache.h
@@ -36,6 +36,7 @@ public:
     return false;
   }
 
+private:
   envoy::config::core::v3::ConfigSource config_;
   std::string type_url_;
   std::size_t pre_computed_hash_{0};

--- a/source/common/config/grpc_mux_cache.h
+++ b/source/common/config/grpc_mux_cache.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/config/grpc_mux.h"
+#include "envoy/config/subscription_factory.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/protobuf/utility.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/hash/hash.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Config {
+
+class GrpcMuxKey {
+public:
+  GrpcMuxKey() = default;
+  GrpcMuxKey(const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url)
+      : config_(config), type_url_(type_url),
+        pre_computed_hash_(absl::HashOf(Envoy::MessageUtil::hash(config), type_url)) {}
+
+  template <typename H> friend H AbslHashValue(H h, const GrpcMuxKey& key) {
+    return H::combine(std::move(h), key.pre_computed_hash_);
+  }
+
+  friend bool operator==(const GrpcMuxKey& lhs, const GrpcMuxKey& rhs) {
+    if (lhs.pre_computed_hash_ == rhs.pre_computed_hash_ && lhs.type_url_ == rhs.type_url_) {
+      return Protobuf::util::MessageDifferencer::Equivalent(lhs.config_, rhs.config_);
+    }
+    return false;
+  }
+
+  envoy::config::core::v3::ConfigSource config_;
+  std::string type_url_;
+  std::size_t pre_computed_hash_{0};
+};
+
+class GrpcMuxCache {
+public:
+  GrpcMuxCache() = default;
+
+  std::shared_ptr<GrpcMux> getOrCreateMux(
+      const envoy::config::core::v3::ConfigSource& config, absl::string_view type_url,
+      std::function<std::shared_ptr<GrpcMux>()> mux_creator);
+
+  void clear();
+
+private:
+  absl::flat_hash_map<GrpcMuxKey, std::weak_ptr<GrpcMux>> cache_;
+};
+
+} // namespace Config
+} // namespace Envoy

--- a/test/common/config/BUILD
+++ b/test/common/config/BUILD
@@ -273,6 +273,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "grpc_mux_cache_test",
+    srcs = ["grpc_mux_cache_test.cc"],
+    deps = [
+        "//source/common/config:grpc_mux_cache_lib",
+        "//test/mocks/config:config_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "xds_manager_impl_test",
     srcs = ["xds_manager_impl_test.cc"],
     rbe_pool = "2core",

--- a/test/common/config/grpc_mux_cache_test.cc
+++ b/test/common/config/grpc_mux_cache_test.cc
@@ -1,0 +1,152 @@
+#include "source/common/config/grpc_mux_cache.h"
+
+#include "test/mocks/config/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Config {
+namespace {
+
+using testing::NiceMock;
+
+class GrpcMuxCacheTest : public testing::Test {
+public:
+  GrpcMuxCacheTest() = default;
+
+  envoy::config::core::v3::ConfigSource config_;
+  GrpcMuxCache cache_;
+};
+
+TEST_F(GrpcMuxCacheTest, NoCacheHit) {
+  config_.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  auto mock_mux = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called = false;
+  auto mux = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called = true;
+    return mock_mux;
+  });
+  EXPECT_TRUE(creator_called);
+  EXPECT_EQ(mux, mock_mux);
+}
+
+TEST_F(GrpcMuxCacheTest, CacheHit) {
+  config_.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  auto mock_mux = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called1 = false;
+  auto mux1 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called1 = true;
+    return mock_mux;
+  });
+  EXPECT_TRUE(creator_called1);
+  EXPECT_EQ(mux1, mock_mux);
+
+  bool creator_called2 = false;
+  auto mux2 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called2 = true;
+    return std::make_shared<NiceMock<MockGrpcMux>>();
+  });
+  EXPECT_FALSE(creator_called2);
+  EXPECT_EQ(mux2, mock_mux);
+}
+
+TEST_F(GrpcMuxCacheTest, CacheHitNullWeakPtr) {
+  config_.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  auto mock_mux1 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called1 = false;
+  auto mux1 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called1 = true;
+    return mock_mux1;
+  });
+  EXPECT_TRUE(creator_called1);
+  EXPECT_EQ(mux1, mock_mux1);
+
+  // Reset mux1 so the weak_ptr in cache expires.
+  mock_mux1.reset();
+  mux1.reset();
+
+  auto mock_mux2 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called2 = false;
+  auto mux2 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called2 = true;
+    return mock_mux2;
+  });
+  EXPECT_TRUE(creator_called2);
+  EXPECT_EQ(mux2, mock_mux2);
+}
+
+TEST_F(GrpcMuxCacheTest, ClearCache) {
+  config_.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  auto mock_mux = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called1 = false;
+  auto mux1 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called1 = true;
+    return mock_mux;
+  });
+  EXPECT_TRUE(creator_called1);
+  EXPECT_EQ(mux1, mock_mux);
+
+  cache_.clear();
+
+  bool creator_called2 = false;
+  auto mux2 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.Type", [&]() {
+    creator_called2 = true;
+    return mock_mux;
+  });
+  EXPECT_TRUE(creator_called2);
+  EXPECT_EQ(mux2, mock_mux);
+}
+
+TEST_F(GrpcMuxCacheTest, DifferentTypeUrlNoCacheHit) {
+  config_.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  auto mock_mux1 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called1 = false;
+  auto mux1 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.TypeA", [&]() {
+    creator_called1 = true;
+    return mock_mux1;
+  });
+  EXPECT_TRUE(creator_called1);
+  EXPECT_EQ(mux1, mock_mux1);
+
+  auto mock_mux2 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called2 = false;
+  auto mux2 = cache_.getOrCreateMux(config_, "type.googleapis.com/some.TypeB", [&]() {
+    creator_called2 = true;
+    return mock_mux2;
+  });
+  EXPECT_TRUE(creator_called2);
+  EXPECT_EQ(mux2, mock_mux2);
+}
+
+TEST_F(GrpcMuxCacheTest, DifferentConfigSourceNoCacheHit) {
+  envoy::config::core::v3::ConfigSource config1;
+  config1.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  config1.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("cluster_1");
+
+  auto mock_mux1 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called1 = false;
+  auto mux1 = cache_.getOrCreateMux(config1, "type.googleapis.com/some.Type", [&]() {
+    creator_called1 = true;
+    return mock_mux1;
+  });
+  EXPECT_TRUE(creator_called1);
+  EXPECT_EQ(mux1, mock_mux1);
+
+  envoy::config::core::v3::ConfigSource config2;
+  config2.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
+  config2.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("cluster_2");
+
+  auto mock_mux2 = std::make_shared<NiceMock<MockGrpcMux>>();
+  bool creator_called2 = false;
+  auto mux2 = cache_.getOrCreateMux(config2, "type.googleapis.com/some.Type", [&]() {
+    creator_called2 = true;
+    return mock_mux2;
+  });
+  EXPECT_TRUE(creator_called2);
+  EXPECT_EQ(mux2, mock_mux2);
+}
+
+} // namespace
+} // namespace Config
+} // namespace Envoy

--- a/test/common/config/grpc_mux_cache_test.cc
+++ b/test/common/config/grpc_mux_cache_test.cc
@@ -122,7 +122,8 @@ TEST_F(GrpcMuxCacheTest, DifferentTypeUrlNoCacheHit) {
 TEST_F(GrpcMuxCacheTest, DifferentConfigSourceNoCacheHit) {
   envoy::config::core::v3::ConfigSource config1;
   config1.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-  config1.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("cluster_1");
+  config1.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
+      "cluster_1");
 
   auto mock_mux1 = std::make_shared<NiceMock<MockGrpcMux>>();
   bool creator_called1 = false;
@@ -135,7 +136,8 @@ TEST_F(GrpcMuxCacheTest, DifferentConfigSourceNoCacheHit) {
 
   envoy::config::core::v3::ConfigSource config2;
   config2.mutable_api_config_source()->set_api_type(envoy::config::core::v3::ApiConfigSource::GRPC);
-  config2.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name("cluster_2");
+  config2.mutable_api_config_source()->add_grpc_services()->mutable_envoy_grpc()->set_cluster_name(
+      "cluster_2");
 
   auto mock_mux2 = std::make_shared<NiceMock<MockGrpcMux>>();
   bool creator_called2 = false;


### PR DESCRIPTION
Commit Message: config: introduce GrpcMuxCache component & tests
Additional Description:

This pr adds a temporarily unused GrpcMuxCache so that we can reuse GrpcMuxes iff they have the exact same config source & type url.

Risk Level: none, adding unused standalone library
Testing: unit tests added 
Docs Changes: none needed
Release Notes: none
Platform Specific Features: none

I used generative AI to help create this change
