### PR TITLE
build: support local LLVM toolchain for compat/openssl

### DIFF
--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -111,13 +111,13 @@ def _envoy_repo_impl(repository_ctx):
                 if "clang version" in line:
                     llvm_version_local = line.split("clang version ")[1].split(" ")[0].strip()
                     break
-        for d in ["lib64", "lib"]:
-            if repository_ctx.path(llvm_path + "/" + d + "/libclang-cpp.so").exists:
-                llvm_lib_dir = d
+        for directory in ["lib64", "lib"]:
+            if repository_ctx.path(llvm_path + "/" + directory + "/libclang-cpp.so").exists:
+                llvm_lib_dir = directory
                 break
-            entries = repository_ctx.execute(["ls", llvm_path + "/" + d + "/"])
+            entries = repository_ctx.execute(["ls", llvm_path + "/" + directory + "/"])
             if entries.return_code == 0 and "libclang-cpp.so" in entries.stdout:
-                llvm_lib_dir = d
+                llvm_lib_dir = directory
                 break
 
     # By default, even when local toolchain is used, we still use the hermetic

--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -99,6 +99,27 @@ def _envoy_repo_impl(repository_ctx):
     llvm_path = repository_ctx.os.environ.get("BAZEL_LLVM_PATH", "")
     local_llvm = "True" if llvm_path else "False"
 
+    # When using a local LLVM, detect its version and library directory so that
+    # downstream BUILD files can reference the correct libclang-cpp.so and
+    # clang resource-dir paths without hardcoding a version.
+    llvm_version_local = ""
+    llvm_lib_dir = "lib"
+    if llvm_path:
+        result = repository_ctx.execute([llvm_path + "/bin/clang", "--version"])
+        if result.return_code == 0:
+            for line in result.stdout.split("\n"):
+                if "clang version" in line:
+                    llvm_version_local = line.split("clang version ")[1].split(" ")[0].strip()
+                    break
+        for d in ["lib64", "lib"]:
+            if repository_ctx.path(llvm_path + "/" + d + "/libclang-cpp.so").exists:
+                llvm_lib_dir = d
+                break
+            entries = repository_ctx.execute(["ls", llvm_path + "/" + d + "/"])
+            if entries.return_code == 0 and "libclang-cpp.so" in entries.stdout:
+                llvm_lib_dir = d
+                break
+
     # By default, even when local toolchain is used, we still use the hermetic
     # sysroot, when it's undesirable, you can set this environment variable to True
     # to fallback to the host libc.
@@ -114,8 +135,10 @@ def _envoy_repo_impl(repository_ctx):
 
     repository_ctx.file("compiler.bzl", """
 LLVM_PATH = '%s'
+LLVM_VERSION_LOCAL = '%s'
+LLVM_LIB_DIR = '%s'
 USE_LOCAL_SYSROOT = %s
-""" % (llvm_path, local_sysroot))
+""" % (llvm_path, llvm_version_local, llvm_lib_dir, local_sysroot))
     repository_ctx.file("version.bzl", "VERSION = '%s'\nAPI_VERSION = '%s'" % (version, api_version))
     repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
     repository_ctx.file("envoy_repo.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -1,11 +1,53 @@
-load("@envoy_repo//:compiler.bzl", "LLVM_PATH", "USE_LOCAL_SYSROOT")
+load("@envoy_repo//:compiler.bzl", "LLVM_LIB_DIR", "LLVM_PATH", "LLVM_VERSION_LOCAL", "USE_LOCAL_SYSROOT")
 load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
-LLVM_VERSION = "18.1.8"
+_LLVM_VERSION_HERMETIC = "18.1.8"
+LLVM_VERSION = LLVM_VERSION_LOCAL if LLVM_VERSION_LOCAL else _LLVM_VERSION_HERMETIC
 LLVM_MAJOR = LLVM_VERSION.split(".")[0]
 LLVM_MAJOR_MINOR = ".".join(LLVM_VERSION.split(".")[:2])
-LIBCLANG_CPP = "@llvm_toolchain_llvm//:lib/libclang-cpp.so." + LLVM_MAJOR_MINOR
+
+_LLVM_LIB_PREFIX = LLVM_LIB_DIR if LLVM_PATH else "lib"
+LIBCLANG_CPP = "@llvm_toolchain_llvm//:" + _LLVM_LIB_PREFIX + "/libclang-cpp.so." + LLVM_MAJOR_MINOR
+
+# On distro-packaged LLVM, libclang-cpp.so dynamically links against libLLVM.so
+# (they're split). The hermetic LLVM bundles everything into libclang-cpp.so.
+LIBLLVM = ("@llvm_toolchain_llvm//:" + _LLVM_LIB_PREFIX + "/libLLVM.so." + LLVM_MAJOR_MINOR) if LLVM_PATH else None
+
+_LLVM_LOCAL_BUILD = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(
+    [
+        "bin/*",
+        "lib/**",
+        "lib64/**",
+        "include/**",
+    ],
+    allow_empty = True,
+))
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "include/**/c++/**",
+        "lib/clang/*/include/**",
+    ]),
+)
+
+filegroup(
+    name = "all_includes",
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "symbolizer",
+    srcs = glob(["bin/llvm-symbolizer*"]),
+)
+"""
 
 def envoy_toolchains():
     native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/gcc/config:cc-toolchain")
@@ -16,11 +58,18 @@ def envoy_toolchains():
             "aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
         },
     )
+
+    if LLVM_PATH and "llvm_toolchain_llvm" not in native.existing_rules():
+        native.new_local_repository(
+            name = "llvm_toolchain_llvm",
+            path = LLVM_PATH,
+            build_file_content = _LLVM_LOCAL_BUILD,
+        )
+
     llvm_toolchain(
         name = "llvm_toolchain",
         llvm_version = LLVM_VERSION,
-        # These libs are only included for cross-compile targets
-        cxx_cross_lib = {
+        cxx_cross_lib = {} if LLVM_PATH else {
             "linux-aarch64": "@libcxx_libs_aarch64",
             "linux-x86_64": "@libcxx_libs_x86_64",
         },

--- a/compat/openssl/BUILD
+++ b/compat/openssl/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//bazel:toolchains.bzl", "LIBCLANG_CPP")
+load("//bazel:toolchains.bzl", "LIBCLANG_CPP", "LIBLLVM")
 load("//compat/openssl:bazel/rules.bzl", "mapping_func_filegroup", "patched_bssl_filegroup")
 
 licenses(["notice"])  # Apache 2
@@ -191,7 +191,7 @@ genrule(
     tools = [
         "//compat/openssl/prefixer",
         LIBCLANG_CPP,
-    ],
+    ] + ([LIBLLVM] if LIBLLVM else []),
     visibility = ["//visibility:private"],
 )
 

--- a/compat/openssl/prefixer/BUILD
+++ b/compat/openssl/prefixer/BUILD
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("//bazel:toolchains.bzl", "LIBCLANG_CPP")
+load("//bazel:toolchains.bzl", "LIBCLANG_CPP", "LIBLLVM")
 
 licenses(["notice"])  # Apache 2
 
@@ -14,7 +14,7 @@ cc_binary(
     srcs = ["prefixer.cpp"],
     additional_linker_inputs = [
         LIBCLANG_CPP,
-    ],
+    ] + ([LIBLLVM] if LIBLLVM else []),
     copts = [
         "-fno-rtti",  # Required by libclang-cpp
         "-isystem external/llvm_toolchain_llvm/include",
@@ -26,6 +26,7 @@ cc_binary(
     ],
     linkopts = [
         "$(location " + LIBCLANG_CPP + ")",
+    ] + (["$(location " + LIBLLVM + ")"] if LIBLLVM else []) + [
         "-Wl,-rpath,$$ORIGIN/../lib",
         # Use libstdc++ for ABI compatibility with libclang-cpp
         "-stdlib=libstdc++",


### PR DESCRIPTION
When `BAZEL_LLVM_PATH` is set, auto-detect the local LLVM version and library directory (lib vs lib64) so that the correct libclang-cpp.so is referenced. Create llvm_toolchain_llvm as a new_local_repository pointing to the local LLVM installation.

Also link against libLLVM.so when using distro-packaged LLVM, since distros split libclang-cpp.so and libLLVM.so (unlike the hermetic toolchain which bundles everything).
