### PR TITLE
Fix Stack Exhaustion via Recursive Destruction of Nested RESP Arrays in Redis Filter

### DIFF
--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/network/common/redis/codec_impl.h"
 
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <vector>
@@ -632,6 +633,10 @@ void DecoderImpl::parseSlice(const Buffer::RawSlice& slice) {
         } else if (pending_integer_.integer_ == 0) {
           state_ = State::ValueComplete;
         } else {
+          if (std::distance(pending_value_stack_.begin(), pending_value_stack_.end()) >
+              MaxArrayNestingDepth) {
+            throw ProtocolError("array nesting depth exceeds limit");
+          }
           std::vector<RespValue> values(pending_integer_.integer_);
           current_value.value_->asArray().swap(values);
           pending_value_stack_.push_front({&current_value.value_->asArray()[0], 0});

--- a/source/extensions/filters/network/common/redis/codec_impl.h
+++ b/source/extensions/filters/network/common/redis/codec_impl.h
@@ -14,6 +14,8 @@ namespace NetworkFilters {
 namespace Common {
 namespace Redis {
 
+constexpr int MaxArrayNestingDepth = 128;
+
 /**
  * Decoder implementation of https://redis.io/topics/protocol
  *

--- a/test/extensions/filters/network/common/redis/codec_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/codec_impl_test.cc
@@ -845,6 +845,18 @@ TEST_F(RedisEncoderDecoderImplTest, InvalidInterjectedInlineCommand) {
   EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
 }
 
+TEST_F(RedisEncoderDecoderImplTest, NestedArrayDepthLimitExceeded) {
+  // Nesting depth of MaxArrayNestingDepth + 1 arrays
+  std::string payload = "";
+  for (int i = 0; i < MaxArrayNestingDepth + 1; ++i) {
+    payload += "*1\r\n";
+  }
+  payload += "+foo\r\n";
+
+  buffer_.add(payload);
+  EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
+}
+
 } // namespace Redis
 } // namespace Common
 } // namespace NetworkFilters


### PR DESCRIPTION
An Envoy issue exists in the Redis network filter (envoy.filters.network.redis_proxy). The issue is due to unbounded recursive object destruction when cleaning up a deeply nested RESP (REdis Serialization Protocol) value tree: virtual ~RespValue() { cleanup(); }. If a highly nested array structure, like > 40000 is provided, the programmatic cascading destructors will exhaust the hardware thread stack, resulting in process termination. In normal case,  such highly nested array structure should not happen. In practical, the nested layer is no more than 5. 

The solution is to add a max nesting depth 128 so the nested RESP arrays will never exceed 128 layers, thus the recursive object destruction is bounded by that number.