### PR TITLE
grpc_als: add grpc_entries_flushed and grpc_entries_flush_failed stats

### DIFF
--- a/changelogs/current/bug_fixes/access_log__fixed-grpc-streaming-client-returning-true-on-stream-creation-failure.rst
+++ b/changelogs/current/bug_fixes/access_log__fixed-grpc-streaming-client-returning-true-on-stream-creation-failure.rst
@@ -1,0 +1,3 @@
+Fixed a bug in the gRPC streaming access log client where a stream creation failure incorrectly
+returned ``true`` from ``log()``, preventing ``grpc_entries_flush_failed`` from being incremented
+in that path.

--- a/changelogs/current/new_features/access_log__added-grpc-entries-flushed-and-flush-failed-stats.rst
+++ b/changelogs/current/new_features/access_log__added-grpc-entries-flushed-and-flush-failed-stats.rst
@@ -1,0 +1,4 @@
+Added ``grpc_entries_flushed`` and ``grpc_entries_flush_failed`` counters to the
+:ref:`gRPC access log statistics <config_access_log_stats>` to track whether log entries are
+actually being delivered to the gRPC endpoint, complementing the existing
+``logs_written``/``logs_dropped`` buffer-level counters.

--- a/docs/root/configuration/observability/access_log/stats.rst
+++ b/docs/root/configuration/observability/access_log/stats.rst
@@ -16,6 +16,8 @@ The gRPC access log has statistics rooted at *access_logs.grpc_access_log.* with
 
    logs_written, Counter, Total log entries sent to the logger which were not dropped. This does not imply the logs have been flushed to the gRPC endpoint yet.
    logs_dropped, Counter, Total log entries dropped due to network or application level back up.
+   grpc_entries_flushed, Counter, Total log entries in batches that were successfully submitted to the gRPC stream. Note that for the streaming gRPC ALS protocol there is no per-batch acknowledgement from the server; this counter reflects entries written to the gRPC send buffer.
+   grpc_entries_flush_failed, Counter, Total log entries in batches where the gRPC send attempt failed (stream creation failure or stream above write buffer high-watermark). An entry counted here may later be counted in ``grpc_entries_flushed`` if the batch is retried successfully on the next flush interval.
 
 
 File access log statistics

--- a/source/extensions/access_loggers/common/grpc_access_logger.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger.h
@@ -83,7 +83,9 @@ public:
  */
 #define ALL_GRPC_ACCESS_LOGGER_STATS(COUNTER)                                                      \
   COUNTER(logs_written)                                                                            \
-  COUNTER(logs_dropped)
+  COUNTER(logs_dropped)                                                                            \
+  COUNTER(grpc_entries_flushed)                                                                    \
+  COUNTER(grpc_entries_flush_failed)
 
 /**
  * Wrapper struct for the access log stats. @see stats_macros.h
@@ -150,6 +152,7 @@ private:
   virtual void addEntry(HttpLogProto&& entry) PURE;
   virtual void addEntry(TcpLogProto&& entry) PURE;
   virtual void clearMessage() { message_.Clear(); }
+  virtual uint32_t countLogEntries() const PURE;
 
   void flush() {
     if (isEmpty()) {
@@ -161,10 +164,13 @@ private:
       initMessage();
     }
 
+    const uint32_t count = countLogEntries();
     if (client_->log(message_)) {
-      // Clear the message regardless of the success.
       approximate_message_size_bytes_ = 0;
       clearMessage();
+      incGrpcEntriesFlushedStats(count);
+    } else {
+      incGrpcEntriesFlushFailedStats(count);
     }
   }
 
@@ -199,6 +205,18 @@ private:
   void incLogsWrittenStats() {
     if (stats_) {
       stats_->logs_written_.inc();
+    }
+  }
+
+  void incGrpcEntriesFlushedStats(uint32_t count) {
+    if (stats_) {
+      stats_->grpc_entries_flushed_.add(count);
+    }
+  }
+
+  void incGrpcEntriesFlushFailedStats(uint32_t count) {
+    if (stats_) {
+      stats_->grpc_entries_flush_failed_.add(count);
     }
   }
 

--- a/source/extensions/access_loggers/common/grpc_access_logger_clients.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger_clients.h
@@ -135,6 +135,7 @@ public:
     } else {
       // Clear out the stream data due to stream creation failure.
       stream_.reset();
+      return false;
     }
     return true;
   }

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.cc
@@ -48,6 +48,11 @@ void GrpcAccessLoggerImpl::initMessage() {
   identifier->set_log_name(log_name_);
 }
 
+uint32_t GrpcAccessLoggerImpl::countLogEntries() const {
+  return (message_.has_http_logs() ? message_.http_logs().log_entry_size() : 0) +
+         (message_.has_tcp_logs() ? message_.tcp_logs().log_entry_size() : 0);
+}
+
 GrpcAccessLoggerCacheImpl::GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& async_client_manager,
                                                      Stats::Scope& scope,
                                                      ThreadLocal::SlotAllocator& tls,

--- a/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/grpc/grpc_access_log_impl.h
@@ -34,6 +34,7 @@ private:
   void addEntry(envoy::data::accesslog::v3::TCPAccessLogEntry&& entry) override;
   bool isEmpty() override;
   void initMessage() override;
+  uint32_t countLogEntries() const override;
 
   const std::string log_name_;
   const LocalInfo::LocalInfo& local_info_;

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.cc
@@ -71,6 +71,8 @@ void GrpcAccessLoggerImpl::initMessage() {}
 
 void GrpcAccessLoggerImpl::clearMessage() { root_->clear_log_records(); }
 
+uint32_t GrpcAccessLoggerImpl::countLogEntries() const { return batched_log_entries_; }
+
 GrpcAccessLoggerCacheImpl::GrpcAccessLoggerCacheImpl(Grpc::AsyncClientManager& async_client_manager,
                                                      Stats::Scope& scope,
                                                      ThreadLocal::SlotAllocator& tls,

--- a/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
+++ b/source/extensions/access_loggers/open_telemetry/grpc_access_log_impl.h
@@ -88,6 +88,7 @@ private:
   bool isEmpty() override;
   void initMessage() override;
   void clearMessage() override;
+  uint32_t countLogEntries() const override;
 
   std::function<OTelLogRequestCallbacks&()> genOTelCallbacksFactory();
 

--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -113,6 +113,17 @@ private:
     num_clears_++;
   }
 
+  uint32_t countLogEntries() const override {
+    uint32_t count = 0;
+    if (message_.fields().contains(MOCK_HTTP_LOG_FIELD_NAME)) {
+      count += static_cast<uint32_t>(message_.fields().at(MOCK_HTTP_LOG_FIELD_NAME).number_value());
+    }
+    if (message_.fields().contains(MOCK_TCP_LOG_FIELD_NAME)) {
+      count += static_cast<uint32_t>(message_.fields().at(MOCK_TCP_LOG_FIELD_NAME).number_value());
+    }
+    return count;
+  }
+
   int num_inits_ = 0;
   int num_clears_ = 0;
 };
@@ -215,6 +226,11 @@ TEST_F(StreamingGrpcAccessLogTest, BasicFlow) {
             TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_dropped")->value());
   EXPECT_EQ(2,
             TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_written")->value());
+  EXPECT_EQ(3, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+  EXPECT_EQ(
+      0, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flush_failed")
+             ->value());
 }
 
 TEST_F(StreamingGrpcAccessLogTest, WatermarksOverrun) {
@@ -262,6 +278,13 @@ TEST_F(StreamingGrpcAccessLogTest, WatermarksOverrun) {
             TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_written")->value());
   EXPECT_EQ(1,
             TestUtility::findCounter(stats_store_, "mock_access_log_prefix.logs_dropped")->value());
+  // The buffered entry failed to flush twice (two above-watermark attempts), then succeeded twice
+  // (once for the stored entry, once for the new entry).
+  EXPECT_EQ(2, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+  EXPECT_EQ(
+      2, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flush_failed")
+             ->value());
 }
 
 // Test that stream failure is handled correctly.
@@ -278,6 +301,11 @@ TEST_F(StreamingGrpcAccessLogTest, StreamFailure) {
           }));
   logger_->log(mockHttpEntry());
   EXPECT_EQ(1, logger_->numInits());
+  EXPECT_EQ(0, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+  EXPECT_EQ(
+      1, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flush_failed")
+             ->value());
 }
 
 TEST_F(StreamingGrpcAccessLogTest, StreamFailureAndRetry) {
@@ -349,6 +377,79 @@ TEST_F(StreamingGrpcAccessLogTest, Flushing) {
   // Flush on empty message does nothing.
   EXPECT_CALL(*timer_, enableTimer(FlushInterval, _));
   timer_->invokeCallback();
+}
+
+// Test that grpc_entries_flushed counts individual entries across batches.
+TEST_F(StreamingGrpcAccessLogTest, GrpcEntriesFlushedCounter) {
+  // Buffer large enough to hold 3 entries before flushing.
+  const int max_buffer_size = 3 * mockHttpEntry().ByteSizeLong();
+  initLogger(FlushInterval, max_buffer_size);
+
+  MockAccessLogStream stream;
+  AccessLogCallbacks* callbacks;
+  expectStreamStart(stream, &callbacks);
+
+  // Batch 3 HTTP entries, expect them flushed together.
+  expectFlushedLogEntriesCount(stream, MOCK_HTTP_LOG_FIELD_NAME, 3);
+  logger_->log(mockHttpEntry());
+  logger_->log(mockHttpEntry());
+  logger_->log(mockHttpEntry());
+  EXPECT_EQ(3, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+  EXPECT_EQ(
+      0, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flush_failed")
+             ->value());
+
+  // One more entry flushed individually.
+  expectFlushedLogEntriesCount(stream, MOCK_HTTP_LOG_FIELD_NAME, 1);
+  Protobuf::Struct big_entry = mockHttpEntry();
+  const std::string big_key(max_buffer_size, 'a');
+  big_entry.mutable_fields()->insert({big_key, Protobuf::Value()});
+  logger_->log(std::move(big_entry));
+  EXPECT_EQ(4, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+}
+
+// Test that grpc_entries_flush_failed counts entries when stream creation fails.
+TEST_F(StreamingGrpcAccessLogTest, GrpcEntriesFlushFailedOnStreamCreationFailure) {
+  initLogger(FlushInterval, 0);
+
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
+      .WillOnce(
+          Invoke([](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks,
+                    const Http::AsyncClient::StreamOptions&) {
+            callbacks.onRemoteClose(Grpc::Status::Internal, "bad");
+            return nullptr;
+          }));
+  logger_->log(mockHttpEntry());
+  EXPECT_EQ(0, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flushed")
+                   ->value());
+  EXPECT_EQ(
+      1, TestUtility::findCounter(stats_store_, "mock_access_log_prefix.grpc_entries_flush_failed")
+             ->value());
+}
+
+class StreamingGrpcAccessLogClientTest : public testing::Test {
+public:
+  StreamingGrpcAccessLogClientTest() {
+    client_ =
+        std::make_unique<Common::StreamingGrpcAccessLogClient<Protobuf::Struct, Protobuf::Struct>>(
+            Grpc::RawAsyncClientSharedPtr{async_client_}, mockMethodDescriptor(), absl::nullopt);
+  }
+
+  Grpc::MockAsyncClient* async_client_{new Grpc::MockAsyncClient()};
+  std::unique_ptr<Common::StreamingGrpcAccessLogClient<Protobuf::Struct, Protobuf::Struct>> client_;
+};
+
+TEST_F(StreamingGrpcAccessLogClientTest, ReturnsFalseOnStreamCreationFailure) {
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
+      .WillOnce(
+          Invoke([](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks,
+                    const Http::AsyncClient::StreamOptions&) {
+            callbacks.onRemoteClose(Grpc::Status::Internal, "bad");
+            return nullptr;
+          }));
+  EXPECT_FALSE(client_->log(Protobuf::Struct{}));
 }
 
 class UnaryGrpcAccessLogTest : public testing::Test {


### PR DESCRIPTION
Commit Message: grpc_als: add grpc_entries_flushed and grpc_entries_flush_failed stats

Additional Description:
Currently there is no accurate way to measure how much data is actually making it to the ALS gRPC
service or how much is being dropped before reaching it. The existing `logs_written` and
`logs_dropped` counters only track operations against Envoy's internal in-memory buffer —
`logs_written` increments when an entry is accepted into the buffer, and `logs_dropped` increments
when the buffer is full. Neither counter reflects whether log entries are actually being delivered
to the downstream gRPC service. A silently failing gRPC stream (e.g. due to a connection error)
will show `logs_dropped = 0` and `logs_written` incrementing normally, giving a false impression
that all logs are being delivered.

This PR adds two new counters to the gRPC access log statistics that track the outcome of the
actual gRPC send operation:

- `grpc_entries_flushed`: number of individual log entries in batches that were successfully
  submitted to the gRPC stream (`sendMessage` was called without error). For the streaming ALS
  protocol there is no per-batch server acknowledgement, so "submitted to gRPC stream" is the best
  available signal.
- `grpc_entries_flush_failed`: number of log entries in batches where the gRPC send attempt failed
  — either due to stream creation failure or the stream being above its write buffer high-watermark.
  Note: a batch that fails may be retried on the next flush interval, so an entry may appear in
  both counters across retries.

The existing `logs_written` / `logs_dropped` semantics are unchanged — they continue to track
buffer-level operations. The new counters are purely additive.

This PR also fixes a pre-existing bug in `StreamingGrpcAccessLogClient::log()` where a stream
creation failure fell through to `return true`, causing `flush()` to believe the send succeeded
and preventing `grpc_entries_flush_failed` from ever being incremented in that path.

Related to https://github.com/envoyproxy/envoy/issues/40806

Generative AI (Claude) was used to assist in drafting this PR. The submitter has reviewed,
understands, and takes full ownership of all code and changes.

Risk Level: low

Testing: Updated existing unit tests (BasicFlow, WatermarksOverrun, StreamFailure) with assertions
for the new counters. Added two new unit tests: GrpcEntriesFlushedCounter (verifies per-entry
counting across batches) and GrpcEntriesFlushFailedOnStreamCreationFailure (verifies the bug fix
and new counter increment on stream creation failure).

Docs Changes: Updated docs/root/configuration/observability/access_log/stats.rst with descriptions
for both new counters.

---
*Note: This is a re-submission of #43649, which was closed due to staleness.