### PR TITLE
gcp_authn: support unbound access token

### DIFF
--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -64,14 +64,15 @@ message GcpAuthnFilterConfig {
 // Audience is the URL of the receiving service that performs token authentication.
 // It will be provided to the filter through cluster's typed_filter_metadata.
 message Audience {
-  message AccessToken {}
+  message AccessToken {
+  }
 
   // The audience URL, used for fetching unbound JWT token.
-  string url = 1 [(validate.rules).string = {min_len: 1, ignore_empty: true}];
+  string url = 1 [(validate.rules).string = {min_len: 1 ignore_empty: true}];
 
   // If defined, the filter will fetch unbound Access Token instead of JWT.
-  // It takes precedence over `url`.
-  AccessToken access_token = 3;
+  // It takes precedence over ``url``.
+  AccessToken access_token = 2;
 }
 
 // Token Cache configuration.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -64,7 +64,14 @@ message GcpAuthnFilterConfig {
 // Audience is the URL of the receiving service that performs token authentication.
 // It will be provided to the filter through cluster's typed_filter_metadata.
 message Audience {
-  string url = 1 [(validate.rules).string = {min_len: 1}];
+  message AccessToken {}
+
+  // The audience URL, used for fetching unbound JWT token.
+  string url = 1 [(validate.rules).string = {min_len: 1, ignore_empty: true}];
+
+  // If defined, the filter will fetch unbound Access Token instead of JWT.
+  // It takes precedence over `url`.
+  AccessToken access_token = 3;
 }
 
 // Token Cache configuration.

--- a/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
+++ b/api/envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.proto
@@ -68,7 +68,7 @@ message Audience {
   }
 
   // The audience URL, used for fetching unbound JWT token.
-  string url = 1 [(validate.rules).string = {min_len: 1 ignore_empty: true}];
+  string url = 1;
 
   // If defined, the filter will fetch unbound Access Token instead of JWT.
   // It takes precedence over ``url``.

--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -52,6 +52,8 @@ areas:
     title: dns_resolver
   dynamic_modules:
     title: dynamic_modules
+  gcp_authn:
+    title: gcp_authn
   golang:
     title: golang
   http:

--- a/changelogs/current/new_features/gcp_authn__support-unbound-access-tokens.rst
+++ b/changelogs/current/new_features/gcp_authn__support-unbound-access-tokens.rst
@@ -1,0 +1,1 @@
+Added support to fetch and inject unbound Access Tokens from the GCE Metadata Server. Configured via the ``access_token`` field in the :ref:`Audience proto <envoy_v3_api_msg_extensions.filters.http.gcp_authn.v3.Audience>`.

--- a/source/extensions/filters/http/gcp_authn/BUILD
+++ b/source/extensions/filters/http/gcp_authn/BUILD
@@ -42,9 +42,11 @@ envoy_cc_library(
     hdrs = ["gcp_authn_client_impl.h"],
     deps = [
         ":gcp_authn_client_interface",
+        "//source/common/common:utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:message_lib",
         "//source/common/http:utility_lib",
+        "//source/common/json:json_loader_lib",
         "//source/common/jwt:jwt_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@abseil-cpp//absl/status:statusor",

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -1,8 +1,10 @@
 #include "source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h"
 
 #include "source/common/common/enum_to_int.h"
+#include "source/common/common/utility.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
+#include "source/common/json/json_loader.h"
 #include "source/common/jwt/jwt.h"
 #include "source/common/jwt/verify.h"
 
@@ -15,9 +17,12 @@ namespace HttpFilters {
 namespace GcpAuthn {
 
 namespace {
-constexpr absl::string_view UrlString =
+constexpr absl::string_view JwtTokenEndpoint =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/"
     "identity?audience=[AUDIENCE]";
+constexpr absl::string_view AccessTokenEndpoint =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/"
+    "token";
 constexpr char MetadataFlavorKey[] = "Metadata-Flavor";
 constexpr char MetadataFlavor[] = "Google";
 
@@ -33,6 +38,36 @@ Http::RequestMessagePtr buildRequest(absl::string_view url) {
            {Envoy::Http::LowerCaseString(MetadataFlavorKey), MetadataFlavor}});
 
   return std::make_unique<Envoy::Http::RequestMessageImpl>(std::move(headers));
+}
+
+absl::StatusOr<GcpToken>
+parseJwtResponse(const std::string& response_body,
+                 const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience) {
+  JwtVerify::Jwt jwt;
+  if (jwt.parseFromString(response_body) == JwtVerify::Status::Ok) {
+    return GcpToken{response_body, jwt.exp_, audience};
+  }
+  return absl::InternalError("Failed to parse identity token/JWT.");
+}
+
+absl::StatusOr<GcpToken> parseAccessTokenResponse(
+    const std::string& response_body,
+    const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience,
+    TimeSource& time_source) {
+  auto json_or_error = Json::Factory::loadFromString(response_body);
+  if (!json_or_error.ok()) {
+    return absl::InternalError("Failed to parse access token response as JSON.");
+  }
+  auto json = json_or_error.value();
+  auto access_token_or_error = json->getString("access_token");
+  auto expires_in_or_error = json->getInteger("expires_in");
+  if (!access_token_or_error.ok() || !expires_in_or_error.ok()) {
+    return absl::InternalError("Failed to extract access_token or expires_in from response.");
+  }
+  std::string access_token = access_token_or_error.value();
+  int64_t expires_in = expires_in_or_error.value();
+  uint64_t expires_at = DateUtil::nowToSeconds(time_source) + expires_in;
+  return GcpToken{access_token, expires_at, audience};
 }
 } // namespace
 
@@ -74,7 +109,14 @@ void GcpAuthnClientImpl::fetchToken(
     options.setBufferBodyForRetry(true);
   }
 
-  std::string final_url = absl::StrReplaceAll(UrlString, {{"[AUDIENCE]", audience.url()}});
+  std::string final_url;
+  if (audience.has_access_token()) {
+    token_type_ = TokenType::AccessToken;
+    final_url = AccessTokenEndpoint;
+  } else {
+    token_type_ = TokenType::Jwt;
+    final_url = absl::StrReplaceAll(JwtTokenEndpoint, {{"[AUDIENCE]", audience.url()}});
+  }
   active_request_ =
       thread_local_cluster->httpAsyncClient().send(buildRequest(final_url), *this, options);
 }
@@ -83,25 +125,35 @@ void GcpAuthnClientImpl::onSuccess(const Http::AsyncClient::Request&,
                                    Http::ResponseMessagePtr&& response) {
   auto status = Envoy::Http::Utility::getResponseStatusOrNullopt(response->headers());
   active_request_ = nullptr;
-  if (status.has_value()) {
-    uint64_t status_code = status.value();
-    if (status_code == Envoy::enumToInt(Envoy::Http::Code::OK)) {
-      ASSERT(callbacks_ != nullptr);
-      std::string token_str = response->bodyAsString();
-      JwtVerify::Jwt jwt;
-      if (jwt.parseFromString(token_str) == JwtVerify::Status::Ok) {
-        callbacks_->onComplete(GcpToken{token_str, jwt.exp_, audience_});
-      } else {
-        onError("Failed to parse identity token/JWT.");
-      }
-      callbacks_ = nullptr;
-    } else {
-      onError(absl::StrFormat("Response status is not OK, status: %d", status_code));
-    }
-  } else {
+  if (!status.has_value()) {
     // This occurs if the response headers are invalid.
     onError("Failed to get the response because response headers are not valid.");
+    return;
   }
+
+  uint64_t status_code = status.value();
+  if (status_code != Envoy::enumToInt(Envoy::Http::Code::OK)) {
+    onError(absl::StrFormat("Response status is not OK, status: %d", status_code));
+    return;
+  }
+
+  ASSERT(callbacks_ != nullptr);
+  std::string response_body = response->bodyAsString();
+  absl::StatusOr<GcpToken> token_or_error;
+  if (token_type_ == TokenType::Jwt) {
+    token_or_error = parseJwtResponse(response_body, audience_);
+  } else {
+    token_or_error = parseAccessTokenResponse(
+        response_body, audience_, context_.serverFactoryContext().timeSource());
+  }
+
+  if (token_or_error.ok()) {
+    callbacks_->onComplete(token_or_error.value());
+  } else {
+    onError(token_or_error.status().message());
+    return;
+  }
+  callbacks_ = nullptr;
 }
 
 void GcpAuthnClientImpl::onFailure(const Http::AsyncClient::Request&,

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -50,10 +50,10 @@ parseJwtResponse(const std::string& response_body,
   return absl::InternalError("Failed to parse identity token/JWT.");
 }
 
-absl::StatusOr<GcpToken> parseAccessTokenResponse(
-    const std::string& response_body,
-    const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience,
-    TimeSource& time_source) {
+absl::StatusOr<GcpToken>
+parseAccessTokenResponse(const std::string& response_body,
+                         const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience,
+                         TimeSource& time_source) {
   auto json_or_error = Json::Factory::loadFromString(response_body);
   if (!json_or_error.ok()) {
     return absl::InternalError("Failed to parse access token response as JSON.");
@@ -143,8 +143,8 @@ void GcpAuthnClientImpl::onSuccess(const Http::AsyncClient::Request&,
   if (token_type_ == TokenType::Jwt) {
     token_or_error = parseJwtResponse(response_body, audience_);
   } else {
-    token_or_error = parseAccessTokenResponse(
-        response_body, audience_, context_.serverFactoryContext().timeSource());
+    token_or_error = parseAccessTokenResponse(response_body, audience_,
+                                              context_.serverFactoryContext().timeSource());
   }
 
   if (token_or_error.ok()) {

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -66,6 +66,12 @@ parseAccessTokenResponse(const std::string& response_body,
   }
   std::string access_token = access_token_or_error.value();
   int64_t expires_in = expires_in_or_error.value();
+  if (access_token.empty()) {
+    return absl::InternalError("Extracted access_token is empty.");
+  }
+  if (expires_in <= 0) {
+    return absl::InternalError("Extracted expires_in is non-positive.");
+  }
   uint64_t expires_at = DateUtil::nowToSeconds(time_source) + expires_in;
   return GcpToken{access_token, expires_at, audience};
 }
@@ -113,9 +119,12 @@ void GcpAuthnClientImpl::fetchToken(
   if (audience.has_access_token()) {
     token_type_ = TokenType::AccessToken;
     final_url = AccessTokenEndpoint;
-  } else {
+  } else if (!audience.url().empty()) {
     token_type_ = TokenType::Jwt;
     final_url = absl::StrReplaceAll(JwtTokenEndpoint, {{"[AUDIENCE]", audience.url()}});
+  } else {
+    onError("Failed to fetch the token: both url and access_token are empty.");
+    return;
   }
   active_request_ =
       thread_local_cluster->httpAsyncClient().send(buildRequest(final_url), *this, options);

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
@@ -38,12 +38,18 @@ public:
                  Http::AsyncClient::FailureReason reason) override;
 
 private:
+  enum class TokenType {
+    Jwt,
+    AccessToken
+  };
+
   void onError(absl::string_view error_msg);
   const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config_;
   Server::Configuration::FactoryContext& context_;
   Http::AsyncClient::Request* active_request_{};
   GcpAuthnClient::Callbacks* callbacks_{};
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience_;
+  TokenType token_type_{TokenType::Jwt};
 };
 
 } // namespace GcpAuthn

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
@@ -38,10 +38,7 @@ public:
                  Http::AsyncClient::FailureReason reason) override;
 
 private:
-  enum class TokenType {
-    Jwt,
-    AccessToken
-  };
+  enum class TokenType { Jwt, AccessToken };
 
   void onError(absl::string_view error_msg);
   const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config_;

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
@@ -232,6 +232,76 @@ TEST_F(GcpAuthnClientImplTest, AccessTokenExpiresInMissing) {
   client_callback_->onSuccess(client_request_, std::move(response));
 }
 
+TEST_F(GcpAuthnClientImplTest, BothUrlAndAccessTokenEmpty) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  // Both url and access_token are unset/empty
+
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(),
+                  "Failed to fetch the token: both url and access_token are empty.");
+      }));
+
+  client_->fetchToken(audience, request_callbacks_);
+}
+
+TEST_F(GcpAuthnClientImplTest, AccessTokenEmptyInResponse) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  // Empty access_token value
+  response->body().add(R"({"access_token": "", "expires_in": 3600, "token_type": "Bearer"})");
+
+  // Assert that callbacks are notified with an error.
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(), "Extracted access_token is empty.");
+      }));
+
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
+TEST_F(GcpAuthnClientImplTest, AccessTokenExpiresInNonPositive) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  // expires_in is 0
+  response->body().add(
+      R"({"access_token": "mock_access_token", "expires_in": 0, "token_type": "Bearer"})");
+
+  // Assert that callbacks are notified with an error.
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(), "Extracted expires_in is non-positive.");
+      }));
+
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
 TEST_F(GcpAuthnClientImplTest, NoCluster) {
   std::string no_cluster_config = R"EOF(
     http_uri:

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
@@ -178,7 +178,7 @@ TEST_F(GcpAuthnClientImplTest, AccessTokenParsingFailure) {
   client_callback_->onSuccess(client_request_, std::move(response));
 }
 
-TEST_F(GcpAuthnClientImplTest, AccessTokenFieldsMissing) {
+TEST_F(GcpAuthnClientImplTest, AccessTokenMissing) {
   setupMockObjects();
   createClient();
 
@@ -193,6 +193,33 @@ TEST_F(GcpAuthnClientImplTest, AccessTokenFieldsMissing) {
       new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
   // Missing access_token field
   response->body().add(R"({"expires_in": 3600, "token_type": "Bearer"})");
+
+  // Assert that callbacks are notified with an error.
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(),
+                  "Failed to extract access_token or expires_in from response.");
+      }));
+
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
+TEST_F(GcpAuthnClientImplTest, AccessTokenExpiresInMissing) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  // Missing expires_in field
+  response->body().add(R"({"access_token": "mock_access_token", "token_type": "Bearer"})");
 
   // Assert that callbacks are notified with an error.
   EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
@@ -121,6 +121,90 @@ TEST_F(GcpAuthnClientImplTest, Success) {
   client_callback_->onSuccess(client_request_, std::move(response));
 }
 
+TEST_F(GcpAuthnClientImplTest, SuccessAccessToken) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+  EXPECT_EQ(message_->headers().Method()->value().getStringView(), "GET");
+  EXPECT_EQ(message_->headers().Path()->value().getStringView(),
+            "/computeMetadata/v1/instance/service-accounts/default/token");
+
+  EXPECT_EQ(options_.retry_policy->num_retries().value(), 5);
+  EXPECT_EQ(options_.retry_policy->retry_back_off().base_interval().seconds(), 1);
+  EXPECT_EQ(options_.retry_policy->retry_back_off().max_interval().seconds(), 10);
+  EXPECT_EQ(options_.retry_policy->retry_on(), "5xx,gateway-error,connect-failure,reset");
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  response->body().add(
+      R"({"access_token": "mock_access_token", "expires_in": 3600, "token_type": "Bearer"})");
+
+  uint64_t current_time = DateUtil::nowToSeconds(context_.server_factory_context_.timeSource());
+  uint64_t expected_exp_time = current_time + 3600;
+  GcpToken expected_token{"mock_access_token", expected_exp_time, audience};
+  EXPECT_CALL(request_callbacks_, onComplete(absl::StatusOr<GcpToken>(expected_token)));
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
+TEST_F(GcpAuthnClientImplTest, AccessTokenParsingFailure) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  // Set invalid JSON body
+  response->body().add("invalid_json_body");
+
+  // Assert that callbacks are notified with an error since JSON parsing failed.
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(), "Failed to parse access token response as JSON.");
+      }));
+
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
+TEST_F(GcpAuthnClientImplTest, AccessTokenFieldsMissing) {
+  setupMockObjects();
+  createClient();
+
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+  client_->fetchToken(audience, request_callbacks_);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  // Missing access_token field
+  response->body().add(R"({"expires_in": 3600, "token_type": "Bearer"})");
+
+  // Assert that callbacks are notified with an error.
+  EXPECT_CALL(request_callbacks_, onComplete(testing::Matcher<absl::StatusOr<GcpToken>>(_)))
+      .WillOnce(Invoke([](absl::StatusOr<GcpToken> token) {
+        EXPECT_FALSE(token.ok());
+        EXPECT_EQ(token.status().message(),
+                  "Failed to extract access_token or expires_in from response.");
+      }));
+
+  client_callback_->onSuccess(client_request_, std::move(response));
+}
+
 TEST_F(GcpAuthnClientImplTest, NoCluster) {
   std::string no_cluster_config = R"EOF(
     http_uri:

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
@@ -177,9 +177,10 @@ TEST_F(GcpAuthnFilterTest, ResumeFilterChainIterationWithAccessToken) {
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
   audience.mutable_access_token();
 
-  (*metadata_.mutable_typed_filter_metadata())
-      [std::string(Envoy::Extensions::HttpFilters::GcpAuthn::FilterName)]
-          .PackFrom(audience);
+  (*metadata_
+        .mutable_typed_filter_metadata())[std::string(
+                                              Envoy::Extensions::HttpFilters::GcpAuthn::FilterName)]
+      .PackFrom(audience);
   ON_CALL(*cluster_info_, metadata()).WillByDefault(testing::ReturnRef(metadata_));
 
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true),

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
@@ -167,6 +167,41 @@ TEST_F(GcpAuthnFilterTest, ResumeFilterChainIteration) {
   client_callback_->onSuccess(client_request_, std::move(response));
 }
 
+TEST_F(GcpAuthnFilterTest, ResumeFilterChainIterationWithAccessToken) {
+  setupMockObjects();
+  setupFilterAndCallback();
+
+  // Set up mock filter metadata with AccessToken instead of url.
+  cluster_info_ = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  EXPECT_CALL(thread_local_cluster_, info()).WillRepeatedly(Return(cluster_info_));
+  envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
+  audience.mutable_access_token();
+
+  (*metadata_.mutable_typed_filter_metadata())
+      [std::string(Envoy::Extensions::HttpFilters::GcpAuthn::FilterName)]
+          .PackFrom(audience);
+  ON_CALL(*cluster_info_, metadata()).WillByDefault(testing::ReturnRef(metadata_));
+
+  EXPECT_EQ(filter_->decodeHeaders(default_headers_, true),
+            Http::FilterHeadersStatus::StopAllIterationAndWatermark);
+
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
+      {":status", "200"},
+  }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
+  response->body().add(
+      R"({"access_token": "mock_access_token", "expires_in": 3600, "token_type": "Bearer"})");
+
+  // continueDecoding() is expected to be called to resume the filter chain iteration after
+  // onSuccess().
+  EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  client_callback_->onSuccess(client_request_, std::move(response));
+
+  // Also check that the authorization header has been added correctly.
+  EXPECT_EQ(default_headers_.get_("Authorization"), "Bearer mock_access_token");
+}
+
 TEST_F(GcpAuthnFilterTest, DestroyFilter) {
   setupMockObjects();
   setupFilterAndCallback();


### PR DESCRIPTION
Commit Message: gcp_authn: support unbound access token
Additional Description:

This PR adds support for unbound access tokens to the gcp authn filter by adding a dedicated field to the Audience proto and branching within the gcp authn client.

Risk Level: low
Testing: tests added
Docs Changes: proto comment added
Release Notes: added