### PR TITLE
mobile: Add absl::Mutex guard for `EnvoyMobileQuicNetworkObserverRegistryFactory`

### DIFF
--- a/mobile/library/common/network/BUILD
+++ b/mobile/library/common/network/BUILD
@@ -37,6 +37,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":network_types_lib",
+        "@abseil-cpp//absl/synchronization",
         "@envoy//source/common/quic:envoy_quic_network_observer_registry_factory_lib",
     ],
 )

--- a/mobile/library/common/network/envoy_mobile_quic_network_observer_registry_factory.cc
+++ b/mobile/library/common/network/envoy_mobile_quic_network_observer_registry_factory.cc
@@ -65,13 +65,28 @@ bool EnvoyMobileQuicNetworkObserverRegistry::isNetworkChangeUpToDate(
   }
 }
 
+EnvoyMobileQuicNetworkObserverRegistryFactory::EnvoyMobileQuicNetworkObserverRegistryFactory(
+    NetworkConnectivityTracker& network_tracker)
+    : network_tracker_(network_tracker) {
+  thread_local_observer_registries_.reserve(1);
+}
+
 EnvoyQuicNetworkObserverRegistryPtr
 EnvoyMobileQuicNetworkObserverRegistryFactory::createQuicNetworkObserverRegistry(
     Event::Dispatcher& dispatcher) {
   auto result =
       std::make_unique<EnvoyMobileQuicNetworkObserverRegistry>(dispatcher, network_tracker_);
-  thread_local_observer_registries_.emplace_back(*result);
+  {
+    absl::WriterMutexLock lock(&mutex_);
+    thread_local_observer_registries_.emplace_back(*result);
+  }
   return result;
+}
+
+std::vector<std::reference_wrapper<EnvoyMobileQuicNetworkObserverRegistry>>
+EnvoyMobileQuicNetworkObserverRegistryFactory::getCreatedObserverRegistries() {
+  absl::ReaderMutexLock lock(&mutex_);
+  return thread_local_observer_registries_;
 }
 
 } // namespace Quic

--- a/mobile/library/common/network/envoy_mobile_quic_network_observer_registry_factory.h
+++ b/mobile/library/common/network/envoy_mobile_quic_network_observer_registry_factory.h
@@ -3,6 +3,8 @@
 #include "source/common/quic/envoy_quic_network_observer_registry_factory.h"
 #include "source/common/quic/quic_network_connectivity_observer.h"
 
+#include "absl/synchronization/mutex.h"
+
 #include "library/common/network/network_types.h"
 
 namespace Envoy {
@@ -66,22 +68,18 @@ class EnvoyMobileQuicNetworkObserverRegistryFactory
     : public EnvoyQuicNetworkObserverRegistryFactory {
 public:
   explicit EnvoyMobileQuicNetworkObserverRegistryFactory(
-      NetworkConnectivityTracker& network_tracker)
-      : network_tracker_(network_tracker) {
-    thread_local_observer_registries_.reserve(1);
-  }
+      NetworkConnectivityTracker& network_tracker);
 
   EnvoyQuicNetworkObserverRegistryPtr
   createQuicNetworkObserverRegistry(Event::Dispatcher& dispatcher) override;
 
-  std::vector<std::reference_wrapper<EnvoyMobileQuicNetworkObserverRegistry>>&
-  getCreatedObserverRegistries() {
-    return thread_local_observer_registries_;
-  }
+  std::vector<std::reference_wrapper<EnvoyMobileQuicNetworkObserverRegistry>>
+  getCreatedObserverRegistries();
 
 private:
+  absl::Mutex mutex_;
   std::vector<std::reference_wrapper<EnvoyMobileQuicNetworkObserverRegistry>>
-      thread_local_observer_registries_;
+      thread_local_observer_registries_ ABSL_GUARDED_BY(mutex_);
   NetworkConnectivityTracker& network_tracker_;
 };
 


### PR DESCRIPTION
Commit Message: `EnvoyMobileQuicNetworkObserverRegistryFactory.thread_local_observer_registries_` is accessed by both Android thread and Envoy engine main or worker thread, thus need to be thread safe.


Risk Level: low
Testing: fix existing TSAN flakiness.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
