### PR TITLE
dynamic_modules: eliminate double allocation in Rust SDK list getters

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -1160,37 +1160,21 @@ impl LogContext {
       return Vec::new();
     }
 
-    let mut headers = vec![
-      abi::envoy_dynamic_module_type_envoy_http_header {
-        key_ptr: ptr::null_mut(),
-        key_length: 0,
-        value_ptr: ptr::null_mut(),
-        value_length: 0,
-      };
-      count
-    ];
-
+    let mut headers: Vec<(EnvoyBuffer, EnvoyBuffer)> = Vec::with_capacity(count);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_access_logger_get_headers(
         self.envoy_ptr,
         header_type,
-        headers.as_mut_ptr(),
+        headers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_http_header,
       )
     };
-
     if !success {
       return Vec::new();
     }
-
+    unsafe {
+      headers.set_len(count);
+    }
     headers
-      .iter()
-      .map(|h| unsafe {
-        (
-          EnvoyBuffer::new_from_raw(h.key_ptr as *const u8, h.key_length),
-          EnvoyBuffer::new_from_raw(h.value_ptr as *const u8, h.value_length),
-        )
-      })
-      .collect()
   }
 
   /// Helper to retrieve an `EnvoyBuffer` from an ABI callback.
@@ -1226,28 +1210,20 @@ impl LogContext {
       return Vec::new();
     }
 
-    let mut buffers = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: ptr::null_mut(),
-        length: 0,
-      };
-      count
-    ];
-
-    if !unsafe { data_cb(self.envoy_ptr, buffers.as_mut_ptr()) } {
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(count);
+    if !unsafe {
+      data_cb(
+        self.envoy_ptr,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
+      )
+    } {
       return Vec::new();
     }
-
+    unsafe {
+      buffers.set_len(count);
+    }
+    buffers.retain(|buf| !buf.as_slice().is_empty());
     buffers
-      .iter()
-      .filter_map(|buf| {
-        if buf.ptr.is_null() || buf.length == 0 {
-          None
-        } else {
-          Some(unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const u8, buf.length) })
-        }
-      })
-      .collect()
   }
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -51,6 +51,7 @@ impl EnvoyBuffer<'_> {
     }
   }
 
+  #[inline]
   pub fn as_slice(&self) -> &[u8] {
     // The null guard is inlined here rather than going through `ffi_helpers` so that this
     // method does not transitively reference `envoy_log_*`. `as_slice` is reached by SDK
@@ -112,6 +113,7 @@ impl EnvoyMutBuffer<'_> {
   }
 
   /// This returns an immutable slice to the underlying memory region managed by Envoy.
+  #[inline]
   pub fn as_slice(&self) -> &[u8] {
     // See `EnvoyBuffer::as_slice` for why the null guard is inlined here.
     if self.raw_ptr.is_null() {
@@ -122,6 +124,7 @@ impl EnvoyMutBuffer<'_> {
   }
 
   /// This returns a mutable slice to the underlying memory region managed by Envoy.
+  #[inline]
   pub fn as_mut_slice(&mut self) -> &mut [u8] {
     // See `EnvoyBuffer::as_slice` for why the null guard is inlined here.
     if self.raw_ptr.is_null() {
@@ -140,5 +143,102 @@ impl Default for EnvoyMutBuffer<'_> {
       length: 0,
       _marker: std::marker::PhantomData,
     }
+  }
+}
+
+// Envoy fills caller-allocated `Vec`s of these types in place by reinterpreting them as the ABI
+// buffer and HTTP header structs, so assert the layouts match to keep those reinterpretations sound.
+const _: () = {
+  type EnvoyBufferPair = (EnvoyBuffer<'static>, EnvoyBuffer<'static>);
+
+  assert!(
+    std::mem::size_of::<EnvoyBuffer<'static>>()
+      == std::mem::size_of::<crate::abi::envoy_dynamic_module_type_envoy_buffer>()
+  );
+  assert!(
+    std::mem::align_of::<EnvoyBuffer<'static>>()
+      == std::mem::align_of::<crate::abi::envoy_dynamic_module_type_envoy_buffer>()
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyBuffer<'static>, raw_ptr)
+      == std::mem::offset_of!(crate::abi::envoy_dynamic_module_type_envoy_buffer, ptr)
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyBuffer<'static>, length)
+      == std::mem::offset_of!(crate::abi::envoy_dynamic_module_type_envoy_buffer, length)
+  );
+
+  assert!(
+    std::mem::size_of::<EnvoyMutBuffer<'static>>()
+      == std::mem::size_of::<crate::abi::envoy_dynamic_module_type_envoy_buffer>()
+  );
+  assert!(
+    std::mem::align_of::<EnvoyMutBuffer<'static>>()
+      == std::mem::align_of::<crate::abi::envoy_dynamic_module_type_envoy_buffer>()
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyMutBuffer<'static>, raw_ptr)
+      == std::mem::offset_of!(crate::abi::envoy_dynamic_module_type_envoy_buffer, ptr)
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyMutBuffer<'static>, length)
+      == std::mem::offset_of!(crate::abi::envoy_dynamic_module_type_envoy_buffer, length)
+  );
+
+  assert!(
+    std::mem::size_of::<EnvoyBufferPair>()
+      == std::mem::size_of::<crate::abi::envoy_dynamic_module_type_envoy_http_header>()
+  );
+  assert!(
+    std::mem::align_of::<EnvoyBufferPair>()
+      == std::mem::align_of::<crate::abi::envoy_dynamic_module_type_envoy_http_header>()
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyBufferPair, 0)
+      == std::mem::offset_of!(
+        crate::abi::envoy_dynamic_module_type_envoy_http_header,
+        key_ptr
+      )
+  );
+  assert!(
+    std::mem::offset_of!(EnvoyBufferPair, 1)
+      == std::mem::offset_of!(
+        crate::abi::envoy_dynamic_module_type_envoy_http_header,
+        value_ptr
+      )
+  );
+};
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_envoy_buffer_as_slice_returns_underlying_bytes() {
+    assert_eq!(EnvoyBuffer::new(b"hello").as_slice(), b"hello");
+  }
+
+  #[test]
+  fn test_envoy_buffer_as_slice_treats_null_and_empty_alike() {
+    // A null buffer and a non-null zero-length buffer both yield an empty slice, so the list getters
+    // can return Envoy-filled entries directly without normalizing empty ones.
+    assert_eq!(EnvoyBuffer::default().as_slice(), b"");
+    assert_eq!(EnvoyBuffer::new(b"").as_slice(), b"");
+  }
+
+  #[test]
+  fn test_envoy_mut_buffer_round_trips_through_slices() {
+    let mut data = *b"hello";
+    let mut buffer = unsafe { EnvoyMutBuffer::new_from_raw(data.as_mut_ptr(), data.len()) };
+    assert_eq!(buffer.as_slice(), b"hello");
+    buffer.as_mut_slice()[0] = b'j';
+    assert_eq!(buffer.as_slice(), b"jello");
+  }
+
+  #[test]
+  fn test_envoy_mut_buffer_slices_are_empty_when_null() {
+    let mut buffer = EnvoyMutBuffer::default();
+    assert_eq!(buffer.as_slice(), b"");
+    assert_eq!(buffer.as_mut_slice(), b"");
   }
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -2421,28 +2421,20 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     if count == 0 {
       return None;
     }
-    let mut buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      count
-    ];
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(count);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_metadata_keys(
         self.raw_ptr,
         source,
         str_to_module_buffer(namespace),
-        buffers.as_mut_ptr() as *mut _,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
-      Some(
-        buffers
-          .into_iter()
-          .map(|b| unsafe { EnvoyBuffer::new_from_raw(b.ptr as *const _, b.length) })
-          .collect(),
-      )
+      unsafe {
+        buffers.set_len(count);
+      }
+      Some(buffers)
     } else {
       None
     }
@@ -2458,27 +2450,19 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     if count == 0 {
       return None;
     }
-    let mut buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      count
-    ];
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(count);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_metadata_namespaces(
         self.raw_ptr,
         source,
-        buffers.as_mut_ptr() as *mut _,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
-      Some(
-        buffers
-          .into_iter()
-          .map(|b| unsafe { EnvoyBuffer::new_from_raw(b.ptr as *const _, b.length) })
-          .collect(),
-      )
+      unsafe {
+        buffers.set_len(count);
+      }
+      Some(buffers)
     } else {
       None
     }
@@ -2687,15 +2671,18 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       return None;
     }
 
-    let buffers: Vec<EnvoyMutBuffer> = vec![EnvoyMutBuffer::default(); size];
+    let mut buffers: Vec<EnvoyMutBuffer> = Vec::with_capacity(size);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_body_chunks(
         self.raw_ptr,
         abi::envoy_dynamic_module_type_http_body_type::ReceivedRequestBody,
-        buffers.as_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
+      unsafe {
+        buffers.set_len(size);
+      }
       Some(buffers)
     } else {
       None
@@ -2713,15 +2700,18 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       return None;
     }
 
-    let buffers: Vec<EnvoyMutBuffer> = vec![EnvoyMutBuffer::default(); size];
+    let mut buffers: Vec<EnvoyMutBuffer> = Vec::with_capacity(size);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_body_chunks(
         self.raw_ptr,
         abi::envoy_dynamic_module_type_http_body_type::BufferedRequestBody,
-        buffers.as_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
+      unsafe {
+        buffers.set_len(size);
+      }
       Some(buffers)
     } else {
       None
@@ -2797,15 +2787,18 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       return None;
     }
 
-    let buffers: Vec<EnvoyMutBuffer> = vec![EnvoyMutBuffer::default(); size];
+    let mut buffers: Vec<EnvoyMutBuffer> = Vec::with_capacity(size);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_body_chunks(
         self.raw_ptr,
         abi::envoy_dynamic_module_type_http_body_type::ReceivedResponseBody,
-        buffers.as_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
+      unsafe {
+        buffers.set_len(size);
+      }
       Some(buffers)
     } else {
       None
@@ -2823,15 +2816,18 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       return None;
     }
 
-    let buffers: Vec<EnvoyMutBuffer> = vec![EnvoyMutBuffer::default(); size];
+    let mut buffers: Vec<EnvoyMutBuffer> = Vec::with_capacity(size);
     let success = unsafe {
       abi::envoy_dynamic_module_callback_http_get_body_chunks(
         self.raw_ptr,
         abi::envoy_dynamic_module_type_http_body_type::BufferedResponseBody,
-        buffers.as_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if success {
+      unsafe {
+        buffers.set_len(size);
+      }
       Some(buffers)
     } else {
       None
@@ -3642,14 +3638,13 @@ impl EnvoyHttpFilterImpl {
         headers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_http_header,
       )
     };
+    if !success {
+      return Vec::default();
+    }
     unsafe {
       headers.set_len(count);
     }
-    if success {
-      headers
-    } else {
-      Vec::default()
-    }
+    headers
   }
 
   /// This implements the common logic for getting the header/trailer values.

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -922,34 +922,20 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       return Vec::new();
     }
 
-    let mut protocol_buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut protocol_buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_listener_filter_get_requested_application_protocols(
         self.raw,
-        protocol_buffers.as_mut_ptr(),
+        protocol_buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
       return Vec::new();
     }
-
+    unsafe {
+      protocol_buffers.set_len(size);
+    }
     protocol_buffers
-      .iter()
-      .take(size)
-      .map(|buf| {
-        if !buf.ptr.is_null() && buf.length > 0 {
-          unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const _, buf.length) }
-        } else {
-          EnvoyBuffer::default()
-        }
-      })
-      .collect()
   }
 
   fn set_requested_application_protocols<'a>(&mut self, protocols: &'a [&'a str]) {
@@ -1029,34 +1015,20 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       return Vec::new();
     }
 
-    let mut sans_buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut sans_buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_listener_filter_get_ssl_uri_sans(
         self.raw,
-        sans_buffers.as_mut_ptr(),
+        sans_buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
       return Vec::new();
     }
-
+    unsafe {
+      sans_buffers.set_len(size);
+    }
     sans_buffers
-      .iter()
-      .take(size)
-      .map(|buf| {
-        if !buf.ptr.is_null() && buf.length > 0 {
-          unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const _, buf.length) }
-        } else {
-          EnvoyBuffer::default()
-        }
-      })
-      .collect()
   }
 
   fn get_ssl_dns_sans(&self) -> Vec<EnvoyBuffer<'_>> {
@@ -1066,34 +1038,20 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
       return Vec::new();
     }
 
-    let mut sans_buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut sans_buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_listener_filter_get_ssl_dns_sans(
         self.raw,
-        sans_buffers.as_mut_ptr(),
+        sans_buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
       return Vec::new();
     }
-
+    unsafe {
+      sans_buffers.set_len(size);
+    }
     sans_buffers
-      .iter()
-      .take(size)
-      .map(|buf| {
-        if !buf.ptr.is_null() && buf.length > 0 {
-          unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const _, buf.length) }
-        } else {
-          EnvoyBuffer::default()
-        }
-      })
-      .collect()
   }
 
   fn get_ssl_subject(&self) -> Option<EnvoyBuffer<'_>> {

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -714,24 +714,20 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       return (Vec::new(), 0);
     }
 
-    let mut buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null_mut(),
-        length: 0,
-      };
-      size
-    ];
-    unsafe {
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
+    let ok = unsafe {
       abi::envoy_dynamic_module_callback_network_filter_get_read_buffer_chunks(
         self.raw,
-        buffers.as_mut_ptr(),
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
-    let envoy_buffers: Vec<EnvoyBuffer> = buffers
-      .iter()
-      .map(|s| unsafe { EnvoyBuffer::new_from_raw(s.ptr as *const _, s.length) })
-      .collect();
-    (envoy_buffers, total_length)
+    if !ok {
+      return (Vec::new(), 0);
+    }
+    unsafe {
+      buffers.set_len(size);
+    }
+    (buffers, total_length)
   }
 
   fn get_write_buffer_chunks(&mut self) -> (Vec<EnvoyBuffer<'_>>, usize) {
@@ -748,24 +744,20 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       return (Vec::new(), 0);
     }
 
-    let mut buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null_mut(),
-        length: 0,
-      };
-      size
-    ];
-    unsafe {
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
+    let ok = unsafe {
       abi::envoy_dynamic_module_callback_network_filter_get_write_buffer_chunks(
         self.raw,
-        buffers.as_mut_ptr(),
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
-    let envoy_buffers: Vec<EnvoyBuffer> = buffers
-      .iter()
-      .map(|s| unsafe { EnvoyBuffer::new_from_raw(s.ptr as *const _, s.length) })
-      .collect();
-    (envoy_buffers, total_length)
+    if !ok {
+      return (Vec::new(), 0);
+    }
+    unsafe {
+      buffers.set_len(size);
+    }
+    (buffers, total_length)
   }
 
   fn drain_read_buffer(&mut self, length: usize) {
@@ -983,34 +975,20 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       return Vec::new();
     }
 
-    let mut sans_buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut sans_buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_network_filter_get_ssl_uri_sans(
         self.raw,
-        sans_buffers.as_mut_ptr(),
+        sans_buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
       return Vec::new();
     }
-
+    unsafe {
+      sans_buffers.set_len(size);
+    }
     sans_buffers
-      .iter()
-      .take(size)
-      .map(|buf| {
-        if !buf.ptr.is_null() && buf.length > 0 {
-          unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const _, buf.length) }
-        } else {
-          EnvoyBuffer::default()
-        }
-      })
-      .collect()
   }
 
   fn get_ssl_dns_sans(&self) -> Vec<EnvoyBuffer<'_>> {
@@ -1020,34 +998,20 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
       return Vec::new();
     }
 
-    let mut sans_buffers: Vec<abi::envoy_dynamic_module_type_envoy_buffer> = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut sans_buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_network_filter_get_ssl_dns_sans(
         self.raw,
-        sans_buffers.as_mut_ptr(),
+        sans_buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
       return Vec::new();
     }
-
+    unsafe {
+      sans_buffers.set_len(size);
+    }
     sans_buffers
-      .iter()
-      .take(size)
-      .map(|buf| {
-        if !buf.ptr.is_null() && buf.length > 0 {
-          unsafe { EnvoyBuffer::new_from_raw(buf.ptr as *const _, buf.length) }
-        } else {
-          EnvoyBuffer::default()
-        }
-      })
-      .collect()
   }
 
   fn get_ssl_subject(&self) -> Option<EnvoyBuffer<'_>> {

--- a/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
@@ -202,17 +202,11 @@ impl EnvoyUdpListenerFilter for EnvoyUdpListenerFilterImpl {
     if size == 0 {
       return (Vec::new(), 0);
     }
-    let mut buffers = vec![
-      abi::envoy_dynamic_module_type_envoy_buffer {
-        ptr: std::ptr::null(),
-        length: 0,
-      };
-      size
-    ];
+    let mut buffers: Vec<EnvoyBuffer> = Vec::with_capacity(size);
     let ok = unsafe {
       abi::envoy_dynamic_module_callback_udp_listener_filter_get_datagram_data_chunks(
         self.raw,
-        buffers.as_mut_ptr(),
+        buffers.as_mut_ptr() as *mut abi::envoy_dynamic_module_type_envoy_buffer,
       )
     };
     if !ok {
@@ -223,15 +217,14 @@ impl EnvoyUdpListenerFilter for EnvoyUdpListenerFilterImpl {
       abi::envoy_dynamic_module_callback_udp_listener_filter_get_datagram_data_size(self.raw)
     };
     if total_length == 0 {
-      // This shouldn't happen if chunks were retrieved, but for safety:
+      // This shouldn't happen if chunks were retrieved, but we guard for safety.
       return (Vec::new(), 0);
     }
 
-    let envoy_buffers: Vec<EnvoyBuffer> = buffers
-      .into_iter()
-      .map(|b| unsafe { EnvoyBuffer::new_from_raw(b.ptr as *const _, b.length) })
-      .collect();
-    (envoy_buffers, total_length)
+    unsafe {
+      buffers.set_len(size);
+    }
+    (buffers, total_length)
   }
 
   fn set_datagram_data(&mut self, data: &[u8]) -> bool {


### PR DESCRIPTION
## Description

Today, the Rust SDK list getters at multiple places do the allocations twice. This PR collapses each getter to a single allocation. 

The change preserves the behavior and also gates the previously ignored fill return in `network.rs`
`get_read_buffer_chunks` and `get_write_buffer_chunks`.

---

**Commit Message:** dynamic_modules: eliminate double allocation in Rust SDK list getters
**Additional Description:** Collapses each SDK list getter to a single `Vec::with_capacity` plus in-place FFI fill and `set_len`, guarded by compile-time layout assertions.
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes:** N/A

Signed-off-by: Rohit Agrawal <rohit.agrawal@databricks.com>