### PR TITLE
http: fix null deref in recreateStream when buffered body crosses watermark

### DIFF
--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2507,7 +2507,6 @@ void ConnectionManagerImpl::ActiveStream::recreateStream(
     StreamInfo::FilterStateSharedPtr filter_state) {
   ENVOY_EXECUTION_SCOPE(trackedStream(), active_span_.get());
   ResponseEncoder* response_encoder = response_encoder_;
-  response_encoder_ = nullptr;
 
   Buffer::InstancePtr request_data = std::make_unique<Buffer::OwnedImpl>();
   const auto& buffered_request_data = filter_manager_.bufferedRequestData();
@@ -2515,6 +2514,10 @@ void ConnectionManagerImpl::ActiveStream::recreateStream(
   if (proxy_body) {
     request_data->move(*buffered_request_data);
   }
+
+  // Null after move(): draining the WatermarkBuffer may synchronously fire
+  // onDecoderFilterBelowWriteBufferLowWatermark which needs a valid encoder.
+  response_encoder_ = nullptr;
 
   response_encoder->getStream().removeCallbacks(*this);
 

--- a/test/common/http/conn_manager_impl_test_3.cc
+++ b/test/common/http/conn_manager_impl_test_3.cc
@@ -445,6 +445,49 @@ TEST_F(HttpConnectionManagerImplTest, CannotContinueEncodingAfterRecreateStream)
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
+// Verify that recreateStream() does not crash when the buffered request body was above the high
+// watermark. Moving the buffer triggers readDisable(false) via the low watermark callback.
+TEST_F(HttpConnectionManagerImplTest, RecreateStreamWithWatermarkedBufferDoesNotCrash) {
+  setup();
+  decoder_filters_.push_back(new NiceMock<MockStreamDecoderFilter>());
+
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([this](FilterChainFactoryCallbacks& callbacks) -> bool {
+        callbacks.setFilterConfigName("");
+        bool applied_filters = false;
+        if (log_handler_ != nullptr) {
+          auto factory = createLogHandlerFactoryCb(log_handler_);
+          factory(callbacks);
+          applied_filters = true;
+        }
+        auto factory =
+            createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{decoder_filters_[0]});
+        factory(callbacks);
+        applied_filters = true;
+        return applied_filters;
+      }))
+      .WillOnce(Return(true));
+
+  EXPECT_CALL(response_encoder_.stream_, bufferLimit()).WillRepeatedly(Return(1));
+
+  EXPECT_CALL(*decoder_filters_[0], decodeHeaders(_, true))
+      .WillOnce(InvokeWithoutArgs([this]() -> FilterHeadersStatus {
+        Buffer::OwnedImpl data("hello");
+        decoder_filters_[0]->callbacks_->addDecodedData(data, /*streaming=*/true);
+        return FilterHeadersStatus::StopIteration;
+      }));
+
+  EXPECT_CALL(response_encoder_.stream_, readDisable(true));
+
+  startRequest(true);
+
+  EXPECT_CALL(response_encoder_.stream_, readDisable(false));
+
+  EXPECT_TRUE(decoder_filters_[0]->callbacks_->recreateStream(nullptr));
+
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+}
+
 // Use filter direct decode/encodeData() calls without trailers.
 TEST_F(HttpConnectionManagerImplTest, FilterDirectDecodeEncodeDataNoTrailers) {
   setup();


### PR DESCRIPTION
## Description

`recreateStream()` sets `response_encoder_ = nullptr` before moving the buffered request body. If the buffer was above the high watermark, `move()` drains it past the low watermark and synchronously fires `onDecoderFilterBelowWriteBufferLowWatermark()`, which dereferences the now-null `response_encoder_`. Crash.

Fix: move the null assignment to after `move()`. The watermark callback sees a valid pointer during drain. The null still happens before `doEndStream()`, so the invariant that prevents codec stream reset is preserved.

## How to trigger

1. `custom_response` filter with `RedirectPolicy` configured
2. Request body exceeds `per_request_buffer_limit_bytes` (~1MB default)
3. 413 local reply in non-streaming mode
4. `RedirectPolicy::encodeHeaders` calls `recreateStream()`
5. Buffer drain → watermark callback → null deref

## Risk level

Low. One assignment moved, no behavioral change outside the brief watermark callback window.

## Testing

Added `RecreateStreamWithWatermarkedBufferDoesNotCrash` — buffers data above high watermark, calls `recreateStream()`, expects `readDisable(false)` without crashing.