### PR TITLE
[bp/1.35] stats: metric expiry & limiting stats number per scope

### DIFF
--- a/api/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/api/envoy/config/bootstrap/v3/bootstrap.proto
@@ -41,7 +41,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_overview_bootstrap>` for more detail.
 
 // Bootstrap :ref:`configuration overview <config_overview_bootstrap>`.
-// [#next-free-field: 42]
+// [#next-free-field: 43]
 message Bootstrap {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.bootstrap.v2.Bootstrap";
@@ -228,6 +228,14 @@ message Bootstrap {
     // a flush timer is not created. Only one of ``stats_flush_on_admin`` or
     // ``stats_flush_interval`` can be set.
     bool stats_flush_on_admin = 29 [(validate.rules).bool = {const: true}];
+  }
+
+  oneof stats_eviction {
+    // Optional duration to perform metric eviction. At every interval, during the stats flush
+    // the unused metrics are removed from the worker caches and the used metrics
+    // are marked as unused. Must be a multiple of the ``stats_flush_interval``.
+    google.protobuf.Duration stats_eviction_interval = 42
+        [(validate.rules).duration = {gte {nanos: 1000000}}];
   }
 
   // Optional watchdog configuration.

--- a/changelogs/current/new_features/stats__added-support-to-remove-unused-metrics.rst
+++ b/changelogs/current/new_features/stats__added-support-to-remove-unused-metrics.rst
@@ -1,0 +1,4 @@
+Added support to remove unused metrics from memory for extensions that
+support evictable metrics. This is done :ref:`periodically
+<envoy_v3_api_field_config.bootstrap.v3.Bootstrap.stats_eviction_interval>`
+during the metric flush.

--- a/changelogs/current/new_features/stats__support-limiting-stats-number-per-scope.rst
+++ b/changelogs/current/new_features/stats__support-limiting-stats-number-per-scope.rst
@@ -1,0 +1,4 @@
+Added support for limiting stats number per scope via
+:ref:`max_counters <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_counters>`,
+:ref:`max_gauges <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_gauges>`, and
+:ref:`max_histograms <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_histograms>`.

--- a/changelogs/current/new_features/stats__support-limiting-stats-number-per-scope.rst
+++ b/changelogs/current/new_features/stats__support-limiting-stats-number-per-scope.rst
@@ -1,4 +1,1 @@
-Added support for limiting stats number per scope via
-:ref:`max_counters <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_counters>`,
-:ref:`max_gauges <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_gauges>`, and
-:ref:`max_histograms <envoy_v3_api_field_config.metrics.v3.StatsConfig.max_histograms>`.
+Added support to limit the number of stats stored in each stats scope in the stats library.

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -34,6 +34,9 @@ Server related statistics are rooted at *server.* with following statistics:
   static_unknown_fields, Counter, Number of messages in static configuration with unknown fields
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
   wip_protos, Counter, Number of messages and fields marked as work-in-progress being used
+  stats_overflow.counter, Counter, Total number of counter lookup or creation attempts dropped due to reaching the configured limit on label cardinality.
+  stats_overflow.gauge, Counter, Total number of gauge lookup or creation attempts dropped due to reaching the configured limit on label cardinality.
+  stats_overflow.histogram, Counter, Total number of histogram lookup or creation attempts dropped due to reaching the configured limit on label cardinality.
 
 .. _server_compilation_settings_statistics:
 

--- a/envoy/server/configuration.h
+++ b/envoy/server/configuration.h
@@ -89,6 +89,11 @@ public:
    * @return true if deferred creation of stats is enabled.
    */
   virtual bool enableDeferredCreationStats() const PURE;
+
+  /**
+   * @return uint32_t a multiple of the flush interval to perform stats eviction, or 0 if disabled.
+   */
+  virtual uint32_t evictOnFlush() const PURE;
 };
 
 /**

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -28,6 +28,17 @@ using TextReadoutOptConstRef = absl::optional<std::reference_wrapper<const TextR
 using ConstScopeSharedPtr = std::shared_ptr<const Scope>;
 using ScopeSharedPtr = std::shared_ptr<Scope>;
 
+// Settings for limiting the number of counters, gauges and histograms allowed
+// in a scope. This currently only supports thread local stats.
+struct ScopeStatsLimitSettings {
+  // Max number of counters allowed in this scope. 0 means no limit.
+  uint32_t max_counters = 0;
+  // Max number of gauges allowed in this scope. 0 means no limit.
+  uint32_t max_gauges = 0;
+  // Max number of histograms allowed in this scope. 0 means no limit.
+  uint32_t max_histograms = 0;
+};
+
 template <class StatType> using IterateFn = std::function<bool(const RefcountPtr<StatType>&)>;
 
 /**
@@ -73,8 +84,10 @@ public:
    * @param name supplies the scope's namespace prefix.
    * @param evictable whether unused metrics can be deleted from the scope caches. This requires
    * that the metrics are not stored by reference.
+   * @param limits metric limits for counters, gauges and histograms allowed in this scope.
    */
-  virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false) PURE;
+  virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+                                     const ScopeStatsLimitSettings& limits = {}) PURE;
 
   /**
    * Allocate a new scope. NOTE: The implementation should correctly handle overlapping scopes
@@ -84,8 +97,10 @@ public:
    * @param name supplies the scope's namespace prefix.
    * @param evictable whether unused metrics can be deleted from the scope caches. This requires
    * that the metrics are not stored by reference.
+   * @param limits metric limits for counters, gauges and histograms allowed in this scope.
    */
-  virtual ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false) PURE;
+  virtual ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
+                                           const ScopeStatsLimitSettings& limits = {}) PURE;
 
   /**
    * Creates a Counter from the stat name. Tag extraction will be performed on the name.

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -71,8 +71,10 @@ public:
    * See also scopeFromStatName, which is preferred.
    *
    * @param name supplies the scope's namespace prefix.
+   * @param evictable whether unused metrics can be deleted from the scope caches. This requires
+   * that the metrics are not stored by reference.
    */
-  virtual ScopeSharedPtr createScope(const std::string& name) PURE;
+  virtual ScopeSharedPtr createScope(const std::string& name, bool evictable = false) PURE;
 
   /**
    * Allocate a new scope. NOTE: The implementation should correctly handle overlapping scopes
@@ -80,8 +82,10 @@ public:
    * gracefully swapped in while an old scope with the same name is being destroyed.
    *
    * @param name supplies the scope's namespace prefix.
+   * @param evictable whether unused metrics can be deleted from the scope caches. This requires
+   * that the metrics are not stored by reference.
    */
-  virtual ScopeSharedPtr scopeFromStatName(StatName name) PURE;
+  virtual ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false) PURE;
 
   /**
    * Creates a Counter from the stat name. Tag extraction will be performed on the name.

--- a/envoy/stats/stats.h
+++ b/envoy/stats/stats.h
@@ -94,6 +94,11 @@ public:
   virtual bool used() const PURE;
 
   /**
+   * Clear any indicator on whether this metric has been updated.
+   */
+  virtual void markUnused() PURE;
+
+  /**
    * Indicates whether this metric is hidden.
    */
   virtual bool hidden() const PURE;

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -118,6 +118,11 @@ public:
   virtual void forEachScope(SizeFn f_size, StatFn<const Scope> f_stat) const PURE;
 
   /**
+   * Delete unused metrics from all the evictable scope caches, and mark the rest as unused.
+   */
+  virtual void evictUnused() PURE;
+
+  /**
    * @return a null counter that will ignore increments and always return 0.
    */
   virtual Counter& nullCounter() PURE;
@@ -172,7 +177,9 @@ public:
   /**
    * @return a scope of the given name.
    */
-  ScopeSharedPtr createScope(const std::string& name) { return rootScope()->createScope(name); }
+  ScopeSharedPtr createScope(const std::string& name, bool evictable = false) {
+    return rootScope()->createScope(name, evictable);
+  }
 
   /**
    * Extracts tags from the name and appends them to the provided StatNameTagVector.

--- a/envoy/stats/store.h
+++ b/envoy/stats/store.h
@@ -177,8 +177,9 @@ public:
   /**
    * @return a scope of the given name.
    */
-  ScopeSharedPtr createScope(const std::string& name, bool evictable = false) {
-    return rootScope()->createScope(name, evictable);
+  ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+                             const ScopeStatsLimitSettings& limits = {}) {
+    return rootScope()->createScope(name, evictable, limits);
   }
 
   /**

--- a/source/common/stats/allocator_impl.cc
+++ b/source/common/stats/allocator_impl.cc
@@ -85,6 +85,7 @@ public:
   // Metric
   SymbolTable& symbolTable() final { return alloc_.symbolTable(); }
   bool used() const override { return flags_ & Metric::Flags::Used; }
+  void markUnused() override { flags_ &= ~Metric::Flags::Used; }
   bool hidden() const override { return flags_ & Metric::Flags::Hidden; }
 
   // RefcountInterface

--- a/source/common/stats/histogram_impl.h
+++ b/source/common/stats/histogram_impl.h
@@ -111,6 +111,7 @@ public:
   void recordValue(uint64_t value) override { parent_.deliverHistogramToSinks(*this, value); }
 
   bool used() const override { return true; }
+  void markUnused() override {}
   bool hidden() const override { return false; }
   SymbolTable& symbolTable() final { return parent_.symbolTable(); }
 
@@ -132,6 +133,7 @@ public:
   ~NullHistogramImpl() override { MetricImpl::clear(symbol_table_); }
 
   bool used() const override { return false; }
+  void markUnused() override {}
   bool hidden() const override { return false; }
   SymbolTable& symbolTable() override { return symbol_table_; }
 

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -63,12 +63,14 @@ ConstScopeSharedPtr IsolatedStoreImpl::constRootScope() const {
 
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
-ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool) {
+ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool,
+                                              const ScopeStatsLimitSettings& limits) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), false);
+  return scopeFromStatName(stat_name_storage.statName(), false, limits);
 }
 
-ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name, bool) {
+ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name, bool,
+                                                    const ScopeStatsLimitSettings&) {
   SymbolTable::StoragePtr prefix_name_storage = symbolTable().join({prefix(), name});
   ScopeSharedPtr scope = store_.makeScope(StatName(prefix_name_storage.get()));
   addScopeToStore(scope);

--- a/source/common/stats/isolated_store_impl.cc
+++ b/source/common/stats/isolated_store_impl.cc
@@ -63,12 +63,12 @@ ConstScopeSharedPtr IsolatedStoreImpl::constRootScope() const {
 
 IsolatedStoreImpl::~IsolatedStoreImpl() = default;
 
-ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name) {
+ScopeSharedPtr IsolatedScopeImpl::createScope(const std::string& name, bool) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName());
+  return scopeFromStatName(stat_name_storage.statName(), false);
 }
 
-ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name) {
+ScopeSharedPtr IsolatedScopeImpl::scopeFromStatName(StatName name, bool) {
   SymbolTable::StoragePtr prefix_name_storage = symbolTable().join({prefix(), name});
   ScopeSharedPtr scope = store_.makeScope(StatName(prefix_name_storage.get()));
   addScopeToStore(scope);

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -203,6 +203,10 @@ public:
     }
   }
 
+  void evictUnused() override {
+    // Do nothing. Eviction is only supported on the thread local stores.
+  }
+
   void forEachSinkedCounter(SizeFn f_size, StatFn<Counter> f_stat) const override {
     forEachCounter(f_size, f_stat);
   }
@@ -295,8 +299,8 @@ public:
                                        StatNameTagVectorOptConstRef tags) override {
     return store_.counters_.get(prefix(), name, tags, symbolTable());
   }
-  ScopeSharedPtr createScope(const std::string& name) override;
-  ScopeSharedPtr scopeFromStatName(StatName name) override;
+  ScopeSharedPtr createScope(const std::string& name, bool evictable) override;
+  ScopeSharedPtr scopeFromStatName(StatName name, bool evictable) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     Gauge& gauge = store_.gauges_.get(prefix(), name, tags, symbolTable(), import_mode);

--- a/source/common/stats/isolated_store_impl.h
+++ b/source/common/stats/isolated_store_impl.h
@@ -299,8 +299,10 @@ public:
                                        StatNameTagVectorOptConstRef tags) override {
     return store_.counters_.get(prefix(), name, tags, symbolTable());
   }
-  ScopeSharedPtr createScope(const std::string& name, bool evictable) override;
-  ScopeSharedPtr scopeFromStatName(StatName name, bool evictable) override;
+  ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+                             const ScopeStatsLimitSettings& limits = {}) override;
+  ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
+                                   const ScopeStatsLimitSettings& limits = {}) override;
   Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                    Gauge::ImportMode import_mode) override {
     Gauge& gauge = store_.gauges_.get(prefix(), name, tags, symbolTable(), import_mode);

--- a/source/common/stats/null_counter.h
+++ b/source/common/stats/null_counter.h
@@ -31,6 +31,7 @@ public:
 
   // Metric
   bool used() const override { return false; }
+  void markUnused() override {}
   bool hidden() const override { return false; }
   SymbolTable& symbolTable() override { return symbol_table_; }
 

--- a/source/common/stats/null_gauge.h
+++ b/source/common/stats/null_gauge.h
@@ -35,6 +35,7 @@ public:
 
   // Metric
   bool used() const override { return false; }
+  void markUnused() override {}
   bool hidden() const override { return false; }
   SymbolTable& symbolTable() override { return symbol_table_; }
 

--- a/source/common/stats/null_text_readout.h
+++ b/source/common/stats/null_text_readout.h
@@ -28,6 +28,7 @@ public:
 
   // Metric
   bool used() const override { return false; }
+  void markUnused() override {}
   bool hidden() const override { return false; }
   SymbolTable& symbolTable() override { return symbol_table_; }
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -38,7 +38,7 @@ ThreadLocalStoreImpl::ThreadLocalStoreImpl(Allocator& alloc)
     well_known_tags_->rememberBuiltin(desc.name_);
   }
   StatNameManagedStorage empty("", alloc.symbolTable());
-  auto new_scope = std::make_shared<ScopeImpl>(*this, StatName(empty.statName()));
+  auto new_scope = std::make_shared<ScopeImpl>(*this, StatName(empty.statName()), false);
   addScope(new_scope);
   default_scope_ = new_scope;
 }
@@ -154,14 +154,15 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
   return ret;
 }
 
-ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name) {
+ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name,
+                                                            bool evictable) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName());
+  return scopeFromStatName(stat_name_storage.statName(), evictable);
 }
 
-ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name) {
+ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
-  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()));
+  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable);
   parent_.addScope(new_scope);
   return new_scope;
 }
@@ -394,8 +395,9 @@ void ThreadLocalStoreImpl::clearHistogramsFromCaches() {
   }
 }
 
-ThreadLocalStoreImpl::ScopeImpl::ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix)
-    : scope_id_(parent.next_scope_id_++), parent_(parent),
+ThreadLocalStoreImpl::ScopeImpl::ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix,
+                                           bool evictable)
+    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable),
       prefix_(prefix, parent.alloc_.symbolTable()),
       central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {}
 
@@ -910,6 +912,14 @@ bool ParentHistogramImpl::used() const {
   return merged_;
 }
 
+void ParentHistogramImpl::markUnused() {
+  merged_ = false;
+  Thread::LockGuard lock(merge_lock_);
+  for (const TlsHistogramSharedPtr& tls_histogram : tls_histograms_) {
+    tls_histogram->markUnused();
+  }
+}
+
 bool ParentHistogramImpl::hidden() const { return false; }
 
 void ParentHistogramImpl::merge() {
@@ -1027,6 +1037,109 @@ void ThreadLocalStoreImpl::forEachScope(std::function<void(std::size_t)> f_size,
   }
   for (const ScopeSharedPtr& scope : scopes) {
     f_scope(*scope);
+  }
+}
+
+namespace {
+struct MetricBag {
+  explicit MetricBag(uint64_t scope_id) : scope_id_(scope_id) {}
+  const uint64_t scope_id_;
+  StatNameHashMap<CounterSharedPtr> counters_;
+  StatNameHashMap<GaugeSharedPtr> gauges_;
+  StatNameHashMap<ParentHistogramImplSharedPtr> histograms_;
+  StatNameHashMap<TextReadoutSharedPtr> text_readouts_;
+  bool empty() const {
+    return counters_.empty() && gauges_.empty() && histograms_.empty() && text_readouts_.empty();
+  }
+};
+
+} // namespace
+
+void ThreadLocalStoreImpl::evictUnused() {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+
+  // If we are shutting down, we no longer perform eviction as workers may be shutting down
+  // and not able to complete their work.
+  if (shutting_down_ || !tls_cache_) {
+    return;
+  }
+
+  auto evicted_metrics = std::make_shared<std::vector<MetricBag>>();
+  {
+    Thread::LockGuard lock(lock_);
+    iterateScopesLockHeld([evicted_metrics](const ScopeImplSharedPtr& scope) -> bool {
+      if (scope->evictable_) {
+        MetricBag metrics(scope->scope_id_);
+        CentralCacheEntrySharedPtr& central_cache = scope->centralCacheMutableNoThreadAnalysis();
+        auto filter_unused = []<typename T>(StatNameHashMap<T>& unused_metrics) {
+          return [&unused_metrics](std::pair<StatName, T> kv) {
+            const auto& [name, metric] = kv;
+            if (metric->used()) {
+              metric->markUnused();
+              return false;
+            } else {
+              unused_metrics.try_emplace(name, metric);
+              return true;
+            }
+          };
+        };
+        absl::erase_if(central_cache->counters_, filter_unused(metrics.counters_));
+        absl::erase_if(central_cache->gauges_, filter_unused(metrics.gauges_));
+        absl::erase_if(central_cache->text_readouts_, filter_unused(metrics.text_readouts_));
+        absl::erase_if(central_cache->histograms_, filter_unused(metrics.histograms_));
+        if (!metrics.empty()) {
+          evicted_metrics->push_back(std::move(metrics));
+        }
+      }
+      return true;
+    });
+  }
+
+  // At this point, central caches no longer return the evicted stats, but we
+  // need to keep the storage for the evicted stats until after the thread
+  // local caches are cleared.
+  if (!evicted_metrics->empty()) {
+    tls_cache_->runOnAllThreads(
+        [evicted_metrics](OptRef<TlsCache> tls_cache) {
+          for (const auto& metrics : *evicted_metrics) {
+            TlsCacheEntry& entry = tls_cache->insertScope(metrics.scope_id_);
+            absl::erase_if(entry.counters_,
+                           [&](std::pair<StatName, std::reference_wrapper<Counter>> kv) {
+                             return metrics.counters_.contains(kv.first);
+                           });
+            absl::erase_if(entry.gauges_,
+                           [&](std::pair<StatName, std::reference_wrapper<Gauge>> kv) {
+                             return metrics.gauges_.contains(kv.first);
+                           });
+            absl::erase_if(entry.text_readouts_,
+                           [&](std::pair<StatName, std::reference_wrapper<TextReadout>> kv) {
+                             return metrics.text_readouts_.contains(kv.first);
+                           });
+            absl::erase_if(entry.parent_histograms_,
+                           [&](std::pair<StatName, ParentHistogramSharedPtr> kv) {
+                             return metrics.histograms_.contains(kv.first);
+                           });
+          }
+        },
+        [evicted_metrics]() {
+          // We want to delete stale stats on the main thread since stat
+          // destructors lock the stats allocator. Note that we might have
+          // received fresh values on the stale cache-local stats after deleting them from the
+          // central cache.. Eventually, we might also want to defer the deletion further in the
+          // allocator until the values are flushed to the sinks.
+          size_t scopes = 0, counters = 0, gauges = 0, readouts = 0, histograms = 0;
+          for (const auto& metrics : *evicted_metrics) {
+            scopes += 1;
+            counters += metrics.counters_.size();
+            gauges += metrics.gauges_.size();
+            readouts += metrics.text_readouts_.size();
+            histograms += metrics.histograms_.size();
+          }
+          ENVOY_LOG(debug,
+                    "deleted stale {} counters, {} gauges, {} text readouts, {} histograms from "
+                    "{} scopes",
+                    counters, gauges, readouts, histograms, scopes);
+        });
   }
 }
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -154,15 +154,17 @@ std::vector<CounterSharedPtr> ThreadLocalStoreImpl::counters() const {
   return ret;
 }
 
-ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name,
-                                                            bool evictable) {
+ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::createScope(const std::string& name, bool evictable,
+                                                            const ScopeStatsLimitSettings& limits) {
   StatNameManagedStorage stat_name_storage(Utility::sanitizeStatsName(name), symbolTable());
-  return scopeFromStatName(stat_name_storage.statName(), evictable);
+  return scopeFromStatName(stat_name_storage.statName(), evictable, limits);
 }
 
-ScopeSharedPtr ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable) {
+ScopeSharedPtr
+ThreadLocalStoreImpl::ScopeImpl::scopeFromStatName(StatName name, bool evictable,
+                                                   const ScopeStatsLimitSettings& limits) {
   SymbolTable::StoragePtr joined = symbolTable().join({prefix_.statName(), name});
-  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable);
+  auto new_scope = std::make_shared<ScopeImpl>(parent_, StatName(joined.get()), evictable, limits);
   parent_.addScope(new_scope);
   return new_scope;
 }
@@ -396,10 +398,12 @@ void ThreadLocalStoreImpl::clearHistogramsFromCaches() {
 }
 
 ThreadLocalStoreImpl::ScopeImpl::ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix,
-                                           bool evictable)
-    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable),
+                                           bool evictable, const ScopeStatsLimitSettings& limits)
+    : scope_id_(parent.next_scope_id_++), parent_(parent), evictable_(evictable), limits_(limits),
       prefix_(prefix, parent.alloc_.symbolTable()),
-      central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {}
+      central_cache_(new CentralCacheEntry(parent.alloc_.symbolTable())) {
+  parent_.ensureOverflowStats(limits_);
+}
 
 ThreadLocalStoreImpl::ScopeImpl::~ScopeImpl() {
   // Helps reproduce a previous race condition by pausing here in tests while we
@@ -514,6 +518,24 @@ StatType& ThreadLocalStoreImpl::ScopeImpl::safeMakeStat(
                                                central_rejected_stats, tls_rejected_stats)) {
     return null_stat;
   } else {
+    // Stat creation here. Check limits.
+    if constexpr (std::is_same_v<StatType, Counter>) {
+      if (limits_.max_counters != 0 && central_cache_map.size() >= limits_.max_counters) {
+        parent_.counters_overflow_->inc();
+        return null_stat;
+      }
+    } else if constexpr (std::is_same_v<StatType, Gauge>) {
+      if (limits_.max_gauges != 0 && central_cache_map.size() >= limits_.max_gauges) {
+        parent_.gauges_overflow_->inc();
+        return null_stat;
+      }
+    } else {
+      // TextReadouts are currently not limited, but we must ensure they are the only
+      // other type being handled. This static_assert will trigger a compilation error
+      // if a new StatType is introduced in the future, forcing the developer to
+      // explicitly decide how to handle its limits.
+      static_assert(std::is_same_v<StatType, TextReadout>, "Unexpected StatType");
+    }
     StatNameTagHelper tag_helper(parent_, name_no_tags, stat_name_tags);
 
     RefcountPtr<StatType> stat = make_stat(
@@ -684,6 +706,11 @@ Histogram& ThreadLocalStoreImpl::ScopeImpl::histogramFromStatNameWithTags(
       if (iter != parent_.histogram_set_.end()) {
         stat = RefcountPtr<ParentHistogramImpl>(*iter);
       } else {
+        if (limits_.max_histograms != 0 &&
+            central_cache->histograms_.size() >= limits_.max_histograms) {
+          parent_.histograms_overflow_->inc();
+          return parent_.null_histogram_;
+        }
         stat = new ParentHistogramImpl(final_stat_name, unit, parent_,
                                        tag_helper.tagExtractedName(), tag_helper.statNameTags(),
                                        *buckets, parent_.next_histogram_id_++);
@@ -1219,6 +1246,33 @@ void ThreadLocalStoreImpl::extractAndAppendTags(absl::string_view name, StatName
   tagProducer().produceTags(name, tags);
   for (const auto& tag : tags) {
     stat_tags.emplace_back(pool.add(tag.name_), pool.add(tag.value_));
+  }
+}
+
+void ThreadLocalStoreImpl::ensureOverflowStats(const ScopeStatsLimitSettings& limits) {
+  const bool need_counter_overflow_stat = limits.max_counters != 0;
+  const bool need_gauge_overflow_stat = limits.max_gauges != 0;
+  const bool need_histogram_overflow_stat = limits.max_histograms != 0;
+
+  if (!need_counter_overflow_stat && !need_gauge_overflow_stat && !need_histogram_overflow_stat) {
+    return;
+  }
+
+  Thread::LockGuard lock(lock_);
+  if (need_counter_overflow_stat && counters_overflow_ == nullptr) {
+    StatNamePool pool(symbolTable());
+    StatName name = pool.add("server.stats_overflow.counter");
+    counters_overflow_ = alloc_.makeCounter(name, name, {});
+  }
+  if (need_gauge_overflow_stat && gauges_overflow_ == nullptr) {
+    StatNamePool pool(symbolTable());
+    StatName name = pool.add("server.stats_overflow.gauge");
+    gauges_overflow_ = alloc_.makeCounter(name, name, {});
+  }
+  if (need_histogram_overflow_stat && histograms_overflow_ == nullptr) {
+    StatNamePool pool(symbolTable());
+    StatName name = pool.add("server.stats_overflow.histogram");
+    histograms_overflow_ = alloc_.makeCounter(name, name, {});
   }
 }
 

--- a/source/common/stats/thread_local_store.h
+++ b/source/common/stats/thread_local_store.h
@@ -230,6 +230,8 @@ public:
                             StatNameTagVector& tags) override;
   const TagVector& fixedTags() override { return tag_producer_->fixedTags(); };
 
+  void ensureOverflowStats(const ScopeStatsLimitSettings& limits);
+
 private:
   friend class ThreadLocalStoreTestingPeer;
 
@@ -281,7 +283,8 @@ private:
   using CentralCacheEntrySharedPtr = RefcountPtr<CentralCacheEntry>;
 
   struct ScopeImpl : public Scope {
-    ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix, bool evictable);
+    ScopeImpl(ThreadLocalStoreImpl& parent, StatName prefix, bool evictable,
+              const ScopeStatsLimitSettings& limits = {});
     ~ScopeImpl() override;
 
     // Stats::Scope
@@ -294,8 +297,10 @@ private:
                                              Histogram::Unit unit) override;
     TextReadout& textReadoutFromStatNameWithTags(const StatName& name,
                                                  StatNameTagVectorOptConstRef tags) override;
-    ScopeSharedPtr createScope(const std::string& name, bool evictale) override;
-    ScopeSharedPtr scopeFromStatName(StatName name, bool evictable) override;
+    ScopeSharedPtr createScope(const std::string& name, bool evictable = false,
+                               const ScopeStatsLimitSettings& limits = {}) override;
+    ScopeSharedPtr scopeFromStatName(StatName name, bool evictable = false,
+                                     const ScopeStatsLimitSettings& limits = {}) override;
     const SymbolTable& constSymbolTable() const final { return parent_.constSymbolTable(); }
     SymbolTable& symbolTable() final { return parent_.symbolTable(); }
 
@@ -452,6 +457,8 @@ private:
     ThreadLocalStoreImpl& parent_;
     const bool evictable_{};
 
+    const ScopeStatsLimitSettings limits_;
+
   private:
     StatNameStorage prefix_;
     mutable CentralCacheEntrySharedPtr central_cache_ ABSL_GUARDED_BY(parent_.lock_);
@@ -589,6 +596,10 @@ private:
   // (e.g. when a scope is deleted), it is likely more efficient to batch their
   // cleanup, which would otherwise entail a post() per histogram per thread.
   std::vector<uint64_t> histograms_to_cleanup_ ABSL_GUARDED_BY(hist_mutex_);
+
+  CounterSharedPtr counters_overflow_;
+  CounterSharedPtr gauges_overflow_;
+  CounterSharedPtr histograms_overflow_;
 };
 
 using ThreadLocalStoreImplPtr = std::unique_ptr<ThreadLocalStoreImpl>;

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -99,6 +99,14 @@ StatsConfigImpl::StatsConfigImpl(const envoy::config::bootstrap::v3::Bootstrap& 
   if (bootstrap.stats_flush_case() == envoy::config::bootstrap::v3::Bootstrap::kStatsFlushOnAdmin) {
     flush_on_admin_ = bootstrap.stats_flush_on_admin();
   }
+
+  const auto evict_interval_ms = PROTOBUF_GET_MS_OR_DEFAULT(bootstrap, stats_eviction_interval, 0);
+  if (evict_interval_ms % flush_interval_.count() != 0) {
+    status = absl::InvalidArgumentError(
+        "stats_eviction_interval must be a multiple of stats_flush_interval");
+    return;
+  }
+  evict_on_flush_ = evict_interval_ms / flush_interval_.count();
 }
 
 absl::Status MainImpl::initialize(const envoy::config::bootstrap::v3::Bootstrap& bootstrap,

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -56,6 +56,7 @@ public:
   const std::list<Stats::SinkPtr>& sinks() const override { return sinks_; }
   std::chrono::milliseconds flushInterval() const override { return flush_interval_; }
   bool flushOnAdmin() const override { return flush_on_admin_; }
+  uint32_t evictOnFlush() const override { return evict_on_flush_; }
 
   void addSink(Stats::SinkPtr sink) { sinks_.emplace_back(std::move(sink)); }
   bool enableDeferredCreationStats() const override {
@@ -67,6 +68,7 @@ private:
   std::chrono::milliseconds flush_interval_;
   bool flush_on_admin_{false};
   const envoy::config::bootstrap::v3::Bootstrap::DeferredStatOptions deferred_stat_options_;
+  uint32_t evict_on_flush_{0};
 };
 
 /**

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -291,6 +291,12 @@ void InstanceBase::flushStatsInternal() {
   auto& stats_config = config_.statsConfig();
   InstanceUtil::flushMetricsToSinks(stats_config.sinks(), stats_store_, clusterManager(),
                                     timeSource());
+  if (const auto evict_on_flush = stats_config.evictOnFlush(); evict_on_flush > 0) {
+    stats_eviction_counter_ = (stats_eviction_counter_ + 1) % evict_on_flush;
+    if (stats_eviction_counter_ == 0) {
+      stats_store_.evictUnused();
+    }
+  }
   // TODO(ramaraochavali): consider adding different flush interval for histograms.
   if (stat_flush_timer_ != nullptr) {
     stat_flush_timer_->enableTimer(stats_config.flushInterval());

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -450,6 +450,8 @@ private:
         : RaiiListElement<T>(callbacks, callback) {}
   };
 
+  uint32_t stats_eviction_counter_{0};
+
 #ifdef ENVOY_PERFETTO
   std::unique_ptr<perfetto::TracingSession> tracing_session_{};
   os_fd_t tracing_fd_{INVALID_HANDLE};
@@ -465,6 +467,8 @@ private:
 //                     copying and probably be a cleaner API in general.
 class MetricSnapshotImpl : public Stats::MetricSnapshot {
 public:
+  // MetricSnapshotImpl captures a snapshot of metrics by latching the delta usage, and optionally
+  // marking the stats as used.
   explicit MetricSnapshotImpl(Stats::Store& store, Upstream::ClusterManager& cluster_manager,
                               TimeSource& time_source);
 

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -77,15 +77,18 @@ public:
   TestScopeWrapper(Thread::MutexBasicLockable& lock, ScopeSharedPtr wrapped_scope, Store& store)
       : lock_(lock), wrapped_scope_(wrapped_scope), store_(store) {}
 
-  ScopeSharedPtr createScope(const std::string& name, bool) override {
+  ScopeSharedPtr createScope(const std::string& name, bool evictable,
+                             const ScopeStatsLimitSettings& limits) override {
     Thread::LockGuard lock(lock_);
-    return std::make_shared<TestScopeWrapper>(lock_, wrapped_scope_->createScope(name), store_);
+    return std::make_shared<TestScopeWrapper>(
+        lock_, wrapped_scope_->createScope(name, evictable, limits), store_);
   }
 
-  ScopeSharedPtr scopeFromStatName(StatName name, bool) override {
+  ScopeSharedPtr scopeFromStatName(StatName name, bool evictable,
+                                   const ScopeStatsLimitSettings& limits) override {
     Thread::LockGuard lock(lock_);
-    return std::make_shared<TestScopeWrapper>(lock_, wrapped_scope_->scopeFromStatName(name),
-                                              store_);
+    return std::make_shared<TestScopeWrapper>(
+        lock_, wrapped_scope_->scopeFromStatName(name, evictable, limits), store_);
   }
 
   Counter& counterFromStatNameWithTags(const StatName& name,

--- a/test/mocks/server/server_factory_context.h
+++ b/test/mocks/server/server_factory_context.h
@@ -51,6 +51,7 @@ public:
   MOCK_METHOD(bool, flushOnAdmin, (), (const));
   MOCK_METHOD(const Stats::SinkPredicates*, sinkPredicates, (), (const));
   MOCK_METHOD(bool, enableDeferredCreationStats, (), (const));
+  MOCK_METHOD(uint32_t, evictOnFlush, (), (const));
 };
 
 class MockServerFactoryContext : public virtual ServerFactoryContext {

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -142,6 +142,7 @@ public:
   MOCK_METHOD(uint64_t, latch, ());
   MOCK_METHOD(void, reset, ());
   MOCK_METHOD(bool, used, (), (const));
+  MOCK_METHOD(void, markUnused, ());
   MOCK_METHOD(bool, hidden, (), (const));
   MOCK_METHOD(uint64_t, value, (), (const));
 
@@ -164,6 +165,7 @@ public:
   MOCK_METHOD(void, sub, (uint64_t amount));
   MOCK_METHOD(void, mergeImportMode, (ImportMode));
   MOCK_METHOD(bool, used, (), (const));
+  MOCK_METHOD(void, markUnused, ());
   MOCK_METHOD(bool, hidden, (), (const));
   MOCK_METHOD(uint64_t, value, (), (const));
   MOCK_METHOD(absl::optional<bool>, cachedShouldImport, (), (const));
@@ -181,6 +183,7 @@ public:
   ~MockHistogram() override;
 
   MOCK_METHOD(bool, used, (), (const));
+  MOCK_METHOD(void, markUnused, ());
   MOCK_METHOD(bool, hidden, (), (const));
   MOCK_METHOD(Histogram::Unit, unit, (), (const));
   MOCK_METHOD(void, recordValue, (uint64_t value));
@@ -206,6 +209,7 @@ public:
   std::string quantileSummary() const override { return ""; };
   std::string bucketSummary() const override { return ""; };
   MOCK_METHOD(bool, used, (), (const));
+  MOCK_METHOD(void, markUnused, ());
   MOCK_METHOD(bool, hidden, (), (const));
   MOCK_METHOD(Histogram::Unit, unit, (), (const));
   MOCK_METHOD(void, recordValue, (uint64_t value));
@@ -292,10 +296,10 @@ class MockScope : public TestUtil::TestScope {
 public:
   MockScope(StatName prefix, MockStore& store);
 
-  ScopeSharedPtr createScope(const std::string& name) override {
+  ScopeSharedPtr createScope(const std::string& name, bool) override {
     return ScopeSharedPtr(createScope_(name));
   }
-  ScopeSharedPtr scopeFromStatName(StatName name) override {
+  ScopeSharedPtr scopeFromStatName(StatName name, bool) override {
     return createScope_(symbolTable().toString(name));
   }
 

--- a/test/mocks/stats/mocks.h
+++ b/test/mocks/stats/mocks.h
@@ -296,10 +296,11 @@ class MockScope : public TestUtil::TestScope {
 public:
   MockScope(StatName prefix, MockStore& store);
 
-  ScopeSharedPtr createScope(const std::string& name, bool) override {
+  ScopeSharedPtr createScope(const std::string& name, bool,
+                             const ScopeStatsLimitSettings&) override {
     return ScopeSharedPtr(createScope_(name));
   }
-  ScopeSharedPtr scopeFromStatName(StatName name, bool) override {
+  ScopeSharedPtr scopeFromStatName(StatName name, bool, const ScopeStatsLimitSettings&) override {
     return createScope_(symbolTable().toString(name));
   }
 

--- a/test/server/configuration_impl_test.cc
+++ b/test/server/configuration_impl_test.cc
@@ -94,6 +94,7 @@ TEST_F(ConfigurationImplTest, DefaultStatsFlushInterval) {
 
   EXPECT_EQ(std::chrono::milliseconds(5000), config.statsConfig().flushInterval());
   EXPECT_FALSE(config.statsConfig().flushOnAdmin());
+  EXPECT_EQ(0, config.statsConfig().evictOnFlush());
 }
 
 TEST_F(ConfigurationImplTest, CustomStatsFlushInterval) {
@@ -222,6 +223,34 @@ TEST_F(ConfigurationImplTest, IntervalAndAdminFlush) {
   MainImpl config;
   EXPECT_EQ(config.initialize(bootstrap, server_, cluster_manager_factory_).message(),
             "Only one of stats_flush_interval or stats_flush_on_admin should be set!");
+}
+
+TEST_F(ConfigurationImplTest, Eviction) {
+  std::string json = R"EOF(
+  {
+    "stats_flush_interval": "0.500s",
+    "stats_eviction_interval": "1.5s"
+  }
+  )EOF";
+
+  auto bootstrap = Upstream::parseBootstrapFromV3Json(json);
+  MainImpl config;
+  EXPECT_TRUE(config.initialize(bootstrap, server_, cluster_manager_factory_).ok());
+  EXPECT_EQ(3, config.statsConfig().evictOnFlush());
+}
+
+TEST_F(ConfigurationImplTest, EvictionNotMultiple) {
+  std::string json = R"EOF(
+  {
+    "stats_flush_interval": "0.500s",
+    "stats_eviction_interval": "0.750s"
+  }
+  )EOF";
+
+  auto bootstrap = Upstream::parseBootstrapFromV3Json(json);
+  MainImpl config;
+  EXPECT_THAT(config.initialize(bootstrap, server_, cluster_manager_factory_).message(),
+              testing::HasSubstr("must be a multiple"));
 }
 
 TEST_F(ConfigurationImplTest, SetUpstreamClusterPerConnectionBufferLimit) {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -957,6 +957,38 @@ TEST_P(ServerInstanceImplTest, FlushStatsOnAdmin) {
   server_thread->join();
 }
 
+TEST_P(ServerInstanceImplTest, EvictStats) {
+  CustomStatsSinkFactory factory;
+  Registry::InjectFactory<Server::Configuration::StatsSinkFactory> registered(factory);
+  auto server_thread =
+      startTestServer("test/server/test_data/server/stats_evict_bootstrap.yaml", true);
+  EXPECT_EQ(2, server_->statsConfig().evictOnFlush());
+  EXPECT_EQ(std::chrono::seconds(5), server_->statsConfig().flushInterval());
+
+  auto counter = TestUtility::findCounter(stats_store_, "stats.flushed");
+
+  time_system_.advanceTimeWait(std::chrono::seconds(6));
+  EXPECT_EQ(1L, counter->value());
+  EXPECT_EQ(0, stats_store_.evictionCount());
+
+  // Eviction applied here: side-effect is that c1 is now marked as unused.
+  time_system_.advanceTimeWait(std::chrono::seconds(6));
+  EXPECT_EQ(2L, counter->value());
+  EXPECT_EQ(1, stats_store_.evictionCount());
+
+  time_system_.advanceTimeWait(std::chrono::seconds(6));
+  EXPECT_EQ(3L, counter->value());
+  EXPECT_EQ(1, stats_store_.evictionCount());
+
+  // Second pass of eviction deletes the counter.
+  time_system_.advanceTimeWait(std::chrono::seconds(6));
+  EXPECT_EQ(4L, counter->value());
+  EXPECT_EQ(2, stats_store_.evictionCount());
+
+  server_->dispatcher().post([&] { server_->shutdown(); });
+  server_thread->join();
+}
+
 TEST_P(ServerInstanceImplTest, ConcurrentFlushes) {
   CustomStatsSinkFactory factory;
   Registry::InjectFactory<Server::Configuration::StatsSinkFactory> registered(factory);

--- a/test/server/test_data/server/stats_evict_bootstrap.yaml
+++ b/test/server/test_data/server/stats_evict_bootstrap.yaml
@@ -1,0 +1,11 @@
+node:
+  id: bootstrap_id
+  cluster: bootstrap_cluster
+  locality:
+    zone: bootstrap_zone
+    sub_zone: bootstrap_sub_zone
+stats_sinks:
+- name: envoy.custom_stats_sink
+  typed_config:
+    "@type": type.googleapis.com/google.protobuf.Struct
+stats_eviction_interval: 10s


### PR DESCRIPTION
Back port of:

- envoyproxy/envoy#40395
- envoyproxy/envoy#42168

This is part of a coordinated backport to back port stats eviction support from Envoy 1.36 / Istio 1.28 to Envoy 1.35 / Istio 1.27, to address unbounded metric memory growth in waypoint proxies. The full set of changes to be back ported across repositories:

- envoyproxy/envoy#40395 (This PR)
- envoyproxy/envoy#42168 (This PR)
- istio/proxy#6529
- istio/api#3562
- istio/istio#57736
- istio/istio#58570