### PR TITLE
dym(rust): fix rust listener filter init macro

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -903,16 +903,14 @@ pub static NEW_NETWORK_FILTER_CONFIG_FUNCTION: OnceLock<
 macro_rules! declare_listener_filter_init_functions {
   ($f:ident, $new_listener_filter_config_fn:expr) => {
     #[no_mangle]
-    pub extern "C" fn envoy_dynamic_module_on_program_init(
-      server_factory_context_ptr: abi::envoy_dynamic_module_type_server_factory_context_envoy_ptr,
-    ) -> *const ::std::os::raw::c_char {
+    pub extern "C" fn envoy_dynamic_module_on_program_init() -> *const ::std::os::raw::c_char {
       match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
         envoy_proxy_dynamic_modules_rust_sdk::set_factory_once!(
           envoy_proxy_dynamic_modules_rust_sdk::NEW_LISTENER_FILTER_CONFIG_FUNCTION,
           $new_listener_filter_config_fn,
           "NEW_LISTENER_FILTER_CONFIG_FUNCTION"
         );
-        if ($f(server_factory_context_ptr)) {
+        if ($f()) {
           envoy_proxy_dynamic_modules_rust_sdk::abi::envoy_dynamic_modules_abi_version.as_ptr()
             as *const ::std::os::raw::c_char
         } else {

--- a/test/extensions/dynamic_modules/test_data/rust/BUILD
+++ b/test/extensions/dynamic_modules/test_data/rust/BUILD
@@ -18,6 +18,8 @@ test_program(name = "no_op")
 
 test_program(name = "network_no_op")
 
+test_program(name = "listener_no_op")
+
 test_program(name = "no_program_init")
 
 test_program(name = "program_init_fail")

--- a/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
+++ b/test/extensions/dynamic_modules/test_data/rust/Cargo.toml
@@ -51,6 +51,12 @@ crate-type = ["cdylib"]
 test = true
 
 [[example]]
+name = "listener_no_op"
+path = "listener_no_op.rs"
+crate-type = ["cdylib"]
+test = true
+
+[[example]]
 name = "bootstrap_function_registry_test"
 path = "bootstrap_function_registry_test.rs"
 crate-type = ["cdylib"]

--- a/test/extensions/dynamic_modules/test_data/rust/listener_no_op.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_no_op.rs
@@ -1,0 +1,34 @@
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+
+declare_listener_filter_init_functions!(init, new_nop_listener_filter_config_fn);
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::ProgramInitFunction`] signature.
+fn init() -> bool {
+  true
+}
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewListenerFilterConfigFunction`]
+/// signature.
+fn new_nop_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListenerFilter>(
+  _envoy_filter_config: &mut EC,
+  _name: &str,
+  _config: &[u8],
+) -> Option<Box<dyn ListenerFilterConfig<ELF>>> {
+  Some(Box::new(NopListenerFilterConfig {}))
+}
+
+/// A no-op listener filter configuration that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::ListenerFilterConfig`].
+struct NopListenerFilterConfig {}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for NopListenerFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(NopListenerFilter {})
+  }
+}
+
+/// A no-op listener filter that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::ListenerFilter`].
+struct NopListenerFilter {}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for NopListenerFilter {}


### PR DESCRIPTION
**Commit Message:**
Update the `declare_listener_filter_init_functions` macro in hte Rust dynamic module SDK to use the correct number of arguments, aligning it to how the `network` and `udp_listener` filters work; the previous macro used a type that does not exist.

**Risk Level:**
Low

**Testing:**
Added additional tests that exercise the modified macro.

**Docs Changes:**
No additional docs

_I used AI to help understand the Rust SDK and ABI and implement the fix_
