### PR TITLE
test/quic: Validate cBPF filter in deterministic CID generator test

### DIFF
--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -422,6 +422,7 @@ envoy_cc_test(
 
 envoy_cc_test_library(
     name = "connection_id_matchers",
+    srcs = ["connection_id_matchers.cc"],
     hdrs = ["connection_id_matchers.h"],
     deps = ["//test/mocks/network:network_mocks"],
 )

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -422,9 +422,16 @@ envoy_cc_test(
 
 envoy_cc_test_library(
     name = "connection_id_matchers",
-    srcs = ["connection_id_matchers.cc"],
-    hdrs = ["connection_id_matchers.h"],
-    deps = ["//test/mocks/network:network_mocks"],
+    srcs = envoy_select_enable_http3(["connection_id_matchers.cc"]),
+    hdrs = envoy_select_enable_http3(["connection_id_matchers.h"]),
+    deps = envoy_select_enable_http3([
+        "//source/common/quic:envoy_quic_connection_id_generator_factory_interface",
+        "//test/mocks/network:network_mocks",
+        "@abseil-cpp//absl/cleanup",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+    ]),
 )
 
 envoy_cc_test(

--- a/test/common/quic/connection_id_matchers.cc
+++ b/test/common/quic/connection_id_matchers.cc
@@ -27,13 +27,13 @@ namespace Matcher {
 namespace {
 
 #ifdef SUPPORTS_TESTING_BPF_PROG
-// Runs `prog` against `data` via a socketpair + SO_ATTACH_FILTER and returns the program's return
+// Runs `prog` against `data` via a socketpair + `SO_ATTACH_FILTER` and returns the program's return
 // value.
 //
-// We can't attach via SO_ATTACH_REUSEPORT_CBPF, that would require a reuseport group sized to
-// `concurrency`. SO_ATTACH_FILTER reinterprets the same uint32_t return as "bytes to deliver", so
-// we read it back via recv(MSG_TRUNC) on a 1-byte buffer. EAGAIN/EWOULDBLOCK signals index 0, which
-// SO_ATTACH_FILTER reinterprets as drop.
+// We can't attach via `SO_ATTACH_REUSEPORT_CBPF`, that would require a reuseport group sized to
+// `concurrency`. `SO_ATTACH_FILTER` reinterprets the return value as "bytes to deliver", so
+// we read it back via `recv(MSG_TRUNC)` on a 1-byte buffer. `EAGAIN/EWOULDBLOCK` signals index 0,
+// which `SO_ATTACH_FILTER` reinterprets as drop.
 absl::StatusOr<uint32_t> runCbpf(const sock_fprog* prog, absl::string_view data, uint32_t min_len) {
   std::string padded(data);
   if (padded.size() < min_len) {

--- a/test/common/quic/connection_id_matchers.cc
+++ b/test/common/quic/connection_id_matchers.cc
@@ -1,14 +1,22 @@
 #include "test/common/quic/connection_id_matchers.h"
 
-#include <string>
-
-#include "absl/cleanup/cleanup.h"
-
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+#define SUPPORTS_TESTING_BPF_PROG
+#endif
+
+#ifdef SUPPORTS_TESTING_BPF_PROG
+#include <linux/filter.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <string>
+
 #include "test/mocks/network/mocks.h"
+
+#include "absl/cleanup/cleanup.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #endif
 
 namespace Envoy {
@@ -18,7 +26,7 @@ namespace ConnectionIdGenerator {
 namespace Matcher {
 namespace {
 
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+#ifdef SUPPORTS_TESTING_BPF_PROG
 // Runs `prog` against `data` via a socketpair + SO_ATTACH_FILTER and returns the program's return
 // value.
 //
@@ -26,7 +34,7 @@ namespace {
 // `concurrency`. SO_ATTACH_FILTER reinterprets the same uint32_t return as "bytes to deliver", so
 // we read it back via recv(MSG_TRUNC) on a 1-byte buffer. EAGAIN/EWOULDBLOCK signals index 0, which
 // SO_ATTACH_FILTER reinterprets as drop.
-absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data, uint32_t min_len) {
+absl::StatusOr<uint32_t> runCbpf(const sock_fprog* prog, absl::string_view data, uint32_t min_len) {
   std::string padded(data);
   if (padded.size() < min_len) {
     padded.resize(min_len, '\0');
@@ -41,7 +49,7 @@ absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data,
     ::close(sv[1]);
   });
 
-  if (::setsockopt(sv[0], SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0) {
+  if (::setsockopt(sv[0], SOL_SOCKET, SO_ATTACH_FILTER, prog, sizeof(*prog)) < 0) {
     return absl::ErrnoToStatus(errno, "setsockopt(SO_ATTACH_FILTER)");
   }
 
@@ -64,9 +72,10 @@ absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data,
 #endif
 
 MATCHER_P2(FactoryFunctionsReturnWorkerId, packet, expected_id, "") {
-  uint32_t id = arg.worker_selector_(*packet, 0xffffffff);
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-  auto bpf_id_or = runCbpf(*arg.bpf_prog_, packet->toString(), arg.concurrency_);
+  const uint32_t id = arg.worker_selector_(*packet, 0xffffffff);
+#ifdef SUPPORTS_TESTING_BPF_PROG
+  const auto bpf_id_or =
+      runCbpf(static_cast<const sock_fprog*>(arg.bpf_prog_), packet->toString(), arg.concurrency_);
   if (!bpf_id_or.ok()) {
     *result_listener << "\nrunCbpf failed: " << bpf_id_or.status();
     return false;
@@ -78,16 +87,17 @@ MATCHER_P2(FactoryFunctionsReturnWorkerId, packet, expected_id, "") {
       (expected_id == 0xffffffff) ? (bpf_id < arg.concurrency_) : (bpf_id == expected_id);
 #else
   std::cout << "warning: not verifying bpf program due to lacking system support" << std::endl;
-  const uint32_t bpf_id = expected_id;
   const bool bpf_ok = true;
 #endif
+
   if (id != expected_id || !bpf_ok) {
     *result_listener << "\nworker selector function returned " << id;
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+#ifdef SUPPORTS_TESTING_BPF_PROG
     *result_listener << "\nbpf function returned " << bpf_id;
 #endif
     return false;
   }
+
   return true;
 }
 
@@ -97,14 +107,14 @@ FactoryFunctions::FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factor
                                    uint32_t concurrency)
     : concurrency_(concurrency),
       worker_selector_(factory.getCompatibleConnectionIdWorkerSelector(concurrency_)) {
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+#ifdef SUPPORTS_TESTING_BPF_PROG
   opt_ = factory.createCompatibleLinuxBpfSocketOption(concurrency);
   // Using a mock socket to capture the socket option which otherwise cannot be
   // extracted from the private field in the Socket::Option.
   Network::MockListenSocket mock_socket;
   EXPECT_CALL(mock_socket, setSocketOption(testing::_, testing::_, testing::_, testing::_))
       .WillOnce([this](int, int, const void* optval, socklen_t) {
-        bpf_prog_ = static_cast<const sock_fprog*>(optval);
+        bpf_prog_ = optval;
         return Api::SysCallIntResult{0, 0};
       });
   opt_->setOption(mock_socket, envoy::config::core::v3::SocketOption::STATE_BOUND);

--- a/test/common/quic/connection_id_matchers.cc
+++ b/test/common/quic/connection_id_matchers.cc
@@ -1,0 +1,128 @@
+#include "test/common/quic/connection_id_matchers.h"
+
+#include <string>
+
+#include "absl/cleanup/cleanup.h"
+
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "test/mocks/network/mocks.h"
+#endif
+
+namespace Envoy {
+namespace Quic {
+namespace Extensions {
+namespace ConnectionIdGenerator {
+namespace Matcher {
+namespace {
+
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+// Runs `prog` against `data` via a socketpair + SO_ATTACH_FILTER and returns the program's return
+// value.
+//
+// We can't attach via SO_ATTACH_REUSEPORT_CBPF, that would require a reuseport group sized to
+// `concurrency`. SO_ATTACH_FILTER reinterprets the same uint32_t return as "bytes to deliver", so
+// we read it back via recv(MSG_TRUNC) on a 1-byte buffer. EAGAIN/EWOULDBLOCK signals index 0, which
+// SO_ATTACH_FILTER reinterprets as drop.
+absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data, uint32_t min_len) {
+  std::string padded(data);
+  if (padded.size() < min_len) {
+    padded.resize(min_len, '\0');
+  }
+
+  int sv[2];
+  if (::socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) < 0) {
+    return absl::ErrnoToStatus(errno, "socketpair");
+  }
+  auto cleanup = absl::MakeCleanup([sv]() {
+    ::close(sv[0]);
+    ::close(sv[1]);
+  });
+
+  if (::setsockopt(sv[0], SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0) {
+    return absl::ErrnoToStatus(errno, "setsockopt(SO_ATTACH_FILTER)");
+  }
+
+  if (::send(sv[1], padded.data(), padded.size(), 0) < 0) {
+    return absl::ErrnoToStatus(errno, "send");
+  }
+
+  char buf[1];
+  ssize_t n = ::recv(sv[0], buf, sizeof(buf), MSG_TRUNC | MSG_DONTWAIT);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0u;
+    } else {
+      return absl::ErrnoToStatus(errno, "recv");
+    }
+  }
+
+  return n;
+}
+#endif
+
+MATCHER_P2(FactoryFunctionsReturnWorkerId, packet, expected_id, "") {
+  uint32_t id = arg.worker_selector_(*packet, 0xffffffff);
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+  auto bpf_id_or = runCbpf(*arg.bpf_prog_, packet->toString(), arg.concurrency_);
+  if (!bpf_id_or.ok()) {
+    *result_listener << "\nrunCbpf failed: " << bpf_id_or.status();
+    return false;
+  }
+  const uint32_t bpf_id = *bpf_id_or;
+
+  // cBPF falls back to rxhash % concurrency, while bpf equivalent function returns 0xffffffff
+  const bool bpf_ok =
+      (expected_id == 0xffffffff) ? (bpf_id < arg.concurrency_) : (bpf_id == expected_id);
+#else
+  std::cout << "warning: not verifying bpf program due to lacking system support" << std::endl;
+  const uint32_t bpf_id = expected_id;
+  const bool bpf_ok = true;
+#endif
+  if (id != expected_id || !bpf_ok) {
+    *result_listener << "\nworker selector function returned " << id;
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+    *result_listener << "\nbpf function returned " << bpf_id;
+#endif
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+FactoryFunctions::FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factory,
+                                   uint32_t concurrency)
+    : concurrency_(concurrency),
+      worker_selector_(factory.getCompatibleConnectionIdWorkerSelector(concurrency_)) {
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+  opt_ = factory.createCompatibleLinuxBpfSocketOption(concurrency);
+  // Using a mock socket to capture the socket option which otherwise cannot be
+  // extracted from the private field in the Socket::Option.
+  Network::MockListenSocket mock_socket;
+  EXPECT_CALL(mock_socket, setSocketOption(testing::_, testing::_, testing::_, testing::_))
+      .WillOnce([this](int, int, const void* optval, socklen_t) {
+        bpf_prog_ = static_cast<const sock_fprog*>(optval);
+        return Api::SysCallIntResult{0, 0};
+      });
+  opt_->setOption(mock_socket, envoy::config::core::v3::SocketOption::STATE_BOUND);
+#endif
+}
+
+GivenPacket::GivenPacket(const Buffer::Instance& packet) : packet_(packet) {}
+
+testing::Matcher<const FactoryFunctions&> GivenPacket::ReturnsWorkerId(uint32_t id) {
+  return FactoryFunctionsReturnWorkerId(&packet_, id);
+}
+
+testing::Matcher<const FactoryFunctions&> GivenPacket::ReturnsDefaultWorkerId() {
+  return FactoryFunctionsReturnWorkerId(&packet_, 0xffffffff);
+}
+
+} // namespace Matcher
+} // namespace ConnectionIdGenerator
+} // namespace Extensions
+} // namespace Quic
+} // namespace Envoy

--- a/test/common/quic/connection_id_matchers.h
+++ b/test/common/quic/connection_id_matchers.h
@@ -5,10 +5,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-#include <linux/filter.h>
-#endif
-
 namespace Envoy {
 namespace Quic {
 namespace Extensions {
@@ -28,12 +24,10 @@ class FactoryFunctions {
 public:
   FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factory, uint32_t concurrency);
 
-  uint32_t concurrency_;
+  const uint32_t concurrency_;
   const QuicConnectionIdWorkerSelector worker_selector_;
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
   Network::Socket::OptionConstSharedPtr opt_;
-  const sock_fprog* bpf_prog_;
-#endif
+  const void* bpf_prog_ = nullptr;
 };
 
 class GivenPacket {

--- a/test/common/quic/connection_id_matchers.h
+++ b/test/common/quic/connection_id_matchers.h
@@ -4,12 +4,14 @@
 
 #include "source/common/quic/envoy_quic_connection_id_generator_factory.h"
 
+#include "absl/cleanup/cleanup.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-#include <linux/bpf.h>
 #include <linux/filter.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "test/mocks/network/mocks.h"
 #endif
@@ -19,11 +21,54 @@ namespace Quic {
 namespace Extensions {
 namespace ConnectionIdGenerator {
 namespace Matcher {
+namespace {
 
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__) &&                                     \
-    defined(TODO_TEST_FOR_BPF_PROG_RUN_SUPPORT)
-#define SUPPORTS_TESTING_BPF_PROG
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+// Runs `prog` against `data` via a socketpair + SO_ATTACH_FILTER and returns the program's return
+// value.
+//
+// We can't attach via SO_ATTACH_REUSEPORT_CBPF, that would require a reuseport group sized to
+// `concurrency`. SO_ATTACH_FILTER reinterprets the same uint32_t return as "bytes to deliver", so
+// we read it back via recv(MSG_TRUNC) on a 1-byte buffer. EAGAIN/EWOULDBLOCK signals index 0, which
+// SO_ATTACH_FILTER reinterprets as drop.
+absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data, uint32_t min_len) {
+  std::string padded(data);
+  if (padded.size() < min_len) {
+    padded.resize(min_len, '\0');
+  }
+
+  int sv[2];
+  if (::socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) < 0) {
+    return absl::ErrnoToStatus(errno, "socketpair");
+  }
+  auto cleanup = absl::MakeCleanup([sv]() {
+    ::close(sv[0]);
+    ::close(sv[1]);
+  });
+
+  if (::setsockopt(sv[0], SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0) {
+    return absl::ErrnoToStatus(errno, "setsockopt(SO_ATTACH_FILTER)");
+  }
+
+  if (::send(sv[1], padded.data(), padded.size(), 0) < 0) {
+    return absl::ErrnoToStatus(errno, "send");
+  }
+
+  char buf[1];
+  ssize_t n = ::recv(sv[0], buf, sizeof(buf), MSG_TRUNC | MSG_DONTWAIT);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0u;
+    } else {
+      return absl::ErrnoToStatus(errno, "recv");
+    }
+  }
+
+  return n;
+}
 #endif
+
+} // namespace
 
 // A matcher for connection id factories to test both the bpf filter and worker selector
 // functions. Recommended usage is like:
@@ -38,40 +83,48 @@ namespace Matcher {
 class FactoryFunctions {
 public:
   FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factory, uint32_t concurrency)
-      : worker_selector_(factory.getCompatibleConnectionIdWorkerSelector(concurrency)) {
-#ifdef SUPPORTS_TESTING_BPF_PROG
-    Network::Socket::OptionConstSharedPtr sockopt =
-        factory.createCompatibleLinuxBpfSocketOption(concurrency);
+      : concurrency_(concurrency),
+        worker_selector_(factory.getCompatibleConnectionIdWorkerSelector(concurrency_)) {
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+    opt_ = factory.createCompatibleLinuxBpfSocketOption(concurrency);
     // Using a mock socket to capture the socket option which otherwise cannot be
     // extracted from the private field in the Socket::Option.
     Network::MockListenSocket mock_socket;
-    const sock_fprog* bpf_prog;
     EXPECT_CALL(mock_socket, setSocketOption(testing::_, testing::_, testing::_, testing::_))
         .WillOnce([this](int, int, const void* optval, socklen_t) {
           bpf_prog_ = static_cast<const sock_fprog*>(optval);
           return Api::SysCallIntResult{0, 0};
         });
-    sockopt->setOption(mock_socket, envoy::config::core::v3::SocketOption::STATE_BOUND);
+    opt_->setOption(mock_socket, envoy::config::core::v3::SocketOption::STATE_BOUND);
 #endif
   }
+  uint32_t concurrency_;
   const QuicConnectionIdWorkerSelector worker_selector_;
-#ifdef SUPPORTS_TESTING_BPF_PROG
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+  Network::Socket::OptionConstSharedPtr opt_;
   const sock_fprog* bpf_prog_;
 #endif
 };
 
 MATCHER_P2(FactoryFunctionsReturnWorkerId, packet, expected_id, "") {
   uint32_t id = arg.worker_selector_(*packet, 0xffffffff);
-  // TODO: run the bpf program, something like the below. The headers we have in the docker
-  //       container don't seem to provide `bpf()` or `bpf_prog_run()`.
-#ifdef SUPPORTS_TESTING_BPF_PROG
-  std::string bytes = packet->toString();
-  uint32_t bpf_id = bpf_prog_run(arg.bpf_prog_, bytes.c_str());
+#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
+  auto bpf_id_or = runCbpf(*arg.bpf_prog_, packet->toString(), arg.concurrency_);
+  if (!bpf_id_or.ok()) {
+    *result_listener << "\nrunCbpf failed: " << bpf_id_or.status();
+    return false;
+  }
+  const uint32_t bpf_id = *bpf_id_or;
+
+  // cBPF falls back to rxhash % concurrency, while bpf equivalent function returns 0xffffffff
+  const bool bpf_ok =
+      (expected_id == 0xffffffff) ? (bpf_id < arg.concurrency_) : (bpf_id == expected_id);
 #else
-  uint32_t bpf_id = expected_id;
   std::cout << "warning: not verifying bpf program due to lacking system support" << std::endl;
+  const uint32_t bpf_id = expected_id;
+  const bool bpf_ok = true;
 #endif
-  if (id != expected_id || bpf_id != expected_id) {
+  if (id != expected_id || !bpf_ok) {
     *result_listener << "\nworker selector function returned " << id;
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
     *result_listener << "\nbpf function returned " << bpf_id;
@@ -94,8 +147,6 @@ public:
 private:
   const Buffer::Instance& packet_;
 };
-
-#undef SUPPORTS_TESTING_BPF_PROG
 
 } // namespace Matcher
 } // namespace ConnectionIdGenerator

--- a/test/common/quic/connection_id_matchers.h
+++ b/test/common/quic/connection_id_matchers.h
@@ -1,19 +1,12 @@
 #pragma once
 
-#include <string>
-
 #include "source/common/quic/envoy_quic_connection_id_generator_factory.h"
 
-#include "absl/cleanup/cleanup.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
 #include <linux/filter.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
-#include "test/mocks/network/mocks.h"
 #endif
 
 namespace Envoy {
@@ -21,54 +14,6 @@ namespace Quic {
 namespace Extensions {
 namespace ConnectionIdGenerator {
 namespace Matcher {
-namespace {
-
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-// Runs `prog` against `data` via a socketpair + SO_ATTACH_FILTER and returns the program's return
-// value.
-//
-// We can't attach via SO_ATTACH_REUSEPORT_CBPF, that would require a reuseport group sized to
-// `concurrency`. SO_ATTACH_FILTER reinterprets the same uint32_t return as "bytes to deliver", so
-// we read it back via recv(MSG_TRUNC) on a 1-byte buffer. EAGAIN/EWOULDBLOCK signals index 0, which
-// SO_ATTACH_FILTER reinterprets as drop.
-absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data, uint32_t min_len) {
-  std::string padded(data);
-  if (padded.size() < min_len) {
-    padded.resize(min_len, '\0');
-  }
-
-  int sv[2];
-  if (::socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) < 0) {
-    return absl::ErrnoToStatus(errno, "socketpair");
-  }
-  auto cleanup = absl::MakeCleanup([sv]() {
-    ::close(sv[0]);
-    ::close(sv[1]);
-  });
-
-  if (::setsockopt(sv[0], SOL_SOCKET, SO_ATTACH_FILTER, &prog, sizeof(prog)) < 0) {
-    return absl::ErrnoToStatus(errno, "setsockopt(SO_ATTACH_FILTER)");
-  }
-
-  if (::send(sv[1], padded.data(), padded.size(), 0) < 0) {
-    return absl::ErrnoToStatus(errno, "send");
-  }
-
-  char buf[1];
-  ssize_t n = ::recv(sv[0], buf, sizeof(buf), MSG_TRUNC | MSG_DONTWAIT);
-  if (n < 0) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      return 0u;
-    } else {
-      return absl::ErrnoToStatus(errno, "recv");
-    }
-  }
-
-  return n;
-}
-#endif
-
-} // namespace
 
 // A matcher for connection id factories to test both the bpf filter and worker selector
 // functions. Recommended usage is like:
@@ -79,25 +24,10 @@ absl::StatusOr<uint32_t> runCbpf(const sock_fprog& prog, absl::string_view data,
 //
 // Wrapping in FactoryFunctions is necessary because calling the factory functions directly is
 // not const.
-
 class FactoryFunctions {
 public:
-  FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factory, uint32_t concurrency)
-      : concurrency_(concurrency),
-        worker_selector_(factory.getCompatibleConnectionIdWorkerSelector(concurrency_)) {
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-    opt_ = factory.createCompatibleLinuxBpfSocketOption(concurrency);
-    // Using a mock socket to capture the socket option which otherwise cannot be
-    // extracted from the private field in the Socket::Option.
-    Network::MockListenSocket mock_socket;
-    EXPECT_CALL(mock_socket, setSocketOption(testing::_, testing::_, testing::_, testing::_))
-        .WillOnce([this](int, int, const void* optval, socklen_t) {
-          bpf_prog_ = static_cast<const sock_fprog*>(optval);
-          return Api::SysCallIntResult{0, 0};
-        });
-    opt_->setOption(mock_socket, envoy::config::core::v3::SocketOption::STATE_BOUND);
-#endif
-  }
+  FactoryFunctions(EnvoyQuicConnectionIdGeneratorFactory& factory, uint32_t concurrency);
+
   uint32_t concurrency_;
   const QuicConnectionIdWorkerSelector worker_selector_;
 #if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
@@ -106,43 +36,11 @@ public:
 #endif
 };
 
-MATCHER_P2(FactoryFunctionsReturnWorkerId, packet, expected_id, "") {
-  uint32_t id = arg.worker_selector_(*packet, 0xffffffff);
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-  auto bpf_id_or = runCbpf(*arg.bpf_prog_, packet->toString(), arg.concurrency_);
-  if (!bpf_id_or.ok()) {
-    *result_listener << "\nrunCbpf failed: " << bpf_id_or.status();
-    return false;
-  }
-  const uint32_t bpf_id = *bpf_id_or;
-
-  // cBPF falls back to rxhash % concurrency, while bpf equivalent function returns 0xffffffff
-  const bool bpf_ok =
-      (expected_id == 0xffffffff) ? (bpf_id < arg.concurrency_) : (bpf_id == expected_id);
-#else
-  std::cout << "warning: not verifying bpf program due to lacking system support" << std::endl;
-  const uint32_t bpf_id = expected_id;
-  const bool bpf_ok = true;
-#endif
-  if (id != expected_id || !bpf_ok) {
-    *result_listener << "\nworker selector function returned " << id;
-#if defined(SO_ATTACH_REUSEPORT_CBPF) && defined(__linux__)
-    *result_listener << "\nbpf function returned " << bpf_id;
-#endif
-    return false;
-  }
-  return true;
-}
-
 class GivenPacket {
 public:
-  GivenPacket(const Buffer::Instance& packet) : packet_(packet) {}
-  testing::Matcher<const FactoryFunctions&> ReturnsWorkerId(uint32_t id) {
-    return FactoryFunctionsReturnWorkerId(&packet_, id);
-  }
-  testing::Matcher<const FactoryFunctions&> ReturnsDefaultWorkerId() {
-    return FactoryFunctionsReturnWorkerId(&packet_, 0xffffffff);
-  }
+  GivenPacket(const Buffer::Instance& packet);
+  testing::Matcher<const FactoryFunctions&> ReturnsWorkerId(uint32_t id);
+  testing::Matcher<const FactoryFunctions&> ReturnsDefaultWorkerId();
 
 private:
   const Buffer::Instance& packet_;


### PR DESCRIPTION
Commit Message: test/quic: Validate cBPF filter in deterministic CID generator test
Additional Description:

cBPF can't be run through BPF syscalls. We test the cBPF program by attaching via `SO_ATTACH_FILTER` and reading the return value back through `recv(MSG_TRUNC)`.

Risk Level: Low
Testing: EnvoyDeterministicConnectionIdGeneratorFactoryTest cBPF now runs on Linux
Docs Changes: None
Release Notes: None
Platform Specific Features: None
