### PR TITLE
mobile: fix `Logger::Context` UAF in test server 

### DIFF
--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -145,10 +145,6 @@ TestServer::TestServer()
 void TestServer::start(TestServerType type, int port) {
   port_ = port;
   ASSERT(!upstream_);
-  // pre-setup: see https://github.com/envoyproxy/envoy/blob/main/test/test_runner.cc
-  Logger::Context logging_state(spdlog::level::level_enum::err,
-                                "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock_, false, false);
-  // end pre-setup
   Network::DownstreamTransportSocketFactoryPtr factory;
 
   Extensions::TransportSockets::Tls::forceRegisterServerContextFactoryImpl();

--- a/mobile/test/common/integration/xds_test_server.cc
+++ b/mobile/test/common/integration/xds_test_server.cc
@@ -51,8 +51,6 @@ XdsTestServer::XdsTestServer()
   ON_CALL(factory_context_.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   ON_CALL(factory_context_, statsScope())
       .WillByDefault(testing::ReturnRef(*stats_store_.rootScope()));
-  Logger::Context logging_state(spdlog::level::level_enum::err,
-                                "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v", lock_, false, false);
   upstream_config_.upstream_protocol_ = Http::CodecType::HTTP2;
   Extensions::TransportSockets::Tls::forceRegisterServerContextFactoryImpl();
   Config::forceRegisterAdsConfigSubscriptionFactory();


### PR DESCRIPTION
Commit Message: remove the temporary Logger::Context variable to avoid UAF. It sets a global variable with scoped life time which, meanwhile, is also accessed by the standalone fake upstream thread outside of the scope. And the same global variable is also set by `MobileProcessWide`. So removing the conflict.


Risk Level: low.
Testing: fix existing flaky test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
