### PR TITLE
bazel: use explicit @envoy// repo labels in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -239,8 +239,8 @@ common:aws-lc-fips --@envoy//bazel:crypto=@aws_lc//:crypto
 common:aws-lc-fips --@envoy//bazel:http3=False
 
 # OpenSSL
-common:openssl --//bazel:ssl=//compat/openssl:ssl
-common:openssl --//bazel:crypto=//compat/openssl:crypto
+common:openssl --@envoy//bazel:ssl=@envoy//compat/openssl:ssl
+common:openssl --@envoy//bazel:crypto=@envoy//compat/openssl:crypto
 common:openssl --copt=-DENVOY_SSL_OPENSSL
 common:openssl --host_copt=-DENVOY_SSL_OPENSSL
 common:openssl --@envoy//bazel:http3=False
@@ -357,7 +357,7 @@ build:fuzz-coverage --test_tag_filters=-nocoverage
 # resources required to build and run the tests.
 build:fuzz-coverage --define=wasm=disabled
 build:fuzz-coverage --config=fuzz-coverage-config
-build:fuzz-coverage-config --//tools/coverage:config=@envoy//test:fuzz_coverage_config
+build:fuzz-coverage-config --@envoy//tools/coverage:config=@envoy//test:fuzz_coverage_config
 
 build:oss-fuzz --config=fuzzing
 build:oss-fuzz --config=libc++
@@ -405,7 +405,7 @@ build:clang-tidy --build_tag_filters=-notidy
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb
 
-common:cves --//tools/dependency:cve-data=//tools/dependency:cve-data-dir
+common:cves --@envoy//tools/dependency:cve-data=@envoy//tools/dependency:cve-data-dir
 
 build:docs-ci --action_env=DOCS_RST_CHECK=1 --host_action_env=DOCS_RST_CHECK=1
 


### PR DESCRIPTION
Replace bare // labels with @envoy// ensuring consistency and correct resolution when .bazelrc is imported by downstream projects.
