### PR TITLE
oauth2: fix use-after-free when downstream stream is destroyed during token exchange

### DIFF
--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -577,6 +577,11 @@ OAuth2Filter::OAuth2Filter(FilterConfigSharedPtr config,
  * 4) user is authorized
  * 5) user is unauthorized
  */
+void OAuth2Filter::onDestroy() {
+  destroyed_ = true;
+  oauth_client_.reset();
+}
+
 Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   // Decrypt the OAuth tokens and update the corresponding cookies in the request headers
   // before forwarding the request upstream. This step must occur early to ensure that
@@ -1134,6 +1139,9 @@ void OAuth2Filter::onGetAccessTokenSuccess(const std::string& access_code,
                                            const std::string& id_token,
                                            const std::string& refresh_token,
                                            std::chrono::seconds expires_in) {
+  if (destroyed_) {
+    return;
+  }
   updateTokens(access_code, id_token, refresh_token, expires_in);
   finishGetAccessTokenFlow();
 }
@@ -1142,6 +1150,9 @@ void OAuth2Filter::onRefreshAccessTokenSuccess(const std::string& access_code,
                                                const std::string& id_token,
                                                const std::string& refresh_token,
                                                std::chrono::seconds expires_in) {
+  if (destroyed_) {
+    return;
+  }
   ASSERT(config_->useRefreshToken());
   updateTokens(access_code, id_token, refresh_token, expires_in);
   finishRefreshAccessTokenFlow();
@@ -1214,6 +1225,9 @@ void OAuth2Filter::finishRefreshAccessTokenFlow() {
 }
 
 void OAuth2Filter::onRefreshAccessTokenFailure() {
+  if (destroyed_) {
+    return;
+  }
   config_->stats().oauth_refreshtoken_failure_.inc();
   // We failed to get an access token via the refresh token, so send the user to the oauth endpoint.
   if (canRedirectToOAuthServer(*request_headers_)) {
@@ -1281,6 +1295,9 @@ void OAuth2Filter::addResponseCookies(Http::ResponseHeaderMap& headers,
 }
 
 void OAuth2Filter::sendUnauthorizedResponse() {
+  if (destroyed_) {
+    return;
+  }
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, UnauthorizedBodyMessage, nullptr,
                                      absl::nullopt, EMPTY_STRING);

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -315,6 +315,7 @@ public:
                TimeSource& time_source, Random::RandomGenerator& random);
 
   // Http::PassThroughFilter
+  void onDestroy() override;
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override;
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers, bool) override;
 
@@ -356,6 +357,7 @@ private:
   std::string original_request_url_;
   Http::RequestHeaderMap* request_headers_{nullptr};
   bool was_refresh_token_flow_{false};
+  bool destroyed_{false};
 
   std::unique_ptr<OAuth2Client> oauth_client_;
   FilterConfigSharedPtr config_;

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -1030,6 +1030,49 @@ TEST_F(OAuth2Test, SetBearerToken) {
   EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
 }
 
+// Regression test for incident-23729: OAuth2 filter use-after-free.
+// The filter's async token callback uses decoder_callbacks_ after onDestroy().
+TEST_F(OAuth2Test, UseAfterFreeOnStreamReset) {
+  init(getConfig(false, true));
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/_oauth?code=123&state=" + TEST_ENCODED_STATE},
+      {Http::Headers::get().Cookie.get(),
+       "OauthNonce=" + TEST_CSRF_TOKEN + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().Cookie.get(),
+       "CodeVerifier=" + TEST_ENCRYPTED_CODE_VERIFIER + ";path=/;Max-Age=600;secure;HttpOnly"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+  EXPECT_CALL(*oauth_client_, asyncGetAccessToken("123", TEST_CLIENT_ID, "asdf_client_secret_fdsa",
+                                                  "https://traffic.example.com" + TEST_CALLBACK,
+                                                  TEST_CODE_VERIFIER, AuthType::UrlEncodedBody));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndBuffer,
+            filter_->decodeHeaders(request_headers, false));
+
+  // Simulate downstream stream destroyed (H2 RST_STREAM).
+  filter_->onDestroy();
+
+  // Simulate the decoder_callbacks_ object being freed, as happens in production
+  // when the H2 stream is destroyed. We do this by creating a new mock on the heap,
+  // pointing the filter at it, then deleting it — leaving a dangling pointer.
+  auto* doomed_callbacks = new NiceMock<Http::MockStreamDecoderFilterCallbacks>();
+  filter_->setDecoderFilterCallbacks(*doomed_callbacks);
+  delete doomed_callbacks;
+
+  // Simulate token callback firing after stream destruction.
+  // The filter will try to use the now-freed decoder_callbacks_.
+  // ASAN will detect the heap-use-after-free.
+  filter_->onGetAccessTokenSuccess("access_code", "some-id-token", "some-refresh-token",
+                                   std::chrono::seconds(600));
+}
+
 TEST_F(OAuth2Test, SetBearerTokenWithEncryptionDisabled) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues({{"envoy.reloadable_features.oauth2_encrypt_tokens", "false"}});


### PR DESCRIPTION
## Description

The OAuth2 filter's async token exchange callback uses a raw `decoder_callbacks_` pointer without checking if the downstream stream is still valid. If the stream is destroyed (e.g., HTTP/2 RST_STREAM or connection drop) while the token exchange is pending, the callback dereferences a freed pointer, causing a segfault.

## Crash details

This was observed in production where 81 Envoy pods crashed with identical stack traces:

```
#0:  __kernel_rt_sigreturn
#1:  Http2::ServerStreamImpl::encodeHeaders()         ← CRASH: dangling pointer
#4:  OAuth2Filter::redirectToOAuthServer()
#5:  OAuth2ClientImpl::onSuccess()
#13: Router::Filter::onResponseTimeout()               ← Upstream timeout fires
```

The bug was present in at least two Envoy versions (v1.35.0 and v1.37.1) and has been confirmed with AddressSanitizer:

```
SUMMARY: AddressSanitizer: heap-use-after-free in
  OAuth2Filter::finishGetAccessTokenFlow()
```

## Root cause

`OAuth2Filter` inherits a no-op `onDestroy()` from `PassThroughFilter`. When the downstream HTTP/2 stream is reset:
1. `onDestroy()` is called but does nothing — no cancellation of pending async requests
2. The stream object (including `decoder_callbacks_`) is freed
3. When the token request later times out, `onGetAccessTokenSuccess()` / `sendUnauthorizedResponse()` dereferences the freed `decoder_callbacks_`

Compare with `GcpAuthnFilter::onDestroy()` which properly cancels pending requests.

## Fix

- Add `onDestroy()` override that sets a `destroyed_` flag and resets `oauth_client_` (cancelling in-flight async requests via its destructor)
- Add early-return guards in all async callback functions

## Testing

Added `UseAfterFreeOnStreamReset` test that reproduces the bug deterministically under ASAN:
1. Send request triggering OAuth2 callback flow (token exchange starts)
2. Call `onDestroy()` (simulating stream destruction)
3. Simulate freed `decoder_callbacks_`
4. Call `onGetAccessTokenSuccess()` — ASAN catches heap-use-after-free without fix, passes with fix

## Risk

Low. The `onDestroy` / `destroyed_` pattern is well-established across other Envoy HTTP filters (`gcp_authn`, `ext_proc`, `cache`, etc.).