### PR TITLE
server: rebuild AdminResponse FSM diagram and fix link.

### DIFF
--- a/source/exe/admin_response.h
+++ b/source/exe/admin_response.h
@@ -34,7 +34,8 @@ class AdminResponse;
 //
 // The lifecycle of an AdminResponse is rendered as a finite state machine
 // bubble diagram:
-// https://docs.google.com/drawings/d/1njUl1twApEMoxmjaG4b7optTh5fcb_YNcfSnkHbdfq0/view
+
+// https://docs.google.com/drawings/d/16kRs5rwi0k7G5d8PgF3B6gcbymiEnafYEoinRSxodtg/view
 class AdminResponse : public std::enable_shared_from_this<AdminResponse> {
 public:
   // AdminResponse can outlive MainCommonBase. But AdminResponse needs a

--- a/source/exe/admin_response.h
+++ b/source/exe/admin_response.h
@@ -34,8 +34,18 @@ class AdminResponse;
 //
 // The lifecycle of an AdminResponse is rendered as a finite state machine
 // bubble diagram:
+/*
+```mermaid
+  stateDiagram-v2 direction TB [*] --> Uninit: Created Uninit --> GetChunks: nextChunk() state
+  GetChunks { [*] --> Ready Ready --> Ready: nextChunk(): Sync chunk, more to come Ready -->
+  WaitingAsync: nextChunk(): Async operation started Ready --> [*]: nextChunk(): Final sync chunk }
+  GetChunks --> Continue: Async op started Continue --> GetChunks: onChunk(): Async data received
+  Continue --> Done: onDrained(): Async finished Uninit --> Done: Cancel / Failure / Shutdown
+  GetChunks --> Done: Cancel / Failure / Shutdown / Error Continue --> Done: Cancel / Failure /
+  Shutdown / Error state Done <<choice>> GetChunks -down-> Done
+```
+*/
 
-// https://docs.google.com/drawings/d/16kRs5rwi0k7G5d8PgF3B6gcbymiEnafYEoinRSxodtg/view
 class AdminResponse : public std::enable_shared_from_this<AdminResponse> {
 public:
   // AdminResponse can outlive MainCommonBase. But AdminResponse needs a

--- a/source/exe/admin_response.h
+++ b/source/exe/admin_response.h
@@ -32,20 +32,8 @@ class AdminResponse;
 // Requests can also be cancelled explicitly by calling cancel(). After
 // cancel() is called, no further callbacks will be called by the response.
 //
-// The lifecycle of an AdminResponse is rendered as a finite state machine
-// bubble diagram:
-/*
-```mermaid
-  stateDiagram-v2 direction TB [*] --> Uninit: Created Uninit --> GetChunks: nextChunk() state
-  GetChunks { [*] --> Ready Ready --> Ready: nextChunk(): Sync chunk, more to come Ready -->
-  WaitingAsync: nextChunk(): Async operation started Ready --> [*]: nextChunk(): Final sync chunk }
-  GetChunks --> Continue: Async op started Continue --> GetChunks: onChunk(): Async data received
-  Continue --> Done: onDrained(): Async finished Uninit --> Done: Cancel / Failure / Shutdown
-  GetChunks --> Done: Cancel / Failure / Shutdown / Error Continue --> Done: Cancel / Failure /
-  Shutdown / Error state Done <<choice>> GetChunks -down-> Done
-```
-*/
-
+// Wee admin_response.md to see a finite-state diagram showing the lifecycle of
+// an AdminResponse.
 class AdminResponse : public std::enable_shared_from_this<AdminResponse> {
 public:
   // AdminResponse can outlive MainCommonBase. But AdminResponse needs a

--- a/source/exe/admin_response.md
+++ b/source/exe/admin_response.md
@@ -23,12 +23,69 @@ stateDiagram-v2
     }
 ```
 
-Explanation of Mermaid Syntax:
+---
 
- * stateDiagram-v2: Declares a state diagram.
- * direction TB: Sets the direction from Top to Bottom.
- * [*]: Represents the start or end state.
-   * [*] --> Uninit: Transition from start to Uninit.
- * State1 --> State2: Label: Defines a transition from State1 to State2 with a given Label.
- * The transitions for cancellation, failure, or shutdown are shown from each active state (Uninit, GetChunks, Continue) to the Done state.
- 
+### Envoy::AdminResponse State Machine
+
+This describes the lifecycle of an `AdminResponse` object, used for streaming potentially large responses from Envoy's admin interface.
+
+#### States
+
+*   **`Uninit`**:
+    *   The initial state of the `AdminResponse` after it has been created.
+    *   No data has been generated or sent yet.
+
+*   **`GetChunks`**:
+    *   The core state for producing data. The system enters this state when it's ready to generate the next part of the response.
+    *   The `nextChunk()` method is called when the response is in this state.
+
+*   **`Continue`**:
+    *   Indicates that the response generation is waiting for an asynchronous operation to complete.
+    *   This state is entered after `nextChunk()` initiates an operation that doesn't return data immediately (e.g., fetching data from another thread or component).
+
+*   **`Done`**:
+    *   The terminal state.
+    *   No more data will be produced or callbacks made by this `AdminResponse`.
+    *   The response is considered complete, cancelled, or has failed.
+
+#### Transitions
+
+1.  **`[*] --> Uninit`** (Label: `Created`)
+    *   The `AdminResponse` object is instantiated and starts in the `Uninit` state.
+
+2.  **`Uninit --> GetChunks`** (Label: `nextChunk()`)
+    *   The first call to `nextChunk()` moves the state from `Uninit` to `GetChunks`, initiating the data generation process.
+
+3.  **`GetChunks --> GetChunks`** (Label: `nextChunk(): Sync, more data`)
+    *   When `nextChunk()` is called, it synchronously produces one or more data chunks, but there's still more data to come in subsequent calls. The state remains `GetChunks`.
+
+4.  **`GetChunks --> Continue`** (Label: `nextChunk(): Async op started`)
+    *   `nextChunk()` initiates an asynchronous operation to fetch/generate the next chunk. The state transitions to `Continue` to wait for the callback.
+
+5.  **`GetChunks --> Done`** (Label: `nextChunk(): Final sync chunk`)
+    *   `nextChunk()` synchronously produces the *final* data chunk. The response is now complete.
+
+6.  **`Continue --> GetChunks`** (Label: `onChunk(): Async data received`)
+    *   The asynchronous operation (started in `GetChunks`) completes and provides a data chunk via the `onChunk()` callback. The state returns to `GetChunks` to process this chunk and prepare for the next.
+
+7.  **`Continue --> Done`** (Label: `onDrained(): Async finished`)
+    *   The asynchronous operation signals that it's completely finished sending data, for example, by calling `onDrained()`.
+
+8.  **`Uninit --> Done`** (Label: `Cancel / Failure / Shutdown`)
+    *   The response is terminated while in the `Uninit` state. This can happen if `cancel()` is called, `onFailure()` is invoked, or the main Envoy server context is shutting down before `nextChunk()` is ever called.
+
+9.  **`GetChunks --> Done`** (Label: `Error in nextChunk()` or `Cancel / Failure / Shutdown`)
+    *   The response is terminated while in the `GetChunks` state. This can be due to:
+        *   An error occurring during the execution of `nextChunk()`.
+        *   `cancel()` being called.
+        *   `onFailure()` being invoked.
+        *   The main Envoy server context shutting down.
+
+10. **`Continue --> Done`** (Label: `Error in callback` or `Cancel / Failure / Shutdown`)
+    *   The response is terminated while waiting in the `Continue` state. This can be due to:
+        *   An error occurring within the asynchronous callback (`onChunk()` or `onDrained()`).
+        *   `cancel()` being called.
+        *   `onFailure()` being invoked.
+        *   The main Envoy server context shutting down.
+
+---

--- a/source/exe/admin_response.md
+++ b/source/exe/admin_response.md
@@ -1,0 +1,19 @@
+```mermaid
+  stateDiagram-v2 direction TB [*] --> Uninit: Created Uninit --> GetChunks: nextChunk() state
+  GetChunks { [*] --> Ready Ready --> Ready: nextChunk(): Sync chunk, more to come Ready -->
+  WaitingAsync: nextChunk(): Async operation started Ready --> [*]: nextChunk(): Final sync chunk }
+  GetChunks --> Continue: Async op started Continue --> GetChunks: onChunk(): Async data received
+  Continue --> Done: onDrained(): Async finished Uninit --> Done: Cancel / Failure / Shutdown
+  GetChunks --> Done: Cancel / Failure / Shutdown / Error Continue --> Done: Cancel / Failure /
+  Shutdown / Error state Done <<choice>> GetChunks -down-> Done
+```
+
+Explanation of Mermaid Syntax:
+
+ * stateDiagram-v2: Declares a state diagram.
+ * direction TB: Sets the direction from Top to Bottom.
+ * [*]: Represents the start or end state.
+   * [*] --> Uninit: Transition from start to Uninit.
+ * State1 --> State2: Label: Defines a transition from State1 to State2 with a given Label.
+ * The transitions for cancellation, failure, or shutdown are shown from each active state (Uninit, GetChunks, Continue) to the Done state.
+ 

--- a/source/exe/admin_response.md
+++ b/source/exe/admin_response.md
@@ -1,11 +1,26 @@
 ```mermaid
-  stateDiagram-v2 direction TB [*] --> Uninit: Created Uninit --> GetChunks: nextChunk() state
-  GetChunks { [*] --> Ready Ready --> Ready: nextChunk(): Sync chunk, more to come Ready -->
-  WaitingAsync: nextChunk(): Async operation started Ready --> [*]: nextChunk(): Final sync chunk }
-  GetChunks --> Continue: Async op started Continue --> GetChunks: onChunk(): Async data received
-  Continue --> Done: onDrained(): Async finished Uninit --> Done: Cancel / Failure / Shutdown
-  GetChunks --> Done: Cancel / Failure / Shutdown / Error Continue --> Done: Cancel / Failure /
-  Shutdown / Error state Done <<choice>> GetChunks -down-> Done
+stateDiagram-v2
+    direction TB
+
+    [*] --> Uninit: Created
+
+    Uninit --> GetChunks: nextChunk()
+    Uninit --> Done: Cancel / Failure / Shutdown
+
+    GetChunks --> GetChunks: nextChunk(): Sync, more data
+    GetChunks --> Continue: nextChunk(): Async op started
+    GetChunks --> Done: nextChunk(): Final sync chunk
+    GetChunks --> Done: Error in nextChunk()
+    GetChunks --> Done: Cancel / Failure / Shutdown
+
+    Continue --> GetChunks: onChunk(): Async data received
+    Continue --> Done: onDrained(): Async finished
+    Continue --> Done: Error in callback
+    Continue --> Done: Cancel / Failure / Shutdown
+
+    state Done {
+        description: Terminal State
+    }
 ```
 
 Explanation of Mermaid Syntax:


### PR DESCRIPTION
Commit Message: When I wrote this class a couple of years ago I made a diagram describing the fininte state machine for life of an AdninResponse in a google drawing. For some reason that drawing disappeared so I re-created it (using AI).

This just fixes the link to point to the new diagram.
Additional Description: n/a
Risk Level: low (comment change)
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a