### PR TITLE
Update QUICHE from d89ce8a14 to 6b6a9b743

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-06-03"
+  release_date: "2026-06-05"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -2435,7 +2435,6 @@ envoy_quic_cc_library(
         "quiche/quic/core/crypto/curve25519_key_exchange.cc",
         "quiche/quic/core/crypto/key_exchange.cc",
         "quiche/quic/core/crypto/p256_key_exchange.cc",
-        "quiche/quic/core/crypto/proof_verifier.cc",
         "quiche/quic/core/crypto/quic_compressed_certs_cache.cc",
         "quiche/quic/core/crypto/transport_parameters.cc",
     ],

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "d89ce8a1499b61418a32552d94a3df15cc666ac1",
-        sha256 = "13a99e539faf2be954aaff8168ba70096d738de8067d57f736d1e3b77afe6ff6",
+        version = "6b6a9b74324ddefa455c1f207788e0a75feeb817",
+        sha256 = "3b0c1f0d078fd61e77788559b53f36e28829da7fc675914a1bc18e33f9c14803",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),

--- a/source/common/quic/envoy_quic_proof_verifier.cc
+++ b/source/common/quic/envoy_quic_proof_verifier.cc
@@ -138,20 +138,5 @@ quic::QuicAsyncStatus EnvoyQuicProofVerifier::VerifyCertChain(
   return quic::QUIC_FAILURE;
 }
 
-quic::QuicAsyncStatus
-EnvoyQuicProofVerifier::VerifyCertChain(const std::string&, uint16_t,
-                                        const std::vector<std::string>&, const std::string&,
-                                        const std::string&, const quic::ProofVerifyContext*,
-                                        std::string*, std::unique_ptr<quic::ProofVerifyDetails>*,
-                                        uint8_t*, std::unique_ptr<quic::ProofVerifierCallback>) {
-  // This function exists only for ProofVerifiers that don't implement the new
-  // VerifyCertChain (that takes a vector of absl::string_views for the certs).
-  // A ProofVerifier needs to implement one of the VerifyCertChain functions
-  // (and it should implement the other one). However, GCC seems to require
-  // both virtual functions to be overridden.
-  QUICHE_NOTREACHED();
-  return quic::QUIC_FAILURE;
-}
-
 } // namespace Quic
 } // namespace Envoy

--- a/source/common/quic/envoy_quic_proof_verifier.h
+++ b/source/common/quic/envoy_quic_proof_verifier.h
@@ -54,18 +54,6 @@ public:
                   uint8_t* out_alert,
                   std::unique_ptr<quic::ProofVerifierCallback> callback) override;
 
-  // Deprecated: Same as VerifyCertChain above, but |certs| contains
-  // std::strings instead of absl::string_views.
-  //
-  // TODO(b/517611362): Remove this once all ProofVerifier implementations
-  // have migrated to the new VerifyCertChain.
-  quic::QuicAsyncStatus
-  VerifyCertChain(const std::string& hostname, uint16_t port, const std::vector<std::string>& certs,
-                  const std::string& ocsp_response, const std::string& cert_sct,
-                  const quic::ProofVerifyContext* context, std::string* error_details,
-                  std::unique_ptr<quic::ProofVerifyDetails>* details, uint8_t* out_alert,
-                  std::unique_ptr<quic::ProofVerifierCallback> callback) override;
-
 private:
   Envoy::Ssl::ClientContextSharedPtr context_;
   // True if the verifier should accept untrusted certs (see documentation for

--- a/test/common/quic/envoy_quic_proof_verifier_test.cc
+++ b/test/common/quic/envoy_quic_proof_verifier_test.cc
@@ -201,12 +201,11 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureInvalidLeafCert) {
   const std::string ocsp_response;
   const std::string cert_sct;
   std::string error_details;
-  const std::vector<std::string> certs{"invalid leaf cert"};
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("www.google.com", 54321, certs, ocsp_response, cert_sct,
-                                       &verify_context_, &error_details, &verify_details, nullptr,
-                                       nullptr));
+            verifier_->VerifyCertChain("www.google.com", 54321, {"invalid leaf cert"},
+                                       ocsp_response, cert_sct, &verify_context_, &error_details,
+                                       &verify_details, nullptr, nullptr));
   EXPECT_EQ("d2i_X509: fail to parse DER", error_details);
 }
 
@@ -301,12 +300,13 @@ VdGXMAjeXhnOnPvmDi5hUz/uvI+Pg6cNmUoCRwSCnK/DazhA
 -----END CERTIFICATE-----)"};
   std::stringstream pem_stream(certs);
   std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
+  std::vector<absl::string_view> chain_view(chain.begin(), chain.end());
   std::unique_ptr<quic::CertificateView> cert_view =
       quic::CertificateView::ParseSingleCertificate(chain[0]);
   ASSERT(cert_view);
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("www.google.com", 54321, chain, ocsp_response, cert_sct,
+            verifier_->VerifyCertChain("www.google.com", 54321, chain_view, ocsp_response, cert_sct,
                                        &verify_context_, &error_details, &verify_details, nullptr,
                                        nullptr));
   EXPECT_EQ("Invalid leaf cert, only P-256 ECDSA certificates are supported", error_details);
@@ -374,10 +374,11 @@ ZCFbredVxDBZuoVsfrKPSQa407Jj1Q==
   std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
   std::unique_ptr<quic::CertificateView> cert_view =
       quic::CertificateView::ParseSingleCertificate(chain[0]);
+  std::vector<absl::string_view> chain_view(chain.begin(), chain.end());
   ASSERT(cert_view);
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("lyft.com", 54321, chain, ocsp_response, cert_sct,
+            verifier_->VerifyCertChain("lyft.com", 54321, chain_view, ocsp_response, cert_sct,
                                        &verify_context_, &error_details, &verify_details, nullptr,
                                        nullptr));
   EXPECT_EQ("verify cert failed: X509_verify_cert: certificate verification error at depth 0: "
@@ -438,8 +439,9 @@ wYsML58R3P8=
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   std::stringstream pem_stream(cert_v1);
   std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
+  std::vector<absl::string_view> chain_view(chain.begin(), chain.end());
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("localhost", 54321, chain, ocsp_response, cert_sct,
+            verifier_->VerifyCertChain("localhost", 54321, chain_view, ocsp_response, cert_sct,
                                        &verify_context_, &error_details, &verify_details, nullptr,
                                        nullptr))
       << error_details;

--- a/test/common/quic/envoy_quic_proof_verifier_test.cc
+++ b/test/common/quic/envoy_quic_proof_verifier_test.cc
@@ -41,8 +41,7 @@ public:
           std::stringstream pem_stream(cert_chain_);
           std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
           return chain[0];
-        }()),
-        leaf_certs_({leaf_cert_}) {
+        }()) {
     ON_CALL(client_context_config_, cipherSuites)
         .WillByDefault(ReturnRef(
             Extensions::TransportSockets::Tls::ClientContextConfigImpl::DEFAULT_CIPHER_SUITES));
@@ -103,7 +102,6 @@ protected:
   const std::string cert_chain_{quic::test::kTestCertificateChainPem};
   std::string root_ca_cert_;
   const std::string leaf_cert_;
-  std::vector<absl::string_view> leaf_certs_;
   absl::optional<envoy::config::core::v3::TypedExtensionConfig> custom_validator_config_{
       absl::nullopt};
   NiceMock<Stats::MockStore> store_;
@@ -127,7 +125,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainSuccess) {
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_SUCCESS,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
-                                       leaf_certs_, ocsp_response, cert_sct, &verify_context_,
+                                       {leaf_cert_}, ocsp_response, cert_sct, &verify_context_,
                                        &error_details, &verify_details, nullptr, nullptr))
       << error_details;
   EXPECT_NE(verify_details, nullptr);
@@ -156,7 +154,7 @@ typed_config:
   Event::MockTimer* verify_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_EQ(quic::QUIC_PENDING,
             verifier_->VerifyCertChain(
-                std::string(cert_view->subject_alt_name_domains()[0]), 54321, leaf_certs_,
+                std::string(cert_view->subject_alt_name_domains()[0]), 54321, {leaf_cert_},
                 ocsp_response, cert_sct, &verify_context_, &error_details, &verify_details, nullptr,
                 std::unique_ptr<MockProofVerifierCallback>(quic_verify_callback)));
   EXPECT_EQ(verify_details, nullptr);
@@ -182,7 +180,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureFromSsl) {
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
-                                       leaf_certs_, ocsp_response, cert_sct, &verify_context_,
+                                       {leaf_cert_}, ocsp_response, cert_sct, &verify_context_,
                                        &error_details, &verify_details, nullptr, nullptr))
       << error_details;
   EXPECT_EQ("verify cert failed: X509_verify_cert: certificate verification error at depth 1: "
@@ -203,7 +201,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureInvalidLeafCert) {
   const std::string ocsp_response;
   const std::string cert_sct;
   std::string error_details;
-  const std::vector<absl::string_view> certs{"invalid leaf cert"};
+  const std::vector<std::string> certs{"invalid leaf cert"};
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain("www.google.com", 54321, certs, ocsp_response, cert_sct,
@@ -219,13 +217,13 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureLeafCertWithGarbage) {
   const std::string ocsp_response;
   const std::string cert_sct;
   std::string cert_with_trailing_garbage = absl::StrCat(leaf_cert_, "AAAAAA");
-  std::vector<absl::string_view> certs = {cert_with_trailing_garbage};
   std::string error_details;
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
-                                       certs, ocsp_response, cert_sct, &verify_context_,
-                                       &error_details, &verify_details, nullptr, nullptr))
+                                       {cert_with_trailing_garbage}, ocsp_response, cert_sct,
+                                       &verify_context_, &error_details, &verify_details, nullptr,
+                                       nullptr))
       << error_details;
   EXPECT_EQ("There is trailing garbage in DER.", error_details);
 }
@@ -237,7 +235,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifyCertChainFailureInvalidHost) {
   std::string error_details;
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("unknown.org", 54321, leaf_certs_, ocsp_response, cert_sct,
+            verifier_->VerifyCertChain("unknown.org", 54321, {leaf_cert_}, ocsp_response, cert_sct,
                                        &verify_context_, &error_details, &verify_details, nullptr,
                                        nullptr))
       << error_details;
@@ -262,7 +260,7 @@ typed_config:
   Event::MockTimer* verify_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
   EXPECT_EQ(
       quic::QUIC_PENDING,
-      verifier_->VerifyCertChain("unknown.org", 54321, leaf_certs_, ocsp_response, cert_sct,
+      verifier_->VerifyCertChain("unknown.org", 54321, {leaf_cert_}, ocsp_response, cert_sct,
                                  &verify_context_, &error_details, &verify_details, nullptr,
                                  std::unique_ptr<MockProofVerifierCallback>(quic_verify_callback)));
   EXPECT_EQ(verify_details, nullptr);
@@ -308,10 +306,9 @@ VdGXMAjeXhnOnPvmDi5hUz/uvI+Pg6cNmUoCRwSCnK/DazhA
   ASSERT(cert_view);
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("www.google.com", 54321,
-                                       std::vector<absl::string_view>(chain.begin(), chain.end()),
-                                       ocsp_response, cert_sct, &verify_context_, &error_details,
-                                       &verify_details, nullptr, nullptr));
+            verifier_->VerifyCertChain("www.google.com", 54321, chain, ocsp_response, cert_sct,
+                                       &verify_context_, &error_details, &verify_details, nullptr,
+                                       nullptr));
   EXPECT_EQ("Invalid leaf cert, only P-256 ECDSA certificates are supported", error_details);
 }
 
@@ -380,10 +377,9 @@ ZCFbredVxDBZuoVsfrKPSQa407Jj1Q==
   ASSERT(cert_view);
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("lyft.com", 54321,
-                                       std::vector<absl::string_view>(chain.begin(), chain.end()),
-                                       ocsp_response, cert_sct, &verify_context_, &error_details,
-                                       &verify_details, nullptr, nullptr));
+            verifier_->VerifyCertChain("lyft.com", 54321, chain, ocsp_response, cert_sct,
+                                       &verify_context_, &error_details, &verify_details, nullptr,
+                                       nullptr));
   EXPECT_EQ("verify cert failed: X509_verify_cert: certificate verification error at depth 0: "
             "unsupported certificate "
             "purpose",
@@ -402,7 +398,7 @@ TEST_F(EnvoyQuicProofVerifierTest, VerifySubjectAltNameListOverrideFailure) {
   std::unique_ptr<quic::ProofVerifyDetails> verify_details;
   EXPECT_EQ(quic::QUIC_FAILURE,
             verifier_->VerifyCertChain(std::string(cert_view->subject_alt_name_domains()[0]), 54321,
-                                       leaf_certs_, ocsp_response, cert_sct, &verify_context_,
+                                       {leaf_cert_}, ocsp_response, cert_sct, &verify_context_,
                                        &error_details, &verify_details, nullptr, nullptr))
       << error_details;
   EXPECT_EQ("verify cert failed: verify SAN list, expected SANs: [non-example.com], certificate "
@@ -443,10 +439,9 @@ wYsML58R3P8=
   std::stringstream pem_stream(cert_v1);
   std::vector<std::string> chain = quic::CertificateView::LoadPemFromStream(&pem_stream);
   EXPECT_EQ(quic::QUIC_FAILURE,
-            verifier_->VerifyCertChain("localhost", 54321,
-                                       std::vector<absl::string_view>(chain.begin(), chain.end()),
-                                       ocsp_response, cert_sct, &verify_context_, &error_details,
-                                       &verify_details, nullptr, nullptr))
+            verifier_->VerifyCertChain("localhost", 54321, chain, ocsp_response, cert_sct,
+                                       &verify_context_, &error_details, &verify_details, nullptr,
+                                       nullptr))
       << error_details;
   EXPECT_EQ("unable to parse certificate", error_details);
   EXPECT_EQ(verify_details, nullptr);


### PR DESCRIPTION
https://github.com/google/quiche/compare/d89ce8a14..6b6a9b743

```
$ git log d89ce8a14..6b6a9b743 --date=short --no-merges --format="%ad %al %s"

2026-06-05 vasilvv Move DispatchControlMessage out of the MoqtBidiStreamBase class.
2026-06-05 quiche-dev Remove old ProofVerifier::VerifyCertChain
2026-06-05 quiche-dev Implement SimpleQuicClient::error_detail()
2026-06-05 quiche-dev Add end to end QUIC test for server padding extension
2026-06-05 rch Convert unnamed enums in third_party/quic to `constexpr` variables.
2026-06-05 rch Convert unnamed enums in third_party/quiche and third_party/http2 to constexpr variables.
2026-06-05 vasilvv Factor out the logic for queueing outgoing control messages from MoqtBidiStreamBase into a separate MoqtControlMessageQueue class.
2026-06-03 wub Fix QUIC MTU discovery enablement while `SoftMaxPacketLength` is set.
```