### PR TITLE
redis: constant-time compare for downstream auth password

### DIFF
--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -134,6 +134,7 @@ envoy_cc_library(
     name = "proxy_filter_lib",
     srcs = ["proxy_filter.cc"],
     hdrs = ["proxy_filter.h"],
+    external_deps = ["ssl"],
     deps = [
         ":command_splitter_interface",
         ":external_auth_lib",

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/network/redis_proxy/proxy_filter.h"
 
+#include <openssl/mem.h>
+
 #include <cstdint>
 #include <string>
 
@@ -264,7 +266,8 @@ void ProxyFilter::onAuth(PendingRequest& request, const std::string& username,
 
 bool ProxyFilter::checkPassword(const std::string& password) {
   for (const auto& p : config_->downstream_auth_passwords_) {
-    if (password == p) {
+    if (password.length() == p.length() &&
+        CRYPTO_memcmp(password.data(), p.data(), p.length()) == 0) {
       return true;
     }
   }


### PR DESCRIPTION
compare the AUTH password against each configured downstream password with CRYPTO_memcmp in checkPassword instead of std::string ==, which short-circuits on the first mismatch and leaks the configured password by timing over the network.