### PR TITLE
zipkin: use system time for timestamp trace ids

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -94,6 +94,8 @@ areas:
     title: tcp_proxy
   tls:
     title: tls
+  tracing:
+    title: tracing
   wasm:
     title: wasm
   dns:

--- a/changelogs/current/bug_fixes/tracing__fixed-zipkin-timestamp-trace-ids.rst
+++ b/changelogs/current/bug_fixes/tracing__fixed-zipkin-timestamp-trace-ids.rst
@@ -1,0 +1,3 @@
+Fixed Zipkin ``timestamp_trace_ids`` to encode Unix epoch seconds in the high 32 bits of generated
+trace IDs, matching the documented ``[32-bit epoch seconds][32-bit random]`` format. Previously
+Envoy used monotonic clock seconds, so the trace ID prefix did not correspond to wall-clock time.

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -17,10 +17,8 @@ uint64_t Tracer::generateTraceId(SystemTime timestamp) {
   if (timestamp_trace_ids_) {
     // Generate timestamp-prefixed 64-bit value:
     // [32-bit epoch seconds][32-bit random]
-    const uint32_t epoch_seconds =
-        static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                  timestamp.time_since_epoch())
-                                  .count());
+    const uint32_t epoch_seconds = static_cast<uint32_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(timestamp.time_since_epoch()).count());
     const uint32_t random_part = static_cast<uint32_t>(random_generator_.random());
 
     // Combine: timestamp in upper 32 bits, random in lower 32 bits

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -19,7 +19,7 @@ uint64_t Tracer::generateTraceId() {
     // [32-bit epoch seconds][32-bit random]
     const uint32_t epoch_seconds =
         static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                  time_source_.monotonicTime().time_since_epoch())
+                                  time_source_.systemTime().time_since_epoch())
                                   .count());
     const uint32_t random_part = static_cast<uint32_t>(random_generator_.random());
 

--- a/source/extensions/tracers/zipkin/tracer.cc
+++ b/source/extensions/tracers/zipkin/tracer.cc
@@ -13,13 +13,13 @@ namespace Extensions {
 namespace Tracers {
 namespace Zipkin {
 
-uint64_t Tracer::generateTraceId() {
+uint64_t Tracer::generateTraceId(SystemTime timestamp) {
   if (timestamp_trace_ids_) {
     // Generate timestamp-prefixed 64-bit value:
     // [32-bit epoch seconds][32-bit random]
     const uint32_t epoch_seconds =
         static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                  time_source_.systemTime().time_since_epoch())
+                                  timestamp.time_since_epoch())
                                   .count());
     const uint32_t random_part = static_cast<uint32_t>(random_generator_.random());
 
@@ -80,11 +80,11 @@ SpanPtr Tracer::startSpan(const Tracing::Config& config, const std::string& span
   // Set trace id(s)
   if (trace_id_128bit_) {
     span_ptr->setTraceId(random_number);
-    span_ptr->setTraceIdHigh(generateTraceId());
+    span_ptr->setTraceIdHigh(generateTraceId(timestamp));
   } else {
     if (timestamp_trace_ids_) {
       // 64-bit: timestamp-prefixed
-      span_ptr->setTraceId(generateTraceId());
+      span_ptr->setTraceId(generateTraceId(timestamp));
     } else {
       // Legacy behavior: trace id equals span id
       span_ptr->setTraceId(random_number);

--- a/source/extensions/tracers/zipkin/tracer.h
+++ b/source/extensions/tracers/zipkin/tracer.h
@@ -80,7 +80,7 @@ private:
    *
    * @return uint64_t value with optional timestamp prefix
    */
-  uint64_t generateTraceId();
+  uint64_t generateTraceId(SystemTime timestamp);
 
   const std::string service_name_;
   Network::Address::InstanceConstSharedPtr address_;

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -721,7 +721,8 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds) {
 
   // Test with timestamp_trace_ids enabled
   Tracer tracer("my_service_name", addr, random_generator, false, true, time_system_, false, true);
-  SystemTime timestamp = time_system_.systemTime();
+  const SystemTime timestamp{std::chrono::seconds(1234567890)};
+  time_system_.setSystemTime(timestamp);
 
   NiceMock<Tracing::MockConfig> config;
   ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
@@ -738,12 +739,8 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds) {
   uint32_t extracted_timestamp = static_cast<uint32_t>(trace_id >> 32);
   uint32_t extracted_random = static_cast<uint32_t>(trace_id & 0xFFFFFFFF);
 
-  // Verify timestamp is approximately correct (within 1 second)
-  uint32_t expected_timestamp =
-      static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                time_system_.systemTime().time_since_epoch())
-                                .count());
-  EXPECT_LE(std::abs(static_cast<int32_t>(extracted_timestamp - expected_timestamp)), 1);
+  // Verify timestamp matches the provided span start timestamp.
+  EXPECT_EQ(1234567890U, extracted_timestamp);
 
   // Verify random part matches what we mocked
   EXPECT_EQ(0x12345678U, extracted_random);
@@ -757,7 +754,8 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds128bit) {
 
   // Test with timestamp_trace_ids enabled and 128-bit trace IDs
   Tracer tracer("my_service_name", addr, random_generator, true, true, time_system_, false, true);
-  SystemTime timestamp = time_system_.systemTime();
+  const SystemTime timestamp{std::chrono::seconds(1234567890)};
+  time_system_.setSystemTime(timestamp);
 
   NiceMock<Tracing::MockConfig> config;
   ON_CALL(config, operationName()).WillByDefault(Return(Tracing::OperationName::Egress));
@@ -781,13 +779,8 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds128bit) {
 
   uint32_t extracted_timestamp_high = static_cast<uint32_t>(trace_id_high >> 32);
 
-  uint32_t expected_timestamp =
-      static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                time_system_.systemTime().time_since_epoch())
-                                .count());
-
   // High part should have the timestamp prefix
-  EXPECT_LE(std::abs(static_cast<int32_t>(extracted_timestamp_high - expected_timestamp)), 1);
+  EXPECT_EQ(1234567890U, extracted_timestamp_high);
 }
 
 // Back-compat: when timestamping is disabled, trace id == span id for root spans (64-bit)

--- a/test/extensions/tracers/zipkin/tracer_test.cc
+++ b/test/extensions/tracers/zipkin/tracer_test.cc
@@ -741,7 +741,7 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds) {
   // Verify timestamp is approximately correct (within 1 second)
   uint32_t expected_timestamp =
       static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                time_system_.monotonicTime().time_since_epoch())
+                                time_system_.systemTime().time_since_epoch())
                                 .count());
   EXPECT_LE(std::abs(static_cast<int32_t>(extracted_timestamp - expected_timestamp)), 1);
 
@@ -783,7 +783,7 @@ TEST_F(ZipkinTracerTest, TimestampTraceIds128bit) {
 
   uint32_t expected_timestamp =
       static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(
-                                time_system_.monotonicTime().time_since_epoch())
+                                time_system_.systemTime().time_since_epoch())
                                 .count());
 
   // High part should have the timestamp prefix


### PR DESCRIPTION
## Background

Zipkin's `timestamp_trace_ids` option is documented in Envoy's `ZipkinConfig` proto to generate trace IDs with the high 32 bits set to epoch seconds, followed by 32 bits of randomness. The previous implementation used `TimeSource::monotonicTime()` for that prefix. `MonotonicTime` is backed by `std::chrono::steady_clock`, whose epoch is implementation-defined and not Unix epoch time.

As a result, timestamp-based trace IDs were stable and non-regressing, but they did not encode wall-clock epoch seconds as documented.

This PR was prepared with AI assistance. I understand the change and am responsible for responding to review feedback and revising it as needed.

## Changes

Derive the timestamp trace ID prefix from the `SystemTime` span start timestamp passed into `Tracer::startSpan()`. This keeps the trace ID prefix aligned with the span's wall-clock start timestamp and avoids taking a second wall-clock reading inside trace ID generation.

The timestamp trace ID tests now use a fixed `SystemTime` and assert exact epoch-second prefixes for both 64-bit and 128-bit trace IDs instead of allowing an approximate one-second delta against the current clock.

## Validation

Ran the targeted Zipkin tracer test with Envoy's clang build config:

```bash
bazel test --config=clang //test/extensions/tracers/zipkin:zipkin_test --test_filter='ZipkinTracerTest.TimestampTraceIds.*'
```

Result:

```text
Executed 1 out of 1 test: 1 test passes.
```

Also validated the bug before this patch in a live smoke test by setting `timestamp_trace_ids=true` and capturing the emitted Zipkin trace ID. The first 32 bits decoded to `33,298` seconds while wall-clock epoch at request time was `1,779,405,328` seconds, confirming the old prefix was steady-clock based rather than Unix epoch based.
