### PR TITLE
Prep for removal of C++ exceptions from formatters

### DIFF
--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -122,6 +122,7 @@ envoy_cc_library(
         "//source/common/json:json_utility_lib",
         "//source/common/protobuf:message_validator_lib",
         "//source/common/stream_info:utility_lib",
+        "@abseil-cpp//absl/status:statusor",
     ],
     alwayslink = 1,  # has factory registration
 )

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2572,7 +2572,10 @@ public:
     THROW_IF_NOT_OK(Envoy::Formatter::CommandSyntaxChecker::verifySyntax(
         (*it).second.first, command, sub_command, max_length));
 
-    return (*it).second.second(sub_command, max_length);
+    StreamInfoFormatterResult result = (*it).second.second(sub_command, max_length);
+    THROW_IF_NOT_OK_REF(result.status());
+
+    return (std::move(result)).value();
   }
 };
 

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -3,6 +3,7 @@
 #include <bitset>
 #include <functional>
 #include <list>
+#include <memory>
 #include <regex>
 #include <string>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "source/common/formatter/substitution_format_utility.h"
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 
 namespace Envoy {
@@ -48,9 +50,10 @@ public:
 };
 
 using StreamInfoFormatterProviderPtr = std::unique_ptr<StreamInfoFormatterProvider>;
+using StreamInfoFormatterResult = absl::StatusOr<StreamInfoFormatterProviderPtr>;
 
 using StreamInfoFormatterProviderCreateFunc =
-    std::function<StreamInfoFormatterProviderPtr(absl::string_view, absl::optional<size_t>)>;
+    std::function<StreamInfoFormatterResult(absl::string_view, absl::optional<size_t>)>;
 
 enum class DurationPrecision { Milliseconds, Microseconds, Nanoseconds };
 


### PR DESCRIPTION
Allow parser factory to return StatusOr. There are no functional changes, errors are still reported using C++ exceptions.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
