### PR TITLE
dym: fixed rust sdk's ABI and also added related integration test

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/catch_unwind.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/catch_unwind.rs
@@ -495,13 +495,22 @@ impl<ELF: EnvoyListenerFilter, F: ListenerFilter<ELF>> ListenerFilter<ELF> for C
   fn on_data(
     &mut self,
     envoy_filter: &mut ELF,
+    data_length: usize,
   ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
     self
-      .catch("on_data", |f| f.on_data(envoy_filter))
+      .catch("on_data", |f| f.on_data(envoy_filter, data_length))
       .unwrap_or_else(|_| {
         envoy_filter.close_socket(Some("filter panic"));
         abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
       })
+  }
+
+  // A panic here means we cannot know how many bytes the filter wants: return 0 so the
+  // filter does not receive any data.
+  fn max_read_bytes(&mut self, envoy_filter: &mut ELF) -> usize {
+    self
+      .catch("max_read_bytes", |f| f.max_read_bytes(envoy_filter))
+      .unwrap_or(0)
   }
 
   // Void callbacks: cleanup after the socket is already closed.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3913,6 +3913,7 @@ fn test_catch_unwind_listener_on_data_panic() {
     fn on_data(
       &mut self,
       _envoy_filter: &mut ELF,
+      _data_length: usize,
     ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
       panic!("intentional panic in on_data");
     }
@@ -3925,7 +3926,7 @@ fn test_catch_unwind_listener_on_data_panic() {
   };
   let mut wrapper = CatchUnwind::new(PanicFilter);
 
-  let status = ListenerFilter::on_data(&mut wrapper, &mut envoy_filter);
+  let status = ListenerFilter::on_data(&mut wrapper, &mut envoy_filter, 256);
   assert_eq!(
     status,
     abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -380,9 +380,14 @@ fn test_envoy_dynamic_module_on_listener_filter_callbacks() {
     fn on_data(
       &mut self,
       _envoy_filter: &mut ELF,
+      _data_length: usize,
     ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
       ON_DATA_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
       abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+    }
+
+    fn max_read_bytes(&mut self, _envoy_filter: &mut ELF) -> usize {
+      128
     }
 
     fn on_close(&mut self, _envoy_filter: &mut ELF) {
@@ -403,8 +408,12 @@ fn test_envoy_dynamic_module_on_listener_filter_callbacks() {
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
   );
   assert_eq!(
-    envoy_dynamic_module_on_listener_filter_on_data(std::ptr::null_mut(), filter),
+    envoy_dynamic_module_on_listener_filter_on_data(std::ptr::null_mut(), filter, 0),
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  );
+  assert_eq!(
+    envoy_dynamic_module_on_listener_filter_get_max_read_bytes(std::ptr::null_mut(), filter),
+    128
   );
   envoy_dynamic_module_on_listener_filter_on_close(std::ptr::null_mut(), filter);
   envoy_dynamic_module_on_listener_filter_destroy(filter);

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -75,13 +75,25 @@ pub trait ListenerFilter<ELF: EnvoyListenerFilter> {
 
   /// This is called when data is available to be read from the connection.
   ///
+  /// * `data_length` is the number of bytes available in the buffer for inspection.
+  ///
   /// This must return [`abi::envoy_dynamic_module_type_on_listener_filter_status`] to
   /// indicate the status of the data processing.
   fn on_data(
     &mut self,
     _envoy_filter: &mut ELF,
+    _data_length: usize,
   ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+
+  /// This is called to query the maximum number of bytes the filter wants to inspect from the
+  /// connection. Returning 0 means the filter does not need any data, in which case
+  /// [`ListenerFilter::on_data`] will not be called.
+  ///
+  /// This is called frequently and should be a fast operation.
+  fn max_read_bytes(&mut self, _envoy_filter: &mut ELF) -> usize {
+    0
   }
 
   /// This is called when the listener filter is destroyed for each accepted connection.
@@ -153,8 +165,29 @@ pub trait EnvoyListenerFilter {
   /// Check if the local address has been restored (e.g., by original_dst filter).
   fn is_local_address_restored(&self) -> bool;
 
+  /// Set the remote address (e.g., for proxy protocol parsing).
+  /// Returns true if the address was set successfully.
+  fn set_remote_address(&mut self, address: &str, port: u32, is_ipv6: bool) -> bool;
+
+  /// Restore the local address (e.g., for original destination or proxy protocol).
+  /// Returns true if the address was restored successfully.
+  fn restore_local_address(&mut self, address: &str, port: u32, is_ipv6: bool) -> bool;
+
+  /// Continue the filter chain after returning
+  /// [`abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration`].
+  /// If `success` is false, the connection will be closed.
+  fn continue_filter_chain(&mut self, success: bool);
+
   /// Indicate to Envoy that the original destination address should be used.
   fn use_original_dst(&mut self);
+
+  /// Set a bytes value in filter state with connection life span.
+  /// Returns true if the operation was successful.
+  fn set_filter_state_bytes(&mut self, key: &[u8], value: &[u8]) -> bool;
+
+  /// Get a bytes value from filter state.
+  /// Returns None if the value is not found.
+  fn get_filter_state_bytes<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
 
   /// Set the downstream transport failure reason.
   fn set_downstream_transport_failure_reason(&mut self, reason: &str);
@@ -184,21 +217,36 @@ pub trait EnvoyListenerFilter {
   /// Returns None if SNI is not available.
   fn get_requested_server_name<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
 
+  /// Set the requested server name (SNI) on the connection socket.
+  fn set_requested_server_name(&mut self, name: &str);
+
   /// Get the detected transport protocol (e.g., "tls", "raw_buffer") from the connection socket.
   /// Returns None if the transport protocol is not available.
   fn get_detected_transport_protocol<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
+
+  /// Set the detected transport protocol (e.g., "tls", "raw_buffer") on the connection socket.
+  fn set_detected_transport_protocol(&mut self, protocol: &str);
 
   /// Get the requested application protocols (ALPN) from the connection socket.
   /// Returns an empty vector if no application protocols are available.
   fn get_requested_application_protocols<'a>(&'a self) -> Vec<EnvoyBuffer<'a>>;
 
+  /// Set the requested application protocols (ALPN) on the connection socket.
+  fn set_requested_application_protocols<'a>(&mut self, protocols: &'a [&'a str]);
+
   /// Get the JA3 fingerprint hash from the connection socket.
   /// Returns None if the JA3 hash is not available.
   fn get_ja3_hash<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
 
+  /// Set the JA3 fingerprint hash on the connection socket.
+  fn set_ja3_hash(&mut self, hash: &str);
+
   /// Get the JA4 fingerprint hash from the connection socket.
   /// Returns None if the JA4 hash is not available.
   fn get_ja4_hash<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
+
+  /// Set the JA4 fingerprint hash on the connection socket.
+  fn set_ja4_hash(&mut self, hash: &str);
 
   /// Check if SSL/TLS connection information is available on the socket.
   fn is_ssl(&self) -> bool;
@@ -667,9 +715,66 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     }
   }
 
+  fn set_remote_address(&mut self, address: &str, port: u32, is_ipv6: bool) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_remote_address(
+        self.raw,
+        str_to_module_buffer(address),
+        port,
+        is_ipv6,
+      )
+    }
+  }
+
+  fn restore_local_address(&mut self, address: &str, port: u32, is_ipv6: bool) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_restore_local_address(
+        self.raw,
+        str_to_module_buffer(address),
+        port,
+        is_ipv6,
+      )
+    }
+  }
+
+  fn continue_filter_chain(&mut self, success: bool) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_continue_filter_chain(self.raw, success);
+    }
+  }
+
   fn use_original_dst(&mut self) {
     unsafe {
       abi::envoy_dynamic_module_callback_listener_filter_use_original_dst(self.raw, true);
+    }
+  }
+
+  fn set_filter_state_bytes(&mut self, key: &[u8], value: &[u8]) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_filter_state(
+        self.raw,
+        crate::bytes_to_module_buffer(key),
+        crate::bytes_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn get_filter_state_bytes(&self, key: &[u8]) -> Option<EnvoyBuffer<'_>> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_get_filter_state(
+        self.raw,
+        crate::bytes_to_module_buffer(key),
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
     }
   }
 
@@ -771,6 +876,15 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     }
   }
 
+  fn set_requested_server_name(&mut self, name: &str) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_requested_server_name(
+        self.raw,
+        str_to_module_buffer(name),
+      );
+    }
+  }
+
   fn get_detected_transport_protocol(&self) -> Option<EnvoyBuffer<'_>> {
     let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
       ptr: std::ptr::null(),
@@ -786,6 +900,15 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
     } else {
       None
+    }
+  }
+
+  fn set_detected_transport_protocol(&mut self, protocol: &str) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_detected_transport_protocol(
+        self.raw,
+        str_to_module_buffer(protocol),
+      );
     }
   }
 
@@ -829,6 +952,18 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       .collect()
   }
 
+  fn set_requested_application_protocols<'a>(&mut self, protocols: &'a [&'a str]) {
+    let mut protocol_buffers: Vec<abi::envoy_dynamic_module_type_module_buffer> =
+      protocols.iter().map(|p| str_to_module_buffer(p)).collect();
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_requested_application_protocols(
+        self.raw,
+        protocol_buffers.as_mut_ptr(),
+        protocol_buffers.len(),
+      );
+    }
+  }
+
   fn get_ja3_hash(&self) -> Option<EnvoyBuffer<'_>> {
     let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
       ptr: std::ptr::null(),
@@ -847,6 +982,15 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     }
   }
 
+  fn set_ja3_hash(&mut self, hash: &str) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_ja3_hash(
+        self.raw,
+        str_to_module_buffer(hash),
+      );
+    }
+  }
+
   fn get_ja4_hash(&self) -> Option<EnvoyBuffer<'_>> {
     let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
       ptr: std::ptr::null(),
@@ -862,6 +1006,15 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
     } else {
       None
+    }
+  }
+
+  fn set_ja4_hash(&mut self, hash: &str) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_ja4_hash(
+        self.raw,
+        str_to_module_buffer(hash),
+      );
     }
   }
 
@@ -1306,15 +1459,35 @@ pub extern "C" fn envoy_dynamic_module_on_listener_filter_on_accept(
 pub extern "C" fn envoy_dynamic_module_on_listener_filter_on_data(
   envoy_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
   filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
+  data_length: usize,
 ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
     let filter = unsafe { &mut *filter };
-    filter.on_data(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+    filter.on_data(&mut EnvoyListenerFilterImpl::new(envoy_ptr), data_length)
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic("envoy_dynamic_module_on_listener_filter_on_data", panic);
     abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
+  })
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_on_listener_filter_get_max_read_bytes(
+  envoy_ptr: abi::envoy_dynamic_module_type_listener_filter_envoy_ptr,
+  filter_ptr: abi::envoy_dynamic_module_type_listener_filter_module_ptr,
+) -> usize {
+  catch_unwind(AssertUnwindSafe(|| {
+    let filter = filter_ptr as *mut Box<dyn ListenerFilter<EnvoyListenerFilterImpl>>;
+    let filter = unsafe { &mut *filter };
+    filter.max_read_bytes(&mut EnvoyListenerFilterImpl::new(envoy_ptr))
+  }))
+  .unwrap_or_else(|panic| {
+    crate::log_ffi_panic(
+      "envoy_dynamic_module_on_listener_filter_get_max_read_bytes",
+      panic,
+    );
+    0
   })
 }
 

--- a/test/extensions/dynamic_modules/listener/BUILD
+++ b/test/extensions/dynamic_modules/listener/BUILD
@@ -79,6 +79,7 @@ envoy_cc_test(
     data = [
         "//test/extensions/dynamic_modules/test_data/cpp:listener_integration_test",
         "//test/extensions/dynamic_modules/test_data/go:listener_integration_test",
+        "//test/extensions/dynamic_modules/test_data/rust:listener_integration_test",
     ],
     env = {"GODEBUG": "cgocheck=0"},
     rbe_pool = "6gig",

--- a/test/extensions/dynamic_modules/listener/integration_test.cc
+++ b/test/extensions/dynamic_modules/listener/integration_test.cc
@@ -48,9 +48,9 @@ protected:
 };
 
 #ifndef __SANITIZE_ADDRESS__
-auto DynamicModulesListenerSdkIntegrationTestValues = testing::Values("go", "cpp");
+auto DynamicModulesListenerSdkIntegrationTestValues = testing::Values("rust", "go", "cpp");
 #else
-auto DynamicModulesListenerSdkIntegrationTestValues = testing::Values("go");
+auto DynamicModulesListenerSdkIntegrationTestValues = testing::Values("rust", "go");
 #endif
 
 INSTANTIATE_TEST_SUITE_P(SdkLanguages, DynamicModulesListenerSdkIntegrationTest,

--- a/test/extensions/dynamic_modules/test_data/rust/BUILD
+++ b/test/extensions/dynamic_modules/test_data/rust/BUILD
@@ -8,6 +8,7 @@ package(default_visibility = [
     "//test/extensions/dynamic_modules:__pkg__",
     "//test/extensions/dynamic_modules/bootstrap:__pkg__",
     "//test/extensions/dynamic_modules/http:__pkg__",
+    "//test/extensions/dynamic_modules/listener:__pkg__",
     "//test/extensions/dynamic_modules/network:__pkg__",
     "//test/extensions/upstreams/http/dynamic_modules:__pkg__",
 ])
@@ -53,6 +54,8 @@ test_program(name = "bootstrap_cluster_lifecycle_test")
 test_program(name = "bootstrap_listener_lifecycle_test")
 
 test_program(name = "network_integration_test")
+
+test_program(name = "listener_integration_test")
 
 test_program(name = "bootstrap_http_combined_test")
 

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -1,0 +1,95 @@
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+
+declare_listener_filter_init_functions!(init, new_listener_filter_config_fn);
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::ProgramInitFunction`] signature.
+fn init() -> bool {
+  true
+}
+
+/// This implements the [`envoy_proxy_dynamic_modules_rust_sdk::NewListenerFilterConfigFunction`]
+/// signature.
+fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListenerFilter>(
+  _envoy_filter_config: &mut EC,
+  name: &str,
+  _config: &[u8],
+) -> Option<Box<dyn ListenerFilterConfig<ELF>>> {
+  match name {
+    "write_to_socket" => Some(Box::new(WriteToSocketFilterConfig)),
+    "buffer_read" => Some(Box::new(BufferReadFilterConfig)),
+    _ => panic!("unknown filter name: {name}"),
+  }
+}
+
+// =============================================================================
+// Write To Socket Test Filter
+// =============================================================================
+
+// Exercises connection-level callbacks on accept: connection start time, remote/local
+// addresses, and the requested server name / detected transport protocol setters.
+struct WriteToSocketFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for WriteToSocketFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(WriteToSocketFilter)
+  }
+}
+
+struct WriteToSocketFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for WriteToSocketFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    assert!(envoy_filter.get_connection_start_time_ms() > 0);
+    assert!(envoy_filter.get_remote_address().is_some());
+    assert!(envoy_filter.get_local_address().is_some());
+    envoy_filter.set_requested_server_name("sdk.listener.test");
+    envoy_filter.set_detected_transport_protocol("sdk_listener");
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+}
+
+// =============================================================================
+// Buffer Read Test Filter
+// =============================================================================
+
+// Stops iteration on accept and waits for data, then inspects the buffered bytes via
+// get_buffer_chunk and verifies the configured max read bytes.
+struct BufferReadFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for BufferReadFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(BufferReadFilter)
+  }
+}
+
+struct BufferReadFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for BufferReadFilter {
+  fn on_accept(
+    &mut self,
+    _envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
+  }
+
+  fn on_data(
+    &mut self,
+    envoy_filter: &mut ELF,
+    data_length: usize,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    assert!(data_length >= 4);
+    let chunk = envoy_filter
+      .get_buffer_chunk()
+      .expect("expected buffer chunk");
+    assert_eq!(&chunk.as_slice()[..4], b"ping");
+    assert_eq!(envoy_filter.max_read_bytes(), 4);
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+
+  fn max_read_bytes(&mut self, _envoy_filter: &mut ELF) -> usize {
+    4
+  }
+}


### PR DESCRIPTION
Commit Message: dym: fixed rust sdk's ABI and also added related integration test
Additional Description:

In the previous implementation, the Rust SDK lost an ABI (`envoy_dynamic_module_on_listener_filter_get_max_read_bytes`) and has an error at `envoy_dynamic_module_on_listener_filter_on_data` ABI.

At same time, the are lots of host callbacks are not exposed to the SDK. This PR addressed these problems and added a new  integration test to ensure the Rust SDK's basic features works correctly.

Risk Level: low. DYM SDK only change.
Testing: unit/integration.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.