### PR TITLE
mcp_cluster: update test to avoid a race on connection shutdown

### DIFF
--- a/test/extensions/clusters/mcp_multicluster/cluster_integration_test.cc
+++ b/test/extensions/clusters/mcp_multicluster/cluster_integration_test.cc
@@ -120,6 +120,7 @@ TEST_P(CompositeClusterIntegrationTest, BasicRetryProgression) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
   ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   fake_upstream_connection_.reset();
 
   // First retry should go to cluster_1 - return 503 to trigger another retry.
@@ -128,6 +129,7 @@ TEST_P(CompositeClusterIntegrationTest, BasicRetryProgression) {
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
   ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
   fake_upstream_connection_.reset();
 
   // Second retry should go to cluster_2 - return 200.


### PR DESCRIPTION
Commit Message: mcp_cluster: update test to avoid a race on connection shutdown
Additional Description:
This is an integration test-only change to prevent a race when closing a connection.

Risk Level: low - test only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
