### PR TITLE
ci: restrict Slack failure notifications to the main envoy repo

### DIFF
--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -465,7 +465,11 @@ jobs:
         ENVOY_PUBLISH_DRY_RUN: ${{ (fromJSON(inputs.request).request.version.dev || ! inputs.trusted) && 1 || '' }}
 
     - name: Notify Slack on failure
-      if: ${{ steps.ci-run.outputs.exit-code != 0 && inputs.slack-channel != '' && github.event.workflow_run.event == 'push' }}
+      if: >-
+        ${{ steps.ci-run.outputs.exit-code != 0
+            && inputs.slack-channel != ''
+            && github.event.workflow_run.event == 'push'
+            && github.repository == 'envoyproxy/envoy' }}
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       env:
         JOB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -466,10 +466,10 @@ jobs:
 
     - name: Notify Slack on failure
       if: >-
-        ${{ steps.ci-run.outputs.exit-code != 0
-            && inputs.slack-channel != ''
-            && github.event.workflow_run.event == 'push'
-            && github.repository == 'envoyproxy/envoy' }}
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.slack-channel != ''
+        && github.event.workflow_run.event == 'push'
+        && github.repository == 'envoyproxy/envoy'
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
       env:
         JOB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Only send Slack notifications on the envoyproxy/envoy repository, preventing forks and variants from triggering notifications.
