### PR TITLE
Fix buffer multislice tests

### DIFF
--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -523,10 +523,8 @@ TEST(UtilityTest, TestBoundaryConditions) {
   // Test with maximum size buffers to ensure all code paths in getSha256Digest
   Buffer::OwnedImpl large_buffer;
   for (int i = 0; i < 1000; ++i) {
-    large_buffer.appendSliceForTest(
-        "This is a large buffer to test digest computation with multiple slices. ");
+    large_buffer.add("This is a large buffer to test digest computation with multiple slices. ");
   }
-  ASSERT_EQ(1000, large_buffer.getRawSlices().size());
 
   auto digest = UtilitySingleton::get().getSha256Digest(large_buffer);
   EXPECT_EQ(32, digest.size()) << "SHA256 digest should always be 32 bytes";

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -31,11 +31,17 @@ TEST(UtilityTest, TestSha256DigestGrowingBuffer) {
   auto digest = UtilitySingleton::get().getSha256Digest(buffer);
   EXPECT_EQ("76571770bb46bdf51e1aba95b23c681fda27f6ae56a8a90898a4cb7556e19dcb",
             Hex::encode(digest));
-  buffer.add("slice 2");
+
+  buffer.appendSliceForTest("slice 2");
+  ASSERT_EQ(2, buffer.getRawSlices().size());
+
   digest = UtilitySingleton::get().getSha256Digest(buffer);
   EXPECT_EQ("290b462b0fe5edcf6b8532de3ca70da8ab77937212042bb959192ec6c9f95b9a",
             Hex::encode(digest));
-  buffer.add("slice 3");
+
+  buffer.appendSliceForTest("slice 3");
+  ASSERT_EQ(3, buffer.getRawSlices().size());
+
   digest = UtilitySingleton::get().getSha256Digest(buffer);
   EXPECT_EQ("29606bbf02fdc40007cdf799de36d931e3587dafc086937efd6599a4ea9397aa",
             Hex::encode(digest));
@@ -517,8 +523,10 @@ TEST(UtilityTest, TestBoundaryConditions) {
   // Test with maximum size buffers to ensure all code paths in getSha256Digest
   Buffer::OwnedImpl large_buffer;
   for (int i = 0; i < 1000; ++i) {
-    large_buffer.add("This is a large buffer to test digest computation with multiple slices. ");
+    large_buffer.appendSliceForTest(
+        "This is a large buffer to test digest computation with multiple slices. ");
   }
+  ASSERT_EQ(1000, large_buffer.getRawSlices().size());
 
   auto digest = UtilitySingleton::get().getSha256Digest(large_buffer);
   EXPECT_EQ(32, digest.size()) << "SHA256 digest should always be 32 bytes";

--- a/test/common/websocket/codec_test.cc
+++ b/test/common/websocket/codec_test.cc
@@ -469,8 +469,10 @@ TEST(WebSocketCodecTest, DecodeTwoFramesInterleavedInDecodeCalls) {
 // Frame spans over two slices
 TEST(WebSocketCodecTest, DecodeFrameSpansOverTwoSlices) {
   Buffer::OwnedImpl buffer;
-  Buffer::addSeq(buffer, {0x80, 0x86, 0x7c, 0x96, 0x26, 0x3f, 0x1f, 0xfa});
-  Buffer::addSeq(buffer, {0x4f, 0x5a, 0x12, 0xe2});
+  buffer.appendSliceForTest("\x80\x86\x7c\x96\x26\x3f\x1f\xfa", 8);
+  buffer.appendSliceForTest("\x4f\x5a\x12\xe2", 4);
+
+  ASSERT_EQ(2, buffer.getRawSlices().size());
 
   Decoder decoder(kDefaultPayloadBufferLength);
   absl::optional<std::vector<Frame>> frames = decoder.decode(buffer);
@@ -502,24 +504,21 @@ TEST(WebSocketCodecTest, DecodeFrameCompleteAndIncompleteFrame) {
 TEST(WebSocketCodecTest, DecodeFrameSpansOverTwoSlicesSplitByLength) {
   Buffer::OwnedImpl buffer;
   // Length is 126 - represented in the wire by two bytes: 0x00 and 0x7e
-  Buffer::addSeq(buffer, {
-                             0x82,
-                             0xfe,
-                             0x00,
-                         });
-  Buffer::addSeq(buffer, {
-                             0x7e, 0xa1, 0xe8, 0xd7, 0xb0, 0x75, 0xe6, 0x2e, 0x56, 0x91, 0x66, 0xb4,
-                             0x89, 0x66, 0xa3, 0xd4, 0xaf, 0x15, 0x3e, 0x7d, 0xa0, 0xd6, 0xca, 0xf9,
-                             0xc7, 0xd9, 0x5d, 0xc6, 0x33, 0x9d, 0xd5, 0x41, 0x22, 0x0f, 0x18, 0xc1,
-                             0xe7, 0xff, 0x8f, 0x2e, 0x6c, 0xaa, 0x81, 0x0f, 0x4e, 0xa5, 0xb6, 0x25,
-                             0x4e, 0x8e, 0x3b, 0x25, 0x1e, 0x14, 0x58, 0x12, 0x5f, 0xfc, 0xe8, 0xb8,
-                             0xc8, 0xc9, 0xd0, 0xa1, 0x53, 0x04, 0xdb, 0x91, 0xd6, 0x9a, 0xc6, 0x49,
-                             0x6d, 0x96, 0x41, 0x8d, 0x9a, 0xd8, 0x00, 0x96, 0x41, 0x8d, 0x54, 0xdf,
-                             0x0a, 0x87, 0xea, 0xe7, 0x4c, 0xdf, 0x16, 0x9a, 0x30, 0xa0, 0x26, 0x1c,
-                             0xc4, 0x2c, 0xad, 0xfd, 0xd0, 0x2a, 0x16, 0xc5, 0xb4, 0xd7, 0x26, 0xa8,
-                             0xca, 0x78, 0xe2, 0x1d, 0xe1, 0x8c, 0xde, 0xa8, 0x35, 0xd7, 0xda, 0x3a,
-                             0x07, 0xb2, 0xf7, 0x71, 0x54, 0xd7, 0x26, 0xa8, 0xca, 0x78, 0xe2,
-                         });
+  buffer.appendSliceForTest("\x82\xfe\x00", 3);
+  buffer.appendSliceForTest("\x7e\xa1\xe8\xd7\xb0\x75\xe6\x2e\x56\x91\x66\xb4"
+                            "\x89\x66\xa3\xd4\xaf\x15\x3e\x7d\xa0\xd6\xca\xf9"
+                            "\xc7\xd9\x5d\xc6\x33\x9d\xd5\x41\x22\x0f\x18\xc1"
+                            "\xe7\xff\x8f\x2e\x6c\xaa\x81\x0f\x4e\xa5\xb6\x25"
+                            "\x4e\x8e\x3b\x25\x1e\x14\x58\x12\x5f\xfc\xe8\xb8"
+                            "\xc8\xc9\xd0\xa1\x53\x04\xdb\x91\xd6\x9a\xc6\x49"
+                            "\x6d\x96\x41\x8d\x9a\xd8\x00\x96\x41\x8d\x54\xdf"
+                            "\x0a\x87\xea\xe7\x4c\xdf\x16\x9a\x30\xa0\x26\x1c"
+                            "\xc4\x2c\xad\xfd\xd0\x2a\x16\xc5\xb4\xd7\x26\xa8"
+                            "\xca\x78\xe2\x1d\xe1\x8c\xde\xa8\x35\xd7\xda\x3a"
+                            "\x07\xb2\xf7\x71\x54\xd7\x26\xa8\xca\x78\xe2",
+                            131);
+
+  ASSERT_EQ(2, buffer.getRawSlices().size());
 
   Decoder decoder(kDefaultPayloadBufferLength);
   absl::optional<std::vector<Frame>> frames = decoder.decode(buffer);

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1088,11 +1088,10 @@ TEST_F(LuaHttpFilterTest, HttpCallMultiSliceBody) {
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   // Add body in multiple parts to create multiple buffer slices.
 
-  Buffer::OwnedImpl body;
-  body.appendSliceForTest("first");
-  body.appendSliceForTest("second");
-  body.appendSliceForTest("third");
-  response_message->body().move(body);
+  auto& response_body = static_cast<Buffer::OwnedImpl&>(response_message->body());
+  response_body.appendSliceForTest("first");
+  response_body.appendSliceForTest("second");
+  response_body.appendSliceForTest("third");
 
   ASSERT_EQ(3, response_message->body().getRawSlices().size());
 

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -1087,9 +1087,15 @@ TEST_F(LuaHttpFilterTest, HttpCallMultiSliceBody) {
   Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
       Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   // Add body in multiple parts to create multiple buffer slices.
-  response_message->body().add("first");
-  response_message->body().add("second");
-  response_message->body().add("third");
+
+  Buffer::OwnedImpl body;
+  body.appendSliceForTest("first");
+  body.appendSliceForTest("second");
+  body.appendSliceForTest("third");
+  response_message->body().move(body);
+
+  ASSERT_EQ(3, response_message->body().getRawSlices().size());
+
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
   EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
                                  {"trace", "16"},


### PR DESCRIPTION
Commit Message: tests: use appendSliceForTest() in multislice buffer tests


Additional Description: These tests use Buffer::add/addSeq to set up buffers intended to test multisliced buffer functionality. However, because add() and addSeq() coalesce small slices into one slice, the multislice behavior was never tested. We replace any multisliced buffer test to use appendSliceForTest(), which creates a new slice on each call and guarantees small slices are not coalesced. Assert statements are added to ensure correct slice numbers.


Risk Level: Low. Test changes only.


Testing: Existing tests now exercise correct multisliced buffer code paths. Existing tests pass.


Docs Changes: None


Release Notes: None.


Platform Specific Features: None.