### PR TITLE
upstream: support logging downstream listener metadata in upstream ne…

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -18,3 +18,6 @@ new_features:
     Added ``close_stream_to_ext_proc_server`` to :ref:`ProcessingResponse
     <envoy_v3_api_msg_service.network_ext_proc.v3.ProcessingResponse>` to allow the external processor to request
     closing the gRPC stream early, causing subsequent data to bypass the network ``ext_proc`` filter.
+- area: upstream
+  change: |
+    Added support for upstream network filters to log downstream listener metadata using the substitution format string ``%METADATA(LISTENER:...)%``.

--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -85,6 +85,8 @@ public:
     bool can_send_early_data_;
     // True if the request can be sent over HTTP/3.
     bool can_use_http3_;
+    // The downstream listener info, if any.
+    std::shared_ptr<const Network::ListenerInfo> listener_info_;
   };
 
   ~Instance() override = default;

--- a/envoy/network/socket.h
+++ b/envoy/network/socket.h
@@ -302,6 +302,11 @@ public:
    * @return the listener info backing this socket.
    */
   virtual OptRef<const ListenerInfo> listenerInfo() const PURE;
+
+  /**
+   * @return the listener info backing this socket as a shared_ptr.
+   */
+  virtual std::shared_ptr<const ListenerInfo> listenerInfoConstSharedPtr() const PURE;
 };
 
 class ConnectionInfoSetter : public ConnectionInfoProvider {

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -676,6 +676,9 @@ public:
   OptRef<const Network::ListenerInfo> listenerInfo() const override {
     return StreamInfoImpl::downstreamAddressProvider().listenerInfo();
   }
+  std::shared_ptr<const Network::ListenerInfo> listenerInfoConstSharedPtr() const override {
+    return StreamInfoImpl::downstreamAddressProvider().listenerInfoConstSharedPtr();
+  }
 
 private:
   Network::Address::InstanceConstSharedPtr overridden_downstream_remote_address_;

--- a/source/common/network/socket_impl.h
+++ b/source/common/network/socket_impl.h
@@ -100,6 +100,9 @@ public:
   OptRef<const ListenerInfo> listenerInfo() const override {
     return makeOptRefFromPtr<const ListenerInfo>(listener_info_.get());
   }
+  std::shared_ptr<const ListenerInfo> listenerInfoConstSharedPtr() const override {
+    return listener_info_;
+  }
   void setListenerInfo(ListenerInfoConstSharedPtr listener_info) override {
     listener_info_ = std::move(listener_info);
   }

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -89,7 +89,12 @@ UpstreamRequest::UpstreamRequest(RouterFilterInterface& parent,
                    StreamInfo::FilterState::LifeSpan::FilterChain),
       start_time_(parent_.callbacks()->dispatcher().timeSource().monotonicTime()),
       record_timeout_budget_(parent_.cluster()->timeoutBudgetStats().has_value()),
-      stream_options_({can_send_early_data, can_use_http3}), enable_half_close_(enable_half_close) {
+      stream_options_({can_send_early_data, can_use_http3,
+                       parent_.callbacks()
+                           ->streamInfo()
+                           .downstreamAddressProvider()
+                           .listenerInfoConstSharedPtr()}),
+      enable_half_close_(enable_half_close) {
   // Get tracing config once and reuse it.
   auto tracing_config = parent_.callbacks()->tracingConfig();
 

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -358,6 +358,11 @@ void TcpConnPool::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data
               connection_id, downstream_info_.downstreamAddressProvider().connectionID().value());
   }
 
+  if (downstream_info_.downstreamAddressProvider().listenerInfo()) {
+    conn_data->connection().connectionInfoSetter().setListenerInfo(
+        downstream_info_.downstreamAddressProvider().listenerInfoConstSharedPtr());
+  }
+
   upstream_handle_ = nullptr;
   Tcp::ConnectionPool::ConnectionData* latched_data = conn_data.get();
   Network::Connection& connection = conn_data->connection();

--- a/source/extensions/formatter/metadata/BUILD
+++ b/source/extensions/formatter/metadata/BUILD
@@ -13,6 +13,9 @@ envoy_cc_library(
     name = "metadata_lib",
     srcs = ["metadata.cc"],
     hdrs = ["metadata.h"],
+    visibility = [
+        "//test/integration:__subpackages__",
+    ],
     deps = [
         "//source/common/formatter:formatter_extension_lib",
         "//source/common/formatter:substitution_formatter_lib",
@@ -24,6 +27,9 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    extra_visibility = [
+        "//test/integration:__subpackages__",
+    ],
     deps = [
         "//envoy/registry",
         "//source/extensions/formatter/metadata:metadata_lib",

--- a/source/extensions/upstreams/http/http/upstream_request.cc
+++ b/source/extensions/upstreams/http/http/upstream_request.cc
@@ -62,6 +62,21 @@ void HttpConnPool::onPoolReady(Envoy::Http::RequestEncoder& request_encoder,
   conn_pool_stream_handle_ = nullptr;
   auto upstream =
       std::make_unique<HttpUpstream>(callbacks_->upstreamToDownstream(), &request_encoder);
+
+  if (callbacks_->upstreamToDownstream().connection().has_value()) {
+    auto listener_info = callbacks_->upstreamToDownstream()
+                             .connection()
+                             ->connectionInfoProvider()
+                             .listenerInfoConstSharedPtr();
+    if (listener_info) {
+      if (auto* setter = const_cast<Network::ConnectionInfoSetter*>(
+              dynamic_cast<const Network::ConnectionInfoSetter*>(
+                  &request_encoder.getStream().connectionInfoProvider()))) {
+        setter->setListenerInfo(listener_info);
+      }
+    }
+  }
+
   callbacks_->onPoolReady(std::move(upstream), host,
                           request_encoder.getStream().connectionInfoProvider(), info, protocol);
 }

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -778,10 +778,13 @@ envoy_cc_test(
     deps = [
         ":http_integration_lib",
         "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/formatter/metadata:config",
+        "//source/extensions/formatter/metadata:metadata_lib",
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/integration/filters:test_network_filter_lib",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",
         "@envoy_api//envoy/service/extension/v3:pkg_cc_proto",

--- a/test/integration/upstream_network_filter_integration_test.cc
+++ b/test/integration/upstream_network_filter_integration_test.cc
@@ -1,11 +1,16 @@
 #include "envoy/access_log/access_log.h"
+#include "envoy/config/core/v3/substitution_format_string.pb.h"
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 #include "envoy/service/extension/v3/config_discovery.pb.h"
 
+#include "source/common/formatter/substitution_format_string.h"
+#include "source/extensions/formatter/metadata/metadata.h"
+
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/integration/filters/test_network_filter.pb.h"
+#include "test/integration/http_integration.h"
 #include "test/integration/integration.h"
 #include "test/test_common/registry.h"
 #include "test/test_common/utility.h"
@@ -693,11 +698,15 @@ TEST_P(UpstreamNetworkExtensionDiscoveryIntegrationTest,
 
 class TestAccessLogFilterAndLogger : public Network::ReadFilter, public AccessLog::Instance {
 public:
-  TestAccessLogFilterAndLogger(Stats::Scope& scope) : scope_(scope) {}
+  TestAccessLogFilterAndLogger(Stats::Scope& scope, std::shared_ptr<Formatter::Formatter> formatter)
+      : scope_(scope), formatter_(std::move(formatter)) {}
 
   // AccessLog::Instance
-  void log(const AccessLog::LogContext&, const StreamInfo::StreamInfo&) override {
+  void log(const AccessLog::LogContext&, const StreamInfo::StreamInfo& stream_info) override {
     ENVOY_LOG_MISC(error, "TestAccessLogger::log called");
+    if (formatter_->format(Formatter::Context{}, stream_info) == "test_value") {
+      scope_.counterFromString("test_access_log_filter.listener_metadata_found").inc();
+    }
     scope_.counterFromString("test_access_log_filter.log_called").inc();
   }
 
@@ -713,17 +722,45 @@ public:
   void initializeReadFilterCallbacks(Network::ReadFilterCallbacks&) override {}
 
   Stats::Scope& scope_;
+  std::shared_ptr<Formatter::Formatter> formatter_;
 };
 
 class TestAccessLogFilterConfigFactory
     : public Server::Configuration::NamedUpstreamNetworkFilterConfigFactory {
 public:
+  class UpstreamGenericFactoryContext : public Server::Configuration::GenericFactoryContext {
+  public:
+    UpstreamGenericFactoryContext(Server::Configuration::UpstreamFactoryContext& context)
+        : context_(context) {}
+    Server::Configuration::ServerFactoryContext& serverFactoryContext() override {
+      return context_.serverFactoryContext();
+    }
+    ProtobufMessage::ValidationVisitor& messageValidationVisitor() override {
+      return context_.serverFactoryContext().messageValidationVisitor();
+    }
+    Init::Manager& initManager() override { return context_.initManager(); }
+    Stats::Scope& scope() override { return context_.scope(); }
+
+  private:
+    Server::Configuration::UpstreamFactoryContext& context_;
+  };
+
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message&,
                                Server::Configuration::UpstreamFactoryContext& context) override {
     Stats::Scope& scope = context.serverFactoryContext().scope();
-    return [&scope](Network::FilterManager& filter_manager) {
-      auto filter = std::make_shared<TestAccessLogFilterAndLogger>(scope);
+
+    envoy::config::core::v3::SubstitutionFormatString format;
+    format.mutable_text_format_source()->set_inline_string(
+        "%METADATA(LISTENER:test_key:test_value_key)%");
+    UpstreamGenericFactoryContext generic_context(context);
+    auto formatter =
+        Formatter::SubstitutionFormatStringUtils::fromProtoConfig(format, generic_context).value();
+
+    std::shared_ptr<Formatter::Formatter> shared_formatter = std::move(formatter);
+
+    return [&scope, shared_formatter](Network::FilterManager& filter_manager) {
+      auto filter = std::make_shared<TestAccessLogFilterAndLogger>(scope, shared_formatter);
       filter_manager.addReadFilter(filter);
       filter_manager.addAccessLogHandler(filter);
     };
@@ -758,6 +795,12 @@ public:
     // Setup generic tcp proxy downstream
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+
+      envoy::config::core::v3::Metadata metadata;
+      Envoy::Config::Metadata::mutableMetadataValue(metadata, "test_key", "test_value_key")
+          .set_string_value("test_value");
+      listener->mutable_metadata()->MergeFrom(metadata);
+
       auto* filter_chain = listener->add_filter_chains();
       auto* filter = filter_chain->add_filters();
       filter->set_name("envoy.filters.network.tcp_proxy");
@@ -775,6 +818,7 @@ public:
     test_server_->waitForCounter("test_access_log_filter.on_new_connection", Ge(1));
     test_server_->waitForCounter("cluster.cluster_0.upstream_cx_destroy", Ge(1));
     test_server_->waitForCounter("test_access_log_filter.log_called", Ge(1));
+    test_server_->waitForCounter("test_access_log_filter.listener_metadata_found", Ge(1));
   }
 };
 
@@ -787,6 +831,62 @@ TEST_F(UpstreamNetworkFilterAccessLogIntegrationTest, LogCalled) {
   sendDataVerifyResults(0);
 
   verifyLog();
+}
+
+class HttpUpstreamNetworkFilterAccessLogIntegrationTest
+    : public testing::TestWithParam<Network::Address::IpVersion>,
+      public HttpIntegrationTest {
+public:
+  HttpUpstreamNetworkFilterAccessLogIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void initialize() override {
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+      auto* filter = cluster->add_filters();
+      filter->set_name("envoy.test.access_log_filter_custom");
+      test::integration::filters::TestNetworkFilterConfig config;
+      filter->mutable_typed_config()->PackFrom(config);
+    });
+
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+      envoy::config::core::v3::Metadata metadata;
+      Envoy::Config::Metadata::mutableMetadataValue(metadata, "test_key", "test_value_key")
+          .set_string_value("test_value");
+      listener->mutable_metadata()->MergeFrom(metadata);
+    });
+
+    HttpIntegrationTest::initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, HttpUpstreamNetworkFilterAccessLogIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(HttpUpstreamNetworkFilterAccessLogIntegrationTest, LogCalled) {
+  TestAccessLogFilterConfigFactory factory;
+  Registry::InjectFactory<Server::Configuration::NamedUpstreamNetworkFilterConfigFactory>
+      register_factory(factory);
+
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Verify log
+  test_server_->waitForCounter("test_access_log_filter.on_new_connection", Ge(1));
+  codec_client_->close();
+  ASSERT_TRUE(fake_upstream_connection_->close());
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  test_server_->waitForCounter("cluster.cluster_0.upstream_cx_destroy", Ge(1));
+  test_server_->waitForCounter("test_access_log_filter.log_called", Ge(1));
+  test_server_->waitForCounter("test_access_log_filter.listener_metadata_found", Ge(1));
 }
 
 } // namespace

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -799,6 +799,8 @@ public:
               (const, override));
   MOCK_METHOD(Envoy::OptRef<const Envoy::Network::ListenerInfo>, listenerInfo, (),
               (const, override));
+  MOCK_METHOD(std::shared_ptr<const Envoy::Network::ListenerInfo>, listenerInfoConstSharedPtr, (),
+              (const, override));
   MOCK_METHOD(absl::string_view, ja4Hash, (), (const, override));
 };
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -475,6 +475,7 @@ visibility_excludes:
 - source/extensions/filters/network/common/BUILD
 - source/extensions/filters/network/generic_proxy/interface/BUILD
 - source/extensions/formatter/file_content/BUILD
+- source/extensions/formatter/metadata/BUILD
 - source/extensions/http/header_validators/envoy_default/BUILD
 - source/extensions/transport_sockets/common/BUILD
 - source/extensions/transport_sockets/tap/BUILD


### PR DESCRIPTION




Commit Message: This change extends HTTP/TCP conn pool and connection providers to propagate downstream listener info to upstream connections, allowing upstream network filters to log downstream listener metadata (e.g., %METADATA(LISTENER:...)%).
Additional Description: NA
Risk Level: lo
Testing: done
Docs Changes: NA
Release Notes: done
Platform Specific Features: No
