### PR TITLE
mobile: fix ODR violation in C++ test shim

### DIFF
--- a/mobile/bazel/envoy_mobile_cc_test.bzl
+++ b/mobile/bazel/envoy_mobile_cc_test.bzl
@@ -30,7 +30,7 @@ def envoy_cc_test_library_with_engine_builder(name, srcs, deps = [], copts = [],
         name = name + "_legacy_builder",
         srcs = srcs,
         copts = copts,
-        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_lib"],
+        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_legacy_lib"],
         **kwargs
     )
 
@@ -64,7 +64,7 @@ def envoy_cc_test_with_engine_builder(name, srcs, deps = [], copts = [], **kwarg
         name = name + "_legacy_builder",
         srcs = srcs,
         copts = copts,
-        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_lib"],
+        deps = overridden_deps + ["//test/cc:engine_builder_test_shim_legacy_lib"],
         **kwargs
     )
 

--- a/mobile/test/cc/BUILD
+++ b/mobile/test/cc/BUILD
@@ -11,6 +11,16 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        "//library/cc:mobile_engine_builder_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "engine_builder_test_shim_legacy_lib",
+    hdrs = ["engine_builder_test_shim.h"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
         "//library/cc:engine_builder_lib",
     ],
 )


### PR DESCRIPTION
Resolve a MemorySanitizer (MSAN) use-of-uninitialized-value in mobile tests.

The issue was caused by an ODR violation where the legacy EngineBuilder implementation (engine_builder.cc) was being linked into test binaries that were compiled for the new MobileEngineBuilder (with `-DUSE_MOBILE_ENGINE_BUILDER` defined). This resulted in the legacy `generateBootstrap()` being called on the new MobileEngineBuilder layout, causing invalid memory accesses.

Changes:
- Split `engine_builder_test_shim_lib` into `engine_builder_test_shim_lib` (for the new builder) and `engine_builder_test_shim_legacy_lib` (for the legacy builder).
- Updated `envoy_mobile_cc_test.bzl` to `use engine_builder_test_shim_legacy_lib` only for legacy targets (suffixed with `_legacy_builder`).

Co-authored with AI 