### PR TITLE
sip_proxy: validate Content-Length header values

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -92,6 +92,8 @@ areas:
     title: router
   set_metadata_filter:
     title: set_metadata_filter
+  sip_proxy:
+    title: sip_proxy
   sockets:
     title: sockets
   spiffe_validator:

--- a/changelogs/current/bug_fixes/sip_proxy__fixed-a-stack-buffer-overflow.rst
+++ b/changelogs/current/bug_fixes/sip_proxy__fixed-a-stack-buffer-overflow.rst
@@ -1,0 +1,5 @@
+Fixed a stack buffer overflow in the SIP decoder. The width of the ``Content-Length`` header value
+field is controlled by the peer and was copied into a fixed-size stack buffer via a ``copyOut()``
+call bounded only by the source buffer, so an over-wide value field overflowed the stack. The
+decoder now validates the value length against the destination size before copying and drops
+messages with an empty, over-long, or negative ``Content-Length`` value instead of decoding them.

--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -111,23 +111,40 @@ int Decoder::reassemble(Buffer::Instance& data) {
 
       ssize_t content_length_end = remaining_data.search(
           "\r\n", strlen("\r\n"), content_length_start + strlen("Content-Length:"), content_pos);
+      if (content_length_end == -1) {
+        // No CRLF terminates the Content-Length header; wait for more data.
+        break;
+      }
 
-      // The "\n\r\n" is always included in remaining_data, so could not return -1
-      // if (content_length_end == -1) {
-      //   break;
-      // }
+      // The number of bytes occupied by the Content-Length value field (everything between the
+      // "Content-Length:" header name and its terminating CRLF) is fully attacker-controlled. It
+      // must be validated against the size of the fixed destination buffer below before copying,
+      // otherwise copyOut() (which is bounded only by the source buffer) overflows the stack.
+      char len[32]{}; // temporary storage for the decimal Content-Length value
+      const ssize_t name_len = static_cast<ssize_t>(strlen("Content-Length:"));
+      const ssize_t value_start = content_length_start + name_len;
+      const ssize_t value_len = content_length_end - value_start;
+      if (value_len <= 0 || static_cast<size_t>(value_len) >= sizeof(len)) {
+        // The value field is empty or implausibly long for a decimal length. The message is
+        // malformed and cannot be recovered. Exceptions must not be thrown on the request-processing
+        // path, so stop reassembly without dispatching the message rather than raising an error.
+        ENVOY_LOG(debug, "sip: invalid Content-Length value field width ({}); dropping message",
+                  value_len);
+        break;
+      }
 
-      char len[10]{}; // temporary storage
-      remaining_data.copyOut(content_length_start + strlen("Content-Length:"),
-                             content_length_end - content_length_start - strlen("Content-Length:"),
-                             len);
+      remaining_data.copyOut(value_start, value_len, len);
+      // Explicitly NUL-terminate before std::atoi(). The bound above guarantees
+      // value_len <= sizeof(len) - 1, so len[value_len] is always in range and leaves room for the
+      // terminator (rather than relying on the buffer's zero-initialization).
+      len[value_len] = '\0';
 
-      clen = std::atoi(len);
-
-      // atoi return value >= 0, could not < 0
-      // if (clen < static_cast<size_t>(0)) {
-      //   break;
-      // }
+      const int parsed_clen = std::atoi(len);
+      if (parsed_clen < 0) {
+        ENVOY_LOG(debug, "sip: negative Content-Length value ({}); dropping message", parsed_clen);
+        break;
+      }
+      clen = static_cast<size_t>(parsed_clen);
 
       full_msg_len = content_pos + clen;
     }

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -617,6 +617,47 @@ TEST_F(SipDecoderTest, DecodeNOTIFY) {
   EXPECT_EQ(0U, store_.counter("test.response").value());
 }
 
+// Regression test for a stack buffer overflow in Decoder::reassemble(). The width of the
+// Content-Length value field is attacker-controlled and was copied into a fixed 10-byte stack
+// buffer with a copyOut() call bounded only by the source buffer, so a value field wider than the
+// destination overflowed the stack with attacker-controlled bytes. Under ASAN the pre-fix decoder
+// crashes on both messages below; the fixed decoder must handle them without memory corruption and
+// without decoding a request.
+TEST_F(SipDecoderTest, DecodeContentLengthWideValueFieldDoesNotOverflowStack) {
+  initializeFilter(yaml);
+
+  // Value field far wider than the old 10-byte buffer but a benign numeric value (leading zeros).
+  // The advertised body is absent, so this is a partial message that is dropped -- but the decoder
+  // must not corrupt the stack while reading the over-wide value field.
+  const std::string SIP_WIDE_CONTENT_LENGTH =
+      "REGISTER sip:User.0000@tas01.defult.svc.cluster.local SIP/2.0\x0d\x0a"
+      "Call-ID: 1-3193@11.0.0.10\x0d\x0a"
+      "Via: SIP/2.0/TCP 11.0.0.10:15060;branch=z9hG4bK-3193-1-0\x0d\x0a"
+      "Content-Length: 0000000000000000000099\x0d\x0a"
+      "\x0d\x0a";
+  buffer_.add(SIP_WIDE_CONTENT_LENGTH);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0U, store_.counter("test.request").value());
+}
+
+TEST_F(SipDecoderTest, DecodeContentLengthOverlongValueFieldIsRejected) {
+  initializeFilter(yaml);
+
+  // An implausibly long value field (far wider than any legitimate decimal length) is rejected:
+  // reassembly stops and no request is dispatched (no exception is thrown on the data path).
+  const std::string SIP_HUGE_CONTENT_LENGTH =
+      "REGISTER sip:User.0000@tas01.defult.svc.cluster.local SIP/2.0\x0d\x0a"
+      "Call-ID: 1-3193@11.0.0.10\x0d\x0a"
+      "Via: SIP/2.0/TCP 11.0.0.10:15060;branch=z9hG4bK-3193-1-0\x0d\x0a"
+      "Content-Length: " +
+      std::string(64, '1') +
+      "\x0d\x0a"
+      "\x0d\x0a";
+  buffer_.add(SIP_HUGE_CONTENT_LENGTH);
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0U, store_.counter("test.request").value());
+}
+
 TEST_F(SipDecoderTest, HeaderTest) {
   StateNameValues stateNameValues_;
   EXPECT_EQ("Done", stateNameValues_.name(State::Done));


### PR DESCRIPTION
This change hardens SIP `Content-Length` parsing by validating the header value before copying and parsing it.

## Changes

* Restored handling for unterminated `Content-Length` headers by checking for the terminating CRLF before processing.
* Added validation of the `Content-Length` value-field length before copying into temporary storage.
* Reject empty, malformed, or excessively long `Content-Length` values.
* Reject negative `Content-Length` values.
* Added regression tests covering oversized and malformed `Content-Length` header values.
* Added a changelog entry for the SIP proxy bug fix.

## Risk Level:
Low

## Testing:

* Added regression tests for oversized and malformed `Content-Length` values in `decoder_test.cc`.
* Existing SIP decoder behavior is unchanged for valid messages.
* Maintainers can verify with:
  bazel test -c dbg --config=clang-asan //contrib/sip_proxy/filters/network/test:decoder_test

## Docs Changes:

* Added changelog entry under `sip_proxy`.

## Release Notes:

* Improved validation of SIP `Content-Length` headers and reject malformed values before parsing.