### PR TITLE
filter_state: remove StateType param from all test calls

### DIFF
--- a/test/common/common/execution_context_test.cc
+++ b/test/common/common/execution_context_test.cc
@@ -76,7 +76,6 @@ public:
     stream_info_.filter_state_ = std::make_shared<StreamInfo::FilterStateImpl>(
         StreamInfo::FilterState::LifeSpan::Connection);
     stream_info_.filter_state_->setData(kConnectionExecutionContextFilterStateName, context_,
-                                        StreamInfo::FilterState::StateType::ReadOnly,
                                         StreamInfo::FilterState::LifeSpan::Connection);
   }
 

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -3769,22 +3769,17 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
   StreamInfo::MockStreamInfo stream_info;
 
   stream_info.filter_state_->setData("key",
-                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"));
   stream_info.filter_state_->setData("key-struct",
-                                     std::make_unique<TestSerializedStructFilterState>(),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<TestSerializedStructFilterState>());
   stream_info.filter_state_->setData("key-no-serialization",
-                                     std::make_unique<StreamInfo::FilterState::Object>(),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<StreamInfo::FilterState::Object>());
 
   stream_info.filter_state_->setData(
       "key-serialization-error",
-      std::make_unique<TestSerializedStructFilterState>(std::chrono::seconds(-281474976710656)),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      std::make_unique<TestSerializedStructFilterState>(std::chrono::seconds(-281474976710656)));
   stream_info.filter_state_->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   {
@@ -4828,11 +4823,9 @@ TEST(SubstitutionFormatterTest, JsonFormatterFilterStateTest) {
   StreamInfo::MockStreamInfo stream_info;
 
   stream_info.filter_state_->setData("test_key",
-                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"));
   stream_info.filter_state_->setData("test_obj",
-                                     std::make_unique<TestSerializedStructFilterState>(),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<TestSerializedStructFilterState>());
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   const std::string expected_json_map = R"EOF(
@@ -4861,8 +4854,7 @@ TEST(SubstitutionFormatterTest, FilterStateSpeciferTest) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   stream_info.filter_state_->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
   stream_info.upstream_info_->setUpstreamFilterState(
       stream_info.filter_state_); // Reuse the same filter state for test only.
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
@@ -4898,8 +4890,7 @@ TEST(SubstitutionFormatterTest, FilterStateErrorSpeciferTest) {
   StreamInfo::MockStreamInfo stream_info;
 
   stream_info.filter_state_->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
 
   // 'ABCDE' is error specifier.
   Protobuf::Struct key_mapping;
@@ -5167,11 +5158,9 @@ TEST(SubstitutionFormatterTest, CompositeFormatterSuccess) {
     EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
     stream_info.filter_state_->setData("testing",
                                        std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("serialized",
                                        std::make_unique<TestSerializedUnknownFilterState>(),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     const std::string format = "%FILTER_STATE(testing)%|%FILTER_STATE(serialized)%|"
                                "%FILTER_STATE(testing):8%|%FILTER_STATE(nonexisting)%";

--- a/test/common/http/conn_manager_impl_test_3.cc
+++ b/test/common/http/conn_manager_impl_test_3.cc
@@ -1669,8 +1669,7 @@ private:
 
 TEST_F(HttpConnectionManagerImplTest, ConnectionFilterState) {
   filter_callbacks_.connection_.stream_info_.filter_state_->setData(
-      "connection_provided_data", std::make_shared<SimpleType>(555),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "connection_provided_data", std::make_shared<SimpleType>(555));
 
   setup(SetupOpts().setTracing(false));
   setupFilterChain(1, 0, /* num_requests = */ 3);
@@ -1690,15 +1689,12 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionFilterState) {
         .WillOnce(Invoke([this](HeaderMap&, bool) -> FilterHeadersStatus {
           decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_filter_chain", std::make_unique<SimpleType>(1),
-              StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::FilterChain);
           decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_downstream_request", std::make_unique<SimpleType>(2),
-              StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::Request);
           decoder_filters_[0]->callbacks_->streamInfo().filterState()->setData(
               "per_downstream_connection", std::make_unique<SimpleType>(3),
-              StreamInfo::FilterState::StateType::ReadOnly,
               StreamInfo::FilterState::LifeSpan::Connection);
           return FilterHeadersStatus::StopIteration;
         }));

--- a/test/common/http/matching/inputs_test.cc
+++ b/test/common/http/matching/inputs_test.cc
@@ -184,9 +184,9 @@ TEST(MatchingData, FilterStateInput) {
     EXPECT_EQ(result.stringData(), absl::nullopt);
   }
 
-  stream_info.filterState()->setData(
-      "unknown_key", std::make_shared<Router::StringAccessorImpl>("some_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info.filterState()->setData("unknown_key",
+                                     std::make_shared<Router::StringAccessorImpl>("some_value"),
+                                     StreamInfo::FilterState::LifeSpan::Connection);
 
   {
     Network::Matching::FilterStateInput<HttpMatchingData> input("filter_state_key");
@@ -197,7 +197,7 @@ TEST(MatchingData, FilterStateInput) {
 
   stream_info.filterState()->setData(
       "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   {
     Network::Matching::FilterStateInput<HttpMatchingData> input("filter_state_key");

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -4214,17 +4214,17 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithFilterStateM
   auto filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
   EXPECT_EQ(filter_chain, nullptr);
 
-  stream_info_.filterState()->setData(
-      "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData("unknown_key",
+                                      std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Filter state set to a non-matching key - no match.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
   EXPECT_EQ(filter_chain, nullptr);
 
-  stream_info_.filterState()->setData(
-      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData("filter_state_key",
+                                      std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Filter state set to a matching key but unknown value - no match.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
@@ -4232,7 +4232,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, SingleFilterChainWithFilterStateM
 
   stream_info_.filterState()->setData(
       "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Known filter state key and matching value - using 1st filter chain.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
@@ -5363,18 +5363,18 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithFilterSta
   ASSERT_NE(filter_chain, nullptr);
   EXPECT_EQ(filter_chain->name(), "foo");
 
-  stream_info_.filterState()->setData(
-      "unknown_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData("unknown_key",
+                                      std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Filter state set to a non-matching key - no match.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
   ASSERT_NE(filter_chain, nullptr);
   EXPECT_EQ(filter_chain->name(), "foo");
 
-  stream_info_.filterState()->setData(
-      "filter_state_key", std::make_shared<Router::StringAccessorImpl>("unknown_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+  stream_info_.filterState()->setData("filter_state_key",
+                                      std::make_shared<Router::StringAccessorImpl>("unknown_value"),
+                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Filter state set to a matching key but unknown value - no match.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);
@@ -5383,7 +5383,7 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleFilterChainsWithFilterSta
 
   stream_info_.filterState()->setData(
       "filter_state_key", std::make_shared<Router::StringAccessorImpl>("filter_state_value"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Known filter state key and matching value - using 1st filter chain.
   filter_chain = findFilterChain(1234, "127.0.0.1", "", "", {}, "8.8.8.8", 111);

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -579,9 +579,9 @@ virtual_hosts:
     EXPECT_EQ("http://bat4.com/new_path", redirect->newUri(headers));
   }
 
-  stream_info.filterState()->setData(
-      Router::OriginalConnectPort::key(), std::make_unique<Router::OriginalConnectPort>(10),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Request);
+  stream_info.filterState()->setData(Router::OriginalConnectPort::key(),
+                                     std::make_unique<Router::OriginalConnectPort>(10),
+                                     StreamInfo::FilterState::LifeSpan::Request);
   // Port addition for CONNECT without port
   {
     Http::TestRequestHeaderMapImpl headers =
@@ -1370,7 +1370,6 @@ virtual_hosts:
     auto address_obj = std::make_unique<Network::Address::InstanceAccessor>(
         Envoy::Network::Utility::parseInternetAddressNoThrow("10.0.0.1", 443, false));
     stream_info.filterState()->setData("envoy.address", std::move(address_obj),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::Request);
     EXPECT_EQ("filter_state_cluster",
               config.route(genHeaders("foo.com", "/", "GET"), stream_info, 0)
@@ -2479,7 +2478,6 @@ protected:
         std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
             Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
     filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                          StreamInfo::FilterState::StateType::ReadOnly,
                           StreamInfo::FilterState::LifeSpan::FilterChain);
     ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
     ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
@@ -3650,13 +3648,10 @@ public:
       : filter_state_(std::make_shared<StreamInfo::FilterStateImpl>(
             StreamInfo::FilterState::LifeSpan::FilterChain)) {
 
-    filter_state_->setData("null-value", nullptr, StreamInfo::FilterState::StateType::ReadOnly,
-                           StreamInfo::FilterState::LifeSpan::FilterChain);
+    filter_state_->setData("null-value", nullptr, StreamInfo::FilterState::LifeSpan::FilterChain);
     filter_state_->setData("nonhashable", std::make_unique<NonHashable>(),
-                           StreamInfo::FilterState::StateType::ReadOnly,
                            StreamInfo::FilterState::LifeSpan::FilterChain);
     filter_state_->setData("hashable", std::make_unique<HashableObj>(),
-                           StreamInfo::FilterState::StateType::ReadOnly,
                            StreamInfo::FilterState::LifeSpan::FilterChain);
   }
   class NonHashable : public StreamInfo::FilterState::Object {};

--- a/test/common/router/header_formatter_test.cc
+++ b/test/common/router/header_formatter_test.cc
@@ -199,7 +199,6 @@ TEST(HeaderParserTest, TestParse) {
       std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
           Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
   filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                        StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
   ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
@@ -616,7 +615,6 @@ request_headers_to_remove: ["x-nope"]
       std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
           Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
   filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                        StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
   ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
@@ -1084,7 +1082,6 @@ response_headers_to_remove: ["x-baz-header"]
       std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
           Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
   filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                        StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
   ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));
@@ -1129,7 +1126,6 @@ response_headers_to_remove: ["x-baz-header"]
       std::make_shared<Envoy::StreamInfo::FilterStateImpl>(
           Envoy::StreamInfo::FilterState::LifeSpan::FilterChain));
   filter_state->setData("testing", std::make_unique<StringAccessorImpl>("test_value"),
-                        StreamInfo::FilterState::StateType::ReadOnly,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
   ON_CALL(stream_info, filterState()).WillByDefault(ReturnRef(filter_state));
   ON_CALL(Const(stream_info), filterState()).WillByDefault(ReturnRef(*filter_state));

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -190,7 +190,6 @@ public:
       // tls_inspector by using the LifeSpan::Connection
       stream_info.filterState()->setData(Network::UpstreamServerName::key(),
                                          std::make_unique<Network::UpstreamServerName>(pre_set_sni),
-                                         StreamInfo::FilterState::StateType::Mutable,
                                          pre_set_life_span);
     }
     expectResponseTimerCreate();
@@ -1572,7 +1571,6 @@ TEST_F(RouterTest, EnvoyAttemptCountInResponseWithRetries) {
 TEST_F(RouterTest, AllDebugConfig) {
   auto debug_config = DebugConfigFactory().createFromBytes("true");
   callbacks_.streamInfo().filterState()->setData(DebugConfig::key(), std::move(debug_config),
-                                                 StreamInfo::FilterState::StateType::ReadOnly,
                                                  StreamInfo::FilterState::LifeSpan::FilterChain);
   cm_.thread_local_cluster_.conn_pool_.host_->hostname_ = "scooby.doo";
 
@@ -6616,7 +6614,7 @@ TEST_F(RouterTest, PropagatesUpstreamFilterState) {
 
   upstream_stream_info_.filterState()->setData(
       "upstream data", std::make_unique<StreamInfo::UInt32AccessorImpl>(123),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
   expectResponseTimerCreate();
   expectNewStreamWithImmediateEncoder(encoder, &response_decoder, Http::Protocol::Http10);
 
@@ -7694,7 +7692,7 @@ TEST_F(RouterTest, RedirectRecords) {
   router_->downstream_connection_.stream_info_.filterState()->setData(
       Network::UpstreamSocketOptionsFilterState::key(),
       std::make_unique<Network::UpstreamSocketOptionsFilterState>(),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
   router_->downstream_connection_.stream_info_.filterState()
       ->getDataMutable<Network::UpstreamSocketOptionsFilterState>(
           Network::UpstreamSocketOptionsFilterState::key())
@@ -7721,7 +7719,7 @@ TEST_F(RouterTest, ApplicationProtocols) {
   callbacks_.streamInfo().filterState()->setData(
       Network::ApplicationProtocols::key(),
       std::make_unique<Network::ApplicationProtocols>(std::vector<std::string>{"foo", "bar"}),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+      StreamInfo::FilterState::LifeSpan::FilterChain);
 
   EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, _, _, _))
       .WillOnce(Invoke([&](Upstream::HostConstSharedPtr, Upstream::ResourcePriority,
@@ -7958,7 +7956,7 @@ TEST_F(RouterTest, Http3DisabledForHttp11Proxies) {
   callbacks_.stream_info_.filterState()->setData(
       Network::Http11ProxyInfoFilterState::key(),
       std::make_unique<Network::Http11ProxyInfoFilterState>(hostname, address),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+      StreamInfo::FilterState::LifeSpan::FilterChain);
   testRequestResponse(true, false);
 }
 

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -191,7 +191,7 @@ void RouterTestBase::setNumPreviousRedirect(uint32_t num_previous_redirects) {
   callbacks_.streamInfo().filterState()->setData(
       "num_internal_redirects",
       std::make_shared<StreamInfo::UInt32AccessorImpl>(num_previous_redirects),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Request);
+      StreamInfo::FilterState::LifeSpan::Request);
 }
 
 void RouterTestBase::setIncludeAttemptCountInRequest(bool include) {

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -67,7 +67,7 @@ TEST_F(FilterStateImplTest, Simple) {
   size_t destruction_count = 0u;
   filterState().setData(
       "test_name", std::make_unique<TestStoredTypeTracking>(5, &access_count, &destruction_count),
-      FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
+      FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(0u, access_count);
   EXPECT_EQ(0u, destruction_count);
 
@@ -85,7 +85,7 @@ TEST_F(FilterStateImplTest, SharedPointerAccessor) {
   size_t destruction_count = 0u;
   filterState().setData(
       "test_name", std::make_shared<TestStoredTypeTracking>(5, &access_count, &destruction_count),
-      FilterState::StateType::Mutable, FilterState::LifeSpan::FilterChain);
+      FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(0u, access_count);
   EXPECT_EQ(0u, destruction_count);
 
@@ -113,11 +113,11 @@ TEST_F(FilterStateImplTest, SameTypes) {
   filterState().setData(
       "test_1",
       std::make_unique<TestStoredTypeTracking>(ValueOne, &access_count_1, &destruction_count),
-      FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
+      FilterState::LifeSpan::FilterChain);
   filterState().setData(
       "test_2",
       std::make_unique<TestStoredTypeTracking>(ValueTwo, &access_count_2, &destruction_count),
-      FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
+      FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(0u, access_count_1);
   EXPECT_EQ(0u, access_count_2);
   EXPECT_EQ(0u, destruction_count);
@@ -133,9 +133,9 @@ TEST_F(FilterStateImplTest, SameTypes) {
 }
 
 TEST_F(FilterStateImplTest, SimpleTypeReadOnly) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::ReadOnly,
+  filterState().setData("test_2", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
 
   EXPECT_EQ(1, filterState().getDataReadOnly<SimpleType>("test_1")->access());
@@ -143,9 +143,9 @@ TEST_F(FilterStateImplTest, SimpleTypeReadOnly) {
 }
 
 TEST_F(FilterStateImplTest, SimpleTypeMutable) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::Mutable,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
 
   EXPECT_EQ(1, filterState().getDataReadOnly<SimpleType>("test_1")->access());
@@ -161,17 +161,17 @@ TEST_F(FilterStateImplTest, NoNameConflictMutableAndMutable) {
   // Mutable data can be overwritten by another mutable data of same or different type.
 
   // mutable + mutable - same type
-  filterState().setData("test_2", std::make_unique<SimpleType>(3), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(3),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(4), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(4),
                         FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(4, filterState().getDataMutable<SimpleType>("test_2")->access());
 
   // mutable + mutable - different types
-  filterState().setData("test_4", std::make_unique<SimpleType>(7), FilterState::StateType::Mutable,
+  filterState().setData("test_4", std::make_unique<SimpleType>(7),
                         FilterState::LifeSpan::FilterChain);
   filterState().setData("test_4", std::make_unique<TestStoredTypeTracking>(8, nullptr, nullptr),
-                        FilterState::StateType::Mutable, FilterState::LifeSpan::FilterChain);
+                        FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(8, filterState().getDataReadOnly<TestStoredTypeTracking>("test_4")->access());
 }
 
@@ -183,7 +183,7 @@ TEST_F(FilterStateImplTest, UnknownName) {
 
 TEST_F(FilterStateImplTest, WrongTypeGet) {
   filterState().setData("test_name", std::make_unique<TestStoredTypeTracking>(5, nullptr, nullptr),
-                        FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
+                        FilterState::LifeSpan::FilterChain);
   EXPECT_EQ(5, filterState().getDataReadOnly<TestStoredTypeTracking>("test_name")->access());
   EXPECT_EQ(nullptr, filterState().getDataReadOnly<SimpleType>("test_name"));
 }
@@ -199,21 +199,19 @@ class C : public B {};
 } // namespace
 
 TEST_F(FilterStateImplTest, FungibleInheritance) {
-  filterState().setData("testB", std::make_unique<B>(), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::FilterChain);
+  filterState().setData("testB", std::make_unique<B>(), FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filterState().hasData<B>("testB"));
   EXPECT_TRUE(filterState().hasData<A>("testB"));
   EXPECT_FALSE(filterState().hasData<C>("testB"));
 
-  filterState().setData("testC", std::make_unique<C>(), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::FilterChain);
+  filterState().setData("testC", std::make_unique<C>(), FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filterState().hasData<B>("testC"));
   EXPECT_TRUE(filterState().hasData<A>("testC"));
   EXPECT_TRUE(filterState().hasData<C>("testC"));
 }
 
 TEST_F(FilterStateImplTest, HasData) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filterState().hasData<SimpleType>("test_1"));
   EXPECT_FALSE(filterState().hasData<SimpleType>("test_2"));
@@ -224,17 +222,15 @@ TEST_F(FilterStateImplTest, HasData) {
 }
 
 TEST_F(FilterStateImplTest, LifeSpanInitFromParent) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::StateType::Mutable,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_5", std::make_unique<SimpleType>(5), FilterState::StateType::ReadOnly,
+  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::LifeSpan::Request);
+  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::LifeSpan::Request);
+  filterState().setData("test_5", std::make_unique<SimpleType>(5),
                         FilterState::LifeSpan::Connection);
-  filterState().setData("test_6", std::make_unique<SimpleType>(6), FilterState::StateType::Mutable,
+  filterState().setData("test_6", std::make_unique<SimpleType>(6),
                         FilterState::LifeSpan::Connection);
 
   FilterStateImpl new_filter_state(filterState().parent(), FilterState::LifeSpan::FilterChain);
@@ -251,17 +247,15 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromParent) {
 }
 
 TEST_F(FilterStateImplTest, LifeSpanInitFromGrandparent) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::StateType::Mutable,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_5", std::make_unique<SimpleType>(5), FilterState::StateType::ReadOnly,
+  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::LifeSpan::Request);
+  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::LifeSpan::Request);
+  filterState().setData("test_5", std::make_unique<SimpleType>(5),
                         FilterState::LifeSpan::Connection);
-  filterState().setData("test_6", std::make_unique<SimpleType>(6), FilterState::StateType::Mutable,
+  filterState().setData("test_6", std::make_unique<SimpleType>(6),
                         FilterState::LifeSpan::Connection);
 
   FilterStateImpl new_filter_state(filterState().parent()->parent(),
@@ -277,17 +271,15 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromGrandparent) {
 }
 
 TEST_F(FilterStateImplTest, LifeSpanInitFromNonParent) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::StateType::Mutable,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("test_5", std::make_unique<SimpleType>(5), FilterState::StateType::ReadOnly,
+  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::LifeSpan::Request);
+  filterState().setData("test_4", std::make_unique<SimpleType>(4), FilterState::LifeSpan::Request);
+  filterState().setData("test_5", std::make_unique<SimpleType>(5),
                         FilterState::LifeSpan::Connection);
-  filterState().setData("test_6", std::make_unique<SimpleType>(6), FilterState::StateType::Mutable,
+  filterState().setData("test_6", std::make_unique<SimpleType>(6),
                         FilterState::LifeSpan::Connection);
 
   FilterStateImpl new_filter_state(filterState().parent(), FilterState::LifeSpan::Request);
@@ -301,23 +293,20 @@ TEST_F(FilterStateImplTest, LifeSpanInitFromNonParent) {
 
 TEST_F(FilterStateImplTest, SharedWithUpstream) {
   auto shared = std::make_shared<SimpleType>(1);
-  filterState().setData("shared_1", shared, FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::FilterChain,
+  filterState().setData("shared_1", shared, FilterState::LifeSpan::FilterChain,
                         StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
-  filterState().setData("test_2", std::make_shared<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_2", std::make_shared<SimpleType>(2),
                         FilterState::LifeSpan::FilterChain);
-  filterState().setData("test_3", std::make_shared<SimpleType>(3), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::Request);
-  filterState().setData("shared_4", std::make_shared<SimpleType>(4),
-                        FilterState::StateType::Mutable, FilterState::LifeSpan::Request,
+  filterState().setData("test_3", std::make_shared<SimpleType>(3), FilterState::LifeSpan::Request);
+  filterState().setData("shared_4", std::make_shared<SimpleType>(4), FilterState::LifeSpan::Request,
                         StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   filterState().setData("shared_5", std::make_shared<SimpleType>(5),
-                        FilterState::StateType::ReadOnly, FilterState::LifeSpan::Connection,
+                        FilterState::LifeSpan::Connection,
                         StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
-  filterState().setData("test_6", std::make_shared<SimpleType>(6), FilterState::StateType::Mutable,
+  filterState().setData("test_6", std::make_shared<SimpleType>(6),
                         FilterState::LifeSpan::Connection);
   filterState().setData("shared_7", std::make_shared<SimpleType>(7),
-                        FilterState::StateType::ReadOnly, FilterState::LifeSpan::Connection,
+                        FilterState::LifeSpan::Connection,
                         StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce);
   auto objects = filterState().objectsSharedWithUpstreamConnection();
   EXPECT_EQ(objects->size(), 4);
@@ -338,19 +327,18 @@ TEST_F(FilterStateImplTest, SharedWithUpstream) {
 }
 
 TEST_F(FilterStateImplTest, HasDataAtOrAboveLifeSpan) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::ReadOnly,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);
   EXPECT_TRUE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::FilterChain));
   EXPECT_FALSE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::Request));
   EXPECT_FALSE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::Connection));
 
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::ReadOnly,
-                        FilterState::LifeSpan::Request);
+  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::LifeSpan::Request);
   EXPECT_TRUE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::FilterChain));
   EXPECT_TRUE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::Request));
   EXPECT_FALSE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::Connection));
 
-  filterState().setData("test_3", std::make_unique<SimpleType>(3), FilterState::StateType::ReadOnly,
+  filterState().setData("test_3", std::make_unique<SimpleType>(3),
                         FilterState::LifeSpan::Connection);
   EXPECT_TRUE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::FilterChain));
   EXPECT_TRUE(filterState().hasDataAtOrAboveLifeSpan(FilterState::LifeSpan::Request));
@@ -358,44 +346,38 @@ TEST_F(FilterStateImplTest, HasDataAtOrAboveLifeSpan) {
 }
 
 TEST_F(FilterStateImplTest, SetSameDataWithDifferentLifeSpan) {
-  filterState().setData("test_1", std::make_unique<SimpleType>(1), FilterState::StateType::Mutable,
+  filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::Connection);
   // Test reset on smaller LifeSpan
   EXPECT_ENVOY_BUG(filterState().setData("test_1", std::make_unique<SimpleType>(2),
-                                         FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::FilterChain),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
                    "conflicting life_span on the same data_name: test_1.");
   Assert::resetEnvoyBugCountersForTest();
   EXPECT_ENVOY_BUG(filterState().setData("test_1", std::make_unique<SimpleType>(2),
-                                         FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::Request),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
                    "conflicting life_span on the same data_name: test_1.");
 
   // Still mutable on the correct LifeSpan.
-  filterState().setData("test_1", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
+  filterState().setData("test_1", std::make_unique<SimpleType>(2),
                         FilterState::LifeSpan::Connection);
   EXPECT_EQ(2, filterState().getDataMutable<SimpleType>("test_1")->access());
 
-  filterState().setData("test_2", std::make_unique<SimpleType>(1), FilterState::StateType::Mutable,
-                        FilterState::LifeSpan::Request);
+  filterState().setData("test_2", std::make_unique<SimpleType>(1), FilterState::LifeSpan::Request);
   // Test reset on smaller and greater LifeSpan
   EXPECT_ENVOY_BUG(filterState().setData("test_2", std::make_unique<SimpleType>(2),
-                                         FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::FilterChain),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
                    "conflicting life_span on the same data_name: test_2.");
   Assert::resetEnvoyBugCountersForTest();
   EXPECT_ENVOY_BUG(filterState().setData("test_2", std::make_unique<SimpleType>(2),
-                                         FilterState::StateType::Mutable,
                                          FilterState::LifeSpan::Connection),
                    "FilterStateAccessViolation: FilterState::setData<T> called twice with "
                    "conflicting life_span on the same data_name: test_2.");
 
   // Still mutable on the correct LifeSpan.
-  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::StateType::Mutable,
-                        FilterState::LifeSpan::Request);
+  filterState().setData("test_2", std::make_unique<SimpleType>(2), FilterState::LifeSpan::Request);
   EXPECT_EQ(2, filterState().getDataMutable<SimpleType>("test_2")->access());
 }
 

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -342,7 +342,6 @@ TEST_F(StreamInfoImplTest, MiscSettersAndGetters) {
     EXPECT_EQ(route.get(), stream_info.route().ptr());
 
     stream_info.filterState()->setData("test", std::make_unique<TestIntAccessor>(1),
-                                       FilterState::StateType::ReadOnly,
                                        FilterState::LifeSpan::FilterChain);
     EXPECT_EQ(1, stream_info.filterState()->getDataReadOnly<TestIntAccessor>("test")->access());
 
@@ -445,7 +444,7 @@ TEST_F(StreamInfoImplTest, SetFrom) {
   s1.route_ = std::make_shared<NiceMock<Router::MockRoute>>();
   s1.setDynamicMetadata("com.test", MessageUtil::keyValueStruct("test_key", "test_value"));
   s1.filterState()->setData("test", std::make_unique<TestIntAccessor>(1),
-                            FilterState::StateType::ReadOnly, FilterState::LifeSpan::FilterChain);
+                            FilterState::LifeSpan::FilterChain);
   Http::TestRequestHeaderMapImpl headers1;
   s1.setRequestHeaders(headers1);
   Upstream::ClusterInfoConstSharedPtr cluster_info(new NiceMock<Upstream::MockClusterInfo>());

--- a/test/common/tcp_proxy/config_test.cc
+++ b/test/common/tcp_proxy/config_test.cc
@@ -713,7 +713,7 @@ TEST(ConfigTest, PerConnectionClusterWithTopLevelMetadataMatchConfig) {
   NiceMock<Network::MockConnection> connection;
   connection.stream_info_.filterState()->setData(
       "envoy.tcp_proxy.cluster", std::make_unique<PerConnectionCluster>("filter_state_cluster"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   const auto route = config_obj.getRouteFromEntries(connection);
   EXPECT_NE(nullptr, route);
@@ -1003,7 +1003,6 @@ TEST_F(TcpProxyHashingTest, HashWithFilterState) {
   {
     initializeFilter();
     connection_.stream_info_.filter_state_->setData("foo", std::make_unique<HashableObj>(),
-                                                    StreamInfo::FilterState::StateType::ReadOnly,
                                                     StreamInfo::FilterState::LifeSpan::FilterChain);
     EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
                 tcpConnPool(_, _, _))

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -101,7 +101,6 @@ public:
     filter_callbacks_.connection().streamInfo().filterState()->setData(
         TcpProxy::ReceiveBeforeConnectKey,
         std::make_unique<StreamInfo::BoolAccessorImpl>(receive_before_connect),
-        StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::Connection);
 
     // Create and initialize filter.
@@ -175,7 +174,6 @@ public:
         filter_callbacks_.connection_.streamInfo().filterState()->setData(
             Network::UpstreamSocketOptionsFilterState::key(),
             std::make_unique<Network::UpstreamSocketOptionsFilterState>(),
-            StreamInfo::FilterState::StateType::Mutable,
             StreamInfo::FilterState::LifeSpan::Connection);
         filter_callbacks_.connection_.streamInfo()
             .filterState()
@@ -188,7 +186,6 @@ public:
       filter_callbacks_.connection().streamInfo().filterState()->setData(
           TcpProxy::ReceiveBeforeConnectKey,
           std::make_unique<StreamInfo::BoolAccessorImpl>(receive_before_connect),
-          StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::Connection);
 
       filter_ = std::make_unique<Filter>(config_,
@@ -1487,7 +1484,7 @@ TEST_P(TcpProxyTest, IdleTimeoutWithFilterStateOverride) {
   filter_callbacks_.connection_.streamInfo().filterState()->setData(
       TcpProxy::PerConnectionIdleTimeoutMs,
       std::make_unique<StreamInfo::UInt64AccessorImpl>(idle_timeout_override),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   Event::MockTimer* idle_timer = new Event::MockTimer(&filter_callbacks_.connection_.dispatcher_);
   EXPECT_CALL(*idle_timer, enableTimer(std::chrono::milliseconds(idle_timeout_override), _));
@@ -1972,7 +1969,7 @@ TEST_P(TcpProxyTest, ShareFilterState) {
 
   upstream_connections_.at(0)->streamInfo().filterState()->setData(
       "envoy.tcp_proxy.cluster", std::make_unique<PerConnectionCluster>("filter_state_cluster"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
   raiseEventUpstreamConnected(0);
   EXPECT_EQ("filter_state_cluster",
             filter_callbacks_.connection_.streamInfo()
@@ -2563,7 +2560,7 @@ TEST_P(TcpProxyTest, SetDynamicTLVWithFilterState) {
   // Set filter state on the connection streamInfo.
   filter_callbacks_.connection_.stream_info_.filter_state_->setData(
       "test.key", std::make_unique<Router::StringAccessorImpl>("filter_state_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
@@ -3009,7 +3006,6 @@ public:
     filter_callbacks_.connection().streamInfo().filterState()->setData(
         TcpProxy::ReceiveBeforeConnectKey,
         std::make_unique<StreamInfo::BoolAccessorImpl>(receive_before_connect),
-        StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::Connection);
 
     // Create and initialize filter.
@@ -3098,7 +3094,7 @@ TEST_P(TcpProxyTlsHandshakeTest,
   filter_callbacks_.connection_.stream_info_.filter_state_->setData(
       Envoy::TcpProxy::PerConnectionCluster::key(),
       std::make_shared<Envoy::TcpProxy::PerConnectionCluster>("state_fake_cluster"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   // Set up connection pool expectations for when TLS handshake completes.
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
@@ -3402,7 +3398,7 @@ TEST_P(TcpProxyTest, DelayRouteSelectionAllowsFilterStateChanges) {
   filter_callbacks_.connection_.stream_info_.filter_state_->setData(
       Envoy::TcpProxy::PerConnectionCluster::key(),
       std::make_shared<Envoy::TcpProxy::PerConnectionCluster>("state_fake_cluster"),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _, _))
@@ -3528,7 +3524,7 @@ TEST_P(TcpProxyTest, MergeWithDownstreamTlvsWithDownstreamState) {
           Network::ProxyProtocolDataWithVersion{
               {downstream_src_addr, downstream_dst_addr, downstream_tlvs},
               Network::ProxyProtocolVersion::V2}),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
@@ -3583,7 +3579,7 @@ TEST_P(TcpProxyTest, MergeWithDownstreamTlvsPrecedence) {
           Network::ProxyProtocolDataWithVersion{
               {downstream_src_addr, downstream_dst_addr, downstream_tlvs},
               Network::ProxyProtocolVersion::V2}),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
@@ -3629,7 +3625,7 @@ TEST_P(TcpProxyTest, NoMergeWithDownstreamTlvsWhenDisabled) {
           Network::ProxyProtocolDataWithVersion{
               {downstream_src_addr, downstream_dst_addr, downstream_tlvs},
               Network::ProxyProtocolVersion::V2}),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
@@ -3678,7 +3674,7 @@ TEST_P(TcpProxyTest, MergeWithDownstreamTlvsWithDynamicTlv) {
           Network::ProxyProtocolDataWithVersion{
               {downstream_src_addr, downstream_dst_addr, downstream_tlvs},
               Network::ProxyProtocolVersion::V2}),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);
@@ -3730,7 +3726,7 @@ TEST_P(TcpProxyTest, AppendToDownstreamTlvsPreservesDuplicates) {
           Network::ProxyProtocolDataWithVersion{
               {downstream_src_addr, downstream_dst_addr, downstream_tlvs},
               Network::ProxyProtocolVersion::V2}),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   setup(1, config);
   raiseEventUpstreamConnected(0);

--- a/test/common/tls/cert_validator/default_validator_integration_test.cc
+++ b/test/common/tls/cert_validator/default_validator_integration_test.cc
@@ -151,8 +151,7 @@ TEST_P(SslCertValidatorIntegrationTest, CertValidationFailedDepthWithTrustRootOn
 class TestSanListenerFilter : public Network::ListenerFilter {
 public:
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
-    cb.filterState().setData("test_san_filter_state", nullptr,
-                             StreamInfo::FilterState::StateType::ReadOnly);
+    cb.filterState().setData("test_san_filter_state", nullptr);
     return Network::FilterStatus::Continue;
   }
   size_t maxReadBytes() const override { return 0; }

--- a/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
+++ b/test/extensions/access_loggers/grpc/grpc_access_log_utils_test.cc
@@ -83,7 +83,6 @@ TEST(UtilityExtractCommonAccessLogPropertiesTest, FilterStateFromDownstream) {
   auto state = std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
   state->setValue("value_from_downstream_peer");
   stream_info.filter_state_->setData("downstream_peer", std::move(state),
-                                     StreamInfo::FilterState::StateType::Mutable,
                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   Formatter::Context formatter_context;
@@ -161,7 +160,6 @@ TEST(UtilityExtractCommonAccessLogPropertiesTest,
       std::make_unique<::Envoy::Extensions::Filters::Common::Expr::CelState>(prototype);
   downstream_state->setValue("value_from_downstream_peer");
   stream_info.filter_state_->setData("same_key", std::move(downstream_state),
-                                     StreamInfo::FilterState::StateType::Mutable,
                                      StreamInfo::FilterState::LifeSpan::Connection);
 
   auto upstream_state =

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -241,14 +241,11 @@ TEST_F(HttpGrpcAccessLogTest, Marshalling) {
     (*stream_info.metadata_.mutable_filter_metadata())["foo"] = Protobuf::Struct();
     stream_info.filter_state_->setData("string_accessor",
                                        std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("uint32_accessor",
                                        std::make_unique<StreamInfo::UInt32AccessorImpl>(42),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("serialized", std::make_unique<TestSerializedFilterState>(),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.onRequestComplete();
 
@@ -811,14 +808,11 @@ response: {}
     (*stream_info.metadata_.mutable_filter_metadata())["foo"] = Protobuf::Struct();
     stream_info.filter_state_->setData("string_accessor",
                                        std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("uint32_accessor",
                                        std::make_unique<StreamInfo::UInt32AccessorImpl>(42),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
     stream_info.filter_state_->setData("serialized", std::make_unique<TestSerializedFilterState>(),
-                                       StreamInfo::FilterState::StateType::ReadOnly,
                                        StreamInfo::FilterState::LifeSpan::FilterChain);
 
     expectLog(R"EOF(

--- a/test/extensions/access_loggers/open_telemetry/otlp_log_utils_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/otlp_log_utils_test.cc
@@ -235,7 +235,7 @@ TEST(OtlpLogUtilsTest, AddFilterStateToAttributesFromDownstream) {
 
   stream_info.filter_state_->setData(
       "downstream_key", std::make_unique<Router::StringAccessorImpl>("downstream_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+      StreamInfo::FilterState::LifeSpan::FilterChain);
 
   std::vector<std::string> filter_state_objects = {"downstream_key"};
   addFilterStateToAttributes(stream_info, filter_state_objects, log_entry);
@@ -274,7 +274,7 @@ TEST(OtlpLogUtilsTest, AddFilterStateToAttributesDownstreamPrecedence) {
   // Add to downstream.
   stream_info.filter_state_->setData(
       "same_key", std::make_unique<Router::StringAccessorImpl>("downstream_wins"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+      StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add to upstream.
   auto upstream_filter_state =

--- a/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/substitution_formatter_test.cc
@@ -653,11 +653,9 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterClusterMetadataNoClusterIn
 TEST(SubstitutionFormatterTest, OpenTelemetryFormatterFilterStateTest) {
   StreamInfo::MockStreamInfo stream_info;
   stream_info.filter_state_->setData("test_key",
-                                     std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<Router::StringAccessorImpl>("test_value"));
   stream_info.filter_state_->setData("test_obj",
-                                     std::make_unique<TestSerializedStructFilterState>(),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+                                     std::make_unique<TestSerializedStructFilterState>());
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   OpenTelemetryFormatMap expected = {{"test_key", "\"test_value\""},
@@ -686,10 +684,8 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateTest) {
   const StreamInfo::FilterStateSharedPtr upstream_filter_state =
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Request);
   upstream_filter_state->setData("test_key",
-                                 std::make_unique<Router::StringAccessorImpl>("test_value"),
-                                 StreamInfo::FilterState::StateType::ReadOnly);
-  upstream_filter_state->setData("test_obj", std::make_unique<TestSerializedStructFilterState>(),
-                                 StreamInfo::FilterState::StateType::ReadOnly);
+                                 std::make_unique<Router::StringAccessorImpl>("test_value"));
+  upstream_filter_state->setData("test_obj", std::make_unique<TestSerializedStructFilterState>());
 
   EXPECT_CALL(stream_info, upstreamInfo()).Times(testing::AtLeast(1));
   // Get pointer to MockUpstreamInfo.
@@ -724,8 +720,7 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateTest) {
 TEST(SubstitutionFormatterTest, OpenTelemetryFormatterFilterStateSpeciferTest) {
   StreamInfo::MockStreamInfo stream_info;
   stream_info.filter_state_->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
   EXPECT_CALL(Const(stream_info), filterState()).Times(testing::AtLeast(1));
 
   OpenTelemetryFormatMap expected = {
@@ -759,8 +754,7 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateSpecife
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Request));
 
   stream_info.upstream_info_->upstreamFilterState()->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
 
   EXPECT_CALL(Const(stream_info), upstreamInfo()).Times(testing::AtLeast(1));
 
@@ -790,8 +784,7 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterFilterStateErrorSpeciferTe
   StreamInfo::MockStreamInfo stream_info;
   std::string body;
   stream_info.filter_state_->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
 
   // 'ABCDE' is error specifier.
   KeyValueList key_mapping;
@@ -821,8 +814,7 @@ TEST(SubstitutionFormatterTest, OpenTelemetryFormatterUpstreamFilterStateErrorSp
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Request));
 
   stream_info.upstream_info_->upstreamFilterState()->setData(
-      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "test_key", std::make_unique<TestSerializedStringFilterState>("test_value"));
 
   // 'ABCDE' is error specifier.
   KeyValueList key_mapping;

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -125,10 +125,10 @@ public:
   Upstream::MockLoadBalancerContext* setFilterStateHostAndReturnContext(const std::string& host) {
     StreamInfo::FilterStateSharedPtr filter_state = lb_context_.requestStreamInfo()->filterState();
 
-    filter_state->setData(
-        "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
-        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
+    filter_state->setData("envoy.upstream.dynamic_host",
+                          std::make_shared<Router::StringAccessorImpl>(host),
+                          StreamInfo::FilterState::LifeSpan::Connection,
+                          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
 
     return &lb_context_;
   }

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -2180,8 +2180,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateBytesNotFound) {
 TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateBytesFound) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filter_state_->setData("k", std::make_unique<Router::StringAccessorImpl>("v"),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("k", std::make_unique<Router::StringAccessorImpl>("v"));
   ON_CALL(context, requestStreamInfo()).WillByDefault(Return(&stream_info));
   auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
   std::string key = "k";
@@ -2240,8 +2239,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateTypedNotFound) {
 TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateTypedNotSerializable) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filter_state_->setData("k", std::make_unique<UnserializableFilterStateObject>(),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("k", std::make_unique<UnserializableFilterStateObject>());
   ON_CALL(context, requestStreamInfo()).WillByDefault(Return(&stream_info));
   auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
   std::string key = "k";
@@ -2255,8 +2253,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateTypedNotSerializable) {
 TEST_F(DynamicModuleClusterTest, LbContextGetFilterStateTypedFound) {
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
-  stream_info.filter_state_->setData("k", std::make_unique<Router::StringAccessorImpl>("typed-v"),
-                                     StreamInfo::FilterState::StateType::ReadOnly);
+  stream_info.filter_state_->setData("k", std::make_unique<Router::StringAccessorImpl>("typed-v"));
   ON_CALL(context, requestStreamInfo()).WillByDefault(Return(&stream_info));
   auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
   std::string key = "k";

--- a/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
+++ b/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
@@ -1067,8 +1067,7 @@ TEST_F(OriginalDstClusterTest, UseFilterState) {
   connection.stream_info_.filterState()->setData(
       Upstream::OriginalDstClusterFilterStateKey,
       std::make_shared<Network::AddressObject>(
-          std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11", 6666)),
-      StreamInfo::FilterState::StateType::ReadOnly);
+          std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11", 6666)));
   TestLoadBalancerContext lb_context1(&connection, Http::Headers::get().EnvoyOriginalDstHost.get(),
                                       "127.0.0.1:5555");
 
@@ -1135,8 +1134,7 @@ TEST_F(OriginalDstClusterTest, UseFilterStateWithPortOverride) {
   connection.stream_info_.filterState()->setData(
       Upstream::OriginalDstClusterFilterStateKey,
       std::make_shared<Network::AddressObject>(
-          std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11", 6666)),
-      StreamInfo::FilterState::StateType::ReadOnly);
+          std::make_shared<Network::Address::Ipv4Instance>("10.10.11.11", 6666)));
   TestLoadBalancerContext lb_context1(&connection, Http::Headers::get().EnvoyOriginalDstHost.get(),
                                       "127.0.0.1:5555");
 

--- a/test/extensions/filters/common/expr/expr_context_speed_test.cc
+++ b/test/extensions/filters/common/expr/expr_context_speed_test.cc
@@ -128,7 +128,7 @@ private:
       std::string key = absl::StrCat("key_", i);
       std::string value = absl::StrCat("value_", i);
       auto accessor = std::make_shared<Router::StringAccessorImpl>(value);
-      info_.filterState()->setData(key, accessor, StreamInfo::FilterState::StateType::ReadOnly);
+      info_.filterState()->setData(key, accessor);
       filter_state_keys_.push_back(key);
     }
   }

--- a/test/extensions/filters/common/set_filter_state/filter_config_test.cc
+++ b/test/extensions/filters/common/set_filter_state/filter_config_test.cc
@@ -131,8 +131,7 @@ TEST_F(ConfigTest, UpdateValue) {
       text_format_source:
         inline_string: "XXX"
   )YAML"});
-  info_.filterState()->setData("foo", std::make_unique<Router::StringAccessorImpl>("OLD"),
-                               StateType::Mutable);
+  info_.filterState()->setData("foo", std::make_unique<Router::StringAccessorImpl>("OLD"));
   update();
   EXPECT_FALSE(info_.filterState()->hasDataAtOrAboveLifeSpan(LifeSpan::Request));
   const auto* foo = info_.filterState()->getDataReadOnly<Router::StringAccessor>("foo");

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -672,7 +672,6 @@ TEST_F(FilterTest, FilterStateShouldBeUpdatedWithTheMatchingAction) {
 
   filter_state->setData(MatchedActionsFilterStateKey,
                         std::make_shared<MatchedActionInfo>("rootFilterName", "oldActionName"),
-                        StreamInfo::FilterState::StateType::Mutable,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Http::FilterFactoryCb factory_callback = [&](Http::FilterChainFactoryCallbacks& cb) {
@@ -703,7 +702,6 @@ TEST_F(FilterTest, MatchingActionShouldNotCollitionWithOtherRootFilter) {
 
   filter_state->setData(MatchedActionsFilterStateKey,
                         std::make_shared<MatchedActionInfo>("otherRootFilterName", "anyActionName"),
-                        StreamInfo::FilterState::StateType::Mutable,
                         StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Http::FilterFactoryCb factory_callback = [&](Http::FilterChainFactoryCallbacks& cb) {

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -629,7 +629,6 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
   const auto pre_address = Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 80);
   filter_state->setData(StreamInfo::UpstreamAddress::key(),
                         std::make_unique<StreamInfo::UpstreamAddress>(pre_address),
-                        StreamInfo::FilterState::StateType::Mutable,
                         StreamInfo::FilterState::LifeSpan::Request);
 
   InSequence s;
@@ -842,7 +841,6 @@ TEST_F(ProxyFilterWithFilterStateHostTest, WithFilterStateHostPresent) {
   const std::string filter_state_host = "filter-state-host.example.com";
   filter_state_->setData("envoy.upstream.dynamic_host",
                          std::make_unique<Router::StringAccessorImpl>(filter_state_host),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Should use the value from filter state, not host header.
@@ -911,7 +909,6 @@ TEST_F(ProxyFilterWithFilterStateHostDisabledTest, DoesNotUseFilterStateWhenFlag
   const std::string filter_state_host = "filter-state-host.example.com";
   filter_state_->setData("envoy.upstream.dynamic_host",
                          std::make_unique<Router::StringAccessorImpl>(filter_state_host),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   ON_CALL(callbacks_, streamInfo()).WillByDefault(ReturnRef(callbacks_.stream_info_));
@@ -949,7 +946,6 @@ TEST_F(ProxyFilterWithFilterStateHostDisabledTest, IgnoresFilterStateHostWhenFla
   const std::string filter_state_host = "filter-state-host.example.com";
   filter_state_->setData("envoy.upstream.dynamic_host",
                          std::make_unique<Router::StringAccessorImpl>(filter_state_host),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Should use host header "foo", not filter state, when the flag is disabled.
@@ -983,7 +979,6 @@ TEST_F(ProxyFilterWithFilterStateHostTest, WithFilterStatePortPresent) {
   constexpr uint32_t filter_state_port = 9999;
   filter_state_->setData("envoy.upstream.dynamic_port",
                          std::make_unique<StreamInfo::UInt32AccessorImpl>(filter_state_port),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Should use "foo" from host header but port from filter state.
@@ -1019,11 +1014,9 @@ TEST_F(ProxyFilterWithFilterStateHostTest, WithFilterStateHostAndPortPresent) {
   constexpr uint32_t filter_state_port = 9999;
   filter_state_->setData("envoy.upstream.dynamic_host",
                          std::make_unique<Router::StringAccessorImpl>(filter_state_host),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
   filter_state_->setData("envoy.upstream.dynamic_port",
                          std::make_unique<StreamInfo::UInt32AccessorImpl>(filter_state_port),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Should use both host and port from filter state.
@@ -1059,11 +1052,9 @@ TEST_F(ProxyFilterWithFilterStateHostDisabledTest, IgnoresFilterStatePortWhenFla
   constexpr uint32_t filter_state_port = 9999;
   filter_state_->setData("envoy.upstream.dynamic_host",
                          std::make_unique<Router::StringAccessorImpl>(filter_state_host),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
   filter_state_->setData("envoy.upstream.dynamic_port",
                          std::make_unique<StreamInfo::UInt32AccessorImpl>(filter_state_port),
-                         StreamInfo::FilterState::StateType::ReadOnly,
                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Should use "foo" from host header and default port 80, ignoring filter state.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -5302,8 +5302,7 @@ TEST_P(EmitFilterStateTest, PreexistingFilterStateDifferentTypeMutable) {
       FilterConfigName,
       // This will not cast to ExtAuthzLoggingInfo, so when the filter tries to
       // getMutableData<ExtAuthzLoggingInfo>(...), it will return nullptr.
-      std::make_shared<TestObject>(), Envoy::StreamInfo::FilterState::StateType::Mutable,
-      Envoy::StreamInfo::FilterState::LifeSpan::Request);
+      std::make_shared<TestObject>(), Envoy::StreamInfo::FilterState::LifeSpan::Request);
 
   Filters::Common::ExtAuthz::Response response{};
   response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
@@ -5323,7 +5322,6 @@ TEST_P(EmitFilterStateTest, PreexistingFilterStateSameTypeMutable) {
       // This will not cast to ExtAuthzLoggingInfo, so when the filter tries to
       // getMutableData<ExtAuthzLoggingInfo>(...), it will return nullptr.
       std::make_shared<ExtAuthzLoggingInfo>(absl::nullopt),
-      Envoy::StreamInfo::FilterState::StateType::Mutable,
       Envoy::StreamInfo::FilterState::LifeSpan::Request);
 
   Filters::Common::ExtAuthz::Response response{};

--- a/test/extensions/filters/http/ext_proc/mapped_attribute_builder_test.cc
+++ b/test/extensions/filters/http/ext_proc/mapped_attribute_builder_test.cc
@@ -92,8 +92,7 @@ TEST_F(MappedAttributeBuilderTest, CelFilterState) {
 
   Http::TestRequestHeaderMapImpl request_headers;
   stream_info_.filter_state_->setData("fs_key",
-                                      std::make_unique<Router::StringAccessorImpl>("fs_value"),
-                                      StreamInfo::FilterState::StateType::ReadOnly);
+                                      std::make_unique<Router::StringAccessorImpl>("fs_value"));
 
   ProcessingRequestModifier::Params params{
       envoy::config::core::v3::TrafficDirection::INBOUND,

--- a/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
+++ b/test/extensions/filters/http/jwt_authn/jwt_authn_fuzz_test.cc
@@ -106,7 +106,6 @@ DEFINE_PROTO_FUZZER(const JwtAuthnFuzzInput& input) {
     if (!rules.name().empty() && !rules.requires_().empty()) {
       filter_callbacks.stream_info_.filter_state_->setData(
           rules.name(), std::make_unique<Router::StringAccessorImpl>(input.filter_state_selector()),
-          StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::FilterChain);
     }
   }

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -1030,9 +1030,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateBasic) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Create a simple string accessor for testing.
-  stream_info.filterState()->setData(
-      "test_key", std::make_shared<Router::StringAccessorImpl>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("test_key",
+                                     std::make_shared<Router::StringAccessorImpl>("test_value"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1100,11 +1100,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetMultipleFilterStateObjects) {
 
   // Add multiple filter state objects.
   stream_info.filterState()->setData("key1", std::make_shared<Router::StringAccessorImpl>("value1"),
-                                     StreamInfo::FilterState::StateType::ReadOnly,
                                      StreamInfo::FilterState::LifeSpan::FilterChain);
 
   stream_info.filterState()->setData("key2", std::make_shared<Router::StringAccessorImpl>("value2"),
-                                     StreamInfo::FilterState::StateType::ReadOnly,
                                      StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
@@ -1143,9 +1141,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateNumericAccessor) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add numeric filter state object.
-  stream_info.filterState()->setData(
-      "numeric_key", std::make_shared<StreamInfo::UInt64AccessorImpl>(12345),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("numeric_key",
+                                     std::make_shared<StreamInfo::UInt64AccessorImpl>(12345),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1181,9 +1179,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateBooleanAccessor) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add boolean filter state object.
-  stream_info.filterState()->setData(
-      "bool_key", std::make_shared<StreamInfo::BoolAccessorImpl>(true),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("bool_key",
+                                     std::make_shared<StreamInfo::BoolAccessorImpl>(true),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1244,9 +1242,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateFieldAccessString) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add field-supporting filter state object.
-  stream_info.filterState()->setData(
-      "field_key", std::make_shared<TestFieldSupportingFilterState>("base_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("field_key",
+                                     std::make_shared<TestFieldSupportingFilterState>("base_value"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1282,9 +1280,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateFieldAccessNumeric) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add field-supporting filter state object.
-  stream_info.filterState()->setData(
-      "field_key", std::make_shared<TestFieldSupportingFilterState>("base_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("field_key",
+                                     std::make_shared<TestFieldSupportingFilterState>("base_value"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1315,9 +1313,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateFieldAccessNonExistent) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add field-supporting filter state object.
-  stream_info.filterState()->setData(
-      "field_key", std::make_shared<TestFieldSupportingFilterState>("base_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("field_key",
+                                     std::make_shared<TestFieldSupportingFilterState>("base_value"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1346,9 +1344,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateFieldAccessNoSupport) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add regular string accessor without field support.
-  stream_info.filterState()->setData(
-      "no_field_key", std::make_shared<Router::StringAccessorImpl>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("no_field_key",
+                                     std::make_shared<Router::StringAccessorImpl>("test_value"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);
@@ -1384,9 +1382,9 @@ TEST_F(LuaStreamInfoWrapperTest, GetFilterStateFieldAccessFallback) {
                                          StreamInfo::FilterState::LifeSpan::FilterChain);
 
   // Add field-supporting filter state object.
-  stream_info.filterState()->setData(
-      "field_key", std::make_shared<TestFieldSupportingFilterState>("test_base"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::FilterChain);
+  stream_info.filterState()->setData("field_key",
+                                     std::make_shared<TestFieldSupportingFilterState>("test_base"),
+                                     StreamInfo::FilterState::LifeSpan::FilterChain);
 
   Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> wrapper(
       StreamInfoWrapper::create(coroutine_->luaState(), stream_info), true);

--- a/test/extensions/filters/http/proto_api_scrubber/integration_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/integration_test.cc
@@ -54,8 +54,7 @@ public:
     const std::string key = kFilterStateLabelKey;
     const std::string value = kFilterStateLabelValue;
     decoder_callbacks_->streamInfo().filterState()->setData(
-        key, std::make_shared<::Envoy::Router::StringAccessorImpl>(value),
-        ::Envoy::StreamInfo::FilterState::StateType::ReadOnly);
+        key, std::make_shared<::Envoy::Router::StringAccessorImpl>(value));
     return ::Envoy::Http::FilterHeadersStatus::Continue;
   }
 };

--- a/test/extensions/filters/http/ratelimit/ratelimit_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_test.cc
@@ -362,8 +362,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithAdditionalHitsAddend) {
   InSequence s;
 
   filter_callbacks_.stream_info_.filter_state_->setData(
-      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(5),
-      StreamInfo::FilterState::StateType::Mutable);
+      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(5));
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))
@@ -410,8 +409,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithAdditionalHitsAddend) {
   testing::Mock::VerifyAndClearExpectations(&vh_rate_limit_);
   filter_callbacks_.stream_info_.filter_state_->setData(
       // Ensures that addend can be set differently than the request path.
-      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(100),
-      StreamInfo::FilterState::StateType::Mutable);
+      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(100));
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
   EXPECT_CALL(vh_rate_limit_, applyOnStreamDone()).WillRepeatedly(Return(true));
   EXPECT_CALL(vh_rate_limit_, populateDescriptors(_, _, _, _))
@@ -432,8 +430,7 @@ TEST_F(HttpRateLimitFilterTest, OkResponseWithHitsAddendFilterState) {
   InSequence s;
 
   filter_callbacks_.stream_info_.filter_state_->setData(
-      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(10),
-      StreamInfo::FilterState::StateType::Mutable);
+      "envoy.ratelimit.hits_addend", std::make_unique<StreamInfo::UInt32AccessorImpl>(10));
   EXPECT_CALL(filter_callbacks_.route_->route_entry_.rate_limit_policy_, getApplicableRateLimit(0));
 
   EXPECT_CALL(route_rate_limit_, populateDescriptors(_, _, _, _))

--- a/test/extensions/filters/http/rbac/rbac_filter_test.cc
+++ b/test/extensions/filters/http/rbac/rbac_filter_test.cc
@@ -1279,7 +1279,7 @@ public:
         std::make_unique<StreamInfo::UpstreamAddress>(
             Envoy::Network::Utility::parseInternetAddressAndPortNoThrow(upstream_ips.back(),
                                                                         false)),
-        StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Request);
+        StreamInfo::FilterState::LifeSpan::Request);
   }
 };
 

--- a/test/extensions/filters/network/geoip/geoip_filter_test.cc
+++ b/test/extensions/filters/network/geoip/geoip_filter_test.cc
@@ -109,7 +109,6 @@ public:
 
   void setFilterStateClientIp(const std::string& key, const std::string& ip) {
     filter_state_->setData(key, std::make_shared<Router::StringAccessorImpl>(ip),
-                           StreamInfo::FilterState::StateType::Mutable,
                            StreamInfo::FilterState::LifeSpan::Connection);
   }
 

--- a/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
+++ b/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
@@ -107,7 +107,6 @@ public:
     if (!value_.empty()) {
       read_callbacks_->connection().streamInfo().filterState()->setData(
           "test_key", std::make_shared<Router::StringAccessorImpl>(value_),
-          StreamInfo::FilterState::StateType::Mutable,
           StreamInfo::FilterState::LifeSpan::Connection);
     }
     return Network::FilterStatus::Continue;

--- a/test/extensions/filters/network/redis_proxy/router_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/router_impl_test.cc
@@ -110,8 +110,7 @@ TEST(PrefixRoutesTest, TestFormatterWithCatchAllRoute) {
       "{%KEY%}-%ENVIRONMENT(ENVOY_TEST_ENV)%-%FILTER_STATE(redisKey)%-{%KEY%}";
 
   stream_info.filterState()->setData(
-      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"));
 
   ON_CALL(filter_callbacks, connection()).WillByDefault(ReturnRef(connection));
   ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(stream_info));
@@ -148,8 +147,7 @@ TEST(PrefixRoutesTest, TestFormatterWithPrefixRoute) {
       "{%KEY%}-%ENVIRONMENT(ENVOY_TEST_ENV)%-%FILTER_STATE(redisKey)%-{%KEY%}";
 
   stream_info.filterState()->setData(
-      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"));
 
   ON_CALL(filter_callbacks, connection()).WillByDefault(ReturnRef(connection));
   ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(stream_info));
@@ -185,8 +183,7 @@ TEST(PrefixRoutesTest, TestFormatterWithPercentInKey) {
       "{%KEY%}-%ENVIRONMENT(ENVOY_TEST_ENV)%-%FILTER_STATE(redisKey)%-{%KEY%}";
 
   stream_info.filterState()->setData(
-      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "redisKey", std::make_unique<Envoy::Router::StringAccessorImpl>("subjectCN"));
 
   ON_CALL(filter_callbacks, connection()).WillByDefault(ReturnRef(connection));
   ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(stream_info));
@@ -220,8 +217,7 @@ TEST(PrefixRoutesTest, TestKeyPrefixFormatterWithMissingFilterState) {
   const std::string format = "%FILTER_STATE(redisKey)%";
 
   stream_info.filterState()->setData(
-      "randomKey", std::make_unique<Envoy::Router::StringAccessorImpl>("test_value"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      "randomKey", std::make_unique<Envoy::Router::StringAccessorImpl>("test_value"));
 
   ON_CALL(filter_callbacks, connection()).WillByDefault(ReturnRef(connection));
   ON_CALL(connection, streamInfo()).WillByDefault(ReturnRef(stream_info));

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_test.cc
@@ -55,13 +55,13 @@ public:
   void setFilterStateHost(const std::string& host) {
     connection_.streamInfo().filterState()->setData(
         "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+        StreamInfo::FilterState::LifeSpan::Connection);
   }
 
   void setFilterStatePort(uint32_t port) {
     connection_.streamInfo().filterState()->setData(
         "envoy.upstream.dynamic_port", std::make_shared<StreamInfo::UInt32AccessorImpl>(port),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+        StreamInfo::FilterState::LifeSpan::Connection);
   }
 
   ~SniDynamicProxyFilterTest() override {
@@ -349,7 +349,7 @@ TEST_F(UpstreamResolvedHostFilterStateHelper, UpdateResolvedHostFilterStateMetad
       StreamInfo::UpstreamAddress::key(),
       std::make_unique<StreamInfo::UpstreamAddress>(
           Network::Utility::parseInternetAddressNoThrow("1.2.3.3", 443)),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   InSequence s;
 

--- a/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/buffer_filter.h
@@ -41,16 +41,14 @@ public:
     read_callbacks_ = &callbacks;
     // Verify that the filter is able to access the stream info.
     callbacks.streamInfo().filterState()->setData(
-        "test.read", std::make_shared<Router::StringAccessorImpl>("val"),
-        Envoy::StreamInfo::FilterState::StateType::Mutable);
+        "test.read", std::make_shared<Router::StringAccessorImpl>("val"));
   }
 
   void initializeWriteFilterCallbacks(WriteFilterCallbacks& callbacks) override {
     write_callbacks_ = &callbacks;
     // Verify that the filter is able to access the stream info.
     callbacks.streamInfo().filterState()->setData(
-        "test.write", std::make_shared<Router::StringAccessorImpl>("val"),
-        Envoy::StreamInfo::FilterState::StateType::Mutable);
+        "test.write", std::make_shared<Router::StringAccessorImpl>("val"));
   }
 
   ReadFilterStatus onNewSession() override { return ReadFilterStatus::Continue; }

--- a/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/drainer_filter.h
@@ -44,7 +44,7 @@ public:
     read_callbacks_->streamInfo().filterState()->setData(
         "test.udp_session.drainer.on_session_complete",
         std::make_shared<Envoy::Router::StringAccessorImpl>("session_complete"),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection,
+        StreamInfo::FilterState::LifeSpan::Connection,
         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
   }
 

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/dfp_setter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/dfp_setter.h
@@ -32,11 +32,9 @@ public:
 
   ReadFilterStatus onNewSession() override {
     read_callbacks_->streamInfo().filterState()->setData(
-        "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host_),
-        StreamInfo::FilterState::StateType::Mutable);
+        "envoy.upstream.dynamic_host", std::make_shared<Router::StringAccessorImpl>(host_));
     read_callbacks_->streamInfo().filterState()->setData(
-        "envoy.upstream.dynamic_port", std::make_shared<StreamInfo::UInt32AccessorImpl>(port_),
-        StreamInfo::FilterState::StateType::Mutable);
+        "envoy.upstream.dynamic_port", std::make_shared<StreamInfo::UInt32AccessorImpl>(port_));
     return ReadFilterStatus::Continue;
   }
 

--- a/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/dynamic_forward_proxy/proxy_filter_test.cc
@@ -35,15 +35,15 @@ public:
   }
 
   void setFilterStateHost(const std::string& host) {
-    stream_info_.filterState()->setData(
-        "envoy.upstream.dynamic_host", std::make_shared<Envoy::Router::StringAccessorImpl>(host),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    stream_info_.filterState()->setData("envoy.upstream.dynamic_host",
+                                        std::make_shared<Envoy::Router::StringAccessorImpl>(host),
+                                        StreamInfo::FilterState::LifeSpan::Connection);
   }
 
   void setFilterStatePort(uint32_t port) {
-    stream_info_.filterState()->setData(
-        "envoy.upstream.dynamic_port", std::make_shared<StreamInfo::UInt32AccessorImpl>(port),
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    stream_info_.filterState()->setData("envoy.upstream.dynamic_port",
+                                        std::make_shared<StreamInfo::UInt32AccessorImpl>(port),
+                                        StreamInfo::FilterState::LifeSpan::Connection);
   }
 
   void setFilterState(const std::string& host, uint32_t port) {

--- a/test/extensions/filters/udp/udp_proxy/session_filters/psc_setter.h
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/psc_setter.h
@@ -35,8 +35,7 @@ public:
     }
 
     read_callbacks_->streamInfo().filterState()->setData(
-        "envoy.udp_proxy.cluster", std::make_shared<UdpProxy::PerSessionCluster>(cluster_),
-        StreamInfo::FilterState::StateType::Mutable);
+        "envoy.udp_proxy.cluster", std::make_shared<UdpProxy::PerSessionCluster>(cluster_));
     return ReadFilterStatus::Continue;
   }
 

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -2271,15 +2271,13 @@ public:
     if (proxy_port) {
       stream_info_.filterState()->setData(
           "udp.connect.proxy_port",
-          std::make_shared<StreamInfo::UInt32AccessorImpl>(proxy_port.value()),
-          Envoy::StreamInfo::FilterState::StateType::Mutable);
+          std::make_shared<StreamInfo::UInt32AccessorImpl>(proxy_port.value()));
     }
 
     if (target_port) {
       stream_info_.filterState()->setData(
           "udp.connect.target_port",
-          std::make_shared<StreamInfo::UInt32AccessorImpl>(target_port.value()),
-          Envoy::StreamInfo::FilterState::StateType::Mutable);
+          std::make_shared<StreamInfo::UInt32AccessorImpl>(target_port.value()));
     }
   }
 
@@ -2740,8 +2738,7 @@ TEST(TunnelingConfigImplTest, HeadersToAdd) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   stream_info.filterState()->setData(
-      "test_key", std::make_shared<Envoy::Router::StringAccessorImpl>("test_val"),
-      Envoy::StreamInfo::FilterState::StateType::Mutable);
+      "test_key", std::make_shared<Envoy::Router::StringAccessorImpl>("test_val"));
 
   TunnelingConfig proto_config;
   auto* header_to_add = proto_config.add_headers_to_add();
@@ -2760,8 +2757,7 @@ TEST(TunnelingConfigImplTest, ProxyHostFromFilterState) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   stream_info.filterState()->setData(
-      "test-proxy-host", std::make_shared<Envoy::Router::StringAccessorImpl>("test.host.com"),
-      Envoy::StreamInfo::FilterState::StateType::Mutable);
+      "test-proxy-host", std::make_shared<Envoy::Router::StringAccessorImpl>("test.host.com"));
 
   TunnelingConfig proto_config;
   proto_config.set_proxy_host("%FILTER_STATE(test-proxy-host:PLAIN)%");
@@ -2775,8 +2771,7 @@ TEST(TunnelingConfigImplTest, TargetHostFromFilterState) {
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
 
   stream_info.filterState()->setData(
-      "test-proxy-host", std::make_shared<Envoy::Router::StringAccessorImpl>("test.host.com"),
-      Envoy::StreamInfo::FilterState::StateType::Mutable);
+      "test-proxy-host", std::make_shared<Envoy::Router::StringAccessorImpl>("test.host.com"));
 
   TunnelingConfig proto_config;
   proto_config.set_target_host("%FILTER_STATE(test-proxy-host:PLAIN)%");

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -508,8 +508,7 @@ TEST_F(CELFormatterTest, TestFilterStateConditionalWithKey) {
 
   // Add the filter state key to simulate it being set by previous filters
   stream_info_.filter_state_->setData(
-      kFilterStateKey, std::make_unique<Router::StringAccessorImpl>("192.168.1.100:9443"),
-      StreamInfo::FilterState::StateType::ReadOnly);
+      kFilterStateKey, std::make_unique<Router::StringAccessorImpl>("192.168.1.100:9443"));
 
   auto formatter =
       *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);

--- a/test/extensions/transport_sockets/http_11_proxy/connect_test.cc
+++ b/test/extensions/transport_sockets/http_11_proxy/connect_test.cc
@@ -68,7 +68,6 @@ public:
     transport_callbacks_.connection_.stream_info_.filterState()->setData(
         "envoy.network.transport_socket.http_11_proxy.address",
         std::make_unique<Network::Http11ProxyInfoFilterState>("www.foo.com", address),
-        StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::FilterChain);
   }
 

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_test.cc
@@ -527,7 +527,7 @@ typed_config:
   callbacks.connection().streamInfo().filterState()->setData(
       "envoy.tls.cert_validator.spiffe.workload_trust_domain",
       std::make_shared<Router::StringAccessorImpl>("mydomain.org"),
-      StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   {
     SCOPED_TRACE("Trust domain matches so should be accepted (server).");

--- a/test/extensions/upstreams/tcp/generic/config_test.cc
+++ b/test/extensions/upstreams/tcp/generic/config_test.cc
@@ -71,7 +71,7 @@ TEST_P(TcpConnPoolTest, TestTunnelingDisabledByFilterState) {
   downstream_stream_info_.filterState()->setData(
       TcpProxy::DisableTunnelingFilterStateKey,
       std::make_shared<StreamInfo::BoolAccessorImpl>(true),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   EXPECT_CALL(thread_local_cluster_, tcpConnPool(_, _, _)).WillOnce(Return(absl::nullopt));
   EXPECT_EQ(nullptr,
@@ -88,7 +88,7 @@ TEST_P(TcpConnPoolTest, TestTunnelingNotDisabledIfFilterStateHasFalseValue) {
   downstream_stream_info_.filterState()->setData(
       TcpProxy::DisableTunnelingFilterStateKey,
       std::make_shared<StreamInfo::BoolAccessorImpl>(false),
-      StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+      StreamInfo::FilterState::LifeSpan::Connection);
 
   if (!useUpstreamFilters()) {
     EXPECT_CALL(thread_local_cluster_, httpConnPool(_, _, _, _)).WillOnce(Return(absl::nullopt));

--- a/test/integration/filters/encoder_recreate_stream_filter.cc
+++ b/test/integration/filters/encoder_recreate_stream_filter.cc
@@ -32,7 +32,7 @@ public:
 
     decoder_callbacks_->streamInfo().filterState()->setData(
         "test_key", std::make_unique<Router::StringAccessorImpl>("test_value"),
-        StreamInfo::FilterState::StateType::ReadOnly, StreamInfo::FilterState::LifeSpan::Request);
+        StreamInfo::FilterState::LifeSpan::Request);
 
     if (decoder_callbacks_->recreateStream(nullptr)) {
       return ::Envoy::Http::FilterHeadersStatus::StopIteration;

--- a/test/integration/filters/header_to_proxy_filter.cc
+++ b/test/integration/filters/header_to_proxy_filter.cc
@@ -26,7 +26,6 @@ public:
       decoder_callbacks_->streamInfo().filterState()->setData(
           Network::Http11ProxyInfoFilterState::key(),
           std::make_unique<Network::Http11ProxyInfoFilterState>(hostname, address),
-          StreamInfo::FilterState::StateType::ReadOnly,
           StreamInfo::FilterState::LifeSpan::FilterChain);
       request_headers.remove(connect_proxy);
     }

--- a/test/integration/filters/test_listener_filter.h
+++ b/test/integration/filters/test_listener_filter.h
@@ -131,11 +131,10 @@ public:
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
     cb.filterState().setData(TestStringFilterState::key(),
                              std::make_unique<TestStringFilterState>(added_value_),
-                             StreamInfo::FilterState::StateType::ReadOnly,
                              StreamInfo::FilterState::LifeSpan::Connection);
-    cb.filterState().setData(
-        TestFirstPacketReceivedFilterState::key(), test_first_packet_received_filter_state_,
-        StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::Connection);
+    cb.filterState().setData(TestFirstPacketReceivedFilterState::key(),
+                             test_first_packet_received_filter_state_,
+                             StreamInfo::FilterState::LifeSpan::Connection);
     dispatcher_ = &cb.dispatcher();
     return Network::FilterStatus::Continue;
   }

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1927,7 +1927,6 @@ public:
     // the connection.
     read_callbacks_->connection().streamInfo().filterState()->setData(
         TcpProxy::ReceiveBeforeConnectKey, std::make_unique<StreamInfo::BoolAccessorImpl>(true),
-        StreamInfo::FilterState::StateType::ReadOnly,
         StreamInfo::FilterState::LifeSpan::Connection);
   }
 

--- a/test/integration/upstream_access_log_integration_test.cc
+++ b/test/integration/upstream_access_log_integration_test.cc
@@ -45,8 +45,7 @@ public:
   void onConnected() override {
     const Envoy::StreamInfo::FilterStateSharedPtr& filter_state =
         callbacks_->connection().streamInfo().filterState();
-    filter_state->setData("test_key", std::make_unique<Router::StringAccessorImpl>("test_value"),
-                          StreamInfo::FilterState::StateType::ReadOnly);
+    filter_state->setData("test_key", std::make_unique<Router::StringAccessorImpl>("test_value"));
     transport_socket_->onConnected();
   }
 


### PR DESCRIPTION
This is a follow-up to #44343