### PR TITLE
Fix bug where RTDS runtime overrides being deleted would not restore the default value

### DIFF
--- a/changelogs/current/bug_fixes/runtime__fixed-rtds-runtime-guard-removal.rst
+++ b/changelogs/current/bug_fixes/runtime__fixed-rtds-runtime-guard-removal.rst
@@ -1,0 +1,3 @@
+Fixed a bug where removing an RTDS override for an ``envoy.reloadable_features`` runtime guard
+updated the admin runtime view but left the process-wide runtime guard set to the previous
+overridden value.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -45,7 +45,21 @@ void countDeprecatedFeatureUseInternal(const RuntimeStats& stats) {
   stats.deprecated_feature_seen_since_process_start_.inc();
 }
 
-void refreshReloadableFlags(const Snapshot::EntryMap& flag_map) {
+void refreshReloadableFlags(const Snapshot::EntryMap& flag_map,
+                            absl::node_hash_map<std::string, bool>& runtime_feature_defaults) {
+  for (const auto& it : flag_map) {
+    if (it.second.bool_value_.has_value() && isRuntimeFeature(it.first)) {
+      runtime_feature_defaults.try_emplace(it.first, Runtime::runtimeFeatureEnabled(it.first));
+    }
+  }
+
+  for (const auto& it : runtime_feature_defaults) {
+    const auto flag = flag_map.find(it.first);
+    if (flag == flag_map.end() || !flag->second.bool_value_.has_value()) {
+      maybeSetRuntimeGuard(it.first, it.second);
+    }
+  }
+
   for (const auto& it : flag_map) {
     if (it.second.bool_value_.has_value() && isRuntimeFeature(it.first)) {
       maybeSetRuntimeGuard(it.first, it.second.bool_value_.value());
@@ -654,7 +668,7 @@ absl::Status LoaderImpl::loadNewSnapshot() {
     return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(ptr);
   });
 
-  refreshReloadableFlags(ptr->values());
+  refreshReloadableFlags(ptr->values(), runtime_feature_defaults_);
 
   {
     absl::MutexLock lock(snapshot_mutex_);

--- a/source/common/runtime/runtime_impl.h
+++ b/source/common/runtime/runtime_impl.h
@@ -259,6 +259,7 @@ private:
   Init::WatcherImpl init_watcher_;
   Init::ManagerImpl init_manager_{"RTDS"};
   std::vector<RtdsSubscriptionPtr> subscriptions_;
+  absl::node_hash_map<std::string, bool> runtime_feature_defaults_;
   Upstream::ClusterManager* cm_{};
   Stats::Store& store_;
 

--- a/test/common/runtime/runtime_impl_test.cc
+++ b/test/common/runtime/runtime_impl_test.cc
@@ -1107,6 +1107,29 @@ TEST_F(RtdsLoaderImplTest, OnConfigUpdateSuccess) {
   EXPECT_EQ(2, store_.gauge("runtime.num_layers", Stats::Gauge::ImportMode::NeverImport).value());
 }
 
+TEST_F(RtdsLoaderImplTest, RuntimeFeatureRemovalRestoresRuntimeGuardDefault) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.test_feature_false", true);
+  setup();
+
+  auto runtime = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
+    name: some_resource
+    layer:
+      envoy.reloadable_features.test_feature_false: false
+  )EOF");
+  EXPECT_CALL(rtds_init_callback_, Call());
+  doOnConfigUpdateVerifyNoThrow(runtime);
+
+  EXPECT_FALSE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_false"));
+
+  runtime = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
+    name: some_resource
+    layer: {}
+  )EOF");
+  doOnConfigUpdateVerifyNoThrow(runtime);
+
+  EXPECT_TRUE(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.test_feature_false"));
+}
+
 // Delta style successful update.
 TEST_F(RtdsLoaderImplTest, DeltaOnConfigUpdateSuccess) {
   setup();

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1876,8 +1876,16 @@ envoy_cc_test(
     ],
     deps = [
         ":http_integration_lib",
+        "//envoy/http:codes_interface",
+        "//envoy/http:filter_interface",
+        "//envoy/registry",
+        "//envoy/server:filter_config_interface",
+        "//source/common/runtime:runtime_features_lib",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//test/common/grpc:grpc_client_integration_lib",
         "//test/config:v2_link_hacks",
+        "//test/extensions/filters/http/common:empty_http_filter_config_lib",
+        "//test/integration/filters:test_filters_proto_cc_proto",
         "@envoy_api//envoy/service/runtime/v3:pkg_cc_proto",
     ],
 )

--- a/test/integration/filters/test_filters.proto
+++ b/test/integration/filters/test_filters.proto
@@ -96,6 +96,8 @@ message ModifyBufferFilterConfig {
 }
 message ProcessContextFilterConfig {
 }
+message RuntimeFeatureTestFilterConfig {
+}
 message RandomPauseFilterConfig {
 }
 message RefreshRouteClusterConfig {

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -1,16 +1,85 @@
+#include <memory>
+#include <string>
+
+#include "envoy/http/codes.h"
+#include "envoy/http/filter.h"
+#include "envoy/registry/registry.h"
 #include "envoy/service/runtime/v3/rtds.pb.h"
+
+#include "source/common/runtime/runtime_features.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/config/v2_link_hacks.h"
+#include "test/extensions/filters/http/common/empty_http_filter_config.h"
+#include "test/integration/filters/test_filters.pb.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::Eq;
 using testing::Ge;
 namespace Envoy {
 namespace {
+
+constexpr char RuntimeFeatureFilterName[] = "rtds-runtime-feature-test";
+constexpr char RuntimeFeaturePath[] = "/runtime-feature";
+constexpr char TestRuntimeFeature[] = "envoy.reloadable_features.test_feature_false";
+
+MATCHER_P(RuntimeStatusFilterResponds, expected_status, "") {
+  if (arg == nullptr) {
+    *result_listener << "response is null";
+    return false;
+  }
+  if (!arg->complete()) {
+    *result_listener << "response is incomplete";
+    return false;
+  }
+
+  const std::string expected_status_string = std::to_string(expected_status);
+  const std::string actual_status{arg->headers().getStatusValue()};
+  if (actual_status != expected_status_string) {
+    *result_listener << "status was " << actual_status;
+    return false;
+  }
+
+  return true;
+}
+
+class RuntimeFeatureTestFilter : public Http::PassThroughFilter {
+public:
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
+    if (!headers.Path() || headers.getPathValue() != RuntimeFeaturePath) {
+      return Http::FilterHeadersStatus::Continue;
+    }
+
+    const Http::Code code = Runtime::runtimeFeatureEnabled(TestRuntimeFeature)
+                                ? Http::Code::NoContent
+                                : static_cast<Http::Code>(418);
+    decoder_callbacks_->sendLocalReply(code, "", nullptr, absl::nullopt, "");
+    return Http::FilterHeadersStatus::StopIteration;
+  }
+};
+
+class RuntimeFeatureTestFilterConfig
+    : public Extensions::HttpFilters::Common::UniqueEmptyHttpFilterConfig<
+          test::integration::filters::RuntimeFeatureTestFilterConfig> {
+public:
+  RuntimeFeatureTestFilterConfig() : UniqueEmptyHttpFilterConfig(RuntimeFeatureFilterName) {}
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilter(const std::string&, Server::Configuration::FactoryContext&) override {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) {
+      callbacks.addStreamFilter(std::make_shared<RuntimeFeatureTestFilter>());
+    };
+  }
+};
+
+static Registry::RegisterFactory<RuntimeFeatureTestFilterConfig,
+                                 Server::Configuration::NamedHttpFilterConfigFactory>
+    register_runtime_feature_test_filter_;
 
 // TODO(fredlas) set_node_on_first_message_only was true; the delta+SotW unification
 //               work restores it here.
@@ -48,6 +117,38 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 0
+  listeners:
+  - name: http
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 0
+    filter_chains:
+    - filters:
+      - name: http
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: config_test
+          delayed_close_timeout:
+            nanos: 10000000
+          http_filters:
+          - name: rtds-runtime-feature-test
+            typed_config:
+              "@type": type.googleapis.com/test.integration.filters.RuntimeFeatureTestFilterConfig
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          codec_type: HTTP2
+          route_config:
+            name: route_config_0
+            virtual_hosts:
+            - name: integration
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                direct_response:
+                  status: 418
 layered_runtime:
   layers:
   - name: some_static_layer
@@ -136,6 +237,11 @@ public:
       return entries->getObject(key).value()->getString("final_value").value();
     }
     return "";
+  }
+
+  BufferingStreamDecoderPtr requestToRuntimeStatusFilter() {
+    return IntegrationUtil::makeSingleRequest(lookupPort("http"), "GET", RuntimeFeaturePath, "",
+                                              downstreamProtocol(), version_);
   }
 
   uint32_t initial_load_success_{};
@@ -266,6 +372,51 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   EXPECT_EQ(initial_load_success_ + 2, test_server_->counter("runtime.load_success")->value());
   EXPECT_EQ(2, test_server_->counter("runtime.update_success")->value());
   EXPECT_EQ(initial_keys_ + 1, test_server_->gauge("runtime.num_keys")->value());
+  EXPECT_EQ(3, test_server_->gauge("runtime.num_layers")->value());
+}
+
+TEST_P(RtdsIntegrationTest, RtdsOverrideRemovalClearsRuntimeFeature) {
+  initialize();
+  acceptXdsConnection();
+
+  EXPECT_THAT(requestToRuntimeStatusFilter(), RuntimeStatusFilterResponds(418))
+      << "[before RTDS override]";
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Runtime, "", {"some_rtds_layer"},
+                                      {"some_rtds_layer"}, {}, true));
+  auto some_rtds_layer = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
+    name: some_rtds_layer
+    layer:
+      envoy.reloadable_features.test_feature_false: true
+  )EOF");
+  sendDiscoveryResponse<envoy::service::runtime::v3::Runtime>(
+      Config::TestTypeUrl::get().Runtime, {some_rtds_layer}, {some_rtds_layer}, {}, "1");
+  test_server_->waitForCounter("runtime.load_success", Ge(initial_load_success_ + 1));
+
+  EXPECT_THAT(requestToRuntimeStatusFilter(), RuntimeStatusFilterResponds(204))
+      << "[after RTDS override]";
+  EXPECT_EQ("true", getRuntimeKey(TestRuntimeFeature));
+  EXPECT_EQ(initial_keys_ + 1, test_server_->gauge("runtime.num_keys")->value());
+
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Runtime, "1", {"some_rtds_layer"},
+                                      {}, {}));
+  some_rtds_layer = TestUtility::parseYaml<envoy::service::runtime::v3::Runtime>(R"EOF(
+    name: some_rtds_layer
+    layer: {}
+  )EOF");
+  sendDiscoveryResponse<envoy::service::runtime::v3::Runtime>(
+      Config::TestTypeUrl::get().Runtime, {some_rtds_layer}, {some_rtds_layer}, {}, "2");
+  test_server_->waitForCounter("runtime.load_success", Ge(initial_load_success_ + 2));
+
+  EXPECT_EQ("", getRuntimeKey(TestRuntimeFeature));
+  EXPECT_THAT(requestToRuntimeStatusFilter(), RuntimeStatusFilterResponds(418))
+      << "[after RTDS override removal]";
+
+  EXPECT_EQ(0, test_server_->counter("runtime.load_error")->value());
+  EXPECT_EQ(0, test_server_->counter("runtime.update_failure")->value());
+  EXPECT_EQ(initial_load_success_ + 2, test_server_->counter("runtime.load_success")->value());
+  EXPECT_EQ(2, test_server_->counter("runtime.update_success")->value());
+  EXPECT_EQ(initial_keys_, test_server_->gauge("runtime.num_keys")->value());
   EXPECT_EQ(3, test_server_->gauge("runtime.num_layers")->value());
 }
 

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -14,6 +14,7 @@
 #include "test/extensions/filters/http/common/empty_http_filter_config.h"
 #include "test/integration/filters/test_filters.pb.h"
 #include "test/integration/http_integration.h"
+#include "test/test_common/network_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -117,38 +118,6 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 0
-  listeners:
-  - name: http
-    address:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 0
-    filter_chains:
-    - filters:
-      - name: http
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          stat_prefix: config_test
-          delayed_close_timeout:
-            nanos: 10000000
-          http_filters:
-          - name: rtds-runtime-feature-test
-            typed_config:
-              "@type": type.googleapis.com/test.integration.filters.RuntimeFeatureTestFilterConfig
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          codec_type: HTTP2
-          route_config:
-            name: route_config_0
-            virtual_hosts:
-            - name: integration
-              domains: ["*"]
-              routes:
-              - match:
-                  prefix: "/"
-                direct_response:
-                  status: 418
 layered_runtime:
   layers:
   - name: some_static_layer
@@ -179,6 +148,46 @@ admin:
       port_value: 0
 )EOF",
                      api_type, Platform::null_device_path);
+}
+
+void addRuntimeFeatureListener(envoy::config::bootstrap::v3::Bootstrap& bootstrap,
+                               Network::Address::IpVersion ip_version) {
+  auto* listener = bootstrap.mutable_static_resources()->add_listeners();
+  TestUtility::loadFromYaml(fmt::format(R"EOF(
+name: http
+address:
+  socket_address:
+    address: "{}"
+    port_value: 0
+filter_chains:
+- filters:
+  - name: http
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      stat_prefix: config_test
+      delayed_close_timeout:
+        nanos: 10000000
+      http_filters:
+      - name: rtds-runtime-feature-test
+        typed_config:
+          "@type": type.googleapis.com/test.integration.filters.RuntimeFeatureTestFilterConfig
+      - name: envoy.filters.http.router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      codec_type: HTTP2
+      route_config:
+        name: route_config_0
+        virtual_hosts:
+        - name: integration
+          domains: ["*"]
+          routes:
+          - match:
+              prefix: "/"
+            direct_response:
+              status: 418
+)EOF",
+                                        Network::Test::getLoopbackAddressString(ip_version)),
+                            *listener);
 }
 
 class RtdsIntegrationTest : public Grpc::DeltaSotwIntegrationParamTest, public HttpIntegrationTest {
@@ -376,6 +385,10 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
 }
 
 TEST_P(RtdsIntegrationTest, RtdsOverrideRemovalClearsRuntimeFeature) {
+  config_helper_.addConfigModifier(
+      [ip_version = ipVersion()](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        addRuntimeFeatureListener(bootstrap, ip_version);
+      });
   initialize();
   acceptXdsConnection();
 

--- a/test/integration/rtds_integration_test.cc
+++ b/test/integration/rtds_integration_test.cc
@@ -460,6 +460,7 @@ TEST_P(RtdsIntegrationTest, RtdsUpdate) {
 // This test uses health checking of the first cluster to make primary cluster initialization to
 // complete asynchronously.
 TEST_P(RtdsIntegrationTest, RtdsAfterAsyncPrimaryClusterInitialization) {
+  autonomous_upstream_ = true;
   config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
     // Enable health checking for the first cluster.
     auto* dummy_cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
@@ -483,10 +484,8 @@ TEST_P(RtdsIntegrationTest, RtdsAfterAsyncPrimaryClusterInitialization) {
   EXPECT_EQ("yar", getRuntimeKey("bar"));
   EXPECT_EQ("", getRuntimeKey("baz"));
 
-  // Respond to the initial health check, which should complete initialization of primary clusters.
-  waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-  test_server_->waitForGauge("cluster.dummy_cluster.membership_healthy", Eq(1));
+  // Wait for the initial health check, which should complete initialization of primary clusters.
+  test_server_->waitForCounter("cluster.dummy_cluster.health_check.success", Ge(1));
 
   // After this xDS connection should be established. Verify that dynamic runtime values are loaded.
   acceptXdsConnection();


### PR DESCRIPTION
Commit Message: Fix bug where RTDS runtime overrides being deleted would not restore the default value
Additional Description:

Implemented failing-integration-test-first, proving the bug existed.

Assisted by Codex 5.5 xhigh, but I went over all the changes manually and cleaned up several.

I don't think it's possible to sanely runtime-guard the change, because how can you possibly make runtime-guards optionally not update correctly based on a runtime-guard? Updating that value would work if set and not work if not set, very confusingly.

Issue was discovered when we tried to turn the recent "cookie overload" patch back on after tuning the limits, and it appeared to be fine, but then wasn't fine on instances deployed after the reset - the runtime override to "off" was still in effect on the original instances, while admin `/runtime` on the same instance was reporting no such override.

Risk Level: Small - it is a behavior change, but the old behavior was incorrect, and unlikely to have been positively relied upon.
Testing: Integration test and unit test.
Docs Changes: n/a
Release Notes: yes
Platform Specific Features: n/a
