### PR TITLE
ci: also publish release container images to ghcr.io

### DIFF
--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -8,6 +8,7 @@ on:
     secrets:
       dockerhub-token:
       dockerhub-write-token:
+      ghcr-write-token:
       ENVOY_CI_SYNC_APP_ID:
       ENVOY_CI_SYNC_APP_KEY:
       ENVOY_CI_PUBLISH_APP_ID:
@@ -18,6 +19,9 @@ on:
         required: true
     inputs:
       dockerhub-username:
+        type: string
+        required: true
+      ghcr-username:
         type: string
         required: true
       request:
@@ -80,6 +84,7 @@ jobs:
   container:
     secrets:
       dockerhub-write-token: ${{ secrets.dockerhub-write-token }}
+      ghcr-write-token: ${{ secrets.ghcr-write-token }}
     permissions:
       actions: read
       contents: read
@@ -89,6 +94,8 @@ jobs:
     with:
       dockerhub-repo: ${{ vars.DOCKERHUB_REPO || 'envoy' }}
       dockerhub-username: ${{ inputs.dockerhub-username }}
+      ghcr-repo: ${{ vars.GHCR_REPO || 'envoy' }}
+      ghcr-username: ${{ inputs.ghcr-username }}
       dev: ${{ fromJSON(inputs.request).request.version.dev }}
       sha: ${{ fromJSON(inputs.request).request.sha }}
       target-branch: ${{ fromJSON(inputs.request).request.target-branch }}

--- a/.github/workflows/_publish_release_container.yml
+++ b/.github/workflows/_publish_release_container.yml
@@ -7,6 +7,7 @@ on:
   workflow_call:
     secrets:
       dockerhub-write-token:
+      ghcr-write-token:
     inputs:
       dev:
         required: true
@@ -17,6 +18,13 @@ on:
         default: envoy
         type: string
       dockerhub-username:
+        required: true
+        type: string
+      ghcr-repo:
+        required: false
+        default: envoy
+        type: string
+      ghcr-username:
         required: true
         type: string
       sha:
@@ -62,73 +70,62 @@ jobs:
       with:
         input-format: yaml
         filter: >-
-          {manifests: .}
+          {manifests:
+            [.[] as $e
+             | ({name: "${{ inputs.dockerhub-repo }}", registry: "docker.io/envoyproxy"} + $e)
+               ${{ (inputs.trusted && (inputs.target-branch == 'main' || ! inputs.dev))
+                   && format(', ({{name: "{0}", registry: "ghcr.io/envoyproxy"}} + $e)', inputs.ghcr-repo)
+                   || '' }}]}
         input: |
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: dev
-            registry: docker.io/envoyproxy
+          - tag: dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy.{arch}.tar
             additional-tags:
             - dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-dev
-            registry: docker.io/envoyproxy
+          - tag: contrib-dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib.{arch}.tar
             additional-tags:
             - contrib-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-debug-dev
-            registry: docker.io/envoyproxy
+          - tag: contrib-debug-dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib-debug.{arch}.tar
             additional-tags:
             - contrib-debug-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-distroless-dev
-            registry: docker.io/envoyproxy
+          - tag: contrib-distroless-dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib-distroless.{arch}.tar
             additional-tags:
             - contrib-distroless-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: debug-dev
-            registry: docker.io/envoyproxy
+          - tag: debug-dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-debug.{arch}.tar
             additional-tags:
             - debug-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: distroless-dev
-            registry: docker.io/envoyproxy
+          - tag: distroless-dev
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-distroless.{arch}.tar
             additional-tags:
             - distroless-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: google-vrp-dev
-            registry: docker.io/envoyproxy
+          - tag: google-vrp-dev
             architectures:
             - amd64
             artifact-pattern: envoy-google-vrp.{arch}.tar
             additional-tags:
             - google-vrp-dev-${{ github.sha }}
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: tools-dev
-            registry: docker.io/envoyproxy
+          - tag: tools-dev
             architectures:
             - amd64
             - arm64
@@ -148,83 +145,83 @@ jobs:
               [.manifests[]
                | select(
                    (.tag | test("contrib-distroless") | not)
-                   or ($v.major > 1 or ($v.major == 1 and $v.minor >= 37)))]}
+                   or ($v.major > 1 or ($v.major == 1 and $v.minor >= 37)))
+               | . as $e
+               | ({name: "${{ inputs.dockerhub-repo }}", registry: "docker.io/envoyproxy"} + $e)
+                 ${{ (inputs.trusted && (inputs.target-branch == 'main' || ! inputs.dev))
+                     && format(', ({{name: "{0}", registry: "ghcr.io/envoyproxy"}} + $e)', inputs.ghcr-repo)
+                     || '' }}]}
         input: |
           version:
             major: ${{ inputs.version-major }}
             minor: ${{ inputs.version-minor }}
           manifests:
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy.{arch}.tar
             additional-tags:
             - v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: contrib-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib.{arch}.tar
             additional-tags:
             - contrib-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: contrib-debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib-debug.{arch}.tar
             additional-tags:
             - contrib-debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: contrib-distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: contrib-distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-contrib-distroless.{arch}.tar
             additional-tags:
             - contrib-distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-debug.{arch}.tar
             additional-tags:
             - debug-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-distroless.{arch}.tar
             additional-tags:
             - distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: google-vrp-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: google-vrp-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             artifact-pattern: envoy-google-vrp.{arch}.tar
             additional-tags:
             - google-vrp-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
-          - name: ${{ inputs.dockerhub-repo }}
-            tag: tools-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
-            registry: docker.io/envoyproxy
+          - tag: tools-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             architectures:
             - amd64
             - arm64
             artifact-pattern: envoy-tools.{arch}.tar
             additional-tags:
             - tools-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
+
+    - name: Authenticate GHCR
+      if: ${{ inputs.trusted && (inputs.target-branch == 'main' || ! inputs.dev) }}
+      shell: bash
+      env:
+        GHCR_USERNAME: ${{ inputs.ghcr-username }}
+        GHCR_PASSWORD: ${{ secrets.ghcr-write-token }}
+      run: |
+        echo "::group::Authenticating with GHCR"
+        echo "$GHCR_PASSWORD" | buildah login --username "$GHCR_USERNAME" --password-stdin ghcr.io
+        echo "::endgroup::"
 
     - name: Collect and push OCI artifacts
       uses: envoyproxy/toolshed/actions/oci/collector@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17

--- a/.github/workflows/envoy-publish.yml
+++ b/.github/workflows/envoy-publish.yml
@@ -85,6 +85,7 @@ jobs:
     secrets:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       dockerhub-write-token: ${{ secrets.DOCKERHUB_WRITE_TOKEN }}
+      ghcr-write-token: ${{ secrets.GHCR_WRITE_TOKEN }}
       ENVOY_CI_SYNC_APP_ID: >-
         ${{ needs.load.outputs.trusted
             && fromJSON(needs.load.outputs.trusted)
@@ -127,6 +128,7 @@ jobs:
     name: Release
     with:
       dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
+      ghcr-username: ${{ vars.GHCR_USERNAME }}
       request: ${{ needs.load.outputs.request }}
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
 


### PR DESCRIPTION
The release workflow currently builds multi-arch OCI images and pushes
them only to `docker.io/envoyproxy/envoy*`. This PR mirrors every push
to GitHub Container Registry under `ghcr.io/envoyproxy/envoy*` so that
consumers have a second authoritative source and are not solely
dependent on Docker Hub.

### Required steps beyond merging

Merging this PR alone will not start pushing to GHCR. An `envoyproxy`
org admin needs to complete the following, ideally before or
immediately after merge:

1. **Mint a token** with `write:packages` scope on `envoyproxy/*`
   (fine-grained PAT or GitHub App installation token). Store it as
   the repository secret `GHCR_WRITE_TOKEN` on
   `github.com/envoyproxy/envoy`.
2. **Set `vars.GHCR_USERNAME`** to the account that owns the token
   (e.g. `envoyproxy-ci`).
3. **Optionally set `vars.GHCR_REPO`** if the GHCR image base name
   should differ from Docker Hub. Defaults to `envoy` (matching
   Docker Hub).
4. On the first successful trusted push, mark each newly created
   `ghcr.io/envoyproxy/envoy*` package **public** in the org's
   Packages settings, and link each package to the
   `envoyproxy/envoy` repository so it inherits provenance, badges,
   and security advisories.
5. Update the project's published documentation / release notes
   (separately, not in this PR) to advertise `ghcr.io/envoyproxy/envoy`
   as a supported pull source once the first dev tags land.

Until step 1–2 are done, the `Authenticate GHCR` step will fail loudly
on the next trusted publish run, that failure is the intended signal
to provision the secrets, and it does not affect Docker Hub publishing
(see Risk Level below).

### Verification plan

* **Pre-merge dry-run** (this PR): the publish workflow runs in
  dry-run mode for untrusted PRs. Confirm in the workflow logs that
  the generated `manifest-config` JSON contains two entries per
  variant — one `docker.io/envoyproxy/...`, one
  `ghcr.io/envoyproxy/...` and that the `Authenticate GHCR` step is
  skipped because `inputs.trusted` is false.
* **First trusted dev push** (after merge + secrets/vars in place):
  on the next `main` commit, confirm
  `docker pull ghcr.io/envoyproxy/envoy:dev` and
  `docker pull ghcr.io/envoyproxy/envoy:dev-<sha>` succeed, that
  `docker buildx imagetools inspect ghcr.io/envoyproxy/envoy:dev`
  shows both `linux/amd64` and `linux/arm64`, and that
  `docker.io/envoyproxy/envoy:dev` is unchanged.
* **First trusted release push**: at the next tagged release, confirm
  all eight variants (`envoy`, `contrib`, `contrib-debug`,
  `contrib-distroless`, `debug`, `distroless`, `google-vrp`, `tools`)
  appear under `ghcr.io/envoyproxy/envoy:<variant>-v<x.y.z>` and that
  the floating `<variant>-v<x.y>-latest` tags update.

### Testing

  * Locally validated that all three modified workflows parse as YAML.
  * Locally simulated the new jq filter against a representative input
    and confirmed it emits two manifest entries per variant (one per
    registry) with `tag`, `architectures`, `artifact-pattern`, and
    `additional-tags` preserved.
  * End-to-end verification will happen on the next trusted publish
    run after the org-side secrets/vars described above are
    provisioned.

Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
