### PR TITLE
bazel: use bool_flag for OpenSSL detection instead of label match

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -239,6 +239,7 @@ common:aws-lc-fips --@envoy//bazel:crypto=@aws_lc//:crypto
 common:aws-lc-fips --@envoy//bazel:http3=False
 
 # OpenSSL
+common:openssl --@envoy//bazel:openssl=True
 common:openssl --@envoy//bazel:ssl=@envoy//compat/openssl:ssl
 common:openssl --@envoy//bazel:crypto=@envoy//compat/openssl:crypto
 common:openssl --copt=-DENVOY_SSL_OPENSSL

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -516,6 +516,11 @@ bool_flag(
     build_setting_default = False,
 )
 
+bool_flag(
+    name = "openssl",
+    build_setting_default = False,
+)
+
 config_setting(
     name = "fips_build",
     flag_values = {":fips": "True"},
@@ -538,7 +543,7 @@ config_setting(
 
 config_setting(
     name = "using_openssl",
-    flag_values = {":ssl": "//compat/openssl:ssl"},
+    flag_values = {":openssl": "True"},
 )
 
 # Convenience grouping for any FIPS SSL library


### PR DESCRIPTION
The `using_openssl` config_setting previously matched the exact ssl label (`//compat/openssl:ssl`), which meant downstream projects using their own OpenSSL libraries (e.g. `@openssl//:ssl`) were not detected as OpenSSL builds. Replace the label match with a dedicated bool_flag so downstream projects can set `--@envoy//bazel:openssl=True` alongside their custom ssl/crypto labels.
