### PR TITLE
Envoy: allow multi-packet ClientHello in tests.

### DIFF
--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -14,6 +14,7 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/host.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/simulated_time_system.h"
 
 using testing::NiceMock;
@@ -51,6 +52,20 @@ public:
     factory_->initialize();
     quic_info_ = Quic::createPersistentQuicInfoForCluster(dispatcher_, mockHost().cluster_,
                                                           context_.server_context_);
+
+    // Create dummy peer sockets for sending the packets to.
+    //
+    // This is necessary once ClientHello does not fit in a single packet
+    // anymore, as on Linux sending the first packet to an unreachable port
+    // always succeeds, but sending subsequent packets returns ECONNREFUSED.
+    // And that error will ultimately fail the tests.
+    dummy_peer_v4_ = std::make_unique<Network::Test::UdpSyncPeer>(Network::Address::IpVersion::v4);
+    dummy_peer_v6_ = std::make_unique<Network::Test::UdpSyncPeer>(Network::Address::IpVersion::v6);
+
+    test_address_ = dummy_peer_v4_->localAddress();
+    address_list_ = std::make_shared<Upstream::HostDescription::AddressVector>(
+        Upstream::HostDescription::AddressVector{dummy_peer_v4_->localAddress(),
+                                                 dummy_peer_v6_->localAddress()});
   }
 
   void initialize() {
@@ -76,7 +91,7 @@ public:
                          transport_options, state_, quic_stat_names_, {}, *store_.rootScope(),
                          makeOptRef<PoolConnectResultCallback>(connect_result_callback_),
                          *quic_info_, {observers_}, overload_manager_, happy_eyeballs_);
-    EXPECT_EQ(3000, Http3ConnPoolImplPeer::getServerId(*pool_).port());
+    EXPECT_EQ(test_address_->ip()->port(), Http3ConnPoolImplPeer::getServerId(*pool_).port());
   }
 
   void createNewStream();
@@ -90,12 +105,8 @@ public:
   NiceMock<Random::MockRandomGenerator> random_;
   Upstream::ClusterConnectivityState state_;
   NiceMock<Server::MockOverloadManager> overload_manager_;
-  Network::Address::InstanceConstSharedPtr test_address_ =
-      *Network::Utility::resolveUrl("tcp://127.0.0.1:3000");
-  std::shared_ptr<Upstream::HostDescription::AddressVector> address_list_{
-      new Upstream::HostDescription::AddressVector{
-          *Network::Utility::resolveUrl("tcp://127.0.0.1:3000"),
-          *Network::Utility::resolveUrl("tcp://[::]:3000")}};
+  Network::Address::InstanceConstSharedPtr test_address_;
+  std::shared_ptr<Upstream::HostDescription::AddressVector> address_list_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   Ssl::ClientContextSharedPtr ssl_context_{new Ssl::MockClientContext()};
@@ -108,6 +119,8 @@ public:
   std::shared_ptr<Network::MockSocketOption> socket_option_{new Network::MockSocketOption()};
   absl::Status creation_status_;
   bool happy_eyeballs_ = false;
+  std::unique_ptr<Network::Test::UdpSyncPeer> dummy_peer_v4_;
+  std::unique_ptr<Network::Test::UdpSyncPeer> dummy_peer_v6_;
 };
 
 class MockQuicClientTransportSocketFactory : public Quic::QuicClientTransportSocketFactory {

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -1,14 +1,19 @@
 #include <cstdlib>
 #include <memory>
+#include <vector>
 
+#include "envoy/buffer/buffer.h"
 #include "envoy/config/listener/v3/quic_config.pb.validate.h"
 #include "envoy/network/exception.h"
 
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/listener_manager/connection_handler_impl.h"
+#include "source/common/network/address_impl.h"
 #include "source/common/network/listen_socket_impl.h"
 #include "source/common/network/socket_option_factory.h"
 #include "source/common/network/udp_packet_writer_handler_impl.h"
+#include "source/common/network/utility.h"
 #include "source/common/quic/active_quic_listener.h"
 #include "source/common/quic/envoy_quic_clock.h"
 #include "source/common/quic/envoy_quic_utils.h"
@@ -276,26 +281,28 @@ protected:
     }
     int value = kECT1;
     client_sockets_.back()->setSocketOption(level, optname, &value, sizeof(value));
-    Buffer::OwnedImpl payload =
-        generateChloPacketToSend(quic_version_, quic_config_, connection_id);
-    Buffer::RawSliceVector slice = payload.getRawSlices();
-    ASSERT_EQ(1u, slice.size());
-    Network::Address::InstanceConstSharedPtr dest_address;
-    if (client_address->ip()->version() == Network::Address::IpVersion::v4) {
-      dest_address = std::make_shared<const Network::Address::Ipv4Instance>(
-          client_address->ip()->addressAsString(),
-          listen_socket_->connectionInfoProvider().localAddress()->ip()->port(),
-          &(listen_socket_->connectionInfoProvider().localAddress()->socketInterface()));
-    } else {
-      dest_address = std::make_shared<const Network::Address::Ipv6Instance>(
-          client_address->ip()->addressAsString(),
-          listen_socket_->connectionInfoProvider().localAddress()->ip()->port(),
-          &(listen_socket_->connectionInfoProvider().localAddress()->socketInterface()));
+    std::vector<Buffer::OwnedImpl> payloads =
+        generateChloPacketsToSend(quic_version_, quic_config_, connection_id);
+    for (Buffer::OwnedImpl& payload : payloads) {
+      Buffer::RawSliceVector slice = payload.getRawSlices();
+      ASSERT_EQ(1u, slice.size());
+      Network::Address::InstanceConstSharedPtr dest_address;
+      if (client_address->ip()->version() == Network::Address::IpVersion::v4) {
+        dest_address = std::make_shared<const Network::Address::Ipv4Instance>(
+            client_address->ip()->addressAsString(),
+            listen_socket_->connectionInfoProvider().localAddress()->ip()->port(),
+            &(listen_socket_->connectionInfoProvider().localAddress()->socketInterface()));
+      } else {
+        dest_address = std::make_shared<const Network::Address::Ipv6Instance>(
+            client_address->ip()->addressAsString(),
+            listen_socket_->connectionInfoProvider().localAddress()->ip()->port(),
+            &(listen_socket_->connectionInfoProvider().localAddress()->socketInterface()));
+      }
+      // Send a full CHLO to finish 0-RTT handshake.
+      auto send_rc = Network::Utility::writeToSocket(client_sockets_.back()->ioHandle(),
+                                                     slice.data(), 1, nullptr, *dest_address);
+      ASSERT_EQ(slice[0].len_, send_rc.return_value_);
     }
-    // Send a full CHLO to finish 0-RTT handshake.
-    auto send_rc = Network::Utility::writeToSocket(client_sockets_.back()->ioHandle(), slice.data(),
-                                                   1, nullptr, *dest_address);
-    ASSERT_EQ(slice[0].len_, send_rc.return_value_);
   }
 
   void readFromClientSockets() {
@@ -469,7 +476,8 @@ TEST_P(ActiveQuicListenerTest, ReceiveCHLODuringHotRestartShouldForwardPacket) {
       quic::test::QuicDispatcherPeer::GetBufferedPackets(quic_dispatcher_);
   maybeConfigureMocks(/* connection_count = */ 0);
   quic::QuicConnectionId connection_id = quic::test::TestConnectionId(1);
-  EXPECT_CALL(mock_packet_forwarding, handle(_, _));
+  EXPECT_CALL(mock_packet_forwarding, handle(_, _))
+      .Times(generateChloPacketsToSend(quic_version_, quic_config_, connection_id).size());
   sendCHLO(connection_id);
   dispatcher_->run(Event::Dispatcher::RunType::Block);
   EXPECT_FALSE(buffered_packets->HasChlosBuffered());

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -1,5 +1,7 @@
 #include <chrono>
+#include <memory>
 
+#include "source/common/network/listen_socket_impl.h"
 #include "source/common/quic/client_connection_factory_impl.h"
 #include "source/common/quic/quic_client_transport_socket_factory.h"
 
@@ -17,6 +19,7 @@
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
+#include "absl/strings/str_cat.h"
 #include "quiche/quic/core/crypto/quic_client_session_cache.h"
 #include "quiche/quic/core/deterministic_connection_id_generator.h"
 
@@ -85,6 +88,9 @@ protected:
 
     test_address_ = *Network::Utility::resolveUrl(absl::StrCat(
         "tcp://", Network::Test::getLoopbackAddressUrlString(GetParam()), ":", PEER_PORT));
+    local_address_ = *Network::Utility::resolveUrl(
+        absl::StrCat("tcp://", Network::Test::getLoopbackAddressUrlString(GetParam()), ":0"));
+    peer_socket_ = std::make_unique<Network::UdpListenSocket>(test_address_, nullptr, true);
     Ssl::ClientContextSharedPtr context{new Ssl::MockClientContext()};
     EXPECT_CALL(context_.server_context_.ssl_context_manager_, createSslClientContext(_, _))
         .WillOnce(Return(context));
@@ -108,6 +114,8 @@ protected:
   NiceMock<Random::MockRandomGenerator> random_;
   Upstream::ClusterConnectivityState state_;
   Network::Address::InstanceConstSharedPtr test_address_;
+  Network::Address::InstanceConstSharedPtr local_address_;
+  Network::UdpListenSocketPtr peer_socket_;
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config_;
@@ -124,8 +132,8 @@ TEST_P(QuicNetworkConnectionTest, BufferLimits) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(), nullptr,
-      nullptr, connection_id_generator_, *factory_);
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
+      nullptr, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -149,8 +157,8 @@ TEST_P(QuicNetworkConnectionTest, QuicheHandlesMigrationOfIdleSessions) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(), nullptr,
-      nullptr, connection_id_generator_, *factory_);
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
+      nullptr, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -185,8 +193,8 @@ TEST_P(QuicNetworkConnectionTest, QuicheHandlesMigration) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(), nullptr,
-      nullptr, connection_id_generator_, *factory_);
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
+      nullptr, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -224,7 +232,7 @@ TEST_P(QuicNetworkConnectionTest, SocketOptions) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(),
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
       socket_options, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
@@ -244,7 +252,7 @@ TEST_P(QuicNetworkConnectionTest, PreBindSocketOptionsFailure) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(),
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
       socket_options, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
@@ -266,7 +274,7 @@ TEST_P(QuicNetworkConnectionTest, PostBindSocketOptionsFailure) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(),
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
       socket_options, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
@@ -277,15 +285,11 @@ TEST_P(QuicNetworkConnectionTest, PostBindSocketOptionsFailure) {
 
 TEST_P(QuicNetworkConnectionTest, LocalAddress) {
   initialize();
-  Network::Address::InstanceConstSharedPtr local_addr =
-      (GetParam() == Network::Address::IpVersion::v6)
-          ? Network::Utility::getIpv6LoopbackAddress()
-          : Network::Utility::getCanonicalIpv4LoopbackAddress();
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, local_addr, quic_stat_names_, {}, *store_.rootScope(), nullptr,
-      nullptr, connection_id_generator_, *factory_);
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
+      nullptr, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -317,8 +321,8 @@ TEST_P(QuicNetworkConnectionTest, GetV6OnlySocketOptionFailure) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, {}, *store_.rootScope(), nullptr,
-      nullptr, connection_id_generator_, *factory_);
+      dispatcher_, test_address_, local_address_, quic_stat_names_, {}, *store_.rootScope(),
+      nullptr, nullptr, connection_id_generator_, *factory_);
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());
   session->Initialize();
   client_connection->connect();
@@ -338,7 +342,7 @@ TEST_P(QuicNetworkConnectionTest, Srtt) {
   std::unique_ptr<Network::ClientConnection> client_connection = createQuicNetworkConnection(
       *quic_info_, crypto_config_,
       quic::QuicServerId{factory_->clientContextConfig()->serverNameIndication(), PEER_PORT},
-      dispatcher_, test_address_, test_address_, quic_stat_names_, rtt_cache, *store_.rootScope(),
+      dispatcher_, test_address_, local_address_, quic_stat_names_, rtt_cache, *store_.rootScope(),
       nullptr, nullptr, connection_id_generator_, *factory_);
 
   EnvoyQuicClientSession* session = static_cast<EnvoyQuicClientSession*>(client_connection.get());

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -2,7 +2,12 @@
 
 #include <memory>
 #include <optional>
+#include <vector>
 
+#include "envoy/buffer/buffer.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/assert.h"
 #include "source/common/http/session_idle_list.h"
 #include "source/common/listener_manager/connection_handler_impl.h"
 #include "source/common/network/listen_socket_impl.h"
@@ -31,6 +36,7 @@
 #include "gtest/gtest.h"
 #include "quiche/quic/core/deterministic_connection_id_generator.h"
 #include "quiche/quic/core/quic_dispatcher.h"
+#include "quiche/quic/core/quic_packets.h"
 #include "quiche/quic/test_tools/crypto_test_utils.h"
 #include "quiche/quic/test_tools/quic_dispatcher_peer.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
@@ -115,20 +121,22 @@ public:
   void processValidChloPacket(const quic::QuicSocketAddress& peer_addr) {
     // Create a Quic Crypto or TLS1.3 CHLO packet.
     EnvoyQuicClock clock(*dispatcher_);
-    Buffer::OwnedImpl payload =
-        generateChloPacketToSend(quic_version_, quic_config_, connection_id_);
-    Buffer::RawSliceVector slice = payload.getRawSlices();
-    ASSERT(slice.size() == 1);
-    auto encrypted_packet = std::make_unique<quic::QuicEncryptedPacket>(
-        static_cast<char*>(slice[0].mem_), slice[0].len_);
-    std::unique_ptr<quic::QuicReceivedPacket> received_packet =
-        std::unique_ptr<quic::QuicReceivedPacket>(
-            quic::test::ConstructReceivedPacket(*encrypted_packet, clock.Now()));
+    std::vector<Buffer::OwnedImpl> payloads =
+        generateChloPacketsToSend(quic_version_, quic_config_, connection_id_);
+    for (Buffer::OwnedImpl& payload : payloads) {
+      Buffer::RawSliceVector slice = payload.getRawSlices();
+      ASSERT(slice.size() == 1);
+      auto encrypted_packet = std::make_unique<quic::QuicEncryptedPacket>(
+          static_cast<char*>(slice[0].mem_), slice[0].len_);
+      std::unique_ptr<quic::QuicReceivedPacket> received_packet =
+          std::unique_ptr<quic::QuicReceivedPacket>(
+              quic::test::ConstructReceivedPacket(*encrypted_packet, clock.Now()));
 
-    envoy_quic_dispatcher_.ProcessPacket(
-        envoyIpAddressToQuicSocketAddress(
-            listen_socket_->connectionInfoProvider().localAddress()->ip()),
-        peer_addr, *received_packet);
+      envoy_quic_dispatcher_.ProcessPacket(
+          envoyIpAddressToQuicSocketAddress(
+              listen_socket_->connectionInfoProvider().localAddress()->ip()),
+          peer_addr, *received_packet);
+    }
   }
 
   void processValidChloPacketAndCheckStatus(bool should_buffer) {
@@ -419,10 +427,12 @@ TEST_P(EnvoyQuicDispatcherTest, ProcessPacketReturnsTrueForDispatchedPacket) {
                                         ? quic::QuicIpAddress::Loopback4()
                                         : quic::QuicIpAddress::Loopback6(),
                                     54321);
-  auto chlo_packet = wrapPacket(*encryptPacket(*quic::test::GetFirstFlightOfPackets(
-                                    quic_version_, quic_config_, connection_id_)[0]),
-                                clock);
-  EXPECT_TRUE(envoy_quic_dispatcher_.processPacket(self_addr, peer_addr, *chlo_packet));
+  std::vector<std::unique_ptr<quic::QuicReceivedPacket>> chlo_packets =
+      quic::test::GetFirstFlightOfPackets(quic_version_, quic_config_, connection_id_);
+  for (const auto& packet : chlo_packets) {
+    auto wrapped_packet = wrapPacket(*encryptPacket(*packet), clock);
+    EXPECT_TRUE(envoy_quic_dispatcher_.processPacket(self_addr, peer_addr, *wrapped_packet));
+  }
   auto packet = wrapPacket(*testEncryptedPacket(quic_version_, connection_id_, "hello"), clock);
   EXPECT_TRUE(envoy_quic_dispatcher_.processPacket(self_addr, peer_addr, *packet));
   envoy_quic_dispatcher_.ProcessBufferedChlos(kNumSessionsToCreatePerLoopForTests);
@@ -438,10 +448,12 @@ TEST_P(EnvoyQuicDispatcherTest, ProcessPacketReturnsTrueForDispatchedPacketOnExi
                                         ? quic::QuicIpAddress::Loopback4()
                                         : quic::QuicIpAddress::Loopback6(),
                                     54321);
-  auto chlo_packet = wrapPacket(*encryptPacket(*quic::test::GetFirstFlightOfPackets(
-                                    quic_version_, quic_config_, connection_id_)[0]),
-                                clock);
-  EXPECT_TRUE(envoy_quic_dispatcher_.processPacket(self_addr, peer_addr, *chlo_packet));
+  std::vector<std::unique_ptr<quic::QuicReceivedPacket>> chlo_packets =
+      quic::test::GetFirstFlightOfPackets(quic_version_, quic_config_, connection_id_);
+  for (const auto& packet : chlo_packets) {
+    auto wrapped_packet = wrapPacket(*encryptPacket(*packet), clock);
+    EXPECT_TRUE(envoy_quic_dispatcher_.processPacket(self_addr, peer_addr, *wrapped_packet));
+  }
   envoy_quic_dispatcher_.ProcessBufferedChlos(kNumSessionsToCreatePerLoopForTests);
   // Stop accepting new connections after processing the CHLO.
   envoy_quic_dispatcher_.StopAcceptingNewConnections();

--- a/test/common/quic/test_utils.h
+++ b/test/common/quic/test_utils.h
@@ -254,15 +254,19 @@ protected:
   QuicStatNames quic_stat_names_{stats_store_.symbolTable()};
 };
 
-Buffer::OwnedImpl generateChloPacketToSend(quic::ParsedQuicVersion quic_version,
-                                           quic::QuicConfig& quic_config,
-                                           quic::QuicConnectionId connection_id) {
-  std::unique_ptr<quic::QuicReceivedPacket> packet =
-      std::move(quic::test::GetFirstFlightOfPackets(quic_version, quic_config, connection_id)[0]);
-  return {packet->data(), packet->length()};
+inline std::vector<Buffer::OwnedImpl>
+generateChloPacketsToSend(quic::ParsedQuicVersion quic_version, quic::QuicConfig& quic_config,
+                          quic::QuicConnectionId connection_id) {
+  std::vector<std::unique_ptr<quic::QuicReceivedPacket>> packets =
+      quic::test::GetFirstFlightOfPackets(quic_version, quic_config, connection_id);
+  std::vector<Buffer::OwnedImpl> results;
+  for (auto& packet : packets) {
+    results.emplace_back(packet->data(), packet->length());
+  }
+  return results;
 }
 
-void setQuicConfigWithDefaultValues(quic::QuicConfig* config) {
+inline void setQuicConfigWithDefaultValues(quic::QuicConfig* config) {
   quic::test::QuicConfigPeer::SetReceivedMaxBidirectionalStreams(
       config, quic::kDefaultMaxStreamsPerConnection);
   quic::test::QuicConfigPeer::SetReceivedMaxUnidirectionalStreams(
@@ -277,7 +281,7 @@ void setQuicConfigWithDefaultValues(quic::QuicConfig* config) {
       config, quic::kMinimumFlowControlSendWindow);
 }
 
-std::string spdyHeaderToHttp3StreamPayload(const quiche::HttpHeaderBlock& header) {
+inline std::string spdyHeaderToHttp3StreamPayload(const quiche::HttpHeaderBlock& header) {
   quic::test::NoopQpackStreamSenderDelegate encoder_stream_sender_delegate;
   quic::NoopDecoderStreamErrorDelegate decoder_stream_error_delegate;
   auto qpack_encoder = std::make_unique<quic::QpackEncoder>(&decoder_stream_error_delegate,
@@ -292,7 +296,7 @@ std::string spdyHeaderToHttp3StreamPayload(const quiche::HttpHeaderBlock& header
   return absl::StrCat(headers_frame_header, payload);
 }
 
-std::string bodyToHttp3StreamPayload(const std::string& body) {
+inline std::string bodyToHttp3StreamPayload(const std::string& body) {
   quiche::SimpleBufferAllocator allocator;
   quiche::QuicheBuffer header =
       quic::HttpEncoder::SerializeDataFrameHeader(body.length(), &allocator);
@@ -304,7 +308,8 @@ class QuicMultiVersionTest : public testing::TestWithParam<
                                  std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>> {
 };
 
-std::vector<std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>> generateTestParam() {
+inline std::vector<std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>>
+generateTestParam() {
   std::vector<std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>> param;
   for (auto ip_version : TestEnvironment::getIpVersionsForTest()) {
     for (const auto& quic_version : quic::CurrentSupportedHttp3Versions()) {
@@ -314,7 +319,7 @@ std::vector<std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>> gen
   return param;
 }
 
-std::string testParamsToString(
+inline std::string testParamsToString(
     const ::testing::TestParamInfo<std::pair<Network::Address::IpVersion, quic::ParsedQuicVersion>>&
         params) {
   return absl::StrCat(TestUtility::ipVersionToString(params.param.first),

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -15,6 +15,8 @@ std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_
 
   SSL_CTX_set_min_proto_version(ctx.get(), tls_min_version);
   SSL_CTX_set_max_proto_version(ctx.get(), tls_max_version);
+  static const uint16_t kGroups[] = {SSL_GROUP_X25519, SSL_GROUP_SECP256R1, SSL_GROUP_SECP384R1};
+  SSL_CTX_set1_group_ids(ctx.get(), kGroups, std::size(kGroups));
 
   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
 


### PR DESCRIPTION
This unblocks BoringSSL to enable ML-KEM by default.

Commit Message: Envoy: allow multi-packet ClientHello in tests.
Additional Description: This unblocks BoringSSL to enable ML-KEM by default.
Risk Level: low
Testing: unit test fix only; tested manually with patched BoringSSL