### PR TITLE
QUIC: add options to configure SSL reset and resumption in QuicDownstreamTransport.

### DIFF
--- a/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
+++ b/api/envoy/extensions/transport_sockets/quic/v3/quic_transport.proto
@@ -27,6 +27,14 @@ message QuicDownstreamTransport {
   // If false, QUIC will tell TLS to reject any early data and to stop issuing 0-RTT credentials with resumption session tickets. This will prevent clients from sending 0-RTT requests.
   // Default to true.
   google.protobuf.BoolValue enable_early_data = 2;
+
+  // If false, QUIC will reject resumption attempts.
+  // Default to true.
+  google.protobuf.BoolValue enable_resumption = 3;
+
+  // If true, the SSL object will be reset after the handshake completes to
+  // reduce memory usage. Default to false.
+  google.protobuf.BoolValue enable_reset_ssl = 4;
 }
 
 // Configuration for Upstream QUIC transport socket. This provides Google's implementation of Google QUIC and IETF QUIC to Envoy.

--- a/source/common/quic/quic_server_transport_socket_factory.cc
+++ b/source/common/quic/quic_server_transport_socket_factory.cc
@@ -31,6 +31,8 @@ QuicServerTransportSocketConfigFactory::createTransportSocketFactory(
 
   auto factory_or_error = QuicServerTransportSocketFactory::create(
       PROTOBUF_GET_WRAPPED_OR_DEFAULT(quic_transport, enable_early_data, true),
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(quic_transport, enable_reset_ssl, false),
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(quic_transport, enable_resumption, true),
       context.statsScope(), std::move(server_config),
       context.serverFactoryContext().sslContextManager());
   RETURN_IF_NOT_OK(factory_or_error.status());
@@ -99,21 +101,25 @@ absl::Status initializeQuicCertAndKey(Ssl::TlsContext& context,
 } // namespace
 
 absl::StatusOr<std::unique_ptr<QuicServerTransportSocketFactory>>
-QuicServerTransportSocketFactory::create(bool enable_early_data, Stats::Scope& store,
+QuicServerTransportSocketFactory::create(bool enable_early_data, bool enable_reset_ssl,
+                                         bool enable_resumption, Stats::Scope& store,
                                          Ssl::ServerContextConfigPtr config,
                                          Envoy::Ssl::ContextManager& manager) {
   absl::Status creation_status = absl::OkStatus();
-  auto ret = std::unique_ptr<QuicServerTransportSocketFactory>(new QuicServerTransportSocketFactory(
-      enable_early_data, store, std::move(config), manager, creation_status));
+  auto ret = std::unique_ptr<QuicServerTransportSocketFactory>(
+      new QuicServerTransportSocketFactory(enable_early_data, enable_reset_ssl, enable_resumption,
+                                           store, std::move(config), manager, creation_status));
   RETURN_IF_NOT_OK(creation_status);
   return ret;
 }
 
 QuicServerTransportSocketFactory::QuicServerTransportSocketFactory(
-    bool enable_early_data, Stats::Scope& scope, Ssl::ServerContextConfigPtr config,
-    Envoy::Ssl::ContextManager& manager, absl::Status& creation_status)
+    bool enable_early_data, bool enable_reset_ssl, bool enable_resumption, Stats::Scope& scope,
+    Ssl::ServerContextConfigPtr config, Envoy::Ssl::ContextManager& manager,
+    absl::Status& creation_status)
     : QuicTransportSocketFactoryBase(scope, "server"), manager_(manager), stats_scope_(scope),
-      config_(std::move(config)), enable_early_data_(enable_early_data) {
+      config_(std::move(config)), enable_early_data_(enable_early_data),
+      enable_reset_ssl_(enable_reset_ssl), enable_resumption_(enable_resumption) {
   auto ctx_or_error = createSslServerContext();
   SET_AND_RETURN_IF_NOT_OK(ctx_or_error.status(), creation_status);
   ssl_ctx_ = *ctx_or_error;

--- a/source/common/quic/quic_server_transport_socket_factory.h
+++ b/source/common/quic/quic_server_transport_socket_factory.h
@@ -20,8 +20,8 @@ class QuicServerTransportSocketFactory : public Network::DownstreamTransportSock
                                          public QuicTransportSocketFactoryBase {
 public:
   static absl::StatusOr<std::unique_ptr<QuicServerTransportSocketFactory>>
-  create(bool enable_early_data, Stats::Scope& store, Ssl::ServerContextConfigPtr config,
-         Envoy::Ssl::ContextManager& manager);
+  create(bool enable_early_data, bool enable_reset_ssl, bool enable_resumption, Stats::Scope& store,
+         Ssl::ServerContextConfigPtr config, Envoy::Ssl::ContextManager& manager);
   ~QuicServerTransportSocketFactory() override;
 
   // Network::DownstreamTransportSocketFactory
@@ -37,6 +37,8 @@ public:
   getTlsCertificateAndKey(absl::string_view sni, bool* cert_matched_sni) const;
 
   bool earlyDataEnabled() const { return enable_early_data_; }
+  bool resetSslEnabled() const { return enable_reset_ssl_; }
+  bool resumptionEnabled() const { return enable_resumption_; }
 
   struct SessionTicketConfig {
     // True when session ticket encryption keys are explicitly configured via
@@ -67,7 +69,8 @@ public:
   }
 
 protected:
-  QuicServerTransportSocketFactory(bool enable_early_data, Stats::Scope& store,
+  QuicServerTransportSocketFactory(bool enable_early_data, bool enable_reset_ssl,
+                                   bool enable_resumption, Stats::Scope& store,
                                    Ssl::ServerContextConfigPtr config,
                                    Envoy::Ssl::ContextManager& manager,
                                    absl::Status& creation_status);
@@ -83,6 +86,8 @@ private:
   mutable absl::Mutex ssl_ctx_mu_;
   Envoy::Ssl::ServerContextSharedPtr ssl_ctx_ ABSL_GUARDED_BY(ssl_ctx_mu_);
   bool enable_early_data_;
+  bool enable_reset_ssl_;
+  bool enable_resumption_;
 };
 
 class QuicServerTransportSocketConfigFactory

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -130,7 +130,8 @@ protected:
         local_address_(Network::Test::getAnyAddress(version_, true)),
         connection_handler_(*dispatcher_, absl::nullopt),
         transport_socket_factory_(*Quic::QuicServerTransportSocketFactory::create(
-            true, *store_.rootScope(), std::make_unique<NiceMock<Ssl::MockServerContextConfig>>(),
+            /*enable_early_data=*/true, /*enable_reset_ssl=*/false, /*enable_resumption=*/true,
+            *store_.rootScope(), std::make_unique<NiceMock<Ssl::MockServerContextConfig>>(),
             ssl_context_manager_)),
         quic_version_(quic::CurrentSupportedHttp3Versions()[0]),
         quic_stat_names_(listener_config_.listenerScope().symbolTable()) {}

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -82,7 +82,8 @@ public:
             std::make_unique<Http::SessionIdleList>(*dispatcher_)),
         connection_id_(quic::test::TestConnectionId(1)),
         transport_socket_factory_(*QuicServerTransportSocketFactory::create(
-            true, listener_config_.listenerScope(),
+            /*enable_early_data=*/true, /*enable_reset_ssl=*/false, /*enable_resumption=*/true,
+            listener_config_.listenerScope(),
             std::make_unique<NiceMock<Ssl::MockServerContextConfig>>(), ssl_context_manager_)) {
     auto writer = new testing::NiceMock<quic::test::MockPacketWriter>();
     envoy_quic_dispatcher_.InitializeWithWriter(writer);

--- a/test/common/quic/envoy_quic_proof_source_test.cc
+++ b/test/common/quic/envoy_quic_proof_source_test.cc
@@ -164,7 +164,8 @@ public:
         .WillRepeatedly(SaveArg<0>(&secret_update_callback_));
     EXPECT_CALL(*mock_context_config_, alpnProtocols()).WillRepeatedly(ReturnRef(alpn_));
     transport_socket_factory_ = *QuicServerTransportSocketFactory::create(
-        true, listener_config_.listenerScope(),
+        /*enable_early_data=*/true, /*enable_reset_ssl=*/false, /*enable_resumption=*/true,
+        listener_config_.listenerScope(),
         std::unique_ptr<Ssl::MockServerContextConfig>(mock_context_config_), ssl_context_manager_);
     transport_socket_factory_->initialize();
     EXPECT_CALL(filter_chain_, name()).WillRepeatedly(Return(""));


### PR DESCRIPTION
…reamTransport.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: QUIC: add options to configure SSL reset and resumption in QuicDownstreamTransport.
Additional Description: This change introduces  enable_resumption  and  enable_reset_ssl  configuration fields to the  QuicDownstreamTransport  proto.           
  enable_resumption  provides the ability to disable TLS session resumption, while  enable_reset_ssl  allows resetting the underlying SSL  
  object after the handshake completes to optimize memory usage. These configuration options are propagated from the                       
  QuicServerTransportSocketFactory  to the downstream QUIC session, allowing for more granular control over SSL resources.  
Risk Level: low
Testing: n/a
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
