### PR TITLE
opentelemetry: set _other for unknown http methods

### DIFF
--- a/changelogs/current/minor_behavior_changes/opentelemetry__set_other_for_unknown_methods.rst
+++ b/changelogs/current/minor_behavior_changes/opentelemetry__set_other_for_unknown_methods.rst
@@ -1,0 +1,1 @@
+OpenTelemetry tracer now sets the ``http.method`` attribute to ``_OTHER`` if the HTTP method is not one of the known methods (CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, QUERY, TRACE), adhering to OpenTelemetry semantic conventions.

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <string>
 
+#include "absl/container/flat_hash_set.h"
+
 #include "envoy/config/trace/v3/opentelemetry.pb.h"
 
 #include "source/common/common/empty_string.h"
@@ -162,6 +164,13 @@ convertGrpcStatusToTraceStatusCode(::opentelemetry::proto::trace::v1::Span_SpanK
 }
 
 void Span::setTag(absl::string_view name, absl::string_view value) {
+  if (name == Tracing::Tags::get().HttpMethod) {
+    static const absl::flat_hash_set<absl::string_view> known_methods{
+        "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "QUERY", "TRACE"};
+    if (!known_methods.contains(value)) {
+      value = "_OTHER";
+    }
+  }
   if (name == Tracing::Tags::get().GrpcStatusCode) {
     span_.mutable_status()->set_code(convertGrpcStatusToTraceStatusCode(span_.kind(), value));
   } else if (name == Tracing::Tags::get().HttpStatusCode) {

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -1,9 +1,9 @@
 #include "source/extensions/tracers/opentelemetry/tracer.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <string>
-
-#include "absl/container/flat_hash_set.h"
 
 #include "envoy/config/trace/v3/opentelemetry.pb.h"
 
@@ -165,9 +165,9 @@ convertGrpcStatusToTraceStatusCode(::opentelemetry::proto::trace::v1::Span_SpanK
 
 void Span::setTag(absl::string_view name, absl::string_view value) {
   if (name == Tracing::Tags::get().HttpMethod) {
-    static const absl::flat_hash_set<absl::string_view> known_methods{
+    static constexpr std::array<absl::string_view, 10> KnownMethods{
         "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "QUERY", "TRACE"};
-    if (!known_methods.contains(value)) {
+    if (std::find(KnownMethods.begin(), KnownMethods.end(), value) == KnownMethods.end()) {
       value = "_OTHER";
     }
   }

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -809,6 +809,140 @@ resource_spans:
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
+// Verifies spans are exported with known HTTP method
+TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithKnownMethod) {
+  setupValidDriver();
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context_.server_factory_context_.api_.random_;
+  int64_t generated_int = 1;
+  EXPECT_CALL(mock_random_generator_, random()).Times(3).WillRepeatedly(Return(generated_int));
+  SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
+
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
+  EXPECT_NE(span.get(), nullptr);
+
+  span->setTag("http.method", "GET");
+
+  constexpr absl::string_view request_yaml = R"(
+resource_spans:
+  resource:
+    attributes:
+      key: "service.name"
+      value:
+        string_value: "unknown_service:envoy"
+      key: "key1"
+      value:
+        string_value: "val1"
+  scope_spans:
+    scope:
+      name: "envoy"
+      version: {}
+    spans:
+      trace_id: "AAA"
+      span_id: "AAA"
+      name: "test"
+      kind: SPAN_KIND_SERVER
+      start_time_unix_nano: {}
+      end_time_unix_nano: {}
+      attributes:
+        - key: "http.method"
+          value:
+            string_value: "GET"
+  )";
+  opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
+  int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();
+  absl::string_view envoy_version = Envoy::VersionInfo::version();
+
+  TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
+                            request_proto);
+  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
+  auto* expected_span =
+      request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
+  expected_span->set_trace_id(
+      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
+  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
+      .Times(1)
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
+  span->finishSpan();
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
+// Verifies spans are exported with unknown HTTP method mapped to _OTHER
+TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithUnknownMethod) {
+  setupValidDriver();
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+  NiceMock<Random::MockRandomGenerator>& mock_random_generator_ =
+      context_.server_factory_context_.api_.random_;
+  int64_t generated_int = 1;
+  EXPECT_CALL(mock_random_generator_, random()).Times(3).WillRepeatedly(Return(generated_int));
+  SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
+
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
+  EXPECT_NE(span.get(), nullptr);
+
+  span->setTag("http.method", "PURGE");
+
+  constexpr absl::string_view request_yaml = R"(
+resource_spans:
+  resource:
+    attributes:
+      key: "service.name"
+      value:
+        string_value: "unknown_service:envoy"
+      key: "key1"
+      value:
+        string_value: "val1"
+  scope_spans:
+    scope:
+      name: "envoy"
+      version: {}
+    spans:
+      trace_id: "AAA"
+      span_id: "AAA"
+      name: "test"
+      kind: SPAN_KIND_SERVER
+      start_time_unix_nano: {}
+      end_time_unix_nano: {}
+      attributes:
+        - key: "http.method"
+          value:
+            string_value: "_OTHER"
+  )";
+  opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
+  int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();
+  absl::string_view envoy_version = Envoy::VersionInfo::version();
+
+  TestUtility::loadFromYaml(fmt::format(request_yaml, envoy_version, timestamp_ns, timestamp_ns),
+                            request_proto);
+  std::string generated_int_hex = Hex::uint64ToHex(generated_int);
+  auto* expected_span =
+      request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
+  expected_span->set_trace_id(
+      absl::HexStringToBytes(absl::StrCat(generated_int_hex, generated_int_hex)));
+  expected_span->set_span_id(absl::HexStringToBytes(absl::StrCat(generated_int_hex)));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
+      .Times(1)
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
+  span->finishSpan();
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
 // Verifies spans are exported with their events
 TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanWithEvents) {
   setupValidDriver();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

### Commit Message
The OpenTelemetry semantic conventions state, for both [client](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-span) and [server](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span) spans:

---

HTTP request method value SHOULD be “known” to the instrumentation. By default, this convention defines “known” methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods), the `PATCH` method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html) and the `QUERY` method defined in [httpbis-safe-method-w-body](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/?include_text=1).

If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.

---

This PR updates Envoy's OpenTelemetry tracer to align with this standard.

### Additional Description
AI was used to generate the code and tests in this PR. I have reviewed – and fully understand – the code.

It should be noted that Envoy's OTel tracer uses `http.method` instead of the more up-to-date `http.request.method`. However, I believe there is ongoing work to update these names happening in #45184.

### Risk Level
Low

### Testing
I've added unit tests that exercise the new code.

### Docs Changes
None required

### Release Notes
Added a changelog under minor_behavior_changes (area: opentelemetry).

### Platform Specific Features
None
