### PR TITLE
Update QUICHE from f129e801d to 6460010e2

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-05-14"
+  release_date: "2026-05-18"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "f129e801d183fd095620d3bd68f8119ca9d5c0ea",
-        sha256 = "f70ab89a950bb46f239c29e7e9757b3ce3082403a65e9e1920ccd2cf3fcedbeb",
+        version = "6460010e28a23919ce1f6db92d9fa125ce41fab6",
+        sha256 = "807c62410050395fc8d26eac6454e206490b12ac2e0a98b808a5250e303174d3",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/f129e801d..6460010e2

```
$ git log f129e801d..6460010e2 --date=short --no-merges --format="%ad %al %s"

2026-05-18 martinduke Factor PublishedSubscription out of MoqtSession, into SubscriptionPublisher.
2026-05-18 martinduke Deprecate quic_update_max_datagram.
2026-05-18 haoyuewang Add alpn() & ciphersuite() methods with a default implementation to QuicCryptoStream.
2026-05-17 vasilvv Update ACK timestamp encoding to use Delta Largest Acknowledged rather than Gap.
2026-05-15 wub No public description
2026-05-15 martinduke Create OutgoingFetchStream and factor out OutgoingUniStream as a parent of both data stream types.
2026-05-14 martinduke Cleanup OutgoingSubgroupStream.
2026-05-14 martinduke Refactor: Move OutgoingDataStream to a separate file and make the interfaces with PublishedSubscription explicit.
```