### PR TITLE
tcp_proxy: do not RST downstream when HTTP stream already completed

### DIFF
--- a/changelogs/current/bug_fixes/tcp_proxy__rst_drops_data.rst
+++ b/changelogs/current/bug_fixes/tcp_proxy__rst_drops_data.rst
@@ -1,4 +1,4 @@
-Fixed a bug where upstream TCP RST was propagated to downstream even when the HTTP
-stream had already completed, causing buffered response data to be dropped and the
+Fixed a bug in tcp_proxy where an upstream TCP RST was propagated to downstream even when the
+HTTP stream had already completed, causing buffered response data to be dropped and the
 client to receive EOF instead of the response. The RST is now only propagated when
 the stream was not already complete.

--- a/changelogs/current/bug_fixes/tcp_proxy__rst_drops_data.rst
+++ b/changelogs/current/bug_fixes/tcp_proxy__rst_drops_data.rst
@@ -1,0 +1,4 @@
+Fixed a bug where upstream TCP RST was propagated to downstream even when the HTTP
+stream had already completed, causing buffered response data to be dropped and the
+client to receive EOF instead of the response. The RST is now only propagated when
+the stream was not already complete.

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -264,7 +264,6 @@ void HttpUpstream::onResetStream(Http::StreamResetReason reason, absl::string_vi
     default:
       event = Network::ConnectionEvent::LocalClose;
       detected_close_type_ = StreamInfo::DetectedCloseType::Normal;
-      break;
     }
   } else {
     event = Network::ConnectionEvent::LocalClose;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -244,20 +244,23 @@ HttpUpstream::onDownstreamEvent(Network::ConnectionEvent event, absl::string_vie
 }
 
 void HttpUpstream::onResetStream(Http::StreamResetReason reason, absl::string_view) {
+  const bool already_complete = read_half_closed_ && write_half_closed_;
   read_half_closed_ = true;
   write_half_closed_ = true;
   Network::ConnectionEvent event;
   if (Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.map_http_stream_reset_to_tcp_rst")) {
-    // Map remote-originated resets to RemoteClose.
     switch (reason) {
     case Http::StreamResetReason::RemoteReset:
     case Http::StreamResetReason::RemoteRefusedStreamReset:
     case Http::StreamResetReason::RemoteConnectionFailure:
     case Http::StreamResetReason::RemoteResetNoError:
-      event = Network::ConnectionEvent::RemoteClose;
-      detected_close_type_ = StreamInfo::DetectedCloseType::RemoteReset;
-      break;
+      if (!already_complete) {
+        event = Network::ConnectionEvent::RemoteClose;
+        detected_close_type_ = StreamInfo::DetectedCloseType::RemoteReset;
+        break;
+      }
+      FALLTHRU;
     default:
       event = Network::ConnectionEvent::LocalClose;
       detected_close_type_ = StreamInfo::DetectedCloseType::Normal;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -244,7 +244,7 @@ HttpUpstream::onDownstreamEvent(Network::ConnectionEvent event, absl::string_vie
 }
 
 void HttpUpstream::onResetStream(Http::StreamResetReason reason, absl::string_view) {
-  const bool already_complete = read_half_closed_ && write_half_closed_;
+  const bool already_complete = read_half_closed_;
   read_half_closed_ = true;
   write_half_closed_ = true;
   Network::ConnectionEvent event;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -264,6 +264,7 @@ void HttpUpstream::onResetStream(Http::StreamResetReason reason, absl::string_vi
     default:
       event = Network::ConnectionEvent::LocalClose;
       detected_close_type_ = StreamInfo::DetectedCloseType::Normal;
+      break;
     }
   } else {
     event = Network::ConnectionEvent::LocalClose;

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -213,6 +213,25 @@ TEST_P(HttpUpstreamTest, UpstreamResetWithGuardDisabled) {
   this->upstream_->onResetStream(Http::StreamResetReason::RemoteReset, "");
   EXPECT_EQ(this->upstream_->detectedCloseType(), StreamInfo::DetectedCloseType::Normal);
 }
+TEST_P(HttpUpstreamTest, UpstreamRemoteResetAfterStreamCompleteProducesLocalClose) {
+  this->setupUpstream();
+  testing::Mock::VerifyAndClearExpectations(&this->encoder_);
+  EXPECT_CALL(this->encoder_, getStream()).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, encodeHeaders(_, false)).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, http1StreamEncoderOptions()).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, enableTcpTunneling()).Times(AnyNumber());
+
+  // Simulate stream already completed normally via half-close path.
+  EXPECT_CALL(this->callbacks_, onEvent(_)).Times(AnyNumber());
+  this->upstream_->doneReading();
+  this->upstream_->doneWriting();
+
+  // Remote reset after completion should NOT produce RST.
+  EXPECT_CALL(this->encoder_.stream_, resetStream(_)).Times(0);
+  EXPECT_CALL(this->callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  this->upstream_->onResetStream(Http::StreamResetReason::RemoteReset, "");
+  EXPECT_EQ(this->upstream_->detectedCloseType(), StreamInfo::DetectedCloseType::Normal);
+}
 
 TEST_P(HttpUpstreamTest, UpstreamWatermarks) {
   this->setupUpstream();

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -310,6 +310,7 @@ TEST_P(HttpUpstreamTest, DumpsResponseDecoderWithoutAllocatingMemory) {
 TEST_P(HttpUpstreamTest, UpstreamTrailersMarksDoneReading) {
   this->setupUpstream();
   EXPECT_CALL(this->encoder_.stream_, resetStream(_)).Times(0);
+  this->upstream_->doneWriting();
   Http::ResponseTrailerMapPtr trailers{new Http::TestResponseTrailerMapImpl{{"key", "value"}}};
   this->upstream_->responseDecoder().decodeTrailers(std::move(trailers));
 }

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -871,6 +871,7 @@ TEST_F(CombinedUpstreamTest, DumpsResponseDecoderWithoutAllocatingMemory) {
 }
 TEST_F(CombinedUpstreamTest, UpstreamTrailersMarksDoneReading) {
   this->setup();
+  this->upstream_->doneWriting();
   Http::ResponseTrailerMapPtr trailers{new Http::TestResponseTrailerMapImpl{{"key", "value"}}};
   this->upstream_->responseDecoder().decodeTrailers(std::move(trailers));
 }

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -213,6 +213,7 @@ TEST_P(HttpUpstreamTest, UpstreamResetWithGuardDisabled) {
   this->upstream_->onResetStream(Http::StreamResetReason::RemoteReset, "");
   EXPECT_EQ(this->upstream_->detectedCloseType(), StreamInfo::DetectedCloseType::Normal);
 }
+
 TEST_P(HttpUpstreamTest, UpstreamRemoteResetAfterStreamCompleteProducesLocalClose) {
   this->setupUpstream();
   testing::Mock::VerifyAndClearExpectations(&this->encoder_);
@@ -230,6 +231,22 @@ TEST_P(HttpUpstreamTest, UpstreamRemoteResetAfterStreamCompleteProducesLocalClos
   EXPECT_CALL(this->callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
   this->upstream_->onResetStream(Http::StreamResetReason::RemoteReset, "");
   EXPECT_EQ(this->upstream_->detectedCloseType(), StreamInfo::DetectedCloseType::Normal);
+}
+
+TEST_P(HttpUpstreamTest, UpstreamRemoteResetBeforeStreamCompleteProducesRemoteClose) {
+  this->setupUpstream();
+  testing::Mock::VerifyAndClearExpectations(&this->encoder_);
+  EXPECT_CALL(this->encoder_, getStream()).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, encodeHeaders(_, false)).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, http1StreamEncoderOptions()).Times(AnyNumber());
+  EXPECT_CALL(this->encoder_, enableTcpTunneling()).Times(AnyNumber());
+
+  // Stream has NOT completed - doneReading() is intentionally not called.
+  // Remote reset before completion SHOULD propagate as RemoteReset downstream.
+  EXPECT_CALL(this->encoder_.stream_, resetStream(_)).Times(0);
+  EXPECT_CALL(this->callbacks_, onEvent(Network::ConnectionEvent::RemoteClose));
+  this->upstream_->onResetStream(Http::StreamResetReason::RemoteReset, "");
+  EXPECT_EQ(this->upstream_->detectedCloseType(), StreamInfo::DetectedCloseType::RemoteReset);
 }
 
 TEST_P(HttpUpstreamTest, UpstreamWatermarks) {

--- a/test/common/tcp_proxy/upstream_test.cc
+++ b/test/common/tcp_proxy/upstream_test.cc
@@ -224,7 +224,6 @@ TEST_P(HttpUpstreamTest, UpstreamRemoteResetAfterStreamCompleteProducesLocalClos
   // Simulate stream already completed normally via half-close path.
   EXPECT_CALL(this->callbacks_, onEvent(_)).Times(AnyNumber());
   this->upstream_->doneReading();
-  this->upstream_->doneWriting();
 
   // Remote reset after completion should NOT produce RST.
   EXPECT_CALL(this->encoder_.stream_, resetStream(_)).Times(0);
@@ -294,7 +293,6 @@ TEST_P(HttpUpstreamTest, DumpsResponseDecoderWithoutAllocatingMemory) {
 TEST_P(HttpUpstreamTest, UpstreamTrailersMarksDoneReading) {
   this->setupUpstream();
   EXPECT_CALL(this->encoder_.stream_, resetStream(_)).Times(0);
-  this->upstream_->doneWriting();
   Http::ResponseTrailerMapPtr trailers{new Http::TestResponseTrailerMapImpl{{"key", "value"}}};
   this->upstream_->responseDecoder().decodeTrailers(std::move(trailers));
 }
@@ -855,7 +853,6 @@ TEST_F(CombinedUpstreamTest, DumpsResponseDecoderWithoutAllocatingMemory) {
 }
 TEST_F(CombinedUpstreamTest, UpstreamTrailersMarksDoneReading) {
   this->setup();
-  this->upstream_->doneWriting();
   Http::ResponseTrailerMapPtr trailers{new Http::TestResponseTrailerMapImpl{{"key", "value"}}};
   this->upstream_->responseDecoder().decodeTrailers(std::move(trailers));
 }

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -2518,6 +2518,30 @@ TEST_P(TcpTunnelingIntegrationTest,
   EXPECT_THAT(waitForAccessLog(access_log_filename), testing::HasSubstr(expected_log));
 }
 
+TEST_P(TcpTunnelingIntegrationTest, UpstreamRstAfterCompleteResponseNotPropagatedDownstream) {
+  if (upstreamProtocol() != Http::CodecType::HTTP1) {
+    return;
+  }
+  initialize();
+  tcp_client_ = makeTcpConnection(lookupPort("tcp_proxy"));
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+
+  // Send a complete response with Connection: close, then RST.
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"connection", "close"}};
+  upstream_request_->encodeHeaders(response_headers, false);
+  upstream_request_->encodeData(5, true);
+
+  // Upstream RSTs after completing the response.
+  ASSERT_TRUE(fake_upstream_connection_->close(Network::ConnectionCloseType::AbortReset));
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+
+  // Client should receive the full response data, not EOF.
+  ASSERT_TRUE(tcp_client_->waitForData(5));
+  tcp_client_->close();
+}
+
 INSTANTIATE_TEST_SUITE_P(
     IpAndHttpVersions, TcpTunnelingIntegrationTest,
     testing::ValuesIn(BaseTcpTunnelingIntegrationTest::getProtocolTestParams(


### PR DESCRIPTION
Commit Message: tcp_proxy: do not RST downstream when HTTP stream already completed

Additional Description:When an HTTP/1 upstream sends a response with Connection: close, the
response completes and then the upstream TCP connection closes, firing
a remote reset. PR #44150 mapped remote resets to
DetectedCloseType::RemoteReset, and PR #44148 then propagated that as
AbortReset downstream, dropping buffered response data.

The fix checks whether the read half-close was already set before
onResetStream fires. If so, the stream completed normally and the reset
is cleanup, not a hard failure. So RST propagation is skipped.

Risk Level: low
Testing: CI
Docs Changes: none
Release Notes: changelogs/current/bug_fixes/tcp_proxy__rst_drops_data.rst
Platform Specific Features: none

Fixes #45190

AI Usage: AI tools were used to help navigate the codebase.