### PR TITLE
mcp_transcoder: Add McpServerInfo API.

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -216,6 +216,12 @@ message ToolsListSpecificConfig {
   string input_schema = 3;
 }
 
+message McpServerInfo {
+  string path = 1;
+
+  string host = 2;
+}
+
 message ToolConfig {
   // Unique identifier of the tool. Used both for tools/list and tools/call transcoding.
   string name = 1 [(validate.rules).string = {min_len: 1}];
@@ -227,6 +233,10 @@ message ToolConfig {
   // Config for this tool's entry in a local tools/list response. Used when tool_list_local is set
   // in the ServerToolConfig.
   ToolsListSpecificConfig tool_list_config = 3;
+
+  // [#not-implemented-hide:]
+  // Path and host of the MCP server that hosts this tool.
+  McpServerInfo server_info = 4;
 }
 
 // Defines the schema of the JSON-RPC to REST mapping. It specifies how the "arguments"

--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -252,7 +252,7 @@ message ToolConfig {
 
   // [#not-implemented-hide:]
   // Path and host of the MCP server that hosts this tool.
-  McpServerInfo server_info = 5;
+  repeated McpServerInfo server_info = 5;
 }
 
 // Defines the schema of the JSON-RPC to REST mapping. It specifies how the "arguments"

--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -217,8 +217,10 @@ message ToolsListSpecificConfig {
 }
 
 message McpServerInfo {
+  // The path to the endpoint hosting this tool.
   string path = 1;
 
+  // The host hosting this tool.
   string host = 2;
 }
 


### PR DESCRIPTION
Commit Message: mcp_transcoder: API changes for specifying MCP server host and path per tool.

Additional Description:

Add `McpServerInfo` to `McpJsonRestBridgeFilter` config.

Risk Level: Low. API definitions only.
Testing: No new tests.
Docs Changes: API docs.
Release Notes:
Platform Specific Features: N/A
[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md): Feature is gated by xDS-delivered config; off by default.