### PR TITLE
stats: fix a bug where empty StatName cannot initialize storage correctly

### DIFF
--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -29,21 +29,17 @@ void StatName::debugPrint() {
   // TODO(jmarantz): capture this functionality (always prints regardless of
   // loglevel) in an ENVOY_LOG macro variant or similar, perhaps
   // ENVOY_LOG_MISC(stderr, ...);
-  if (size_and_data_ == nullptr) {
-    std::cerr << "Null StatName" << std::endl;
-  } else {
-    const size_t nbytes = dataSize();
-    std::cerr << "dataSize=" << nbytes << ":";
-    for (size_t i = 0; i < nbytes; ++i) {
-      std::cerr << " " << static_cast<uint64_t>(data()[i]);
-    }
-    const SymbolVec encoding = SymbolTable::Encoding::decodeSymbols(*this);
-    std::cerr << ", numSymbols=" << encoding.size() << ":";
-    for (Symbol symbol : encoding) {
-      std::cerr << " " << symbol;
-    }
-    std::cerr << std::endl;
+  const size_t nbytes = dataSize();
+  std::cerr << "dataSize=" << nbytes << ":";
+  for (size_t i = 0; i < nbytes; ++i) {
+    std::cerr << " " << static_cast<uint64_t>(data()[i]);
   }
+  const SymbolVec encoding = SymbolTable::Encoding::decodeSymbols(*this);
+  std::cerr << ", numSymbols=" << encoding.size() << ":";
+  for (Symbol symbol : encoding) {
+    std::cerr << " " << symbol;
+  }
+  std::cerr << std::endl;
 }
 #endif
 
@@ -118,14 +114,9 @@ public:
 
   TokenIter(StatName stat_name) {
     const uint8_t* raw_data = stat_name.dataIncludingSize();
-    if (raw_data == nullptr) {
-      size_ = 0;
-      array_ = nullptr;
-    } else {
-      std::pair<uint64_t, size_t> size_consumed = decodeNumber(raw_data);
-      size_ = size_consumed.first;
-      array_ = raw_data + size_consumed.second;
-    }
+    std::pair<uint64_t, size_t> size_consumed = decodeNumber(raw_data);
+    size_ = size_consumed.first;
+    array_ = raw_data + size_consumed.second;
   }
 
   /**
@@ -253,12 +244,7 @@ void SymbolTable::Encoding::moveToMemBlock(MemBlockBuilder<uint8_t>& mem_block) 
 
 void SymbolTable::Encoding::appendToMemBlock(StatName stat_name,
                                              MemBlockBuilder<uint8_t>& mem_block) {
-  const uint8_t* data = stat_name.dataIncludingSize();
-  if (data == nullptr) {
-    mem_block.appendOne(0);
-  } else {
-    mem_block.appendData(absl::MakeSpan(data, stat_name.size()));
-  }
+  mem_block.appendData(absl::MakeSpan(stat_name.dataIncludingSize(), stat_name.size()));
 }
 
 SymbolTable::SymbolTable()

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -573,6 +573,7 @@ protected:
   StatNameStorage() = default;
 };
 
+// Backing store for empty StatName constructor; the 0 indicates there are 0 bytes in the encoding.
 constexpr uint8_t EmptyStatNameData[] = {0};
 
 /**

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -573,6 +573,8 @@ protected:
   StatNameStorage() = default;
 };
 
+constexpr uint8_t EmptyStatNameData[] = {0};
+
 /**
  * Efficiently represents a stat name using a variable-length array of uint8_t.
  * This class does not own the backing store for this array; the backing-store
@@ -590,7 +592,7 @@ public:
   explicit StatName(const SymbolTable::Storage size_and_data) : size_and_data_(size_and_data) {}
 
   // Constructs an empty StatName object.
-  StatName() = default;
+  StatName() : size_and_data_(EmptyStatNameData) {}
 
   /**
    * Defines default hash function so StatName can be used as a key in an absl
@@ -702,7 +704,7 @@ private:
    * this method so the decode happens in exactly one place.
    */
   absl::string_view dataAsStringView() const {
-    if (size_and_data_ == nullptr) {
+    if (empty()) {
       return {};
     }
     const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -620,10 +620,6 @@ public:
       return true;
     }
 
-    if (size_and_data_ == nullptr || rhs.size_and_data_ == nullptr) {
-      return empty() && rhs.empty();
-    }
-
     return dataAsStringView() == rhs.dataAsStringView();
   }
   bool operator!=(const StatName& rhs) const { return !(*this == rhs); }
@@ -684,7 +680,7 @@ public:
   bool empty() const {
     // Avoid a full varint decode: it is sufficient to know the first byte,
     // since 0x00 uniquely encodes zero
-    return size_and_data_ == nullptr || size_and_data_[0] == 0;
+    return size_and_data_[0] == 0;
   }
 
   /**
@@ -704,14 +700,11 @@ private:
    * this method so the decode happens in exactly one place.
    */
   absl::string_view dataAsStringView() const {
-    if (empty()) {
-      return {};
-    }
     const auto [data_size, prefix_size] = SymbolTable::Encoding::decodeNumber(size_and_data_);
     return {reinterpret_cast<const char*>(size_and_data_ + prefix_size), data_size};
   }
 
-  const uint8_t* size_and_data_{nullptr};
+  const uint8_t* size_and_data_;
 };
 
 StatName StatNameStorageBase::statName() const { return StatName(bytes_.get()); }

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -701,6 +701,15 @@ TEST_F(StatNameTest, StorageCopy) {
   EXPECT_NE(a.data(), c.data());
 }
 
+TEST_F(StatNameTest, StorageFromEmptyStatName) {
+  StatName empty;
+  StatNameStorage b_storage(empty, table_);
+  const StatName b = b_storage.statName();
+  EXPECT_EQ(empty, b);
+  EXPECT_NE(empty.data(), b.data());
+  b_storage.free(table_);
+}
+
 TEST_F(StatNameTest, AddingToPoolViaStatNamePreservesDynamicSegments) {
   const StatNameDynamicStorage tag_name("tag", table_);
   const StatNameDynamicStorage tag_value("value", table_);


### PR DESCRIPTION
Commit Message: stats: fix a bug where empty StatName cannot initialize storage correctly
Additional Description:

In the previous implementation, if we use StatName that constructed with default constructor (data_and_size_ be nullptr) to construct StatNameStorage, it will crash Envoy.

This is because `copyToMemBlock` method of StatName not handle the case where data_and_size_ be nullptr correctly. Now, this PR unified related calling to Encoding's helper methods.

Risk Level: low.
Testing: unit.
Docs Changes: n/a. 
Release Notes: n/a.
Platform Specific Features: n/a.