### PR TITLE
Adding API doc change to specify ext_authz/ext_proc ignores keep_empty_value API

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -486,6 +486,7 @@ message HeaderValueOption {
 
   // Is the header value allowed to be empty? If false (default), custom headers with empty values are dropped,
   // otherwise they are added.
+  //
   // .. note::
   //   The :ref:`external authorization service <envoy_v3_api_msg_service.auth.v3.CheckResponse>` and
   //   :ref:`external processor service <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -488,9 +488,7 @@ message HeaderValueOption {
   // otherwise they are added.
   //
   // .. note::
-  //   The :ref:`external authorization service <envoy_v3_api_msg_service.auth.v3.CheckResponse>` and
-  //   :ref:`external processor service <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`
-  //   are ignoring this field.
+  //   This field is only supported by the router filter. Please check: https://github.com/envoyproxy/envoy/pull/21291.
   bool keep_empty_value = 4;
 }
 

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -486,6 +486,10 @@ message HeaderValueOption {
 
   // Is the header value allowed to be empty? If false (default), custom headers with empty values are dropped,
   // otherwise they are added.
+  // .. note::
+  //   The :ref:`external authorization service <envoy_v3_api_msg_service.auth.v3.CheckResponse>` and
+  //   :ref:`external processor service <envoy_v3_api_msg_service.ext_proc.v3.ProcessingResponse>`
+  //   are ignoring this field.
   bool keep_empty_value = 4;
 }
 

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -488,7 +488,8 @@ message HeaderValueOption {
   // otherwise they are added.
   //
   // .. note::
-  //   This field is only supported by the router filter. Please check: https://github.com/envoyproxy/envoy/pull/21291.
+  // In any context other than the router filter, we always act as if keep_empty_value is true,
+  // regardless of the setting of this field.
   bool keep_empty_value = 4;
 }
 

--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -488,8 +488,9 @@ message HeaderValueOption {
   // otherwise they are added.
   //
   // .. note::
-  // In any context other than the router filter, we always act as if keep_empty_value is true,
-  // regardless of the setting of this field.
+  //   In any context other than the router filter, we always act as if keep_empty_value is true,
+  //   regardless of the setting of this field.
+  //
   bool keep_empty_value = 4;
 }
 

--- a/api/envoy/service/auth/v3/external_auth.proto
+++ b/api/envoy/service/auth/v3/external_auth.proto
@@ -52,6 +52,8 @@ message DeniedHttpResponse {
   // This field allows the authorization service to send HTTP response headers
   // to the downstream client. Note that the :ref:`append field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.append>` defaults to
   // false when used in this message.
+  // The :ref:`keep_empty_value field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>`
+  // is not supported.
   repeated config.core.v3.HeaderValueOption headers = 2;
 
   // This field allows the authorization service to send a response body data
@@ -72,6 +74,8 @@ message OkHttpResponse {
   // the filter will append the correspondent header value to the matched request header.
   // By leaving ``append`` as false, the filter will either add a new header, or override an existing
   // one if there is a match.
+  // The :ref:`keep_empty_value field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>`
+  // is not supported.
   repeated config.core.v3.HeaderValueOption headers = 2;
 
   // HTTP entity headers to remove from the original request before dispatching
@@ -101,6 +105,8 @@ message OkHttpResponse {
   // This field allows the authorization service to send HTTP response headers
   // to the downstream client on success. Note that the :ref:`append field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.append>`
   // defaults to false when used in this message.
+  // The :ref:`keep_empty_value field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>`
+  // is not supported.
   repeated config.core.v3.HeaderValueOption response_headers_to_add = 6;
 
   // This field allows the authorization service to set (and overwrite) query

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -457,6 +457,10 @@ message HeaderMutation {
   // ``:authority``, ``:scheme``, or ``host`` headers will be ignored.
   // The header value is encoded in the
   // :ref:`raw_value <envoy_v3_api_field_config.core.v3.HeaderValue.raw_value>` field.
+  // Note that the :ref:`append field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.append>`
+  // defaults to false when used in this message.
+  // The :ref:`keep_empty_value field in HeaderValueOption <envoy_v3_api_field_config.core.v3.HeaderValueOption.keep_empty_value>`
+  // is not supported.
   repeated config.core.v3.HeaderValueOption set_headers = 1;
 
   // Remove these HTTP headers. Attempts to remove system headers --


### PR DESCRIPTION
Addressing: https://github.com/envoyproxy/envoy/issues/45003

Please check: https://github.com/envoyproxy/envoy/issues/45003#issuecomment-4577493554 for details of this change.