### PR TITLE
internal_upstream: reverse-propagate filter state across the internal listener boundary at close

### DIFF
--- a/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
+++ b/api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto
@@ -159,6 +159,11 @@ message TcpProxy {
 
     // Save response headers to the downstream connection's filter state for consumption
     // by network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_headers``.
+    //
+    // When the tcp_proxy is on the inner side of an internal-listener boundary, the captured
+    // filter state object is additionally reverse-propagated to the outer (downstream)
+    // connection's filter state at upstream close, making it readable by HTTP filters on the
+    // downstream HCM via ``%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers)%``.
     bool propagate_response_headers = 4;
 
     // The path used with the POST method. The default path is ``/``. If this field is specified and
@@ -168,6 +173,9 @@ message TcpProxy {
 
     // Save response trailers to the downstream connection's filter state for consumption
     // by network filters. The filter state key is ``envoy.tcp_proxy.propagate_response_trailers``.
+    //
+    // See the note on ``propagate_response_headers`` above regarding reverse propagation across
+    // an internal-listener boundary.
     bool propagate_response_trailers = 6;
 
     // The configuration of the request ID extension used for generation, validation, and

--- a/changelogs/current/new_features/filter_state__shared-with-downstream-connection-on-close.rst
+++ b/changelogs/current/new_features/filter_state__shared-with-downstream-connection-on-close.rst
@@ -1,0 +1,4 @@
+added ``StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose`` for marking
+filter state objects that should be reverse-propagated from the upstream (inner-side) to the
+downstream (outer-side) connection at upstream close. Currently honored across the
+internal-listener boundary by ``PassthroughState`` / ``InternalSocket``.

--- a/changelogs/current/new_features/tcp_proxy__reverse-propagate-across-internal-listener.rst
+++ b/changelogs/current/new_features/tcp_proxy__reverse-propagate-across-internal-listener.rst
@@ -1,0 +1,8 @@
+when :ref:`propagate_response_headers
+<envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_headers>`
+or :ref:`propagate_response_trailers
+<envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_trailers>`
+is enabled and the tcp_proxy sits on the inner side of an internal-listener boundary, the
+captured response headers/trailers filter state object is now additionally reverse-propagated
+to the outer (downstream) connection's filter state at upstream close. Pre-existing names on
+the recipient are not overwritten. Refs #43977.

--- a/changelogs/current/new_features/tcp_proxy__reverse-propagate-across-internal-listener.rst
+++ b/changelogs/current/new_features/tcp_proxy__reverse-propagate-across-internal-listener.rst
@@ -4,5 +4,6 @@ or :ref:`propagate_response_trailers
 <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.TunnelingConfig.propagate_response_trailers>`
 is enabled and the tcp_proxy sits on the inner side of an internal-listener boundary, the
 captured response headers/trailers filter state object is now additionally reverse-propagated
-to the outer (downstream) connection's filter state at upstream close. Pre-existing names on
-the recipient are not overwritten. Refs #43977.
+to the outer (downstream) connection's filter state at upstream close. A pre-existing object
+of the same name is overwritten (last-writer-wins), consistent with forward propagation.
+Refs #43977.

--- a/envoy/stream_info/filter_state.h
+++ b/envoy/stream_info/filter_state.h
@@ -44,6 +44,15 @@ enum class StreamSharingMayImpactPooling {
   // not transitively shared. The filter state is imported into the upstream
   // connection filter state as exclusive to the upstream connection.
   SharedWithUpstreamConnectionOnce,
+
+  // Mark a filter state object as shared back to the downstream connection
+  // when the upstream connection closes. This is the reverse of
+  // SharedWithUpstreamConnection: at upstream close, marked objects are
+  // captured from the upstream connection filter state and merged into the
+  // downstream connection filter state. Currently honored across the
+  // internal-listener boundary (the upstream connection is the inner side of
+  // the internal listener pair; the downstream connection is the outer side).
+  SharedWithDownstreamConnectionOnClose,
 };
 
 /**
@@ -231,6 +240,13 @@ public:
    * @return filter objects that are shared with the upstream connection.
    **/
   virtual ObjectsPtr objectsSharedWithUpstreamConnection() const PURE;
+
+  /**
+   * @return filter objects marked SharedWithDownstreamConnectionOnClose. Used
+   * at upstream connection close to capture objects for reverse propagation
+   * across the internal-listener boundary back to the downstream connection.
+   **/
+  virtual ObjectsPtr objectsSharedWithDownstreamConnectionOnClose() const PURE;
 };
 
 } // namespace StreamInfo

--- a/source/common/stream_info/filter_state_impl.cc
+++ b/source/common/stream_info/filter_state_impl.cc
@@ -126,6 +126,20 @@ FilterState::ObjectsPtr FilterStateImpl::objectsSharedWithUpstreamConnection() c
   return objects;
 }
 
+FilterState::ObjectsPtr FilterStateImpl::objectsSharedWithDownstreamConnectionOnClose() const {
+  auto objects = parent_ ? parent_->objectsSharedWithDownstreamConnectionOnClose()
+                         : std::make_unique<FilterState::Objects>();
+  for (const auto& [name, object] : data_storage_) {
+    if (object->stream_sharing_ ==
+        StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose) {
+      // Imported into the recipient as exclusive to it; the recipient must
+      // not transitively re-propagate.
+      objects->push_back({object->data_, StreamSharingMayImpactPooling::None, name});
+    }
+  }
+  return objects;
+}
+
 bool FilterStateImpl::hasDataWithNameInternally(absl::string_view data_name) const {
   return data_storage_.contains(data_name);
 }

--- a/source/common/stream_info/filter_state_impl.h
+++ b/source/common/stream_info/filter_state_impl.h
@@ -43,6 +43,7 @@ public:
   std::shared_ptr<Object> getDataSharedMutableGeneric(absl::string_view data_name) override;
   bool hasDataAtOrAboveLifeSpan(FilterState::LifeSpan life_span) const override;
   FilterState::ObjectsPtr objectsSharedWithUpstreamConnection() const override;
+  FilterState::ObjectsPtr objectsSharedWithDownstreamConnectionOnClose() const override;
 
   FilterState::LifeSpan lifeSpan() const override { return life_span_; }
   FilterStateSharedPtr parent() const override { return parent_; }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1060,9 +1060,11 @@ void TunnelingConfigHelperImpl::propagateResponseTrailers(
   if (!propagate_response_trailers_) {
     return;
   }
-  filter_state->setData(TunnelResponseTrailers::key(),
-                        std::make_shared<TunnelResponseTrailers>(std::move(trailers)),
-                        StreamInfo::FilterState::LifeSpan::Connection);
+  filter_state->setData(
+      TunnelResponseTrailers::key(),
+      std::make_shared<TunnelResponseTrailers>(std::move(trailers)),
+      StreamInfo::FilterState::LifeSpan::Connection,
+      StreamInfo::StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
 }
 
 void Filter::onConnectTimeout() {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1061,8 +1061,7 @@ void TunnelingConfigHelperImpl::propagateResponseTrailers(
     return;
   }
   filter_state->setData(
-      TunnelResponseTrailers::key(),
-      std::make_shared<TunnelResponseTrailers>(std::move(trailers)),
+      TunnelResponseTrailers::key(), std::make_shared<TunnelResponseTrailers>(std::move(trailers)),
       StreamInfo::FilterState::LifeSpan::Connection,
       StreamInfo::StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
 }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1048,9 +1048,10 @@ void TunnelingConfigHelperImpl::propagateResponseHeaders(
   if (!propagate_response_headers_) {
     return;
   }
-  filter_state->setData(TunnelResponseHeaders::key(),
-                        std::make_shared<TunnelResponseHeaders>(std::move(headers)),
-                        StreamInfo::FilterState::LifeSpan::Connection);
+  filter_state->setData(
+      TunnelResponseHeaders::key(), std::make_shared<TunnelResponseHeaders>(std::move(headers)),
+      StreamInfo::FilterState::LifeSpan::Connection,
+      StreamInfo::StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
 }
 
 void TunnelingConfigHelperImpl::propagateResponseTrailers(

--- a/source/extensions/bootstrap/internal_listener/active_internal_listener.cc
+++ b/source/extensions/bootstrap/internal_listener/active_internal_listener.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
+#include "envoy/stream_info/filter_state.h"
 
 #include "source/common/listener_manager/active_stream_listener_base.h"
 #include "source/common/network/address_impl.h"
@@ -82,6 +83,26 @@ void ActiveInternalListener::newActiveConnection(
         debug, "new connection from {}", *active_connection->connection_,
         active_connection->connection_->connectionInfoProvider().remoteAddress()->asString());
     active_connection->connection_->addConnectionCallbacks(*active_connection);
+
+    // Register a pre-close hook on the user-space IoHandle so that filter
+    // state objects marked SharedWithDownstreamConnectionOnClose are captured
+    // into the shared PassthroughState before this (inner-side) connection
+    // tears down. The peer (outer-side) connection will merge them into its
+    // own filter state when its transport socket is torn down.
+    //
+    // Capture filter_state by value so the lambda remains safe if it fires
+    // from the IoHandle destructor after the owning Connection has gone away.
+    auto& connection = *active_connection->connection_;
+    auto* io_handle =
+        dynamic_cast<Extensions::IoSocket::UserSpace::IoHandle*>(&connection.getSocket()->ioHandle());
+    if (io_handle != nullptr && io_handle->passthroughState()) {
+      io_handle->addOnPreCloseCallback(
+          [passthrough_state = io_handle->passthroughState(),
+           filter_state = connection.streamInfo().filterState()]() {
+            passthrough_state->captureReverse(*filter_state);
+          });
+    }
+
     LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);
   }
 }

--- a/source/extensions/bootstrap/internal_listener/active_internal_listener.cc
+++ b/source/extensions/bootstrap/internal_listener/active_internal_listener.cc
@@ -93,14 +93,13 @@ void ActiveInternalListener::newActiveConnection(
     // Capture filter_state by value so the lambda remains safe if it fires
     // from the IoHandle destructor after the owning Connection has gone away.
     auto& connection = *active_connection->connection_;
-    auto* io_handle =
-        dynamic_cast<Extensions::IoSocket::UserSpace::IoHandle*>(&connection.getSocket()->ioHandle());
+    auto* io_handle = dynamic_cast<Extensions::IoSocket::UserSpace::IoHandle*>(
+        &connection.getSocket()->ioHandle());
     if (io_handle != nullptr && io_handle->passthroughState()) {
-      io_handle->addOnPreCloseCallback(
-          [passthrough_state = io_handle->passthroughState(),
-           filter_state = connection.streamInfo().filterState()]() {
-            passthrough_state->captureReverse(*filter_state);
-          });
+      io_handle->addOnPreCloseCallback([passthrough_state = io_handle->passthroughState(),
+                                        filter_state = connection.streamInfo().filterState()]() {
+        passthrough_state->captureReverse(*filter_state);
+      });
     }
 
     LinkedList::moveIntoList(std::move(active_connection), active_connections.connections_);

--- a/source/extensions/io_socket/user_space/io_handle.h
+++ b/source/extensions/io_socket/user_space/io_handle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/optref.h"
 #include "envoy/common/pure.h"
@@ -29,6 +31,21 @@ public:
    */
   virtual void mergeInto(envoy::config::core::v3::Metadata& metadata,
                          StreamInfo::FilterState& filter_state) PURE;
+
+  /**
+   * Capture filter state objects marked SharedWithDownstreamConnectionOnClose
+   * from the upstream-side (inner) connection's filter state at upstream close.
+   * Stores captured objects internally for later delivery via `mergeReverse`.
+   * Called at most once.
+   */
+  virtual void captureReverse(const StreamInfo::FilterState& filter_state) PURE;
+
+  /**
+   * Merge previously-captured reverse-propagation objects into the
+   * downstream-side (outer) connection's filter state. Called at most once
+   * after `captureReverse`. Safe to call without a prior capture (no-op).
+   */
+  virtual void mergeReverse(StreamInfo::FilterState& filter_state) PURE;
 };
 
 using PassthroughStateSharedPtr = std::shared_ptr<PassthroughState>;
@@ -93,6 +110,14 @@ public:
    * @return shared state between peering user space IO handles.
    */
   virtual PassthroughStateSharedPtr passthroughState() PURE;
+
+  /**
+   * Register a callback to be invoked exactly once, when this handle is about
+   * to close. Used to capture filter state from the owning connection's
+   * stream info before the connection is torn down (reverse passthrough
+   * propagation across the internal listener boundary).
+   */
+  virtual void addOnPreCloseCallback(std::function<void()> callback) PURE;
 };
 } // namespace UserSpace
 } // namespace IoSocket

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -402,7 +402,12 @@ void PassthroughStateImpl::mergeInto(envoy::config::core::v3::Metadata& metadata
 }
 
 void PassthroughStateImpl::captureReverse(const StreamInfo::FilterState& filter_state) {
-  ASSERT(reverse_state_ == ReverseState::Created);
+  // Close ordering across the internal-listener boundary is not guaranteed, so
+  // this hook may run after mergeReverse has already finalized the shared state.
+  // Capture only on the first invocation while still in the initial state.
+  if (reverse_state_ != ReverseState::Created) {
+    return;
+  }
   auto objects = filter_state.objectsSharedWithDownstreamConnectionOnClose();
   if (objects) {
     reverse_filter_state_objects_ = std::move(*objects);

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -416,15 +416,13 @@ void PassthroughStateImpl::captureReverse(const StreamInfo::FilterState& filter_
 }
 
 void PassthroughStateImpl::mergeReverse(StreamInfo::FilterState& filter_state) {
-  ASSERT(reverse_state_ == ReverseState::Created || reverse_state_ == ReverseState::Captured);
+  // Close ordering across the internal-listener boundary is not guaranteed, so this may run
+  // in an unexpected state; merge only once, from the initial/captured state.
+  if (!(reverse_state_ == ReverseState::Created || reverse_state_ == ReverseState::Captured)) {
+    return;
+  }
   for (const auto& object : reverse_filter_state_objects_) {
-    // Skip if the recipient already has data for this name; reverse propagation
-    // is opportunistic and must not overwrite an existing entry.
-    if (filter_state.hasDataWithName(object.name_)) {
-      ENVOY_LOG(debug, "reverse-passthrough skipping filter state '{}' (already set on recipient)",
-                object.name_);
-      continue;
-    }
+    // Last-writer-wins, consistent with the forward PassthroughState::mergeInto path.
     filter_state.setData(object.name_, object.data_, StreamInfo::FilterState::LifeSpan::Connection,
                          object.stream_sharing_);
   }

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -71,7 +71,7 @@ Api::IoCallUint64Result IoHandleImpl::close() {
     // Fire pre-close callbacks before notifying the peer or tearing down the
     // file event. This lets the owning connection (e.g. inside the internal
     // listener) capture filter state into the shared PassthroughState while
-    // the connection's stream info is still queryable.
+    // the connection's stream info is still accessible.
     auto callbacks = std::move(pre_close_callbacks_);
     for (auto& cb : callbacks) {
       cb();

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -68,6 +68,14 @@ IoHandleImpl::~IoHandleImpl() {
 Api::IoCallUint64Result IoHandleImpl::close() {
   ASSERT(!closed_);
   if (!closed_) {
+    // Fire pre-close callbacks before notifying the peer or tearing down the
+    // file event. This lets the owning connection (e.g. inside the internal
+    // listener) capture filter state into the shared PassthroughState while
+    // the connection's stream info is still queryable.
+    auto callbacks = std::move(pre_close_callbacks_);
+    for (auto& cb : callbacks) {
+      cb();
+    }
     if (peer_handle_) {
       ENVOY_LOG(trace, "socket {} close before peer {} closes.", static_cast<void*>(this),
                 static_cast<void*>(peer_handle_));
@@ -391,6 +399,32 @@ void PassthroughStateImpl::mergeInto(envoy::config::core::v3::Metadata& metadata
   metadata_ = nullptr;
   filter_state_objects_.clear();
   state_ = State::Done;
+}
+
+void PassthroughStateImpl::captureReverse(const StreamInfo::FilterState& filter_state) {
+  ASSERT(reverse_state_ == ReverseState::Created);
+  auto objects = filter_state.objectsSharedWithDownstreamConnectionOnClose();
+  if (objects) {
+    reverse_filter_state_objects_ = std::move(*objects);
+  }
+  reverse_state_ = ReverseState::Captured;
+}
+
+void PassthroughStateImpl::mergeReverse(StreamInfo::FilterState& filter_state) {
+  ASSERT(reverse_state_ == ReverseState::Created || reverse_state_ == ReverseState::Captured);
+  for (const auto& object : reverse_filter_state_objects_) {
+    // Skip if the recipient already has data for this name; reverse propagation
+    // is opportunistic and must not overwrite an existing entry.
+    if (filter_state.hasDataWithName(object.name_)) {
+      ENVOY_LOG(debug, "reverse-passthrough skipping filter state '{}' (already set on recipient)",
+                object.name_);
+      continue;
+    }
+    filter_state.setData(object.name_, object.data_, StreamInfo::FilterState::LifeSpan::Connection,
+                         object.stream_sharing_);
+  }
+  reverse_filter_state_objects_.clear();
+  reverse_state_ = ReverseState::Done;
 }
 
 std::pair<IoHandleImplPtr, IoHandleImplPtr>

--- a/source/extensions/io_socket/user_space/io_handle_impl.h
+++ b/source/extensions/io_socket/user_space/io_handle_impl.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <vector>
 
 #include "envoy/api/io_error.h"
 #include "envoy/api/os_sys_calls.h"
@@ -159,6 +161,10 @@ public:
 
   PassthroughStateSharedPtr passthroughState() override { return passthrough_state_; }
 
+  void addOnPreCloseCallback(std::function<void()> callback) override {
+    pre_close_callbacks_.push_back(std::move(callback));
+  }
+
 private:
   friend class IoHandleFactory;
   explicit IoHandleImpl(PassthroughStateSharedPtr passthrough_state = nullptr);
@@ -189,6 +195,12 @@ private:
 
   // Shared state between peer handles.
   PassthroughStateSharedPtr passthrough_state_{nullptr};
+
+  // Callbacks fired exactly once when this handle is about to close. Used to
+  // capture filter state from the owning connection's stream info before the
+  // connection is torn down, enabling reverse propagation across the internal
+  // listener boundary.
+  std::vector<std::function<void()>> pre_close_callbacks_;
 };
 
 class PassthroughStateImpl : public PassthroughState, public Logger::Loggable<Logger::Id::io> {
@@ -197,12 +209,18 @@ public:
                   const StreamInfo::FilterState::Objects& filter_state_objects) override;
   void mergeInto(envoy::config::core::v3::Metadata& metadata,
                  StreamInfo::FilterState& filter_state) override;
+  void captureReverse(const StreamInfo::FilterState& filter_state) override;
+  void mergeReverse(StreamInfo::FilterState& filter_state) override;
 
 protected:
   enum class State { Created, Initialized, Done };
   State state_{State::Created};
   std::unique_ptr<envoy::config::core::v3::Metadata> metadata_;
   StreamInfo::FilterState::Objects filter_state_objects_;
+
+  enum class ReverseState { Created, Captured, Done };
+  ReverseState reverse_state_{ReverseState::Created};
+  StreamInfo::FilterState::Objects reverse_filter_state_objects_;
 };
 
 using IoHandleImplPtr = std::unique_ptr<IoHandleImpl>;

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
@@ -13,12 +13,27 @@ InternalSocket::InternalSocket(Network::TransportSocketPtr inner_socket,
 
 void InternalSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) {
   transport_socket_->setTransportSocketCallbacks(callbacks);
+  transport_callbacks_ = &callbacks;
   auto* io_handle = dynamic_cast<IoSocket::UserSpace::IoHandle*>(&callbacks.ioHandle());
   if (io_handle != nullptr && io_handle->passthroughState()) {
-    io_handle->passthroughState()->initialize(std::move(metadata_), filter_state_objects_);
+    passthrough_state_ = io_handle->passthroughState();
+    passthrough_state_->initialize(std::move(metadata_), filter_state_objects_);
   }
   metadata_ = nullptr;
   filter_state_objects_.clear();
+}
+
+void InternalSocket::closeSocket(Network::ConnectionEvent event, bool abort_reset) {
+  // Pull any filter state objects that the peer (inner-side) connection marked
+  // SharedWithDownstreamConnectionOnClose into this (outer-side) connection's
+  // stream info before the inner transport socket close runs. This makes the
+  // propagated values accessible to upstream-access-log formatters and other
+  // consumers on the downstream HCM side.
+  if (passthrough_state_ != nullptr && transport_callbacks_ != nullptr) {
+    passthrough_state_->mergeReverse(
+        *transport_callbacks_->connection().streamInfo().filterState());
+  }
+  PassthroughSocket::closeSocket(event, abort_reset);
 }
 
 } // namespace InternalUpstream

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
@@ -18,10 +18,17 @@ public:
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
+  void closeSocket(Network::ConnectionEvent event, bool abort_reset) override;
 
 private:
   std::unique_ptr<envoy::config::core::v3::Metadata> metadata_;
   StreamInfo::FilterState::Objects filter_state_objects_;
+
+  // Captured at setTransportSocketCallbacks time. Used at closeSocket time to
+  // pull reverse-propagated filter state objects from the shared
+  // PassthroughState into this connection's stream info.
+  Network::TransportSocketCallbacks* transport_callbacks_{nullptr};
+  IoSocket::UserSpace::PassthroughStateSharedPtr passthrough_state_{nullptr};
 };
 
 } // namespace InternalUpstream

--- a/test/common/stream_info/filter_state_impl_test.cc
+++ b/test/common/stream_info/filter_state_impl_test.cc
@@ -326,6 +326,30 @@ TEST_F(FilterStateImplTest, SharedWithUpstream) {
   EXPECT_EQ(objects->at(3).stream_sharing_, StreamSharingMayImpactPooling::None);
 }
 
+TEST_F(FilterStateImplTest, SharedWithDownstreamConnectionOnClose) {
+  auto shared = std::make_shared<SimpleType>(1);
+  filterState().setData("shared_close_1", shared, FilterState::LifeSpan::Connection,
+                        StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
+  filterState().setData("unshared_2", std::make_shared<SimpleType>(2),
+                        FilterState::LifeSpan::Connection);
+  filterState().setData("upstream_only_3", std::make_shared<SimpleType>(3),
+                        FilterState::LifeSpan::Connection,
+                        StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
+  filterState().setData("shared_close_4", std::make_shared<SimpleType>(4),
+                        FilterState::LifeSpan::Request,
+                        StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
+  auto objects = filterState().objectsSharedWithDownstreamConnectionOnClose();
+  EXPECT_EQ(objects->size(), 2);
+  std::sort(objects->begin(), objects->end(),
+            [](const auto& lhs, const auto& rhs) -> bool { return lhs.name_ < rhs.name_; });
+  EXPECT_EQ(objects->at(0).name_, "shared_close_1");
+  EXPECT_EQ(objects->at(0).data_.get(), shared.get());
+  // Captured objects are imported as exclusive (None) to prevent transitive re-propagation.
+  EXPECT_EQ(objects->at(0).stream_sharing_, StreamSharingMayImpactPooling::None);
+  EXPECT_EQ(objects->at(1).name_, "shared_close_4");
+  EXPECT_EQ(objects->at(1).stream_sharing_, StreamSharingMayImpactPooling::None);
+}
+
 TEST_F(FilterStateImplTest, HasDataAtOrAboveLifeSpan) {
   filterState().setData("test_1", std::make_unique<SimpleType>(1),
                         FilterState::LifeSpan::FilterChain);

--- a/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
+++ b/test/extensions/bootstrap/internal_listener/active_internal_listener_test.cc
@@ -173,6 +173,14 @@ TEST_F(ActiveInternalListenerTest, AcceptSocketAndCreateNetworkFilter) {
   EXPECT_CALL(*filter_chain_, networkFilterFactories).WillOnce(ReturnRef(*filter_factory_callback));
   auto* connection = new NiceMock<Network::MockServerConnection>();
   EXPECT_CALL(dispatcher_, createServerConnection_(_)).WillOnce(Return(connection));
+  // newActiveConnection inspects the connection socket's ioHandle to decide whether to
+  // register the reverse-propagation pre-close hook; provide a non-UserSpace handle so that
+  // path is a no-op in this test.
+  auto* connection_socket = new NiceMock<Network::MockConnectionSocket>();
+  Network::ConnectionSocketPtr connection_socket_ptr{connection_socket};
+  NiceMock<Network::MockIoHandle> connection_io_handle;
+  ON_CALL(*connection_socket, ioHandle()).WillByDefault(ReturnRef(connection_io_handle));
+  ON_CALL(*connection, getSocket()).WillByDefault(ReturnRef(connection_socket_ptr));
   EXPECT_CALL(conn_handler_, incNumConnections());
   EXPECT_CALL(filter_chain_factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   EXPECT_CALL(listener_config_, perConnectionBufferLimitBytes());
@@ -222,6 +230,14 @@ TEST_F(ActiveInternalListenerTest, DestroyListenerCloseAllConnections) {
   EXPECT_CALL(*filter_chain_, networkFilterFactories).WillOnce(ReturnRef(*filter_factory_callback));
   auto* connection = new NiceMock<Network::MockServerConnection>();
   EXPECT_CALL(dispatcher_, createServerConnection_(_)).WillOnce(Return(connection));
+  // newActiveConnection inspects the connection socket's ioHandle to decide whether to
+  // register the reverse-propagation pre-close hook; provide a non-UserSpace handle so that
+  // path is a no-op in this test.
+  auto* connection_socket = new NiceMock<Network::MockConnectionSocket>();
+  Network::ConnectionSocketPtr connection_socket_ptr{connection_socket};
+  NiceMock<Network::MockIoHandle> connection_io_handle;
+  ON_CALL(*connection_socket, ioHandle()).WillByDefault(ReturnRef(connection_io_handle));
+  ON_CALL(*connection, getSocket()).WillByDefault(ReturnRef(connection_socket_ptr));
   EXPECT_CALL(conn_handler_, incNumConnections());
   EXPECT_CALL(filter_chain_factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   EXPECT_CALL(listener_config_, perConnectionBufferLimitBytes());

--- a/test/extensions/io_socket/user_space/file_event_impl_test.cc
+++ b/test/extensions/io_socket/user_space/file_event_impl_test.cc
@@ -51,6 +51,7 @@ public:
   MOCK_METHOD(void, onPeerBufferLowWatermark, ());
   MOCK_METHOD(bool, isReadable, (), (const));
   MOCK_METHOD(PassthroughStateSharedPtr, passthroughState, ());
+  MOCK_METHOD(void, addOnPreCloseCallback, (std::function<void()> callback));
 };
 
 class FileEventImplTest : public testing::Test {

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -83,10 +83,9 @@ TEST(IoHandleImplPreCloseCallback, FiresExactlyOnceOnClose) {
   pair.first->addOnPreCloseCallback([&call_count]() { ++call_count; });
   pair.first->close();
   EXPECT_EQ(call_count, 1);
-  // A second close (e.g. via dtor) must not refire callbacks because close()
+  // A second close (e.g. via dtor) must not run the callbacks again because close()
   // asserts !closed_; pair.first will be destroyed at end of scope with closed_=true.
 }
-
 
 constexpr int CONNECTED = 0;
 

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -21,6 +21,73 @@ namespace IoSocket {
 namespace UserSpace {
 namespace {
 
+class ReverseSimpleType : public StreamInfo::FilterState::Object {
+public:
+  explicit ReverseSimpleType(int v) : value_(v) {}
+  int value() const { return value_; }
+
+private:
+  int value_;
+};
+
+TEST(PassthroughStateImplReverse, RoundTripsSingleMarkedObject) {
+  PassthroughStateImpl state;
+  StreamInfo::FilterStateImpl inner(StreamInfo::FilterState::LifeSpan::Connection);
+  auto value = std::make_shared<ReverseSimpleType>(42);
+  inner.setData("reverse.test.key", value, StreamInfo::FilterState::LifeSpan::Connection,
+                StreamInfo::StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
+  state.captureReverse(inner);
+
+  StreamInfo::FilterStateImpl outer(StreamInfo::FilterState::LifeSpan::Connection);
+  state.mergeReverse(outer);
+
+  const auto* got = outer.getDataReadOnly<ReverseSimpleType>("reverse.test.key");
+  ASSERT_NE(got, nullptr);
+  EXPECT_EQ(got->value(), 42);
+}
+
+TEST(PassthroughStateImplReverse, MergeReverseDoesNotOverwriteExistingName) {
+  PassthroughStateImpl state;
+  StreamInfo::FilterStateImpl inner(StreamInfo::FilterState::LifeSpan::Connection);
+  auto inner_value = std::make_shared<ReverseSimpleType>(1);
+  inner.setData("reverse.test.key", inner_value, StreamInfo::FilterState::LifeSpan::Connection,
+                StreamInfo::StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose);
+  state.captureReverse(inner);
+
+  StreamInfo::FilterStateImpl outer(StreamInfo::FilterState::LifeSpan::Connection);
+  auto outer_existing = std::make_shared<ReverseSimpleType>(99);
+  outer.setData("reverse.test.key", outer_existing, StreamInfo::FilterState::LifeSpan::Connection);
+
+  state.mergeReverse(outer);
+
+  const auto* got = outer.getDataReadOnly<ReverseSimpleType>("reverse.test.key");
+  ASSERT_NE(got, nullptr);
+  EXPECT_EQ(got->value(), 99); // existing value preserved
+}
+
+TEST(PassthroughStateImplReverse, CaptureWithNoMarkedObjectsIsNoOp) {
+  PassthroughStateImpl state;
+  StreamInfo::FilterStateImpl inner(StreamInfo::FilterState::LifeSpan::Connection);
+  inner.setData("not.marked", std::make_shared<ReverseSimpleType>(7),
+                StreamInfo::FilterState::LifeSpan::Connection);
+  state.captureReverse(inner);
+
+  StreamInfo::FilterStateImpl outer(StreamInfo::FilterState::LifeSpan::Connection);
+  state.mergeReverse(outer);
+  EXPECT_FALSE(outer.hasDataWithName("not.marked"));
+}
+
+TEST(IoHandleImplPreCloseCallback, FiresExactlyOnceOnClose) {
+  auto pair = IoHandleFactory::createIoHandlePair();
+  int call_count = 0;
+  pair.first->addOnPreCloseCallback([&call_count]() { ++call_count; });
+  pair.first->close();
+  EXPECT_EQ(call_count, 1);
+  // A second close (e.g. via dtor) must not refire callbacks because close()
+  // asserts !closed_; pair.first will be destroyed at end of scope with closed_=true.
+}
+
+
 constexpr int CONNECTED = 0;
 
 MATCHER(IsInvalidAddress, "") {

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -46,7 +46,7 @@ TEST(PassthroughStateImplReverse, RoundTripsSingleMarkedObject) {
   EXPECT_EQ(got->value(), 42);
 }
 
-TEST(PassthroughStateImplReverse, MergeReverseDoesNotOverwriteExistingName) {
+TEST(PassthroughStateImplReverse, MergeReverseOverwritesExistingName) {
   PassthroughStateImpl state;
   StreamInfo::FilterStateImpl inner(StreamInfo::FilterState::LifeSpan::Connection);
   auto inner_value = std::make_shared<ReverseSimpleType>(1);
@@ -62,7 +62,7 @@ TEST(PassthroughStateImplReverse, MergeReverseDoesNotOverwriteExistingName) {
 
   const auto* got = outer.getDataReadOnly<ReverseSimpleType>("reverse.test.key");
   ASSERT_NE(got, nullptr);
-  EXPECT_EQ(got->value(), 99); // existing value preserved
+  EXPECT_EQ(got->value(), 1); // last-writer-wins: propagated value overwrites the existing one
 }
 
 TEST(PassthroughStateImplReverse, CaptureWithNoMarkedObjectsIsNoOp) {

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -370,7 +370,7 @@ public:
     config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       envoy::extensions::bootstrap::internal_listener::v3::InternalListener config;
       auto* bootstrap_extension = bootstrap.add_bootstrap_extensions();
-      bootstrap_extension->mutable_typed_config()->PackFrom(config);
+      std::ignore = bootstrap_extension->mutable_typed_config()->PackFrom(config);
       bootstrap_extension->set_name("envoy.bootstrap.internal_listener");
 
       auto* static_resources = bootstrap.mutable_static_resources();

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -428,8 +428,7 @@ public:
               ->mutable_routes(0)
               ->mutable_route()
               ->set_cluster("internal_listener");
-          TestUtility::loadFromYaml(
-              fmt::format(R"EOF(
+          TestUtility::loadFromYaml(fmt::format(R"EOF(
           name: envoy.file_access_log
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
@@ -438,8 +437,8 @@ public:
               text_format_source:
                 inline_string: "%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%\n"
           )EOF",
-                          access_log_name_),
-              *hcm.add_access_log());
+                                                access_log_name_),
+                                    *hcm.add_access_log());
         });
 
     HttpIntegrationTest::initialize();

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -352,5 +352,123 @@ TEST_F(InternalUpstreamIntegrationTest, TcpProxyHalfCloseLeak) {
                              testing::Eq(0));
 }
 
+// Reverse propagation of tcp_proxy propagate_response_headers across the
+// internal-listener boundary: an inner tcp_proxy whose CONNECT receives a
+// non-2xx response must surface the captured response-headers filter state
+// object on the outer proxy's upstream connection, readable via
+// %UPSTREAM_FILTER_STATE% on the outer HCM.
+class InternalUpstreamTunnelingIntegrationTest : public testing::Test, public HttpIntegrationTest {
+public:
+  InternalUpstreamTunnelingIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, TestEnvironment::getIpVersionsForTest().front(),
+                            ConfigHelper::httpProxyConfig()) {
+    setUpstreamCount(1);
+  }
+
+  void initialize() override {
+    access_log_name_ = TestEnvironment::temporaryPath(TestUtility::uniqueFilename("upstream_fs"));
+    config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      envoy::extensions::bootstrap::internal_listener::v3::InternalListener config;
+      auto* bootstrap_extension = bootstrap.add_bootstrap_extensions();
+      bootstrap_extension->mutable_typed_config()->PackFrom(config);
+      bootstrap_extension->set_name("envoy.bootstrap.internal_listener");
+
+      auto* static_resources = bootstrap.mutable_static_resources();
+
+      // Cluster reaching the internal listener over the internal_upstream
+      // transport socket (the outer side of the boundary).
+      auto* cluster = static_resources->mutable_clusters()->Add();
+      cluster->set_name("internal_listener");
+      cluster->clear_load_assignment();
+      cluster->mutable_load_assignment()->set_cluster_name("internal_listener");
+      auto* endpoint = cluster->mutable_load_assignment()
+                           ->add_endpoints()
+                           ->add_lb_endpoints()
+                           ->mutable_endpoint();
+      auto* addr = endpoint->mutable_address()->mutable_envoy_internal_address();
+      addr->set_server_listener_name("internal_listener");
+      addr->set_endpoint_id("lorem_ipsum");
+      TestUtility::loadFromYaml(R"EOF(
+      name: envoy.transport_sockets.internal_upstream
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport
+        transport_socket:
+          name: envoy.transport_sockets.raw_buffer
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+      )EOF",
+                                *cluster->mutable_transport_socket());
+
+      // Internal listener whose tcp_proxy CONNECT-tunnels to cluster_0 and
+      // propagates non-2xx response headers into filter state.
+      TestUtility::loadFromYaml(R"EOF(
+      name: internal_listener
+      internal_listener: {}
+      filter_chains:
+      - filters:
+        - name: tcp_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+            cluster: cluster_0
+            stat_prefix: internal_tunnel
+            tunneling_config:
+              hostname: host.com:443
+              propagate_response_headers: true
+      )EOF",
+                                *static_resources->mutable_listeners()->Add());
+    });
+
+    // Route the outer HCM to the internal listener and emit the reverse-
+    // propagated object from the outer (upstream) connection filter state.
+    config_helper_.addConfigModifier(
+        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          hcm.mutable_route_config()
+              ->mutable_virtual_hosts(0)
+              ->mutable_routes(0)
+              ->mutable_route()
+              ->set_cluster("internal_listener");
+          TestUtility::loadFromYaml(
+              fmt::format(R"EOF(
+          name: envoy.file_access_log
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            path: {}
+            log_format:
+              text_format_source:
+                inline_string: "%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%\n"
+          )EOF",
+                          access_log_name_),
+              *hcm.add_access_log());
+        });
+
+    HttpIntegrationTest::initialize();
+  }
+};
+
+TEST_F(InternalUpstreamTunnelingIntegrationTest, PropagateNon2xxConnectResponseAcrossBoundary) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  EXPECT_EQ(upstream_request_->headers().getMethodValue(), "CONNECT");
+
+  const std::string header_value = "secret-value";
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  response_headers.addCopy("test-header-name", header_value);
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  ASSERT_TRUE(response->waitForEndStream());
+  cleanupUpstreamAndDownstream();
+
+  // The propagated response-headers object crossed the internal-listener
+  // boundary onto the outer proxy's upstream connection filter state.
+  EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr(header_value));
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -38,6 +38,7 @@ public:
   MOCK_METHOD(void, onPeerBufferLowWatermark, ());
   MOCK_METHOD(bool, isReadable, (), (const));
   MOCK_METHOD(std::shared_ptr<PassthroughState>, passthroughState, ());
+  MOCK_METHOD(void, addOnPreCloseCallback, (std::function<void()> callback));
 };
 
 class MockPassthroughState : public PassthroughState {
@@ -48,6 +49,8 @@ public:
   MOCK_METHOD(void, mergeInto,
               (envoy::config::core::v3::Metadata & metadata,
                StreamInfo::FilterState& filter_state));
+  MOCK_METHOD(void, captureReverse, (const StreamInfo::FilterState& filter_state));
+  MOCK_METHOD(void, mergeReverse, (StreamInfo::FilterState & filter_state));
 };
 
 class InternalSocketTest : public testing::Test {
@@ -75,6 +78,22 @@ public:
 TEST_F(InternalSocketTest, NativeSocket) {
   NiceMock<Network::MockIoHandle> io_handle;
   initialize(io_handle);
+}
+
+// Test that closeSocket invokes mergeReverse on the shared PassthroughState
+// before delegating to the inner transport socket's closeSocket.
+TEST_F(InternalSocketTest, CloseSocketInvokesMergeReverse) {
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+  EXPECT_CALL(*state, initialize(testing::_, testing::_));
+  initialize(io_handle);
+
+  // closeSocket should call mergeReverse exactly once and then forward to the
+  // wrapped transport socket's closeSocket.
+  EXPECT_CALL(*state, mergeReverse(testing::_));
+  EXPECT_CALL(*inner_socket_, closeSocket(Network::ConnectionEvent::LocalClose, false));
+  socket_->closeSocket(Network::ConnectionEvent::LocalClose, false);
 }
 
 // Test that internal transport socket updates the passthrough state for the user space sockets.


### PR DESCRIPTION
# internal_upstream: reverse-propagate filter state across the internal listener boundary at close

## Commit Message

internal_upstream: reverse-propagate filter state across the internal listener boundary at close

## Additional Description

When an internal listener is used (cluster `transport_socket: envoy.transport_sockets.internal_upstream` → `tunneling_encap_listener` → tcp_proxy), the userspace IoHandle pair currently propagates dynamic metadata and filter state objects *forward* (downstream → internal-listener stream) at connection creation via `PassthroughState::initialize`/`mergeInto`. There is no reverse path: filter state produced on the inner side never crosses back to the outer (downstream) side.

This is the first piece of a fix for #43977 — propagating a non-2xx CONNECT response status (e.g. a `tcp_proxy` upstream tunnel that returns 403) from the inner side back to the downstream HCM, so operators see the real upstream status instead of a canonical 503.

This change is the *primitive* only. It introduces:

- A new `StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose` enum variant, symmetric to the existing `SharedWithUpstreamConnection`. Marks filter state objects that should flow upstream → downstream at upstream close.
- `FilterState::objectsSharedWithDownstreamConnectionOnClose()` accessor (parent-chain walk identical to `objectsSharedWithUpstreamConnection`).
- `PassthroughState::captureReverse(FilterState&)` and `PassthroughState::mergeReverse(FilterState&)`. `captureReverse` is called on the inner side at connection close to harvest marked objects into the shared `PassthroughState`. `mergeReverse` is called on the outer side at its own close to deposit them into its connection's filter state. Names already present on the recipient are overwritten (last-writer-wins), matching the forward `mergeInto`.
- `IoHandle::addOnPreCloseCallback`. `IoHandleImpl::close()` fires registered callbacks exactly once, before notifying the peer or tearing down the file event. This is the hook the inner side uses to call `captureReverse` while its connection's StreamInfo is still queryable.
- Wiring on both sides of the boundary:
  - Inner side: `ActiveInternalListener::newActiveConnection` registers a pre-close callback that calls `captureReverse(connection.streamInfo().filterState())`, capturing the `FilterStateSharedPtr` by value so the callback is safe even if it fires from the IoHandle destructor (i.e. after the Connection is gone).
  - Outer side: `InternalSocket::closeSocket` calls `mergeReverse(connection.streamInfo().filterState())` before delegating to the base `PassthroughSocket::closeSocket`.
- One concrete consumer: `TunnelingConfigHelperImpl::propagateResponseHeaders` and `propagateResponseTrailers` now set their filter state objects with `SharedWithDownstreamConnectionOnClose`. With `propagate_response_headers: true` on the inner `tcp_proxy`, the captured response headers/trailers are now reverse-propagated to the downstream connection's filter state automatically.

The primitive is general: any inner-side network or HTTP filter can mark a filter state object with the new flag to opt into reverse propagation.

### captureReverse is idempotent (close-ordering robustness)
The reverse channel relies on `captureReverse` (inner/accepted side, at close) running before `mergeReverse` (outer/InternalSocket side, at close). That close ordering is not guaranteed: on a client-initiated teardown the outer side closes first, so `mergeReverse` finalizes the shared `PassthroughState` before `captureReverse` runs. `captureReverse` therefore captures only while still in its initial state (mirroring the re-entry tolerance `mergeReverse` already has) instead of asserting single invocation; first-state-wins is correct because when merge precedes capture there is nothing to propagate. Without this, existing `InternalUpstreamIntegrationTest` cases abort on close.

Reverse propagation is thus effective in the inner-closes-first ordering (the intended `tcp_proxy` non-2xx-CONNECT path). Making it order-independent (capturing eagerly when the object is set, rather than at close) is left as a follow-up.

### What's *not* in this PR

- Plumbing the propagated filter state through `Router::UpstreamRequest::onPoolFailure` (currently it only flows through `onPoolReady` via `setUpstreamFilterState`). On the failure path, `streamInfo:upstreamFilterState()` and `%UPSTREAM_FILTER_STATE%` still see nothing. That fix is intended as a separate follow-up PR — it widens the connection pool callback API and is structurally bigger than this primitive.
- Lua/access-log accessors beyond the existing surface. Existing `%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%` continues to work on the success path; the failure-path fix is in the followup.
- Any change to the wire-level behavior of `tcp_proxy` itself (CONNECT semantics, reset behavior, retries).

## Risk Level

Low.

- The new enum variant is opt-in. No existing filter state objects set this flag, so no existing behavior changes.
- The `IoHandle::addOnPreCloseCallback` interface is new and has zero existing registrations outside this PR's wiring; the close path's behavior is unchanged when the callback list is empty.
- The change to `propagateResponseHeaders`/`propagateResponseTrailers` requires `propagate_response_headers: true` (already opt-in) to fire at all. With the option off, the call is a no-op as before. With the option on, the only observable difference is that the captured `TunnelResponseHeaders` filter state object additionally appears on the downstream connection's filter state at upstream close — operators get *more* information, not different information.
- The reverse-merge is last-writer-wins, matching the forward mergeInto. Only objects explicitly marked with the new opt-in flag propagate, so no unrelated downstream filter state is touched..

## Testing

- Existing `propagate_response_headers` integration tests cover the inner-side access-log path; the change to `propagateResponseHeaders`/`propagateResponseTrailers` only adds an opt-in sharing flag to `setData` and does not alter the data placed on the inner-side filter state.
- New unit tests in `test/extensions/io_socket/user_space/io_handle_impl_test.cc` exercising `captureReverse` → `mergeReverse` with a marked filter state object.
- New unit tests in `test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc` verifying `InternalSocket::closeSocket` invokes `mergeReverse` exactly once and passes the right filter state.
- Validated end-to-end on a private envoy deployment in a real-traffic test environment: an inner `tcp_proxy` CONNECT receiving a 403 from its upstream now lands a `TunnelResponseHeaders` filter state object (with the propagated `:status`) on the downstream connection's filter state. Without the patch, the downstream connection's filter state is empty for this case.
- New integration test in `test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc`: an outer HCM → internal-listener → inner tcp_proxy that CONNECT-tunnels and receives a non-2xx response; asserts the captured response-headers filter state object is readable on the downstream HCM via `%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%`. Also guards the close-ordering fix — it reproduces the existing-suite abort without the `captureReverse` idempotency change.

## Docs Changes

`api/envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.proto` updated to note that when `propagate_response_headers`/`propagate_response_trailers` are true and the tcp_proxy is on the inner side of an internal-listener boundary, the resulting filter state objects also become available on the downstream (outer-side) connection's filter state at upstream close. No new config fields.

## Release Notes

Added as `changelogs/current/new_features/` fragments (the changelog was migrated from the monolithic `current.yaml` to per-entry `.rst` files):

`tcp_proxy__reverse-propagate-across-internal-listener.rst`:

> tcp_proxy: when ``propagate_response_headers`` or ``propagate_response_trailers`` is enabled and the tcp_proxy sits on the inner side of an internal-listener boundary, the captured response headers/trailers filter state object is now additionally reverse-propagated to the outer (downstream) connection's filter state at upstream close. Operators reading filter state from the downstream side via ``%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%`` (or equivalent) on the success path will now also see the value when the inner upstream returns a non-2xx response on CONNECT. A pre-existing object of the same name is overwritten (last-writer-wins), consistent with forward propagation.

`filter_state__shared-with-downstream-connection-on-close.rst`:

> filter state: added ``StreamSharingMayImpactPooling::SharedWithDownstreamConnectionOnClose`` for marking filter state objects that should be reverse-propagated from the upstream (inner-side) to the downstream (outer-side) connection at upstream close. Currently honored across the internal-listener boundary by ``PassthroughState`` / ``InternalSocket``.

## Platform Specific Features

N/A.

## Fixes

#43977
