### PR TITLE
Update QUICHE from 6460010e2 to cc76be8d4

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-05-18"
+  release_date: "2026-05-26"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "6460010e28a23919ce1f6db92d9fa125ce41fab6",
-        sha256 = "807c62410050395fc8d26eac6454e206490b12ac2e0a98b808a5250e303174d3",
+        version = "cc76be8d43b3841d9ce53b2b24015202a132654e",
+        sha256 = "233b212154119c0b96c27bafcda271bb2befe3c716ea4598d58892a56b40ac29",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/6460010e2..cc76be8d4

```
$ git log 6460010e2..cc76be8d4 --date=short --no-merges --format="%ad %al %s"

2026-05-26 quiche-dev Enabling rolled out flags.
2026-05-22 dschinazi Allow non-OHTTP requests in OHTTP test client
2026-05-22 dschinazi Minor tweak to private_tokens CLI tool
2026-05-22 asedeno Conditionalize QUIC client support of requesting server padding.
2026-05-22 asedeno Fix OSS QUICHE build.
2026-05-22 wub Add `quic::CredentialExData` as the ex_data of QUIC's SSL_CREDENTIAL objects.
2026-05-22 quiche-dev Add QUIC client support to support requesting server padding through an extension in the TLS handshake. This is to support the cert padding experiment for Chrome (see go/cert-padding-experiment-2026)
2026-05-20 martinduke Remove unnecessary tests from MoqtSessionTest. Putting the logic in OutgoingSubgroupStreamTest and SubscriptionPublisherTest is more compact and cleaner conceptually.
2026-05-20 quiche-dev Enabling rolled out flags.
2026-05-20 dschinazi Log probe numbers in OHTTP test client
2026-05-20 reubent Remove balsa_fuzz_test.[c|h] and dependency in http_validation_policy.h
2026-05-20 ianswett Remove QuicIetfStatelessResetPacket, because it was never being used.
2026-05-20 quiche-dev No public description
2026-05-20 dschinazi Make OHTTP toy client ping pong mode report failures
2026-05-19 reubent No public description
2026-05-19 reubent No public description
2026-05-19 martinduke Validate the correct stateless reset token on the alternate path.
2026-05-19 quiche-dev Provide a default implementation for QuicCryptoClientStream::ProofHandler::OnCertificateRequested.
2026-05-19 martinduke Fix asan error in moqt_session_test.
```

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
