### PR TITLE
upstream: drop stats from original upstream clusters missing zone

### DIFF
--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -226,7 +226,7 @@ public:
   const envoy::config::core::v3::Locality& locality() const override { return *locality_; }
   const MetadataConstSharedPtr localityMetadata() const override { return locality_metadata_; }
   Stats::StatName localityZoneStatName() const override {
-    return locality_zone_stat_name_.statName();
+    return locality_->zone().empty() ? Stats::StatName() : locality_zone_stat_name_.statName();
   }
   uint32_t priority() const override { return priority_; }
   void priority(uint32_t priority) override { priority_ = priority; }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1933,6 +1933,17 @@ TEST_F(HostImplTest, HostnameCanaryAndLocality) {
   EXPECT_EQ(1, host->priority());
 }
 
+TEST_F(HostImplTest, EmptyLocalityZoneStatName) {
+  MockClusterMockPrioritySet cluster;
+  std::unique_ptr<HostImpl> host = *HostImpl::create(
+      cluster.info_, "", *Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
+      nullptr, nullptr, 1,
+      std::make_shared<const envoy::config::core::v3::Locality>(),
+      envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
+      envoy::config::core::v3::UNKNOWN);
+  EXPECT_TRUE(host->localityZoneStatName().empty());
+}
+
 TEST_F(HostImplTest, CreateConnection) {
   MockClusterMockPrioritySet cluster;
   envoy::config::core::v3::Metadata metadata;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1936,8 +1936,7 @@ TEST_F(HostImplTest, HostnameCanaryAndLocality) {
 TEST_F(HostImplTest, EmptyLocalityZoneStatName) {
   MockClusterMockPrioritySet cluster;
   std::unique_ptr<HostImpl> host = *HostImpl::create(
-      cluster.info_, "", *Network::Utility::resolveUrl("tcp://10.0.0.1:1234"),
-      nullptr, nullptr, 1,
+      cluster.info_, "", *Network::Utility::resolveUrl("tcp://10.0.0.1:1234"), nullptr, nullptr, 1,
       std::make_shared<const envoy::config::core::v3::Locality>(),
       envoy::config::endpoint::v3::Endpoint::HealthCheckConfig::default_instance(), 0,
       envoy::config::core::v3::UNKNOWN);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: drop stats from original upstream clusters missing zone
Additional Description: Original destination and dynamic forward proxy clusters create hosts with empty locality zones, producing stats with double dots (e.g., `cluster.foo.zone.bar..upstream_rq_200`). `StatNameDynamicStorage("")` produces a non-empty `StatName` that bypasses the empty zone guard in `codes.cc`, unlike `StatNameStorage("")` which correctly produces an empty one.
This PR fixes `localityZoneStatName()` to return a truly empty `StatName` when the locality zone is empty. This then matches what I believe is the intended logic in `codes.cc` to skip stats that are missing either zone.
Risk Level: Low
Testing: Added a new unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
