### PR TITLE
reverse tunnels: allow setting custom upgrade type token

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -23,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // them as socket connections for downstream requests.
 message DownstreamReverseConnectionSocketInterface {
   // HTTP handshake settings for initiator envoy initiated reverse tunnels.
+  // [#next-free-field: 6]
   message HttpHandshakeConfig {
     // Request path used when issuing the HTTP reverse-connection handshake. Defaults to
     // "/reverse_connections/request".

--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -7,6 +7,7 @@ import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3";
 option java_outer_classname = "DownstreamReverseConnectionSocketInterfaceProto";
@@ -30,7 +31,7 @@ message DownstreamReverseConnectionSocketInterface {
     // Additional headers to include in the HTTP handshake request.
     repeated config.core.v3.HeaderValueOption additional_headers = 2;
 
-    // Perform the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: reverse-tunnel``,
+    // Perform the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: <upgrade_type>``,
     // success on ``101``) so HTTP proxies can route the handshake and splice the tunnel
     // afterward. The responder must set this flag to the same value.
     // Defaults to ``false``.
@@ -41,6 +42,11 @@ message DownstreamReverseConnectionSocketInterface {
     // as substitution format strings; when empty, the values are sent literally.
     // [#extension-category: envoy.formatter]
     repeated config.core.v3.TypedExtensionConfig formatters = 4;
+
+    // Upgrade token sent in the ``Upgrade`` header when ``use_http_upgrade`` is ``true``.
+    // The responder must be configured with the same value.
+    // If empty, defaults to ``reverse-tunnel``.
+    string upgrade_type = 5 [(validate.rules).string = {max_len: 255 ignore_empty: true}];
   }
 
   // Stat prefix to be used for downstream reverse connection socket interface stats.

--- a/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
+++ b/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
@@ -96,7 +96,7 @@ message Validation {
 // Configuration for the reverse tunnel network filter.
 // This filter handles reverse tunnel connection acceptance and rejection by processing
 // HTTP requests where required identification values are provided via HTTP headers.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message ReverseTunnel {
   // Ping interval for health checks on established reverse tunnel connections.
   // If not specified, defaults to ``2 seconds``.
@@ -134,7 +134,7 @@ message ReverseTunnel {
   // cluster names are rejected with HTTP ``400 Bad Request``. When empty, no cluster name validation is performed.
   string required_cluster_name = 6 [(validate.rules).string = {max_len: 255 ignore_empty: true}];
 
-  // Accept the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: reverse-tunnel``,
+  // Accept the handshake as an HTTP/1.1 ``Upgrade`` exchange (``Upgrade: <upgrade_type>``,
   // reply ``101``) so HTTP proxies can route the handshake and splice the tunnel
   // afterward. Non-upgrade requests are rejected with ``426``. The initiator must set this
   // flag to the same value.
@@ -145,4 +145,11 @@ message ReverseTunnel {
   // This avoids the cross-worker lock in pickLeastLoadedSocketManager.
   // Default: false (rebalancing enabled).
   bool skip_rebalancing = 8;
+
+  // Upgrade token advertised when ``use_http_upgrade`` is ``true``. The filter matches the
+  // incoming ``Upgrade`` header against this value (case-insensitive) and echoes it back in
+  // the ``101 Switching Protocols`` response. The initiator must be configured with the same
+  // value.
+  // If empty, defaults to ``reverse-tunnel``.
+  string upgrade_type = 9 [(validate.rules).string = {max_len: 255 ignore_empty: true}];
 }

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -141,9 +141,7 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
     // the connection raw after `101 Switching Protocols`. Both ends must agree.
     headers->setReferenceKey(Http::Headers::get().Connection,
                              Http::Headers::get().ConnectionValues.Upgrade);
-    headers->setReferenceKey(Http::Headers::get().Upgrade,
-                             ::Envoy::Extensions::Bootstrap::ReverseConnection::
-                                 ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+    headers->setCopy(Http::Headers::get().Upgrade, parent_.upgradeType());
   }
   headers->addCopy(node_hdr, std::string(node_id));
   headers->addCopy(cluster_hdr, std::string(cluster_id));

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -90,6 +90,8 @@ struct ReverseConnectionSocketConfig {
       additional_headers;       // Additional headers for the handshake request.
   bool use_http_upgrade{false}; // Negotiate handshake as HTTP/1.1 Upgrade -> 101.
   std::shared_ptr<const std::vector<HandshakeHeader>> handshake_headers;
+  std::string upgrade_type{std::string(
+      ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL)}; // Upgrade token sent.
   // TODO(basundhara-c): Add support for multiple remote clusters using the same
   // ReverseConnectionIOHandle. Currently, each ReverseConnectionIOHandle handles
   // reverse connections for a single upstream cluster since a different ReverseConnectionAddress
@@ -330,6 +332,11 @@ public:
   const std::shared_ptr<const std::vector<HandshakeHeader>>& handshakeHeaders() const {
     return config_.handshake_headers;
   }
+
+  /**
+   * @return the upgrade token used during the HTTP/1.1 Upgrade handshake.
+   */
+  const std::string& upgradeType() const { return config_.upgrade_type; }
 
 private:
   /**

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
@@ -130,6 +130,7 @@ ReverseTunnelInitiator::socket(Envoy::Network::Socket::Type socket_type,
       socket_config.additional_headers = extension_->handshakeAdditionalHeaders();
       socket_config.use_http_upgrade = extension_->handshakeUsesHttpUpgrade();
       socket_config.handshake_headers = extension_->handshakeHeaders();
+      socket_config.upgrade_type = extension_->handshakeUpgradeType();
     }
 
     // Pass config directly to helper method.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -41,6 +41,7 @@ ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
     additional_headers_ = {config.http_handshake().additional_headers().begin(),
                            config.http_handshake().additional_headers().end()};
     use_http_upgrade_ = config.http_handshake().use_http_upgrade();
+    upgrade_type_ = config.http_handshake().upgrade_type();
 
     if (!config.http_handshake().formatters().empty()) {
       Server::GenericFactoryContextImpl formatter_context(context,
@@ -59,6 +60,9 @@ ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
       }
       handshake_headers_ = std::move(handshake_headers);
     }
+  }
+  if (upgrade_type_.empty()) {
+    upgrade_type_ = std::string(ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL);
   }
   // Instantiate access loggers from config.
   Server::GenericFactoryContextImpl generic_context(context, context.scope(),

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -123,6 +123,11 @@ public:
   const HandshakeHeadersConstSharedPtr& handshakeHeaders() const { return handshake_headers_; }
 
   /**
+   * @return the upgrade token sent during the HTTP/1.1 Upgrade handshake.
+   */
+  const std::string& handshakeUpgradeType() const { return upgrade_type_; }
+
+  /**
    * @return reference to the configured access loggers for reverse tunnel lifecycle events.
    */
   const AccessLog::InstanceSharedPtrVector& accessLogs() const { return access_logs_; }
@@ -178,6 +183,7 @@ private:
   std::vector<envoy::config::core::v3::HeaderValueOption> additional_headers_;
   bool use_http_upgrade_{false};
   HandshakeHeadersConstSharedPtr handshake_headers_;
+  std::string upgrade_type_;
   AccessLog::InstanceSharedPtrVector access_logs_;
 
   /**

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -167,7 +167,11 @@ ReverseTunnelFilterConfig::ReverseTunnelFilterConfig(
               : "envoy.filters.network.reverse_tunnel"),
       required_cluster_name_(proto_config.required_cluster_name()),
       use_http_upgrade_(proto_config.use_http_upgrade()),
-      skip_rebalancing_(proto_config.skip_rebalancing()) {}
+      skip_rebalancing_(proto_config.skip_rebalancing()),
+      upgrade_type_(proto_config.upgrade_type().empty()
+                        ? std::string(::Envoy::Extensions::Bootstrap::ReverseConnection::
+                                          ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL)
+                        : proto_config.upgrade_type()) {}
 
 bool ReverseTunnelFilterConfig::validateIdentifiers(
     absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
@@ -370,19 +374,17 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
   // `Connection: Upgrade` paired token, so we only re-check the `Upgrade` value here.
   if (parent_.config_->useHttpUpgrade()) {
     const auto upgrade = headers_->getUpgradeValue();
-    if (!absl::EqualsIgnoreCase(upgrade, Bootstrap::ReverseConnection::ReverseConnectionUtility::
-                                             REVERSE_TUNNEL_UPGRADE_PROTOCOL)) {
+    const std::string& expected_upgrade = parent_.config_->upgradeType();
+    if (!absl::EqualsIgnoreCase(upgrade, expected_upgrade)) {
       parent_.stats_.parse_error_.inc();
       ENVOY_CONN_LOG(debug,
                      "reverse_tunnel: upgrade negotiation enabled but Upgrade header missing or "
-                     "unexpected (got '{}')",
-                     parent_.read_callbacks_->connection(), upgrade);
+                     "unexpected (got '{}', expected '{}')",
+                     parent_.read_callbacks_->connection(), upgrade, expected_upgrade);
       sendLocalReply(
-          Http::Code::UpgradeRequired, "Upgrade: reverse-tunnel required",
-          [](Http::ResponseHeaderMap& h) {
-            h.setReferenceKey(Http::Headers::get().Upgrade,
-                              Bootstrap::ReverseConnection::ReverseConnectionUtility::
-                                  REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+          Http::Code::UpgradeRequired, fmt::format("Upgrade: {} required", expected_upgrade),
+          [&expected_upgrade](Http::ResponseHeaderMap& h) {
+            h.setCopy(Http::Headers::get().Upgrade, expected_upgrade);
           },
           absl::nullopt, "reverse_tunnel_upgrade_required");
       parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
@@ -501,9 +503,7 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
     resp_headers->setStatus(101);
     resp_headers->setReferenceKey(Http::Headers::get().Connection,
                                   Http::Headers::get().ConnectionValues.Upgrade);
-    resp_headers->setReferenceKey(
-        Http::Headers::get().Upgrade,
-        Bootstrap::ReverseConnection::ReverseConnectionUtility::REVERSE_TUNNEL_UPGRADE_PROTOCOL);
+    resp_headers->setCopy(Http::Headers::get().Upgrade, parent_.config_->upgradeType());
   } else {
     resp_headers->setStatus(200);
   }

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -68,6 +68,9 @@ public:
   // Returns whether worker-thread rebalancing should be skipped for accepted connections.
   bool skipRebalancing() const { return skip_rebalancing_; }
 
+  // Returns the upgrade token used during the HTTP/1.1 Upgrade handshake.
+  const std::string& upgradeType() const { return upgrade_type_; }
+
 private:
   ReverseTunnelFilterConfig(
       const envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel& proto_config,
@@ -90,10 +93,13 @@ private:
   // Required cluster name for validation (empty means no validation).
   const std::string required_cluster_name_;
 
-  // When true, expect `Connection: Upgrade` + `Upgrade: reverse-tunnel` and respond `101`.
+  // When true, expect `Connection: Upgrade` + `Upgrade: <upgrade_type_>` and respond `101`.
   const bool use_http_upgrade_{false};
 
   const bool skip_rebalancing_{false};
+
+  // Upgrade token advertised when `use_http_upgrade_` is true. Defaults to "reverse-tunnel".
+  const std::string upgrade_type_;
 };
 
 using ReverseTunnelFilterConfigSharedPtr = std::shared_ptr<ReverseTunnelFilterConfig>;

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1239,6 +1239,45 @@ TEST_F(RCConnectionWrapperTest, ConnectEmitsUpgradeHeaders) {
   EXPECT_THAT(written, testing::HasSubstr("connection: upgrade"));
 }
 
+// In upgrade mode with a custom upgrade_type, connect() emits the configured token
+// in the `Upgrade:` header instead of the default `reverse-tunnel`.
+TEST_F(RCConnectionWrapperTest, ConnectEmitsCustomUpgradeType) {
+  ReverseConnectionSocketConfig upgrade_config = createDefaultTestConfig();
+  upgrade_config.use_http_upgrade = true;
+  upgrade_config.upgrade_type = "rt-custom";
+  auto upgrade_io_handle = createTestIOHandle(upgrade_config);
+
+  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  std::string written;
+  EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, addReadFilter(_));
+  EXPECT_CALL(*mock_connection, connect());
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(44));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+  EXPECT_CALL(*mock_connection, write(_, _))
+      .WillRepeatedly(Invoke([&](Buffer::Instance& buffer, bool) {
+        written.append(buffer.toString());
+        buffer.drain(buffer.length());
+      }));
+
+  auto mock_remote = std::make_shared<Network::Address::Ipv4Instance>("10.0.0.1", 80);
+  auto mock_local = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 10001);
+  EXPECT_CALL(*mock_connection, connectionInfoProvider())
+      .WillRepeatedly(Invoke([mock_remote, mock_local]() -> const Network::ConnectionInfoProvider& {
+        static auto provider =
+            std::make_unique<Network::ConnectionInfoSetterImpl>(mock_local, mock_remote);
+        return *provider;
+      }));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  RCConnectionWrapper wrapper(*upgrade_io_handle, std::move(mock_connection), mock_host,
+                              "test-cluster");
+  (void)wrapper.connect("tenant", "cluster", "node");
+
+  EXPECT_THAT(written, testing::HasSubstr("upgrade: rt-custom"));
+  EXPECT_THAT(written, testing::HasSubstr("connection: upgrade"));
+}
+
 // Test dispatchHttp1 error path by initializing codec via connect() and
 // then feeding invalid bytes to the parser.
 TEST_F(RCConnectionWrapperTest, DispatchHttp1ErrorPath) {

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -2193,6 +2193,101 @@ TEST_F(ReverseTunnelFilterUnitTest, FilterConfigLoadsSkipRebalancing) {
   EXPECT_TRUE(config_or_error.value()->skipRebalancing());
 }
 
+// Custom `upgrade_type` is matched and echoed back in the 101 response.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, UpgradeMode_CustomUpgradeType) {
+  proto_config_.set_use_http_upgrade(true);
+  proto_config_.set_upgrade_type("rt-custom");
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  config_ = config_or_error.value();
+  filter_ =
+      std::make_unique<ReverseTunnelFilter>(config_, *stats_store_.rootScope(), overload_manager_);
+  filter_->initializeReadFilterCallbacks(callbacks_);
+
+  // Provide a socket whose io_handle.duplicate() returns a valid duped handle; same pattern
+  // as UpgradeMode_RespondsWith101.
+  auto mock_socket = std::make_unique<Network::MockConnectionSocket>();
+  auto mock_io_handle = std::make_unique<Network::MockIoHandle>();
+  auto dup_handle = std::make_unique<Network::MockIoHandle>();
+  EXPECT_CALL(*dup_handle, isOpen()).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*dup_handle, resetFileEvents());
+  EXPECT_CALL(*dup_handle, fdDoNotUse()).WillRepeatedly(testing::Return(125));
+  EXPECT_CALL(*mock_io_handle, duplicate())
+      .WillOnce(testing::Return(testing::ByMove(std::move(dup_handle))));
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(testing::ReturnRef(*mock_io_handle));
+  EXPECT_CALL(*mock_socket, isOpen()).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*mock_io_handle, fdDoNotUse()).WillRepeatedly(testing::Return(124));
+  static Network::ConnectionSocketPtr stored_socket;
+  static std::unique_ptr<Network::MockIoHandle> stored_handle;
+  stored_handle = std::move(mock_io_handle);
+  stored_socket = std::move(mock_socket);
+  EXPECT_CALL(callbacks_.connection_, getSocket())
+      .WillRepeatedly(testing::ReturnRef(stored_socket));
+
+  std::string written;
+  EXPECT_CALL(callbacks_.connection_, write(testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke([&](Buffer::Instance& data, bool) {
+        written.append(data.toString());
+        data.drain(data.length());
+      }));
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "Connection: Upgrade\r\n"
+                    "Upgrade: RT-Custom\r\n"
+                    "x-envoy-reverse-tunnel-node-id: n\r\n"
+                    "x-envoy-reverse-tunnel-cluster-id: c\r\n"
+                    "x-envoy-reverse-tunnel-tenant-id: t\r\n"
+                    "Content-Length: 0\r\n\r\n";
+  Buffer::OwnedImpl request(req);
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+  EXPECT_THAT(written, testing::HasSubstr("101 Switching Protocols"));
+  EXPECT_THAT(written, testing::HasSubstr("upgrade: rt-custom"));
+
+  auto accepted = TestUtility::findCounter(stats_store_, "reverse_tunnel.handshake.accepted");
+  ASSERT_NE(nullptr, accepted);
+  EXPECT_EQ(1, accepted->value());
+}
+
+// When `upgrade_type` is customized and the request advertises a different token, the filter
+// rejects with `426 Upgrade Required` echoing the configured token.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, UpgradeMode_CustomUpgradeType_MismatchRejected) {
+  proto_config_.set_use_http_upgrade(true);
+  proto_config_.set_upgrade_type("rt-custom");
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  config_ = config_or_error.value();
+  filter_ =
+      std::make_unique<ReverseTunnelFilter>(config_, *stats_store_.rootScope(), overload_manager_);
+  filter_->initializeReadFilterCallbacks(callbacks_);
+
+  std::string written;
+  EXPECT_CALL(callbacks_.connection_, write(testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke([&](Buffer::Instance& data, bool) {
+        written.append(data.toString());
+        data.drain(data.length());
+      }));
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "Connection: Upgrade\r\n"
+                    "Upgrade: reverse-tunnel\r\n"
+                    "x-envoy-reverse-tunnel-node-id: n\r\n"
+                    "x-envoy-reverse-tunnel-cluster-id: c\r\n"
+                    "x-envoy-reverse-tunnel-tenant-id: t\r\n"
+                    "Content-Length: 0\r\n\r\n";
+  Buffer::OwnedImpl request(req);
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+  EXPECT_THAT(written, testing::HasSubstr("426 Upgrade Required"));
+  EXPECT_THAT(written, testing::HasSubstr("upgrade: rt-custom"));
+
+  auto parse_error = TestUtility::findCounter(stats_store_, "reverse_tunnel.handshake.parse_error");
+  ASSERT_NE(nullptr, parse_error);
+  EXPECT_EQ(1, parse_error->value());
+}
+
 } // namespace
 } // namespace ReverseTunnel
 } // namespace NetworkFilters


### PR DESCRIPTION
Commit Message: reverse tunnels: allow setting custom upgrade type token
Additional Description: 
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

Allows setting custom tokens, is useful to allow upgrades when known existing tokens are already allowed (websocket)