### PR TITLE
stats: optimize the parameter types

### DIFF
--- a/envoy/stats/BUILD
+++ b/envoy/stats/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "//envoy/common:interval_set_interface",
         "//envoy/common:optref_lib",
         "//envoy/common:time_interface",
+        "//source/common/stats:symbol_table_lib",
         "@abseil-cpp//absl/container:inlined_vector",
     ],
 )

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -9,6 +9,9 @@
 #include "envoy/stats/stats_matcher.h"
 #include "envoy/stats/tag.h"
 
+#include "source/common/stats/symbol_table.h"
+
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -96,7 +99,7 @@ public:
    * NOTE: If the scope specific matcher is set, then the sub scope will inherit the same matcher
    * unless another matcher is explicitly set.
    */
-  virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+  virtual ScopeSharedPtr createScope(absl::string_view name, bool evictable = false,
                                      const ScopeStatsLimitSettings& limits = {},
                                      StatsMatcherSharedPtr matcher = nullptr) PURE;
 
@@ -122,9 +125,7 @@ public:
    * @param name The name of the stat, obtained from the SymbolTable.
    * @return a counter within the scope's namespace.
    */
-  Counter& counterFromStatName(const StatName& name) {
-    return counterFromStatNameWithTags(name, absl::nullopt);
-  }
+  Counter& counterFromStatName(StatName name) { return counterFromStatNameWithTags(name); }
   /**
    * Creates a Counter from the stat name and tags. If tags are not provided, tag extraction
    * will be performed on the name.
@@ -132,15 +133,16 @@ public:
    * @param tags optionally specified tags.
    * @return a counter within the scope's namespace.
    */
-  virtual Counter& counterFromStatNameWithTags(const StatName& name,
-                                               StatNameTagVectorOptConstRef tags) PURE;
+  virtual Counter&
+  counterFromStatNameWithTags(StatName name,
+                              absl::optional<StatNameTagSpan> tags = absl::nullopt) PURE;
 
   /**
    * TODO(#6667): this variant is deprecated: use counterFromStatName.
    * @param name The name, expressed as a string.
    * @return a counter within the scope's namespace.
    */
-  virtual Counter& counterFromString(const std::string& name) PURE;
+  virtual Counter& counterFromString(absl::string_view name) PURE;
 
   /**
    * Creates a Gauge from the stat name. Tag extraction will be performed on the name.
@@ -148,7 +150,7 @@ public:
    * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
-  Gauge& gaugeFromStatName(const StatName& name, Gauge::ImportMode import_mode) {
+  Gauge& gaugeFromStatName(StatName name, Gauge::ImportMode import_mode) {
     return gaugeFromStatNameWithTags(name, absl::nullopt, import_mode);
   }
 
@@ -160,7 +162,7 @@ public:
    * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
-  virtual Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+  virtual Gauge& gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                            Gauge::ImportMode import_mode) PURE;
 
   /**
@@ -169,7 +171,7 @@ public:
    * @param import_mode Whether hot-restart should accumulate this value.
    * @return a gauge within the scope's namespace.
    */
-  virtual Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) PURE;
+  virtual Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) PURE;
 
   /**
    * Creates a Histogram from the stat name. Tag extraction will be performed on the name.
@@ -177,7 +179,7 @@ public:
    * @param unit The unit of measurement.
    * @return a histogram within the scope's namespace with a particular value type.
    */
-  Histogram& histogramFromStatName(const StatName& name, Histogram::Unit unit) {
+  Histogram& histogramFromStatName(StatName name, Histogram::Unit unit) {
     return histogramFromStatNameWithTags(name, absl::nullopt, unit);
   }
 
@@ -189,8 +191,8 @@ public:
    * @param unit The unit of measurement.
    * @return a histogram within the scope's namespace with a particular value type.
    */
-  virtual Histogram& histogramFromStatNameWithTags(const StatName& name,
-                                                   StatNameTagVectorOptConstRef tags,
+  virtual Histogram& histogramFromStatNameWithTags(StatName name,
+                                                   absl::optional<StatNameTagSpan> tags,
                                                    Histogram::Unit unit) PURE;
 
   /**
@@ -199,15 +201,15 @@ public:
    * @param unit The unit of measurement.
    * @return a histogram within the scope's namespace with a particular value type.
    */
-  virtual Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) PURE;
+  virtual Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) PURE;
 
   /**
    * Creates a TextReadout from the stat name. Tag extraction will be performed on the name.
    * @param name The name of the stat, obtained from the SymbolTable.
    * @return a text readout within the scope's namespace.
    */
-  TextReadout& textReadoutFromStatName(const StatName& name) {
-    return textReadoutFromStatNameWithTags(name, absl::nullopt);
+  TextReadout& textReadoutFromStatName(StatName name) {
+    return textReadoutFromStatNameWithTags(name);
   }
 
   /**
@@ -217,15 +219,16 @@ public:
    * @param tags optionally specified tags.
    * @return a text readout within the scope's namespace.
    */
-  virtual TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
-                                                       StatNameTagVectorOptConstRef tags) PURE;
+  virtual TextReadout&
+  textReadoutFromStatNameWithTags(StatName name,
+                                  absl::optional<StatNameTagSpan> tags = absl::nullopt) PURE;
 
   /**
    * TODO(#6667): this variant is deprecated: use textReadoutFromStatName.
    * @param name The name, expressed as a string.
    * @return a text readout within the scope's namespace.
    */
-  virtual TextReadout& textReadoutFromString(const std::string& name) PURE;
+  virtual TextReadout& textReadoutFromString(absl::string_view name) PURE;
 
   /**
    * @param The name of the stat, obtained from the SymbolTable.

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -12,6 +12,8 @@
 #include "envoy/stats/stats_matcher.h"
 #include "envoy/stats/tag_producer.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Event {
 
@@ -161,23 +163,23 @@ public:
   // Delegate some methods to the root scope; these are exposed to make it more
   // convenient to use stats_macros.h. We may consider dropping them if desired,
   // when we resolve #24007 or in the next follow-up.
-  Counter& counterFromString(const std::string& name) {
+  Counter& counterFromString(absl::string_view name) {
     return rootScope()->counterFromString(name);
   }
-  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) {
+  Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) {
     return rootScope()->gaugeFromString(name, import_mode);
   }
-  TextReadout& textReadoutFromString(const std::string& name) {
+  TextReadout& textReadoutFromString(absl::string_view name) {
     return rootScope()->textReadoutFromString(name);
   }
-  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) {
+  Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) {
     return rootScope()->histogramFromString(name, unit);
   }
 
   /**
    * @return a scope of the given name.
    */
-  ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+  ScopeSharedPtr createScope(absl::string_view name, bool evictable = false,
                              const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) {
     return rootScope()->createScope(name, evictable, limits, std::move(matcher));

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -60,7 +60,7 @@ ConstScopeSharedPtr IsolatedStoreImpl::constRootScope() const {
 
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
-ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool,
+ScopeSharedPtr IsolatedScopeImpl::createScope(absl::string_view name, bool,
                                               const ScopeStatsLimitSettings& limits,
                                               StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -330,19 +330,19 @@ public:
   // Stats::Scope
   SymbolTable& symbolTable() override { return store_.symbolTable(); }
   const SymbolTable& constSymbolTable() const override { return store_.symbolTable(); }
-  Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptConstRef tags) override {
+  Counter& counterFromStatNameWithTags(StatName name,
+                                       absl::optional<StatNameTagSpan> tags) override {
     const OptRef<const StatsMatcher> matcher = makeOptRefFromPtr(scope_matcher_.get());
     const TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
     return store_.counters_.get(joiner, matcher).value_or(store_.null_counter_);
   }
-  ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+  ScopeSharedPtr createScope(absl::string_view name, bool evictable = false,
                              const ScopeStatsLimitSettings& limits = {},
                              StatsMatcherSharedPtr matcher = nullptr) override;
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
                                    const ScopeStatsLimitSettings& limits = {},
                                    StatsMatcherSharedPtr matcher = nullptr) override;
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+  Gauge& gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                    Gauge::ImportMode import_mode) override {
     const OptRef<const StatsMatcher> matcher = makeOptRefFromPtr(scope_matcher_.get());
     const TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
@@ -353,14 +353,14 @@ public:
     gauge->mergeImportMode(import_mode);
     return *gauge;
   }
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+  Histogram& histogramFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                            Histogram::Unit unit) override {
     const OptRef<const StatsMatcher> matcher = makeOptRefFromPtr(scope_matcher_.get());
     const TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
     return store_.histograms_.get(joiner, unit, matcher).value_or(store_.null_histogram_);
   }
-  TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
-                                               StatNameTagVectorOptConstRef tags) override {
+  TextReadout& textReadoutFromStatNameWithTags(StatName name,
+                                               absl::optional<StatNameTagSpan> tags) override {
     const OptRef<const StatsMatcher> matcher = makeOptRefFromPtr(scope_matcher_.get());
     const TagUtility::TagStatNameJoiner joiner(prefix(), name, tags, symbolTable());
     return store_.text_readouts_.get(joiner, TextReadout::Type::Default, matcher)
@@ -390,19 +390,19 @@ public:
     return store_.text_readouts_.iterate(iterFilter(fn));
   }
 
-  Counter& counterFromString(const std::string& name) override {
+  Counter& counterFromString(absl::string_view name) override {
     StatNameManagedStorage storage(name, symbolTable());
     return counterFromStatName(storage.statName());
   }
-  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) override {
     StatNameManagedStorage storage(name, symbolTable());
     return gaugeFromStatName(storage.statName(), import_mode);
   }
-  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override {
+  Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) override {
     StatNameManagedStorage storage(name, symbolTable());
     return histogramFromStatName(storage.statName(), unit);
   }
-  TextReadout& textReadoutFromString(const std::string& name) override {
+  TextReadout& textReadoutFromString(absl::string_view name) override {
     StatNameManagedStorage storage(name, symbolTable());
     return textReadoutFromStatName(storage.statName());
   }

--- a/source/common/stats/tag_utility.cc
+++ b/source/common/stats/tag_utility.cc
@@ -10,23 +10,22 @@ namespace Stats {
 namespace TagUtility {
 
 TagStatNameJoiner::TagStatNameJoiner(StatName prefix, StatName stat_name,
-                                     StatNameTagVectorOptConstRef stat_name_tags,
+                                     absl::optional<StatNameTagSpan> stat_name_tags,
                                      SymbolTable& symbol_table)
     : stat_name_tags_(stat_name_tags) {
   prefix_storage_ = symbol_table.join({prefix, stat_name});
   tag_extracted_name_ = StatName(prefix_storage_.get());
 
-  if (stat_name_tags) {
+  if (!stat_name_tags.has_value() || stat_name_tags->empty()) {
+    name_with_tags_ = StatName(prefix_storage_.get());
+  } else {
     full_name_storage_ =
         joinNameAndTags(StatName(prefix_storage_.get()), *stat_name_tags, symbol_table);
     name_with_tags_ = StatName(full_name_storage_.get());
-  } else {
-    name_with_tags_ = StatName(prefix_storage_.get());
   }
 }
 
-SymbolTable::StoragePtr TagStatNameJoiner::joinNameAndTags(StatName name,
-                                                           const StatNameTagVector& tags,
+SymbolTable::StoragePtr TagStatNameJoiner::joinNameAndTags(StatName name, StatNameTagSpan tags,
                                                            SymbolTable& symbol_table) {
   StatNameVec stat_names;
   stat_names.reserve(1 + 2 * tags.size());

--- a/source/common/stats/tag_utility.h
+++ b/source/common/stats/tag_utility.h
@@ -17,8 +17,8 @@ class TagStatNameJoiner {
 public:
   /**
    * Combines a prefix, stat name and tags into a single stat name.
-   * @param prefix StaName the stat prefix to use.
-   * @param name StaName the stat name to use.
+   * @param prefix StatName the stat prefix to use.
+   * @param name StatName the stat name to use.
    * @param stat_name_tags optional explicit tags to add to the stat name. absl::nullopt means no
    *        explicit tags were provided, in which case tag extraction will later be performed on
    *        the name. A present-but-empty span means "explicitly no tags" and suppresses extraction.

--- a/source/common/stats/tag_utility.h
+++ b/source/common/stats/tag_utility.h
@@ -19,10 +19,13 @@ public:
    * Combines a prefix, stat name and tags into a single stat name.
    * @param prefix StaName the stat prefix to use.
    * @param name StaName the stat name to use.
-   * @param stat_name_tags optionally StatNameTagVector the stat name tags to add to the stat name.
+   * @param stat_name_tags optional explicit tags to add to the stat name. absl::nullopt means no
+   *        explicit tags were provided, in which case tag extraction will later be performed on
+   *        the name. A present-but-empty span means "explicitly no tags" and suppresses extraction.
+   *        This nullopt-vs-present distinction is preserved and surfaced via effectiveTags().
    */
   TagStatNameJoiner(StatName prefix, StatName stat_name,
-                    StatNameTagVectorOptConstRef stat_name_tags, SymbolTable& symbol_table);
+                    absl::optional<StatNameTagSpan> stat_name_tags, SymbolTable& symbol_table);
 
   /**
    * @return StatName the full stat name, including the tag suffix.
@@ -35,15 +38,11 @@ public:
   StatName tagExtractedName() const { return tag_extracted_name_; }
 
   /**
-   * @return the optional effective tags.
+   * @return the optional effective tags, exactly as provided to the constructor. absl::nullopt
+   *         (no explicit tags) is preserved so that downstream code performs tag extraction on
+   *         the name.
    */
-  absl::optional<StatNameTagSpan> effectiveTags() const {
-    if (stat_name_tags_) {
-      return stat_name_tags_->get();
-    } else {
-      return {};
-    }
-  }
+  absl::optional<StatNameTagSpan> effectiveTags() const { return stat_name_tags_; }
 
 private:
   // TODO(snowp): This isn't really "tag extracted", but we'll use this for the sake of consistency
@@ -54,16 +53,30 @@ private:
   StatName name_with_tags_;
 
   // The tags are provided to the constructor. The TagStatNameJoiner must not outlive the
-  // tags; therefore, it is safe to keep a reference here.
-  StatNameTagVectorOptConstRef stat_name_tags_;
+  // tags; therefore, it is safe to keep a view here.
+  absl::optional<StatNameTagSpan> stat_name_tags_;
 
-  SymbolTable::StoragePtr joinNameAndTags(StatName name, const StatNameTagVector& stat_name_tags,
+  SymbolTable::StoragePtr joinNameAndTags(StatName name, StatNameTagSpan stat_name_tags,
                                           SymbolTable& symbol_table);
 };
 
 bool isTagNameValid(absl::string_view name);
 
 bool isTagValueValid(absl::string_view value);
+
+/**
+ * Converts the legacy optional-reference tag representation to an
+ * absl::optional<StatNameTagSpan>, preserving the nullopt-vs-present distinction (absl::nullopt
+ * stays absl::nullopt). This is a convenience for call-sites that still hold a
+ * StatNameTagVectorOptConstRef but need to call the absl::optional<StatNameTagSpan>-based Scope
+ * APIs.
+ */
+inline absl::optional<StatNameTagSpan> toStatNameTagSpan(StatNameTagVectorOptConstRef tags) {
+  if (tags.has_value()) {
+    return StatNameTagSpan(tags->get());
+  }
+  return absl::nullopt;
+}
 
 } // namespace TagUtility
 } // namespace Stats

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -158,7 +158,7 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
   return ret;
 }
 
-ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name, bool evictable,
+ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(absl::string_view name, bool evictable,
                                                             const ScopeStatsLimitSettings& limits,
                                                             StatsMatcherSharedPtr matcher) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
@@ -578,7 +578,7 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
 }
 
 Counter& ThreadLocalStoreImpl::ScopeImpl::counterFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags) {
+    StatName name, absl::optional<StatNameTagSpan> stat_name_tags) {
   if (scopeRejectsAll()) {
     return parent_.null_counter_;
   }
@@ -633,8 +633,7 @@ void ThreadLocalStoreImpl::deliverHistogramToSinks(const Histogram& histogram, u
 }
 
 Gauge& ThreadLocalStoreImpl::ScopeImpl::gaugeFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags,
-    Gauge::ImportMode import_mode) {
+    StatName name, absl::optional<StatNameTagSpan> stat_name_tags, Gauge::ImportMode import_mode) {
   // If a gauge is "hidden" it should not be rejected as these are used for deferred stats.
   if (scopeRejectsAll() && import_mode != Gauge::ImportMode::HiddenAccumulate) {
     return parent_.null_gauge_;
@@ -685,7 +684,7 @@ ThreadLocalStoreImpl::ScopeImpl::getOrCreateGaugeBase(const TagUtility::TagStatN
 }
 
 Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags, Histogram::Unit unit) {
+    StatName name, absl::optional<StatNameTagSpan> stat_name_tags, Histogram::Unit unit) {
   // See safety analysis comment in counterFromStatNameWithTags above.
 
   if (scopeRejectsAll()) {
@@ -778,7 +777,7 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::getOrCreateHistogramBase(
 }
 
 TextReadout& ThreadLocalStoreImpl::ScopeImpl::textReadoutFromStatNameWithTags(
-    const StatName& name, StatNameTagVectorOptConstRef stat_name_tags) {
+    StatName name, absl::optional<StatNameTagSpan> stat_name_tags) {
   if (scopeRejectsAll()) {
     return parent_.null_text_readout_;
   }

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -300,16 +300,15 @@ private:
     }
 
     // Stats::Scope
-    Counter& counterFromStatNameWithTags(const StatName& name,
-                                         StatNameTagVectorOptConstRef tags) override;
-    Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+    Counter& counterFromStatNameWithTags(StatName name,
+                                         absl::optional<StatNameTagSpan> tags) override;
+    Gauge& gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                      Gauge::ImportMode import_mode) override;
-    Histogram& histogramFromStatNameWithTags(const StatName& name,
-                                             StatNameTagVectorOptConstRef tags,
+    Histogram& histogramFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                              Histogram::Unit unit) override;
-    TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
-                                                 StatNameTagVectorOptConstRef tags) override;
-    ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+    TextReadout& textReadoutFromStatNameWithTags(StatName name,
+                                                 absl::optional<StatNameTagSpan> tags) override;
+    ScopeSharedPtr createScope(absl::string_view name, bool evictable = false,
                                const ScopeStatsLimitSettings& limits = {},
                                StatsMatcherSharedPtr matcher = nullptr) override;
     ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
@@ -318,20 +317,20 @@ private:
     const SymbolTable& constSymbolTable() const final { return parent_.constSymbolTable(); }
     SymbolTable& symbolTable() final { return parent_.symbolTable(); }
 
-    Counter& counterFromString(const std::string& name) override {
+    Counter& counterFromString(absl::string_view name) override {
       StatNameManagedStorage storage(name, symbolTable());
       return counterFromStatName(storage.statName());
     }
 
-    Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
+    Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) override {
       StatNameManagedStorage storage(name, symbolTable());
       return gaugeFromStatName(storage.statName(), import_mode);
     }
-    Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override {
+    Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) override {
       StatNameManagedStorage storage(name, symbolTable());
       return histogramFromStatName(storage.statName(), unit);
     }
-    TextReadout& textReadoutFromString(const std::string& name) override {
+    TextReadout& textReadoutFromString(absl::string_view name) override {
       StatNameManagedStorage storage(name, symbolTable());
       return textReadoutFromStatName(storage.statName());
     }

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -68,6 +68,16 @@ struct ElementVisitor {
   SymbolTable::StoragePtr joined_;
 };
 
+// Converts the legacy optional-reference tag representation accepted by these helpers to the
+// absl::optional<StatNameTagSpan> expected by the Scope APIs, preserving the nullopt-vs-present
+// distinction so that absl::nullopt continues to trigger tag extraction downstream.
+absl::optional<StatNameTagSpan> toSpan(StatNameTagVectorOptConstRef tags) {
+  if (tags.has_value()) {
+    return StatNameTagSpan(tags->get());
+  }
+  return absl::nullopt;
+}
+
 } // namespace
 
 namespace Utility {
@@ -80,49 +90,49 @@ ScopeSharedPtr scopeFromStatNames(Scope& scope, const StatNameVec& elements) {
 Counter& counterFromElements(Scope& scope, const ElementVec& elements,
                              StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.counterFromStatNameWithTags(visitor.statName(), tags);
+  return scope.counterFromStatNameWithTags(visitor.statName(), toSpan(tags));
 }
 
 Counter& counterFromStatNames(Scope& scope, const StatNameVec& elements,
                               StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.counterFromStatNameWithTags(StatName(joined.get()), tags);
+  return scope.counterFromStatNameWithTags(StatName(joined.get()), toSpan(tags));
 }
 
 Gauge& gaugeFromElements(Scope& scope, const ElementVec& elements, Gauge::ImportMode import_mode,
                          StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.gaugeFromStatNameWithTags(visitor.statName(), tags, import_mode);
+  return scope.gaugeFromStatNameWithTags(visitor.statName(), toSpan(tags), import_mode);
 }
 
 Gauge& gaugeFromStatNames(Scope& scope, const StatNameVec& elements, Gauge::ImportMode import_mode,
                           StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.gaugeFromStatNameWithTags(StatName(joined.get()), tags, import_mode);
+  return scope.gaugeFromStatNameWithTags(StatName(joined.get()), toSpan(tags), import_mode);
 }
 
 Histogram& histogramFromElements(Scope& scope, const ElementVec& elements, Histogram::Unit unit,
                                  StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.histogramFromStatNameWithTags(visitor.statName(), tags, unit);
+  return scope.histogramFromStatNameWithTags(visitor.statName(), toSpan(tags), unit);
 }
 
 Histogram& histogramFromStatNames(Scope& scope, const StatNameVec& elements, Histogram::Unit unit,
                                   StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.histogramFromStatNameWithTags(StatName(joined.get()), tags, unit);
+  return scope.histogramFromStatNameWithTags(StatName(joined.get()), toSpan(tags), unit);
 }
 
 TextReadout& textReadoutFromElements(Scope& scope, const ElementVec& elements,
                                      StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.textReadoutFromStatNameWithTags(visitor.statName(), tags);
+  return scope.textReadoutFromStatNameWithTags(visitor.statName(), toSpan(tags));
 }
 
 TextReadout& textReadoutFromStatNames(Scope& scope, const StatNameVec& elements,
                                       StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.textReadoutFromStatNameWithTags(StatName(joined.get()), tags);
+  return scope.textReadoutFromStatNameWithTags(StatName(joined.get()), toSpan(tags));
 }
 
 } // namespace Utility

--- a/source/extensions/access_loggers/stats/stats.cc
+++ b/source/extensions/access_loggers/stats/stats.cc
@@ -56,6 +56,16 @@ struct StatTagMetric : public Stats::StatTagMatchingData {
   absl::string_view value_;
 };
 
+// Converts the optional-reference tag representation used by this logger's caches to the
+// absl::optional<StatNameTagSpan> expected by the Scope APIs, preserving the nullopt-vs-present
+// distinction so that absl::nullopt continues to trigger tag extraction downstream.
+absl::optional<Stats::StatNameTagSpan> toSpan(Stats::StatNameTagVectorOptConstRef tags) {
+  if (tags.has_value()) {
+    return Stats::StatNameTagSpan(tags->get());
+  }
+  return absl::nullopt;
+}
+
 class ActionValidationVisitor
     : public Matcher::MatchTreeValidationVisitor<Stats::StatMatchingData> {
 public:
@@ -80,7 +90,7 @@ public:
 AccessLogState::~AccessLogState() {
   for (const auto& p : inflight_gauges_) {
     Stats::Gauge& gauge_stat = parent_->scope().gaugeFromStatNameWithTags(
-        p.first.statName(), p.first.tags(), p.second.import_mode_);
+        p.first.statName(), toSpan(p.first.tags()), p.second.import_mode_);
     gauge_stat.sub(p.second.value_);
   }
 }
@@ -103,7 +113,7 @@ void AccessLogState::addInflightGauge(Stats::StatName stat_name,
     it = new_it;
   }
   it->second.value_ += value;
-  parent_->scope().gaugeFromStatNameWithTags(stat_name, tags, import_mode).add(value);
+  parent_->scope().gaugeFromStatNameWithTags(stat_name, toSpan(tags), import_mode).add(value);
 }
 
 void AccessLogState::removeInflightGauge(Stats::StatName stat_name,
@@ -116,7 +126,7 @@ void AccessLogState::removeInflightGauge(Stats::StatName stat_name,
   GaugeKey key{stat_name, tags};
 
   Stats::Gauge& gauge_stat =
-      parent_->scope().gaugeFromStatNameWithTags(stat_name, tags, import_mode);
+      parent_->scope().gaugeFromStatNameWithTags(stat_name, toSpan(tags), import_mode);
 
   auto it = inflight_gauges_.find(key);
   const bool was_found = (it != inflight_gauges_.end());

--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -130,7 +130,7 @@ TestScope::TestScope(StatName prefix, TestStore& store, StatsMatcherSharedPtr ma
 //
 // Stats::Scope
 Counter& TestScope::counterFromString(absl::string_view leaf_name) {
-  std::string name = prefix_str_ + std::string(leaf_name);
+  std::string name = absl::StrCat(prefix_str_, leaf_name);
   Counter*& counter_ref = store_.counter_map_[name];
   if (counter_ref == nullptr) {
     counter_ref = &IsolatedScopeImpl::counterFromString(leaf_name);
@@ -139,7 +139,7 @@ Counter& TestScope::counterFromString(absl::string_view leaf_name) {
 }
 
 Gauge& TestScope::gaugeFromString(absl::string_view leaf_name, Gauge::ImportMode import_mode) {
-  std::string name = prefix_str_ + std::string(leaf_name);
+  std::string name = absl::StrCat(prefix_str_, leaf_name);
   Gauge*& gauge_ref = store_.gauge_map_[name];
   if (gauge_ref == nullptr) {
     gauge_ref = &IsolatedScopeImpl::gaugeFromString(leaf_name, import_mode);
@@ -148,7 +148,7 @@ Gauge& TestScope::gaugeFromString(absl::string_view leaf_name, Gauge::ImportMode
 }
 
 Histogram& TestScope::histogramFromString(absl::string_view leaf_name, Histogram::Unit unit) {
-  std::string name = prefix_str_ + std::string(leaf_name);
+  std::string name = absl::StrCat(prefix_str_, leaf_name);
   Histogram*& histogram_ref = store_.histogram_map_[name];
   if (histogram_ref == nullptr) {
     histogram_ref = &IsolatedScopeImpl::histogramFromString(leaf_name, unit);

--- a/test/common/stats/stat_test_utility.cc
+++ b/test/common/stats/stat_test_utility.cc
@@ -129,8 +129,8 @@ TestScope::TestScope(StatName prefix, TestStore& store, StatsMatcherSharedPtr ma
 // to keep the maps up-to-date.
 //
 // Stats::Scope
-Counter& TestScope::counterFromString(const std::string& leaf_name) {
-  std::string name = prefix_str_ + leaf_name;
+Counter& TestScope::counterFromString(absl::string_view leaf_name) {
+  std::string name = prefix_str_ + std::string(leaf_name);
   Counter*& counter_ref = store_.counter_map_[name];
   if (counter_ref == nullptr) {
     counter_ref = &IsolatedScopeImpl::counterFromString(leaf_name);
@@ -138,8 +138,8 @@ Counter& TestScope::counterFromString(const std::string& leaf_name) {
   return *counter_ref;
 }
 
-Gauge& TestScope::gaugeFromString(const std::string& leaf_name, Gauge::ImportMode import_mode) {
-  std::string name = prefix_str_ + leaf_name;
+Gauge& TestScope::gaugeFromString(absl::string_view leaf_name, Gauge::ImportMode import_mode) {
+  std::string name = prefix_str_ + std::string(leaf_name);
   Gauge*& gauge_ref = store_.gauge_map_[name];
   if (gauge_ref == nullptr) {
     gauge_ref = &IsolatedScopeImpl::gaugeFromString(leaf_name, import_mode);
@@ -147,8 +147,8 @@ Gauge& TestScope::gaugeFromString(const std::string& leaf_name, Gauge::ImportMod
   return *gauge_ref;
 }
 
-Histogram& TestScope::histogramFromString(const std::string& leaf_name, Histogram::Unit unit) {
-  std::string name = prefix_str_ + leaf_name;
+Histogram& TestScope::histogramFromString(absl::string_view leaf_name, Histogram::Unit unit) {
+  std::string name = prefix_str_ + std::string(leaf_name);
   Histogram*& histogram_ref = store_.histogram_map_[name];
   if (histogram_ref == nullptr) {
     histogram_ref = &IsolatedScopeImpl::histogramFromString(leaf_name, unit);
@@ -156,14 +156,13 @@ Histogram& TestScope::histogramFromString(const std::string& leaf_name, Histogra
   return *histogram_ref;
 }
 
-std::string TestScope::statNameWithTags(const StatName& stat_name,
-                                        StatNameTagVectorOptConstRef tags) {
+std::string TestScope::statNameWithTags(StatName stat_name, absl::optional<StatNameTagSpan> tags) {
   TagUtility::TagStatNameJoiner joiner(prefix(), stat_name, tags, symbolTable());
   return symbolTable().toString(joiner.nameWithTags());
 }
 
 void TestScope::verifyConsistency(StatName ref_stat_name, StatName stat_name,
-                                  StatNameTagVectorOptConstRef tags) {
+                                  absl::optional<StatNameTagSpan> tags) {
   // Ensures StatNames with the same string representation are specified
   // consistently using symbolic/dynamic components on every access.
   TagUtility::TagStatNameJoiner joiner(prefix(), stat_name, tags, symbolTable());
@@ -174,8 +173,8 @@ void TestScope::verifyConsistency(StatName ref_stat_name, StatName stat_name,
                       " stat_name=", symbolTable().toString(joined_stat_name)));
 }
 
-Counter& TestScope::counterFromStatNameWithTags(const StatName& stat_name,
-                                                StatNameTagVectorOptConstRef tags) {
+Counter& TestScope::counterFromStatNameWithTags(StatName stat_name,
+                                                absl::optional<StatNameTagSpan> tags) {
   std::string name = statNameWithTags(stat_name, tags);
   Counter*& counter_ref = store_.counter_map_[name];
   if (counter_ref == nullptr) {
@@ -186,8 +185,8 @@ Counter& TestScope::counterFromStatNameWithTags(const StatName& stat_name,
   return *counter_ref;
 }
 
-Gauge& TestScope::gaugeFromStatNameWithTags(const StatName& stat_name,
-                                            StatNameTagVectorOptConstRef tags,
+Gauge& TestScope::gaugeFromStatNameWithTags(StatName stat_name,
+                                            absl::optional<StatNameTagSpan> tags,
                                             Gauge::ImportMode import_mode) {
   std::string name = statNameWithTags(stat_name, tags);
   Gauge*& gauge_ref = store_.gauge_map_[name];
@@ -199,8 +198,8 @@ Gauge& TestScope::gaugeFromStatNameWithTags(const StatName& stat_name,
   return *gauge_ref;
 }
 
-Histogram& TestScope::histogramFromStatNameWithTags(const StatName& stat_name,
-                                                    StatNameTagVectorOptConstRef tags,
+Histogram& TestScope::histogramFromStatNameWithTags(StatName stat_name,
+                                                    absl::optional<StatNameTagSpan> tags,
                                                     Histogram::Unit unit) {
   std::string name = statNameWithTags(stat_name, tags);
   Histogram*& histogram_ref = store_.histogram_map_[name];

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -135,21 +135,20 @@ public:
   // to keep the maps up-to-date.
   //
   // Stats::Scope
-  Counter& counterFromString(const std::string& name) override;
-  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override;
-  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override;
-  Counter& counterFromStatNameWithTags(const StatName& stat_name,
-                                       StatNameTagVectorOptConstRef tags) override;
-  Gauge& gaugeFromStatNameWithTags(const StatName& stat_name, StatNameTagVectorOptConstRef tags,
+  Counter& counterFromString(absl::string_view name) override;
+  Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) override;
+  Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) override;
+  Counter& counterFromStatNameWithTags(StatName stat_name,
+                                       absl::optional<StatNameTagSpan> tags) override;
+  Gauge& gaugeFromStatNameWithTags(StatName stat_name, absl::optional<StatNameTagSpan> tags,
                                    Gauge::ImportMode import_mode) override;
-  Histogram& histogramFromStatNameWithTags(const StatName& stat_name,
-                                           StatNameTagVectorOptConstRef tags,
+  Histogram& histogramFromStatNameWithTags(StatName stat_name, absl::optional<StatNameTagSpan> tags,
                                            Histogram::Unit unit) override;
   TestStore& store() override { return store_; }
   const TestStore& constStore() const override { return store_; }
 
 private:
-  std::string statNameWithTags(const StatName& stat_name, StatNameTagVectorOptConstRef tags);
+  std::string statNameWithTags(StatName stat_name, absl::optional<StatNameTagSpan> tags);
   static std::string addDot(const std::string& prefix) {
     if (prefix.empty() || prefix[prefix.size() - 1] == '.') {
       return prefix;
@@ -158,7 +157,7 @@ private:
   }
 
   void verifyConsistency(StatName ref_stat_name, StatName stat_name,
-                         StatNameTagVectorOptConstRef tags);
+                         absl::optional<StatNameTagSpan> tags);
 
   TestStore& store_;
   const std::string prefix_str_;

--- a/test/extensions/access_loggers/stats/stats_speed_test.cc
+++ b/test/extensions/access_loggers/stats/stats_speed_test.cc
@@ -30,7 +30,8 @@ public:
       return;
     }
 
-    Stats::TagUtility::TagStatNameJoiner joiner(Stats::StatName(), stat_name, tags,
+    Stats::TagUtility::TagStatNameJoiner joiner(Stats::StatName(), stat_name,
+                                                Stats::TagUtility::toStatNameTagSpan(tags),
                                                 logger_->scope().symbolTable());
     Stats::StatName joined_name = joiner.nameWithTags();
     auto it = inflight_gauges_.find(joined_name);
@@ -49,7 +50,8 @@ public:
       return;
     }
 
-    Stats::TagUtility::TagStatNameJoiner joiner(Stats::StatName(), stat_name, tags,
+    Stats::TagUtility::TagStatNameJoiner joiner(Stats::StatName(), stat_name,
+                                                Stats::TagUtility::toStatNameTagSpan(tags),
                                                 logger_->scope().symbolTable());
     Stats::StatName joined_name = joiner.nameWithTags();
     auto it = inflight_gauges_.find(joined_name);

--- a/test/extensions/access_loggers/stats/stats_test.cc
+++ b/test/extensions/access_loggers/stats/stats_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/stats/sink.h"
 #include "envoy/type/v3/scope.pb.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/config/decoded_resource_impl.h"
 #include "source/common/stats/allocator_impl.h"
 #include "source/common/stats/thread_local_store.h"
@@ -32,11 +33,11 @@ public:
   using Stats::MockScope::MockScope;
 
   MOCK_METHOD(Stats::Gauge&, gaugeFromStatNameWithTags,
-              (const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef tags,
+              (Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                Stats::Gauge::ImportMode import_mode),
               (override));
   MOCK_METHOD(Stats::Histogram&, histogramFromStatNameWithTags,
-              (const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef tags,
+              (Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                Stats::Histogram::Unit unit),
               (override));
 };
@@ -137,21 +138,22 @@ public:
               scope_name_storage->statName(), store_);
           ON_CALL(*scope, gaugeFromStatNameWithTags(_, _, _))
               .WillByDefault(
-                  Invoke([this](const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef,
+                  Invoke([this](Stats::StatName name, absl::optional<Stats::StatNameTagSpan>,
                                 Stats::Gauge::ImportMode import_mode) -> Stats::Gauge& {
                     return this->store_.gauge(this->context_.store_.symbolTable().toString(name),
                                               import_mode);
                   }));
           ON_CALL(*scope, counterFromStatNameWithTags(_, _))
-              .WillByDefault(Invoke([this](const Stats::StatName& name,
-                                           Stats::StatNameTagVectorOptConstRef) -> Stats::Counter& {
-                return this->store_.counter(this->context_.store_.symbolTable().toString(name));
-              }));
+              .WillByDefault(
+                  Invoke([this](Stats::StatName name,
+                                absl::optional<Stats::StatNameTagSpan>) -> Stats::Counter& {
+                    return this->store_.counter(this->context_.store_.symbolTable().toString(name));
+                  }));
 
           ON_CALL(*scope, histogramFromStatNameWithTags(_, _, _))
               .WillByDefault(Invoke([scope_ptr = scope.get()](
-                                        const Stats::StatName& name,
-                                        Stats::StatNameTagVectorOptConstRef tags,
+                                        Stats::StatName name,
+                                        absl::optional<Stats::StatNameTagSpan> tags,
                                         Stats::Histogram::Unit unit) -> Stats::Histogram& {
                 return scope_ptr->Stats::MockScope::histogramFromStatNameWithTags(name, tags, unit);
               }));
@@ -431,11 +433,12 @@ TEST_F(StatsAccessLoggerTest, EmptyTagFormatter) {
       .WillRepeatedly(testing::Return(absl::optional<uint32_t>{200}));
   EXPECT_CALL(*scope_, counterFromStatNameWithTags(_, _))
       .WillOnce(
-          testing::Invoke([this](const Stats::StatName& name,
-                                 Stats::StatNameTagVectorOptConstRef tags) -> Stats::Counter& {
+          testing::Invoke([this](Stats::StatName name,
+                                 absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            EXPECT_EQ(1, tags->get().size());
-            EXPECT_EQ(":200", scope_->symbolTable().toString(tags->get().front().second));
+            ASSERT(tags.has_value());
+            EXPECT_EQ(1, tags->size());
+            EXPECT_EQ(":200", scope_->symbolTable().toString(tags->front().second));
 
             return store_.counter_;
           }));
@@ -850,22 +853,22 @@ TEST_F(StatsAccessLoggerTest, AccessLogStateDestructorSubtractsFromSavedGauge) {
 
   // Initial lookup and add
   EXPECT_CALL(*mock_scope, gaugeFromStatNameWithTags(_, _, Stats::Gauge::ImportMode::Accumulate))
-      .WillRepeatedly(
-          Invoke([&](const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef tags,
-                     Stats::Gauge::ImportMode) -> Stats::Gauge& {
-            saved_name = name;
-            if (tags) {
-              for (const auto& tag : tags->get()) {
-                saved_tags_strs.emplace_back(store_.symbolTable().toString(tag.first),
-                                             store_.symbolTable().toString(tag.second));
-              }
-              EXPECT_FALSE(saved_tags_strs.empty());
-              auto* gauge_with_tags = dynamic_cast<MockGaugeWithTags*>(gauge_);
-              EXPECT_TRUE(gauge_with_tags != nullptr);
-              gauge_with_tags->setTags(tags->get(), store_.symbolTable());
-            }
-            return *gauge_;
-          }));
+      .WillRepeatedly(Invoke([&](Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
+                                 Stats::Gauge::ImportMode) -> Stats::Gauge& {
+        saved_name = name;
+        if (tags.has_value() && !tags->empty()) {
+          for (const auto& tag : *tags) {
+            saved_tags_strs.emplace_back(store_.symbolTable().toString(tag.first),
+                                         store_.symbolTable().toString(tag.second));
+          }
+          EXPECT_FALSE(saved_tags_strs.empty());
+          auto* gauge_with_tags = dynamic_cast<MockGaugeWithTags*>(gauge_);
+          EXPECT_TRUE(gauge_with_tags != nullptr);
+          gauge_with_tags->setTags(Stats::StatNameTagVector(tags->begin(), tags->end()),
+                                   store_.symbolTable());
+        }
+        return *gauge_;
+      }));
 
   EXPECT_CALL(*gauge_, add(10));
   logger_->log(formatter_context_, local_stream_info);
@@ -1127,12 +1130,13 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTag) {
   // Case 1: Filter matches (tag foo=bar), so update tag action is executed.
   EXPECT_CALL(*scope_, counterFromStatNameWithTags(_, _))
       .WillOnce(
-          testing::Invoke([this](const Stats::StatName& name,
-                                 Stats::StatNameTagVectorOptConstRef tags) -> Stats::Counter& {
+          testing::Invoke([this](Stats::StatName name,
+                                 absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            EXPECT_EQ(1, tags->get().size());
-            EXPECT_EQ("foo", scope_->symbolTable().toString(tags->get()[0].first));
-            EXPECT_EQ("baz", scope_->symbolTable().toString(tags->get()[0].second));
+            ASSERT(tags.has_value());
+            EXPECT_EQ(1, tags->size());
+            EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
+            EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));
             return scope_->counterFromStatNameWithTags_(name, tags);
           }));
   logger_->log(formatter_context_, stream_info_);
@@ -1170,10 +1174,11 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterDropTag) {
   // Case 1: Filter matches (tag foo=bar), so drop tag action is executed.
   EXPECT_CALL(*scope_, counterFromStatNameWithTags(_, _))
       .WillOnce(
-          testing::Invoke([this](const Stats::StatName& name,
-                                 Stats::StatNameTagVectorOptConstRef tags) -> Stats::Counter& {
+          testing::Invoke([this](Stats::StatName name,
+                                 absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            EXPECT_EQ(0, tags->get().size());
+            ASSERT(tags.has_value());
+            EXPECT_EQ(0, tags->size());
             return scope_->counterFromStatNameWithTags_(name, tags);
           }));
   logger_->log(formatter_context_, stream_info_);
@@ -1289,12 +1294,13 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTagOnGauge) {
 
   // Case 1: Filter matches (tag foo=bar), so update tag action is executed.
   EXPECT_CALL(*mock_scope, gaugeFromStatNameWithTags(_, _, _))
-      .WillOnce(Invoke([&](const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef tags,
+      .WillOnce(Invoke([&](Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                            Stats::Gauge::ImportMode) -> Stats::Gauge& {
         EXPECT_EQ("gauge", scope_->symbolTable().toString(name));
-        EXPECT_EQ(1, tags->get().size());
-        EXPECT_EQ("foo", scope_->symbolTable().toString(tags->get()[0].first));
-        EXPECT_EQ("baz", scope_->symbolTable().toString(tags->get()[0].second));
+        ASSERT(tags.has_value());
+        EXPECT_EQ(1, tags->size());
+        EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
+        EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));
         return *gauge_;
       }));
   logger_->log(formatter_context_, stream_info_);
@@ -1336,12 +1342,13 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTagOnHistogram) {
 
   // Case 1: Filter matches (tag foo=bar), so update tag action is executed.
   EXPECT_CALL(*mock_scope, histogramFromStatNameWithTags(_, _, _))
-      .WillOnce(Invoke([&](const Stats::StatName& name, Stats::StatNameTagVectorOptConstRef tags,
+      .WillOnce(Invoke([&](Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                            Stats::Histogram::Unit) -> Stats::Histogram& {
         EXPECT_EQ("histogram", scope_->symbolTable().toString(name));
-        EXPECT_EQ(1, tags->get().size());
-        EXPECT_EQ("foo", scope_->symbolTable().toString(tags->get()[0].first));
-        EXPECT_EQ("baz", scope_->symbolTable().toString(tags->get()[0].second));
+        ASSERT(tags.has_value());
+        EXPECT_EQ(1, tags->size());
+        EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
+        EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));
         return store_.mockScope().histogramFromStatNameWithTags(name, tags,
                                                                 Stats::Histogram::Unit::Bytes);
       }));

--- a/test/extensions/access_loggers/stats/stats_test.cc
+++ b/test/extensions/access_loggers/stats/stats_test.cc
@@ -1,7 +1,6 @@
 #include "envoy/stats/sink.h"
 #include "envoy/type/v3/scope.pb.h"
 
-#include "source/common/common/assert.h"
 #include "source/common/config/decoded_resource_impl.h"
 #include "source/common/stats/allocator_impl.h"
 #include "source/common/stats/thread_local_store.h"
@@ -436,7 +435,6 @@ TEST_F(StatsAccessLoggerTest, EmptyTagFormatter) {
           testing::Invoke([this](Stats::StatName name,
                                  absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            ASSERT(tags.has_value());
             EXPECT_EQ(1, tags->size());
             EXPECT_EQ(":200", scope_->symbolTable().toString(tags->front().second));
 
@@ -1133,7 +1131,6 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTag) {
           testing::Invoke([this](Stats::StatName name,
                                  absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            ASSERT(tags.has_value());
             EXPECT_EQ(1, tags->size());
             EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
             EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));
@@ -1177,7 +1174,6 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterDropTag) {
           testing::Invoke([this](Stats::StatName name,
                                  absl::optional<Stats::StatNameTagSpan> tags) -> Stats::Counter& {
             EXPECT_EQ("counter", scope_->symbolTable().toString(name));
-            ASSERT(tags.has_value());
             EXPECT_EQ(0, tags->size());
             return scope_->counterFromStatNameWithTags_(name, tags);
           }));
@@ -1297,7 +1293,6 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTagOnGauge) {
       .WillOnce(Invoke([&](Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                            Stats::Gauge::ImportMode) -> Stats::Gauge& {
         EXPECT_EQ("gauge", scope_->symbolTable().toString(name));
-        ASSERT(tags.has_value());
         EXPECT_EQ(1, tags->size());
         EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
         EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));
@@ -1345,7 +1340,6 @@ TEST_F(StatsAccessLoggerTest, StatTagFilterUpdateTagOnHistogram) {
       .WillOnce(Invoke([&](Stats::StatName name, absl::optional<Stats::StatNameTagSpan> tags,
                            Stats::Histogram::Unit) -> Stats::Histogram& {
         EXPECT_EQ("histogram", scope_->symbolTable().toString(name));
-        ASSERT(tags.has_value());
         EXPECT_EQ(1, tags->size());
         EXPECT_EQ("foo", scope_->symbolTable().toString((*tags)[0].first));
         EXPECT_EQ("baz", scope_->symbolTable().toString((*tags)[0].second));

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -77,7 +77,7 @@ public:
   TestScopeWrapper(Thread::MutexBasicLockable& lock, ScopeSharedPtr wrapped_scope, Store& store)
       : lock_(lock), wrapped_scope_(wrapped_scope), store_(store) {}
 
-  ScopeSharedPtr createScope(const std::string& name, bool evictable,
+  ScopeSharedPtr createScope(absl::string_view name, bool evictable,
                              const ScopeStatsLimitSettings& limits,
                              StatsMatcherSharedPtr matcher = nullptr) override {
     Thread::LockGuard lock(lock_);
@@ -94,43 +94,43 @@ public:
         store_);
   }
 
-  Counter& counterFromStatNameWithTags(const StatName& name,
-                                       StatNameTagVectorOptConstRef tags) override {
+  Counter& counterFromStatNameWithTags(StatName name,
+                                       absl::optional<StatNameTagSpan> tags) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->counterFromStatNameWithTags(name, tags);
   }
 
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+  Gauge& gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                    Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->gaugeFromStatNameWithTags(name, tags, import_mode);
   }
 
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+  Histogram& histogramFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan> tags,
                                            Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->histogramFromStatNameWithTags(name, tags, unit);
   }
 
-  TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
-                                               StatNameTagVectorOptConstRef tags) override {
+  TextReadout& textReadoutFromStatNameWithTags(StatName name,
+                                               absl::optional<StatNameTagSpan> tags) override {
     Thread::LockGuard lock(lock_);
     return wrapped_scope_->textReadoutFromStatNameWithTags(name, tags);
   }
 
-  Counter& counterFromString(const std::string& name) override {
+  Counter& counterFromString(absl::string_view name) override {
     StatNameManagedStorage storage(name, symbolTable());
     return counterFromStatName(storage.statName());
   }
-  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromString(absl::string_view name, Gauge::ImportMode import_mode) override {
     StatNameManagedStorage storage(name, symbolTable());
     return gaugeFromStatName(storage.statName(), import_mode);
   }
-  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override {
+  Histogram& histogramFromString(absl::string_view name, Histogram::Unit unit) override {
     StatNameManagedStorage storage(name, symbolTable());
     return histogramFromStatName(storage.statName(), unit);
   }
-  TextReadout& textReadoutFromString(const std::string& name) override {
+  TextReadout& textReadoutFromString(absl::string_view name) override {
     StatNameManagedStorage storage(name, symbolTable());
     return textReadoutFromStatName(storage.statName());
   }

--- a/test/mocks/stats/mocks.cc
+++ b/test/mocks/stats/mocks.cc
@@ -85,28 +85,26 @@ MockScope::MockScope(StatName prefix, MockStore& store)
     : TestUtil::TestScope(prefix, store), mock_store_(store) {
   ON_CALL(*this, counterFromStatNameWithTags(_, _))
       .WillByDefault(
-          Invoke([this](const StatName& name, StatNameTagVectorOptConstRef tags) -> Counter& {
+          Invoke([this](StatName name, absl::optional<StatNameTagSpan> tags) -> Counter& {
             return counterFromStatNameWithTags_(name, tags);
           }));
 }
 
-Counter& MockScope::counterFromStatNameWithTags_(const StatName& name,
-                                                 StatNameTagVectorOptConstRef) {
+Counter& MockScope::counterFromStatNameWithTags_(StatName name, absl::optional<StatNameTagSpan>) {
   // We always just respond with the mocked counter, so the tags don't matter.
   return mock_store_.counter(symbolTable().toString(name));
 }
-Gauge& MockScope::gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef,
+Gauge& MockScope::gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan>,
                                             Gauge::ImportMode import_mode) {
   // We always just respond with the mocked gauge, so the tags don't matter.
   return mock_store_.gauge(symbolTable().toString(name), import_mode);
 }
-Histogram& MockScope::histogramFromStatNameWithTags(const StatName& name,
-                                                    StatNameTagVectorOptConstRef,
+Histogram& MockScope::histogramFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan>,
                                                     Histogram::Unit unit) {
   return mock_store_.histogram(symbolTable().toString(name), unit);
 }
-TextReadout& MockScope::textReadoutFromStatNameWithTags(const StatName& name,
-                                                        StatNameTagVectorOptConstRef) {
+TextReadout& MockScope::textReadoutFromStatNameWithTags(StatName name,
+                                                        absl::optional<StatNameTagSpan>) {
   // We always just respond with the mocked counter, so the tags don't matter.
   return mock_store_.textReadout(symbolTable().toString(name));
 }

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -297,11 +297,11 @@ class MockScope : public TestUtil::TestScope {
 public:
   MockScope(StatName prefix, MockStore& store);
 
-  ScopeSharedPtr createScope(const std::string& name, bool evictable,
+  ScopeSharedPtr createScope(absl::string_view name, bool evictable,
                              const ScopeStatsLimitSettings& limits,
                              StatsMatcherSharedPtr = nullptr) override {
     checkCreateScopeArgs(evictable, limits);
-    return ScopeSharedPtr(createScope_(name));
+    return ScopeSharedPtr(createScope_(std::string(name)));
   }
   ScopeSharedPtr scopeFromStatName(StatName name, bool evictable,
                                    const ScopeStatsLimitSettings& limits,
@@ -320,17 +320,17 @@ public:
   // Override the lowest level of stat creation based on StatName to redirect
   // back to the old string-based mechanisms still on the MockStore object
   // to allow tests to inject EXPECT_CALL hooks for those.
-  MOCK_METHOD(Counter&, counterFromStatNameWithTags,
-              (const StatName&, StatNameTagVectorOptConstRef));
+  MOCK_METHOD(Counter&, counterFromStatNameWithTags, (StatName, absl::optional<StatNameTagSpan>),
+              (override));
   // NOLINTNEXTLINE(readability-identifier-naming)
-  Counter& counterFromStatNameWithTags_(const StatName& name, StatNameTagVectorOptConstRef);
+  Counter& counterFromStatNameWithTags_(StatName name, absl::optional<StatNameTagSpan>);
 
-  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef,
+  Gauge& gaugeFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan>,
                                    Gauge::ImportMode import_mode) override;
-  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef,
+  Histogram& histogramFromStatNameWithTags(StatName name, absl::optional<StatNameTagSpan>,
                                            Histogram::Unit unit) override;
-  TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
-                                               StatNameTagVectorOptConstRef) override;
+  TextReadout& textReadoutFromStatNameWithTags(StatName name,
+                                               absl::optional<StatNameTagSpan>) override;
 
   MockStore& mock_store_;
 };


### PR DESCRIPTION
Commit Message: stats: optimize the parameter types
Additional Description:

1. Prefer string_view and StatName rather than reference to string or StatName.
2. Prefer Span rather to vector as parameter type so we can use different underlying container on need for better performance, like initializer_list.

Note, this change basically won't affects call sites because:
1. `const std::string&` could be converted to `absl::string_view` automatically.
2. `const StatNameTagVector&` could be converted to `absl::optional<StatNameTagSpan>` automatically.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.