### PR TITLE
drain: add new onDrain support to connection callbacks

### DIFF
--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -61,6 +61,17 @@ public:
    * watermark to under its low watermark.
    */
   virtual void onBelowWriteBufferLowWatermark() PURE;
+
+  /**
+   * Called when the connection has been notified that it is being drained (for example
+   * because the filter chain or listener that owns it is being drained). Callbacks may
+   * use this signal to begin a graceful shutdown of any state layered on top of the
+   * connection (e.g. send an HTTP/2 GOAWAY or close-after-current-request).
+   *
+   * The connection remains usable after this call; it is not closed by drain() itself.
+   * The default implementation is a no-op.
+   */
+  virtual void onDrain() {}
 };
 
 /**
@@ -165,6 +176,14 @@ public:
    * @return true if half-close semantics are enabled, false otherwise.
    */
   virtual bool isHalfCloseEnabled() const PURE;
+
+  /**
+   * Notify the connection that it is being drained. This will fire onDrain() on every
+   * registered ConnectionCallbacks. Drain is a notification only: the connection is
+   * not closed and remains usable. Callbacks may react by initiating a graceful
+   * shutdown of any higher-level state (e.g. HTTP/2 GOAWAY).
+   */
+  virtual void drain() PURE;
 
   /**
    * Close the connection.

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -68,7 +68,7 @@ public:
    * use this signal to begin a graceful shutdown of any state layered on top of the
    * connection (e.g. send an HTTP/2 GOAWAY or close-after-current-request).
    *
-   * The connection remains usable after this call; it is not closed by drain() itself.
+   * The connection remains usable after this call; it is not closed by onDrain() itself.
    * The default implementation is a no-op.
    */
   virtual void onDrain() {}
@@ -183,7 +183,7 @@ public:
    * not closed and remains usable. Callbacks may react by initiating a graceful
    * shutdown of any higher-level state (e.g. HTTP/2 GOAWAY).
    */
-  virtual void drain() PURE;
+  virtual void onDrain() PURE;
 
   /**
    * Close the connection.

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -100,6 +100,23 @@ public:
                              const Network::ExtraShutdownListenerOptions& options) PURE;
 
   /**
+   * Notify the connections in the given filter chains that they are being drained. This is
+   * intended to be invoked at the start of a filter-chain drain sequence (before the drain
+   * timer expires and connections are forcibly closed). It does not close connections.
+   * @param listener_tag supplies the tag passed to addListener().
+   * @param filter_chains supplies the filter chains whose connections should be notified.
+   */
+  virtual void drainFilterChains(uint64_t listener_tag,
+                                 const std::list<const FilterChain*>& filter_chains) PURE;
+
+  /**
+   * Notify all connections belonging to the listener with the given tag that they are being
+   * drained. Does not close any connections.
+   * @param listener_tag supplies the tag passed to addListener().
+   */
+  virtual void drainListeners(uint64_t listener_tag) PURE;
+
+  /**
    * Stop all listeners. This will not close any connections and is used for draining.
    */
   virtual void stopListeners() PURE;
@@ -177,6 +194,22 @@ public:
      */
     virtual void onFilterChainDraining(
         const std::list<const Network::FilterChain*>& draining_filter_chains) PURE;
+
+    /**
+     * Called at the start of the drain sequence for the given filter chains. Implementations
+     * should notify all owned connections that they are being drained (by invoking
+     * Network::Connection::drain()) so that callbacks registered on those connections can
+     * react to the drain (e.g. send GOAWAY). Connections are not closed by this call.
+     */
+    virtual void onFilterChainDrainStart(
+        const std::list<const Network::FilterChain*>& draining_filter_chains) PURE;
+
+    /**
+     * Called at the start of the drain sequence for the listener as a whole. Implementations
+     * should notify all owned connections that they are being drained. Connections are not
+     * closed by this call.
+     */
+    virtual void onListenerDrainStart() PURE;
 
     // New method for handling idle connection closing
     virtual void onCloseIdleHttpConnections(bool /*is_saturated*/) {

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -106,15 +106,15 @@ public:
    * @param listener_tag supplies the tag passed to addListener().
    * @param filter_chains supplies the filter chains whose connections should be notified.
    */
-  virtual void drainFilterChains(uint64_t listener_tag,
-                                 const std::list<const FilterChain*>& filter_chains) PURE;
+  virtual void onFilterChainDrain(uint64_t listener_tag,
+                                  const std::list<const FilterChain*>& filter_chains) PURE;
 
   /**
    * Notify all connections belonging to the listener with the given tag that they are being
    * drained. Does not close any connections.
    * @param listener_tag supplies the tag passed to addListener().
    */
-  virtual void drainListeners(uint64_t listener_tag) PURE;
+  virtual void onListenerDrain(uint64_t listener_tag) PURE;
 
   /**
    * Stop all listeners. This will not close any connections and is used for draining.
@@ -198,7 +198,7 @@ public:
     /**
      * Called at the start of the drain sequence for the given filter chains. Implementations
      * should notify all owned connections that they are being drained (by invoking
-     * Network::Connection::drain()) so that callbacks registered on those connections can
+     * Network::Connection::onDrain()) so that callbacks registered on those connections can
      * react to the drain (e.g. send GOAWAY). Connections are not closed by this call.
      */
     virtual void onFilterChainDrainStart(

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -102,8 +102,8 @@ public:
    * @param listener_tag supplies the tag passed to addListener().
    * @param filter_chains supplies the filter chains whose connections should be notified.
    */
-  virtual void drainFilterChains(uint64_t listener_tag,
-                                 const std::list<const Network::FilterChain*>& filter_chains) PURE;
+  virtual void onFilterChainDrain(uint64_t listener_tag,
+                                  const std::list<const Network::FilterChain*>& filter_chains) PURE;
 
   /**
    * Notify all connections of the given listener that they are being drained. Connections
@@ -111,7 +111,7 @@ public:
    * dispatcher.
    * @param listener supplies the listener whose connections should be notified.
    */
-  virtual void drainListener(Network::ListenerConfig& listener) PURE;
+  virtual void onListenerDrain(Network::ListenerConfig& listener) PURE;
 };
 
 using WorkerPtr = std::unique_ptr<Worker>;

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -93,6 +93,25 @@ public:
   virtual void stopListener(Network::ListenerConfig& listener,
                             const Network::ExtraShutdownListenerOptions& options,
                             std::function<void()> completion) PURE;
+
+  /**
+   * Notify all connections in the given filter chains of the listener that they are being
+   * drained. This is intended to be invoked at the start of a drain sequence (before the
+   * drain timer expires). Connections are not closed. This is a fire-and-forget operation
+   * that is posted to the worker's dispatcher.
+   * @param listener_tag supplies the tag passed to addListener().
+   * @param filter_chains supplies the filter chains whose connections should be notified.
+   */
+  virtual void drainFilterChains(uint64_t listener_tag,
+                                 const std::list<const Network::FilterChain*>& filter_chains) PURE;
+
+  /**
+   * Notify all connections of the given listener that they are being drained. Connections
+   * are not closed. This is a fire-and-forget operation that is posted to the worker's
+   * dispatcher.
+   * @param listener supplies the listener whose connections should be notified.
+   */
+  virtual void drainListener(Network::ListenerConfig& listener) PURE;
 };
 
 using WorkerPtr = std::unique_ptr<Worker>;

--- a/source/common/listener_manager/active_stream_listener_base.cc
+++ b/source/common/listener_manager/active_stream_listener_base.cc
@@ -152,6 +152,45 @@ ActiveConnections& OwnedActiveStreamListenerBase::getOrCreateActiveConnections(
   return *connections;
 }
 
+void OwnedActiveStreamListenerBase::onFilterChainDrainStart(
+    const std::list<const Network::FilterChain*>& draining_filter_chains) {
+  // A drain callback may synchronously close the current connection, which removes it from
+  // `connections_` via removeConnection(). Capture `next` before invoking drain() so the
+  // std::list iteration survives erasure of the current node. Pin `is_deleting_` while
+  // iterating so removeConnection() does not also erase the map entry mid-loop if the
+  // filter chain's last connection closes.
+  const bool was_deleting = is_deleting_;
+  is_deleting_ = true;
+  for (const auto* filter_chain : draining_filter_chains) {
+    auto map_iter = connections_by_context_.find(filter_chain);
+    if (map_iter == connections_by_context_.end()) {
+      continue;
+    }
+    auto& connections = map_iter->second->connections_;
+    for (auto it = connections.begin(); it != connections.end();) {
+      auto next = std::next(it);
+      (*it)->connection_->drain();
+      it = next;
+    }
+  }
+  is_deleting_ = was_deleting;
+}
+
+void OwnedActiveStreamListenerBase::onListenerDrainStart() {
+  // See onFilterChainDrainStart for why `next` is captured and `is_deleting_` is pinned.
+  const bool was_deleting = is_deleting_;
+  is_deleting_ = true;
+  for (auto& entry : connections_by_context_) {
+    auto& connections = entry.second->connections_;
+    for (auto it = connections.begin(); it != connections.end();) {
+      auto next = std::next(it);
+      (*it)->connection_->drain();
+      it = next;
+    }
+  }
+  is_deleting_ = was_deleting;
+}
+
 void OwnedActiveStreamListenerBase::removeFilterChain(const Network::FilterChain* filter_chain) {
   auto iter = connections_by_context_.find(filter_chain);
   if (iter == connections_by_context_.end()) {

--- a/source/common/listener_manager/active_stream_listener_base.cc
+++ b/source/common/listener_manager/active_stream_listener_base.cc
@@ -155,7 +155,7 @@ ActiveConnections& OwnedActiveStreamListenerBase::getOrCreateActiveConnections(
 void OwnedActiveStreamListenerBase::onFilterChainDrainStart(
     const std::list<const Network::FilterChain*>& draining_filter_chains) {
   // A drain callback may synchronously close the current connection, which removes it from
-  // `connections_` via removeConnection(). Capture `next` before invoking drain() so the
+  // `connections_` via removeConnection(). Capture `next` before invoking onDrain() so the
   // std::list iteration survives erasure of the current node. Pin `is_deleting_` while
   // iterating so removeConnection() does not also erase the map entry mid-loop if the
   // filter chain's last connection closes.
@@ -169,7 +169,7 @@ void OwnedActiveStreamListenerBase::onFilterChainDrainStart(
     auto& connections = map_iter->second->connections_;
     for (auto it = connections.begin(); it != connections.end();) {
       auto next = std::next(it);
-      (*it)->connection_->drain();
+      (*it)->connection_->onDrain();
       it = next;
     }
   }
@@ -184,7 +184,7 @@ void OwnedActiveStreamListenerBase::onListenerDrainStart() {
     auto& connections = entry.second->connections_;
     for (auto it = connections.begin(); it != connections.end();) {
       auto next = std::next(it);
-      (*it)->connection_->drain();
+      (*it)->connection_->onDrain();
       it = next;
     }
   }

--- a/source/common/listener_manager/active_stream_listener_base.h
+++ b/source/common/listener_manager/active_stream_listener_base.h
@@ -203,6 +203,11 @@ public:
    */
   void removeConnection(ActiveTcpConnection& connection);
 
+  // Network::ConnectionHandler::ActiveListener
+  void onFilterChainDrainStart(
+      const std::list<const Network::FilterChain*>& draining_filter_chains) override;
+  void onListenerDrainStart() override;
+
 protected:
   /**
    * Return the active connections container attached to the given filter chain.

--- a/source/common/listener_manager/connection_handler_impl.cc
+++ b/source/common/listener_manager/connection_handler_impl.cc
@@ -265,6 +265,27 @@ void ConnectionHandlerImpl::stopListeners(uint64_t listener_tag,
   }
 }
 
+void ConnectionHandlerImpl::drainFilterChains(
+    uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains) {
+  if (auto listener_it = listener_map_by_tag_.find(listener_tag);
+      listener_it != listener_map_by_tag_.end()) {
+    listener_it->second->invokeListenerMethod(
+        [&filter_chains](Network::ConnectionHandler::ActiveListener& listener) {
+          listener.onFilterChainDrainStart(filter_chains);
+        });
+  }
+}
+
+void ConnectionHandlerImpl::drainListeners(uint64_t listener_tag) {
+  if (auto listener_it = listener_map_by_tag_.find(listener_tag);
+      listener_it != listener_map_by_tag_.end()) {
+    listener_it->second->invokeListenerMethod(
+        [](Network::ConnectionHandler::ActiveListener& listener) {
+          listener.onListenerDrainStart();
+        });
+  }
+}
+
 void ConnectionHandlerImpl::stopListeners() {
   for (auto& iter : listener_map_by_tag_) {
     iter.second->invokeListenerMethod([](Network::ConnectionHandler::ActiveListener& listener) {

--- a/source/common/listener_manager/connection_handler_impl.cc
+++ b/source/common/listener_manager/connection_handler_impl.cc
@@ -265,7 +265,7 @@ void ConnectionHandlerImpl::stopListeners(uint64_t listener_tag,
   }
 }
 
-void ConnectionHandlerImpl::drainFilterChains(
+void ConnectionHandlerImpl::onFilterChainDrain(
     uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains) {
   if (auto listener_it = listener_map_by_tag_.find(listener_tag);
       listener_it != listener_map_by_tag_.end()) {
@@ -276,7 +276,7 @@ void ConnectionHandlerImpl::drainFilterChains(
   }
 }
 
-void ConnectionHandlerImpl::drainListeners(uint64_t listener_tag) {
+void ConnectionHandlerImpl::onListenerDrain(uint64_t listener_tag) {
   if (auto listener_it = listener_map_by_tag_.find(listener_tag);
       listener_it != listener_map_by_tag_.end()) {
     listener_it->second->invokeListenerMethod(

--- a/source/common/listener_manager/connection_handler_impl.h
+++ b/source/common/listener_manager/connection_handler_impl.h
@@ -53,6 +53,9 @@ public:
   void stopListeners(uint64_t listener_tag,
                      const Network::ExtraShutdownListenerOptions& options) override;
   void stopListeners() override;
+  void drainFilterChains(uint64_t listener_tag,
+                         const std::list<const Network::FilterChain*>& filter_chains) override;
+  void drainListeners(uint64_t listener_tag) override;
   void disableListeners() override;
   void enableListeners() override;
   void setListenerRejectFraction(UnitFloat reject_fraction) override;

--- a/source/common/listener_manager/connection_handler_impl.h
+++ b/source/common/listener_manager/connection_handler_impl.h
@@ -53,9 +53,9 @@ public:
   void stopListeners(uint64_t listener_tag,
                      const Network::ExtraShutdownListenerOptions& options) override;
   void stopListeners() override;
-  void drainFilterChains(uint64_t listener_tag,
-                         const std::list<const Network::FilterChain*>& filter_chains) override;
-  void drainListeners(uint64_t listener_tag) override;
+  void onFilterChainDrain(uint64_t listener_tag,
+                          const std::list<const Network::FilterChain*>& filter_chains) override;
+  void onListenerDrain(uint64_t listener_tag) override;
   void disableListeners() override;
   void enableListeners() override;
   void setListenerRejectFraction(UnitFloat reject_fraction) override;

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -741,6 +741,13 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
     }
   });
 
+  // Notify existing connections on this listener that draining has begun so that callbacks
+  // (e.g. HTTP/2 codecs) can react before the drain timer expires and connections are
+  // forcibly closed.
+  for (const auto& worker : workers_) {
+    worker->drainListener(*draining_it->listener_);
+  }
+
   // Start the drain sequence which completes when the listener's drain manager has completed
   // draining at whatever the server configured drain times are.
   draining_it->listener_->localDrainManager().startDrainSequence(
@@ -931,6 +938,14 @@ void ListenerManagerImpl::drainFilterChains(ListenerImplPtr&& draining_listener,
   draining_group->getDrainingListener().debugLog(
       absl::StrCat("draining ", filter_chain_size, " filter chains in listener ",
                    draining_group->getDrainingListener().name()));
+
+  // Notify existing connections in the draining filter chains that draining has begun so
+  // callbacks (e.g. HTTP/2 codecs) can react before the drain timer expires and the
+  // connections are forcibly closed.
+  for (const auto& worker : workers_) {
+    worker->drainFilterChains(draining_group->getDrainingListenerTag(),
+                              draining_group->getDrainingFilterChains());
+  }
 
   // Start the drain sequence which completes when the listener's drain manager has completed
   // draining at whatever the server configured drain times are.

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -745,7 +745,7 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
   // (e.g. HTTP/2 codecs) can react before the drain timer expires and connections are
   // forcibly closed.
   for (const auto& worker : workers_) {
-    worker->drainListener(*draining_it->listener_);
+    worker->onListenerDrain(*draining_it->listener_);
   }
 
   // Start the drain sequence which completes when the listener's drain manager has completed
@@ -943,8 +943,8 @@ void ListenerManagerImpl::drainFilterChains(ListenerImplPtr&& draining_listener,
   // callbacks (e.g. HTTP/2 codecs) can react before the drain timer expires and the
   // connections are forcibly closed.
   for (const auto& worker : workers_) {
-    worker->drainFilterChains(draining_group->getDrainingListenerTag(),
-                              draining_group->getDrainingFilterChains());
+    worker->onFilterChainDrain(draining_group->getDrainingListenerTag(),
+                               draining_group->getDrainingFilterChains());
   }
 
   // Start the drain sequence which completes when the listener's drain manager has completed

--- a/source/common/network/connection_impl_base.cc
+++ b/source/common/network/connection_impl_base.cc
@@ -28,6 +28,14 @@ void ConnectionImplBase::removeConnectionCallbacks(ConnectionCallbacks& callback
   }
 }
 
+void ConnectionImplBase::drain() {
+  for (ConnectionCallbacks* callback : callbacks_) {
+    if (callback != nullptr) {
+      callback->onDrain();
+    }
+  }
+}
+
 OptRef<const StreamInfo::StreamInfo> ConnectionImplBase::trackedStream() const {
   return streamInfo();
 }

--- a/source/common/network/connection_impl_base.cc
+++ b/source/common/network/connection_impl_base.cc
@@ -28,7 +28,7 @@ void ConnectionImplBase::removeConnectionCallbacks(ConnectionCallbacks& callback
   }
 }
 
-void ConnectionImplBase::drain() {
+void ConnectionImplBase::onDrain() {
   for (ConnectionCallbacks* callback : callbacks_) {
     if (callback != nullptr) {
       callback->onDrain();

--- a/source/common/network/connection_impl_base.h
+++ b/source/common/network/connection_impl_base.h
@@ -23,6 +23,7 @@ public:
   // Network::Connection
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
+  void drain() override;
 
   // Network::FilterManagerConnection
   void onFilterAboveHighWatermark() override;

--- a/source/common/network/connection_impl_base.h
+++ b/source/common/network/connection_impl_base.h
@@ -23,7 +23,7 @@ public:
   // Network::Connection
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
-  void drain() override;
+  void onDrain() override;
 
   // Network::FilterManagerConnection
   void onFilterAboveHighWatermark() override;

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -348,16 +348,30 @@ void MultiConnectionBaseImpl::removeConnectionCallbacks(ConnectionCallbacks& cb)
     connections_[0]->removeConnectionCallbacks(cb);
     return;
   }
-  // Callbacks should only be notified of events on the final connection, so remove
-  // the callback from the list of deferred callbacks.
-  auto i = post_connect_state_.connection_callbacks_.begin();
-  while (i != post_connect_state_.connection_callbacks_.end()) {
-    if (*i == &cb) {
-      post_connect_state_.connection_callbacks_.erase(i);
+  // For performance/safety reasons we just clear the entry and do not resize the vector,
+  // matching ConnectionImplBase::removeConnectionCallbacks. Callers that iterate
+  // connection_callbacks_ skip null entries.
+  for (auto& entry : post_connect_state_.connection_callbacks_) {
+    if (entry == &cb) {
+      entry = nullptr;
       return;
     }
   }
   IS_ENVOY_BUG("Failed to remove connection callbacks");
+}
+
+void MultiConnectionBaseImpl::drain() {
+  if (connect_finished_) {
+    connections_[0]->drain();
+    return;
+  }
+  // Notify all deferred callbacks directly since no underlying connection has been
+  // chosen yet.
+  for (auto* cb : post_connect_state_.connection_callbacks_) {
+    if (cb != nullptr) {
+      cb->onDrain();
+    }
+  }
 }
 
 void MultiConnectionBaseImpl::close(ConnectionCloseType type, absl::string_view details) {

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -360,9 +360,9 @@ void MultiConnectionBaseImpl::removeConnectionCallbacks(ConnectionCallbacks& cb)
   IS_ENVOY_BUG("Failed to remove connection callbacks");
 }
 
-void MultiConnectionBaseImpl::drain() {
+void MultiConnectionBaseImpl::onDrain() {
   if (connect_finished_) {
-    connections_[0]->drain();
+    connections_[0]->onDrain();
     return;
   }
   // Notify all deferred callbacks directly since no underlying connection has been

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -86,7 +86,7 @@ public:
   void write(Buffer::Instance& data, bool end_stream) override;
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
-  void drain() override;
+  void onDrain() override;
 
   // Methods which are applied to each connection attempt.
   void enableHalfClose(bool enabled) override;

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -86,6 +86,7 @@ public:
   void write(Buffer::Instance& data, bool end_stream) override;
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
+  void drain() override;
 
   // Methods which are applied to each connection attempt.
   void enableHalfClose(bool enabled) override;

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -272,6 +272,17 @@ void ActiveQuicListener::onFilterChainDraining(
   }
 }
 
+void ActiveQuicListener::onFilterChainDrainStart(
+    const std::list<const Network::FilterChain*>& /*draining_filter_chains*/) {
+  // TODO: notify QUIC connections in the given filter chains that draining has begun
+  // (e.g. via HTTP/3 GOAWAY) without closing them.
+}
+
+void ActiveQuicListener::onListenerDrainStart() {
+  // TODO: notify all QUIC connections on this listener that draining has begun without
+  // closing them.
+}
+
 void ActiveQuicListener::closeConnectionsWithFilterChain(const Network::FilterChain* filter_chain) {
   quic_dispatcher_->closeConnectionsWithFilterChain(filter_chain);
 }

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -72,6 +72,9 @@ public:
   void updateListenerConfig(Network::ListenerConfig& config) override;
   void onFilterChainDraining(
       const std::list<const Network::FilterChain*>& draining_filter_chains) override;
+  void onFilterChainDrainStart(
+      const std::list<const Network::FilterChain*>& draining_filter_chains) override;
+  void onListenerDrainStart() override;
 
   void onCloseIdleHttpConnections(bool is_saturated) override;
 

--- a/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
+++ b/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
@@ -134,7 +134,7 @@ protected:
         IS_ENVOY_BUG("Unexpected function call");
         return false;
       }
-      void drain() override {}
+      void onDrain() override {}
       void close(Network::ConnectionCloseType) override {}
       void close(Network::ConnectionCloseType, absl::string_view) override {}
       StreamInfo::DetectedCloseType detectedCloseType() const override {

--- a/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
+++ b/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
@@ -134,6 +134,7 @@ protected:
         IS_ENVOY_BUG("Unexpected function call");
         return false;
       }
+      void drain() override {}
       void close(Network::ConnectionCloseType) override {}
       void close(Network::ConnectionCloseType, absl::string_view) override {}
       StreamInfo::DetectedCloseType detectedCloseType() const override {

--- a/source/server/active_udp_listener.h
+++ b/source/server/active_udp_listener.h
@@ -114,6 +114,10 @@ public:
   void onFilterChainDraining(const std::list<const Network::FilterChain*>&) override {
     IS_ENVOY_BUG("unexpected call to onFilterChainDraining");
   }
+  void onFilterChainDrainStart(const std::list<const Network::FilterChain*>&) override {
+    IS_ENVOY_BUG("unexpected call to onFilterChainDrainStart");
+  }
+  void onListenerDrainStart() override { IS_ENVOY_BUG("unexpected call to onListenerDrainStart"); }
 
   // Network::UdpListenerFilterManager
   void addReadFilter(Network::UdpListenerReadFilterPtr&& filter) override;

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -155,14 +155,14 @@ void WorkerImpl::drainFilterChains(uint64_t listener_tag,
                                    const std::list<const Network::FilterChain*>& filter_chains) {
   ASSERT(thread_);
   dispatcher_->post([this, listener_tag, &filter_chains]() -> void {
-    handler_->drainFilterChains(listener_tag, filter_chains);
+    handler_->onFilterChainDrain(listener_tag, filter_chains);
   });
 }
 
 void WorkerImpl::drainListener(Network::ListenerConfig& listener) {
   ASSERT(thread_);
   const uint64_t listener_tag = listener.listenerTag();
-  dispatcher_->post([this, listener_tag]() -> void { handler_->drainListeners(listener_tag); });
+  dispatcher_->post([this, listener_tag]() -> void { handler_->onListenerDrain(listener_tag); });
 }
 
 void WorkerImpl::threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb) {

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -151,6 +151,20 @@ void WorkerImpl::stopListener(Network::ListenerConfig& listener,
   });
 }
 
+void WorkerImpl::drainFilterChains(uint64_t listener_tag,
+                                   const std::list<const Network::FilterChain*>& filter_chains) {
+  ASSERT(thread_);
+  dispatcher_->post([this, listener_tag, &filter_chains]() -> void {
+    handler_->drainFilterChains(listener_tag, filter_chains);
+  });
+}
+
+void WorkerImpl::drainListener(Network::ListenerConfig& listener) {
+  ASSERT(thread_);
+  const uint64_t listener_tag = listener.listenerTag();
+  dispatcher_->post([this, listener_tag]() -> void { handler_->drainListeners(listener_tag); });
+}
+
 void WorkerImpl::threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb) {
   ENVOY_LOG(debug, "worker entering dispatch loop");
   // The watch dog must be created after the dispatcher starts running and has post events flushed,

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -151,16 +151,14 @@ void WorkerImpl::stopListener(Network::ListenerConfig& listener,
   });
 }
 
-void WorkerImpl::drainFilterChains(uint64_t listener_tag,
-                                   const std::list<const Network::FilterChain*>& filter_chains) {
-  ASSERT(thread_);
+void WorkerImpl::onFilterChainDrain(uint64_t listener_tag,
+                                    const std::list<const Network::FilterChain*>& filter_chains) {
   dispatcher_->post([this, listener_tag, &filter_chains]() -> void {
     handler_->onFilterChainDrain(listener_tag, filter_chains);
   });
 }
 
-void WorkerImpl::drainListener(Network::ListenerConfig& listener) {
-  ASSERT(thread_);
+void WorkerImpl::onListenerDrain(Network::ListenerConfig& listener) {
   const uint64_t listener_tag = listener.listenerTag();
   dispatcher_->post([this, listener_tag]() -> void { handler_->onListenerDrain(listener_tag); });
 }

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -68,6 +68,9 @@ public:
   void stopListener(Network::ListenerConfig& listener,
                     const Network::ExtraShutdownListenerOptions& options,
                     std::function<void()> completion) override;
+  void drainFilterChains(uint64_t listener_tag,
+                         const std::list<const Network::FilterChain*>& filter_chains) override;
+  void drainListener(Network::ListenerConfig& listener) override;
 
 private:
   void threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb);

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -68,9 +68,9 @@ public:
   void stopListener(Network::ListenerConfig& listener,
                     const Network::ExtraShutdownListenerOptions& options,
                     std::function<void()> completion) override;
-  void drainFilterChains(uint64_t listener_tag,
-                         const std::list<const Network::FilterChain*>& filter_chains) override;
-  void drainListener(Network::ListenerConfig& listener) override;
+  void onFilterChainDrain(uint64_t listener_tag,
+                          const std::list<const Network::FilterChain*>& filter_chains) override;
+  void onListenerDrain(Network::ListenerConfig& listener) override;
 
 private:
   void threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb);

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -3181,7 +3181,7 @@ filter_chains:
   checkStats(__LINE__, 1, 0, 1, 0, 0, 0, 0);
 }
 
-// Verify ListenerManagerImpl::drainListener fans out worker_->drainListener at the start
+// Verify ListenerManagerImpl::drainListener fans out worker_->onListenerDrain at the start
 // of the drain sequence, before connections are closed.
 TEST_P(ListenerManagerImplTest, DrainListenerFansOutToWorker) {
   InSequence s;
@@ -3205,11 +3205,11 @@ filter_chains:
   EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
   worker_->callAddCompletion();
 
-  // ListenerManagerImpl::drainListener orders: stopListener, worker->drainListener, then
+  // ListenerManagerImpl::drainListener orders: stopListener, worker->onListenerDrain, then
   // drain_manager->startDrainSequence. Override the AnyNumber() default from SetUp() so we
-  // assert worker->drainListener is invoked exactly once.
+  // assert worker->onListenerDrain is invoked exactly once.
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*worker_, drainListener(_));
+  EXPECT_CALL(*worker_, onListenerDrain(_));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
 

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -3181,6 +3181,45 @@ filter_chains:
   checkStats(__LINE__, 1, 0, 1, 0, 0, 0, 0);
 }
 
+// Verify ListenerManagerImpl::drainListener fans out worker_->drainListener at the start
+// of the drain sequence, before connections are closed.
+TEST_P(ListenerManagerImplTest, DrainListenerFansOutToWorker) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_, _));
+  ASSERT_TRUE(manager_->startWorkers(guard_dog_, callback_.AsStdFunction()).ok());
+
+  const std::string listener_foo_yaml = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters: []
+  )EOF";
+
+  ListenerHandle* listener_foo = expectListenerCreate(false, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  worker_->callAddCompletion();
+
+  // ListenerManagerImpl::drainListener orders: stopListener, worker->drainListener, then
+  // drain_manager->startDrainSequence. Override the AnyNumber() default from SetUp() so we
+  // assert worker->drainListener is invoked exactly once.
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
+  EXPECT_CALL(*worker_, drainListener(_));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
+  EXPECT_TRUE(manager_->removeListener("foo"));
+
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  listener_foo->drain_manager_->drain_sequence_completion_();
+
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callRemovalCompletion();
+}
+
 TEST_P(ListenerManagerImplTest, RemoveListener) {
   InSequence s;
 

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -79,8 +79,8 @@ protected:
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
     // Drain notifications are scheduled whenever a listener or its filter chains begin draining.
     // They are not the focus of these tests, so allow them in any number.
-    EXPECT_CALL(*worker_, drainListener(_)).Times(::testing::AnyNumber());
-    EXPECT_CALL(*worker_, drainFilterChains(_, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(*worker_, onListenerDrain(_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(*worker_, onFilterChainDrain(_, _)).Times(::testing::AnyNumber());
     ON_CALL(server_.validation_context_, staticValidationVisitor())
         .WillByDefault(ReturnRef(validation_visitor));
     ON_CALL(server_.validation_context_, dynamicValidationVisitor())

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -77,6 +77,10 @@ protected:
     ON_CALL(server_, api()).WillByDefault(ReturnRef(*api_));
     ON_CALL(*server_.server_factory_context_, api()).WillByDefault(ReturnRef(*api_));
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
+    // Drain notifications are scheduled whenever a listener or its filter chains begin draining.
+    // They are not the focus of these tests, so allow them in any number.
+    EXPECT_CALL(*worker_, drainListener(_)).Times(::testing::AnyNumber());
+    EXPECT_CALL(*worker_, drainFilterChains(_, _)).Times(::testing::AnyNumber());
     ON_CALL(server_.validation_context_, staticValidationVisitor())
         .WillByDefault(ReturnRef(validation_visitor));
     ON_CALL(server_.validation_context_, dynamicValidationVisitor())

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -366,6 +366,46 @@ TEST_P(ConnectionImplTest, GetCongestionWindow) {
   disconnect(true);
 }
 
+TEST_P(ConnectionImplTest, DrainFiresOnDrainOnAllCallbacks) {
+  setUpBasicConnection();
+  connect();
+
+  StrictMock<MockConnectionCallbacks> cb_a;
+  StrictMock<MockConnectionCallbacks> cb_b;
+  client_connection_->addConnectionCallbacks(cb_a);
+  client_connection_->addConnectionCallbacks(cb_b);
+
+  // client_callbacks_ was registered by setUpBasicConnection(); it also receives onDrain().
+  EXPECT_CALL(client_callbacks_, onDrain());
+  EXPECT_CALL(cb_a, onDrain());
+  EXPECT_CALL(cb_b, onDrain());
+  client_connection_->drain();
+
+  client_connection_->removeConnectionCallbacks(cb_a);
+  client_connection_->removeConnectionCallbacks(cb_b);
+  disconnect(true);
+}
+
+TEST_P(ConnectionImplTest, DrainSkipsRemovedCallbacks) {
+  setUpBasicConnection();
+  connect();
+
+  StrictMock<MockConnectionCallbacks> removed_cb;
+  StrictMock<MockConnectionCallbacks> kept_cb;
+  client_connection_->addConnectionCallbacks(removed_cb);
+  client_connection_->addConnectionCallbacks(kept_cb);
+  // removeConnectionCallbacks nulls out the slot without resizing; drain() must skip it.
+  client_connection_->removeConnectionCallbacks(removed_cb);
+
+  EXPECT_CALL(client_callbacks_, onDrain());
+  EXPECT_CALL(kept_cb, onDrain());
+  // removed_cb.onDrain must NOT be invoked (StrictMock catches it).
+  client_connection_->drain();
+
+  client_connection_->removeConnectionCallbacks(kept_cb);
+  disconnect(true);
+}
+
 TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
   setUpBasicConnection();
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -379,7 +379,7 @@ TEST_P(ConnectionImplTest, DrainFiresOnDrainOnAllCallbacks) {
   EXPECT_CALL(client_callbacks_, onDrain());
   EXPECT_CALL(cb_a, onDrain());
   EXPECT_CALL(cb_b, onDrain());
-  client_connection_->drain();
+  client_connection_->onDrain();
 
   client_connection_->removeConnectionCallbacks(cb_a);
   client_connection_->removeConnectionCallbacks(cb_b);
@@ -394,13 +394,13 @@ TEST_P(ConnectionImplTest, DrainSkipsRemovedCallbacks) {
   StrictMock<MockConnectionCallbacks> kept_cb;
   client_connection_->addConnectionCallbacks(removed_cb);
   client_connection_->addConnectionCallbacks(kept_cb);
-  // removeConnectionCallbacks nulls out the slot without resizing; drain() must skip it.
+  // removeConnectionCallbacks nulls out the slot without resizing; onDrain() must skip it.
   client_connection_->removeConnectionCallbacks(removed_cb);
 
   EXPECT_CALL(client_callbacks_, onDrain());
   EXPECT_CALL(kept_cb, onDrain());
   // removed_cb.onDrain must NOT be invoked (StrictMock catches it).
-  client_connection_->drain();
+  client_connection_->onDrain();
 
   client_connection_->removeConnectionCallbacks(kept_cb);
   disconnect(true);

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -215,7 +215,7 @@ TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedFiresOnDeferredCal
 
   EXPECT_CALL(cb_a, onDrain());
   EXPECT_CALL(cb_b, onDrain());
-  impl_->drain();
+  impl_->onDrain();
 }
 
 TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedSkipsRemovedCallbacks) {
@@ -226,13 +226,13 @@ TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedSkipsRemovedCallba
   StrictMock<MockConnectionCallbacks> kept_cb;
   impl_->addConnectionCallbacks(removed_cb);
   impl_->addConnectionCallbacks(kept_cb);
-  // Pre-connect removeConnectionCallbacks nulls the slot rather than erasing it; drain()
+  // Pre-connect removeConnectionCallbacks nulls the slot rather than erasing it; onDrain()
   // must skip the null entry.
   impl_->removeConnectionCallbacks(removed_cb);
 
   EXPECT_CALL(kept_cb, onDrain());
   // StrictMock catches any call on removed_cb.
-  impl_->drain();
+  impl_->onDrain();
 }
 
 TEST_F(MultiConnectionBaseImplTest, DrainAfterConnectFinishedDelegatesToFinalConnection) {
@@ -244,9 +244,9 @@ TEST_F(MultiConnectionBaseImplTest, DrainAfterConnectFinishedDelegatesToFinalCon
   EXPECT_CALL(*createdConnections()[0], removeConnectionCallbacks(_));
   connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
 
-  // drain() now delegates to the surviving connection.
-  EXPECT_CALL(*createdConnections()[0], drain());
-  impl_->drain();
+  // onDrain() now delegates to the surviving connection.
+  EXPECT_CALL(*createdConnections()[0], onDrain());
+  impl_->onDrain();
 }
 
 TEST_F(MultiConnectionBaseImplTest, DisallowedFunctions) {

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -204,6 +204,51 @@ TEST_F(MultiConnectionBaseImplTest, ConnectTimeoutThenFirstSuccess) {
   EXPECT_FALSE(impl_->connecting());
 }
 
+TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedFiresOnDeferredCallbacks) {
+  setupMultiConnectionImpl(2);
+  startConnect();
+
+  StrictMock<MockConnectionCallbacks> cb_a;
+  StrictMock<MockConnectionCallbacks> cb_b;
+  impl_->addConnectionCallbacks(cb_a);
+  impl_->addConnectionCallbacks(cb_b);
+
+  EXPECT_CALL(cb_a, onDrain());
+  EXPECT_CALL(cb_b, onDrain());
+  impl_->drain();
+}
+
+TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedSkipsRemovedCallbacks) {
+  setupMultiConnectionImpl(2);
+  startConnect();
+
+  StrictMock<MockConnectionCallbacks> removed_cb;
+  StrictMock<MockConnectionCallbacks> kept_cb;
+  impl_->addConnectionCallbacks(removed_cb);
+  impl_->addConnectionCallbacks(kept_cb);
+  // Pre-connect removeConnectionCallbacks nulls the slot rather than erasing it; drain()
+  // must skip the null entry.
+  impl_->removeConnectionCallbacks(removed_cb);
+
+  EXPECT_CALL(kept_cb, onDrain());
+  // StrictMock catches any call on removed_cb.
+  impl_->drain();
+}
+
+TEST_F(MultiConnectionBaseImplTest, DrainAfterConnectFinishedDelegatesToFinalConnection) {
+  setupMultiConnectionImpl(2);
+  startConnect();
+
+  // Finish connect on the only-created connection (index 0).
+  EXPECT_CALL(*failover_timer_, disableTimer());
+  EXPECT_CALL(*createdConnections()[0], removeConnectionCallbacks(_));
+  connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
+
+  // drain() now delegates to the surviving connection.
+  EXPECT_CALL(*createdConnections()[0], drain());
+  impl_->drain();
+}
+
 TEST_F(MultiConnectionBaseImplTest, DisallowedFunctions) {
   setupMultiConnectionImpl(2);
   startConnect();

--- a/test/extensions/bootstrap/internal_listener/client_connection_factory_test.cc
+++ b/test/extensions/bootstrap/internal_listener/client_connection_factory_test.cc
@@ -75,6 +75,8 @@ public:
   MOCK_METHOD(void, shutdownListener, (const Network::ExtraShutdownListenerOptions&));
   MOCK_METHOD(void, updateListenerConfig, (Network::ListenerConfig&));
   MOCK_METHOD(void, onFilterChainDraining, (const std::list<const Network::FilterChain*>&));
+  MOCK_METHOD(void, onFilterChainDrainStart, (const std::list<const Network::FilterChain*>&));
+  MOCK_METHOD(void, onListenerDrainStart, ());
   MOCK_METHOD(void, onAccept, (Network::ConnectionSocketPtr&&));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -52,7 +52,7 @@ public:
   /* Network::Connection */                                                                        \
   MOCK_METHOD(void, addConnectionCallbacks, (ConnectionCallbacks & cb));                           \
   MOCK_METHOD(void, removeConnectionCallbacks, (ConnectionCallbacks & cb));                        \
-  MOCK_METHOD(void, drain, ());                                                                    \
+  MOCK_METHOD(void, onDrain, ());                                                                  \
   MOCK_METHOD(void, addBytesSentCallback, (BytesSentCb cb));                                       \
   MOCK_METHOD(void, addWriteFilter, (WriteFilterSharedPtr filter));                                \
   MOCK_METHOD(void, addFilter, (FilterSharedPtr filter));                                          \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -25,6 +25,7 @@ public:
   MOCK_METHOD(void, onEvent, (Network::ConnectionEvent event));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
+  MOCK_METHOD(void, onDrain, ());
 };
 
 class MockConnectionBase {
@@ -51,6 +52,7 @@ public:
   /* Network::Connection */                                                                        \
   MOCK_METHOD(void, addConnectionCallbacks, (ConnectionCallbacks & cb));                           \
   MOCK_METHOD(void, removeConnectionCallbacks, (ConnectionCallbacks & cb));                        \
+  MOCK_METHOD(void, drain, ());                                                                    \
   MOCK_METHOD(void, addBytesSentCallback, (BytesSentCb cb));                                       \
   MOCK_METHOD(void, addWriteFilter, (WriteFilterSharedPtr filter));                                \
   MOCK_METHOD(void, addFilter, (FilterSharedPtr filter));                                          \

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -578,6 +578,9 @@ public:
   MOCK_METHOD(void, stopListeners,
               (uint64_t listener_tag, const Network::ExtraShutdownListenerOptions& options));
   MOCK_METHOD(void, stopListeners, ());
+  MOCK_METHOD(void, drainFilterChains,
+              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
+  MOCK_METHOD(void, drainListeners, (uint64_t listener_tag));
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());
   MOCK_METHOD(void, setListenerRejectFraction, (UnitFloat), (override));

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -578,9 +578,9 @@ public:
   MOCK_METHOD(void, stopListeners,
               (uint64_t listener_tag, const Network::ExtraShutdownListenerOptions& options));
   MOCK_METHOD(void, stopListeners, ());
-  MOCK_METHOD(void, drainFilterChains,
+  MOCK_METHOD(void, onFilterChainDrain,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
-  MOCK_METHOD(void, drainListeners, (uint64_t listener_tag));
+  MOCK_METHOD(void, onListenerDrain, (uint64_t listener_tag));
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());
   MOCK_METHOD(void, setListenerRejectFraction, (UnitFloat), (override));

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -47,6 +47,9 @@ public:
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
+  MOCK_METHOD(void, drainFilterChains,
+              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
+  MOCK_METHOD(void, drainListener, (Network::ListenerConfig & listener));
 
   AddListenerCompletion add_listener_completion_;
   std::function<void()> remove_listener_completion_;

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -47,9 +47,9 @@ public:
   MOCK_METHOD(void, removeFilterChains,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
-  MOCK_METHOD(void, drainFilterChains,
+  MOCK_METHOD(void, onFilterChainDrain,
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
-  MOCK_METHOD(void, drainListener, (Network::ListenerConfig & listener));
+  MOCK_METHOD(void, onListenerDrain, (Network::ListenerConfig & listener));
 
   AddListenerCompletion add_listener_completion_;
   std::function<void()> remove_listener_completion_;

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -430,5 +430,90 @@ api_listener:
   api_listener.reset();
 }
 
+// Exercise the remaining SyntheticConnection stub methods and the base listener's
+// addOnDrainCloseCb for coverage.
+TEST_F(ApiListenerTest, SyntheticConnectionStubMethods) {
+  const std::string yaml = R"EOF(
+name: test_api_listener
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+api_listener:
+  api_listener:
+    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+    stat_prefix: hcm
+    route_config:
+      name: api_router
+      virtual_hosts:
+        - name: api
+          domains:
+            - "*"
+          routes:
+            - match:
+                prefix: "/"
+              route:
+                cluster: dynamic_forward_proxy_cluster
+  )EOF";
+
+  const envoy::config::listener::v3::Listener config = parseListenerFromV3Yaml(yaml);
+  server_.server_factory_context_->cluster_manager_.initializeClusters(
+      {"dynamic_forward_proxy_cluster"}, {});
+  HttpApiListenerFactory factory;
+  auto http_api_listener = factory.create(config, server_, config.name()).value();
+  auto api_listener = http_api_listener->createHttpApiListener(server_.dispatcher());
+  ASSERT_NE(api_listener, nullptr);
+  auto& connection = dynamic_cast<HttpApiListener::ApiListenerWrapper*>(api_listener.get())
+                         ->readCallbacks()
+                         .connection();
+
+  // Unimplemented methods raise an ENVOY_BUG.
+  EXPECT_ENVOY_BUG(connection.addWriteFilter(nullptr), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.addFilter(nullptr), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.addReadFilter(nullptr), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.removeReadFilter(nullptr), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.addBytesSentCallback([](uint64_t) { return true; }),
+                   "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.noDelay(true), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.detectEarlyCloseWhenReadDisabled(true), "Unexpected function call");
+  Buffer::OwnedImpl buffer("x");
+  EXPECT_ENVOY_BUG(connection.write(buffer, false), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.setBufferLimits(100), "Unexpected function call");
+  EXPECT_ENVOY_BUG(connection.startSecureTransport(), "Unexpected function call");
+
+  // No-op and trivial accessors.
+  EXPECT_TRUE(connection.initializeReadFilters());
+  connection.onDrain();
+  connection.close(Network::ConnectionCloseType::NoFlush);
+  connection.close(Network::ConnectionCloseType::NoFlush, "details");
+  EXPECT_EQ(StreamInfo::DetectedCloseType::Normal, connection.detectedCloseType());
+  EXPECT_EQ(12345, connection.id());
+  std::vector<uint8_t> hash;
+  connection.hashKey(hash);
+  EXPECT_TRUE(hash.empty());
+  EXPECT_EQ(Network::Connection::ReadDisableStatus::NoTransition, connection.readDisable(true));
+  EXPECT_TRUE(connection.readEnabled());
+  EXPECT_EQ(&connection.connectionInfoSetter(), connection.connectionInfoProviderSharedPtr().get());
+  EXPECT_FALSE(connection.unixSocketPeerCredentials().has_value());
+  EXPECT_EQ(EMPTY_STRING, connection.requestedServerName());
+  EXPECT_EQ(Network::Connection::State::Open, connection.state());
+  EXPECT_FALSE(connection.aboveHighWatermark());
+  EXPECT_EQ(EMPTY_STRING, connection.transportFailureReason());
+  EXPECT_EQ(EMPTY_STRING, connection.localCloseReason());
+  EXPECT_FALSE(connection.congestionWindowInBytes().has_value());
+  std::stringstream os;
+  connection.dumpState(os, 0);
+  EXPECT_EQ("SyntheticConnection", os.str());
+
+  // The base listener's drain decision rejects drain close callbacks.
+  auto& drain_decision = dynamic_cast<Network::DrainDecision&>(*http_api_listener);
+  EXPECT_FALSE(drain_decision.drainClose(Network::DrainDirection::All));
+  EXPECT_ENVOY_BUG(EXPECT_EQ(drain_decision.addOnDrainCloseCb(
+                                 Network::DrainDirection::All,
+                                 [](std::chrono::milliseconds) { return absl::OkStatus(); }),
+                             nullptr),
+                   "Unexpected call to addOnDrainCloseCb");
+}
+
 } // namespace Server
 } // namespace Envoy

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -2364,10 +2364,10 @@ TEST_F(ConnectionHandlerTest, TcpListenerDrainFilterChainsNotifiesConnections) {
   EXPECT_EQ(1UL, handler_->numConnections());
 
   const std::list<const Network::FilterChain*> filter_chains{filter_chain_.get()};
-  // drainFilterChains must call drain() on every connection owned by the listed filter chains
+  // onFilterChainDrain must call onDrain() on every connection owned by the listed filter chains
   // without closing them.
-  EXPECT_CALL(*server_connection, drain());
-  handler_->drainFilterChains(listener_tag, filter_chains);
+  EXPECT_CALL(*server_connection, onDrain());
+  handler_->onFilterChainDrain(listener_tag, filter_chains);
   // Connection remains tracked; only when filter chains are actually removed does it close.
   EXPECT_EQ(1UL, handler_->numConnections());
 
@@ -2396,9 +2396,9 @@ TEST_F(ConnectionHandlerTest, TcpListenerDrainListenersNotifiesAllConnections) {
   EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
 
-  // drainListeners should fan out drain() to every connection in the listener.
-  EXPECT_CALL(*server_connection, drain());
-  handler_->drainListeners(listener_tag);
+  // onListenerDrain should fan out onDrain() to every connection in the listener.
+  EXPECT_CALL(*server_connection, onDrain());
+  handler_->onListenerDrain(listener_tag);
   EXPECT_EQ(1UL, handler_->numConnections());
 
   // Cleanup.

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -2345,6 +2345,72 @@ TEST_F(ConnectionHandlerTest, TcpListenerInplaceUpdate) {
   EXPECT_CALL(*old_listener, onDestroy());
 }
 
+TEST_F(ConnectionHandlerTest, TcpListenerDrainFilterChainsNotifiesConnections) {
+  InSequence s;
+  uint64_t listener_tag = 1;
+  Network::TcpListenerCallbacks* listener_callbacks;
+  auto listener = new NiceMock<Network::MockListener>();
+  TestListener* test_listener =
+      addListener(listener_tag, true, false, "test_listener", listener, &listener_callbacks);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_, random_);
+
+  Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
+  EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(filter_chain_.get()));
+  auto* server_connection = new NiceMock<Network::MockServerConnection>();
+  EXPECT_CALL(dispatcher_, createServerConnection_(_)).WillOnce(Return(server_connection));
+  EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
+
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
+  EXPECT_EQ(1UL, handler_->numConnections());
+
+  const std::list<const Network::FilterChain*> filter_chains{filter_chain_.get()};
+  // drainFilterChains must call drain() on every connection owned by the listed filter chains
+  // without closing them.
+  EXPECT_CALL(*server_connection, drain());
+  handler_->drainFilterChains(listener_tag, filter_chains);
+  // Connection remains tracked; only when filter chains are actually removed does it close.
+  EXPECT_EQ(1UL, handler_->numConnections());
+
+  EXPECT_CALL(*access_log_, log(_, _));
+  handler_->removeFilterChains(listener_tag, filter_chains, []() {});
+  dispatcher_.clearDeferredDeleteList();
+
+  EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
+  EXPECT_CALL(*listener, onDestroy());
+  handler_.reset();
+}
+
+TEST_F(ConnectionHandlerTest, TcpListenerDrainListenersNotifiesAllConnections) {
+  InSequence s;
+  uint64_t listener_tag = 1;
+  Network::TcpListenerCallbacks* listener_callbacks;
+  auto listener = new NiceMock<Network::MockListener>();
+  TestListener* test_listener =
+      addListener(listener_tag, true, false, "test_listener", listener, &listener_callbacks);
+  handler_->addListener(absl::nullopt, *test_listener, runtime_, random_);
+
+  Network::MockConnectionSocket* connection = new NiceMock<Network::MockConnectionSocket>();
+  EXPECT_CALL(manager_, findFilterChain(_, _)).WillOnce(Return(filter_chain_.get()));
+  auto* server_connection = new NiceMock<Network::MockServerConnection>();
+  EXPECT_CALL(dispatcher_, createServerConnection_(_)).WillOnce(Return(server_connection));
+  EXPECT_CALL(factory_, createNetworkFilterChain(_, _)).WillOnce(Return(true));
+  listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
+
+  // drainListeners should fan out drain() to every connection in the listener.
+  EXPECT_CALL(*server_connection, drain());
+  handler_->drainListeners(listener_tag);
+  EXPECT_EQ(1UL, handler_->numConnections());
+
+  // Cleanup.
+  EXPECT_CALL(*access_log_, log(_, _));
+  const std::list<const Network::FilterChain*> filter_chains{filter_chain_.get()};
+  handler_->removeFilterChains(listener_tag, filter_chains, []() {});
+  dispatcher_.clearDeferredDeleteList();
+  EXPECT_CALL(dispatcher_, clearDeferredDeleteList());
+  EXPECT_CALL(*listener, onDestroy());
+  handler_.reset();
+}
+
 TEST_F(ConnectionHandlerTest, TcpListenerRemoveFilterChain) {
   InSequence s;
   uint64_t listener_tag = 1;

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -151,6 +151,42 @@ TEST_F(WorkerImplTest, BasicFlow) {
   worker_.stop();
 }
 
+TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
+  InSequence s;
+  std::thread::id current_thread_id = std::this_thread::get_id();
+  ConditionalInitializer ci;
+
+  NiceMock<Network::MockListenerConfig> listener;
+  ON_CALL(listener, listenerTag()).WillByDefault(Return(7UL));
+  EXPECT_CALL(*handler_, addListener(_, _, _, _));
+  worker_.addListener(absl::nullopt, listener, [&ci]() { ci.setReady(); }, runtime_, random_);
+  worker_.start(guard_dog_, emptyCallback);
+  ci.waitReady();
+
+  // drainListener posts to the worker dispatcher and invokes handler->drainListeners on
+  // the worker thread.
+  EXPECT_CALL(*handler_, drainListeners(7UL))
+      .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() {
+        EXPECT_NE(current_thread_id, std::this_thread::get_id());
+        ci.setReady();
+      }));
+  worker_.drainListener(listener);
+  ci.waitReady();
+
+  // drainFilterChains likewise posts and forwards on the worker thread.
+  const std::list<const Network::FilterChain*> filter_chains;
+  EXPECT_CALL(*handler_, drainFilterChains(7UL, _))
+      .WillOnce(
+          Invoke([current_thread_id, &ci](uint64_t, const std::list<const Network::FilterChain*>&) {
+            EXPECT_NE(current_thread_id, std::this_thread::get_id());
+            ci.setReady();
+          }));
+  worker_.drainFilterChains(7UL, filter_chains);
+  ci.waitReady();
+
+  worker_.stop();
+}
+
 TEST_F(WorkerImplTest, WorkerInvokesProvidedCallback) {
   absl::Notification callback_ran;
   auto cb = [&callback_ran]() { callback_ran.Notify(); };

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -163,9 +163,9 @@ TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
   worker_.start(guard_dog_, emptyCallback);
   ci.waitReady();
 
-  // drainListener posts to the worker dispatcher and invokes handler->drainListeners on
+  // drainListener posts to the worker dispatcher and invokes handler->onListenerDrain on
   // the worker thread.
-  EXPECT_CALL(*handler_, drainListeners(7UL))
+  EXPECT_CALL(*handler_, onListenerDrain(7UL))
       .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
         ci.setReady();
@@ -175,7 +175,7 @@ TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
 
   // drainFilterChains likewise posts and forwards on the worker thread.
   const std::list<const Network::FilterChain*> filter_chains;
-  EXPECT_CALL(*handler_, drainFilterChains(7UL, _))
+  EXPECT_CALL(*handler_, onFilterChainDrain(7UL, _))
       .WillOnce(
           Invoke([current_thread_id, &ci](uint64_t, const std::list<const Network::FilterChain*>&) {
             EXPECT_NE(current_thread_id, std::this_thread::get_id());

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -163,17 +163,17 @@ TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
   worker_.start(guard_dog_, emptyCallback);
   ci.waitReady();
 
-  // drainListener posts to the worker dispatcher and invokes handler->onListenerDrain on
+  // onListenerDrain posts to the worker dispatcher and invokes handler->onListenerDrain on
   // the worker thread.
   EXPECT_CALL(*handler_, onListenerDrain(7UL))
       .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
         ci.setReady();
       }));
-  worker_.drainListener(listener);
+  worker_.onListenerDrain(listener);
   ci.waitReady();
 
-  // drainFilterChains likewise posts and forwards on the worker thread.
+  // onFilterChainDrain likewise posts and forwards on the worker thread.
   const std::list<const Network::FilterChain*> filter_chains;
   EXPECT_CALL(*handler_, onFilterChainDrain(7UL, _))
       .WillOnce(
@@ -181,7 +181,7 @@ TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
             EXPECT_NE(current_thread_id, std::this_thread::get_id());
             ci.setReady();
           }));
-  worker_.drainFilterChains(7UL, filter_chains);
+  worker_.onFilterChainDrain(7UL, filter_chains);
   ci.waitReady();
 
   worker_.stop();


### PR DESCRIPTION
Commit Message: drain: add new onDrain support to connection callbacks
Additional Description:

Similar to #44932 to add support of watch drain event. But rather than to register per filter/stream state to FactoryContext, this PR makes the connection as the core. The drain even will notify all connections first and then let the connection to notify other callbacks.

Risk Level: mid.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.