### PR TITLE
mobile/ci: Temporarily disable Mobile/Perf

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -89,11 +89,6 @@ checks:
     required: true
     on-run:
     - mobile-ios-tests
-  mobile-perf:
-    name: Mobile/Perf
-    required: true
-    on-run:
-    - mobile-perf
   mobile-python:
     name: Mobile/Python
     required: true


### PR DESCRIPTION
It's permafailing, so disable it till we figure out what's wrong.