### PR TITLE
dynamic_modules: write stat names directly into module buffers

### DIFF
--- a/changelogs/current/new_features/stat_sinks__added-a-dynamic-modules-stats-sink.rst
+++ b/changelogs/current/new_features/stat_sinks__added-a-dynamic-modules-stats-sink.rst
@@ -1,6 +1,8 @@
 Added a new dynamic modules stats sink extension (``envoy.stat_sinks.dynamic_modules``) that
 delegates metric flushing and histogram observations to a dynamic module loaded via ``dlopen``.
-On each flush the module receives a snapshot of the counters, gauges, and text readouts, and it
-receives a callback for every completed histogram sample. The Rust and Go SDKs expose this through
-a ``StatSink`` interface and a matching stat sink init function. Configured via
-:ref:`DynamicModuleStatsSink <envoy_v3_api_msg_extensions.stat_sinks.dynamic_modules.v3.DynamicModuleStatsSink>`.
+On each flush the module receives a snapshot of the counters, gauges, and text readouts, plus a
+callback for every completed histogram sample. Metric names are decoded directly into a
+module-provided buffer to avoid intermediate allocations. The Rust and Go SDKs expose this through
+a ``StatSink`` interface and a matching stat sink init function. See
+:ref:`DynamicModuleStatsSink <envoy_v3_api_msg_extensions.stat_sinks.dynamic_modules.v3.DynamicModuleStatsSink>`
+for configuration details.

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -1,6 +1,7 @@
 #include "source/common/stats/symbol_table.h"
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -313,6 +314,37 @@ uint64_t SymbolTable::numSymbols() const {
 
 std::string SymbolTable::toString(const StatName& stat_name) const {
   return absl::StrJoin(decodeStrings(stat_name), ".");
+}
+
+size_t SymbolTable::serializeToBuffer(const StatName& stat_name, char* buffer,
+                                      size_t buffer_size) const {
+  // A null buffer is only valid as a length query when buffer_size is 0.
+  ASSERT(buffer != nullptr || buffer_size == 0);
+  // Tracks the full required length even when it exceeds buffer_size, so the caller can detect
+  // truncation and retry. Tokens are copied only while they still fit.
+  size_t bytes_required = 0;
+  const auto append = [&](absl::string_view token) {
+    if (bytes_required < buffer_size && !token.empty()) {
+      const size_t copy_size = std::min(token.size(), buffer_size - bytes_required);
+      memcpy(buffer + bytes_required, token.data(), copy_size); // NOLINT(safe-memcpy)
+    }
+    bytes_required += token.size();
+  };
+
+  Thread::LockGuard lock(lock_);
+  Encoding::TokenIter iter(stat_name);
+  bool first = true;
+  for (Encoding::TokenIter::TokenType type = iter.next();
+       type != Encoding::TokenIter::TokenType::End; type = iter.next()) {
+    if (!first) {
+      append(".");
+    }
+    first = false;
+    // fromSymbol() requires lock_, which is held for the duration of this call.
+    append(type == Encoding::TokenIter::TokenType::Symbol ? fromSymbol(iter.symbol())
+                                                          : iter.stringView());
+  }
+  return bytes_required;
 }
 
 void SymbolTable::incRefCount(const StatName& stat_name) {

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -242,6 +242,24 @@ public:
   std::string toString(const StatName& stat_name) const;
 
   /**
+   * Serializes stat_name to the same period-delimited form as toString() directly into a
+   * caller-provided buffer, without allocating. This lets callers that already own a buffer, such
+   * as stats sinks during flush, avoid the per-name std::string allocation that toString() incurs.
+   *
+   * At most buffer_size bytes are written and no null terminator is added. The symbol-table lock is
+   * acquired once for the call, so this suits periodic operations such as the stats flush rather
+   * than the request hot path.
+   *
+   * @param stat_name the stat name to serialize.
+   * @param buffer the destination buffer. May be null only if buffer_size is 0, which makes this a
+   *               length query that writes nothing.
+   * @param buffer_size the capacity of buffer in bytes.
+   * @return the total number of bytes the full name requires. If the return value is greater than
+   *         buffer_size the output was truncated and the caller may retry with a larger buffer.
+   */
+  size_t serializeToBuffer(const StatName& stat_name, char* buffer, size_t buffer_size) const;
+
+  /**
    * @return uint64_t the number of symbols in the symbol table.
    */
   uint64_t numSymbols() const;

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -81,6 +81,13 @@ go_library(
 )
 
 go_library(
+    name = "go_sdk_internal_buffer",
+    srcs = ["sdk/go/internal/buffer/buffer.go"],
+    importpath = "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/internal/buffer",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
     name = "go_sdk_abi",
     srcs = [
         "sdk/go/abi/internal.go",
@@ -99,6 +106,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//source/extensions/dynamic_modules:go_sdk",
+        "//source/extensions/dynamic_modules:go_sdk_internal_buffer",
         "//source/extensions/dynamic_modules:go_sdk_shared",
     ],
 )

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -12478,21 +12478,27 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr);
 
 /**
- * envoy_dynamic_module_callback_stat_sink_snapshot_get_counter returns the name and values of
- * a counter at the given index.
+ * envoy_dynamic_module_callback_stat_sink_snapshot_get_counter writes the name and returns the
+ * values of a counter at the given index. The name is written directly into a module-provided
+ * buffer, allowing the module to decode it straight into its own storage (for example a socket
+ * write buffer) without Envoy allocating an intermediate string.
  *
  * @param snapshot_envoy_ptr is the opaque snapshot handle.
  * @param index is the index of the counter (0-based).
- * @param name_out is the output buffer for the counter name. The buffer is owned by Envoy and
- *        is guaranteed to be valid until the end of the envoy_dynamic_module_on_stat_sink_flush
- *        event hook.
+ * @param name_buffer is the module-owned buffer that receives the counter name. No null
+ *        terminator is written. May be null only if name_buffer_capacity is 0.
+ * @param name_buffer_capacity is the capacity of name_buffer in bytes.
+ * @param name_size is set to the full length of the name. If it exceeds name_buffer_capacity the
+ *        name was truncated and the module should retry with a buffer of at least name_size bytes.
+ *        Must not be null.
  * @param value_out is the output for the current accumulated counter value.
  * @param delta_out is the output for the counter delta since the last flush.
- * @return true if the index is valid, false otherwise.
+ * @return true if the index is valid, false otherwise. When false, no outputs are written.
  */
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out, uint64_t* value_out, uint64_t* delta_out);
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, uint64_t* value_out,
+    uint64_t* delta_out);
 
 /**
  * envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count returns the number of
@@ -12505,20 +12511,24 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr);
 
 /**
- * envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge returns the name and value of
- * a gauge at the given index.
+ * envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge writes the name and returns the
+ * value of a gauge at the given index. The name is written directly into a module-provided
+ * buffer, as described for the counter callback above.
  *
  * @param snapshot_envoy_ptr is the opaque snapshot handle.
  * @param index is the index of the gauge (0-based).
- * @param name_out is the output buffer for the gauge name. The buffer is owned by Envoy and
- *        is guaranteed to be valid until the end of the envoy_dynamic_module_on_stat_sink_flush
- *        event hook.
+ * @param name_buffer is the module-owned buffer that receives the gauge name. No null terminator
+ *        is written. May be null only if name_buffer_capacity is 0.
+ * @param name_buffer_capacity is the capacity of name_buffer in bytes.
+ * @param name_size is set to the full length of the name. If it exceeds name_buffer_capacity the
+ *        name was truncated and the module should retry with a buffer of at least name_size bytes.
+ *        Must not be null.
  * @param value_out is the output for the current gauge value.
- * @return true if the index is valid, false otherwise.
+ * @return true if the index is valid, false otherwise. When false, no outputs are written.
  */
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out, uint64_t* value_out);
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, uint64_t* value_out);
 
 /**
  * envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count returns the number
@@ -12531,23 +12541,28 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr);
 
 /**
- * envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout returns the name and value
- * of a text readout at the given index.
+ * envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout writes the name and value
+ * of a text readout at the given index into module-provided buffers.
  *
  * @param snapshot_envoy_ptr is the opaque snapshot handle.
  * @param index is the index of the text readout (0-based).
- * @param name_out is the output buffer for the text readout name. The buffer is owned by Envoy
- *        and is guaranteed to be valid until the end of the
- *        envoy_dynamic_module_on_stat_sink_flush event hook.
- * @param value_out is the output buffer for the text readout value. The buffer is owned by Envoy
- *        and is guaranteed to be valid until the end of the
- *        envoy_dynamic_module_on_stat_sink_flush event hook.
- * @return true if the index is valid, false otherwise.
+ * @param name_buffer is the module-owned buffer that receives the text readout name. No null
+ *        terminator is written. May be null only if name_buffer_capacity is 0.
+ * @param name_buffer_capacity is the capacity of name_buffer in bytes.
+ * @param name_size is set to the full length of the name. If it exceeds name_buffer_capacity the
+ *        name was truncated and the module should retry with a buffer of at least name_size bytes.
+ *        Must not be null.
+ * @param value_buffer is the module-owned buffer that receives the text readout value. No null
+ *        terminator is written. May be null only if value_buffer_capacity is 0.
+ * @param value_buffer_capacity is the capacity of value_buffer in bytes.
+ * @param value_size is set to the full length of the value, with the same truncation contract as
+ *        name_size. Must not be null.
+ * @return true if the index is valid, false otherwise. When false, no outputs are written.
  */
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out,
-    envoy_dynamic_module_type_envoy_buffer* value_out);
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, char* value_buffer,
+    size_t value_buffer_capacity, size_t* value_size);
 
 #ifdef __cplusplus
 }

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -3472,8 +3472,8 @@ __attribute__((weak)) size_t envoy_dynamic_module_callback_stat_sink_snapshot_ge
 }
 
 __attribute__((weak)) bool envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t,
-    envoy_dynamic_module_type_envoy_buffer*, uint64_t*, uint64_t*) {
+    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t, char*, size_t, size_t*,
+    uint64_t*, uint64_t*) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_stat_sink_snapshot_get_counter: "
                "not implemented in this context");
   return false;
@@ -3487,8 +3487,8 @@ __attribute__((weak)) size_t envoy_dynamic_module_callback_stat_sink_snapshot_ge
 }
 
 __attribute__((weak)) bool envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
-    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t,
-    envoy_dynamic_module_type_envoy_buffer*, uint64_t*) {
+    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t, char*, size_t, size_t*,
+    uint64_t*) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge: "
                "not implemented in this context");
   return false;
@@ -3503,8 +3503,8 @@ envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(
 }
 
 __attribute__((weak)) bool envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
-    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t,
-    envoy_dynamic_module_type_envoy_buffer*, envoy_dynamic_module_type_envoy_buffer*) {
+    envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr, size_t, char*, size_t, size_t*, char*,
+    size_t, size_t*) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout: "
                "not implemented in this context");
   return false;

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	sdk "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go"
+	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/internal/buffer"
 	"github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared"
 )
 
@@ -2421,57 +2422,67 @@ func (s *dymMetricSnapshot) CounterCount() uint64 {
 	return uint64(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(s.snapshotPtr))
 }
 
-func (s *dymMetricSnapshot) GetCounter(index uint64) (shared.CounterSnapshot, bool) {
-	var nameBuf C.envoy_dynamic_module_type_envoy_buffer
+func (s *dymMetricSnapshot) GetCounter(index uint64, name []byte) ([]byte, shared.CounterValue, bool) {
 	var value, delta C.uint64_t
-	ok := bool(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-		s.snapshotPtr, C.size_t(index), &nameBuf, &value, &delta,
-	))
+	name, ok := buffer.Fill(name, func(buf []byte) (uint64, bool) {
+		var size C.size_t
+		ret := C.envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
+			s.snapshotPtr, C.size_t(index), sliceDataPtr(buf), C.size_t(cap(buf)), &size, &value, &delta,
+		)
+		runtime.KeepAlive(buf)
+		return uint64(size), bool(ret)
+	})
 	if !ok {
-		return shared.CounterSnapshot{}, false
+		return name, shared.CounterValue{}, false
 	}
-	return shared.CounterSnapshot{
-		Name:  envoyBufferToUnsafeEnvoyBuffer(nameBuf),
-		Value: uint64(value),
-		Delta: uint64(delta),
-	}, true
+	return name, shared.CounterValue{Value: uint64(value), Delta: uint64(delta)}, true
 }
 
 func (s *dymMetricSnapshot) GaugeCount() uint64 {
 	return uint64(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(s.snapshotPtr))
 }
 
-func (s *dymMetricSnapshot) GetGauge(index uint64) (shared.GaugeSnapshot, bool) {
-	var nameBuf C.envoy_dynamic_module_type_envoy_buffer
+func (s *dymMetricSnapshot) GetGauge(index uint64, name []byte) ([]byte, uint64, bool) {
 	var value C.uint64_t
-	ok := bool(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
-		s.snapshotPtr, C.size_t(index), &nameBuf, &value,
-	))
+	name, ok := buffer.Fill(name, func(buf []byte) (uint64, bool) {
+		var size C.size_t
+		ret := C.envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+			s.snapshotPtr, C.size_t(index), sliceDataPtr(buf), C.size_t(cap(buf)), &size, &value,
+		)
+		runtime.KeepAlive(buf)
+		return uint64(size), bool(ret)
+	})
 	if !ok {
-		return shared.GaugeSnapshot{}, false
+		return name, 0, false
 	}
-	return shared.GaugeSnapshot{
-		Name:  envoyBufferToUnsafeEnvoyBuffer(nameBuf),
-		Value: uint64(value),
-	}, true
+	return name, uint64(value), true
 }
 
 func (s *dymMetricSnapshot) TextReadoutCount() uint64 {
 	return uint64(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(s.snapshotPtr))
 }
 
-func (s *dymMetricSnapshot) GetTextReadout(index uint64) (shared.TextReadoutSnapshot, bool) {
-	var nameBuf, valueBuf C.envoy_dynamic_module_type_envoy_buffer
-	ok := bool(C.envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
-		s.snapshotPtr, C.size_t(index), &nameBuf, &valueBuf,
-	))
-	if !ok {
-		return shared.TextReadoutSnapshot{}, false
+func (s *dymMetricSnapshot) GetTextReadout(index uint64, name, value []byte) ([]byte, []byte, bool) {
+	return buffer.FillTwo(name, value, func(nameBuf, valueBuf []byte) (uint64, uint64, bool) {
+		var nameSize, valueSize C.size_t
+		ret := C.envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+			s.snapshotPtr, C.size_t(index),
+			sliceDataPtr(nameBuf), C.size_t(cap(nameBuf)), &nameSize,
+			sliceDataPtr(valueBuf), C.size_t(cap(valueBuf)), &valueSize,
+		)
+		runtime.KeepAlive(nameBuf)
+		runtime.KeepAlive(valueBuf)
+		return uint64(nameSize), uint64(valueSize), bool(ret)
+	})
+}
+
+// sliceDataPtr returns a pointer to the backing array of b for passing to Envoy, or nil when b
+// has no capacity. Envoy treats a nil/zero-capacity buffer as a length query and writes nothing.
+func sliceDataPtr(b []byte) *C.char {
+	if cap(b) == 0 {
+		return nil
 	}
-	return shared.TextReadoutSnapshot{
-		Name:  envoyBufferToUnsafeEnvoyBuffer(nameBuf),
-		Value: envoyBufferToUnsafeEnvoyBuffer(valueBuf),
-	}, true
+	return (*C.char)(unsafe.Pointer(unsafe.SliceData(b)))
 }
 
 // statSinkConfigManager keeps each statSinkWrapper alive for as long as Envoy

--- a/source/extensions/dynamic_modules/sdk/go/internal/buffer/buffer.go
+++ b/source/extensions/dynamic_modules/sdk/go/internal/buffer/buffer.go
@@ -1,0 +1,51 @@
+// Package buffer holds SDK-internal helpers for decoding runtime values into caller-provided byte
+// buffers. The runtime writes up to the buffer capacity and reports the full size, so these helpers
+// grow the buffer and retry when it was too small. It lives under internal/ so it stays out of the
+// public module API.
+package buffer
+
+// Fill decodes a single value into buf, growing it and retrying when the value did not fit. fill
+// writes up to cap(buf) bytes and returns the full size of the value and whether it exists. On
+// success the returned slice holds exactly the bytes written. When the value does not exist, buf is
+// returned unchanged with false. The size is stable during a flush, so this converges in at most
+// two iterations. Pass buf[:0] and assign the result back to reuse the allocation.
+func Fill(buf []byte, fill func(buf []byte) (size uint64, ok bool)) ([]byte, bool) {
+	for {
+		size, ok := fill(buf)
+		if !ok {
+			return buf, false
+		}
+		if size <= uint64(cap(buf)) {
+			return buf[:size], true
+		}
+		buf = make([]byte, 0, size)
+	}
+}
+
+// FillTwo decodes a name and a value produced by a single call, growing whichever did not fit and
+// retrying until both fit. fill rewrites both buffers on every call, so a retry repopulates the one
+// that already fit before the final reslice. Both sizes are stable during a flush, so this
+// converges in at most two iterations. When the value does not exist, the buffers are returned
+// unchanged with false. nameBuf and valueBuf must not share a backing array.
+func FillTwo(
+	nameBuf, valueBuf []byte,
+	fill func(nameBuf, valueBuf []byte) (nameSize, valueSize uint64, ok bool),
+) ([]byte, []byte, bool) {
+	for {
+		nameSize, valueSize, ok := fill(nameBuf, valueBuf)
+		if !ok {
+			return nameBuf, valueBuf, false
+		}
+		nameFits := nameSize <= uint64(cap(nameBuf))
+		valueFits := valueSize <= uint64(cap(valueBuf))
+		if nameFits && valueFits {
+			return nameBuf[:nameSize], valueBuf[:valueSize], true
+		}
+		if !nameFits {
+			nameBuf = make([]byte, 0, nameSize)
+		}
+		if !valueFits {
+			valueBuf = make([]byte, 0, valueSize)
+		}
+	}
+}

--- a/source/extensions/dynamic_modules/sdk/go/internal/buffer/buffer_test.go
+++ b/source/extensions/dynamic_modules/sdk/go/internal/buffer/buffer_test.go
@@ -1,0 +1,208 @@
+package buffer
+
+import (
+	"testing"
+)
+
+// snprintfFiller returns a fill function that mimics the runtime's snprintf-style writer for a
+// fixed value. It writes min(size, cap(buf)) bytes into the backing array and reports the full
+// size. It records the number of invocations so tests can assert grow-and-retry convergence.
+func snprintfFiller(value string, exists bool, calls *int) func([]byte) (uint64, bool) {
+	return func(buf []byte) (uint64, bool) {
+		*calls++
+		if !exists {
+			return 0, false
+		}
+		copy(buf[:cap(buf)], value)
+		return uint64(len(value)), true
+	}
+}
+
+func TestFillGrowsAndRetriesFromZeroCapacity(t *testing.T) {
+	calls := 0
+	// A zero-capacity buffer forces a length query followed by a single grow-and-retry.
+	got, ok := Fill(make([]byte, 0), snprintfFiller("hello.world", true, &calls))
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if string(got) != "hello.world" {
+		t.Errorf("expected %q, got %q", "hello.world", string(got))
+	}
+	if cap(got) < len("hello.world") {
+		t.Errorf("expected capacity >= %d, got %d", len("hello.world"), cap(got))
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fill calls (length query + write), got %d", calls)
+	}
+}
+
+func TestFillGrowsAndRetriesFromTooSmallCapacity(t *testing.T) {
+	calls := 0
+	// A non-zero but too-small buffer exercises the partial-write-then-discard-and-grow path.
+	got, ok := Fill(make([]byte, 0, 3), snprintfFiller("metric", true, &calls))
+	if !ok || string(got) != "metric" {
+		t.Fatalf("expected %q, got %q ok=%v", "metric", string(got), ok)
+	}
+	if cap(got) < len("metric") {
+		t.Errorf("expected capacity >= %d, got %d", len("metric"), cap(got))
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fill calls (truncated + retry), got %d", calls)
+	}
+}
+
+func TestFillExactFit(t *testing.T) {
+	calls := 0
+	got, ok := Fill(make([]byte, 0, len("metric")), snprintfFiller("metric", true, &calls))
+	if !ok || string(got) != "metric" {
+		t.Fatalf("expected %q, got %q ok=%v", "metric", string(got), ok)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call, got %d", calls)
+	}
+}
+
+func TestFillRoomToSpare(t *testing.T) {
+	calls := 0
+	got, ok := Fill(make([]byte, 0, 64), snprintfFiller("short", true, &calls))
+	if !ok || string(got) != "short" {
+		t.Fatalf("expected %q, got %q ok=%v", "short", string(got), ok)
+	}
+	if len(got) != len("short") {
+		t.Errorf("expected len %d, got %d", len("short"), len(got))
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call, got %d", calls)
+	}
+}
+
+func TestFillNotFoundReturnsBufferUnchanged(t *testing.T) {
+	calls := 0
+	got, ok := Fill(make([]byte, 0, 8), snprintfFiller("", false, &calls))
+	if ok {
+		t.Fatal("expected not found")
+	}
+	if len(got) != 0 || cap(got) != 8 {
+		t.Errorf("expected buffer unchanged (len 0 cap 8), got len %d cap %d", len(got), cap(got))
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call, got %d", calls)
+	}
+}
+
+func TestFillReusesAllocationAcrossCalls(t *testing.T) {
+	calls := 0
+	buf, ok := Fill(make([]byte, 0), snprintfFiller("a.very.long.metric.name", true, &calls))
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	grownCap := cap(buf)
+
+	// Reusing the grown buffer for a shorter value must not reallocate or retry.
+	calls = 0
+	got, ok := Fill(buf[:0], snprintfFiller("short", true, &calls))
+	if !ok || string(got) != "short" {
+		t.Fatalf("expected %q, got %q ok=%v", "short", string(got), ok)
+	}
+	if cap(got) != grownCap {
+		t.Errorf("expected reuse of capacity %d, got %d", grownCap, cap(got))
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call on reuse, got %d", calls)
+	}
+}
+
+func TestFillEmptyValue(t *testing.T) {
+	calls := 0
+	got, ok := Fill(make([]byte, 0), snprintfFiller("", true, &calls))
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %q", string(got))
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call for empty value, got %d", calls)
+	}
+}
+
+// snprintfFillerTwo mimics the dual-buffer text-readout getter. It writes both the name and value,
+// min(size, capacity) bytes each, on every call and reports both full sizes.
+func snprintfFillerTwo(name, value string, exists bool, calls *int) func([]byte, []byte) (uint64, uint64, bool) {
+	return func(nameBuf, valueBuf []byte) (uint64, uint64, bool) {
+		*calls++
+		if !exists {
+			return 0, 0, false
+		}
+		copy(nameBuf[:cap(nameBuf)], name)
+		copy(valueBuf[:cap(valueBuf)], value)
+		return uint64(len(name)), uint64(len(value)), true
+	}
+}
+
+func TestFillTwoBothFit(t *testing.T) {
+	calls := 0
+	name, value, ok := FillTwo(make([]byte, 0, 32), make([]byte, 0, 32),
+		snprintfFillerTwo("pilot.version", "1.28.0", true, &calls))
+	if !ok || string(name) != "pilot.version" || string(value) != "1.28.0" {
+		t.Fatalf("expected pilot.version/1.28.0, got %q/%q ok=%v", string(name), string(value), ok)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call, got %d", calls)
+	}
+}
+
+func TestFillTwoNameGrows(t *testing.T) {
+	calls := 0
+	// Name starts too small at cap 0 while the value already fits, so only the name must grow.
+	name, value, ok := FillTwo(make([]byte, 0), make([]byte, 0, 32),
+		snprintfFillerTwo("pilot.version", "1.28.0", true, &calls))
+	if !ok || string(name) != "pilot.version" || string(value) != "1.28.0" {
+		t.Fatalf("expected pilot.version/1.28.0, got %q/%q ok=%v", string(name), string(value), ok)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fill calls (name grows), got %d", calls)
+	}
+}
+
+func TestFillTwoValueGrows(t *testing.T) {
+	calls := 0
+	// Value starts too small at cap 0 while the name already fits, so only the value must grow.
+	name, value, ok := FillTwo(make([]byte, 0, 32), make([]byte, 0),
+		snprintfFillerTwo("pilot.version", "1.28.0", true, &calls))
+	if !ok || string(name) != "pilot.version" || string(value) != "1.28.0" {
+		t.Fatalf("expected pilot.version/1.28.0, got %q/%q ok=%v", string(name), string(value), ok)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fill calls (value grows), got %d", calls)
+	}
+}
+
+func TestFillTwoBothGrow(t *testing.T) {
+	calls := 0
+	// Both buffers start at zero capacity, so both must grow in a single retry.
+	name, value, ok := FillTwo(make([]byte, 0), make([]byte, 0),
+		snprintfFillerTwo("pilot.version", "1.28.0", true, &calls))
+	if !ok || string(name) != "pilot.version" || string(value) != "1.28.0" {
+		t.Fatalf("expected pilot.version/1.28.0, got %q/%q ok=%v", string(name), string(value), ok)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 fill calls (both grow), got %d", calls)
+	}
+}
+
+func TestFillTwoNotFoundReturnsBuffersUnchanged(t *testing.T) {
+	calls := 0
+	name, value, ok := FillTwo(make([]byte, 0, 8), make([]byte, 0, 8),
+		snprintfFillerTwo("", "", false, &calls))
+	if ok {
+		t.Fatal("expected not found")
+	}
+	if len(name) != 0 || cap(name) != 8 || len(value) != 0 || cap(value) != 8 {
+		t.Errorf("expected buffers unchanged, got name(len %d cap %d) value(len %d cap %d)",
+			len(name), cap(name), len(value), cap(value))
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 fill call, got %d", calls)
+	}
+}

--- a/source/extensions/dynamic_modules/sdk/go/shared/stats_sink.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/stats_sink.go
@@ -1,50 +1,44 @@
 package shared
 
-// CounterSnapshot is one counter in a MetricSnapshot. The Name field points into
-// Envoy-owned memory that is only valid during the enclosing OnFlush callback.
-// Copy it with ToString() if you need to keep it.
-type CounterSnapshot struct {
-	Name  UnsafeEnvoyBuffer
+// CounterValue holds the values of a counter returned by
+// MetricSnapshot.GetCounter.
+type CounterValue struct {
 	Value uint64
 	Delta uint64
-}
-
-// GaugeSnapshot is one gauge in a MetricSnapshot. Name is only valid during the
-// enclosing OnFlush callback. See CounterSnapshot for details.
-type GaugeSnapshot struct {
-	Name  UnsafeEnvoyBuffer
-	Value uint64
-}
-
-// TextReadoutSnapshot is one text readout in a MetricSnapshot. Name and Value
-// are only valid during the enclosing OnFlush callback.
-type TextReadoutSnapshot struct {
-	Name  UnsafeEnvoyBuffer
-	Value UnsafeEnvoyBuffer
 }
 
 // MetricSnapshot gives the stats sink random access to all counters, gauges, and
 // text readouts in a single flush cycle. The runtime provides the implementation
 // and modules only consume this interface.
 //
-// The returned UnsafeEnvoyBuffer fields point into Envoy-owned memory that is
-// only valid during the OnFlush call. Copy any data you need to retain.
+// Names and text-readout values are decoded directly into a caller-provided byte
+// slice, which the runtime reslices and grows (like append) as needed, so a
+// single buffer can be reused across every entry to avoid allocating per metric
+// (for example writing each name straight to a socket). Pass buf[:0] and assign
+// the returned slice back to keep reusing the buffer.
 type MetricSnapshot interface {
 	// CounterCount returns the number of counters in the snapshot.
 	CounterCount() uint64
-	// GetCounter returns the counter at the given index. If the index is out of
-	// range, the second return value is false.
-	GetCounter(index uint64) (CounterSnapshot, bool)
+	// GetCounter writes the counter name at index into name and returns the
+	// (possibly reallocated) name slice, the counter values, and whether the
+	// index was valid. When false, name is returned unchanged.
+	GetCounter(index uint64, name []byte) ([]byte, CounterValue, bool)
 
 	// GaugeCount returns the number of gauges in the snapshot.
 	GaugeCount() uint64
-	// GetGauge returns the gauge at the given index.
-	GetGauge(index uint64) (GaugeSnapshot, bool)
+	// GetGauge writes the gauge name at index into name and returns the
+	// (possibly reallocated) name slice, the gauge value, and whether the index
+	// was valid. When false, name is returned unchanged.
+	GetGauge(index uint64, name []byte) ([]byte, uint64, bool)
 
 	// TextReadoutCount returns the number of text readouts in the snapshot.
 	TextReadoutCount() uint64
-	// GetTextReadout returns the text readout at the given index.
-	GetTextReadout(index uint64) (TextReadoutSnapshot, bool)
+	// GetTextReadout writes the text readout name and value at index into name
+	// and value, returning the (possibly reallocated) slices and whether the
+	// index was valid. When false, name and value are returned unchanged. name
+	// and value must not share a backing array, as both are written by the same
+	// call.
+	GetTextReadout(index uint64, name, value []byte) ([]byte, []byte, bool)
 }
 
 // StatSinkHandle is passed to StatSink methods. It currently exposes only

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -6248,6 +6248,41 @@ const STUB_COUNTERS: [(&str, u64, u64); 2] = [("counter_0", 10, 5), ("counter_1"
 const STUB_GAUGES: [(&str, u64); 1] = [("gauge_0", 42)];
 const STUB_TEXT_READOUTS: [(&str, &str); 1] = [("text_0", "value_0")];
 
+// Counts stub_write invocations on the calling thread so tests can assert the grow-and-retry
+// behavior (each ABI getter call writes its name once, plus a value for text readouts). It is
+// thread-local so it stays correct even if tests run in parallel.
+thread_local! {
+  static STUB_WRITE_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+fn reset_stub_write_calls() {
+  STUB_WRITE_CALLS.with(|c| c.set(0));
+}
+
+fn stub_write_calls() -> usize {
+  STUB_WRITE_CALLS.with(|c| c.get())
+}
+
+// Mirrors Envoy's snprintf-style name writer. It copies up to `capacity` bytes with no null
+// terminator and reports the full source length, exercising the SDK's grow-and-retry path.
+//
+// # Safety
+// `buffer` must point to at least `capacity` writable bytes and `size_out` must be valid.
+unsafe fn stub_write(
+  src: &str,
+  buffer: *mut std::ffi::c_char,
+  capacity: usize,
+  size_out: *mut usize,
+) {
+  STUB_WRITE_CALLS.with(|c| c.set(c.get() + 1));
+  let bytes = src.as_bytes();
+  let copy = bytes.len().min(capacity);
+  if copy > 0 {
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), buffer as *mut u8, copy);
+  }
+  *size_out = bytes.len();
+}
+
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(
   _snapshot: abi::envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr,
@@ -6259,7 +6294,9 @@ pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_c
 pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
   _snapshot: abi::envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr,
   index: usize,
-  name_out: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+  name_buffer: *mut std::ffi::c_char,
+  name_buffer_capacity: usize,
+  name_size: *mut usize,
   value_out: *mut u64,
   delta_out: *mut u64,
 ) -> bool {
@@ -6268,10 +6305,7 @@ pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
   }
   let (name, value, delta) = STUB_COUNTERS[index];
   unsafe {
-    *name_out = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: name.as_ptr() as *const _,
-      length: name.len(),
-    };
+    stub_write(name, name_buffer, name_buffer_capacity, name_size);
     *value_out = value;
     *delta_out = delta;
   }
@@ -6289,7 +6323,9 @@ pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_cou
 pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
   _snapshot: abi::envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr,
   index: usize,
-  name_out: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+  name_buffer: *mut std::ffi::c_char,
+  name_buffer_capacity: usize,
+  name_size: *mut usize,
   value_out: *mut u64,
 ) -> bool {
   if index >= STUB_GAUGES.len() {
@@ -6297,10 +6333,7 @@ pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
   }
   let (name, value) = STUB_GAUGES[index];
   unsafe {
-    *name_out = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: name.as_ptr() as *const _,
-      length: name.len(),
-    };
+    stub_write(name, name_buffer, name_buffer_capacity, name_size);
     *value_out = value;
   }
   true
@@ -6317,22 +6350,20 @@ pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_text_read
 pub extern "C" fn envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
   _snapshot: abi::envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr,
   index: usize,
-  name_out: *mut abi::envoy_dynamic_module_type_envoy_buffer,
-  value_out: *mut abi::envoy_dynamic_module_type_envoy_buffer,
+  name_buffer: *mut std::ffi::c_char,
+  name_buffer_capacity: usize,
+  name_size: *mut usize,
+  value_buffer: *mut std::ffi::c_char,
+  value_buffer_capacity: usize,
+  value_size: *mut usize,
 ) -> bool {
   if index >= STUB_TEXT_READOUTS.len() {
     return false;
   }
   let (name, value) = STUB_TEXT_READOUTS[index];
   unsafe {
-    *name_out = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: name.as_ptr() as *const _,
-      length: name.len(),
-    };
-    *value_out = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: value.as_ptr() as *const _,
-      length: value.len(),
-    };
+    stub_write(name, name_buffer, name_buffer_capacity, name_size);
+    stub_write(value, value_buffer, value_buffer_capacity, value_size);
   }
   true
 }
@@ -6390,32 +6421,99 @@ fn test_metric_snapshot_reads_all_entry_types() {
   let mut dummy = 0u8;
   let snapshot = stats_sink::MetricSnapshot::new(&mut dummy as *mut _ as *mut std::ffi::c_void);
 
+  // A single reusable buffer, starting empty, serves every read and is grown by the SDK.
+  let mut name = Vec::new();
+
   assert_eq!(snapshot.counter_count(), 2);
-  let counter = snapshot.counter(0).unwrap();
-  assert_eq!(counter.name.as_slice(), b"counter_0");
+  let counter = snapshot.counter(0, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_0");
   assert_eq!(counter.value, 10);
   assert_eq!(counter.delta, 5);
-  assert!(snapshot.counter(2).is_none());
+  let counter = snapshot.counter(1, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_1");
+  assert_eq!(counter.value, 20);
+  assert_eq!(counter.delta, 0);
+  // An out-of-range read returns None and leaves the buffer untouched.
+  assert!(snapshot.counter(2, &mut name).is_none());
+  assert_eq!(name.as_slice(), b"counter_1");
 
   assert_eq!(snapshot.gauge_count(), 1);
-  let gauge = snapshot.gauge(0).unwrap();
-  assert_eq!(gauge.name.as_slice(), b"gauge_0");
-  assert_eq!(gauge.value, 42);
-  assert!(snapshot.gauge(1).is_none());
+  let value = snapshot.gauge(0, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"gauge_0");
+  assert_eq!(value, 42);
+  // An out-of-range read returns None and leaves the buffer untouched.
+  assert!(snapshot.gauge(1, &mut name).is_none());
+  assert_eq!(name.as_slice(), b"gauge_0");
 
   assert_eq!(snapshot.text_readout_count(), 1);
-  let text_readout = snapshot.text_readout(0).unwrap();
-  assert_eq!(text_readout.name.as_slice(), b"text_0");
-  assert_eq!(text_readout.value.as_slice(), b"value_0");
-  assert!(snapshot.text_readout(1).is_none());
+  let mut text_value = Vec::new();
+  assert!(snapshot.text_readout(0, &mut name, &mut text_value));
+  assert_eq!(name.as_slice(), b"text_0");
+  assert_eq!(text_value.as_slice(), b"value_0");
+  // An out-of-range read returns false and leaves both buffers untouched.
+  assert!(!snapshot.text_readout(1, &mut name, &mut text_value));
+  assert_eq!(name.as_slice(), b"text_0");
+  assert_eq!(text_value.as_slice(), b"value_0");
+}
 
-  let counter_names: Vec<String> = snapshot
-    .counters()
-    .map(|c| String::from_utf8_lossy(c.name.as_slice()).into_owned())
-    .collect();
-  assert_eq!(counter_names, vec!["counter_0", "counter_1"]);
-  assert_eq!(snapshot.gauges().count(), 1);
-  assert_eq!(snapshot.text_readouts().count(), 1);
+#[test]
+fn test_metric_snapshot_reuses_buffer_without_reallocating() {
+  let mut dummy = 0u8;
+  let snapshot = stats_sink::MetricSnapshot::new(&mut dummy as *mut _ as *mut std::ffi::c_void);
+
+  // A buffer larger than the name is reused in place. Its length is set to the name length, not
+  // the capacity, and no reallocation occurs.
+  let mut name = Vec::with_capacity(64);
+  let ptr_before = name.as_ptr();
+  snapshot.counter(0, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_0");
+  assert_eq!(name.as_ptr(), ptr_before);
+  assert!(name.capacity() >= 64);
+
+  // The next read overwrites the same buffer with a different name.
+  snapshot.counter(1, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_1");
+  assert_eq!(name.as_ptr(), ptr_before);
+}
+
+#[test]
+fn test_metric_snapshot_grows_then_reuses_buffer() {
+  let mut dummy = 0u8;
+  let snapshot = stats_sink::MetricSnapshot::new(&mut dummy as *mut _ as *mut std::ffi::c_void);
+
+  // Starting empty forces a length query (writes nothing) followed by a grow-and-retry, so the
+  // getter is invoked twice for the first name.
+  let mut name = Vec::new();
+  reset_stub_write_calls();
+  snapshot.counter(0, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_0");
+  assert!(name.capacity() >= b"counter_0".len());
+  assert_eq!(stub_write_calls(), 2);
+
+  // The grown buffer is large enough for the next equal-length name, so it is reused in place with
+  // a single getter call and no reallocation.
+  let ptr_after_grow = name.as_ptr();
+  reset_stub_write_calls();
+  snapshot.counter(1, &mut name).unwrap();
+  assert_eq!(name.as_slice(), b"counter_1");
+  assert_eq!(name.as_ptr(), ptr_after_grow);
+  assert_eq!(stub_write_calls(), 1);
+}
+
+#[test]
+fn test_metric_snapshot_text_readout_grows_both_buffers() {
+  let mut dummy = 0u8;
+  let snapshot = stats_sink::MetricSnapshot::new(&mut dummy as *mut _ as *mut std::ffi::c_void);
+
+  // Both buffers start empty, so the first getter call truncates both. The SDK grows both and
+  // retries, giving two getter calls that each write a name and a value, for four stub_write calls.
+  let mut name = Vec::new();
+  let mut value = Vec::new();
+  reset_stub_write_calls();
+  assert!(snapshot.text_readout(0, &mut name, &mut value));
+  assert_eq!(name.as_slice(), b"text_0");
+  assert_eq!(value.as_slice(), b"value_0");
+  assert_eq!(stub_write_calls(), 4);
 }
 
 #[test]
@@ -6426,12 +6524,15 @@ fn test_envoy_dynamic_module_on_stat_sink_flush_reads_snapshot() {
   impl stats_sink::StatSink for RecordingStatSink {
     fn on_flush(&self, snapshot: &stats_sink::MetricSnapshot<'_>) {
       let mut seen = SEEN_COUNTERS.lock().unwrap();
-      for counter in snapshot.counters() {
-        seen.push((
-          String::from_utf8_lossy(counter.name.as_slice()).into_owned(),
-          counter.value,
-          counter.delta,
-        ));
+      let mut name = Vec::new();
+      for index in 0..snapshot.counter_count() {
+        if let Some(counter) = snapshot.counter(index, &mut name) {
+          seen.push((
+            String::from_utf8_lossy(&name).into_owned(),
+            counter.value,
+            counter.delta,
+          ));
+        }
       }
     }
     fn on_histogram_complete(&self, _name: EnvoyBuffer<'_>, _value: u64) {}

--- a/source/extensions/dynamic_modules/sdk/rust/src/stats_sink.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/stats_sink.rs
@@ -6,44 +6,27 @@
 //! return a [`StatSink`] from it.
 
 use crate::{abi, EnvoyBuffer, NewStatSinkConfigFunction};
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 use std::marker::PhantomData;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
-/// A counter entry in a [`MetricSnapshot`].
-#[derive(Debug, Clone, Copy)]
-pub struct CounterSnapshot<'a> {
-  /// The counter name. Valid only for the duration of the [`StatSink::on_flush`] call.
-  pub name: EnvoyBuffer<'a>,
+/// The values of a counter, returned by [`MetricSnapshot::counter`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CounterValue {
   /// The current accumulated value.
   pub value: u64,
   /// The increase since the previous flush.
   pub delta: u64,
 }
 
-/// A gauge entry in a [`MetricSnapshot`].
-#[derive(Debug, Clone, Copy)]
-pub struct GaugeSnapshot<'a> {
-  /// The gauge name. Valid only for the duration of the [`StatSink::on_flush`] call.
-  pub name: EnvoyBuffer<'a>,
-  /// The current value.
-  pub value: u64,
-}
-
-/// A text readout entry in a [`MetricSnapshot`].
-#[derive(Debug, Clone, Copy)]
-pub struct TextReadoutSnapshot<'a> {
-  /// The text readout name. Valid only for the duration of the [`StatSink::on_flush`] call.
-  pub name: EnvoyBuffer<'a>,
-  /// The text readout value. Valid only for the duration of the [`StatSink::on_flush`] call.
-  pub value: EnvoyBuffer<'a>,
-}
-
 /// Read-only view over the metrics captured for a single flush.
 ///
-/// The snapshot and every buffer it returns are owned by Envoy and remain valid only until the
-/// [`StatSink::on_flush`] call returns. Copy any data that must outlive the call.
+/// The snapshot is owned by Envoy and is valid only until the [`StatSink::on_flush`] call
+/// returns. Stat names and text-readout values are decoded directly into a caller-provided
+/// `Vec<u8>`, which the SDK clears and grows as needed, so a single buffer can be reused across
+/// every entry to avoid allocating a string per metric. The bytes are the same UTF-8 form
+/// produced by Envoy's stats subsystem.
 pub struct MetricSnapshot<'a> {
   envoy_ptr: *mut c_void,
   _marker: PhantomData<&'a ()>,
@@ -66,33 +49,24 @@ impl<'a> MetricSnapshot<'a> {
     }
   }
 
-  /// The counter at `index`, or `None` if the index is out of range.
-  pub fn counter(&self, index: usize) -> Option<CounterSnapshot<'a>> {
-    let mut name = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: ptr::null(),
-      length: 0,
-    };
+  /// Reads the counter at `index`, writing its name into `name` and returning its values. On
+  /// success `name` holds exactly the name bytes. Returns `None` and leaves `name` unchanged when
+  /// the index is out of range.
+  pub fn counter(&self, index: usize, name: &mut Vec<u8>) -> Option<CounterValue> {
     let mut value: u64 = 0;
     let mut delta: u64 = 0;
-    let found = unsafe {
+    let found = fill_buffer(name, |ptr, capacity, size| unsafe {
       abi::envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
         self.envoy_ptr,
         index,
-        &mut name,
+        ptr,
+        capacity,
+        size,
         &mut value,
         &mut delta,
       )
-    };
-    found.then(|| CounterSnapshot {
-      name: unsafe { EnvoyBuffer::new_from_raw(name.ptr as *const u8, name.length) },
-      value,
-      delta,
-    })
-  }
-
-  /// An iterator over all counters in the snapshot.
-  pub fn counters(&self) -> impl Iterator<Item = CounterSnapshot<'a>> + '_ {
-    (0..self.counter_count()).filter_map(|index| self.counter(index))
+    });
+    found.then_some(CounterValue { value, delta })
   }
 
   /// The number of gauges in the snapshot.
@@ -100,30 +74,22 @@ impl<'a> MetricSnapshot<'a> {
     unsafe { abi::envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(self.envoy_ptr) }
   }
 
-  /// The gauge at `index`, or `None` if the index is out of range.
-  pub fn gauge(&self, index: usize) -> Option<GaugeSnapshot<'a>> {
-    let mut name = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: ptr::null(),
-      length: 0,
-    };
+  /// Reads the gauge at `index`, writing its name into `name` and returning its value. On success
+  /// `name` holds exactly the name bytes. Returns `None` and leaves `name` unchanged when the index
+  /// is out of range.
+  pub fn gauge(&self, index: usize, name: &mut Vec<u8>) -> Option<u64> {
     let mut value: u64 = 0;
-    let found = unsafe {
+    let found = fill_buffer(name, |ptr, capacity, size| unsafe {
       abi::envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
         self.envoy_ptr,
         index,
-        &mut name,
+        ptr,
+        capacity,
+        size,
         &mut value,
       )
-    };
-    found.then(|| GaugeSnapshot {
-      name: unsafe { EnvoyBuffer::new_from_raw(name.ptr as *const u8, name.length) },
-      value,
-    })
-  }
-
-  /// An iterator over all gauges in the snapshot.
-  pub fn gauges(&self) -> impl Iterator<Item = GaugeSnapshot<'a>> + '_ {
-    (0..self.gauge_count()).filter_map(|index| self.gauge(index))
+    });
+    found.then_some(value)
   }
 
   /// The number of text readouts in the snapshot.
@@ -133,33 +99,82 @@ impl<'a> MetricSnapshot<'a> {
     }
   }
 
-  /// The text readout at `index`, or `None` if the index is out of range.
-  pub fn text_readout(&self, index: usize) -> Option<TextReadoutSnapshot<'a>> {
-    let mut name = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: ptr::null(),
-      length: 0,
-    };
-    let mut value = abi::envoy_dynamic_module_type_envoy_buffer {
-      ptr: ptr::null(),
-      length: 0,
-    };
-    let found = unsafe {
-      abi::envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
-        self.envoy_ptr,
-        index,
-        &mut name,
-        &mut value,
-      )
-    };
-    found.then(|| TextReadoutSnapshot {
-      name: unsafe { EnvoyBuffer::new_from_raw(name.ptr as *const u8, name.length) },
-      value: unsafe { EnvoyBuffer::new_from_raw(value.ptr as *const u8, value.length) },
-    })
+  /// Reads the text readout at `index`, writing its name into `name` and its value into `value`.
+  /// Returns `true` on success with both buffers holding exactly their bytes. Returns `false` and
+  /// leaves both buffers unchanged when the index is out of range.
+  pub fn text_readout(&self, index: usize, name: &mut Vec<u8>, value: &mut Vec<u8>) -> bool {
+    // Both outputs come from a single call, and either may be truncated independently, so grow
+    // whichever did not fit and retry until both fit. The snapshot is stable for the duration of
+    // the flush, so this converges in at most two iterations. As with `fill_buffer`, a
+    // zero-capacity `Vec` passes a dangling-but-non-null pointer that Envoy leaves untouched.
+    loop {
+      let name_capacity = name.capacity();
+      let value_capacity = value.capacity();
+      let mut name_size: usize = 0;
+      let mut value_size: usize = 0;
+      let found = unsafe {
+        abi::envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+          self.envoy_ptr,
+          index,
+          name.as_mut_ptr() as *mut c_char,
+          name_capacity,
+          &mut name_size,
+          value.as_mut_ptr() as *mut c_char,
+          value_capacity,
+          &mut value_size,
+        )
+      };
+      if !found {
+        return false;
+      }
+      if name_size <= name_capacity && value_size <= value_capacity {
+        // SAFETY: by Envoy's snprintf-style contract, when each size is within its buffer capacity
+        // Envoy wrote exactly that many bytes, so no uninitialized bytes are exposed.
+        unsafe {
+          name.set_len(name_size);
+          value.set_len(value_size);
+        }
+        return true;
+      }
+      if name_size > name_capacity {
+        name.clear();
+        name.reserve(name_size);
+      }
+      if value_size > value_capacity {
+        value.clear();
+        value.reserve(value_size);
+      }
+    }
   }
+}
 
-  /// An iterator over all text readouts in the snapshot.
-  pub fn text_readouts(&self) -> impl Iterator<Item = TextReadoutSnapshot<'a>> + '_ {
-    (0..self.text_readout_count()).filter_map(|index| self.text_readout(index))
+/// Invokes `fill` to decode a single stat name into `buffer`, growing and retrying if the name did
+/// not fit. `fill` receives the buffer pointer, its capacity, and an out-parameter for the full
+/// name length. On success `buffer` holds exactly the bytes written and this returns `true`. If the
+/// entry does not exist `buffer` is left unchanged and this returns `false`. The reported size is
+/// stable during a flush, so this converges in at most two iterations. A zero-capacity `Vec` yields
+/// a dangling-but-non-null pointer that Envoy never dereferences because the capacity is 0.
+fn fill_buffer<F>(buffer: &mut Vec<u8>, mut fill: F) -> bool
+where
+  F: FnMut(*mut c_char, usize, &mut usize) -> bool,
+{
+  loop {
+    let capacity = buffer.capacity();
+    let mut size: usize = 0;
+    if !fill(buffer.as_mut_ptr() as *mut c_char, capacity, &mut size) {
+      return false;
+    }
+    if size <= capacity {
+      // SAFETY: Envoy's snprintf-style contract guarantees that when `size <= capacity` it wrote
+      // exactly `size` bytes into the buffer's allocation, so no uninitialized bytes are exposed.
+      unsafe {
+        buffer.set_len(size);
+      }
+      return true;
+    }
+    // The name was truncated, so grow to the reported size and retry.
+    buffer.clear();
+    buffer.reserve(size);
   }
 }
 

--- a/source/extensions/stat_sinks/dynamic_modules/BUILD
+++ b/source/extensions/stat_sinks/dynamic_modules/BUILD
@@ -18,8 +18,11 @@ envoy_cc_library(
     hdrs = ["flush_context.h"],
     deps = [
         "//envoy/stats:sink_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/stats:symbol_table_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules/abi",
+        "@abseil-cpp//absl/strings:string_view",
     ],
     alwayslink = True,
 )

--- a/source/extensions/stat_sinks/dynamic_modules/abi_impl.cc
+++ b/source/extensions/stat_sinks/dynamic_modules/abi_impl.cc
@@ -1,9 +1,14 @@
 // NOLINT(namespace-envoy)
 
-#include <string>
+#include <algorithm>
+#include <cstring>
 
+#include "source/common/common/assert.h"
+#include "source/common/stats/symbol_table.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/stat_sinks/dynamic_modules/flush_context.h"
+
+#include "absl/strings/string_view.h"
 
 namespace {
 
@@ -12,6 +17,17 @@ using Envoy::Extensions::StatSinks::DynamicModules::DynamicModuleStatsSinkFlushC
 DynamicModuleStatsSinkFlushContext*
 toFlushContext(envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr ptr) {
   return static_cast<DynamicModuleStatsSinkFlushContext*>(ptr);
+}
+
+// Writes up to capacity bytes of src into buffer with no null terminator and reports the full size
+// via size_out, so the module can detect truncation and retry with a larger buffer.
+void copyToModuleBuffer(absl::string_view src, char* buffer, size_t capacity, size_t* size_out) {
+  // A null buffer is only valid as a length query when capacity is 0.
+  ASSERT(buffer != nullptr || capacity == 0);
+  if (capacity > 0 && !src.empty()) {
+    memcpy(buffer, src.data(), std::min(src.size(), capacity)); // NOLINT(safe-memcpy)
+  }
+  *size_out = src.size();
 }
 
 } // namespace
@@ -25,7 +41,8 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(
 
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out, uint64_t* value_out, uint64_t* delta_out) {
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, uint64_t* value_out,
+    uint64_t* delta_out) {
   auto* context = toFlushContext(snapshot_envoy_ptr);
   const auto& counters = context->snapshot_.counters();
   if (index >= counters.size()) {
@@ -33,8 +50,8 @@ bool envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
   }
   const auto& snap = counters[index];
   const Envoy::Stats::Counter& counter = snap.counter_.get();
-  const std::string& name = context->string_storage_.emplace_back(counter.name());
-  *name_out = {.ptr = name.data(), .length = name.size()};
+  *name_size = counter.constSymbolTable().serializeToBuffer(counter.statName(), name_buffer,
+                                                            name_buffer_capacity);
   *value_out = counter.value();
   *delta_out = snap.delta_;
   return true;
@@ -47,15 +64,15 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(
 
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out, uint64_t* value_out) {
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, uint64_t* value_out) {
   auto* context = toFlushContext(snapshot_envoy_ptr);
   const auto& gauges = context->snapshot_.gauges();
   if (index >= gauges.size()) {
     return false;
   }
   const Envoy::Stats::Gauge& gauge = gauges[index].get();
-  const std::string& name = context->string_storage_.emplace_back(gauge.name());
-  *name_out = {.ptr = name.data(), .length = name.size()};
+  *name_size = gauge.constSymbolTable().serializeToBuffer(gauge.statName(), name_buffer,
+                                                          name_buffer_capacity);
   *value_out = gauge.value();
   return true;
 }
@@ -67,18 +84,19 @@ size_t envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(
 
 bool envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
     envoy_dynamic_module_type_stat_sink_snapshot_envoy_ptr snapshot_envoy_ptr, size_t index,
-    envoy_dynamic_module_type_envoy_buffer* name_out,
-    envoy_dynamic_module_type_envoy_buffer* value_out) {
+    char* name_buffer, size_t name_buffer_capacity, size_t* name_size, char* value_buffer,
+    size_t value_buffer_capacity, size_t* value_size) {
   auto* context = toFlushContext(snapshot_envoy_ptr);
   const auto& readouts = context->snapshot_.textReadouts();
   if (index >= readouts.size()) {
     return false;
   }
   const Envoy::Stats::TextReadout& readout = readouts[index].get();
-  const std::string& name = context->string_storage_.emplace_back(readout.name());
-  const std::string& value = context->string_storage_.emplace_back(readout.value());
-  *name_out = {.ptr = name.data(), .length = name.size()};
-  *value_out = {.ptr = value.data(), .length = value.size()};
+  *name_size = readout.constSymbolTable().serializeToBuffer(readout.statName(), name_buffer,
+                                                            name_buffer_capacity);
+  // TextReadout exposes only an owning value() accessor, so copy from the temporary into the
+  // module buffer. Names stay allocation-free above.
+  copyToModuleBuffer(readout.value(), value_buffer, value_buffer_capacity, value_size);
   return true;
 }
 

--- a/source/extensions/stat_sinks/dynamic_modules/flush_context.h
+++ b/source/extensions/stat_sinks/dynamic_modules/flush_context.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <deque>
-#include <string>
-
 #include "envoy/stats/sink.h"
 
 namespace Envoy {
@@ -13,16 +10,14 @@ namespace DynamicModules {
 /**
  * Per-flush snapshot handle passed to the module as the opaque snapshot pointer.
  *
- * It owns the stat names and values materialized by the snapshot callbacks so their buffers stay
- * valid until the flush hook returns. A std::deque is used because element addresses remain stable
- * as strings are appended.
+ * The snapshot callbacks decode stat names directly into module-provided buffers, so no Envoy-side
+ * storage is needed. This only borrows the snapshot for the duration of the flush hook.
  */
 struct DynamicModuleStatsSinkFlushContext {
   explicit DynamicModuleStatsSinkFlushContext(Stats::MetricSnapshot& snapshot)
       : snapshot_(snapshot) {}
 
   Stats::MetricSnapshot& snapshot_;
-  std::deque<std::string> string_storage_;
 };
 
 } // namespace DynamicModules

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -94,6 +94,101 @@ TEST_F(StatNameTest, SerializeStrings) {
 
 TEST_F(StatNameTest, AllocFree) { encodeDecode("hello.world"); }
 
+TEST_F(StatNameTest, SerializeToBuffer) {
+  StatName stat_name = makeStat("hello.world.foo");
+  const std::string expected = "hello.world.foo";
+
+  // A null buffer with zero capacity acts as a length query that writes nothing and reports the
+  // size.
+  EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, nullptr, 0));
+
+  // A buffer that exactly fits receives the full name and matches toString().
+  {
+    std::string buffer(expected.size(), '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ(expected, buffer);
+    EXPECT_EQ(table_.toString(stat_name), buffer);
+  }
+
+  // A larger buffer is written only up to the name length, leaving trailing bytes untouched.
+  {
+    std::string buffer(expected.size() + 4, '#');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ(expected, buffer.substr(0, expected.size()));
+    EXPECT_EQ("####", buffer.substr(expected.size()));
+  }
+
+  // A short buffer truncates mid-token but still reports the full size so the caller can retry.
+  {
+    std::string buffer(8, '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ("hello.wo", buffer);
+  }
+}
+
+TEST_F(StatNameTest, SerializeToBufferEmpty) {
+  StatName empty = makeStat("");
+  char sentinel = '#';
+  EXPECT_EQ(0, table_.serializeToBuffer(empty, &sentinel, 1));
+  EXPECT_EQ('#', sentinel); // Nothing is written for an empty name.
+  EXPECT_EQ(0, table_.serializeToBuffer(empty, nullptr, 0));
+}
+
+TEST_F(StatNameTest, SerializeToBufferDynamic) {
+  StatNameDynamicPool dynamic_pool(table_);
+  StatName dynamic = dynamic_pool.add("dynamic.token");
+  const std::string expected = "dynamic.token";
+  std::string buffer(expected.size(), '\0');
+  EXPECT_EQ(expected.size(), table_.serializeToBuffer(dynamic, buffer.data(), buffer.size()));
+  EXPECT_EQ(expected, buffer);
+
+  // A short buffer truncates a dynamic (string-view) token but still reports the full size.
+  std::string truncated(4, '\0');
+  EXPECT_EQ(expected.size(), table_.serializeToBuffer(dynamic, truncated.data(), truncated.size()));
+  EXPECT_EQ("dyna", truncated);
+}
+
+TEST_F(StatNameTest, SerializeToBufferBoundaries) {
+  // Exercises the separator-writing path at every buffer boundary around the "." token.
+  StatName stat_name = makeStat("ab.cd");
+  const std::string expected = "ab.cd"; // Tokens "ab", ".", "cd" total 5 bytes.
+
+  // A single-byte buffer captures only the first character.
+  {
+    std::string buffer(1, '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ("a", buffer);
+  }
+  // A buffer ending exactly before the separator writes just the first token.
+  {
+    std::string buffer(2, '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ("ab", buffer);
+  }
+  // A buffer ending exactly on the separator writes the first token and the separator.
+  {
+    std::string buffer(3, '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ("ab.", buffer);
+  }
+  // A buffer ending one byte into the second token writes through that first byte.
+  {
+    std::string buffer(4, '\0');
+    EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+    EXPECT_EQ("ab.c", buffer);
+  }
+}
+
+TEST_F(StatNameTest, SerializeToBufferEmptyInteriorToken) {
+  // A name with an empty interior token ("a..b") exercises the empty-token branch of the append
+  // helper, and must still match toString().
+  StatName stat_name = makeStat("a..b");
+  const std::string expected = table_.toString(stat_name);
+  std::string buffer(expected.size(), '\0');
+  EXPECT_EQ(expected.size(), table_.serializeToBuffer(stat_name, buffer.data(), buffer.size()));
+  EXPECT_EQ(expected, buffer);
+}
+
 TEST_F(StatNameTest, TestArbitrarySymbolRoundtrip) {
   const std::vector<std::string> stat_names = {"", " ", "  ", ",", "\t", "$", "%", "`", ".x"};
   for (auto& stat_name : stat_names) {

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1303,16 +1303,18 @@ WEAK_STUB(TransportSocketFlushWriteBuffer,
 WEAK_STUB(StatSinkSnapshotGetCounterCount,
           envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(nullptr))
 WEAK_STUB(StatSinkSnapshotGetCounter,
-          envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(nullptr, 0, nullptr, nullptr,
-                                                                       nullptr))
+          envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(nullptr, 0, nullptr, 0,
+                                                                       nullptr, nullptr, nullptr))
 WEAK_STUB(StatSinkSnapshotGetGaugeCount,
           envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(nullptr))
 WEAK_STUB(StatSinkSnapshotGetGauge,
-          envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(nullptr, 0, nullptr, nullptr))
+          envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(nullptr, 0, nullptr, 0,
+                                                                     nullptr, nullptr))
 WEAK_STUB(StatSinkSnapshotGetTextReadoutCount,
           envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(nullptr))
 WEAK_STUB(StatSinkSnapshotGetTextReadout,
-          envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(nullptr, 0, nullptr,
+          envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(nullptr, 0, nullptr, 0,
+                                                                            nullptr, nullptr, 0,
                                                                             nullptr))
 
 // Tests for the additional weak stubs added for ABI declarations missing from abi_impl.cc.

--- a/test/extensions/dynamic_modules/stat_sink/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/abi_impl_test.cc
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/stat_sinks/dynamic_modules/flush_context.h"
 
@@ -17,15 +19,18 @@ using testing::NiceMock;
 using testing::ReturnRef;
 
 // Exercises the C ABI snapshot callbacks the module uses to read counters, gauges, and text
-// readouts through the per-flush snapshot handle.
+// readouts through the per-flush snapshot handle. Names and values are decoded straight into
+// module-provided buffers, so the tests pass their own buffers and read back the reported size.
 class DynamicModuleStatsSinkAbiTest : public testing::Test {
 public:
   void SetUp() override {
     ON_CALL(snapshot_, textReadouts()).WillByDefault(ReturnRef(snapshot_.text_readouts_));
   }
 
-  static std::string toString(const envoy_dynamic_module_type_envoy_buffer& buf) {
-    return std::string(buf.ptr, buf.length);
+  // Returns the bytes actually written into a module buffer, clamped to its capacity so a
+  // truncated result is observable.
+  static std::string written(const char* buffer, size_t size, size_t capacity) {
+    return std::string(buffer, std::min(size, capacity));
   }
 
   // The snapshot callbacks take the opaque per-flush handle, so wrap the mock snapshot in a flush
@@ -66,12 +71,13 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetCounterValid) {
   c0_.value_ = 100;
   snapshot_.counters_.push_back({/*delta=*/7, c0_});
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
+  char name_buffer[256];
+  size_t name_size = 0;
   uint64_t value_out = 0;
   uint64_t delta_out = 0;
   EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-      snapshotHandle(), 0, &name_out, &value_out, &delta_out));
-  EXPECT_EQ("requests_total", toString(name_out));
+      snapshotHandle(), 0, name_buffer, sizeof(name_buffer), &name_size, &value_out, &delta_out));
+  EXPECT_EQ("requests_total", written(name_buffer, name_size, sizeof(name_buffer)));
   EXPECT_EQ(100u, value_out);
   EXPECT_EQ(7u, delta_out);
 }
@@ -94,15 +100,41 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetCounterIndexMany) {
   } expected[] = {{"a", 1, 10}, {"b", 2, 20}, {"c", 3, 30}};
 
   for (size_t i = 0; i < 3; i++) {
-    envoy_dynamic_module_type_envoy_buffer name_out{};
+    char name_buffer[256];
+    size_t name_size = 0;
     uint64_t value_out = 0;
     uint64_t delta_out = 0;
     ASSERT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-        snapshotHandle(), i, &name_out, &value_out, &delta_out));
-    EXPECT_EQ(expected[i].name, toString(name_out));
+        snapshotHandle(), i, name_buffer, sizeof(name_buffer), &name_size, &value_out, &delta_out));
+    EXPECT_EQ(expected[i].name, written(name_buffer, name_size, sizeof(name_buffer)));
     EXPECT_EQ(expected[i].value, value_out);
     EXPECT_EQ(expected[i].delta, delta_out);
   }
+}
+
+// A buffer smaller than the name receives a truncated prefix, but name_size reports the full
+// length so the module can retry with a large enough buffer.
+TEST_F(DynamicModuleStatsSinkAbiTest, GetCounterNameTruncatedThenRetry) {
+  c0_.name_ = "requests_total"; // 14 bytes.
+  c0_.value_ = 1;
+  snapshot_.counters_.push_back({/*delta=*/2, c0_});
+
+  char small[5];
+  size_t name_size = 0;
+  uint64_t value_out = 0;
+  uint64_t delta_out = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
+      snapshotHandle(), 0, small, sizeof(small), &name_size, &value_out, &delta_out));
+  EXPECT_EQ(14u, name_size);
+  EXPECT_EQ("reque", written(small, name_size, sizeof(small)));
+  EXPECT_EQ(1u, value_out);
+  EXPECT_EQ(2u, delta_out);
+
+  std::string retry(name_size, '\0');
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
+      snapshotHandle(), 0, retry.data(), retry.size(), &name_size, &value_out, &delta_out));
+  EXPECT_EQ(14u, name_size);
+  EXPECT_EQ("requests_total", written(retry.data(), name_size, retry.size()));
 }
 
 TEST_F(DynamicModuleStatsSinkAbiTest, GetCounterOutOfRange) {
@@ -110,13 +142,21 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetCounterOutOfRange) {
   c0_.value_ = 1;
   snapshot_.counters_.push_back({1, c0_});
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
-  uint64_t value_out = 0;
-  uint64_t delta_out = 0;
+  // The ABI contract is that no outputs are written when the index is out of range, so seed the
+  // outputs (including the first buffer byte) with sentinels and verify they survive the false
+  // return.
+  char name_buffer[256] = {'Z'};
+  size_t name_size = 12345;
+  uint64_t value_out = 999;
+  uint64_t delta_out = 888;
   EXPECT_FALSE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-      snapshotHandle(), 1, &name_out, &value_out, &delta_out));
+      snapshotHandle(), 1, name_buffer, sizeof(name_buffer), &name_size, &value_out, &delta_out));
   EXPECT_FALSE(envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
-      snapshotHandle(), 42, &name_out, &value_out, &delta_out));
+      snapshotHandle(), 42, name_buffer, sizeof(name_buffer), &name_size, &value_out, &delta_out));
+  EXPECT_EQ(12345u, name_size);
+  EXPECT_EQ(999u, value_out);
+  EXPECT_EQ(888u, delta_out);
+  EXPECT_EQ('Z', name_buffer[0]);
 }
 
 // =============================================================================
@@ -143,12 +183,37 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetGaugeValid) {
   g0_.value_ = 7;
   snapshot_.gauges_.push_back(g0_);
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
+  char name_buffer[256];
+  size_t name_size = 0;
   uint64_t value_out = 0;
-  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(snapshotHandle(), 0,
-                                                                         &name_out, &value_out));
-  EXPECT_EQ("in_flight", toString(name_out));
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+      snapshotHandle(), 0, name_buffer, sizeof(name_buffer), &name_size, &value_out));
+  EXPECT_EQ("in_flight", written(name_buffer, name_size, sizeof(name_buffer)));
   EXPECT_EQ(7u, value_out);
+}
+
+// A buffer smaller than the gauge name receives a truncated prefix, but name_size reports the full
+// length so the module can retry with a large enough buffer.
+TEST_F(DynamicModuleStatsSinkAbiTest, GetGaugeNameTruncatedThenRetry) {
+  g0_.name_ = "memory_allocated"; // 16 bytes.
+  g0_.value_ = 42;
+  snapshot_.gauges_.push_back(g0_);
+
+  char small[5];
+  size_t name_size = 0;
+  uint64_t value_out = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+      snapshotHandle(), 0, small, sizeof(small), &name_size, &value_out));
+  EXPECT_EQ(16u, name_size);
+  EXPECT_EQ("memor", written(small, name_size, sizeof(small)));
+  EXPECT_EQ(42u, value_out);
+
+  std::string retry(name_size, '\0');
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+      snapshotHandle(), 0, retry.data(), retry.size(), &name_size, &value_out));
+  EXPECT_EQ(16u, name_size);
+  EXPECT_EQ("memory_allocated", written(retry.data(), name_size, retry.size()));
+  EXPECT_EQ(42u, value_out);
 }
 
 TEST_F(DynamicModuleStatsSinkAbiTest, GetGaugeOutOfRange) {
@@ -156,10 +221,16 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetGaugeOutOfRange) {
   g0_.value_ = 1;
   snapshot_.gauges_.push_back(g0_);
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
-  uint64_t value_out = 0;
-  EXPECT_FALSE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(snapshotHandle(), 1,
-                                                                          &name_out, &value_out));
+  // No outputs may be written on a false return, so seed the size and the first buffer byte with
+  // sentinels and verify they survive.
+  char name_buffer[256] = {'Z'};
+  size_t name_size = 12345;
+  uint64_t value_out = 999;
+  EXPECT_FALSE(envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+      snapshotHandle(), 1, name_buffer, sizeof(name_buffer), &name_size, &value_out));
+  EXPECT_EQ(12345u, name_size);
+  EXPECT_EQ(999u, value_out);
+  EXPECT_EQ('Z', name_buffer[0]);
 }
 
 // =============================================================================
@@ -188,12 +259,79 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutValid) {
   t0_.value_ = "1.28.0";
   snapshot_.text_readouts_.push_back(t0_);
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
-  envoy_dynamic_module_type_envoy_buffer value_out{};
+  char name_buffer[256];
+  size_t name_size = 0;
+  char value_buffer[256];
+  size_t value_size = 0;
   EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
-      snapshotHandle(), 0, &name_out, &value_out));
-  EXPECT_EQ("version", toString(name_out));
-  EXPECT_EQ("1.28.0", toString(value_out));
+      snapshotHandle(), 0, name_buffer, sizeof(name_buffer), &name_size, value_buffer,
+      sizeof(value_buffer), &value_size));
+  EXPECT_EQ("version", written(name_buffer, name_size, sizeof(name_buffer)));
+  EXPECT_EQ("1.28.0", written(value_buffer, value_size, sizeof(value_buffer)));
+}
+
+// An empty value reports size 0 and writes nothing, while the name still decodes normally.
+TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutEmptyValue) {
+  t0_.name_ = "version";
+  t0_.value_ = "";
+  snapshot_.text_readouts_.push_back(t0_);
+
+  char name_buffer[256];
+  size_t name_size = 0;
+  char value_buffer[256] = {'Y'};
+  size_t value_size = 999;
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+      snapshotHandle(), 0, name_buffer, sizeof(name_buffer), &name_size, value_buffer,
+      sizeof(value_buffer), &value_size));
+  EXPECT_EQ("version", written(name_buffer, name_size, sizeof(name_buffer)));
+  EXPECT_EQ(0u, value_size);
+  EXPECT_EQ('Y', value_buffer[0]);
+}
+
+// Both the name and value honor the truncation-and-retry contract independently.
+TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutValueTruncated) {
+  t0_.name_ = "control_plane";
+  t0_.value_ = "pilot-1.28.0"; // 12 bytes.
+  snapshot_.text_readouts_.push_back(t0_);
+
+  char name_buffer[256];
+  size_t name_size = 0;
+  char small_value[4];
+  size_t value_size = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+      snapshotHandle(), 0, name_buffer, sizeof(name_buffer), &name_size, small_value,
+      sizeof(small_value), &value_size));
+  EXPECT_EQ("control_plane", written(name_buffer, name_size, sizeof(name_buffer)));
+  EXPECT_EQ(12u, value_size);
+  EXPECT_EQ("pilo", written(small_value, value_size, sizeof(small_value)));
+}
+
+// The name and value can both be truncated in one call, and name_size and value_size report the
+// full lengths so the module can grow both buffers and retry to recover the complete strings.
+TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutNameAndValueTruncatedThenRetry) {
+  t0_.name_ = "control_plane"; // 13 bytes.
+  t0_.value_ = "pilot-1.28.0"; // 12 bytes.
+  snapshot_.text_readouts_.push_back(t0_);
+
+  char small_name[5];
+  size_t name_size = 0;
+  char small_value[4];
+  size_t value_size = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+      snapshotHandle(), 0, small_name, sizeof(small_name), &name_size, small_value,
+      sizeof(small_value), &value_size));
+  EXPECT_EQ(13u, name_size);
+  EXPECT_EQ("contr", written(small_name, name_size, sizeof(small_name)));
+  EXPECT_EQ(12u, value_size);
+  EXPECT_EQ("pilo", written(small_value, value_size, sizeof(small_value)));
+
+  std::string name_retry(name_size, '\0');
+  std::string value_retry(value_size, '\0');
+  EXPECT_TRUE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+      snapshotHandle(), 0, name_retry.data(), name_retry.size(), &name_size, value_retry.data(),
+      value_retry.size(), &value_size));
+  EXPECT_EQ("control_plane", written(name_retry.data(), name_size, name_retry.size()));
+  EXPECT_EQ("pilot-1.28.0", written(value_retry.data(), value_size, value_retry.size()));
 }
 
 TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutOutOfRange) {
@@ -201,10 +339,19 @@ TEST_F(DynamicModuleStatsSinkAbiTest, GetTextReadoutOutOfRange) {
   t0_.value_ = "x";
   snapshot_.text_readouts_.push_back(t0_);
 
-  envoy_dynamic_module_type_envoy_buffer name_out{};
-  envoy_dynamic_module_type_envoy_buffer value_out{};
+  // No outputs may be written on a false return, so seed both sizes and the first buffer bytes
+  // with sentinels and verify they survive.
+  char name_buffer[256] = {'Z'};
+  size_t name_size = 12345;
+  char value_buffer[256] = {'Y'};
+  size_t value_size = 54321;
   EXPECT_FALSE(envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
-      snapshotHandle(), 1, &name_out, &value_out));
+      snapshotHandle(), 1, name_buffer, sizeof(name_buffer), &name_size, value_buffer,
+      sizeof(value_buffer), &value_size));
+  EXPECT_EQ(12345u, name_size);
+  EXPECT_EQ(54321u, value_size);
+  EXPECT_EQ('Z', name_buffer[0]);
+  EXPECT_EQ('Y', value_buffer[0]);
 }
 
 } // namespace

--- a/test/extensions/dynamic_modules/stat_sink/integration_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/integration_test.cc
@@ -72,9 +72,12 @@ INSTANTIATE_TEST_SUITE_P(
     DynamicModulesStatsSinkIntegrationTest::testParamsToString);
 
 TEST_P(DynamicModulesStatsSinkIntegrationTest, BasicFlush) {
+  // The "found gauge server.uptime" marker proves the module decoded a gauge name through the
+  // buffer-based snapshot API.
   EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({
                                  {"info", "stat sink integration test: config_new called"},
                                  {"info", "stat sink integration test: flush called"},
+                                 {"info", "stat sink integration test: found gauge server.uptime"},
                              }),
                              {
                                addStatSinkAndInitialize();

--- a/test/extensions/dynamic_modules/test_data/c/stat_sink_integration_test.c
+++ b/test/extensions/dynamic_modules/test_data/c/stat_sink_integration_test.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -51,6 +52,65 @@ void envoy_dynamic_module_on_stat_sink_flush(
       envoy_dynamic_module_callback_stat_sink_snapshot_get_counter_count(snapshot_envoy_ptr);
   const size_t gauge_count =
       envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge_count(snapshot_envoy_ptr);
+
+  // Decode each name straight into a stack buffer to exercise the module-provided
+  // buffer API. Names longer than the buffer are simply truncated here.
+  char name_buf[256];
+  size_t name_size = 0;
+  uint64_t value = 0;
+  uint64_t delta = 0;
+  for (size_t i = 0; i < counter_count; i++) {
+    envoy_dynamic_module_callback_stat_sink_snapshot_get_counter(
+        snapshot_envoy_ptr, i, name_buf, sizeof(name_buf), &name_size, &value, &delta);
+  }
+
+  // Look for the always-present "server.uptime" gauge to prove a name round-trips through the buffer
+  // API. A small stack buffer is tried first, then a heap retry when the name does not fit, which
+  // exercises the truncation-and-retry contract.
+  static const char kUptime[] = "server.uptime";
+  const size_t uptime_len = sizeof(kUptime) - 1;
+  int found_uptime = 0;
+  for (size_t i = 0; i < gauge_count; i++) {
+    char small[8];
+    size_t needed = 0;
+    if (!envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(
+            snapshot_envoy_ptr, i, small, sizeof(small), &needed, &value)) {
+      continue;
+    }
+    const char* full = small;
+    char* heap = NULL;
+    if (needed > sizeof(small)) {
+      heap = (char*)malloc(needed);
+      if (heap == NULL) {
+        continue;
+      }
+      size_t heap_size = 0;
+      envoy_dynamic_module_callback_stat_sink_snapshot_get_gauge(snapshot_envoy_ptr, i, heap, needed,
+                                                                 &heap_size, &value);
+      full = heap;
+    }
+    if (needed == uptime_len && memcmp(full, kUptime, uptime_len) == 0) {
+      found_uptime = 1;
+    }
+    free(heap); // free(NULL) is a no-op.
+  }
+
+  // Read back any text readouts to exercise the dual-buffer (name and value) getter during flush.
+  const size_t text_readout_count =
+      envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout_count(snapshot_envoy_ptr);
+  char tr_name[256];
+  char tr_value[256];
+  size_t tr_name_size = 0;
+  size_t tr_value_size = 0;
+  for (size_t i = 0; i < text_readout_count; i++) {
+    envoy_dynamic_module_callback_stat_sink_snapshot_get_text_readout(
+        snapshot_envoy_ptr, i, tr_name, sizeof(tr_name), &tr_name_size, tr_value, sizeof(tr_value),
+        &tr_value_size);
+  }
+
+  if (found_uptime) {
+    log_info("stat sink integration test: found gauge server.uptime");
+  }
 
   char buf[128];
   int n = snprintf(buf, sizeof(buf),

--- a/test/extensions/dynamic_modules/test_data/go/stat_sink_integration_test/stat_sink_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/stat_sink_integration_test/stat_sink_integration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 
 	sdk "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go"
@@ -32,17 +33,32 @@ func (s *integrationTestSink) OnFlush(snapshot shared.MetricSnapshot) {
 	counterCount := snapshot.CounterCount()
 	gaugeCount := snapshot.GaugeCount()
 
+	// Reuse a single name/value buffer across every entry, decoding each name straight into
+	// module-owned memory. This is the allocation-free pattern the buffer API enables (for
+	// example writing each name to a socket). Start from zero capacity so the first decode
+	// exercises the SDK grow-and-retry path, after which the buffer stays sized for later entries.
+	var name []byte
+	var value []byte
 	for i := uint64(0); i < counterCount; i++ {
-		snapshot.GetCounter(i)
+		name, _, _ = snapshot.GetCounter(i, name[:0])
 	}
+	// Decode every gauge name and look for the always-present "server.uptime" gauge, which proves a
+	// name round-trips byte-for-byte through the buffer API end to end.
+	foundUptime := false
 	for i := uint64(0); i < gaugeCount; i++ {
-		snapshot.GetGauge(i)
+		name, _, _ = snapshot.GetGauge(i, name[:0])
+		if bytes.Equal(name, []byte("server.uptime")) {
+			foundUptime = true
+		}
 	}
 	textReadoutCount := snapshot.TextReadoutCount()
 	for i := uint64(0); i < textReadoutCount; i++ {
-		snapshot.GetTextReadout(i)
+		name, value, _ = snapshot.GetTextReadout(i, name[:0], value[:0])
 	}
 
+	if foundUptime {
+		s.handle.Log(shared.LogLevelInfo, "stat sink integration test: found gauge server.uptime")
+	}
 	s.handle.Log(shared.LogLevelInfo, fmt.Sprintf(
 		"stat sink integration test: flush called counters=%d gauges=%d", counterCount, gaugeCount))
 }

--- a/test/extensions/dynamic_modules/test_data/rust/stat_sink_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/stat_sink_integration_test.rs
@@ -22,16 +22,28 @@ struct TestStatSink {}
 
 impl StatSink for TestStatSink {
   fn on_flush(&self, snapshot: &MetricSnapshot<'_>) {
-    // Exercise the snapshot read-back callbacks to prove they are usable during flush. The specific
-    // counts depend on the test setup, so we just log them.
-    for counter in snapshot.counters() {
-      let _ = counter.name.as_slice();
+    // Exercise the buffer-based snapshot callbacks to prove names decode straight into a
+    // module-owned buffer during flush. A single buffer is reused across every entry, starting
+    // empty so the first decode exercises the SDK grow-and-retry path. This is the allocation-free
+    // pattern the API enables (for example writing each name to a socket).
+    let mut name = Vec::new();
+    let mut value = Vec::new();
+    for index in 0..snapshot.counter_count() {
+      let _ = snapshot.counter(index, &mut name);
     }
-    for gauge in snapshot.gauges() {
-      let _ = gauge.name.as_slice();
+    // Decode every gauge name and look for the always-present "server.uptime" gauge, which proves a
+    // name round-trips byte-for-byte through the buffer API end to end.
+    let mut found_uptime = false;
+    for index in 0..snapshot.gauge_count() {
+      if snapshot.gauge(index, &mut name).is_some() && name.as_slice() == b"server.uptime" {
+        found_uptime = true;
+      }
     }
-    for text_readout in snapshot.text_readouts() {
-      let _ = text_readout.value.as_slice();
+    for index in 0..snapshot.text_readout_count() {
+      let _ = snapshot.text_readout(index, &mut name, &mut value);
+    }
+    if found_uptime {
+      envoy_log_info!("stat sink integration test: found gauge server.uptime");
     }
     envoy_log_info!(
       "stat sink integration test: flush called counters={} gauges={}",


### PR DESCRIPTION
## Description

In this PR we are adding a new feature for stats sink snapshot getters to decode counter, gauge, and text readout names straight into a module-provided buffer instead of materializing an intermediate `std::string` per metric on every flush.

As part of the change we added a new `SymbolTable::serializeToBuffer()` which writes a `StatName` into a caller buffer using `snprintf`-style truncation, and the RUST and Go SDKs grow and retry on truncation. This removes the per-name allocation on the flush path and lets a module stream names straight to its own sink such as a UDS socket.

---

**Commit Message:** dynamic_modules: write stat names directly into module buffers
**Additional Description:** Added a new feature for stats sink snapshot getters to decode counter, gauge, and text readout names straight into a module-provided buffer instead of materializing an intermediate `std::string` per metric on every flush.
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes:** Added
**Release Notes**: Added