### PR TITLE
upstream: turn off coalesce_lb_rebuilds_on_batch_update by default

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -36,7 +36,6 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_cel_message_serialize_text_format);
-RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);
 RUNTIME_GUARD(envoy_reloadable_features_codec_client_enable_idle_timer_only_when_connected);
 RUNTIME_GUARD(envoy_reloadable_features_decouple_explicit_drain_pools_and_dns_refresh);
 RUNTIME_GUARD(envoy_reloadable_features_dfp_cluster_resolves_hosts);
@@ -204,6 +203,9 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_multiplexed_upstream_half_cl
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
 
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_getaddrinfo_no_ai_flags);
+
+// See: `https://github.com/envoyproxy/envoy/issues/45212` for more details.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);
 
 // Flag to remove legacy route formatter support in header parser
 // Flip to true after two release periods.

--- a/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
+++ b/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
@@ -626,10 +626,65 @@ TEST(LoadBalancerBaseCoalesceDisabledTest, FallbackPathExercised) {
   EXPECT_EQ(100, lb.percentageLoad(0));
 }
 
+// Exercises the coalescing change in `LoadBalancerBase` where `PriorityUpdateCb` stages dirty
+// priorities and `MemberUpdateCb` flushes them via `processDirtyPriorities()` and recalculates
+// panic state.
+TEST(LoadBalancerBaseCoalesceEnabledTest, CoalescedPathExercised) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "true"}});
+
+  Stats::IsolatedStoreImpl stats_store;
+  ClusterLbStatNames stat_names(stats_store.symbolTable());
+  ClusterLbStats stats(stat_names, *stats_store.rootScope());
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Random::MockRandomGenerator> random;
+  NiceMock<MockPrioritySet> priority_set;
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+
+  envoy::config::cluster::v3::Cluster::CommonLbConfig common_config;
+  TestLb lb(priority_set, stats, runtime, random, common_config);
+
+  MockHostSet& host_set = *priority_set.getMockHostSet(0);
+  host_set.hosts_ = {makeTestHost(info, "tcp://127.0.0.1:80")};
+  host_set.healthy_hosts_ = host_set.hosts_;
+  host_set.runCallbacks({}, {});
+
+  EXPECT_EQ(100, lb.percentageLoad(0));
+}
+
 TEST(ZoneAwareLbCoalesceDisabledTest, FallbackPathExercised) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "false"}});
+
+  Stats::IsolatedStoreImpl stats_store;
+  ClusterLbStatNames stat_names(stats_store.symbolTable());
+  ClusterLbStats stats(stat_names, *stats_store.rootScope());
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Random::MockRandomGenerator> random;
+  NiceMock<MockPrioritySet> priority_set;
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+
+  ZoneAwareLoadBalancerBase::LocalityLbConfig locality_config;
+  locality_config.mutable_locality_weighted_lb_config();
+  TestZoneAwareLb lb(priority_set, stats, runtime, random, 50, locality_config);
+
+  MockHostSet& host_set = *priority_set.getMockHostSet(0);
+  host_set.hosts_ = {makeTestHost(info, "tcp://127.0.0.1:80")};
+  host_set.healthy_hosts_ = host_set.hosts_;
+  host_set.runCallbacks({}, {});
+
+  EXPECT_FALSE(lb.lifetimeCallbacks().has_value());
+}
+
+// Exercises the coalescing branch of ZoneAwareLoadBalancerBase: PriorityUpdateCb stages dirty
+// priorities, MemberUpdateCb resizes per-priority state and rebuilds locality WRR for each dirty
+// priority. Locality-weighted balancing is enabled to cover the inner per-priority rebuild loop.
+TEST(ZoneAwareLbCoalesceEnabledTest, CoalescedPathExercised) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "true"}});
 
   Stats::IsolatedStoreImpl stats_store;
   ClusterLbStatNames stat_names(stats_store.symbolTable());

--- a/test/extensions/load_balancing_policies/least_request/least_request_lb_test.cc
+++ b/test/extensions/load_balancing_policies/least_request/least_request_lb_test.cc
@@ -665,6 +665,38 @@ TEST(EdfLbCoalesceDisabledTest, FallbackPathExercised) {
   EXPECT_NE(nullptr, result.host);
 }
 
+// Exercises the coalescing change in `EdfLoadBalancerBase` where `PriorityUpdateCb` stages dirty
+// priorities and `MemberUpdateCb` refreshes each dirty priority's scheduler before reapplying
+// slow start. Slow start is configured so the post-flush `recalculateHostsInSlowStart` change
+// is also covered.
+TEST(EdfLbCoalesceEnabledTest, CoalescedPathExercised) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "true"}});
+
+  Stats::IsolatedStoreImpl stats_store;
+  ClusterLbStatNames stat_names(stats_store.symbolTable());
+  ClusterLbStats stats(stat_names, *stats_store.rootScope());
+  NiceMock<Runtime::MockLoader> runtime;
+  NiceMock<Random::MockRandomGenerator> random;
+  NiceMock<MockPrioritySet> priority_set;
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+
+  envoy::extensions::load_balancing_policies::least_request::v3::LeastRequest config;
+  config.mutable_slow_start_config()->mutable_slow_start_window()->set_seconds(60);
+  Event::SimulatedTimeSystem time_system;
+  LeastRequestLoadBalancer lb(priority_set, nullptr, stats, runtime, random, 50, config,
+                              time_system);
+
+  MockHostSet& host_set = *priority_set.getMockHostSet(0);
+  host_set.hosts_ = {makeTestHost(info, "tcp://127.0.0.1:80")};
+  host_set.healthy_hosts_ = host_set.hosts_;
+  host_set.runCallbacks(host_set.hosts_, {});
+
+  auto result = lb.chooseHost(nullptr);
+  EXPECT_NE(nullptr, result.host);
+}
+
 } // namespace
 } // namespace Upstream
 } // namespace Envoy


### PR DESCRIPTION
## Description

`coalesce_lb_rebuilds_on_batch_update` is causing multiple regressions in `RING_HASH`. We are seeing CPU regressions and overall LB functionality regressions for `RING_HASH`. Per the internal discussion among maintainers, we are disabling the feature by default until all the existing regressions are fixed. 

Fix https://github.com/envoyproxy/envoy/issues/45212

---

**Commit Message:** upstream: turn off coalesce_lb_rebuilds_on_batch_update by default
**Additional Description:** Turn `coalesce_lb_rebuilds_on_batch_update = false` by default. 
**Risk Level:** Low
**Testing:**
**Docs Changes:** N/A
**Release Notes:** N/A