### PR TITLE
build: centralize LLVM version in bazel/toolchains.bzl

### DIFF
--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -2,6 +2,11 @@ load("@envoy_repo//:compiler.bzl", "LLVM_PATH", "USE_LOCAL_SYSROOT")
 load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
+LLVM_VERSION = "18.1.8"
+LLVM_MAJOR = LLVM_VERSION.split(".")[0]
+LLVM_MAJOR_MINOR = ".".join(LLVM_VERSION.split(".")[:2])
+LIBCLANG_CPP = "@llvm_toolchain_llvm//:lib/libclang-cpp.so." + LLVM_MAJOR_MINOR
+
 def envoy_toolchains():
     native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/gcc/config:cc-toolchain")
     arch_alias(
@@ -13,7 +18,7 @@ def envoy_toolchains():
     )
     llvm_toolchain(
         name = "llvm_toolchain",
-        llvm_version = "18.1.8",
+        llvm_version = LLVM_VERSION,
         # These libs are only included for cross-compile targets
         cxx_cross_lib = {
             "linux-aarch64": "@libcxx_libs_aarch64",

--- a/compat/openssl/BUILD
+++ b/compat/openssl/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:toolchains.bzl", "LIBCLANG_CPP")
 load("//compat/openssl:bazel/rules.bzl", "mapping_func_filegroup", "patched_bssl_filegroup")
 
 licenses(["notice"])  # Apache 2
@@ -174,7 +175,7 @@ genrule(
         done
 
         # Set up LD_LIBRARY_PATH for libclang-cpp.so
-        LLVM_LIB_DIR=$$(dirname $(location @llvm_toolchain_llvm//:lib/libclang-cpp.so.18.1))
+        LLVM_LIB_DIR=$$(dirname $(location """ + LIBCLANG_CPP + """))
         export LD_LIBRARY_PATH="$$LLVM_LIB_DIR$${LD_LIBRARY_PATH:+:$$LD_LIBRARY_PATH}"
 
         # Run the prefixer with absolute source path and relative output path
@@ -189,7 +190,7 @@ genrule(
     """,
     tools = [
         "//compat/openssl/prefixer",
-        "@llvm_toolchain_llvm//:lib/libclang-cpp.so.18.1",
+        LIBCLANG_CPP,
     ],
     visibility = ["//visibility:private"],
 )

--- a/compat/openssl/prefixer/BUILD
+++ b/compat/openssl/prefixer/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//bazel:toolchains.bzl", "LIBCLANG_CPP")
 
 licenses(["notice"])  # Apache 2
 
@@ -12,7 +13,7 @@ cc_binary(
     name = "prefixer",
     srcs = ["prefixer.cpp"],
     additional_linker_inputs = [
-        "@llvm_toolchain_llvm//:lib/libclang-cpp.so.18.1",
+        LIBCLANG_CPP,
     ],
     copts = [
         "-fno-rtti",  # Required by libclang-cpp
@@ -24,8 +25,7 @@ cc_binary(
         "-isystem external/sysroot_linux_amd64/usr/include/x86_64-linux-gnu/c++/13",
     ],
     linkopts = [
-        # Directly link to the versioned shared library
-        "$(location @llvm_toolchain_llvm//:lib/libclang-cpp.so.18.1)",
+        "$(location " + LIBCLANG_CPP + ")",
         "-Wl,-rpath,$$ORIGIN/../lib",
         # Use libstdc++ for ABI compatibility with libclang-cpp
         "-stdlib=libstdc++",

--- a/source/extensions/dynamic_modules/sdk/rust/BUILD
+++ b/source/extensions/dynamic_modules/sdk/rust/BUILD
@@ -6,6 +6,7 @@ load(
     "//bazel:envoy_build_system.bzl",
     "envoy_extension_package",
 )
+load("//bazel:toolchains.bzl", "LLVM_MAJOR")
 
 licenses(["notice"])  # Apache 2
 
@@ -20,8 +21,8 @@ cargo_build_script(
         "@envoy_repo//:use_local_llvm": {
             "LIBCLANG_PATH": "%s/lib/libclang.so" % LLVM_PATH,
             "BINDGEN_EXTRA_CLANG_ARGS": " ".join([
-                "-resource-dir %s/lib/clang/18" % LLVM_PATH,
-                "-isystem %s/lib/clang/18/include" % LLVM_PATH,
+                "-resource-dir %s/lib/clang/%s" % (LLVM_PATH, LLVM_MAJOR),
+                "-isystem %s/lib/clang/%s/include" % (LLVM_PATH, LLVM_MAJOR),
                 "-isystem %s/include/x86_64-unknown-linux-gnu/c++/v1/" % LLVM_PATH,
                 "-isystem %s/include/aarch64-unknown-linux-gnu/c++/v1/" % LLVM_PATH,
             ]),
@@ -29,8 +30,8 @@ cargo_build_script(
         "@platforms//os:linux": {
             "LIBCLANG_PATH": "$(location @llvm_toolchain_llvm//:lib/libclang.so)",
             "BINDGEN_EXTRA_CLANG_ARGS": " ".join([
-                "-resource-dir $${pwd}/external/llvm_toolchain_llvm/lib/clang/18",
-                "-isystem $${pwd}/external/llvm_toolchain_llvm/lib_legacy/clang/18/include",
+                "-resource-dir $${pwd}/external/llvm_toolchain_llvm/lib/clang/" + LLVM_MAJOR,
+                "-isystem $${pwd}/external/llvm_toolchain_llvm/lib_legacy/clang/" + LLVM_MAJOR + "/include",
                 "-isystem $${pwd}/external/llvm_toolchain_llvm/include/x86_64-unknown-linux-gnu/c++/v1/",
                 "-isystem $${pwd}/external/llvm_toolchain_llvm/include/aarch64-unknown-linux-gnu/c++/v1/",
                 # This allows the cross-compilation of the SDK to succeed by providing the necessary system headers for the target platform.

--- a/test/fuzz/BUILD
+++ b/test/fuzz/BUILD
@@ -11,6 +11,7 @@ load(
     "envoy_proto_library",
     "envoy_select_signal_trace",
 )
+load("//bazel:toolchains.bzl", "LLVM_MAJOR")
 
 licenses(["notice"])  # Apache 2
 
@@ -26,9 +27,9 @@ exports_files(["headers.dict"])
 
 cc_library(
     name = "fuzzed_data_provider",
-    hdrs = ["@llvm_toolchain_llvm//:lib/clang/18/include/fuzzer/FuzzedDataProvider.h"],
+    hdrs = ["@llvm_toolchain_llvm//:lib/clang/" + LLVM_MAJOR + "/include/fuzzer/FuzzedDataProvider.h"],
     include_prefix = "",
-    strip_include_prefix = "/lib/clang/18/include",
+    strip_include_prefix = "/lib/clang/" + LLVM_MAJOR + "/include",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Extract LLVM version constants (LLVM_VERSION, LLVM_MAJOR, LLVM_MAJOR_MINOR, LIBCLANG_CPP) into `bazel/toolchains.bzl` so that bumping LLVM only requires a single-line change instead of updating multiple BUILD files.
