### PR TITLE
dns_resolver: fix macOS build for Hickory by linking SystemConfiguration

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -102,6 +102,12 @@ bug_fixes:
     Fixed ``Illegal ambiguous match`` error when building contrib targets with ``--config=boringssl-fips``
     on aarch64 by restricting the ``using_boringssl_fips`` branch of ``SELECTED_CONTRIB_EXTENSIONS`` to
     ``linux_x86_64``. Mirrors the approach taken by #44661 for ``aws-lc``.
+- area: dns_resolver
+  change: |
+    Fixed macOS build failure (#45061) for the Hickory DNS resolver by linking
+    Apple's ``SystemConfiguration`` framework. The framework is required by the
+    ``system-configuration`` crate that ``hickory-resolver`` pulls in via its
+    ``system-config`` feature.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/extensions/network/dns_resolver/hickory/BUILD
+++ b/source/extensions/network/dns_resolver/hickory/BUILD
@@ -13,6 +13,14 @@ envoy_cc_library(
     name = "hickory_dns_lib",
     srcs = ["hickory_dns_impl.cc"],
     hdrs = ["hickory_dns_impl.h"],
+    linkopts = select({
+        # Apple's SystemConfiguration framework is required by the
+        # system-configuration crate, which is pulled in transitively by
+        # hickory-resolver's `system-config` feature.
+        # https://github.com/envoyproxy/envoy/issues/45061
+        "//bazel:apple": ["-Wl,-framework,SystemConfiguration"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//envoy/event:dispatcher_interface",
         "//envoy/network:dns_interface",


### PR DESCRIPTION
## Description

The `hickory-resolver` RIST crate's `system-config` feature transitively pulls in the `system-configuration` crate, which links against Apple's SystemConfiguration framework. Envoy does not link this framework by default on Apple platforms, leading to undefined-symbol errors when linking targets that depend on the Hickory extension on macOS.

This PR adds a conditional `linkopts` on `hickory_dns_lib` that links the SystemConfiguration framework on Apple platforms. The flag propagates transitively through `cc_library` deps to any binary or test that pulls in the Hickory extension.

Fixes #45061

---

**Commit Message:** dns_resolver: fix macOS build for Hickory by linking SystemConfiguration
**Additional Description:** Added a conditional `linkopts` on `hickory_dns_lib` that links the SystemConfiguration framework on Apple platforms
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added