### PR TITLE
mobile: fix assertion failure in NCF::resolveProxy

### DIFF
--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -87,7 +87,11 @@ NetworkConfigurationFilter::decodeHeaders(Http::RequestHeaderMap& request_header
   auto* proxy_resolver = static_cast<Network::ProxyResolverApi*>(
       Api::External::retrieveApi("envoy_proxy_resolver", /*allow_absent=*/true));
   if (proxy_resolver != nullptr) {
-    return resolveProxy(request_headers, proxy_resolver);
+    if (Thread::MainThread::isMainOrTestThread()) {
+      return resolveProxy(request_headers, proxy_resolver);
+    } else {
+      ENVOY_LOG(debug, "Skipping proxy resolution as not on main thread (likely running on worker thread)");
+    }
   }
 
   // For Android, proxy settings are pushed to the ConnectivityManager and synchronously handled

--- a/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/mobile/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -90,7 +90,9 @@ NetworkConfigurationFilter::decodeHeaders(Http::RequestHeaderMap& request_header
     if (Thread::MainThread::isMainOrTestThread()) {
       return resolveProxy(request_headers, proxy_resolver);
     } else {
-      ENVOY_LOG(debug, "Skipping proxy resolution as not on main thread (likely running on worker thread)");
+      ENVOY_LOG(
+          debug,
+          "Skipping proxy resolution as not on main thread (likely running on worker thread)");
     }
   }
 

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -11,10 +11,21 @@
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
+#include "library/common/api/external.h"
+#include "library/common/network/proxy_api.h"
 
 using testing::Ge;
 namespace Envoy {
 namespace {
+
+class DummyProxyResolver : public Network::ProxyResolver {
+public:
+  Network::ProxyResolutionResult resolveProxy(const std::string&, std::vector<Network::ProxySettings>&,
+                                              Network::ProxySettingsResolvedCallback) override {
+    return Network::ProxyResolutionResult::NoProxyConfigured;
+  }
+  void setDispatcher(Event::Dispatcher*) override {}
+};
 
 class RtdsIntegrationTest : public XdsIntegrationTest {
 public:
@@ -121,6 +132,10 @@ TEST_P(RtdsIntegrationTest, RtdsReloadWithoutDfpMixedScheme) {
 }
 
 TEST_P(RtdsIntegrationTest, RtdsReloadWithWorkerThread) {
+  auto proxy_resolver_api = std::make_unique<Network::ProxyResolverApi>();
+  proxy_resolver_api->resolver = std::make_unique<DummyProxyResolver>();
+  Api::External::registerApi("envoy_proxy_resolver", proxy_resolver_api.release());
+
   builder_.enableWorkerThread(true);
   runReloadTest();
 }

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -20,7 +20,8 @@ namespace {
 
 class DummyProxyResolver : public Network::ProxyResolver {
 public:
-  Network::ProxyResolutionResult resolveProxy(const std::string&, std::vector<Network::ProxySettings>&,
+  Network::ProxyResolutionResult resolveProxy(const std::string&,
+                                              std::vector<Network::ProxySettings>&,
                                               Network::ProxySettingsResolvedCallback) override {
     return Network::ProxyResolutionResult::NoProxyConfigured;
   }


### PR DESCRIPTION
The test `//test/common/integration:rtds_integration_test` was failing in release mode due to an assertion that `NetworkConfigurationFilter::resolveProxy` must run on the main or test thread, after the changes in https://github.com/envoyproxy/envoy/pull/44295 enabled separating Envoy Mobile into a main thread and worker thread. This assumption may no longer hold if requests are handled on a worker thread.

This change skips calling `resolveProxy` if not on the main thread.

Also updated `rtds_integration_test.cc` to register a dummy proxy resolver in the worker thread test to provide coverage for this path.

This commit was generated with AI.