### PR TITLE
dns_resolver: fix Hickory cancel leak and dispatcher-post UAF

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -97,6 +97,18 @@ bug_fixes:
     resulting binary "plaintext" was written back into the ``Cookie:`` request header and tripped a
     ``HeaderString`` validation assert. Such plaintexts are now rejected and the original cookie value
     is preserved, matching the behavior already documented for the explicit decryption-failure case.
+- area: dns_resolver
+  change: |
+    Fixed a memory leak in the Hickory DNS resolver where ``ActiveDnsQuery::cancel()``
+    did not free the pending query state or decrement the ``pending_resolutions`` gauge. Cancelled
+    queries now release their shell object, Rust-side query box, and gauge tick synchronously,
+    matching the contract followed by the c-ares and Apple DNS resolvers.
+- area: dns_resolver
+  change: |
+    Fixed a UAF in the Hickory DNS resolver where the dispatcher lambda posted by the
+    Rust-thread completion callback captured a raw pointer to the resolver. If the resolver was
+    destroyed before the dispatcher drained the lambda, dereferencing the pointer was undefined
+    behavior. The lambda now captures a ``std::weak_ptr`` and locks it before touching the resolver.
 - area: build
   change: |
     Fixed ``Illegal ambiguous match`` error when building contrib targets with ``--config=boringssl-fips``

--- a/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.cc
+++ b/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.cc
@@ -89,8 +89,22 @@ HickoryPendingResolution::HickoryPendingResolution(HickoryDnsResolver& parent,
     : callback_(std::move(callback)), query_id_(query_id), dns_name_(dns_name), parent_(parent) {}
 
 void HickoryPendingResolution::cancel(CancelReason) {
-  cancelled_ = true;
+  ASSERT(parent_.dispatcher_.isThreadSafe());
+
+  // Drop the Rust-side query state. The Rust cancel implementation flips the per-query
+  // `AtomicBool` so any in-flight Tokio task observes the cancellation and skips invoking
+  // the resolve-complete callback. The resolver pointer is unused by the cancel FFI; only
+  // the query pointer is consumed.
   parent_.config_->on_dns_resolve_cancel_(parent_.resolver_module_ptr_, query_module_ptr_);
+  query_module_ptr_ = nullptr;
+
+  // Reconcile shell state synchronously so the gauge tracks reality and the
+  // `HickoryPendingResolution` object is not leaked. Per the `ActiveDnsQuery::cancel()`
+  // contract, callers must treat the pointer as invalidated after this returns. A late
+  // `onResolveComplete` for this `query_id` will find no map entry and safely no-op.
+  parent_.stats_.pending_resolutions_.dec();
+  parent_.pending_queries_.erase(query_id_);
+  delete this;
 }
 
 // -- HickoryDnsResolver -------------------------------------------------------
@@ -110,25 +124,27 @@ HickoryDnsResolver::HickoryDnsResolver(HickoryDnsResolverConfigSharedPtr config,
 }
 
 HickoryDnsResolver::~HickoryDnsResolver() {
-  // Step 1: Set the C++ shutdown flag so the ABI callback called from `Tokio` threads
-  // will not post to the dispatcher. This provides TSAN-visible synchronization since
-  // the Rust code is not instrumented by TSAN.
+  // Step 1: Set the C++ shutdown flag so the ABI callback called from Tokio threads
+  // skips posting to the dispatcher. The posted lambda also locks a `weak_ptr` to this
+  // resolver as the final use-after-free guard.
   shutting_down_.store(true, std::memory_order_release);
 
-  // Step 2: Destroy the module resolver, which shuts down the `Tokio` runtime and
-  // blocks until all worker threads have exited.
+  // Step 2: Destroy the module resolver. The Rust `Drop` impl signals its own
+  // shutting-down flag and then performs `runtime.shutdown_timeout(5s)`, waiting up to
+  // five seconds for Tokio tasks to finish; any tasks still running when the timeout
+  // expires are dropped.
   config_->on_dns_resolver_destroy_(resolver_module_ptr_);
 
-  // Step 3: Free Rust-side query objects for all remaining pending queries, and delete
-  // the C++ pending resolution objects. Already-cancelled queries have their Rust-side
-  // objects freed by the cancel() call, so only free non-cancelled ones. Decrement the
-  // pending_resolutions gauge for each query since their callbacks will never arrive.
+  // Step 3: Free Rust-side query objects for all remaining pending queries and delete
+  // the C++ pending resolution objects. Cancelled queries are not present here: they
+  // were removed and freed by `HickoryPendingResolution::cancel()`. Decrement the
+  // `pending_resolutions` gauge for each remaining query since their callbacks will
+  // never arrive.
   for (auto& [id, pending] : pending_queries_) {
     stats_.pending_resolutions_.dec();
-    if (!pending->cancelled_) {
-      // Safe: on_dns_resolve_cancel_ does not dereference the resolver pointer.
-      config_->on_dns_resolve_cancel_(resolver_module_ptr_, pending->query_module_ptr_);
-    }
+    // Safe: the Rust cancel FFI ignores the resolver pointer; only the query box is
+    // consumed. See `envoy_dynamic_module_on_dns_resolve_cancel` in the Rust SDK.
+    config_->on_dns_resolve_cancel_(resolver_module_ptr_, pending->query_module_ptr_);
     delete pending;
   }
   pending_queries_.clear();
@@ -190,12 +206,6 @@ void HickoryDnsResolver::onResolveComplete(uint64_t query_id,
   stats_.resolve_total_.inc();
   stats_.pending_resolutions_.dec();
 
-  if (pending->cancelled_) {
-    ENVOY_LOG(debug, "dropping cancelled query [{}]", pending->dns_name_);
-    delete pending;
-    return;
-  }
-
   const auto envoy_status = status == envoy_dynamic_module_type_dns_resolution_status_Completed
                                 ? ResolutionStatus::Completed
                                 : ResolutionStatus::Failure;
@@ -208,8 +218,8 @@ void HickoryDnsResolver::onResolveComplete(uint64_t query_id,
               response.size());
   }
 
-  // Free the Rust-side query object. The cancel ABI function takes ownership and drops it.
-  // Calling cancel on an already-completed query is harmless (it only sets the AtomicBool).
+  // Free the Rust-side query object now that its task has produced a result. The cancel
+  // ABI function takes ownership of the boxed query and drops it.
   config_->on_dns_resolve_cancel_(resolver_module_ptr_, pending->query_module_ptr_);
   pending->query_module_ptr_ = nullptr;
 
@@ -234,6 +244,7 @@ void HickoryDnsResolver::chargeGetAddrInfoErrorStats(absl::string_view details) 
 absl::StatusOr<DnsResolverSharedPtr> HickoryDnsResolverFactory::createDnsResolver(
     Event::Dispatcher& dispatcher, Api::Api& api,
     const envoy::config::core::v3::TypedExtensionConfig& typed_config) const {
+  ASSERT(dispatcher.isThreadSafe());
   envoy::extensions::network::dns_resolver::hickory::v3::HickoryDnsResolverConfig proto_config;
   RETURN_IF_NOT_OK(Envoy::MessageUtil::unpackTo(typed_config.typed_config(), proto_config));
 
@@ -260,11 +271,21 @@ void envoy_dynamic_module_callback_dns_resolve_complete(
   auto* resolver = const_cast<Envoy::Network::HickoryDnsResolver*>(
       static_cast<const Envoy::Network::HickoryDnsResolver*>(resolver_envoy_ptr));
 
-  // Check the C++ shutdown flag before accessing any resolver state. This provides
-  // TSAN-visible synchronization for accesses from `Tokio` worker threads.
+  // Fast path: if the resolver is already shutting down, skip the response copy entirely.
+  // The Rust task is expected to observe the Rust-side shutdown flag and bail out before
+  // reaching this callback, but this guard also covers the narrow window where the C++
+  // destructor has set the flag while the callback is in flight on a Tokio thread.
   if (resolver->shutting_down_.load(std::memory_order_acquire)) {
     return;
   }
+
+  // The resolver storage is kept alive across this FFI call because
+  // `on_dns_resolver_destroy_` (invoked from the C++ destructor) blocks on
+  // `runtime.shutdown_timeout(5s)` until in-flight FFI calls return. Capture a
+  // `weak_ptr` so the posted lambda does not extend the resolver's lifetime; if the
+  // dispatcher fails to drain the lambda before the resolver is destroyed, the
+  // lambda's `lock()` returns `nullptr` and the callback is safely skipped.
+  std::weak_ptr<Envoy::Network::HickoryDnsResolver> weak_resolver = resolver->weak_from_this();
 
   const std::string details_str = (details.ptr != nullptr && details.length > 0)
                                       ? std::string(details.ptr, details.length)
@@ -283,8 +304,13 @@ void envoy_dynamic_module_callback_dns_resolve_complete(
     }
   }
 
-  resolver->dispatcher_.post([resolver, query_id, status, details = std::move(details_str),
+  resolver->dispatcher_.post([weak_resolver = std::move(weak_resolver), query_id, status,
+                              details = std::move(details_str),
                               response = std::move(response)]() mutable {
-    resolver->onResolveComplete(query_id, status, details, std::move(response));
+    // If the resolver was destroyed between `post()` and now, `lock()` returns `nullptr`
+    // and the lambda exits safely without touching freed memory.
+    if (auto resolver_shared = weak_resolver.lock()) {
+      resolver_shared->onResolveComplete(query_id, status, details, std::move(response));
+    }
   });
 }

--- a/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.h
+++ b/source/extensions/network/dns_resolver/hickory/hickory_dns_impl.h
@@ -102,7 +102,6 @@ public:
   DnsResolver::ResolveCb callback_;
   const uint64_t query_id_;
   const std::string dns_name_;
-  bool cancelled_ = false;
   HickoryDnsResolver& parent_;
 };
 
@@ -111,8 +110,15 @@ public:
  * This is a thread-safe resolver: resolve() is called on the dispatcher thread, and the
  * module may deliver results from any thread. The shell posts results back to the correct
  * dispatcher thread.
+ *
+ * Inherits from `std::enable_shared_from_this` so the ABI completion callback can capture
+ * a `std::weak_ptr` into the lambda it posts to the dispatcher. Locking the weak pointer
+ * inside the lambda detects whether the resolver has been destroyed in the window between
+ * posting and execution, avoiding a use-after-free on the dispatcher drain path.
  */
-class HickoryDnsResolver : public DnsResolver, protected Logger::Loggable<Logger::Id::dns> {
+class HickoryDnsResolver : public DnsResolver,
+                           public std::enable_shared_from_this<HickoryDnsResolver>,
+                           protected Logger::Loggable<Logger::Id::dns> {
 public:
   HickoryDnsResolver(HickoryDnsResolverConfigSharedPtr config, Event::Dispatcher& dispatcher,
                      Stats::Scope& root_scope);

--- a/test/extensions/network/dns_resolver/hickory/hickory_dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/hickory/hickory_dns_impl_test.cc
@@ -49,6 +49,9 @@ public:
     EXPECT_EQ(timeouts, stats_store_.counter("dns.hickory.timeouts").value());
   }
 
+  // The resolver assigns query IDs starting at 1 and increments monotonically.
+  static constexpr uint64_t kFirstQueryId = 1;
+
   Stats::TestUtil::TestStore stats_store_;
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
@@ -241,7 +244,18 @@ TEST_F(HickoryDnsImplTest, CancelQuery) {
       });
 
   EXPECT_NE(query, nullptr);
+  // The pending_resolutions gauge tracks the live query.
+  EXPECT_EQ(1, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+
   query->cancel(ActiveDnsQuery::CancelReason::QueryAbandoned);
+
+  // cancel() must reconcile the gauge synchronously and free the pending object. This is
+  // the regression test for https://github.com/envoyproxy/envoy/issues/45058.
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
 
   // Resolve a second query to verify the resolver is still functional after cancel.
   bool second_callback_called = false;
@@ -420,7 +434,8 @@ TEST_F(HickoryDnsImplTest, CancelledQueryResultIsDropped) {
   query->cancel(ActiveDnsQuery::CancelReason::QueryAbandoned);
 
   // Issue a second query and wait for it to complete. By the time it finishes, the
-  // first query's async result has also arrived and been dropped by the dispatcher.
+  // first query's async result has also arrived and been dropped because cancel()
+  // removed the entry from pending_queries_.
   bool second_callback_called = false;
   resolver_->resolve("localhost", DnsLookupFamily::All,
                      [this, &second_callback_called](DnsResolver::ResolutionStatus,
@@ -432,6 +447,11 @@ TEST_F(HickoryDnsImplTest, CancelledQueryResultIsDropped) {
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   EXPECT_TRUE(second_callback_called);
   EXPECT_FALSE(callback_called);
+  // Only the second query produces a resolve_total bump; the cancelled query does not.
+  EXPECT_EQ(1, stats_store_.counter("dns.hickory.resolve_total").value());
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
 }
 
 TEST_F(HickoryDnsImplTest, OnResolveCompleteForCancelledQuery) {
@@ -439,8 +459,9 @@ TEST_F(HickoryDnsImplTest, OnResolveCompleteForCancelledQuery) {
   auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
   ASSERT_NE(hickory_resolver, nullptr);
 
-  // Issue a query and immediately cancel it. The query remains in pending_queries_ with
-  // cancelled_ set to true.
+  // Issue a query and immediately cancel it. cancel() removes the entry from
+  // `pending_queries_` synchronously, so a late `onResolveComplete` for the same
+  // query ID must safely no-op without invoking the user callback.
   bool callback_called = false;
   auto* query =
       resolver_->resolve("localhost", DnsLookupFamily::All,
@@ -449,13 +470,14 @@ TEST_F(HickoryDnsImplTest, OnResolveCompleteForCancelledQuery) {
   EXPECT_NE(query, nullptr);
   query->cancel(ActiveDnsQuery::CancelReason::QueryAbandoned);
 
-  // Simulate the `Tokio` task delivering a result for the cancelled query. The query ID
-  // is 1 (first query issued on a fresh resolver). This exercises the cancelled path in
-  // onResolveComplete where the result is dropped without invoking the callback.
-  hickory_resolver->onResolveComplete(1, envoy_dynamic_module_type_dns_resolution_status_Completed,
-                                      "resolved", {});
+  // Simulate the Tokio task delivering a late result for the cancelled query. The
+  // lookup must hit the unknown-id early return because cancel() removed the entry.
+  hickory_resolver->onResolveComplete(
+      kFirstQueryId, envoy_dynamic_module_type_dns_resolution_status_Completed, "resolved", {});
 
   EXPECT_FALSE(callback_called);
+  // resolve_total is not incremented for cancelled queries.
+  EXPECT_EQ(0, stats_store_.counter("dns.hickory.resolve_total").value());
 }
 
 TEST_F(HickoryDnsImplTest, DestroyWithPendingQueries) {
@@ -469,9 +491,77 @@ TEST_F(HickoryDnsImplTest, DestroyWithPendingQueries) {
         [](DnsResolver::ResolutionStatus, absl::string_view, std::list<DnsResponse>&&) {});
   }
 
-  // Destroy the resolver immediately. The destructor should cancel all pending queries
-  // and shut down the `Tokio` runtime cleanly.
+  // Destroy the resolver immediately. The destructor cancels remaining queries, shuts
+  // down the Tokio runtime, and decrements the gauge for each abandoned query.
   resolver_.reset();
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/45058 with high
+// cancel volume. The DFP scenario in the issue cancels a query for every timeout, and
+// previously each cancel leaked one pending_resolutions gauge tick and one heap object.
+TEST_F(HickoryDnsImplTest, RepeatedCancelDoesNotLeakGauge) {
+  initialize();
+
+  constexpr int kIterations = 50;
+  for (int i = 0; i < kIterations; ++i) {
+    auto* query = resolver_->resolve(
+        "localhost", DnsLookupFamily::All,
+        [](DnsResolver::ResolutionStatus, absl::string_view, std::list<DnsResponse>&&) {
+          FAIL() << "callback must not fire for a cancelled query";
+        });
+    ASSERT_NE(query, nullptr);
+    query->cancel(ActiveDnsQuery::CancelReason::Timeout);
+  }
+
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+  EXPECT_EQ(0, stats_store_.counter("dns.hickory.resolve_total").value());
+}
+
+// Regression test for a use-after-free in the ABI callback. If the resolver is destroyed
+// after the callback has copied response data and posted a lambda to the dispatcher but
+// before the dispatcher runs that lambda, the lambda must not dereference a freed
+// resolver. The fix uses `std::weak_ptr` to detect destruction inside the lambda.
+TEST_F(HickoryDnsImplTest, ResolverDestroyedBeforePostedCallbackRuns) {
+  initialize();
+  auto* hickory_resolver = dynamic_cast<HickoryDnsResolver*>(resolver_.get());
+  ASSERT_NE(hickory_resolver, nullptr);
+
+  // Issue a query so the first query ID is registered in pending_queries_.
+  bool callback_called = false;
+  resolver_->resolve("localhost", DnsLookupFamily::All,
+                     [&callback_called](DnsResolver::ResolutionStatus, absl::string_view,
+                                        std::list<DnsResponse>&&) { callback_called = true; });
+
+  // Invoke the ABI callback directly to deterministically reproduce the post sequence
+  // without depending on Tokio timing. This posts a lambda capturing a weak_ptr.
+  const std::string addr_str = "127.0.0.1:0";
+  envoy_dynamic_module_type_dns_address addr;
+  addr.address_ptr = addr_str.c_str();
+  addr.address_length = addr_str.size();
+  addr.ttl_seconds = 60;
+
+  envoy_dynamic_module_type_module_buffer details_buf;
+  details_buf.ptr = nullptr;
+  details_buf.length = 0;
+
+  envoy_dynamic_module_callback_dns_resolve_complete(
+      static_cast<const void*>(hickory_resolver), kFirstQueryId,
+      envoy_dynamic_module_type_dns_resolution_status_Completed, details_buf, &addr, 1);
+
+  // Destroy the resolver before the dispatcher processes the queued lambda. Without
+  // weak_ptr, the lambda's captured raw pointer would dangle and dereferencing it would
+  // be undefined behavior (ASan would catch the use-after-free).
+  resolver_.reset();
+
+  // Drain the dispatcher. The lambda's weak_ptr.lock() returns nullptr, so the lambda
+  // exits without touching the freed resolver and the user callback is not invoked.
+  dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+  EXPECT_FALSE(callback_called);
 }
 
 TEST_F(HickoryDnsImplTest, StatsNotFoundOnDirectCallback) {
@@ -586,6 +676,12 @@ TEST_F(HickoryDnsImplTest, StatsOnCancelledQuery) {
   EXPECT_NE(query, nullptr);
   query->cancel(ActiveDnsQuery::CancelReason::QueryAbandoned);
 
+  // cancel() reconciles the gauge synchronously; no need to drive the dispatcher or
+  // destroy the resolver to observe the decrement.
+  EXPECT_EQ(0, stats_store_
+                   .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
+                   .value());
+
   // Resolve a second query and wait for it to complete.
   bool second_callback_called = false;
   resolver_->resolve("localhost", DnsLookupFamily::All,
@@ -597,16 +693,12 @@ TEST_F(HickoryDnsImplTest, StatsOnCancelledQuery) {
   dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit);
   EXPECT_TRUE(second_callback_called);
 
-  // The second query is guaranteed to complete. The cancelled query's `Tokio` task may or may
-  // not have posted a result before seeing the cancel flag, so resolve_total is at least 1.
-  EXPECT_GE(stats_store_.counter("dns.hickory.resolve_total").value(), 1);
+  // Exactly one query completed (the second one). The cancelled query never produces a
+  // resolve_total bump.
+  EXPECT_EQ(1, stats_store_.counter("dns.hickory.resolve_total").value());
   EXPECT_EQ(0, stats_store_.counter("dns.hickory.not_found").value());
   EXPECT_EQ(0, stats_store_.counter("dns.hickory.get_addr_failure").value());
   EXPECT_EQ(0, stats_store_.counter("dns.hickory.timeouts").value());
-
-  // Destroying the resolver ensures that any remaining pending queries have their
-  // pending_resolutions gauge decremented in the destructor.
-  resolver_.reset();
   EXPECT_EQ(0, stats_store_
                    .gauge("dns.hickory.pending_resolutions", Stats::Gauge::ImportMode::NeverImport)
                    .value());

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -214,6 +214,7 @@ FB
 FCDS
 FCM
 FFFF
+FFI
 FIN
 FIPS
 FIRSTHDR
@@ -1528,6 +1529,7 @@ tokenize
 tokenized
 tokenizes
 tokenizing
+tokio
 toolchain
 tos
 traceid


### PR DESCRIPTION
## Description

This PR fixes two related lifecycle bugs in the Hickory DNS resolver shell.
`ActiveDnsQuery::cancel()` only flipped a `cancelled_` flag and forwarded to the Rust cancel FFI. It did not erase the pending query from the resolver's map, decrement the `pending_resolutions` gauge, or free the `HickoryPendingResolution` heap object. 

The RUST task observed the cancel and skipped its result callback, so `onResolveComplete()` never ran for the cancelled query and the shell state was leaked. Under the dynamic forward proxy timeout scenario in #45058, every timeout grew the gauge by one and leaked one heap object. `cancel()` now performs the full local cleanup synchronously (drop the Rust query box, decrement the gauge, erase the map entry, `delete this`), matching the contract followed by the Apple DNS resolver.

The ABI completion callback runs on a Tokio worker thread and posts a lambda to the dispatcher capturing a raw pointer to the resolver. If the resolver's last `shared_ptr` reference was released between the post and the dispatcher draining the queue, the captured pointer dangled and the lambda's dereference was a use-after-free. `HickoryDnsResolver` now derives from `std::enable_shared_from_this` and the posted lambda captures `weak_from_this()`; a failed `lock()` inside the lambda skips the callback without touching freed memory. The pre-existing `shutting_down_` flag is kept as a fast-path optimization to avoid the response copy when destruction is already in progress.

After the cancel fix, cancelled queries are no longer in the map by the time `onResolveComplete()` looks them up, so the dead `cancelled_` field, the `if (pending->cancelled_)` branch in `onResolveComplete()`, and the destructor's matching skip are removed. `cancel()` also asserts `dispatcher_.isThreadSafe()` to enforce the DnsResolver threading contract.

Fix https://github.com/envoyproxy/envoy/issues/45058

---

**Commit Message:** dns_resolver: fix Hickory cancel leak and dispatcher-post UAF
**Additional Description:**
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added