### PR TITLE
mobile: add unregisterApi to external API and use in RtdsIntegrationTest

### DIFF
--- a/mobile/library/common/api/external.cc
+++ b/mobile/library/common/api/external.cc
@@ -32,6 +32,10 @@ void* retrieveApi(absl::string_view name, bool allow_absent) {
   return api;
 }
 
+void unregisterApi(absl::string_view name) {
+  registry_.erase(name);
+}
+
 } // namespace External
 } // namespace Api
 } // namespace Envoy

--- a/mobile/library/common/api/external.cc
+++ b/mobile/library/common/api/external.cc
@@ -32,9 +32,7 @@ void* retrieveApi(absl::string_view name, bool allow_absent) {
   return api;
 }
 
-void unregisterApi(absl::string_view name) {
-  registry_.erase(name);
-}
+void unregisterApi(absl::string_view name) { registry_.erase(name); }
 
 } // namespace External
 } // namespace Api

--- a/mobile/library/common/api/external.h
+++ b/mobile/library/common/api/external.h
@@ -18,6 +18,11 @@ void registerApi(std::string&& name, void* api);
  */
 void* retrieveApi(absl::string_view name, bool allow_absent = false);
 
+/**
+ * Unregister an external runtime API.
+ */
+void unregisterApi(absl::string_view name);
+
 } // namespace External
 } // namespace Api
 } // namespace Envoy

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -141,6 +141,7 @@ envoy_cc_test_with_engine_builder(
     repository = "@envoy",
     deps = [
         ":xds_integration_test_lib",
+        "//library/common/api:external_api_lib",
         "@envoy//test/test_common:environment_lib",
         "@envoy//test/test_common:test_runtime_lib",
         "@envoy//test/test_common:utility_lib",

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -10,6 +10,7 @@
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
+#include "library/common/api/external.h"
 #include "gtest/gtest.h"
 
 using testing::Ge;
@@ -43,6 +44,11 @@ public:
   }
 
   void SetUp() override {}
+
+  void TearDown() override {
+    Api::External::unregisterApi("envoy_proxy_resolver");
+    XdsIntegrationTest::TearDown();
+  }
 
   void runReloadTest() {
     initialize();


### PR DESCRIPTION
 * Added `unregisterApi` to external.h and external.cc to allow removing APIs in the global registry.
 * Used `unregisterApi` in `RtdsIntegrationTest::TearDown` to clean up "envoy_proxy_resolver" between test runs. With the `RtdsReloadWithWorkerThread` test, depending on the options used, "envoy_proxy_resolver" will be registered in the global registry on some test runs and linger on for the `RtdsReloadWithWorkerThread` where it should *not* be registered, causing the test to fail.