### PR TITLE
oauth2: forward ID token

### DIFF
--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -152,6 +152,7 @@ message OAuth2Credentials {
 // Defines how an OAuth token is forwarded upstream.
 message OAuth2TokenForwarding {
   // The upstream request header that will carry the token.
+  // Pseudo-headers (names starting with ``:``) and the ``Host`` header are not allowed.
   string header = 1
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 }
@@ -214,7 +215,7 @@ message OAuth2Config {
   // Forward the OAuth token as a Bearer to upstream web service.
   bool forward_bearer_token = 7;
 
-    // Forward the OIDC ID token to the upstream.
+  // Forward the OIDC ID token to the upstream.
   //
   // If the configured header is ``Authorization``, Envoy forwards the ID token using the
   // ``Bearer `` prefix. For any other header, Envoy forwards the raw token value.

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -218,7 +218,7 @@ message OAuth2Config {
   // Forward the OIDC ID token to the upstream.
   //
   // If the configured header is ``Authorization``, Envoy forwards the ID token using the
-  // ``Bearer `` prefix. For any other header, Envoy forwards the raw token value.
+  // ``Bearer`` prefix. For any other header, Envoy forwards the raw token value.
   // If not specified, the ID token will not be forwarded.
   //
   // This can not be configured with :ref:`forward_bearer_token

--- a/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
+++ b/api/envoy/extensions/filters/http/oauth2/v3/oauth.proto
@@ -149,9 +149,16 @@ message OAuth2Credentials {
       [(validate.rules).string = {pattern: "^$|^[^\\x00-\\x1f\\x7f \",;<>\\\\]+$"}];
 }
 
+// Defines how an OAuth token is forwarded upstream.
+message OAuth2TokenForwarding {
+  // The upstream request header that will carry the token.
+  string header = 1
+      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+}
+
 // OAuth config
 //
-// [#next-free-field: 31]
+// [#next-free-field: 32]
 message OAuth2Config {
   enum AuthType {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
@@ -206,6 +213,19 @@ message OAuth2Config {
 
   // Forward the OAuth token as a Bearer to upstream web service.
   bool forward_bearer_token = 7;
+
+    // Forward the OIDC ID token to the upstream.
+  //
+  // If the configured header is ``Authorization``, Envoy forwards the ID token using the
+  // ``Bearer `` prefix. For any other header, Envoy forwards the raw token value.
+  // If not specified, the ID token will not be forwarded.
+  //
+  // This can not be configured with :ref:`forward_bearer_token
+  // <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.forward_bearer_token>`
+  // or :ref:`preserve_authorization_header
+  // <envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.preserve_authorization_header>`
+  // when the header is ``Authorization``.
+  OAuth2TokenForwarding forward_id_token = 31;
 
   // If set to true, preserve the existing authorization header.
   // By default the client strips the existing authorization header before forwarding upstream.

--- a/changelogs/current/new_features/oauth2__forward-id-token.rst
+++ b/changelogs/current/new_features/oauth2__forward-id-token.rst
@@ -1,0 +1,13 @@
+Added :ref:`forward_id_token
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.forward_id_token>` to let the
+OAuth2 filter forward the OIDC ID token to the upstream on a configurable request header. When the
+configured header is ``Authorization`` the ID token is forwarded using the ``Bearer `` prefix; for
+any other header the raw token value is forwarded. When forwarding on a custom header, that header
+is stripped from the incoming request on every upstream-bound path, including requests bypassed via
+:ref:`pass_through_matcher
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.pass_through_matcher>`, so a
+client can not spoof the forwarded ID token (Envoy only sets it from a validated cookie).
+Forwarding on the ``Authorization`` header can not be combined with :ref:`forward_bearer_token
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.forward_bearer_token>` or
+:ref:`preserve_authorization_header
+<envoy_v3_api_field_extensions.filters.http.oauth2.v3.OAuth2Config.preserve_authorization_header>`.

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -91,9 +91,9 @@ createFilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Con
         "allowed"));
   }
 
-  // The forward_id_token header is owned by Envoy. Reject configs whose pass_through_matcher keys on
-  // it: otherwise a client could control the pass-through decision (and thus bypass OAuth entirely)
-  // simply by sending that header.
+  // The forward_id_token header is owned by Envoy. Reject configs whose pass_through_matcher keys
+  // on it: otherwise a client could control the pass-through decision (and thus bypass OAuth
+  // entirely) simply by sending that header.
   if (proto_config.has_forward_id_token()) {
     const Http::LowerCaseString id_token_header(proto_config.forward_id_token().header());
     for (const auto& matcher : proto_config.pass_through_matcher()) {

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -14,9 +14,13 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
+#include "source/common/http/header_utility.h"
+#include "source/common/http/headers.h"
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/http/oauth2/filter.h"
 #include "source/extensions/filters/http/oauth2/oauth.h"
+
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -76,11 +80,48 @@ createFilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Con
     return absl::InvalidArgumentError("invalid HMAC secret configuration");
   }
 
-  if (proto_config.preserve_authorization_header() && proto_config.forward_bearer_token()) {
+  // Reject headers that must not be set by configuration (pseudo-headers such as ":path" and the
+  // "Host" header) for the forwarded ID token.
+  if (proto_config.has_forward_id_token() &&
+      !Http::HeaderUtility::isModifiableHeader(proto_config.forward_id_token().header())) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "invalid forward_id_token configuration: header '",
+        proto_config.forward_id_token().header(),
+        "' can not be used to forward the ID token; pseudo-headers and the Host header are not "
+        "allowed"));
+  }
+
+  // The forward_id_token header is owned by Envoy. Reject configs whose pass_through_matcher keys on
+  // it: otherwise a client could control the pass-through decision (and thus bypass OAuth entirely)
+  // simply by sending that header.
+  if (proto_config.has_forward_id_token()) {
+    const Http::LowerCaseString id_token_header(proto_config.forward_id_token().header());
+    for (const auto& matcher : proto_config.pass_through_matcher()) {
+      if (Http::LowerCaseString(matcher.name()) == id_token_header) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("invalid forward_id_token configuration: pass_through_matcher can not "
+                         "match on the forwarded ID token header '",
+                         proto_config.forward_id_token().header(), "'"));
+      }
+    }
+  }
+
+  // The Authorization header has at most one owner. It is written by forward_bearer_token (the
+  // access token) and by forward_id_token when its target header is "Authorization" (the ID
+  // token); preserve_authorization_header instead keeps the client-supplied value. None of these
+  // can be combined, since they would otherwise fight over the same header.
+  const bool forward_id_token_on_authorization_header =
+      proto_config.has_forward_id_token() &&
+      Http::LowerCaseString(proto_config.forward_id_token().header()) ==
+          Http::CustomHeaders::get().Authorization;
+  if (static_cast<int>(proto_config.forward_bearer_token()) +
+          static_cast<int>(forward_id_token_on_authorization_header) +
+          static_cast<int>(proto_config.preserve_authorization_header()) >
+      1) {
     return absl::InvalidArgumentError(
-        "invalid combination of forward_bearer_token and preserve_authorization_header "
-        "configuration. If forward_bearer_token is set to true, then "
-        "preserve_authorization_header must be false");
+        "invalid OAuth2 configuration: at most one of forward_bearer_token, "
+        "preserve_authorization_header, or forward_id_token (when forwarding the ID token on the "
+        "Authorization header) may be set, as they all use the Authorization header");
   }
 
   auto secret_reader = std::make_shared<SDSSecretReader>(

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -528,6 +528,9 @@ FilterConfig::FilterConfig(
       disable_token_encryption_(proto_config.disable_token_encryption()),
       use_access_token_expiry_for_id_token_cookie_(
           proto_config.use_access_token_expiry_for_id_token_cookie()),
+      forward_id_token_header_(proto_config.has_forward_id_token()
+                                   ? Http::LowerCaseString(proto_config.forward_id_token().header())
+                                   : Http::LowerCaseString("")),
       bearer_token_cookie_settings_(
           (proto_config.has_cookie_configs() &&
            proto_config.cookie_configs().has_bearer_token_cookie_config())
@@ -710,6 +713,13 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
   // If no config is set, OAuth2 is disabled for this request.
   if (config_ == nullptr) {
     return Http::FilterHeadersStatus::Continue;
+  }
+
+  // Strip the configured forward_id_token header before any upstream-bound path (including the
+  // pass-through bypass below) so a client can never spoof it; Envoy re-sets it from a validated
+  // cookie later. The Authorization-header case is handled by the sanitization further down.
+  if (config_->forwardIdToken() && !config_->forwardIdTokenOnAuthorizationHeader()) {
+    headers.remove(config_->forwardIdTokenHeader());
   }
 
   // Skip Filter and continue chain if a Passthrough header is matching.
@@ -915,6 +925,9 @@ bool OAuth2Filter::canSkipOAuth(Http::RequestHeaderMap& headers) const {
     if (config_->forwardBearerToken() && !validator_->token().empty()) {
       setBearerToken(headers, validator_->token());
     }
+    if (config_->forwardIdToken() && !validator_->idToken().empty()) {
+      forwardIdToken(headers, validator_->idToken());
+    }
     ENVOY_STREAM_LOG(debug, "skipping oauth flow due to valid hmac cookie", *decoder_callbacks_);
     return true;
   }
@@ -956,6 +969,17 @@ void OAuth2Filter::decryptAndUpdateOAuthTokenCookies(Http::RequestHeaderMap& hea
       !encrypted_refresh_token.empty()) {
     std::string new_cookies(absl::StrJoin(cookies, "; ", absl::PairFormatter("=")));
     headers.setReferenceKey(Http::Headers::get().Cookie, new_cookies);
+  }
+}
+
+void OAuth2Filter::forwardIdToken(Http::RequestHeaderMap& headers,
+                                  const std::string& id_token) const {
+  if (config_->forwardIdTokenOnAuthorizationHeader()) {
+    // Forward on the Authorization header using the standard Bearer scheme.
+    setBearerToken(headers, id_token);
+  } else {
+    // Forward the raw token value on the configured custom header.
+    headers.setCopy(config_->forwardIdTokenHeader(), id_token);
   }
 }
 
@@ -1386,6 +1410,9 @@ void OAuth2Filter::finishRefreshAccessTokenFlow() {
   request_headers_->setReferenceKey(Http::Headers::get().Cookie, new_cookies);
   if (config_->forwardBearerToken() && !access_token_.empty()) {
     setBearerToken(*request_headers_, access_token_);
+  }
+  if (config_->forwardIdToken() && !id_token_.empty()) {
+    forwardIdToken(*request_headers_, id_token_);
   }
 
   was_refresh_token_flow_ = true;

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -158,6 +158,15 @@ public:
   const std::string& clientId() const { return client_id_; }
   bool forwardBearerToken() const { return forward_bearer_token_; }
   bool preserveAuthorizationHeader() const { return preserve_authorization_header_; }
+  // Whether the OIDC ID token should be forwarded upstream.
+  bool forwardIdToken() const { return !forward_id_token_header_.get().empty(); }
+  // The upstream header that carries the forwarded ID token (empty when forwarding is disabled).
+  const Http::LowerCaseString& forwardIdTokenHeader() const { return forward_id_token_header_; }
+  // Whether the ID token is forwarded on the ``Authorization`` header (using the ``Bearer ``
+  // prefix) rather than a custom header carrying the raw token value.
+  bool forwardIdTokenOnAuthorizationHeader() const {
+    return forward_id_token_header_ == Http::CustomHeaders::get().Authorization;
+  }
   const std::vector<Http::HeaderUtility::HeaderDataPtr>& passThroughMatchers() const {
     return pass_through_header_matchers_;
   }
@@ -278,6 +287,9 @@ private:
   const bool disable_refresh_token_set_cookie_ : 1;
   const bool disable_token_encryption_ : 1;
   const bool use_access_token_expiry_for_id_token_cookie_ : 1;
+  // The upstream header used to forward the OIDC ID token. Empty when ID token forwarding is
+  // disabled.
+  const Http::LowerCaseString forward_id_token_header_;
   Router::RetryPolicyConstSharedPtr retry_policy_;
   const CookieSettings bearer_token_cookie_settings_;
   const CookieSettings hmac_cookie_settings_;
@@ -305,6 +317,7 @@ class CookieValidator {
 public:
   virtual ~CookieValidator() = default;
   virtual const std::string& token() const PURE;
+  virtual const std::string& idToken() const PURE;
   virtual const std::string& refreshToken() const PURE;
   virtual void setParams(const Http::RequestHeaderMap& headers, const std::string& secret) PURE;
   virtual bool isValid() const PURE;
@@ -318,6 +331,7 @@ public:
       : time_source_(time_source), cookie_names_(cookie_names), cookie_domain_(cookie_domain) {}
 
   const std::string& token() const override { return access_token_; }
+  const std::string& idToken() const override { return id_token_; }
   const std::string& refreshToken() const override { return refresh_token_; }
 
   void setParams(const Http::RequestHeaderMap& headers, const std::string& secret) override;
@@ -388,6 +402,11 @@ public:
 
   void finishGetAccessTokenFlow();
   void finishRefreshAccessTokenFlow();
+
+  // Forwards the OIDC ID token upstream on the configured header, if ID token forwarding is
+  // enabled and the token is non-empty. When the configured header is ``Authorization`` the token
+  // is forwarded with the ``Bearer `` prefix; otherwise the raw token value is set on the header.
+  void forwardIdToken(Http::RequestHeaderMap& headers, const std::string& id_token) const;
   void updateTokens(const std::string& access_token, const std::string& id_token,
                     const std::string& refresh_token, std::chrono::seconds expires_in);
 

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -581,13 +581,14 @@ TEST(ConfigTest, ForwardIdTokenRejectsHostHeader) {
 TEST(ConfigTest, ForwardIdTokenRejectsPassThroughMatcherOnSameHeader) {
   // Matching the pass-through rule on the forwarded ID token header (case-insensitively) is
   // rejected, since pass-through skips sanitization and would let a client spoof the ID token.
-  expectForwardIdTokenConfigError("  forward_id_token:\n"
-                                  "    header: x-id-token\n"
-                                  "  pass_through_matcher:\n"
-                                  "  - name: X-Id-Token\n"
-                                  "    present_match: true",
-                                  "invalid forward_id_token configuration: pass_through_matcher can "
-                                  "not match on the forwarded ID token header 'x-id-token'");
+  expectForwardIdTokenConfigError(
+      "  forward_id_token:\n"
+      "    header: x-id-token\n"
+      "  pass_through_matcher:\n"
+      "  - name: X-Id-Token\n"
+      "    present_match: true",
+      "invalid forward_id_token configuration: pass_through_matcher can "
+      "not match on the forwarded ID token header 'x-id-token'");
 }
 
 // A custom (non-Authorization) header for forward_id_token can coexist with forward_bearer_token.

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -9,6 +9,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/logging.h"
 
+#include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -492,9 +493,144 @@ config:
   const auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().message(),
-            "invalid combination of forward_bearer_token and preserve_authorization_header "
-            "configuration. If forward_bearer_token is set to true, then "
-            "preserve_authorization_header must be false");
+            "invalid OAuth2 configuration: at most one of forward_bearer_token, "
+            "preserve_authorization_header, or forward_id_token (when forwarding the ID token on "
+            "the Authorization header) may be set, as they all use the Authorization header");
+}
+
+// Builds a minimal valid OAuth2 config YAML with the given extra fields spliced in, then asserts
+// that creating the filter factory fails with the expected status message.
+void expectForwardIdTokenConfigError(const std::string& extra_config,
+                                     const std::string& expected_message) {
+  const std::string yaml = R"EOF(
+config:
+)EOF" + extra_config + R"EOF(
+  token_endpoint:
+    cluster: foo
+    uri: oauth.com/token
+    timeout: 3s
+  credentials:
+    client_id: "secret"
+    token_secret:
+      name: token
+    hmac_secret:
+      name: hmac
+  authorization_endpoint: https://oauth.com/oauth/authorize/
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_path_matcher:
+    path:
+      exact: /callback
+  signout_path:
+    path:
+      exact: /signout
+    )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
+
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  const auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status().message(), expected_message);
+}
+
+constexpr absl::string_view kAuthorizationHeaderConflictMessage =
+    "invalid OAuth2 configuration: at most one of forward_bearer_token, "
+    "preserve_authorization_header, or forward_id_token (when forwarding the ID token on the "
+    "Authorization header) may be set, as they all use the Authorization header";
+
+TEST(ConfigTest, ForwardIdTokenOnAuthorizationHeaderConflictsWithForwardBearerToken) {
+  expectForwardIdTokenConfigError("  forward_bearer_token: true\n"
+                                  "  forward_id_token:\n"
+                                  "    header: Authorization",
+                                  std::string(kAuthorizationHeaderConflictMessage));
+}
+
+TEST(ConfigTest, ForwardIdTokenOnAuthorizationHeaderConflictsWithPreserveAuthorizationHeader) {
+  expectForwardIdTokenConfigError("  preserve_authorization_header: true\n"
+                                  "  forward_id_token:\n"
+                                  "    header: authorization",
+                                  std::string(kAuthorizationHeaderConflictMessage));
+}
+
+TEST(ConfigTest, ForwardIdTokenRejectsPseudoHeader) {
+  expectForwardIdTokenConfigError(
+      "  forward_id_token:\n"
+      "    header: \":path\"",
+      "invalid forward_id_token configuration: header ':path' can not be used to forward the ID "
+      "token; pseudo-headers and the Host header are not allowed");
+}
+
+TEST(ConfigTest, ForwardIdTokenRejectsHostHeader) {
+  expectForwardIdTokenConfigError(
+      "  forward_id_token:\n"
+      "    header: host",
+      "invalid forward_id_token configuration: header 'host' can not be used to forward the ID "
+      "token; pseudo-headers and the Host header are not allowed");
+}
+
+TEST(ConfigTest, ForwardIdTokenRejectsPassThroughMatcherOnSameHeader) {
+  // Matching the pass-through rule on the forwarded ID token header (case-insensitively) is
+  // rejected, since pass-through skips sanitization and would let a client spoof the ID token.
+  expectForwardIdTokenConfigError("  forward_id_token:\n"
+                                  "    header: x-id-token\n"
+                                  "  pass_through_matcher:\n"
+                                  "  - name: X-Id-Token\n"
+                                  "    present_match: true",
+                                  "invalid forward_id_token configuration: pass_through_matcher can "
+                                  "not match on the forwarded ID token header 'x-id-token'");
+}
+
+// A custom (non-Authorization) header for forward_id_token can coexist with forward_bearer_token.
+TEST(ConfigTest, ForwardIdTokenOnCustomHeaderWithForwardBearerTokenIsValid) {
+  const std::string yaml = R"EOF(
+config:
+  forward_bearer_token: true
+  forward_id_token:
+    header: x-id-token
+  token_endpoint:
+    cluster: foo
+    uri: oauth.com/token
+    timeout: 3s
+  credentials:
+    client_id: "secret"
+    token_secret:
+      name: token
+    hmac_secret:
+      name: hmac
+  authorization_endpoint: https://oauth.com/oauth/authorize/
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_path_matcher:
+    path:
+      exact: /callback
+  signout_path:
+    path:
+      exact: /signout
+    )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  context.server_factory_context_.cluster_manager_.initializeClusters({"foo"}, {});
+
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(context.server_factory_context_, secretManager())
+      .WillByDefault(ReturnRef(secret_manager));
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(*proto_config, "stats", context).ok());
 }
 
 TEST(ConfigTest, ValidSameSiteConfigs) {

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -87,6 +87,7 @@ class MockOAuth2CookieValidator : public CookieValidator {
 public:
   MOCK_METHOD(std::string&, username, (), (const));
   MOCK_METHOD(std::string&, token, (), (const));
+  MOCK_METHOD(std::string&, idToken, (), (const));
   MOCK_METHOD(std::string&, refreshToken, (), (const));
 
   MOCK_METHOD(bool, canUpdateTokenByRefreshToken, (), (const));
@@ -317,6 +318,47 @@ public:
         p, factory_context_.server_factory_context_, secret_reader, scope_, "test.");
 
     return c;
+  }
+
+  // Builds a minimal valid config that forwards the ID token on the given header. When
+  // `forward_bearer_token` is true the access token is also forwarded on the Authorization header.
+  FilterConfigSharedPtr getConfigWithIdTokenForwarding(const std::string& id_token_header,
+                                                       bool forward_bearer_token = false) {
+    envoy::extensions::filters::http::oauth2::v3::OAuth2Config p;
+    auto* endpoint = p.mutable_token_endpoint();
+    endpoint->set_cluster("auth.example.com");
+    endpoint->set_uri("auth.example.com/_oauth");
+    endpoint->mutable_timeout()->set_seconds(1);
+    p.set_redirect_uri("%REQ(:scheme)%://%REQ(:authority)%" + TEST_CALLBACK);
+    p.mutable_redirect_path_matcher()->mutable_path()->set_exact(TEST_CALLBACK);
+    p.set_authorization_endpoint("https://auth.example.com/oauth/authorize/");
+    p.mutable_signout_path()->mutable_path()->set_exact("/_signout");
+    p.set_stat_prefix("my_prefix");
+    p.set_forward_bearer_token(forward_bearer_token);
+    p.mutable_forward_id_token()->set_header(id_token_header);
+    // Disable refresh so the OAuth-failure path is exercised directly without a refresh attempt.
+    p.mutable_use_refresh_token()->set_value(false);
+
+    // Allow requests under /allowfailed to continue upstream as unauthenticated when OAuth fails.
+    auto* allow_failed_matcher = p.add_allow_failed_matcher();
+    allow_failed_matcher->set_name(":path");
+    allow_failed_matcher->mutable_string_match()->set_prefix("/allowfailed");
+
+    // OPTIONS requests bypass OAuth entirely via pass-through.
+    auto* pass_through_matcher = p.add_pass_through_matcher();
+    pass_through_matcher->set_name(":method");
+    pass_through_matcher->mutable_string_match()->set_exact("OPTIONS");
+
+    auto credentials = p.mutable_credentials();
+    credentials->set_client_id(TEST_CLIENT_ID);
+    credentials->mutable_token_secret()->set_name("secret");
+    credentials->mutable_hmac_secret()->set_name("hmac");
+
+    MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
+
+    auto secret_reader = std::make_shared<MockSecretReader>();
+    return std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
+                                          secret_reader, scope_, "test.");
   }
 
   // Test helpers exposing private OAuth2Filter methods. OAuth2Filter declares
@@ -1124,6 +1166,189 @@ TEST_F(OAuth2Test, OAuthOkPass) {
 
   EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_failure").value(), 0);
   EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: forward_id_token is configured with the Authorization header and the request carries
+ * valid OAuth cookies.
+ *
+ * Expected behavior: the ID token is forwarded on the Authorization header using the Bearer prefix,
+ * replacing any client-supplied Authorization value.
+ */
+TEST_F(OAuth2Test, ForwardIdTokenOnAuthorizationHeader) {
+  init(getConfigWithIdTokenForwarding("Authorization"));
+
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer injected_malice!"},
+  };
+
+  Http::TestRequestHeaderMapImpl expected_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_id_token"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+
+  std::string legit_id_token{"legit_id_token"};
+  EXPECT_CALL(*validator_, idToken()).WillRepeatedly(ReturnRef(legit_id_token));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(mock_request_headers, false));
+
+  EXPECT_EQ(mock_request_headers, expected_headers);
+  EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: forward_id_token is configured with a custom header alongside forward_bearer_token, and
+ * the request carries valid OAuth cookies.
+ *
+ * Expected behavior: the access token is forwarded on the Authorization header with the Bearer
+ * prefix, and the raw ID token value is forwarded on the configured custom header.
+ */
+TEST_F(OAuth2Test, ForwardIdTokenOnCustomHeader) {
+  init(getConfigWithIdTokenForwarding("x-id-token", true /* forward_bearer_token */));
+
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  Http::TestRequestHeaderMapImpl expected_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {Http::CustomHeaders::get().Authorization.get(), "Bearer legit_access_token"},
+      {"x-id-token", "legit_id_token"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+
+  std::string legit_access_token{"legit_access_token"};
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_access_token));
+  std::string legit_id_token{"legit_id_token"};
+  EXPECT_CALL(*validator_, idToken()).WillRepeatedly(ReturnRef(legit_id_token));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(mock_request_headers, false));
+
+  EXPECT_EQ(mock_request_headers, expected_headers);
+  EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: forward_id_token is configured on a custom header and OAuth fails, but the path matches
+ * allow_failed_matcher so the request is forwarded upstream as unauthenticated. The client supplies
+ * a spoofed value on the configured ID-token header.
+ *
+ * Expected behavior: the client-supplied ID-token header is stripped early, so the upstream never
+ * receives a spoofed identity token on a request Envoy marked as OAuth failed.
+ */
+TEST_F(OAuth2Test, ForwardIdTokenCustomHeaderSanitizedOnAllowFailed) {
+  init(getConfigWithIdTokenForwarding("x-id-token"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/allowfailed/api"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {"x-id-token", "spoofed-id-token"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+
+  // OAuth failed, but allow_failed_matcher lets the request continue unauthenticated.
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _)).Times(0);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  // The spoofed ID-token header must have been removed before forwarding upstream.
+  EXPECT_TRUE(request_headers.get(Http::LowerCaseString("x-id-token")).empty());
+  EXPECT_EQ(request_headers.get(OAuth2Headers::get().OAuthStatus)[0]->value().getStringView(),
+            "failed");
+  EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_allow_failed_passthrough").value(), 1);
+}
+
+/**
+ * Scenario: forward_id_token is configured on a custom header and the client supplies a spoofed
+ * value on that header on a request with valid OAuth cookies.
+ *
+ * Expected behavior: the spoofed value is replaced with the ID token from the validated cookie.
+ */
+TEST_F(OAuth2Test, ForwardIdTokenCustomHeaderOverwritesSpoofedValue) {
+  init(getConfigWithIdTokenForwarding("x-id-token"));
+
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {"x-id-token", "spoofed-id-token"},
+  };
+
+  Http::TestRequestHeaderMapImpl expected_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {"x-id-token", "legit_id_token"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+
+  std::string legit_id_token{"legit_id_token"};
+  EXPECT_CALL(*validator_, idToken()).WillRepeatedly(ReturnRef(legit_id_token));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter_->decodeHeaders(mock_request_headers, false));
+
+  EXPECT_EQ(mock_request_headers, expected_headers);
+  EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: forward_id_token is configured on a custom header and a request matches
+ * pass_through_matcher (so OAuth is bypassed). The client supplies a spoofed value on the
+ * configured ID-token header.
+ *
+ * Expected behavior: the configured header is stripped before the pass-through bypass, so the
+ * upstream never receives a client-supplied ID token even though OAuth processing is skipped.
+ */
+TEST_F(OAuth2Test, ForwardIdTokenCustomHeaderSanitizedOnPassThrough) {
+  init(getConfigWithIdTokenForwarding("x-id-token"));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Options},
+      {Http::Headers::get().Scheme.get(), "https"},
+      {"x-id-token", "spoofed-id-token"},
+  };
+
+  // Pass-through bypasses OAuth: the validator is never consulted.
+  EXPECT_CALL(*validator_, setParams(_, _)).Times(0);
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  // The spoofed ID-token header must have been removed even though OAuth was bypassed.
+  EXPECT_TRUE(request_headers.get(Http::LowerCaseString("x-id-token")).empty());
+  EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_passthrough").value(), 1);
 }
 
 /**


### PR DESCRIPTION
Implements #15489

This PR only adds support for forwarding the ID token.

Issue #15489 also requests support for forwarding the refresh token, but that is intentionally left out of this PR. Refresh tokens are more sensitive because forwarding them broadens the trust boundary: an upstream service could use the refresh token to mint new access tokens. That behavior should be considered separately and, if added, should be an explicit opt-in with clear security guidance.