### PR TITLE
mcp_router: add lazy initialization option

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_router/v3/mcp_router.proto
+++ b/api/envoy/extensions/filters/http/mcp_router/v3/mcp_router.proto
@@ -125,4 +125,11 @@ message McpRouter {
   // If set, extracts a request "subject" and binds it into the MCP session.
   // If not set, sessions are created without identity binding.
   SessionIdentity session_identity = 2;
+
+  // If true, backend initialization is deferred until the first request that targets each backend.
+  // The ``initialize`` response is returned immediately with gateway capabilities and an empty
+  // backend session map. Each backend is initialized on-demand when a request first routes to it.
+  // This avoids blocking the client ``initialize`` on slow or misbehaving backends.
+  // Default is false (eager initialization of all backends during ``initialize``).
+  bool lazy_initialization = 3;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -175,6 +175,12 @@ new_features:
     that a dynamic-module cluster's load balancer can read filter state set by an upstream HTTP
     filter (or any other producer) when picking a host. The Rust SDK exposes these as
     ``ClusterLbContext::get_filter_state_bytes`` and ``ClusterLbContext::get_filter_state_typed``.
+- area: mcp_router
+  change: |
+    Added :ref:`lazy_initialization <envoy_v3_api_field_extensions.filters.http.mcp_router.v3.McpRouter.lazy_initialization>`
+    option to the MCP router filter. When enabled, the ``initialize`` response is returned immediately
+    without contacting backends. Each backend is initialized on-demand when a request first routes to it,
+    avoiding slow or misbehaving backends from blocking client initialization.
 - area: access_log
   change: |
     Supported the singleton stats scope in the :ref:`stats access logger <envoy_v3_api_msg_extensions.access_loggers.stats.v3.Config>`.

--- a/docs/root/configuration/http/http_filters/mcp_router_filter.rst
+++ b/docs/root/configuration/http/http_filters/mcp_router_filter.rst
@@ -23,11 +23,24 @@ Example configuration:
   - name: envoy.filters.http.mcp_router
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_router.v3.McpRouter
+      lazy_initialization: true
       servers:
       - name: backend1
         mcp_cluster:
           cluster: backend1_cluster
           path: /mcp
+
+.. _config_http_filters_mcp_router_lazy_initialization:
+
+Lazy initialization
+~~~~~~~~~~~~~~~~~~~
+
+By default, the MCP router eagerly initializes all backend servers during the client's ``initialize``
+request, blocking until every backend responds (or times out). When ``lazy_initialization`` is set to
+``true``, the ``initialize`` response is returned immediately with gateway capabilities and an empty
+backend session map. Each backend is then initialized on-demand when a request first routes to it.
+
+This is useful when some backends are slow or unreliable and should not block client initialization.
 
 .. _config_http_filters_mcp_router_statistics:
 

--- a/source/extensions/filters/http/mcp_router/filter_config.cc
+++ b/source/extensions/filters/http/mcp_router/filter_config.cc
@@ -79,7 +79,8 @@ McpRouterConfigImpl::McpRouterConfigImpl(
     Server::Configuration::FactoryContext& context)
     : backends_(parseBackends(proto_config)),
       default_backend_name_(backends_.size() == 1 ? backends_[0].name : ""),
-      factory_context_(context), session_identity_(parseSessionIdentity(proto_config)),
+      factory_context_(context), lazy_initialization_(proto_config.lazy_initialization()),
+      session_identity_(parseSessionIdentity(proto_config)),
       metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
       stats_(generateStats(stats_prefix, scope)) {}
 

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -91,6 +91,8 @@ public:
   virtual Server::Configuration::FactoryContext& factoryContext() const = 0;
   virtual const McpBackendConfig* findBackend(const std::string& name) const = 0;
 
+  virtual bool lazyInitialization() const = 0;
+
   virtual bool hasSessionIdentity() const = 0;
   virtual const SubjectSource& subjectSource() const = 0;
   virtual ValidationMode validationMode() const = 0;
@@ -117,6 +119,8 @@ public:
   }
   const McpBackendConfig* findBackend(const std::string& name) const override;
 
+  bool lazyInitialization() const override { return lazy_initialization_; }
+
   bool hasSessionIdentity() const override {
     return !absl::holds_alternative<absl::monostate>(session_identity_.subject_source);
   }
@@ -133,6 +137,7 @@ private:
   std::vector<McpBackendConfig> backends_;
   std::string default_backend_name_;
   Server::Configuration::FactoryContext& factory_context_;
+  bool lazy_initialization_;
   SessionIdentityConfig session_identity_;
   std::string metadata_namespace_;
   McpRouterStats stats_;
@@ -155,6 +160,8 @@ public:
     return base_config_->factoryContext();
   }
   const McpBackendConfig* findBackend(const std::string& name) const override;
+
+  bool lazyInitialization() const override { return base_config_->lazyInitialization(); }
 
   bool hasSessionIdentity() const override { return base_config_->hasSessionIdentity(); }
   const SubjectSource& subjectSource() const override { return base_config_->subjectSource(); }

--- a/source/extensions/filters/http/mcp_router/mcp_router.cc
+++ b/source/extensions/filters/http/mcp_router/mcp_router.cc
@@ -243,6 +243,12 @@ Http::FilterDataStatus McpRouterFilter::decodeData(Buffer::Instance& data, bool 
 
     initialized_ = true;
 
+    // If lazy init is in progress, buffer data — the completion callback will replay it.
+    if (lazy_init_pending_) {
+      lazy_init_request_body_.move(data);
+      return Http::FilterDataStatus::StopIterationNoBuffer;
+    }
+
     // Perform body rewriting if needed (e.g., tool/prompt name or URI prefix stripping).
     // This is done once on the first data chunk after initialization.
     if (needs_body_rewrite_) {
@@ -259,6 +265,12 @@ Http::FilterDataStatus McpRouterFilter::decodeData(Buffer::Instance& data, bool 
       }
       needs_body_rewrite_ = false;
     }
+  }
+
+  // If lazy init is in progress, buffer data — the completion callback will replay it.
+  if (lazy_init_pending_) {
+    lazy_init_request_body_.move(data);
+    return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
   streamData(data, end_stream);
@@ -604,7 +616,8 @@ ssize_t McpRouterFilter::rewriteAtPosition(Buffer::Instance& buffer, ssize_t pos
   return size_delta;
 }
 
-void McpRouterFilter::initializeFanout(AggregationCallback callback) {
+void McpRouterFilter::initializeFanout(AggregationCallback callback,
+                                       const std::vector<std::string>& target_backends) {
   config_->stats().rq_fanout_.inc();
   if (config_->backends().empty()) {
     sendHttpError(500, "No backends configured");
@@ -617,7 +630,21 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
     return;
   }
 
-  size_t expected = config_->backends().size();
+  // Build list of backends to fan out to.
+  absl::flat_hash_set<std::string> target_set(target_backends.begin(), target_backends.end());
+  std::vector<const McpBackendConfig*> backends_to_use;
+  for (const auto& backend : config_->backends()) {
+    if (target_set.empty() || target_set.contains(backend.name)) {
+      backends_to_use.push_back(&backend);
+    }
+  }
+
+  size_t expected = backends_to_use.size();
+  if (expected == 0) {
+    sendHttpError(500, "No matching backends for fanout");
+    return;
+  }
+
   pending_responses_ = std::make_shared<std::vector<BackendResponse>>();
   pending_responses_->reserve(expected);
   response_count_ = std::make_shared<size_t>(0);
@@ -626,18 +653,14 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
   std::vector<Http::MuxDemux::Callbacks> mux_callbacks;
   mux_callbacks.reserve(expected);
 
-  for (const auto& backend : config_->backends()) {
+  for (const auto* backend : backends_to_use) {
     auto responses = pending_responses_;
     auto count = response_count_;
     auto expected_count = expected;
     auto agg_callback = aggregation_callback_;
 
-    // Pass request_id and aggregate_mode=true for fanout operations.
-    // This enables early completion when SSE backends return a valid JSON-RPC response,
-    // avoiding the need to wait for end_stream (which never comes for SSE).
-    // Pass parent weak_ptr to enable intermediate event (notification/server request) forwarding.
     auto stream_cb = std::make_shared<BackendStreamCallbacks>(
-        backend.name,
+        backend->name,
         [responses, count, expected_count, agg_callback](BackendResponse resp) {
           responses->push_back(std::move(resp));
           if (++(*count) >= expected_count && agg_callback) {
@@ -646,19 +669,17 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
         },
         request_id_, true /* aggregate_mode */, weak_from_this());
 
-    // Create per-backend StreamOptions with the backend-specific timeout.
     Http::AsyncClient::StreamOptions backend_options;
-    backend_options.setTimeout(backend.timeout);
+    backend_options.setTimeout(backend->timeout);
 
     stream_callbacks_.push_back(stream_cb);
     mux_callbacks.push_back({
-        .cluster_name = backend.cluster_name,
+        .cluster_name = backend->cluster_name,
         .callbacks = std::weak_ptr<Http::AsyncClient::StreamCallbacks>(stream_cb),
         .options = backend_options,
     });
   }
 
-  // Default options (used as fallback if per-backend options are not set).
   Http::AsyncClient::StreamOptions default_options;
 
   auto multistream_or = muxdemux_->multicast(default_options, mux_callbacks);
@@ -673,15 +694,13 @@ void McpRouterFilter::initializeFanout(AggregationCallback callback) {
   upstream_headers_.clear();
   upstream_headers_.reserve(expected);
 
-  // Store headers in upstream_headers_ because AsyncStreamImpl::sendHeaders only
-  // stores a pointer to the headers.
   auto stream_it = multistream_->begin();
-  for (const auto& backend : config_->backends()) {
+  for (const auto* backend : backends_to_use) {
     if (stream_it == multistream_->end()) {
       break;
     }
 
-    auto headers = createUpstreamHeaders(backend, backend_sessions_[backend.name]);
+    auto headers = createUpstreamHeaders(*backend, backend_sessions_[backend->name]);
     upstream_headers_.push_back(std::move(headers));
     (*stream_it)->sendHeaders(*upstream_headers_.back(), false);
     ++stream_it;
@@ -825,11 +844,27 @@ void McpRouterFilter::handleInitialize() {
         sendHttpError(403, "Unable to determine session identity");
         return;
       }
-      // In DISABLED mode, proceed with anonymous session.
       ENVOY_LOG(debug, "Subject extraction failed, proceeding with anonymous session");
     } else {
       subject = *auth_subject;
     }
+  }
+
+  if (config_->lazyInitialization()) {
+    ENVOY_LOG(debug, "Lazy init: responding immediately without backend fanout");
+
+    session_subject_ = subject;
+    std::vector<BackendResponse> empty_responses;
+    std::string response_body = aggregateInitialize(empty_responses);
+
+    absl::flat_hash_map<std::string, std::string> empty_sessions;
+    std::string composite =
+        SessionCodec::buildCompositeSessionId(route_name_, subject, empty_sessions);
+    std::string encoded_session = SessionCodec::encode(composite);
+    encoded_session_id_ = encoded_session;
+
+    sendJsonResponse(response_body, encoded_session);
+    return;
   }
 
   initializeFanout([weak_self = weak_from_this(),
@@ -858,8 +893,6 @@ void McpRouterFilter::handleInitialize() {
       return;
     }
 
-    // Only build a composite session if at least one backend returned a session ID.
-    // If all backends are session-less, don't return a session ID to the client.
     std::string encoded_session;
     if (!sessions.empty()) {
       std::string composite =
@@ -886,32 +919,70 @@ void McpRouterFilter::handleNotification(absl::string_view notification_name) {
   config_->stats().rq_direct_response_.inc();
   ENVOY_LOG(debug, "{}: forwarding to {} backends", notification_name, config_->backends().size());
 
-  // Forward notification to all backends and wait for responses.
-  // Notifications are fire-and-forget, so we respond with 202 Accepted once all backends respond.
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse>) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "notifications/initialized callback ignored: filter destroyed");
-      return;
-    }
-    // All backends have responded (or failed), send 202 to client.
-    self->sendAccepted();
-  });
+  if (config_->lazyInitialization() && initialized_backends_.empty()) {
+    ENVOY_LOG(debug, "{}: no backends initialized yet (lazy init), responding 202",
+              notification_name);
+    sendAccepted();
+    return;
+  }
+
+  std::vector<std::string> targets;
+  if (config_->lazyInitialization()) {
+    targets.assign(initialized_backends_.begin(), initialized_backends_.end());
+  }
+
+  initializeFanout(
+      [weak_self = weak_from_this()](std::vector<BackendResponse>) {
+        auto self = weak_self.lock();
+        if (!self) {
+          ENVOY_LOG(debug, "notification callback ignored: filter destroyed");
+          return;
+        }
+        self->sendAccepted();
+      },
+      targets);
 }
 
 void McpRouterFilter::handleToolsList() {
   ENVOY_LOG(debug, "tools/list: setting up fanout to {} backends", config_->backends().size());
 
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "tools/list callback ignored: filter destroyed");
-      return;
+  auto start_tools_list = [this]() {
+    initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
+      auto self = weak_self.lock();
+      if (!self) {
+        ENVOY_LOG(debug, "tools/list callback ignored: filter destroyed");
+        return;
+      }
+      std::string response_body = self->aggregateToolsList(responses);
+      ENVOY_LOG(debug, "tools/list: response body: {}", response_body);
+      self->sendJsonResponse(response_body, self->encoded_session_id_);
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      streamData(lazy_init_request_body_, true);
     }
-    std::string response_body = self->aggregateToolsList(responses);
-    ENVOY_LOG(debug, "tools/list: response body: {}", response_body);
-    self->sendJsonResponse(response_body, self->encoded_session_id_);
-  });
+  };
+
+  if (config_->lazyInitialization() && initialized_backends_.size() < config_->backends().size()) {
+    lazy_init_pending_ = true;
+    lazyInitFanout([weak_self = weak_from_this(),
+                    start_tools_list = std::move(start_tools_list)](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_fanout_failure_.inc();
+        self->sendHttpError(500, "Failed to initialize backends");
+        return;
+      }
+      start_tools_list();
+    });
+    return;
+  }
+
+  start_tools_list();
 }
 
 void McpRouterFilter::handleToolsCall() {
@@ -930,52 +1001,108 @@ void McpRouterFilter::handleToolsCall() {
     return;
   }
 
-  // Store the unprefixed tool name for body rewriting.
   unprefixed_tool_name_ = actual_tool;
   needs_body_rewrite_ = (tool_name_ != unprefixed_tool_name_);
 
   ENVOY_LOG(debug, "tools/call: backend='{}', tool='{}' -> '{}', needs_rewrite={}", backend_name,
             tool_name_, actual_tool, needs_body_rewrite_);
 
-  // Use streaming mode for SSE pass-through, with fallback for JSON responses.
-  initializeSingleBackend(
-      *backend,
-      [weak_self = weak_from_this()](BackendResponse resp) {
-        auto self = weak_self.lock();
-        if (!self) {
-          return;
-        }
-        // This callback is invoked for non-SSE responses (JSON) or errors.
-        // SSE responses are streamed directly by the parent filter.
-        if (resp.success) {
-          if (resp.isSse()) {
-            // Should not reach here for successful SSE in streaming mode.
-            ENVOY_LOG(warn, "tools/call: SSE response reached non-streaming path");
-            self->sendHttpError(500, "Internal error: streaming failed for SSE response");
-          } else {
-            self->sendJsonResponse(resp.body, self->encoded_session_id_);
+  auto start_tools_call = [this, backend]() {
+    initializeSingleBackend(
+        *backend,
+        [weak_self = weak_from_this()](BackendResponse resp) {
+          auto self = weak_self.lock();
+          if (!self) {
+            return;
           }
-        } else {
-          self->config_->stats().rq_backend_failure_.inc();
-          self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
-        }
-      },
-      true /* streaming_enabled */);
+          if (resp.success) {
+            if (resp.isSse()) {
+              ENVOY_LOG(warn, "tools/call: SSE response reached non-streaming path");
+              self->sendHttpError(500, "Internal error: streaming failed for SSE response");
+            } else {
+              self->sendJsonResponse(resp.body, self->encoded_session_id_);
+            }
+          } else {
+            self->config_->stats().rq_backend_failure_.inc();
+            self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
+          }
+        },
+        true /* streaming_enabled */);
+
+    // Replay buffered data if we came from lazy init.
+    if (lazy_init_request_body_.length() > 0) {
+      if (needs_body_rewrite_) {
+        config_->stats().rq_body_rewrite_.inc();
+        rewriteToolCallBody(lazy_init_request_body_);
+        needs_body_rewrite_ = false;
+      }
+      streamData(lazy_init_request_body_, true);
+    }
+  };
+
+  if (config_->lazyInitialization() && !initialized_backends_.contains(backend_name)) {
+    lazy_init_pending_ = true;
+    lazyInitSingleBackend(*backend, [weak_self = weak_from_this(),
+                                     start_tools_call = std::move(start_tools_call),
+                                     backend_name](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, fmt::format("Failed to initialize backend '{}'", backend_name));
+        return;
+      }
+      start_tools_call();
+    });
+    return;
+  }
+
+  start_tools_call();
 }
 
 void McpRouterFilter::handleResourcesList() {
   ENVOY_LOG(debug, "resources/list: setting up fanout to {} backends", config_->backends().size());
 
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "resources/list callback ignored: filter destroyed");
-      return;
+  auto start_resources_list = [this]() {
+    initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
+      auto self = weak_self.lock();
+      if (!self) {
+        ENVOY_LOG(debug, "resources/list callback ignored: filter destroyed");
+        return;
+      }
+      std::string response_body = self->aggregateResourcesList(responses);
+      ENVOY_LOG(debug, "resources/list: response body: {}", response_body);
+      self->sendJsonResponse(response_body, self->encoded_session_id_);
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      streamData(lazy_init_request_body_, true);
     }
-    std::string response_body = self->aggregateResourcesList(responses);
-    ENVOY_LOG(debug, "resources/list: response body: {}", response_body);
-    self->sendJsonResponse(response_body, self->encoded_session_id_);
-  });
+  };
+
+  if (config_->lazyInitialization() && initialized_backends_.size() < config_->backends().size()) {
+    lazy_init_pending_ = true;
+    lazyInitFanout([weak_self = weak_from_this(),
+                    start_resources_list = std::move(start_resources_list)](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_fanout_failure_.inc();
+        self->sendHttpError(500, "Failed to initialize backends");
+        return;
+      }
+      start_resources_list();
+    });
+    return;
+  }
+
+  start_resources_list();
 }
 
 void McpRouterFilter::handleSingleBackendResourceMethod(absl::string_view method_name) {
@@ -1001,18 +1128,51 @@ void McpRouterFilter::handleSingleBackendResourceMethod(absl::string_view method
   ENVOY_LOG(debug, "{}: backend='{}', uri='{}' -> '{}', needs_rewrite={}", method_name,
             backend_name, resource_uri_, actual_uri, needs_body_rewrite_);
 
-  initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
-    auto self = weak_self.lock();
-    if (!self) {
-      return;
+  auto start_resource_method = [this, backend]() {
+    initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      if (resp.success) {
+        self->sendJsonResponse(resp.body, self->encoded_session_id_);
+      } else {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
+      }
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      if (needs_body_rewrite_) {
+        config_->stats().rq_body_rewrite_.inc();
+        rewriteResourceUriBody(lazy_init_request_body_);
+        needs_body_rewrite_ = false;
+      }
+      streamData(lazy_init_request_body_, true);
     }
-    if (resp.success) {
-      self->sendJsonResponse(resp.body, self->encoded_session_id_);
-    } else {
-      self->config_->stats().rq_backend_failure_.inc();
-      self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
-    }
-  });
+  };
+
+  if (config_->lazyInitialization() && !initialized_backends_.contains(backend_name)) {
+    lazy_init_pending_ = true;
+    lazyInitSingleBackend(*backend, [weak_self = weak_from_this(),
+                                     start_resource_method = std::move(start_resource_method),
+                                     backend_name](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, fmt::format("Failed to initialize backend '{}'", backend_name));
+        return;
+      }
+      start_resource_method();
+    });
+    return;
+  }
+
+  start_resource_method();
 }
 
 void McpRouterFilter::handleResourcesRead() { handleSingleBackendResourceMethod("resources/read"); }
@@ -1029,31 +1189,85 @@ void McpRouterFilter::handleResourcesTemplatesList() {
   ENVOY_LOG(debug, "resources/templates/list: setting up fanout to {} backends",
             config_->backends().size());
 
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "resources/templates/list callback ignored: filter destroyed");
-      return;
+  auto start_templates_list = [this]() {
+    initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
+      auto self = weak_self.lock();
+      if (!self) {
+        ENVOY_LOG(debug, "resources/templates/list callback ignored: filter destroyed");
+        return;
+      }
+      std::string response_body = self->aggregateResourcesTemplatesList(responses);
+      ENVOY_LOG(debug, "resources/templates/list: response body: {}", response_body);
+      self->sendJsonResponse(response_body, self->encoded_session_id_);
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      streamData(lazy_init_request_body_, true);
     }
-    std::string response_body = self->aggregateResourcesTemplatesList(responses);
-    ENVOY_LOG(debug, "resources/templates/list: response body: {}", response_body);
-    self->sendJsonResponse(response_body, self->encoded_session_id_);
-  });
+  };
+
+  if (config_->lazyInitialization() && initialized_backends_.size() < config_->backends().size()) {
+    lazy_init_pending_ = true;
+    lazyInitFanout([weak_self = weak_from_this(),
+                    start_templates_list = std::move(start_templates_list)](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_fanout_failure_.inc();
+        self->sendHttpError(500, "Failed to initialize backends");
+        return;
+      }
+      start_templates_list();
+    });
+    return;
+  }
+
+  start_templates_list();
 }
 
 void McpRouterFilter::handlePromptsList() {
   ENVOY_LOG(debug, "prompts/list: setting up fanout to {} backends", config_->backends().size());
 
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "prompts/list callback ignored: filter destroyed");
-      return;
+  auto start_prompts_list = [this]() {
+    initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
+      auto self = weak_self.lock();
+      if (!self) {
+        ENVOY_LOG(debug, "prompts/list callback ignored: filter destroyed");
+        return;
+      }
+      std::string response_body = self->aggregatePromptsList(responses);
+      ENVOY_LOG(debug, "prompts/list: response body: {}", response_body);
+      self->sendJsonResponse(response_body, self->encoded_session_id_);
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      streamData(lazy_init_request_body_, true);
     }
-    std::string response_body = self->aggregatePromptsList(responses);
-    ENVOY_LOG(debug, "prompts/list: response body: {}", response_body);
-    self->sendJsonResponse(response_body, self->encoded_session_id_);
-  });
+  };
+
+  if (config_->lazyInitialization() && initialized_backends_.size() < config_->backends().size()) {
+    lazy_init_pending_ = true;
+    lazyInitFanout([weak_self = weak_from_this(),
+                    start_prompts_list = std::move(start_prompts_list)](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_fanout_failure_.inc();
+        self->sendHttpError(500, "Failed to initialize backends");
+        return;
+      }
+      start_prompts_list();
+    });
+    return;
+  }
+
+  start_prompts_list();
 }
 
 void McpRouterFilter::handlePromptsGet() {
@@ -1079,23 +1293,54 @@ void McpRouterFilter::handlePromptsGet() {
   ENVOY_LOG(debug, "prompts/get: backend='{}', prompt='{}' -> '{}', needs_rewrite={}", backend_name,
             prompt_name_, actual_prompt, needs_body_rewrite_);
 
-  initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
-    auto self = weak_self.lock();
-    if (!self) {
-      return;
+  auto start_prompts_get = [this, backend]() {
+    initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      if (resp.success) {
+        self->sendJsonResponse(resp.body, self->encoded_session_id_);
+      } else {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
+      }
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      if (needs_body_rewrite_) {
+        config_->stats().rq_body_rewrite_.inc();
+        rewritePromptsGetBody(lazy_init_request_body_);
+        needs_body_rewrite_ = false;
+      }
+      streamData(lazy_init_request_body_, true);
     }
-    if (resp.success) {
-      self->sendJsonResponse(resp.body, self->encoded_session_id_);
-    } else {
-      self->config_->stats().rq_backend_failure_.inc();
-      self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
-    }
-  });
+  };
+
+  if (config_->lazyInitialization() && !initialized_backends_.contains(backend_name)) {
+    lazy_init_pending_ = true;
+    lazyInitSingleBackend(*backend, [weak_self = weak_from_this(),
+                                     start_prompts_get = std::move(start_prompts_get),
+                                     backend_name](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, fmt::format("Failed to initialize backend '{}'", backend_name));
+        return;
+      }
+      start_prompts_get();
+    });
+    return;
+  }
+
+  start_prompts_get();
 }
 
 void McpRouterFilter::handleCompletionComplete() {
-  // Route based on ref type: ref/prompt uses prompt name, ref/resource uses resource URI.
-  // https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion
   std::string backend_name;
 
   if (completion_ref_type_ == "ref/prompt") {
@@ -1136,51 +1381,107 @@ void McpRouterFilter::handleCompletionComplete() {
     return;
   }
 
-  initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
-    auto self = weak_self.lock();
-    if (!self) {
-      return;
+  auto start_completion = [this, backend]() {
+    initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      if (resp.success) {
+        self->sendJsonResponse(resp.body, self->encoded_session_id_);
+      } else {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
+      }
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      if (needs_body_rewrite_) {
+        config_->stats().rq_body_rewrite_.inc();
+        rewriteCompletionCompleteBody(lazy_init_request_body_);
+        needs_body_rewrite_ = false;
+      }
+      streamData(lazy_init_request_body_, true);
     }
-    if (resp.success) {
-      self->sendJsonResponse(resp.body, self->encoded_session_id_);
-    } else {
-      self->config_->stats().rq_backend_failure_.inc();
-      self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
-    }
-  });
+  };
+
+  if (config_->lazyInitialization() && !initialized_backends_.contains(backend_name)) {
+    lazy_init_pending_ = true;
+    lazyInitSingleBackend(*backend, [weak_self = weak_from_this(),
+                                     start_completion = std::move(start_completion),
+                                     backend_name](bool success) {
+      auto self = weak_self.lock();
+      if (!self) {
+        return;
+      }
+      self->lazy_init_pending_ = false;
+      if (!success) {
+        self->config_->stats().rq_backend_failure_.inc();
+        self->sendHttpError(500, fmt::format("Failed to initialize backend '{}'", backend_name));
+        return;
+      }
+      start_completion();
+    });
+    return;
+  }
+
+  start_completion();
 }
 
 void McpRouterFilter::handleLoggingSetLevel() {
-  // Fan out to all backends and return empty result.
-  // https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging
   ENVOY_LOG(debug, "logging/setLevel: fanout to {} backends", config_->backends().size());
 
-  initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
-    auto self = weak_self.lock();
-    if (!self) {
-      ENVOY_LOG(debug, "logging/setLevel callback ignored: filter destroyed");
-      return;
-    }
-    // Check if at least one backend succeeded.
-    bool any_success = false;
-    for (const auto& resp : responses) {
-      if (resp.success) {
-        any_success = true;
-        break;
+  auto start_logging = [this]() {
+    initializeFanout([weak_self = weak_from_this()](std::vector<BackendResponse> responses) {
+      auto self = weak_self.lock();
+      if (!self) {
+        ENVOY_LOG(debug, "logging/setLevel callback ignored: filter destroyed");
+        return;
       }
-    }
+      bool any_success = false;
+      for (const auto& resp : responses) {
+        if (resp.success) {
+          any_success = true;
+          break;
+        }
+      }
 
-    if (!any_success) {
-      self->config_->stats().rq_fanout_failure_.inc();
-      self->sendHttpError(500, "All backends failed to set logging level");
-      return;
-    }
+      if (!any_success) {
+        self->config_->stats().rq_fanout_failure_.inc();
+        self->sendHttpError(500, "All backends failed to set logging level");
+        return;
+      }
 
-    // Return empty JSON-RPC result.
-    std::string response =
-        fmt::format(R"({{"jsonrpc":"2.0","id":{},"result":{{}}}})", self->request_id_);
-    self->sendJsonResponse(response, self->encoded_session_id_);
-  });
+      std::string response =
+          fmt::format(R"({{"jsonrpc":"2.0","id":{},"result":{{}}}})", self->request_id_);
+      self->sendJsonResponse(response, self->encoded_session_id_);
+    });
+
+    if (lazy_init_request_body_.length() > 0) {
+      streamData(lazy_init_request_body_, true);
+    }
+  };
+
+  if (config_->lazyInitialization() && initialized_backends_.size() < config_->backends().size()) {
+    lazy_init_pending_ = true;
+    lazyInitFanout(
+        [weak_self = weak_from_this(), start_logging = std::move(start_logging)](bool success) {
+          auto self = weak_self.lock();
+          if (!self) {
+            return;
+          }
+          self->lazy_init_pending_ = false;
+          if (!success) {
+            self->config_->stats().rq_fanout_failure_.inc();
+            self->sendHttpError(500, "Failed to initialize backends");
+            return;
+          }
+          start_logging();
+        });
+    return;
+  }
+
+  start_logging();
 }
 
 // Response aggregation helpers.
@@ -1196,14 +1497,16 @@ std::string McpRouterFilter::extractJsonRpcFromResponse(const BackendResponse& r
 }
 
 std::string McpRouterFilter::aggregateInitialize(const std::vector<BackendResponse>& responses) {
-  // Check if at least one backend succeeded.
-  const bool any_success = std::any_of(responses.begin(), responses.end(),
-                                       [](const BackendResponse& resp) { return resp.success; });
+  // Empty responses is valid for lazy initialization (no backends contacted yet).
+  if (!responses.empty()) {
+    const bool any_success = std::any_of(responses.begin(), responses.end(),
+                                         [](const BackendResponse& resp) { return resp.success; });
 
-  if (!any_success) {
-    config_->stats().rq_fanout_failure_.inc();
-    return absl::StrCat(R"({"jsonrpc":"2.0","id":)", request_id_,
-                        R"(,"error":{"code":-32603,"message":"All backends failed"}})");
+    if (!any_success) {
+      config_->stats().rq_fanout_failure_.inc();
+      return absl::StrCat(R"({"jsonrpc":"2.0","id":)", request_id_,
+                          R"(,"error":{"code":-32603,"message":"All backends failed"}})");
+    }
   }
 
   // Return gateway capabilities.
@@ -1630,6 +1933,147 @@ void McpRouterFilter::sendAccepted() {
   }
 
   decoder_callbacks_->encodeHeaders(std::move(headers), true, "mcp_router");
+}
+
+std::string McpRouterFilter::buildSyntheticInitBody() {
+  return absl::StrCat(R"({"jsonrpc":"2.0","id":)", request_id_,
+                      R"(,"method":"initialize","params":{"protocolVersion":")", kProtocolVersion,
+                      R"(","capabilities":{},"clientInfo":{"name":")", kGatewayName,
+                      R"(","version":")", kGatewayVersion, R"("}}})");
+}
+
+void McpRouterFilter::resetStreamState() {
+  if (multistream_) {
+    multistream_.reset();
+  }
+  stream_callbacks_.clear();
+  upstream_headers_.clear();
+  aggregation_callback_ = nullptr;
+  single_backend_callback_ = nullptr;
+  pending_responses_.reset();
+  response_count_.reset();
+}
+
+void McpRouterFilter::updateEncodedSessionId() {
+  std::string composite =
+      SessionCodec::buildCompositeSessionId(route_name_, session_subject_, backend_sessions_);
+  encoded_session_id_ = SessionCodec::encode(composite);
+}
+
+void McpRouterFilter::lazyInitSingleBackend(const McpBackendConfig& backend,
+                                            std::function<void(bool)> on_init_complete) {
+  ENVOY_LOG(debug, "Lazy init: initializing backend '{}'", backend.name);
+
+  std::string init_body = buildSyntheticInitBody();
+
+  auto headers = createUpstreamHeaders(backend);
+  headers->setContentLength(init_body.size());
+
+  if (!muxdemux_->isIdle()) {
+    ENVOY_LOG(warn, "MuxDemux not idle for lazy init of '{}'", backend.name);
+    on_init_complete(false);
+    return;
+  }
+
+  auto stream_cb = std::make_shared<BackendStreamCallbacks>(
+      backend.name,
+      [weak_self = weak_from_this(), backend_name = backend.name,
+       on_init_complete = std::move(on_init_complete)](BackendResponse resp) {
+        auto self = weak_self.lock();
+        if (!self) {
+          return;
+        }
+
+        if (!resp.success) {
+          ENVOY_LOG(warn, "Lazy init failed for backend '{}': {}", backend_name, resp.error);
+          on_init_complete(false);
+          return;
+        }
+
+        if (!resp.session_id.empty()) {
+          self->backend_sessions_[backend_name] = resp.session_id;
+        }
+        self->initialized_backends_.insert(backend_name);
+        self->updateEncodedSessionId();
+
+        ENVOY_LOG(debug, "Lazy init: backend '{}' initialized successfully", backend_name);
+
+        self->resetStreamState();
+        on_init_complete(true);
+      },
+      request_id_, false, weak_from_this());
+
+  stream_callbacks_.push_back(stream_cb);
+
+  Http::AsyncClient::StreamOptions options;
+  options.setTimeout(backend.timeout);
+
+  std::vector<Http::MuxDemux::Callbacks> mux_callbacks;
+  mux_callbacks.push_back({
+      .cluster_name = backend.cluster_name,
+      .callbacks = std::weak_ptr<Http::AsyncClient::StreamCallbacks>(stream_cb),
+      .options = options,
+  });
+
+  Http::AsyncClient::StreamOptions default_options;
+  auto multistream_or = muxdemux_->multicast(default_options, mux_callbacks);
+  if (!multistream_or.ok()) {
+    ENVOY_LOG(error, "Failed to start lazy init for '{}': {}", backend.name,
+              multistream_or.status().message());
+    on_init_complete(false);
+    return;
+  }
+
+  multistream_ = std::move(*multistream_or);
+  upstream_headers_.clear();
+  upstream_headers_.push_back(std::move(headers));
+
+  auto stream_it = multistream_->begin();
+  if (stream_it != multistream_->end()) {
+    (*stream_it)->sendHeaders(*upstream_headers_.back(), false);
+    Buffer::OwnedImpl body(init_body);
+    (*stream_it)->sendData(body, true);
+  }
+}
+
+void McpRouterFilter::lazyInitFanout(std::function<void(bool)> on_init_complete) {
+  std::vector<std::string> uninit_backends;
+  for (const auto& backend : config_->backends()) {
+    if (!initialized_backends_.contains(backend.name)) {
+      uninit_backends.push_back(backend.name);
+    }
+  }
+
+  if (uninit_backends.empty()) {
+    on_init_complete(true);
+    return;
+  }
+
+  ENVOY_LOG(debug, "Lazy init fanout: initializing {} backends", uninit_backends.size());
+  initializeFanout(
+      [weak_self = weak_from_this(),
+       on_init_complete = std::move(on_init_complete)](std::vector<BackendResponse> responses) {
+        auto self = weak_self.lock();
+        if (!self) {
+          return;
+        }
+
+        bool any_success = false;
+        for (const auto& resp : responses) {
+          if (resp.success) {
+            any_success = true;
+            if (!resp.session_id.empty()) {
+              self->backend_sessions_[resp.backend_name] = resp.session_id;
+            }
+            self->initialized_backends_.insert(resp.backend_name);
+          }
+        }
+
+        self->updateEncodedSessionId();
+        self->resetStreamState();
+        on_init_complete(any_success);
+      },
+      uninit_backends);
 }
 
 void McpRouterFilter::sendHttpError(uint64_t status_code, const std::string& message) {

--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -14,6 +14,7 @@
 #include "source/extensions/filters/http/mcp_router/session_codec.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
 
 namespace Envoy {
@@ -134,8 +135,9 @@ private:
   // Extracts JSON-RPC payload from a response, handling SSE event wrapping.
   std::string extractJsonRpcFromResponse(const BackendResponse& response);
 
-  // Initialize fanout connections to all backends.
-  void initializeFanout(AggregationCallback callback);
+  // Initialize fanout connections to all backends (or a subset if target_backends is provided).
+  void initializeFanout(AggregationCallback callback,
+                        const std::vector<std::string>& target_backends = {});
   // Initialize single backend connection.
   void initializeSingleBackend(const McpBackendConfig& backend,
                                std::function<void(BackendResponse)> callback);
@@ -143,6 +145,14 @@ private:
   void initializeSingleBackend(const McpBackendConfig& backend,
                                std::function<void(BackendResponse)> callback,
                                bool streaming_enabled);
+
+  // Lazy initialization helpers.
+  void lazyInitSingleBackend(const McpBackendConfig& backend,
+                             std::function<void(bool)> on_init_complete);
+  void lazyInitFanout(std::function<void(bool)> on_init_complete);
+  std::string buildSyntheticInitBody();
+  void resetStreamState();
+  void updateEncodedSessionId();
 
   // Stream data to established connection(s).
   void streamData(Buffer::Instance& data, bool end_stream);
@@ -197,6 +207,11 @@ private:
   bool initialized_{false};
   // Track if SSE headers were sent (for aggregation with SSE backends)
   bool sse_headers_sent_{false};
+
+  // Lazy initialization state.
+  bool lazy_init_pending_{false};
+  absl::flat_hash_set<std::string> initialized_backends_;
+  Buffer::OwnedImpl lazy_init_request_body_;
 };
 
 } // namespace McpRouter

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -458,6 +458,55 @@ protected:
     (*mcp_metadata.mutable_fields())["id"].set_number_value(static_cast<double>(id));
   }
 
+  void setMcpToolCallMetadata(const std::string& tool_name, int64_t id = 1,
+                              const std::string& metadata_namespace = "envoy.filters.http.mcp") {
+    auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())[metadata_namespace];
+    (*mcp_metadata.mutable_fields())["method"].set_string_value("tools/call");
+    (*mcp_metadata.mutable_fields())["id"].set_number_value(static_cast<double>(id));
+    auto& params = (*mcp_metadata.mutable_fields())["params"];
+    (*params.mutable_struct_value()->mutable_fields())["name"].set_string_value(tool_name);
+  }
+
+  void setupMockAsyncClient(
+      std::vector<Http::AsyncClient::StreamCallbacks*>& http_callbacks,
+      std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>>& http_streams) {
+    factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
+        {"test_cluster", "time_cluster", "calc_cluster"});
+    EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
+                    .async_client_,
+                start(_, _))
+        .WillRepeatedly(
+            [&http_callbacks, &http_streams](Http::AsyncClient::StreamCallbacks& callbacks,
+                                             const Http::AsyncClient::StreamOptions&) {
+              http_callbacks.push_back(&callbacks);
+              http_streams.emplace_back(std::make_unique<NiceMock<Http::MockAsyncClientStream>>());
+              return http_streams.back().get();
+            });
+  }
+
+  void simulateBackendResponse(Http::AsyncClient::StreamCallbacks* cb, const std::string& body,
+                               const std::string& session_id = "",
+                               const std::string& content_type = "application/json") {
+    auto response_headers = Http::ResponseHeaderMapImpl::create();
+    response_headers->setStatus(200);
+    response_headers->setContentType(content_type);
+    if (!session_id.empty()) {
+      response_headers->addCopy(Http::LowerCaseString("mcp-session-id"), session_id);
+    }
+    cb->onHeaders(std::move(response_headers), false);
+    Buffer::OwnedImpl response_data(body);
+    cb->onData(response_data, true);
+  }
+
+  void simulateBackendError(Http::AsyncClient::StreamCallbacks* cb, uint64_t status_code = 500) {
+    auto response_headers = Http::ResponseHeaderMapImpl::create();
+    response_headers->setStatus(status_code);
+    response_headers->setContentType("text/plain");
+    cb->onHeaders(std::move(response_headers), false);
+    Buffer::OwnedImpl response_data("error");
+    cb->onData(response_data, true);
+  }
+
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
@@ -797,6 +846,1286 @@ TEST(AggregateToolsListTest, SerializationPreservesNestedInputSchema) {
   auto count_type = (*count_prop)->getString("type");
   EXPECT_TRUE(count_type.ok());
   EXPECT_EQ(*count_type, "integer");
+}
+
+// Verifies lazy_initialization config field defaults to false and can be enabled.
+TEST_F(McpRouterConfigTest, LazyInitializationDefault) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  EXPECT_FALSE(config.lazyInitialization());
+}
+
+TEST_F(McpRouterConfigTest, LazyInitializationEnabled) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+  proto_config.set_lazy_initialization(true);
+
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  EXPECT_TRUE(config.lazyInitialization());
+}
+
+// Verifies McpRouterClusterConfigImpl delegates lazyInitialization to base.
+TEST_F(McpRouterConfigTest, ClusterConfigDelegatesLazyInit) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter base_proto;
+  base_proto.set_lazy_initialization(true);
+  auto base_config = std::make_shared<McpRouterConfigImpl>(base_proto, "test.", *store_.rootScope(),
+                                                           factory_context_);
+
+  envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig cluster_proto;
+  auto* server = cluster_proto.add_servers();
+  server->set_name("cluster_backend");
+  server->mutable_mcp_cluster()->set_cluster("target_cluster");
+
+  McpRouterClusterConfigImpl cluster_config(cluster_proto, base_config);
+  EXPECT_TRUE(cluster_config.lazyInitialization());
+}
+
+// Verifies lazy initialization responds immediately to initialize without backend fanout.
+TEST_F(McpRouterFilterTest, LazyInitializeRespondsImmediately) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("initialize");
+
+  auto config = createConfig(proto_config);
+  McpRouterFilter filter(config);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        auto session_header = headers.get(Http::LowerCaseString("mcp-session-id"));
+        EXPECT_FALSE(session_header.empty());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  filter.decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter.decodeData(buffer, true);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init tools/call triggers backend initialization then forwards the request.
+TEST_F(McpRouterFilterTest, LazyInitToolsCallInitializesBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpToolCallMetadata("get_time");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  // Build a session ID with empty backend sessions (lazy init state).
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"get_time"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // First stream should be the lazy init (initialize) request to the backend.
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  // Simulate backend init response.
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":2,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  // Second stream should be the actual tools/call request.
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  // Simulate tools/call response.
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string tool_response =
+      R"({"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"12:00"}]}})";
+  simulateBackendResponse(http_callbacks[1], tool_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init tools/list triggers fanout initialization then forwards the list request.
+TEST_F(McpRouterFilterTest, LazyInitToolsListInitializesAllBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server1 = proto_config.add_servers();
+  server1->set_name("time");
+  server1->mutable_mcp_cluster()->set_cluster("time_cluster");
+  auto* server2 = proto_config.add_servers();
+  server2->set_name("calc");
+  server2->mutable_mcp_cluster()->set_cluster("calc_cluster");
+
+  setMcpMethodMetadata("tools/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  // Build a session ID with empty backend sessions.
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"tools/list","id":3})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // First two streams should be the lazy init fanout (initialize to both backends).
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":3,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "time-session");
+  simulateBackendResponse(http_callbacks[1], init_response, "calc-session");
+
+  // Next two streams should be the actual tools/list fanout.
+  ASSERT_GE(http_callbacks.size(), 4);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string time_tools =
+      R"({"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"get_time"}]}})";
+  const std::string calc_tools = R"({"jsonrpc":"2.0","id":3,"result":{"tools":[{"name":"add"}]}})";
+  simulateBackendResponse(http_callbacks[2], time_tools);
+  simulateBackendResponse(http_callbacks[3], calc_tools);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init notifications with no initialized backends respond 202 immediately.
+TEST_F(McpRouterFilterTest, LazyInitNotificationNoBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("notifications/initialized");
+
+  auto config = createConfig(proto_config);
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  // Build a session ID with empty backend sessions.
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool end_stream) {
+        EXPECT_EQ("202", headers.getStatusValue());
+        EXPECT_TRUE(end_stream);
+        response_sent = true;
+      }));
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"notifications/initialized"})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init with eager mode disabled (default) behaves normally.
+TEST_F(McpRouterFilterTest, EagerInitUnchangedWithLazyDisabled) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("initialize");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // Eager mode should have started a backend stream (unlike lazy init which responds immediately).
+  EXPECT_GE(http_callbacks.size(), 1);
+}
+
+// Verifies lazy init prompts/get triggers backend initialization.
+TEST_F(McpRouterFilterTest, LazyInitPromptsGetInitializesBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  // Set prompts/get metadata with prompt name.
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("prompts/get");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(4);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  (*params.mutable_struct_value()->mutable_fields())["name"].set_string_value("greeting");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"prompts/get","id":4,"params":{"name":"greeting"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // First stream should be the lazy init request.
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":4,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  // Second stream should be the actual prompts/get request.
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string prompt_response =
+      R"({"jsonrpc":"2.0","id":4,"result":{"messages":[{"role":"assistant","content":{"type":"text","text":"Hello!"}}]}})";
+  simulateBackendResponse(http_callbacks[1], prompt_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init prompts/list triggers fanout initialization.
+TEST_F(McpRouterFilterTest, LazyInitPromptsListInitializesBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("prompts/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"prompts/list","id":5})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // First stream: lazy init.
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":5,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  // Second stream: actual prompts/list fanout.
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string prompts_response =
+      R"({"jsonrpc":"2.0","id":5,"result":{"prompts":[{"name":"greeting"}]}})";
+  simulateBackendResponse(http_callbacks[1], prompts_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init resources/list triggers fanout initialization.
+TEST_F(McpRouterFilterTest, LazyInitResourcesListInitializesBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("resources/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"resources/list","id":6})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  // First stream: lazy init.
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":6,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  // Second stream: actual resources/list fanout.
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string resources_response =
+      R"({"jsonrpc":"2.0","id":6,"result":{"resources":[{"uri":"file://test","name":"test"}]}})";
+  simulateBackendResponse(http_callbacks[1], resources_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init resources/templates/list triggers fanout initialization.
+TEST_F(McpRouterFilterTest, LazyInitResourcesTemplatesListInitializesBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("resources/templates/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"resources/templates/list","id":7})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":7,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string templates_response =
+      R"({"jsonrpc":"2.0","id":7,"result":{"resourceTemplates":[{"uriTemplate":"file:///{path}","name":"file"}]}})";
+  simulateBackendResponse(http_callbacks[1], templates_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init logging/setLevel triggers fanout initialization.
+TEST_F(McpRouterFilterTest, LazyInitLoggingSetLevelInitializesBackends) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("logging/setLevel");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"logging/setLevel","id":8,"params":{"level":"debug"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":8,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string logging_response = R"({"jsonrpc":"2.0","id":8,"result":{}})";
+  simulateBackendResponse(http_callbacks[1], logging_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init resources/read triggers backend initialization.
+TEST_F(McpRouterFilterTest, LazyInitResourcesReadInitializesBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  // Set resources/read metadata with URI.
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("resources/read");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(9);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  (*params.mutable_struct_value()->mutable_fields())["uri"].set_string_value("file://test.txt");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"resources/read","id":9,"params":{"uri":"file://test.txt"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":9,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string resource_response =
+      R"({"jsonrpc":"2.0","id":9,"result":{"contents":[{"uri":"file://test.txt","text":"hello"}]}})";
+  simulateBackendResponse(http_callbacks[1], resource_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init completion/complete with ref/prompt triggers backend initialization.
+TEST_F(McpRouterFilterTest, LazyInitCompletionCompleteInitializesBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  // Set completion/complete metadata with ref/prompt.
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("completion/complete");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(10);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  auto& ref = (*params.mutable_struct_value()->mutable_fields())["ref"];
+  (*ref.mutable_struct_value()->mutable_fields())["type"].set_string_value("ref/prompt");
+  (*ref.mutable_struct_value()->mutable_fields())["name"].set_string_value("greeting");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"completion/complete","id":10,"params":{"ref":{"type":"ref/prompt","name":"greeting"},"argument":{"name":"name","value":"wo"}}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":10,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string completion_response =
+      R"({"jsonrpc":"2.0","id":10,"result":{"completion":{"values":["world"]}}})";
+  simulateBackendResponse(http_callbacks[1], completion_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies lazy init tools/call sends error when backend init fails.
+TEST_F(McpRouterFilterTest, LazyInitToolsCallInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpToolCallMetadata("get_time");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"tools/call","id":2,"params":{"name":"get_time"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init tools/list sends error when fanout init fails.
+TEST_F(McpRouterFilterTest, LazyInitToolsListInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("tools/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"tools/list","id":3})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init prompts/get sends error when backend init fails.
+TEST_F(McpRouterFilterTest, LazyInitPromptsGetInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("prompts/get");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(4);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  (*params.mutable_struct_value()->mutable_fields())["name"].set_string_value("greeting");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"prompts/get","id":4,"params":{"name":"greeting"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init prompts/list sends error when fanout init fails.
+TEST_F(McpRouterFilterTest, LazyInitPromptsListInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("prompts/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"prompts/list","id":5})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init resources/list sends error when fanout init fails.
+TEST_F(McpRouterFilterTest, LazyInitResourcesListInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("resources/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"resources/list","id":6})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init resources/read sends error when backend init fails.
+TEST_F(McpRouterFilterTest, LazyInitResourcesReadInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("resources/read");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(9);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  (*params.mutable_struct_value()->mutable_fields())["uri"].set_string_value("file://test.txt");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"resources/read","id":9,"params":{"uri":"file://test.txt"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init completion/complete sends error when backend init fails.
+TEST_F(McpRouterFilterTest, LazyInitCompletionCompleteInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("completion/complete");
+  (*mcp_metadata.mutable_fields())["id"].set_number_value(10);
+  auto& params = (*mcp_metadata.mutable_fields())["params"];
+  auto& ref = (*params.mutable_struct_value()->mutable_fields())["ref"];
+  (*ref.mutable_struct_value()->mutable_fields())["type"].set_string_value("ref/prompt");
+  (*ref.mutable_struct_value()->mutable_fields())["name"].set_string_value("greeting");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"completion/complete","id":10,"params":{"ref":{"type":"ref/prompt","name":"greeting"}}})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init resources/templates/list sends error when fanout init fails.
+TEST_F(McpRouterFilterTest, LazyInitResourcesTemplatesListInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("resources/templates/list");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"resources/templates/list","id":7})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies lazy init logging/setLevel sends error when fanout init fails.
+TEST_F(McpRouterFilterTest, LazyInitLoggingSetLevelInitFailure) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("logging/setLevel");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","method":"logging/setLevel","id":8})";
+  Buffer::OwnedImpl buffer(body);
+  filter->decodeData(buffer, true);
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  bool error_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("500", headers.getStatusValue());
+        error_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  simulateBackendError(http_callbacks[0]);
+
+  EXPECT_TRUE(error_sent);
+}
+
+// Verifies multi-chunk data is buffered during lazy init.
+TEST_F(McpRouterFilterTest, LazyInitBuffersMultiChunkData) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpToolCallMetadata("get_time");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite =
+      SessionCodec::buildCompositeSessionId("default", "default", empty_sessions);
+  std::string encoded_session = SessionCodec::encode(composite);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/mcp"},
+                                         {"content-type", "application/json"},
+                                         {"mcp-session-id", encoded_session}};
+
+  filter->decodeHeaders(headers, false);
+
+  // Send first chunk (not end_stream) — triggers lazy init.
+  const std::string body_part1 = R"({"jsonrpc":"2.0","method":"tools/call",)";
+  Buffer::OwnedImpl buffer1(body_part1);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter->decodeData(buffer1, false));
+
+  // Send second chunk while lazy init is still pending — should be buffered.
+  const std::string body_part2 = R"("id":2,"params":{"name":"get_time"}})";
+  Buffer::OwnedImpl buffer2(body_part2);
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter->decodeData(buffer2, true));
+
+  ASSERT_GE(http_callbacks.size(), 1);
+
+  const std::string init_response =
+      R"({"jsonrpc":"2.0","id":2,"result":{"protocolVersion":"2025-06-18","capabilities":{}}})";
+  simulateBackendResponse(http_callbacks[0], init_response, "backend-session-1");
+
+  ASSERT_GE(http_callbacks.size(), 2);
+
+  bool response_sent = false;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([&](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("200", headers.getStatusValue());
+        response_sent = true;
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string tool_response =
+      R"({"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"12:00"}]}})";
+  simulateBackendResponse(http_callbacks[1], tool_response);
+
+  EXPECT_TRUE(response_sent);
+}
+
+// Verifies empty backend session map produces a valid session ID.
+TEST_F(SessionCodecTest, EmptyBackendSessions) {
+  absl::flat_hash_map<std::string, std::string> empty_sessions;
+  std::string composite = SessionCodec::buildCompositeSessionId("route", "user", empty_sessions);
+
+  auto parsed = SessionCodec::parseCompositeSessionId(composite);
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_EQ(parsed->route, "route");
+  EXPECT_EQ(parsed->subject, "user");
+  EXPECT_TRUE(parsed->backend_sessions.empty());
+
+  std::string encoded = SessionCodec::encode(composite);
+  std::string decoded = SessionCodec::decode(encoded);
+  EXPECT_EQ(decoded, composite);
 }
 
 // Verifies tools with icons array are handled correctly.


### PR DESCRIPTION
Add a `lazy_initialization` config option to the MCP router filter. When enabled, the `initialize` response is returned immediately with gateway capabilities without contacting any backends. Each backend is then initialized on-demand when a request first routes to it. This avoids slow or misbehaving backends from blocking client initialization.
