### PR TITLE
basic auth: use constant-time comparison for password hash

### DIFF
--- a/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
+++ b/source/extensions/filters/http/basic_auth/basic_auth_filter.cc
@@ -9,6 +9,8 @@
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 
+#include "openssl/mem.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -101,7 +103,12 @@ bool BasicAuthFilter::validateUser(const UserMap& users, absl::string_view usern
     return false;
   }
 
-  return computeSHA1(password) == user->second.hash;
+  const std::string computed = computeSHA1(password);
+  const std::string& expected = user->second.hash;
+  if (computed.length() != expected.length()) {
+    return false;
+  }
+  return CRYPTO_memcmp(computed.data(), expected.data(), computed.length()) == 0;
 }
 
 Http::FilterHeadersStatus BasicAuthFilter::onDenied(absl::string_view body,


### PR DESCRIPTION
validateUser compares the sha1 of the client password against the stored htpasswd hash with std::string ==, which is a plain memcmp that returns on the first differing byte. Both sides are always 28-byte base64 sha1, so the length never varies and the only timing signal is how many leading bytes match, which leaks the stored digest. Switch to CRYPTO_memcmp like the oauth2 and jwt verifiers already do.