### PR TITLE
sip: bound Content-Length copy to fixed buffer in reassemble

### DIFF
--- a/contrib/sip_proxy/filters/network/source/decoder.cc
+++ b/contrib/sip_proxy/filters/network/source/decoder.cc
@@ -118,9 +118,14 @@ int Decoder::reassemble(Buffer::Instance& data) {
       // }
 
       char len[10]{}; // temporary storage
-      remaining_data.copyOut(content_length_start + strlen("Content-Length:"),
-                             content_length_end - content_length_start - strlen("Content-Length:"),
-                             len);
+      size_t value_len = content_length_end - content_length_start - strlen("Content-Length:");
+      // The Content-Length value comes from the untrusted SIP message and may be
+      // longer than the temporary buffer; cap the copy so it cannot overflow len[]
+      // and keep room for the trailing NUL that atoi() relies on.
+      if (value_len > sizeof(len) - 1) {
+        value_len = sizeof(len) - 1;
+      }
+      remaining_data.copyOut(content_length_start + strlen("Content-Length:"), value_len, len);
 
       clen = std::atoi(len);
 

--- a/contrib/sip_proxy/filters/network/test/decoder_test.cc
+++ b/contrib/sip_proxy/filters/network/test/decoder_test.cc
@@ -617,6 +617,33 @@ TEST_F(SipDecoderTest, DecodeNOTIFY) {
   EXPECT_EQ(0U, store_.counter("test.response").value());
 }
 
+TEST_F(SipDecoderTest, DecodeContentLengthLongerThanBuffer) {
+  initializeFilter(yaml);
+
+  // The Content-Length value is far longer than the temporary buffer the decoder
+  // copies it into. The copy must stay bounded so an attacker-controlled header
+  // cannot overflow the stack buffer. The leading whitespace parses to 0, so this
+  // is a complete message once the copy is capped.
+  const std::string SIP_LONG_CONTENT_LENGTH =
+      "ACK sip:User.0000@tas01.defult.svc.cluster.local SIP/2.0\x0d\x0a"
+      "Call-ID: 1-3193@11.0.0.10\x0d\x0a"
+      "Via: SIP/2.0/TCP 11.0.0.10:15060;branch=z9hG4bK-3193-1-0\x0d\x0a"
+      "To: <sip:User.0000@tas01.defult.svc.cluster.local>\x0d\x0a"
+      "From: <sip:User.0001@tas01.defult.svc.cluster.local>;tag=1\x0d\x0a"
+      "Route: <sip:+16959000000:15306;role=anch;lr;transport=udp>\x0d\x0a"
+      "CSeq: 2 ACK\x0d\x0a"
+      "Contact: <sip:User.0001@11.0.0.10:15060;transport=TCP>;tag=1\x0d\x0a"
+      "Max-Forwards: 70\x0d\x0a"
+      "Content-Length:                    0000000000000000\x0d\x0a"
+      "\x0d\x0a";
+  buffer_.add(SIP_LONG_CONTENT_LENGTH);
+
+  EXPECT_EQ(filter_->onData(buffer_, false), Network::FilterStatus::StopIteration);
+  EXPECT_EQ(1U, store_.counter("test.request").value());
+  EXPECT_EQ(1U, stats_.request_active_.value());
+  EXPECT_EQ(0U, store_.counter("test.response").value());
+}
+
 TEST_F(SipDecoderTest, HeaderTest) {
   StateNameValues stateNameValues_;
   EXPECT_EQ("Done", stateNameValues_.name(State::Done));


### PR DESCRIPTION
ASan in `Decoder::reassemble` on a SIP message with an overlong Content-Length value:

    decoder.cc:121: stack-buffer-overflow
      WRITE of size 26 at 0x... thread T0   <== 'len' (10 bytes)

The value text length is passed straight to `copyOut` as the size for the 10-byte `len[]`. Cap it to the buffer size.
