### PR TITLE
build: exclude OpenSSL-incompatible extensions from builds

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -305,6 +305,14 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
+    name = "disable_http3_on_linux_x86_64",
+    match_all = [
+        ":disable_http3",
+        ":linux_x86_64",
+    ],
+)
+
+selects.config_setting_group(
     name = "disable_http3_on_not_x86_ppc",
     match_all = [
         ":disable_http3",

--- a/contrib/BUILD
+++ b/contrib/BUILD
@@ -37,6 +37,19 @@ selects.config_setting_group(
     visibility = ["//visibility:public"],
 )
 
+# Disambiguation for SELECTED_CONTRIB_EXTENSIONS' select, where both
+# "//bazel:linux_aarch64" and "//bazel:using_openssl" otherwise match for an
+# arm64 openssl build. Restricting the openssl branch to x86_64 lets the
+# aarch64 branch win on arm64.
+selects.config_setting_group(
+    name = "using_openssl_on_linux_x86_64",
+    match_all = [
+        "//bazel:using_openssl",
+        "//bazel:linux_x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 exports_files([
     "extensions_metadata.yaml",
     "contrib_build_config.bzl",

--- a/contrib/all_contrib_extensions.bzl
+++ b/contrib/all_contrib_extensions.bzl
@@ -49,6 +49,13 @@ AWS_LC_SKIP_CONTRIB_TARGETS = [
     "envoy.compression.qatzstd.compressor",
 ]
 
+# OpenSSL is incompatible with Intel-specific private key providers
+# QUIC extensions are already disabled by http3=False in openssl build config
+OPENSSL_SKIP_CONTRIB_TARGETS = [
+    "envoy.tls.key_providers.cryptomb",
+    "envoy.tls.key_providers.qat",
+]
+
 def envoy_all_contrib_extensions(denylist = []):
     return [v + "_envoy_extension" for k, v in CONTRIB_EXTENSIONS.items() if not k in denylist]
 
@@ -57,5 +64,6 @@ SELECTED_CONTRIB_EXTENSIONS = select({
     "//bazel:linux_ppc": envoy_all_contrib_extensions(PPC_SKIP_CONTRIB_TARGETS),
     "//contrib:using_aws_lc_on_linux_x86_64": envoy_all_contrib_extensions(AWS_LC_SKIP_CONTRIB_TARGETS),
     "//contrib:using_boringssl_fips_on_linux_x86_64": envoy_all_contrib_extensions(BORINGSSL_FIPS_SKIP_CONTRIB_TARGETS),
+    "//contrib:using_openssl_on_linux_x86_64": envoy_all_contrib_extensions(OPENSSL_SKIP_CONTRIB_TARGETS),
     "//conditions:default": envoy_all_contrib_extensions(X86_SKIP_CONTRIB_TARGETS),
 })

--- a/source/exe/BUILD
+++ b/source/exe/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
         "//bazel:disable_http3_on_windows_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + WINDOWS_SKIP_TARGETS),
         "//bazel:disable_http3_on_linux_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS + PPC_SKIP_TARGETS),
         "//bazel:disable_http3_on_linux_ppc64le": envoy_all_extensions(PPC_SKIP_TARGETS + NO_HTTP3_SKIP_TARGETS),
+        "//bazel:disable_http3_on_linux_x86_64": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
         "//bazel:disable_http3_on_not_x86_ppc": envoy_all_extensions(NO_HTTP3_SKIP_TARGETS),
         "//conditions:default": envoy_all_extensions(),
     }),


### PR DESCRIPTION
When building with --config=openssl, exclude extensions that are incompatible with OpenSSL: cryptomb and qat private key providers (contrib), and QUIC extensions (core).

For contrib, add OPENSSL_SKIP_CONTRIB_TARGETS and a corresponding select() branch scoped to linux_x86_64 for disambiguation.

For core extensions, add a disable_http3_on_linux_x86_64 branch in the
all_extensions_lib select(). This fixes a pre-existing gap where
disabling HTTP3 on x86_64 Linux (which --config=openssl does) did
not actually exclude QUIC extensions from the build.
