### PR TITLE
conn pool: add NotifyPeerAndDrainExisting drain behavior

### DIFF
--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -52,13 +52,14 @@ enum class DrainBehavior {
   // Same as DrainExistingConnections, but only drains connections unable to migrate to a different
   // network on mobile.
   DrainExistingNonMigratableConnections,
-  // Same as DrainAndDelete, but multiplexed pools (HTTP/2, HTTP/3) first send a
-  // protocol-level GOAWAY so the peer can move new streams to a different connection
-  // while existing streams complete. HTTP/1 and TCP pools fall back to plain
-  // DrainAndDelete (no GOAWAY concept). Useful when the connection pool sits on the
-  // sending side of a long-lived multiplexed link (e.g. reverse-connection clusters,
-  // where the cluster owns outbound H2 sessions whose lifecycle the peer must follow).
-  GoAwayAndDrainAndDelete,
+  // Drain existing connections after notifying the peer, so the peer can migrate to a
+  // different connection while existing streams complete. Unlike DrainAndDelete, the pool
+  // stays usable: new streams are served by fresh clients.
+  // Multiplexed pools (HTTP/2, HTTP/3) send a protocol-level GOAWAY. HTTP/1 and TCP have no
+  // peer signal and behave as DrainExistingConnections.
+  // Motivating use case: pools sitting on the sending side of a long-lived multiplexed link
+  // (e.g. reverse-connection clusters).
+  NotifyPeerAndDrainExisting,
 };
 
 /**

--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -52,6 +52,13 @@ enum class DrainBehavior {
   // Same as DrainExistingConnections, but only drains connections unable to migrate to a different
   // network on mobile.
   DrainExistingNonMigratableConnections,
+  // Same as DrainAndDelete, but multiplexed pools (HTTP/2, HTTP/3) first send a
+  // protocol-level GOAWAY so the peer can move new streams to a different connection
+  // while existing streams complete. HTTP/1 and TCP pools fall back to plain
+  // DrainAndDelete (no GOAWAY concept). Useful when the connection pool sits on the
+  // sending side of a long-lived multiplexed link (e.g. reverse-connection clusters,
+  // where the cluster owns outbound H2 sessions whose lifecycle the peer must follow).
+  GoAwayAndDrainAndDelete,
 };
 
 /**

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -517,6 +517,15 @@ public:
                                 DrainConnectionsHostPredicate predicate) PURE;
 
   /**
+   * Drain all connection pool connections owned by this cluster with a specific drain behavior.
+   * @param cluster the cluster to drain.
+   * @param predicate optional host predicate; if null, all hosts are drained.
+   * @param drain_behavior controls the drain semantics (see ConnectionPool::DrainBehavior).
+   */
+  virtual void drainConnections(const std::string& cluster, DrainConnectionsHostPredicate predicate,
+                                ConnectionPool::DrainBehavior drain_behavior) PURE;
+
+  /**
    * Drain all connection pool connections owned by all clusters in the cluster manager.
    * @param predicate supplies the optional drain connections host predicate. If not supplied, all
    *                  hosts are drained.

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -518,9 +518,11 @@ public:
 
   /**
    * Drain all connection pool connections owned by this cluster with a specific drain behavior.
+   * Use this overload when a drain behavior other than the default DrainExistingConnections is
+   * needed (see ConnectionPool::DrainBehavior).
    * @param cluster the cluster to drain.
    * @param predicate optional host predicate; if null, all hosts are drained.
-   * @param drain_behavior controls the drain semantics (see ConnectionPool::DrainBehavior).
+   * @param drain_behavior controls the drain semantics.
    */
   virtual void drainConnections(const std::string& cluster, DrainConnectionsHostPredicate predicate,
                                 ConnectionPool::DrainBehavior drain_behavior) PURE;

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -1,5 +1,7 @@
 #include "source/common/conn_pool/conn_pool_base.h"
 
+#include <vector>
+
 #include "envoy/server/overload/load_shed_point.h"
 
 #include "source/common/common/assert.h"
@@ -490,6 +492,32 @@ void ConnPoolImplBase::drainClients(std::list<ActiveClientPtr>& clients) {
 }
 
 void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete) {
+    // Mark the pool as draining first so no new connections are created mid-iteration.
+    is_draining_for_deletion_ = true;
+
+    // Snapshot pointers because initiateGoAwayAndDrain() may call transitionActiveClientState
+    // which mutates the per-state lists. Skip connecting_clients_ - those have not exchanged
+    // the protocol preface yet, so sending GOAWAY is unusual; closeIdleConnectionsForDrainingPool
+    // (called via checkForIdleAndCloseIdleConnsIfDraining below) will close them.
+    std::vector<ActiveClient*> snapshot;
+    snapshot.reserve(early_data_clients_.size() + ready_clients_.size() + busy_clients_.size());
+    for (const auto& c : early_data_clients_) {
+      snapshot.push_back(c.get());
+    }
+    for (const auto& c : ready_clients_) {
+      snapshot.push_back(c.get());
+    }
+    for (const auto& c : busy_clients_) {
+      snapshot.push_back(c.get());
+    }
+    for (auto* client : snapshot) {
+      client->initiateGoAwayAndDrain();
+    }
+
+    checkForIdleAndCloseIdleConnsIfDraining();
+    return;
+  }
   if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
     is_draining_for_deletion_ = true;
     checkForIdleAndCloseIdleConnsIfDraining();

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -492,14 +492,8 @@ void ConnPoolImplBase::drainClients(std::list<ActiveClientPtr>& clients) {
 }
 
 void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
-  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete) {
-    // Mark the pool as draining first so no new connections are created mid-iteration.
-    is_draining_for_deletion_ = true;
-
-    // Snapshot pointers because initiateGoAwayAndDrain() may call transitionActiveClientState
-    // which mutates the per-state lists. Skip connecting_clients_ - those have not exchanged
-    // the protocol preface yet, so sending GOAWAY is unusual; closeIdleConnectionsForDrainingPool
-    // (called via checkForIdleAndCloseIdleConnsIfDraining below) will close them.
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting) {
+    // Snapshot before iterating: notifyPeerAndDrain() can move clients between per-state lists.
     std::vector<ActiveClient*> snapshot;
     snapshot.reserve(early_data_clients_.size() + ready_clients_.size() + busy_clients_.size());
     for (const auto& c : early_data_clients_) {
@@ -512,11 +506,11 @@ void ConnPoolImplBase::drainConnectionsImpl(DrainBehavior drain_behavior) {
       snapshot.push_back(c.get());
     }
     for (auto* client : snapshot) {
-      client->initiateGoAwayAndDrain();
+      client->notifyPeerAndDrain();
     }
-
-    checkForIdleAndCloseIdleConnsIfDraining();
-    return;
+    // Fall through into the DrainExistingConnections body below to reuse its cleanup
+    // (closeIdleConnectionsForDrainingPool, etc.). is_draining_for_deletion_ is intentionally
+    // not set, so the pool stays usable for new streams via fresh clients.
   }
   if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
     is_draining_for_deletion_ = true;

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -88,6 +88,11 @@ public:
     return state_ == State::Ready;
   }
 
+  // Send a protocol-level GOAWAY to the peer and transition this client to Draining.
+  // Invoked by the pool under DrainBehavior::GoAwayAndDrainAndDelete. Default no-op for
+  // protocols without GOAWAY (HTTP/1, TCP); multiplexed HTTP clients override.
+  virtual void initiateGoAwayAndDrain() {}
+
   enum class State {
     Connecting,        // Connection is not yet established.
     ReadyForEarlyData, // Any additional early data stream can be immediately dispatched to this

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -88,10 +88,11 @@ public:
     return state_ == State::Ready;
   }
 
-  // Send a protocol-level GOAWAY to the peer and transition this client to Draining.
-  // Invoked by the pool under DrainBehavior::GoAwayAndDrainAndDelete. Default no-op for
-  // protocols without GOAWAY (HTTP/1, TCP); multiplexed HTTP clients override.
-  virtual void initiateGoAwayAndDrain() {}
+  // Notify the peer that this client is draining and transition the client to Draining.
+  // Invoked by the pool under DrainBehavior::NotifyPeerAndDrainExisting. Default no-op for
+  // protocols without a peer-level drain signal (HTTP/1, raw TCP); multiplexed HTTP clients
+  // override to send a GOAWAY.
+  virtual void notifyPeerAndDrain() {}
 
   enum class State {
     Connecting,        // Connection is not yet established.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -120,15 +120,13 @@ void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
   }
 }
 
-void MultiplexedActiveClientBase::initiateGoAwayAndDrain() {
-  // Skip Connecting (no PREFACE exchanged yet) and Draining (already drained or peer already
-  // signaled). The pool's subsequent DrainAndDelete path will close Connecting clients via
-  // closeIdleConnectionsForDrainingPool.
+void MultiplexedActiveClientBase::notifyPeerAndDrain() {
+  // GOAWAY requires a PREFACE; idempotent for already-Draining clients.
   if (state() == Envoy::ConnectionPool::ActiveClient::State::Connecting ||
       state() == Envoy::ConnectionPool::ActiveClient::State::Draining) {
     return;
   }
-  ENVOY_CONN_LOG(debug, "initiate goaway and drain", *codec_client_);
+  ENVOY_CONN_LOG(debug, "notify peer and drain", *codec_client_);
   codec_client_->goAway();
   if (codec_client_->numActiveRequests() == 0) {
     codec_client_->close();

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -120,6 +120,23 @@ void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
   }
 }
 
+void MultiplexedActiveClientBase::initiateGoAwayAndDrain() {
+  // Skip Connecting (no PREFACE exchanged yet) and Draining (already drained or peer already
+  // signaled). The pool's subsequent DrainAndDelete path will close Connecting clients via
+  // closeIdleConnectionsForDrainingPool.
+  if (state() == Envoy::ConnectionPool::ActiveClient::State::Connecting ||
+      state() == Envoy::ConnectionPool::ActiveClient::State::Draining) {
+    return;
+  }
+  ENVOY_CONN_LOG(debug, "initiate goaway and drain", *codec_client_);
+  codec_client_->goAway();
+  if (codec_client_->numActiveRequests() == 0) {
+    codec_client_->close();
+  } else {
+    parent_.transitionActiveClientState(*this, ActiveClient::State::Draining);
+  }
+}
+
 // Adjust the concurrent stream limit if the negotiated concurrent stream limit
 // is lower than the local max configured streams.
 //

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -233,10 +233,9 @@ public:
   bool closingWithIncompleteStream() const override;
   RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
   RequestEncoder& newStreamEncoder(ResponseDecoderHandlePtr response_decoder_handle) override;
-  // Sends a GOAWAY and moves to Draining so the pool stops assigning new streams.
-  // Connecting clients (no PREFACE yet) and already-Draining clients are skipped.
-  // If no active streams remain, the client closes immediately.
-  void initiateGoAwayAndDrain() override;
+  // Sends an HTTP/2 (or HTTP/3) GOAWAY. Idle clients close immediately; busy clients
+  // transition to Draining and close once their in-flight streams finish.
+  void notifyPeerAndDrain() override;
 
   // CodecClientCallbacks
   void onStreamDestroy() override;

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -233,6 +233,10 @@ public:
   bool closingWithIncompleteStream() const override;
   RequestEncoder& newStreamEncoder(ResponseDecoder& response_decoder) override;
   RequestEncoder& newStreamEncoder(ResponseDecoderHandlePtr response_decoder_handle) override;
+  // Sends a GOAWAY and moves to Draining so the pool stops assigning new streams.
+  // Connecting clients (no PREFACE yet) and already-Draining clients are skipped.
+  // If no active streams remain, the client closes immediately.
+  void initiateGoAwayAndDrain() override;
 
   // CodecClientCallbacks
   void onStreamDestroy() override;

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -496,8 +496,7 @@ void ConnectivityGrid::addIdleCallback(IdleCb cb) {
 }
 
 void ConnectivityGrid::drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) {
-  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete ||
-      drain_behavior == Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
     // Note that no new pools should be created from this point on.
     draining_ = true;
   }

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -496,7 +496,8 @@ void ConnectivityGrid::addIdleCallback(IdleCb cb) {
 }
 
 void ConnectivityGrid::drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) {
-  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete) {
+  if (drain_behavior == Envoy::ConnectionPool::DrainBehavior::DrainAndDelete ||
+      drain_behavior == Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete) {
     // Note that no new pools should be created from this point on.
     draining_ = true;
   }

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1093,6 +1093,20 @@ void ClusterManagerImpl::drainConnections(const std::string& cluster,
   });
 }
 
+void ClusterManagerImpl::drainConnections(const std::string& cluster,
+                                          DrainConnectionsHostPredicate predicate,
+                                          ConnectionPool::DrainBehavior drain_behavior) {
+  ENVOY_LOG_EVENT(debug, "drain_connections_call_with_behavior",
+                  "drainConnections called for cluster {} with custom drain behavior", cluster);
+  tls_.runOnAllThreads(
+      [cluster, predicate, drain_behavior](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+        auto cluster_entry = cluster_manager->thread_local_clusters_.find(cluster);
+        if (cluster_entry != cluster_manager->thread_local_clusters_.end()) {
+          cluster_entry->second->drainConnPools(predicate, drain_behavior);
+        }
+      });
+}
+
 void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicate,
                                           ConnectionPool::DrainBehavior drain_behavior) {
   ENVOY_LOG_EVENT(debug, "drain_connections_call_for_all_clusters",

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -382,6 +382,9 @@ public:
   void drainConnections(const std::string& cluster,
                         DrainConnectionsHostPredicate predicate) override;
 
+  void drainConnections(const std::string& cluster, DrainConnectionsHostPredicate predicate,
+                        ConnectionPool::DrainBehavior drain_behavior) override;
+
   void drainConnections(DrainConnectionsHostPredicate predicate,
                         ConnectionPool::DrainBehavior drain_behavior) override;
 

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -2112,10 +2112,10 @@ TEST_F(Http2ConnPoolImplTest, RequestTrackingConnectionFailureNoMetric) {
 }
 
 /**
- * Verify that GoAwayAndDrainAndDelete sends a GOAWAY frame on a ready client with an active
+ * Verify that NotifyPeerAndDrainExisting sends a GOAWAY frame on a ready client with an active
  * stream, transitions it to Draining, and closes the client once the stream completes.
  */
-TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSendsGoAwayThenDrains) {
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingSendsGoAwayThenDrains) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
@@ -2129,7 +2129,7 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSendsGoAwayThenDrains) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   // Complete the in-flight stream; the pool should become idle and the client should close.
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
@@ -2142,10 +2142,10 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSendsGoAwayThenDrains) {
 }
 
 /**
- * Verify that GoAwayAndDrainAndDelete on a ready idle client sends GOAWAY and immediately
+ * Verify that NotifyPeerAndDrainExisting on a ready idle client sends GOAWAY and immediately
  * closes the client (no active streams to wait for).
  */
-TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdleClientClosesImmediately) {
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingIdleClientClosesImmediately) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
@@ -2157,18 +2157,18 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdleClientClosesImmediately
   EXPECT_CALL(drained, ready());
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
   EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
   dispatcher_.clearDeferredDeleteList();
 }
 
 /**
- * Verify that GoAwayAndDrainAndDelete does NOT send GOAWAY on a connecting client (no
+ * Verify that NotifyPeerAndDrainExisting does NOT send GOAWAY on a connecting client (no
  * HTTP/2 PREFACE exchanged yet). The connecting client is still closed once its pending
  * stream is resolved (via connection failure).
  */
-TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSkipsConnectingClient) {
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingSkipsConnectingClient) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   // Do NOT call expectClientConnect — client stays in Connecting state.
@@ -2177,7 +2177,7 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSkipsConnectingClient) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   // The connecting client is not closed yet because it has a pending stream.
   // Simulate the connection failing, which fires pool_failure_ and cleans up.
@@ -2191,9 +2191,9 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSkipsConnectingClient) {
 }
 
 /**
- * Verify that a second GoAwayAndDrainAndDelete call is a no-op — GOAWAY is only sent once.
+ * Verify that a second NotifyPeerAndDrainExisting call is a no-op — GOAWAY is only sent once.
  */
-TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdempotent) {
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingIdempotent) {
   expectClientCreate();
   ActiveTestRequest r1(*this, 0, false);
   expectClientConnect(0, r1);
@@ -2205,9 +2205,9 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdempotent) {
 
   EXPECT_CALL(*test_clients_[0].codec_, goAway());
 
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
   // Second call: should be a no-op (client is already Draining).
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   // Complete the in-flight stream to clean up.
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
@@ -2219,11 +2219,11 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdempotent) {
 }
 
 /**
- * Verify that GoAwayAndDrainAndDelete with multiple clients sends GOAWAY on both Ready
+ * Verify that NotifyPeerAndDrainExisting with multiple clients sends GOAWAY on both Ready
  * clients. Client 0 has an active stream (busy); client 1 is idle. The idle client closes
  * immediately; the busy client drains then closes.
  */
-TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteMultipleClients) {
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingMultipleClients) {
   cluster_->resetResourceManager(2, 1024, 1024, 1, 1);
   cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
 
@@ -2246,7 +2246,7 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteMultipleClients) {
 
   ReadyWatcher drained;
   pool_->addIdleCallback([&]() -> void { drained.ready(); });
-  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   // Complete the in-flight stream on client 0 — pool becomes idle, both clients close.
   EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
@@ -2254,6 +2254,54 @@ TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteMultipleClients) {
   EXPECT_CALL(drained, ready());
   r1.inner_decoder_->decodeHeaders(
       ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+
+  EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * After NotifyPeerAndDrainExisting the pool must stay usable. A new stream issued post-drain
+ * is expected to create a fresh client (all existing clients are in Draining state), not
+ * trip the ASSERT(!is_draining_for_deletion_) in newStreamImpl.
+ */
+TEST_F(Http2ConnPoolImplTest, NotifyPeerAndDrainExistingAllowsNewStreamAfterDrain) {
+  cluster_->resetResourceManager(2, 1024, 1024, 1, 1);
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway());
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
+
+  // The pool must create a fresh client because client 0 is in Draining state.
+  expectClientCreate();
+  ActiveTestRequest r2(*this, 1, false);
+  expectClientConnect(1, r2);
+  EXPECT_CALL(r2.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r2.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+  EXPECT_CALL(r2.decoder_, decodeHeaders_(_, true));
+  r2.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+
+  ReadyWatcher drained;
+  pool_->addIdleCallback([&]() -> void { drained.ready(); });
+  EXPECT_CALL(drained, ready());
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete);
 
   EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
   dispatcher_.clearDeferredDeleteList();

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -2111,6 +2111,154 @@ TEST_F(Http2ConnPoolImplTest, RequestTrackingConnectionFailureNoMetric) {
   EXPECT_EQ(1U, cluster_->traffic_stats_->upstream_cx_destroy_remote_.value());
 }
 
+/**
+ * Verify that GoAwayAndDrainAndDelete sends a GOAWAY frame on a ready client with an active
+ * stream, transitions it to Draining, and closes the client once the stream completes.
+ */
+TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSendsGoAwayThenDrains) {
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway());
+
+  ReadyWatcher drained;
+  pool_->addIdleCallback([&]() -> void { drained.ready(); });
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+
+  // Complete the in-flight stream; the pool should become idle and the client should close.
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(drained, ready());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+  EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Verify that GoAwayAndDrainAndDelete on a ready idle client sends GOAWAY and immediately
+ * closes the client (no active streams to wait for).
+ */
+TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdleClientClosesImmediately) {
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  completeRequest(r1);
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway());
+
+  ReadyWatcher drained;
+  EXPECT_CALL(drained, ready());
+  pool_->addIdleCallback([&]() -> void { drained.ready(); });
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+
+  EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Verify that GoAwayAndDrainAndDelete does NOT send GOAWAY on a connecting client (no
+ * HTTP/2 PREFACE exchanged yet). The connecting client is still closed once its pending
+ * stream is resolved (via connection failure).
+ */
+TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteSkipsConnectingClient) {
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  // Do NOT call expectClientConnect — client stays in Connecting state.
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway()).Times(0);
+
+  ReadyWatcher drained;
+  pool_->addIdleCallback([&]() -> void { drained.ready(); });
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+
+  // The connecting client is not closed yet because it has a pending stream.
+  // Simulate the connection failing, which fires pool_failure_ and cleans up.
+  EXPECT_CALL(r1.callbacks_.pool_failure_, ready());
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  EXPECT_CALL(drained, ready());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  EXPECT_CALL(*this, onClientDestroy());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Verify that a second GoAwayAndDrainAndDelete call is a no-op — GOAWAY is only sent once.
+ */
+TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteIdempotent) {
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway());
+
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+  // Second call: should be a no-op (client is already Draining).
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+
+  // Complete the in-flight stream to clean up.
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+  EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
+  dispatcher_.clearDeferredDeleteList();
+}
+
+/**
+ * Verify that GoAwayAndDrainAndDelete with multiple clients sends GOAWAY on both Ready
+ * clients. Client 0 has an active stream (busy); client 1 is idle. The idle client closes
+ * immediately; the busy client drains then closes.
+ */
+TEST_F(Http2ConnPoolImplTest, GoAwayAndDrainAndDeleteMultipleClients) {
+  cluster_->resetResourceManager(2, 1024, 1024, 1, 1);
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(1);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  expectClientCreate();
+  ActiveTestRequest r2(*this, 1, false);
+  expectClientConnect(1, r2);
+  completeRequest(r2);
+
+  EXPECT_CALL(*test_clients_[0].codec_, goAway());
+  EXPECT_CALL(*test_clients_[1].codec_, goAway());
+
+  ReadyWatcher drained;
+  pool_->addIdleCallback([&]() -> void { drained.ready(); });
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::GoAwayAndDrainAndDelete);
+
+  // Complete the in-flight stream on client 0 — pool becomes idle, both clients close.
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(drained, ready());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+
+  EXPECT_CALL(*this, onClientDestroy()).Times(testing::AnyNumber());
+  dispatcher_.clearDeferredDeleteList();
+}
+
 } // namespace Http2
 } // namespace Http
 } // namespace Envoy

--- a/test/common/upstream/cluster_manager_lifecycle_test.cc
+++ b/test/common/upstream/cluster_manager_lifecycle_test.cc
@@ -2507,6 +2507,73 @@ TEST_P(ClusterManagerLifecycleTest, DrainConnectionsPredicate) {
   });
 }
 
+// Covers the three-argument drainConnections overload that forwards a caller-specified
+// DrainBehavior (e.g. NotifyPeerAndDrainExisting) to every matching host's pool.
+TEST_P(ClusterManagerLifecycleTest, DrainConnectionsWithDrainBehavior) {
+  const std::string yaml = R"EOF(
+  static_resources:
+    clusters:
+    - name: cluster_1
+      connect_timeout: 0.250s
+      lb_policy: ROUND_ROBIN
+      type: STATIC
+  )EOF";
+
+  create(parseBootstrapFromV3Yaml(yaml));
+
+  Cluster& cluster = cluster_manager_->activeClusters().begin()->second;
+  HostSharedPtr host1 = makeTestHost(cluster.info(), "tcp://127.0.0.1:80");
+  HostSharedPtr host2 = makeTestHost(cluster.info(), "tcp://127.0.0.1:81");
+
+  HostVector hosts{host1, host2};
+  auto hosts_ptr = std::make_shared<HostVector>(hosts);
+
+  cluster.prioritySet().updateHosts(
+      0, HostSetImpl::partitionHosts(hosts_ptr, HostsPerLocalityImpl::empty()), nullptr, hosts, {},
+      absl::nullopt, 100);
+
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
+      .Times(2)
+      .WillRepeatedly(ReturnNew<NiceMock<Http::ConnectionPool::MockInstance>>());
+  Http::ConnectionPool::MockInstance* cp1 = HttpPoolDataPeer::getPool(
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->httpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, Http::Protocol::Http11, nullptr));
+  Http::ConnectionPool::MockInstance* cp2 = HttpPoolDataPeer::getPool(
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->httpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, Http::Protocol::Http11, nullptr));
+  EXPECT_NE(cp1, cp2);
+
+  // Predicate selects only host1; behavior is the new NotifyPeerAndDrainExisting value. The
+  // three-arg overload must forward the caller-specified behavior to the selected pool.
+  EXPECT_CALL(
+      *cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  EXPECT_CALL(*cp2, drainConnections(_)).Times(0);
+  cluster_manager_->drainConnections(
+      "cluster_1",
+      [](const Upstream::Host& host) { return host.address()->asString() == "127.0.0.1:80"; },
+      Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
+
+  // Nullptr predicate drains every host's pool with the caller-specified behavior.
+  EXPECT_CALL(
+      *cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  EXPECT_CALL(
+      *cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  cluster_manager_->drainConnections(
+      "cluster_1", /*predicate=*/nullptr,
+      Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
+
+  // Unknown cluster name: the overload short-circuits (no pools touched, no crash).
+  EXPECT_CALL(*cp1, drainConnections(_)).Times(0);
+  EXPECT_CALL(*cp2, drainConnections(_)).Times(0);
+  cluster_manager_->drainConnections(
+      "nonexistent_cluster", /*predicate=*/nullptr,
+      Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
+}
+
 TEST_P(ClusterManagerLifecycleTest, ConnPoolsDrainedOnHostSetChange) {
   const std::string yaml = R"EOF(
   static_resources:

--- a/test/common/upstream/cluster_manager_lifecycle_test.cc
+++ b/test/common/upstream/cluster_manager_lifecycle_test.cc
@@ -2549,8 +2549,8 @@ TEST_P(ClusterManagerLifecycleTest, DrainConnectionsWithDrainBehavior) {
 
   // Predicate selects only host1; behavior is the new NotifyPeerAndDrainExisting value. The
   // three-arg overload must forward the caller-specified behavior to the selected pool.
-  EXPECT_CALL(
-      *cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
   EXPECT_CALL(*cp2, drainConnections(_)).Times(0);
   cluster_manager_->drainConnections(
       "cluster_1",
@@ -2558,10 +2558,10 @@ TEST_P(ClusterManagerLifecycleTest, DrainConnectionsWithDrainBehavior) {
       Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);
 
   // Nullptr predicate drains every host's pool with the caller-specified behavior.
-  EXPECT_CALL(
-      *cp1, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
-  EXPECT_CALL(
-      *cp2, drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  EXPECT_CALL(*cp1,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
+  EXPECT_CALL(*cp2,
+              drainConnections(Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting));
   cluster_manager_->drainConnections(
       "cluster_1", /*predicate=*/nullptr,
       Envoy::ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting);

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -88,6 +88,9 @@ public:
   MOCK_METHOD(void, drainConnections,
               (const std::string& cluster, DrainConnectionsHostPredicate predicate));
   MOCK_METHOD(void, drainConnections,
+              (const std::string& cluster, DrainConnectionsHostPredicate predicate,
+               ConnectionPool::DrainBehavior drain_behavior));
+  MOCK_METHOD(void, drainConnections,
               (DrainConnectionsHostPredicate predicate,
                ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(absl::Status, checkActiveStaticCluster, (const std::string& cluster));


### PR DESCRIPTION
> **This PR is part of a 3-PR stack.** PR2 and PR3 are out-of-tree against `ivpr/envoy` and exist to demonstrate a concrete consumer of the API added here — they do not need to land in `envoyproxy/envoy` for this PR to be useful on its own.
>
> | # | Where | What |
> |---|-------|------|
> | **PR1 (this PR)** | `envoyproxy/envoy` | **Core**: `DrainBehavior::NotifyPeerAndDrainExisting` enum value + virtual hook `ActiveClient::notifyPeerAndDrain()` + `ClusterManager::drainConnections(cluster, predicate, drain_behavior)` overload. |
> | PR2 → [ivpr/envoy#1](https://github.com/ivpr/envoy/pull/1) | `ivpr/envoy` (stacked on PR1) | **Upstream consumer**: reverse-tunnel acceptor extension registers a `POST /reverse_tunnel/drain_cluster` admin endpoint that fans out the new drain behavior to every `envoy.clusters.reverse_connection` cluster. Opt-in via `envoy.reloadable_features.reverse_tunnel_drain_with_goaway`. |
> | PR3 → [ivpr/envoy#2](https://github.com/ivpr/envoy/pull/2) | `ivpr/envoy` (stacked on PR2) | **Downstream consumer**: drain-aware HCM observes peer GOAWAY on reverse-tunnel sockets and asks the initiator IOHandle to drop the tunnel from tracking and dial a replacement. Same runtime guard. |

## End-to-end flow this PR enables

```mermaid
sequenceDiagram
    autonumber
    participant Op as Operator
    participant US as Upstream Envoy
    participant Tun as Reverse tunnel (HTTP/2)
    participant DS as Downstream Envoy

    Note over US,DS: Steady state. DS holds a long-lived HTTP/2 tunnel. <br/>US owns the HTTP/2 client codec via the reverse_connection cluster.

    Op->>US: POST /reverse_tunnel/drain_cluster
    rect rgba(150,200,255,0.15)
        Note over US: PR2 consumer. Admin handler iterates envoy.clusters.reverse_connection clusters <br/>and fans out the new drain behavior.
        US->>US: drainConnections(cluster, nullptr, NotifyPeerAndDrainExisting)
    end

    rect rgba(255,210,150,0.25)
        Note over US: PR1 (this PR). Pool snapshots ready, busy and early-data clients, <br/>then calls MultiplexedActiveClientBase.notifyPeerAndDrain on each, <br/>which calls codec_client_.goAway and transitions to Draining if any streams are active. <br/>is_draining_for_deletion_ stays false so the pool stays usable for new streams via fresh clients.
        US-->>Tun: HTTP/2 GOAWAY
    end

    Tun-->>DS: HTTP/2 GOAWAY

    rect rgba(180,255,180,0.20)
        Note over DS: PR3 consumer. Drain-aware HCM observes peer GOAWAY, <br/>asks the reverse-tunnel IOHandle to drop this tunnel from tracking <br/>and kick maintenance to dial a replacement.
        DS->>DS: markTunnelDrainingAndDialReplacement(key)
        DS-->>Tun: dial new tunnel to sibling US replica
    end

    Note over US,DS: In-flight HTTP/2 streams on the old tunnel complete normally. <br/>The drained client auto-closes once its last stream finishes (onStreamClosed line 311-313). <br/>The tunnel TCP-closes after that.
```

PR1 is the only piece that lands in envoyproxy/envoy core. PR2 and PR3 are in reverse tunnel code and are linked above so you can see exactly what a consumer of this API looks like — both how it's invoked (PR2) and how the multiplexed-peer GOAWAY observation can be wired on the receiving side (PR3). Since PR2 and PR3 depend on PR1, I will raise them as new PRs in envoy proxy once this PR is merged.

## What PR2 and PR3 say about the shape of the new core API

- **`DrainBehavior::NotifyPeerAndDrainExisting` is strictly opt-in.** Existing callers of `drainConnections(DrainAndDelete)` and friends see no behavior change. PR2 / PR3 also keep the *behavior* runtime-guarded so end-user reverse-tunnel deployments do not see it until they explicitly enable it.
- **`ClusterManager::drainConnections(cluster, predicate, drain_behavior)`** is the three-arg overload that lets an extension target a single cluster with a specific behavior. PR2 uses it to target only `envoy.clusters.reverse_connection` clusters; everything else is left alone.
- **`MultiplexedActiveClientBase::notifyPeerAndDrain()`** handles the "preserve in-flight streams" semantics: if `codec_client_->numActiveRequests() > 0`, the client transitions to `Draining` instead of closing; otherwise it closes immediately. This is the property PR2's scenario depends on — sibling-replica failover should not kill the requests already on the wire.

## How drained connections eventually close (no new flag required)

The new branch in `drainConnectionsImpl` does **not** set `is_draining_for_deletion_`. Clients close via existing pre-existing paths instead:

1. **Idle-at-drain-time clients close immediately.** `MultiplexedActiveClientBase::notifyPeerAndDrain` calls `codec_client_->close()` directly when `numActiveRequests() == 0`. The fall-through into `closeIdleConnectionsForDrainingPool()` flushes `connecting_clients_`.
2. **Busy-then-drained clients close on last-stream-finish.** They sit in `Draining` state while in-flight streams complete. When the last stream finishes, the existing block at [conn_pool_base.cc lines 311-313](https://github.com/envoyproxy/envoy/blob/main/source/common/conn_pool/conn_pool_base.cc#L311-L313) inside `onStreamClosed` closes the client. This is the same path the existing `MaxConnectionDuration` and `MaxStreamsPerConnection` drains rely on today.
3. **Peer-initiated close** on receipt of the GOAWAY shows up via the normal `ConnectionEvent::RemoteClose` handling.
4. **Server drain timeout** (`--drain-time-s`) is the last-resort safety net.

The pool itself stays alive (intentionally — that is why we are renaming away from `…AndDelete`). New requests for the same host land in `newStreamImpl` and pass through the `!is_draining_for_deletion_` ASSERT (no crash); they find no ready clients (all drained), so `tryCreateNewConnections()` spins up a fresh non-Draining client.

---

## Commit message body

Add a new `ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting` value that mirrors `DrainExistingConnections` semantically but first notifies the peer that the pool is draining. For multiplexed pools (HTTP/2, HTTP/3) the notification is a protocol-level GOAWAY; for HTTP/1 and raw TCP there is no peer-level signal and the behavior degrades to plain `DrainExistingConnections` (the peer learns about the drain when the TCP socket closes). Unlike `DrainAndDelete`, the pool stays usable: new streams are served by fresh clients while drained clients finish their in-flight work and close on idle.

### What this change introduces

* A new enum value `ConnectionPool::DrainBehavior::NotifyPeerAndDrainExisting`.
* A virtual hook `ConnectionPool::ActiveClient::notifyPeerAndDrain()` with a default no-op implementation (so HTTP/1 + TCP pools support the new behavior without any code change — they just don't emit a peer signal).
* An override on `MultiplexedActiveClientBase` that calls `codec_client_->goAway()` and transitions the client to `Draining` if any streams are active, otherwise closes the client immediately.
* A branch in `ConnPoolImplBase::drainConnectionsImpl()` that snapshots ready / busy / early-data clients, invokes the new hook on each, and **falls through into the existing `DrainExistingConnections` body** so `closeIdleConnectionsForDrainingPool()` handles the connecting-clients cleanup. The branch does NOT set `is_draining_for_deletion_`, so `newStreamImpl` continues to accept new requests after the drain (served by fresh clients).
* A new three-arg `ClusterManager::drainConnections(cluster, predicate, drain_behavior)` overload (parallel to the existing two-arg overload) so callers can target a single cluster with a specific behavior.

### Why this isn't `GoAwayAndDrainAndDelete`

Earlier revisions of this PR named the value `GoAwayAndDrainAndDelete` and modeled it after `DrainAndDelete` (set `is_draining_for_deletion_ = true`, mark the pool for deletion). That was incorrect for the motivating use case (reverse-connection clusters), because the cluster's hosts remain LB-selectable after the drain — a new request after drain would trip `ASSERT(!is_draining_for_deletion_)` in `newStreamImpl` and crash the process. The new semantics keep the pool usable; closure happens naturally on stream completion via the existing `onStreamClosed` close-on-idle logic.

`GoAway` was also HTTP/2-specific vocabulary in the protocol-agnostic `envoy/common/conn_pool.h` enum. `NotifyPeer` generalizes cleanly — HTTP/1 and TCP inherit the no-op virtual without any per-protocol branching.

### Risk Level

Low. The new enum value is opt-in; existing `DrainBehavior` values and their code paths are untouched. The new virtual on `ActiveClient` has a no-op default, so non-multiplexed clients see no behavior change. No structural changes to `ConnectivityGrid` (the renamed value does not set the grid's `draining_=true` flag because the pool stays usable).

### Testing

Six unit tests in `test/common/http/http2/conn_pool_test.cc` exercising `NotifyPeerAndDrainExisting` on the HTTP/2 pool:

* sends GOAWAY then drains a ready client with an active stream
* closes an idle client immediately after GOAWAY
* does not send GOAWAY on a connecting client
* idempotent on repeat calls
* handles multiple clients (mixed busy + idle)
* **NEW regression test**: a new stream issued after drain creates a fresh client and completes successfully (would crash on the old `GoAwayAndDrainAndDelete` semantics with `ASSERT(!is_draining_for_deletion_)`)

Existing `conn_pool_base_test` and `conn_pool_grid_test` pass unchanged.

### Manual validation (in PR2/PR3 stack)

End-to-end validated with a 2-Envoy reverse-tunnel setup: US drains its `reverse_connection` cluster via `POST /reverse_tunnel/drain_cluster`, the pool fires GOAWAY on every reverse tunnel, DS observes GOAWAY and dials replacement tunnels, in-flight streams complete on the old tunnels, US stays alive and serves new requests via fresh clients — no crash.

### Docs

n/a (header doc comments updated for the new enum value, virtual hook, and ClusterManager overload).

### Release Notes

Added a new connection-pool drain behavior `NotifyPeerAndDrainExisting` that sends a protocol-level GOAWAY to each multiplexed client before draining the pool. Unlike `DrainAndDelete`, the pool remains usable for new streams via fresh clients while existing clients drain in the background.
