### PR TITLE
mobile: relax AsyncClient Python API to take different engine builders

### DIFF
--- a/mobile/MODULE.bazel
+++ b/mobile/MODULE.bazel
@@ -24,7 +24,6 @@ local_path_override(
 )
 
 pip.parse(
-    experimental_index_url = "https://us-python.pkg.dev/artifact-foundry-prod/python-3p-trusted/simple/",
     hub_name = "pypi",
     python_version = PYTHON_VERSION,
     requirements_lock = "//:requirements.txt",

--- a/mobile/library/python/envoy_mobile/async_client/client.py
+++ b/mobile/library/python/envoy_mobile/async_client/client.py
@@ -1,16 +1,25 @@
 """High level asyncio client built on top of the Envoy Mobile bindings."""
 
 import asyncio
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Protocol, Union
 
 from .. import envoy_engine
-from ..envoy_engine import EngineBuilder
 
 from .executor import AsyncioExecutor, Executor
 from .response import ClientResponseError, Response
 from .utils import (
     normalize_request,
 )
+
+
+class EngineBuilderLike(Protocol):
+    def set_on_engine_running(self, closure: Callable[[], None]) -> "EngineBuilderLike":
+        """Set callback to be invoked when engine is running."""
+        ...
+
+    def build(self) -> Any:
+        """Build and return the engine instance."""
+        ...
 
 
 class AsyncClient:
@@ -25,11 +34,11 @@ class AsyncClient:
     Use as an async context manager: ``async with AsyncClient(engine_builder) as client:``
     """
 
-    def __init__(self, engine_builder: EngineBuilder) -> None:
+    def __init__(self, engine_builder: EngineBuilderLike) -> None:
         """Construct a new AsyncClient.
 
         Args:
-            engine_builder: A pre-configured EngineBuilder to finalize and build.
+            engine_builder: A pre-configured EngineBuilder (or compatible builder object) to finalize and build.
         """
         self._engine_builder = engine_builder
         self._engine = None


### PR DESCRIPTION
Commit Message: the Python class now takes a custom Protocol `EngineBuilderLike`.

Additional Description: also remove google's private PyPI mirror url override
Risk Level: low
Testing: existing tests passs
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
