### PR TITLE
dynamic_modules: add http_set_dynamic_metadata_string_batch ABI callback

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-string-batch.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-string-batch.rst
@@ -1,0 +1,4 @@
+Added ``envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch`` ABI callback that
+sets multiple string-valued dynamic metadata entries under a single namespace in one call,
+resolving the namespace and merging into the metadata struct once instead of once per entry. The
+Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_metadata_string_batch``.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -128,6 +128,18 @@ typedef struct envoy_dynamic_module_type_module_http_header {
 } envoy_dynamic_module_type_module_http_header;
 
 /**
+ * envoy_dynamic_module_type_module_key_value_pair represents a string key-value pair owned by the
+ * module. It is used to set multiple dynamic metadata entries under a single namespace via
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch.
+ */
+typedef struct envoy_dynamic_module_type_module_key_value_pair {
+  envoy_dynamic_module_type_buffer_module_ptr key_ptr;
+  size_t key_length;
+  envoy_dynamic_module_type_buffer_module_ptr value_ptr;
+  size_t value_length;
+} envoy_dynamic_module_type_module_key_value_pair;
+
+/**
  * envoy_dynamic_module_type_envoy_http_header represents a key-value pair of an HTTP header owned
  * by Envoy's HeaderMap.
  */
@@ -1872,6 +1884,26 @@ void envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
     envoy_dynamic_module_type_module_buffer value);
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch is called by the module to
+ * set multiple string-valued dynamic metadata entries under a single namespace in one call. It is
+ * equivalent to calling envoy_dynamic_module_callback_http_set_dynamic_metadata_string once per
+ * entry but resolves the namespace and merges into the metadata struct only once. Existing entries
+ * with the same key are overwritten. Within a single call, a later entry overwrites an earlier
+ * entry with the same key. An empty array is a no-op and does not create the namespace.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param ns is the namespace of the dynamic metadata.
+ * @param entries is the pointer to an array of key-value pairs whose values are set as strings. It
+ * may be null only when entries_size is zero.
+ * @param entries_size is the number of entries in the array.
+ */
+void envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size);
 
 /**
  * envoy_dynamic_module_callback_http_get_metadata_string is called by the module to get

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -3674,6 +3674,13 @@ __attribute__((weak)) void envoy_dynamic_module_callback_http_set_dynamic_metada
                "this context");
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    const envoy_dynamic_module_type_module_key_value_pair*, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch: not "
+               "implemented in this context");
+}
+
 __attribute__((weak)) bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_metadata_source,
     envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer,

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -896,6 +896,18 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
+  ///
+  /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
+  /// namespace and merges into the metadata struct only once. Existing entries with the same key
+  /// are overwritten. Within `entries`, a later entry overwrites an earlier one with the same key.
+  /// An empty `entries` is a no-op and does not create the namespace.
+  fn set_dynamic_metadata_string_batch<'a>(
+    &mut self,
+    namespace: &'a str,
+    entries: &'a [(&'a str, &'a str)],
+  );
+
   /// Get the bool-typed metadata value with the given key.
   /// Use the `source` parameter to specify which metadata to use.
   /// If the metadata is not found or is the wrong type, this returns `None`.
@@ -2332,6 +2344,30 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),
         str_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_string_batch(&mut self, namespace: &str, entries: &[(&str, &str)]) {
+    // `pairs` borrows the key/value bytes of `entries`, which outlive this call. Envoy copies the
+    // bytes into the metadata Struct synchronously, so the pointers never dangle. An empty
+    // `entries` yields an empty Vec paired with a zero length the callback treats as a no-op.
+    let mut pairs: Vec<abi::envoy_dynamic_module_type_module_key_value_pair> =
+      Vec::with_capacity(entries.len());
+    for (key, value) in entries {
+      pairs.push(abi::envoy_dynamic_module_type_module_key_value_pair {
+        key_ptr: key.as_ptr() as *const _,
+        key_length: key.len(),
+        value_ptr: value.as_ptr() as *const _,
+        value_length: value.len(),
+      });
+    }
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+        self.raw_ptr,
+        str_to_module_buffer(namespace),
+        pairs.as_ptr(),
+        pairs.len(),
       )
     }
   }

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1017,6 +1017,32 @@ void envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
   metadata_namespace->MergeFrom(metadata_value);
 }
 
+void envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size) {
+  if (entries_size == 0) {
+    // An empty batch is a no-op and must not create the namespace.
+    return;
+  }
+  auto metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, ns);
+  if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
+    // TODO(wbpcode): this should never happen and we should simplify this.
+    return;
+  }
+  // Build the whole namespace fragment first, then merge once instead of once per entry.
+  Protobuf::Struct metadata_value;
+  auto* fields = metadata_value.mutable_fields();
+  for (size_t i = 0; i < entries_size; i++) {
+    const auto& entry = entries[i];
+    absl::string_view key_view(entry.key_ptr, entry.key_length);
+    absl::string_view value_view(entry.value_ptr, entry.value_length);
+    (*fields)[key_view].set_string_value(value_view);
+  }
+  metadata_namespace->MergeFrom(metadata_value);
+}
+
 bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_metadata_source metadata_source,

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1374,6 +1374,10 @@ WEAK_STUB(HttpSetDynamicMetadataString,
           envoy_dynamic_module_callback_http_set_dynamic_metadata_string(nullptr, {nullptr, 0},
                                                                          {nullptr, 0},
                                                                          {nullptr, 0}))
+WEAK_STUB(HttpSetDynamicMetadataStringBatch,
+          envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(nullptr,
+                                                                               {nullptr, 0},
+                                                                               nullptr, 0))
 WEAK_STUB(HttpGetMetadataString, envoy_dynamic_module_callback_http_get_metadata_string(
                                      nullptr, envoy_dynamic_module_type_metadata_source_Dynamic,
                                      {nullptr, 0}, {nullptr, 0}, nullptr))

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1083,6 +1083,122 @@ TEST(ABIImpl, metadata_namespaces) {
   EXPECT_EQ(ns_names.count("ns3"), 1);
 }
 
+TEST(ABIImpl, metadata_string_batch) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+
+  const std::string ns = "batch_ns";
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> entries = {
+      {"k1", 2, "v1", 2},
+      {"k2", 2, "v2", 2},
+  };
+
+  // Without stream info the batch set is a no-op and must not crash or create a namespace.
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, entries.data(), entries.size());
+  EXPECT_EQ(envoy_dynamic_module_callback_http_get_metadata_namespaces_count(
+                &filter, envoy_dynamic_module_type_metadata_source_Dynamic),
+            0);
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  envoy_dynamic_module_type_envoy_buffer result_buffer = {nullptr, 0};
+
+  // An empty batch is a no-op and must not create the namespace.
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, nullptr, 0);
+  EXPECT_EQ(envoy_dynamic_module_callback_http_get_metadata_namespaces_count(
+                &filter, envoy_dynamic_module_type_metadata_source_Dynamic),
+            0);
+
+  // A batch creates the namespace once and sets every entry.
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, entries.data(), entries.size());
+  EXPECT_EQ(envoy_dynamic_module_callback_http_get_metadata_namespaces_count(
+                &filter, envoy_dynamic_module_type_metadata_source_Dynamic),
+            1);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()}, {"k1", 2},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "v1");
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()}, {"k2", 2},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "v2");
+
+  // A batch overwrites an existing key and merges new keys while leaving untouched keys intact,
+  // matching the merge semantics of sequential single-key sets.
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string(&filter, {ns.data(), ns.size()},
+                                                                 {"k1", 2}, {"old", 3});
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> overwrite = {
+      {"k1", 2, "new", 3},
+      {"k3", 2, "v3", 2},
+  };
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, overwrite.data(), overwrite.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()}, {"k1", 2},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "new");
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()}, {"k2", 2},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "v2");
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()}, {"k3", 2},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "v3");
+
+  // Within a single batch, a later entry with a duplicate key wins.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> dup = {
+      {"dup", 3, "first", 5},
+      {"dup", 3, "last", 4},
+  };
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, dup.data(), dup.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()},
+      {"dup", 3}, &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "last");
+
+  // A single-entry batch sets exactly that one entry.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> single = {{"solo", 4, "alone", 5}};
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, single.data(), single.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()},
+      {"solo", 4}, &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "alone");
+
+  // A zero-length value is set as an empty string rather than skipped.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> empty_value = {{"empty", 5, "", 0}};
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, empty_value.data(), empty_value.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()},
+      {"empty", 5}, &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "");
+
+  // A batch overwrites a pre-existing number value with a string, matching the replacement that
+  // sequential single-key sets produce.
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_number(&filter, {ns.data(), ns.size()},
+                                                                 {"num", 3}, 7.0);
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> over_num = {{"num", 3, "str", 3}};
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
+      &filter, {ns.data(), ns.size()}, over_num.data(), over_num.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Dynamic, {ns.data(), ns.size()},
+      {"num", 3}, &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), "str");
+}
+
 TEST(ABIImpl, metadata_list) {
   Stats::SymbolTableImpl symbol_table;
   DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -372,6 +372,22 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   key = ns_res_header->second.fields().find("key");
   ASSERT_NE(key, ns_res_header->second.fields().end());
   EXPECT_EQ(key->second.number_value(), 123);
+  // Multiple string entries set in one namespace via the batch setter. The batch SDK wrapper is
+  // Rust-only, so scope these assertions to the rust parameterization like the other language
+  // guards in the dynamic_modules integration tests.
+  if (GetParam() == "rust") {
+    auto ns_req_header_batch = metadata.filter_metadata().find("ns_req_header_batch");
+    ASSERT_NE(ns_req_header_batch, metadata.filter_metadata().end());
+    auto batch_k1 = ns_req_header_batch->second.fields().find("k1");
+    ASSERT_NE(batch_k1, ns_req_header_batch->second.fields().end());
+    EXPECT_EQ(batch_k1->second.string_value(), "v1");
+    auto batch_k2 = ns_req_header_batch->second.fields().find("k2");
+    ASSERT_NE(batch_k2, ns_req_header_batch->second.fields().end());
+    EXPECT_EQ(batch_k2->second.string_value(), "v2");
+    // The empty batch must not have created a namespace.
+    EXPECT_EQ(metadata.filter_metadata().find("ns_req_header_batch_empty"),
+              metadata.filter_metadata().end());
+  }
   auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
   ASSERT_NE(ns_req_body, metadata.filter_metadata().end());
   key = ns_req_body->second.fields().find("key");

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -712,6 +712,13 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     );
     assert!(ns_req_header.is_none());
 
+    // Set multiple string entries in one namespace via the batch setter, plus an empty batch.
+    // The resulting metadata is read back and asserted end-to-end by the C++ integration test in
+    // filter_test.cc.
+    envoy_filter
+      .set_dynamic_metadata_string_batch("ns_req_header_batch", &[("k1", "v1"), ("k2", "v2")]);
+    envoy_filter.set_dynamic_metadata_string_batch("ns_req_header_batch_empty", &[]);
+
     // Try getting metadata from rotuer cluster and host.
     let metadata = envoy_filter.get_metadata_string(
       abi::envoy_dynamic_module_type_metadata_source::Route,

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -298,6 +298,22 @@ fn test_dynamic_metadata_callbacks_on_response_body() {
     .withf(|_, ns, key| ns == "ns_req_header" && key == "key")
     .returning(|_, _, _| None)
     .once();
+  // String-batch metadata with one populated namespace and one empty no-op batch.
+  envoy_filter
+    .expect_set_dynamic_metadata_string_batch()
+    .withf(|ns, entries| {
+      ns == "ns_req_header_batch"
+        && entries.len() == 2
+        && entries[0] == ("k1", "v1")
+        && entries[1] == ("k2", "v2")
+    })
+    .return_const(())
+    .once();
+  envoy_filter
+    .expect_set_dynamic_metadata_string_batch()
+    .withf(|ns, entries| ns == "ns_req_header_batch_empty" && entries.is_empty())
+    .return_const(())
+    .once();
   // Route/Cluster/Host metadata.
   envoy_filter
     .expect_get_metadata_string()


### PR DESCRIPTION
## Description

This PR adds a new HTTP-filter dynamic-module ABI callback, `envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch` which sets multiple string-valued dynamic metadata entries under a single namespace in one call. It is the batch counterpart to the existing `envoy_dynamic_module_callback_http_set_dynamic_metadata_string`.

We are also adding a new `envoy_dynamic_module_type_module_key_value_pair` ABI rather than reusing the byte-identical `envoy_dynamic_module_type_module_http_header` so that metadata key/values stay semantically distinct from HTTP headers.

---

**Commit Message:** dynamic_modules: add http_set_dynamic_metadata_string_batch ABI callback
**Additional Description:**
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added