### PR TITLE
a2a: return 413 for oversized request bodies

### DIFF
--- a/source/extensions/filters/http/a2a/a2a_filter.cc
+++ b/source/extensions/filters/http/a2a/a2a_filter.cc
@@ -157,7 +157,11 @@ Http::FilterDataStatus A2aFilter::decodeData(Buffer::Instance& data, bool end_st
       // TODO(tyxia) Support the case that size limit hit before optional fields.
       if (size_limit_hit) {
         config_->stats().body_too_large_.inc();
-        handleParseError("request body is too large.");
+        ENVOY_LOG(debug, "request body is too large.");
+        is_a2a_request_ = false;
+        decoder_callbacks_->sendLocalReply(Http::Code::PayloadTooLarge,
+                                           "request body is too large.", nullptr, absl::nullopt,
+                                           "a2a_filter_body_too_large");
       } else {
         config_->stats().invalid_json_.inc();
         handleParseError("not a valid JSON (incomplete).");

--- a/test/extensions/filters/http/a2a/a2a_filter_integration_test.cc
+++ b/test/extensions/filters/http/a2a/a2a_filter_integration_test.cc
@@ -218,7 +218,7 @@ TEST_P(A2aFilterIntegrationTest, BodyTooLargeDefaultLimit) {
 
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_FALSE(upstream_request_);
-  EXPECT_EQ("400", response->headers().getStatusValue());
+  EXPECT_EQ("413", response->headers().getStatusValue());
   // Verify it was rejected due to body size.
   EXPECT_THAT(response->body(), testing::HasSubstr("request body is too large."));
 }
@@ -357,7 +357,7 @@ TEST_P(A2aFilterIntegrationTest, BodyTooLargeRejected) {
 
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_FALSE(upstream_request_);
-  EXPECT_EQ("400", response->headers().getStatusValue());
+  EXPECT_EQ("413", response->headers().getStatusValue());
   EXPECT_THAT(response->body(), testing::HasSubstr("request body is too large"));
 }
 

--- a/test/extensions/filters/http/a2a/a2a_filter_test.cc
+++ b/test/extensions/filters/http/a2a/a2a_filter_test.cc
@@ -160,7 +160,7 @@ TEST_F(A2aFilterTest, DecodeDataBodyTooLarge) {
   Buffer::OwnedImpl buffer(json);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Http::Code::BadRequest, "request body is too large.", _, _, _));
+              sendLocalReply(Http::Code::PayloadTooLarge, "request body is too large.", _, _, _));
   // Should increment body_too_large stat
 
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, true));
@@ -186,7 +186,7 @@ TEST_F(A2aFilterTest, DecodeDataBodyTooLargePartial) {
   Buffer::OwnedImpl buffer2(part2);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Http::Code::BadRequest, "request body is too large.", _, _, _));
+              sendLocalReply(Http::Code::PayloadTooLarge, "request body is too large.", _, _, _));
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer2, true));
   EXPECT_EQ(1, config_->stats().body_too_large_.value());
 }


### PR DESCRIPTION
Commit Message: a2a: return 413 for oversized request bodies

Additional Description:
The A2A API docs say requests exceeding `max_request_body_size` are rejected with `413 Payload Too Large`, but the filter routed that path through the generic parse-error helper, which sends `400 Bad Request`.

This updates the body-too-large branch to send `Http::Code::PayloadTooLarge` and updates the unit and integration expectations. Other parser failures, including malformed or incomplete JSON, still return `400`.

Risk Level: Low

Testing:
- `git diff --check`
- Attempted `./ci/run_envoy_docker.sh './ci/do_ci.sh dev //test/extensions/filters/http/a2a:a2a_filter_test //test/extensions/filters/http/a2a:a2a_filter_integration_test'`, but Docker was not running locally.
- Attempted `npx -y @bazel/bazelisk@latest test //test/extensions/filters/http/a2a:a2a_filter_test //test/extensions/filters/http/a2a:a2a_filter_integration_test`, but the local run remained in Bazel analysis and was terminated before compilation/test execution.

Docs Changes: n/a

Release Notes: n/a