### PR TITLE
mcp_router: add server-to-client request handling (elicitation)

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -70,6 +70,8 @@ areas:
     title: load_report
   logging:
     title: logging
+  mcp_router:
+    title: mcp_router
   mysql_proxy:
     title: mysql_proxy
   network_ext_proc:

--- a/changelogs/current/new_features/mcp_router__elicitation-support.rst
+++ b/changelogs/current/new_features/mcp_router__elicitation-support.rst
@@ -1,0 +1,4 @@
+Added elicitation support to the MCP router filter. The gateway now transparently handles
+server-to-client requests (``elicitation/create``, ``sampling/createMessage``, ``roots/list``)
+by rewriting JSON-RPC ``id`` fields for correct routing in multiplexing mode and forwarding
+client responses back to the originating backend.

--- a/docs/root/configuration/advanced/well_known_dynamic_metadata.rst
+++ b/docs/root/configuration/advanced/well_known_dynamic_metadata.rst
@@ -39,8 +39,8 @@ The :ref:`MCP filter <config_http_filters_mcp>` emits the following dynamic meta
   :header: Name, Type, Description
   :widths: 1, 1, 4
 
-  method, string, "The JSON-RPC method name (e.g., ``initialize``, ``tools/list``, ``tools/call``)."
-  id, number, "The JSON-RPC request ID."
+  method, string, "The JSON-RPC method name (e.g., ``initialize``, ``tools/list``, ``tools/call``). For JSON-RPC responses (containing ``result`` or ``error``), this is set to ``__jsonrpc_response``."
+  id, number/string, "The JSON-RPC request ID. Numeric for standard requests; string for server response routing (e.g., ``time__42``)."
   params, struct, "The params object from the JSON-RPC request containing method-specific parameters."
 
 This metadata is consumed internally by the :ref:`MCP router filter <config_http_filters_mcp_router>` for

--- a/docs/root/configuration/http/http_filters/mcp_router_filter.rst
+++ b/docs/root/configuration/http/http_filters/mcp_router_filter.rst
@@ -42,6 +42,31 @@ backend session map. Each backend is then initialized on-demand when a request f
 
 This is useful when some backends are slow or unreliable and should not block client initialization.
 
+.. _config_http_filters_mcp_router_server_requests:
+
+Server-to-client requests
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MCP protocol allows backend servers to send requests to clients mid-stream. This includes
+``elicitation/create`` (requesting additional input from the user), ``sampling/createMessage``
+(requesting LLM completions), and ``roots/list`` (querying available roots).
+
+The MCP router handles these transparently:
+
+1. When a backend sends a server-to-client request via SSE, the gateway forwards it to the client.
+   In multiplexing mode (multiple backends), the JSON-RPC ``id`` field is rewritten to include the
+   backend name as a prefix (e.g., ``42`` becomes ``"time__42"``), enabling correct routing of the
+   client's response.
+
+2. When the client sends a JSON-RPC response back, the gateway parses the prefixed ``id`` to
+   determine which backend should receive the response, restores the original ``id`` value, and
+   forwards the response to that backend.
+
+In single-backend mode, no ``id`` rewriting is performed since there is only one possible target.
+
+No configuration is required. The gateway advertises ``elicitation`` capability to clients
+automatically and handles the request/response routing based on the client's declared capabilities.
+
 .. _config_http_filters_mcp_router_statistics:
 
 Statistics

--- a/source/extensions/filters/common/mcp/constants.h
+++ b/source/extensions/filters/common/mcp/constants.h
@@ -89,6 +89,9 @@ constexpr absl::string_view SAMPLING_CREATE_MESSAGE = "sampling/createMessage";
 // Utility
 constexpr absl::string_view PING = "ping";
 
+// Synthetic method for JSON-RPC responses (no "method" field).
+constexpr absl::string_view JSONRPC_RESPONSE = "__jsonrpc_response";
+
 // Notification prefix
 constexpr absl::string_view NOTIFICATION_PREFIX = "notifications/";
 

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -383,6 +383,13 @@ Http::FilterDataStatus McpFilter::completeParsing() {
 
   Protobuf::Struct metadata = parser_->metadata();
 
+  // For JSON-RPC responses (no method field), set a synthetic method so the
+  // router can identify and dispatch them.
+  if (is_mcp_request_ && parser_->isResponse()) {
+    (*metadata.mutable_fields())["method"].set_string_value(
+        std::string(Filters::Common::Mcp::McpConstants::Methods::JSONRPC_RESPONSE));
+  }
+
   const std::string& group_metadata_key = config_->parserConfig().groupMetadataKey();
   if (!group_metadata_key.empty()) {
     std::string method_group = config_->parserConfig().getMethodGroup(parser_->getMethod());

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -274,6 +274,21 @@ McpFieldExtractor* McpFieldExtractor::StartObject(absl::string_view name) {
     if (depth_ == 2 && name == "params") {
       params_depth_ = depth_;
     }
+
+    // Detect "result" or "error" objects at top level (JSON-RPC responses).
+    if (depth_ == 2) {
+      if (name == "result") {
+        has_result_ = true;
+        if (has_jsonrpc_) {
+          is_valid_mcp_ = true;
+        }
+      } else if (name == "error") {
+        has_error_ = true;
+        if (has_jsonrpc_) {
+          is_valid_mcp_ = true;
+        }
+      }
+    }
   }
 
   // Push a new key set for tracking duplicate keys within this object scope
@@ -392,11 +407,16 @@ McpFieldExtractor* McpFieldExtractor::RenderString(absl::string_view name,
   std::string full_path = buildFullPath(name);
   ENVOY_LOG_MISC(debug, "render string name {} path {}, value {}", name, full_path, value);
 
-  // Check top-level fields for method detection
+  // Check top-level fields for method/response detection
   if (depth_ == 1) {
     if (name == JSONRPC_FIELD && value == JSONRPC_VERSION) {
       has_jsonrpc_ = true;
-      if (has_method_) {
+      if (has_method_ || has_result_ || has_error_) {
+        is_valid_mcp_ = true;
+      }
+    } else if (name == RESULT_FIELD) {
+      has_result_ = true;
+      if (has_jsonrpc_) {
         is_valid_mcp_ = true;
       }
     } else if (name == METHOD_FIELD) {
@@ -563,9 +583,18 @@ bool McpFieldExtractor::requiredFieldsCollected() const {
     if (is_notification_ && field == "id") {
       continue;
     }
+    // Responses don't have a "method" field.
+    if (!has_method_ && (has_result_ || has_error_) && field == "method") {
+      continue;
+    }
     if (collected_fields_.count(field) == 0) {
       return false;
     }
+  }
+
+  // Responses have no method-specific required fields.
+  if (!has_method_ && (has_result_ || has_error_)) {
+    return true;
   }
 
   for (const auto& field : required_fields_) {
@@ -578,9 +607,17 @@ bool McpFieldExtractor::requiredFieldsCollected() const {
 }
 
 void McpFieldExtractor::finalizeExtraction() {
-  if (!has_jsonrpc_ || !has_method_) {
+  if (!has_jsonrpc_ || (!has_method_ && !has_result_ && !has_error_)) {
     ENVOY_LOG(debug, "not a valid MCP message");
     is_valid_mcp_ = false;
+    return;
+  }
+
+  if (!has_method_) {
+    // JSON-RPC response: copy only always-extract fields (jsonrpc, id).
+    for (const auto& field : config_.getAlwaysExtract()) {
+      copyFieldByPath(field);
+    }
     return;
   }
 
@@ -600,8 +637,11 @@ bool McpFieldExtractor::hasOptionalFields() {
 }
 
 bool McpFieldExtractor::hasAllRequiredFields() {
-  if (!has_jsonrpc_ || !has_method_) {
+  if (!has_jsonrpc_ || (!has_method_ && !has_result_ && !has_error_)) {
     return false;
+  }
+  if (!has_method_ && (has_result_ || has_error_)) {
+    return requiredFieldsCollected();
   }
   updateFieldRequirements();
   return requiredFieldsCollected();
@@ -719,6 +759,8 @@ absl::Status McpJsonParser::finishParse() {
 }
 
 bool McpJsonParser::isValidMcpRequest() const { return extractor_ && extractor_->isValidMcp(); }
+
+bool McpJsonParser::isResponse() const { return extractor_ && extractor_->isResponse(); }
 
 bool McpJsonParser::hasOptionalFields() { return extractor_ && extractor_->hasOptionalFields(); }
 

--- a/source/extensions/filters/http/mcp/mcp_json_parser.h
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.h
@@ -143,6 +143,7 @@ public:
 
   // MCP validation getters
   bool isValidMcp() const { return is_valid_mcp_; }
+  bool isResponse() const { return has_result_ || has_error_; }
   const std::string& getMethod() const { return method_; }
 
 private:
@@ -191,6 +192,8 @@ private:
   bool is_valid_mcp_{false};
   bool has_jsonrpc_{false};
   bool has_method_{false};
+  bool has_result_{false};
+  bool has_error_{false};
 
   // Parsing completion state
   bool can_stop_parsing_{false};
@@ -247,6 +250,9 @@ public:
 
   // Check if all required fields have been collected
   bool hasAllRequiredFields();
+
+  // Check if this is a JSON-RPC response (has result/error, no method).
+  bool isResponse() const;
 
   // Get the method string
   const std::string& getMethod() const;

--- a/source/extensions/filters/http/mcp_router/mcp_router.cc
+++ b/source/extensions/filters/http/mcp_router/mcp_router.cc
@@ -55,24 +55,24 @@ using McpMethodMap = absl::flat_hash_map<absl::string_view, McpMethod>;
 
 const McpMethodMap& mcpMethodMap() {
   CONSTRUCT_ON_FIRST_USE(
-      McpMethodMap,
-      {{"initialize", McpMethod::Initialize},
-       {"tools/list", McpMethod::ToolsList},
-       {"tools/call", McpMethod::ToolsCall},
-       {"resources/list", McpMethod::ResourcesList},
-       {"resources/read", McpMethod::ResourcesRead},
-       {"resources/subscribe", McpMethod::ResourcesSubscribe},
-       {"resources/unsubscribe", McpMethod::ResourcesUnsubscribe},
-       {"resources/templates/list", McpMethod::ResourcesTemplatesList},
-       {"prompts/list", McpMethod::PromptsList},
-       {"prompts/get", McpMethod::PromptsGet},
-       {"completion/complete", McpMethod::CompletionComplete},
-       {"logging/setLevel", McpMethod::LoggingSetLevel},
-       {"ping", McpMethod::Ping},
-       // Notifications (client -> server).
-       {"notifications/initialized", McpMethod::NotificationInitialized},
-       {"notifications/cancelled", McpMethod::NotificationCancelled},
-       {"notifications/roots/list_changed", McpMethod::NotificationRootsListChanged}});
+      McpMethodMap, {{"initialize", McpMethod::Initialize},
+                     {"tools/list", McpMethod::ToolsList},
+                     {"tools/call", McpMethod::ToolsCall},
+                     {"resources/list", McpMethod::ResourcesList},
+                     {"resources/read", McpMethod::ResourcesRead},
+                     {"resources/subscribe", McpMethod::ResourcesSubscribe},
+                     {"resources/unsubscribe", McpMethod::ResourcesUnsubscribe},
+                     {"resources/templates/list", McpMethod::ResourcesTemplatesList},
+                     {"prompts/list", McpMethod::PromptsList},
+                     {"prompts/get", McpMethod::PromptsGet},
+                     {"completion/complete", McpMethod::CompletionComplete},
+                     {"logging/setLevel", McpMethod::LoggingSetLevel},
+                     {"ping", McpMethod::Ping},
+                     // Notifications (client -> server).
+                     {"notifications/initialized", McpMethod::NotificationInitialized},
+                     {"notifications/cancelled", McpMethod::NotificationCancelled},
+                     {"notifications/roots/list_changed", McpMethod::NotificationRootsListChanged},
+                     {"__jsonrpc_response", McpMethod::ServerResponse}});
 }
 
 McpMethod parseMethodString(absl::string_view method_str) {
@@ -235,6 +235,10 @@ Http::FilterDataStatus McpRouterFilter::decodeData(Buffer::Instance& data, bool 
       handleNotification("notifications/roots/list_changed");
       break;
 
+    case McpMethod::ServerResponse:
+      handleServerResponse();
+      break;
+
     default:
       config_->stats().rq_invalid_.inc();
       sendHttpError(400, "Unsupported method");
@@ -262,6 +266,8 @@ Http::FilterDataStatus McpRouterFilter::decodeData(Buffer::Instance& data, bool 
         rewritePromptsGetBody(data);
       } else if (method_ == McpMethod::CompletionComplete) {
         rewriteCompletionCompleteBody(data);
+      } else if (method_ == McpMethod::ServerResponse) {
+        rewriteServerResponseId(data);
       }
       needs_body_rewrite_ = false;
     }
@@ -306,10 +312,14 @@ bool McpRouterFilter::readMetadataFromMcpFilter() {
     return false;
   }
 
-  // Extract request ID.
+  // Extract request ID (numeric for requests, string for server responses).
   auto id_it = fields.find("id");
-  if (id_it != fields.end() && id_it->second.has_number_value()) {
-    request_id_ = static_cast<int64_t>(id_it->second.number_value());
+  if (id_it != fields.end()) {
+    if (id_it->second.has_number_value()) {
+      request_id_ = static_cast<int64_t>(id_it->second.number_value());
+    } else if (id_it->second.has_string_value()) {
+      server_response_id_ = id_it->second.string_value();
+    }
   }
 
   // Extract method-specific parameters from metadata.
@@ -594,6 +604,53 @@ ssize_t McpRouterFilter::rewriteCompletionCompleteBody(Buffer::Instance& buffer)
   return 0;
 }
 
+std::pair<std::string, std::string>
+McpRouterFilter::parseServerResponseId(const std::string& prefixed_id) {
+  if (!config_->isMultiplexing()) {
+    return {config_->defaultBackendName(), prefixed_id};
+  }
+
+  size_t pos = prefixed_id.find(kNameDelimiter);
+  if (pos == std::string::npos) {
+    if (!config_->defaultBackendName().empty()) {
+      return {config_->defaultBackendName(), prefixed_id};
+    }
+    return {"", prefixed_id};
+  }
+
+  std::string backend = prefixed_id.substr(0, pos);
+  std::string original_id = prefixed_id.substr(pos + kNameDelimiter.size());
+
+  if (config_->findBackend(backend) != nullptr) {
+    return {backend, original_id};
+  }
+
+  return {"", prefixed_id};
+}
+
+ssize_t McpRouterFilter::rewriteServerResponseId(Buffer::Instance& buffer) {
+  if (server_response_id_.empty() || server_response_id_ == original_response_id_) {
+    return 0;
+  }
+
+  // The prefixed ID is a quoted string in the JSON body: "id":"time__42".
+  // We need to replace it with the original ID, restoring numeric type if possible.
+  std::string search_str = absl::StrCat("\"", server_response_id_, "\"");
+  ssize_t pos = buffer.search(search_str.data(), search_str.size(), 0);
+  if (pos < 0) {
+    return 0;
+  }
+
+  // If the original ID is all digits, output as unquoted number to restore type.
+  bool is_numeric = !original_response_id_.empty() &&
+                    std::all_of(original_response_id_.begin(), original_response_id_.end(),
+                                [](char c) { return c >= '0' && c <= '9'; });
+  std::string replacement =
+      is_numeric ? original_response_id_ : absl::StrCat("\"", original_response_id_, "\"");
+
+  return rewriteAtPosition(buffer, pos, search_str, replacement);
+}
+
 ssize_t McpRouterFilter::rewriteAtPosition(Buffer::Instance& buffer, ssize_t pos,
                                            const std::string& search_str,
                                            const std::string& replacement) {
@@ -812,14 +869,49 @@ void McpRouterFilter::pushSseEvent(const std::string& backend_name, const std::s
     sse_headers_sent_ = true;
   }
 
-  // TODO(botengyao): Transform server-to-client request IDs for proper routing.
-  // For ServerRequest events (roots/list, sampling/createMessage), the ID needs to be
-  // prefixed with backend_name so client responses can be routed back correctly.
+  std::string modified_data = event_data;
+
+  // For ServerRequest events in multiplexing mode, prefix the ID with backend name
+  // so client responses can be routed back to the correct backend.
+  if (event_type == SseMessageType::ServerRequest && config_->isMultiplexing()) {
+    auto parsed_or = Json::Factory::loadFromString(event_data);
+    if (parsed_or.ok()) {
+      // Build the old and new ID value strings, then search for "id":<old>
+      // (with optional space after colon).
+      std::string old_val;
+      std::string new_val;
+      auto id_int_or = (*parsed_or)->getInteger("id");
+      if (id_int_or.ok()) {
+        old_val = std::to_string(*id_int_or);
+        new_val = absl::StrCat("\"", backend_name, kNameDelimiter, old_val, "\"");
+      } else {
+        auto id_str_or = (*parsed_or)->getString("id");
+        if (id_str_or.ok()) {
+          old_val = absl::StrCat("\"", *id_str_or, "\"");
+          new_val = absl::StrCat("\"", backend_name, kNameDelimiter, *id_str_or, "\"");
+        }
+      }
+      if (!old_val.empty()) {
+        // Try "id":VALUE then "id": VALUE (with space).
+        std::string search = absl::StrCat("\"id\":", old_val);
+        std::string replace = absl::StrCat("\"id\":", new_val);
+        size_t pos = modified_data.find(search);
+        if (pos == std::string::npos) {
+          search = absl::StrCat("\"id\": ", old_val);
+          replace = absl::StrCat("\"id\": ", new_val);
+          pos = modified_data.find(search);
+        }
+        if (pos != std::string::npos) {
+          modified_data.replace(pos, search.size(), replace);
+        }
+      }
+    }
+  }
 
   // Format and send the SSE event to client.
   Buffer::OwnedImpl buffer;
   buffer.add("event: message\ndata: ");
-  buffer.add(event_data);
+  buffer.add(modified_data);
   buffer.add("\n\n");
   decoder_callbacks_->encodeData(buffer, false);
 }
@@ -1484,6 +1576,43 @@ void McpRouterFilter::handleLoggingSetLevel() {
   start_logging();
 }
 
+void McpRouterFilter::handleServerResponse() {
+  auto [backend_name, original_id] = parseServerResponseId(server_response_id_);
+
+  if (backend_name.empty()) {
+    config_->stats().rq_unknown_backend_.inc();
+    sendHttpError(400, fmt::format("Invalid server response ID '{}': cannot determine backend",
+                                   server_response_id_));
+    return;
+  }
+
+  const McpBackendConfig* backend = config_->findBackend(backend_name);
+  if (!backend) {
+    config_->stats().rq_unknown_backend_.inc();
+    sendHttpError(400, fmt::format("Unknown backend '{}' in response ID", backend_name));
+    return;
+  }
+
+  original_response_id_ = original_id;
+  needs_body_rewrite_ = (server_response_id_ != original_response_id_);
+
+  ENVOY_LOG(debug, "server_response: backend='{}', id='{}' -> '{}', needs_rewrite={}", backend_name,
+            server_response_id_, original_id, needs_body_rewrite_);
+
+  initializeSingleBackend(*backend, [weak_self = weak_from_this()](BackendResponse resp) {
+    auto self = weak_self.lock();
+    if (!self) {
+      return;
+    }
+    if (resp.success) {
+      self->sendJsonResponse(resp.body, self->encoded_session_id_);
+    } else {
+      self->config_->stats().rq_backend_failure_.inc();
+      self->sendHttpError(500, resp.error.empty() ? "Backend request failed" : resp.error);
+    }
+  });
+}
+
 // Response aggregation helpers.
 
 std::string McpRouterFilter::extractJsonRpcFromResponse(const BackendResponse& response) {
@@ -1513,7 +1642,7 @@ std::string McpRouterFilter::aggregateInitialize(const std::vector<BackendRespon
   return absl::StrCat(
       R"({"jsonrpc":"2.0","id":)", request_id_, R"(,"result":{)", R"("protocolVersion":")",
       kProtocolVersion, R"(",)",
-      R"("capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true},"resources":{"listChanged":true,"subscribe":true}},)",
+      R"("capabilities":{"tools":{"listChanged":true},"prompts":{"listChanged":true},"resources":{"listChanged":true,"subscribe":true},"elicitation":{}},)",
       R"("serverInfo":{"name":")", kGatewayName, R"(","version":")", kGatewayVersion, R"("},)",
       R"("instructions":"MCP gateway aggregating multiple backend servers.")", R"(}})");
 }
@@ -1883,6 +2012,16 @@ McpRouterFilter::createUpstreamHeaders(const McpBackendConfig& backend,
             size_delta = static_cast<int64_t>(rewritten_uri_.size()) -
                          static_cast<int64_t>(resource_uri_.size());
           }
+        } else if (method_ == McpMethod::ServerResponse) {
+          // Server response ID rewriting: "time__42" -> 42 (or "42").
+          std::string quoted_id = absl::StrCat("\"", server_response_id_, "\"");
+          bool is_numeric = !original_response_id_.empty() &&
+                            std::all_of(original_response_id_.begin(), original_response_id_.end(),
+                                        [](char c) { return c >= '0' && c <= '9'; });
+          std::string replacement =
+              is_numeric ? original_response_id_ : absl::StrCat("\"", original_response_id_, "\"");
+          size_delta =
+              static_cast<int64_t>(replacement.size()) - static_cast<int64_t>(quoted_id.size());
         }
         int64_t new_length = static_cast<int64_t>(original_length) + size_delta;
         headers->setContentLength(new_length);

--- a/source/extensions/filters/http/mcp_router/mcp_router.h
+++ b/source/extensions/filters/http/mcp_router/mcp_router.h
@@ -42,6 +42,8 @@ enum class McpMethod {
   NotificationInitialized,
   NotificationCancelled,
   NotificationRootsListChanged,
+  // Client response to a server-to-client request (elicitation, sampling, roots).
+  ServerResponse,
 };
 
 McpMethod parseMethodString(absl::string_view method_str);
@@ -86,6 +88,7 @@ private:
   std::pair<std::string, std::string> parseToolName(const std::string& prefixed_name);
   std::pair<std::string, std::string> parseResourceUri(const std::string& uri);
   std::pair<std::string, std::string> parsePromptName(const std::string& prefixed_name);
+  std::pair<std::string, std::string> parseServerResponseId(const std::string& prefixed_id);
 
   // Rewrites the tool name in the buffer. Returns the size delta (new_size - old_size).
   ssize_t rewriteToolCallBody(Buffer::Instance& buffer);
@@ -95,6 +98,8 @@ private:
   ssize_t rewritePromptsGetBody(Buffer::Instance& buffer);
   // Rewrites the completion ref (prompt name or resource URI) in the buffer.
   ssize_t rewriteCompletionCompleteBody(Buffer::Instance& buffer);
+  // Rewrites the server response ID (strips backend prefix) in the buffer.
+  ssize_t rewriteServerResponseId(Buffer::Instance& buffer);
   // Helper to replace content at a position in the buffer, and return the delta.
   ssize_t rewriteAtPosition(Buffer::Instance& buffer, ssize_t pos, const std::string& search_str,
                             const std::string& replacement);
@@ -121,6 +126,7 @@ private:
   // Completion & logging.
   void handleCompletionComplete();
   void handleLoggingSetLevel();
+  void handleServerResponse();
 
   // Response aggregation.
   std::string aggregateInitialize(const std::vector<BackendResponse>& responses);
@@ -181,6 +187,8 @@ private:
   std::string prompt_name_;          // Original prefixed prompt name (e.g., "time__greeting")
   std::string unprefixed_prompt_name_; // Unprefixed prompt name for backend (e.g., "greeting")
   std::string completion_ref_type_;    // Completion reference type: "ref/prompt" or "ref/resource"
+  std::string server_response_id_;     // Prefixed ID from client response (e.g., "time__42")
+  std::string original_response_id_;   // Original ID after stripping prefix (e.g., "42")
   bool needs_body_rewrite_{false};     // Whether tool/prompt name or URI rewriting is needed
 
   std::string route_name_{"default"};

--- a/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
@@ -1825,6 +1825,64 @@ TEST(McpParserConfigTest, DefaultSecuritySettings) {
   EXPECT_FALSE(config.rejectDuplicateKeys());
 }
 
+TEST_F(McpJsonParserTest, ValidJsonRpcResponse) {
+  std::string json =
+      R"({"jsonrpc":"2.0","id":1,"result":{"action":"accept","content":{"name":"test"}}})";
+
+  EXPECT_OK(parser_->parse(json));
+  ASSERT_TRUE(parser_->finishParse().ok());
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_TRUE(parser_->isResponse());
+  EXPECT_EQ(parser_->getMethod(), "");
+}
+
+TEST_F(McpJsonParserTest, ValidJsonRpcErrorResponse) {
+  std::string json =
+      R"({"jsonrpc":"2.0","id":1,"error":{"code":-32042,"message":"URL elicitation required"}})";
+
+  EXPECT_OK(parser_->parse(json));
+  ASSERT_TRUE(parser_->finishParse().ok());
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_TRUE(parser_->isResponse());
+  EXPECT_EQ(parser_->getMethod(), "");
+}
+
+TEST_F(McpJsonParserTest, ResponseNotConfusedWithRequest) {
+  std::string json = R"({"jsonrpc":"2.0","id":1,"result":{}})";
+
+  EXPECT_OK(parser_->parse(json));
+  ASSERT_TRUE(parser_->finishParse().ok());
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_TRUE(parser_->isResponse());
+
+  const auto& metadata = parser_->metadata();
+  auto id_it = metadata.fields().find("id");
+  ASSERT_NE(id_it, metadata.fields().end());
+  EXPECT_EQ(id_it->second.number_value(), 1);
+}
+
+TEST_F(McpJsonParserTest, ResponseWithStringResult) {
+  std::string json = R"({"jsonrpc":"2.0","id":1,"result":"ok"})";
+
+  EXPECT_OK(parser_->parse(json));
+  ASSERT_TRUE(parser_->finishParse().ok());
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_TRUE(parser_->isResponse());
+}
+
+TEST_F(McpJsonParserTest, NoMethodNoResultInvalid) {
+  std::string json = R"({"jsonrpc":"2.0","id":1})";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_FALSE(parser_->isValidMcpRequest());
+  EXPECT_FALSE(parser_->isResponse());
+}
+
 } // namespace
 } // namespace Mcp
 } // namespace HttpFilters

--- a/test/extensions/filters/http/mcp_router/mcp_router_sse_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_sse_test.cc
@@ -284,6 +284,13 @@ TEST_F(BackendStreamCallbacksSseTest, SetsBackendName) {
   EXPECT_EQ(received_response.backend_name, "my_backend");
 }
 
+// Verifies elicitation/create is classified as ServerRequest.
+TEST_F(ClassifyMessageTest, ClassifiesElicitationCreate) {
+  std::string data =
+      R"({"jsonrpc":"2.0","id":123,"method":"elicitation/create","params":{"message":"Enter credentials"}})";
+  EXPECT_EQ(classifyMessage(data, 1), SseMessageType::ServerRequest);
+}
+
 } // namespace
 } // namespace McpRouter
 } // namespace HttpFilters

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -471,7 +471,7 @@ protected:
       std::vector<Http::AsyncClient::StreamCallbacks*>& http_callbacks,
       std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>>& http_streams) {
     factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
-        {"test_cluster", "time_cluster", "calc_cluster"});
+        {"test_cluster", "time_cluster", "calc_cluster", "tools_cluster"});
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_
                     .async_client_,
                 start(_, _))
@@ -2144,6 +2144,163 @@ TEST(AggregateToolsListTest, IconsArrayPreserved) {
   auto icons = (*parsed)->getObjectArray("icons");
   ASSERT_TRUE(icons.ok());
   EXPECT_EQ(icons->size(), 2);
+}
+
+// Verifies __jsonrpc_response maps to McpMethod::ServerResponse.
+TEST(ParseMethodStringTest, ServerResponse) {
+  EXPECT_EQ(parseMethodString("__jsonrpc_response"), McpMethod::ServerResponse);
+}
+
+// Verifies initialize response includes elicitation capability.
+TEST_F(McpRouterFilterTest, GatewayCapabilitiesIncludeElicitation) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  proto_config.set_lazy_initialization(true);
+  auto* server = proto_config.add_servers();
+  server->set_name("test");
+  server->mutable_mcp_cluster()->set_cluster("test_cluster");
+
+  setMcpMethodMetadata("initialize");
+
+  auto config = createConfig(proto_config);
+  McpRouterFilter filter(config);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+
+  std::string response_body;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true))
+      .WillOnce(
+          testing::Invoke([&](Buffer::Instance& data, bool) { response_body = data.toString(); }));
+
+  filter.decodeHeaders(headers, false);
+  const std::string body =
+      R"({"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter.decodeData(buffer, true);
+
+  EXPECT_THAT(response_body, testing::HasSubstr("\"elicitation\":{}"));
+}
+
+// Verifies server response routes to the correct backend based on prefixed ID.
+TEST_F(McpRouterFilterTest, HandleServerResponseRoutesToBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server1 = proto_config.add_servers();
+  server1->set_name("time");
+  server1->mutable_mcp_cluster()->set_cluster("time_cluster");
+  auto* server2 = proto_config.add_servers();
+  server2->set_name("calc");
+  server2->mutable_mcp_cluster()->set_cluster("calc_cluster");
+
+  // Set metadata for a server response with prefixed ID.
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("__jsonrpc_response");
+  (*mcp_metadata.mutable_fields())["id"].set_string_value("time__42");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+  filter->decodeHeaders(headers, false);
+
+  const std::string body =
+      R"({"jsonrpc":"2.0","id":"time__42","result":{"action":"accept","content":{"name":"test"}}})";
+  Buffer::OwnedImpl buffer(body);
+
+  std::string forwarded_body;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true))
+      .WillOnce(
+          testing::Invoke([&](Buffer::Instance& data, bool) { forwarded_body = data.toString(); }));
+
+  filter->decodeData(buffer, true);
+
+  ASSERT_EQ(http_callbacks.size(), 1);
+
+  simulateBackendResponse(http_callbacks[0], R"({"jsonrpc":"2.0","id":42,"result":{}})");
+
+  EXPECT_FALSE(forwarded_body.empty());
+}
+
+// Verifies server response with invalid prefix returns error.
+TEST_F(McpRouterFilterTest, HandleServerResponseInvalidId) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("time");
+  server->mutable_mcp_cluster()->set_cluster("time_cluster");
+  auto* server2 = proto_config.add_servers();
+  server2->set_name("calc");
+  server2->mutable_mcp_cluster()->set_cluster("calc_cluster");
+
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("__jsonrpc_response");
+  (*mcp_metadata.mutable_fields())["id"].set_string_value("unknown__42");
+
+  auto config = createConfig(proto_config);
+  McpRouterFilter filter(config);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+  filter.decodeHeaders(headers, false);
+
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
+      .WillOnce(testing::Invoke([](Http::ResponseHeaderMap& headers, bool) {
+        EXPECT_EQ("400", headers.getStatusValue());
+      }));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+
+  const std::string body = R"({"jsonrpc":"2.0","id":"unknown__42","result":{"action":"accept"}})";
+  Buffer::OwnedImpl buffer(body);
+  filter.decodeData(buffer, true);
+}
+
+// Verifies single-backend mode routes server responses without prefix parsing.
+TEST_F(McpRouterFilterTest, HandleServerResponseSingleBackend) {
+  envoy::extensions::filters::http::mcp_router::v3::McpRouter proto_config;
+  auto* server = proto_config.add_servers();
+  server->set_name("tools");
+  server->mutable_mcp_cluster()->set_cluster("tools_cluster");
+
+  auto& mcp_metadata = (*dynamic_metadata_.mutable_filter_metadata())["envoy.filters.http.mcp"];
+  (*mcp_metadata.mutable_fields())["method"].set_string_value("__jsonrpc_response");
+  (*mcp_metadata.mutable_fields())["id"].set_string_value("42");
+
+  auto config = createConfig(proto_config);
+
+  std::vector<Http::AsyncClient::StreamCallbacks*> http_callbacks;
+  std::vector<std::unique_ptr<NiceMock<Http::MockAsyncClientStream>>> http_streams;
+  setupMockAsyncClient(http_callbacks, http_streams);
+
+  auto filter = std::make_shared<McpRouterFilter>(config);
+  filter->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/mcp"}, {"content-type", "application/json"}};
+  filter->decodeHeaders(headers, false);
+
+  const std::string body = R"({"jsonrpc":"2.0","id":"42","result":{"action":"accept"}})";
+  Buffer::OwnedImpl buffer(body);
+
+  std::string forwarded_body;
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _));
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true))
+      .WillOnce(
+          testing::Invoke([&](Buffer::Instance& data, bool) { forwarded_body = data.toString(); }));
+
+  filter->decodeData(buffer, true);
+
+  ASSERT_EQ(http_callbacks.size(), 1);
+  simulateBackendResponse(http_callbacks[0], R"({"jsonrpc":"2.0","id":42,"result":{}})");
+  EXPECT_FALSE(forwarded_body.empty());
 }
 
 } // namespace


### PR DESCRIPTION
Enable the MCP router to transparently handle server-to-client requests such as elicitation/create, sampling/createMessage, and roots/list.

In multiplexing mode, JSON-RPC id fields in server requests are rewritten with a backend name prefix so that client responses can be routed back to the originating backend. The MCP JSON parser is extended to accept JSON-RPC responses (result/error) alongside requests (method).
