### PR TITLE
dym: make the file/async data source loading as common method

### DIFF
--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -11,29 +11,29 @@ envoy_extension_package()
 
 envoy_cc_library(
     name = "dynamic_modules_lib",
-    srcs = ["dynamic_modules.cc"],
+    srcs = [
+        "background_fetch_manager.cc",
+        "dynamic_modules.cc",
+    ],
     hdrs = [
+        "background_fetch_manager.h",
         "dynamic_modules.h",
     ],
     external_deps = ["ssl"],
     deps = [
         "//envoy/common:exception_lib",
-        "//source/common/common:hex_lib",
-        "//source/common/common:utility_lib",
-        "//source/extensions/dynamic_modules/abi",
-    ],
-)
-
-envoy_cc_library(
-    name = "background_fetch_manager_lib",
-    srcs = ["background_fetch_manager.cc"],
-    hdrs = ["background_fetch_manager.h"],
-    deps = [
-        ":dynamic_modules_lib",
+        "//envoy/init:manager_interface",
+        "//envoy/server:factory_context_interface",
         "//envoy/singleton:manager_interface",
+        "//source/common/common:hex_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/common:utility_lib",
         "//source/common/config:remote_data_fetcher_lib",
+        "//source/extensions/common/wasm:remote_async_datasource_lib",
+        "//source/extensions/dynamic_modules/abi",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/dynamic_modules/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/dynamic_modules/background_fetch_manager.cc
+++ b/source/extensions/dynamic_modules/background_fetch_manager.cc
@@ -16,10 +16,10 @@ BackgroundFetchManager::singleton(Singleton::Manager& manager) {
       /*pin=*/true);
 }
 
-void BackgroundFetchManager::erase(const std::string& sha256) { background_fetches_.erase(sha256); }
+void BackgroundFetchManager::erase(absl::string_view sha256) { background_fetches_.erase(sha256); }
 
 void BackgroundFetchManager::fetchIfNeeded(
-    const std::string& sha256, Upstream::ClusterManager& cm,
+    absl::string_view sha256, Upstream::ClusterManager& cm,
     const envoy::config::core::v3::RemoteDataSource& source) {
   auto it = background_fetches_.find(sha256);
   if (it != background_fetches_.end() && it->second->completed_) {

--- a/source/extensions/dynamic_modules/background_fetch_manager.h
+++ b/source/extensions/dynamic_modules/background_fetch_manager.h
@@ -31,12 +31,12 @@ public:
   /**
    * Removes any fetch state for this SHA256 (e.g., after a successful cache hit).
    */
-  void erase(const std::string& sha256);
+  void erase(absl::string_view sha256);
 
   /**
    * Cleans up completed fetches and starts a new one if no fetch is in-flight for this SHA256.
    */
-  void fetchIfNeeded(const std::string& sha256, Upstream::ClusterManager& cm,
+  void fetchIfNeeded(absl::string_view sha256, Upstream::ClusterManager& cm,
                      const envoy::config::core::v3::RemoteDataSource& source);
 
 private:

--- a/source/extensions/dynamic_modules/dynamic_modules.cc
+++ b/source/extensions/dynamic_modules/dynamic_modules.cc
@@ -6,12 +6,15 @@
 #include <cerrno>
 #include <fstream>
 #include <string>
+#include <system_error>
 
 #include "envoy/common/exception.h"
 
 #include "source/common/common/hex.h"
+#include "source/common/common/logger.h"
 #include "source/common/common/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/background_fetch_manager.h"
 
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
@@ -285,6 +288,139 @@ absl::StatusOr<DynamicModulePtr> newStaticModule(const absl::string_view module_
                         "Static module ABI version {} matched.", abi_version);
   }
   return dynamic_module;
+}
+
+absl::StatusOr<DynamicModuleLoadResult> newDynamicModuleByConfig(
+    const ProtoDynamicModuleConfig& config, Server::Configuration::ServerFactoryContext& context,
+    OptRef<Init::Manager> init_manager, std::function<void(DynamicModulePtr)> on_loaded) {
+
+  if (!config.has_module()) {
+    // Name-based dynamic module loading: look up the module by name under the search path.
+    if (config.name().empty()) {
+      return absl::InvalidArgumentError(
+          "Either 'name' or 'module' must be specified in dynamic_module_config");
+    }
+    auto dynamic_module =
+        newDynamicModuleByName(config.name(), config.do_not_close(), config.load_globally());
+    if (!dynamic_module.ok()) {
+      return absl::InvalidArgumentError("Failed to load dynamic module: " +
+                                        std::string(dynamic_module.status().message()));
+    }
+    return DynamicModuleLoadResult{std::move(dynamic_module.value()), nullptr};
+  }
+
+  // Data source-based dynamic module loading: load the module from the specified data source, which
+  // may be a local file path or a remote HTTP URL. If the source is remote.
+
+  if (!config.module().local().filename().empty()) {
+    // Module specified by local file path.
+    auto dynamic_module = newDynamicModule(config.module().local().filename(),
+                                           config.do_not_close(), config.load_globally());
+    if (!dynamic_module.ok()) {
+      return absl::InvalidArgumentError("Failed to load dynamic module: " +
+                                        std::string(dynamic_module.status().message()));
+    }
+    return DynamicModuleLoadResult{std::move(dynamic_module.value()), nullptr};
+  }
+
+  if (!config.module().has_remote()) {
+    return absl::InvalidArgumentError(
+        "Only local file path or remote HTTP source is supported for module sources");
+  }
+
+  const absl::string_view sha256 = config.module().remote().sha256();
+
+  // Check if a previously fetched module with the same SHA256 already exists on disk.
+  // newDynamicModuleFromBytes writes to a deterministic path based on SHA256, so the
+  // filesystem itself acts as the cache.
+  auto cached_path = moduleTempPath(sha256);
+  if (std::filesystem::exists(cached_path)) {
+    // Re-verify SHA256 of the cached file before dlopen. The cache path is in /tmp, which
+    // may be writable by other processes (co-tenant containers, shared hosts); without this
+    // check, an attacker who pre-populates ``/tmp/envoy_dynamic_module_<expected_sha>.so``
+    // with a malicious shared object turns the cache-hit fast path into arbitrary code
+    // execution. The fetch path that wrote the cached file already verified the hash, but
+    // we cannot trust that the file was not replaced between writes.
+    const auto verify_status = verifyFileSha256(cached_path, sha256);
+    if (!verify_status.ok()) {
+      // Tampered or corrupted cache entry — remove it and fall through to the fetch path
+      // below so the legitimate remote source can re-supply correct bytes.
+      std::error_code ec;
+      std::filesystem::remove(cached_path, ec);
+      ENVOY_LOG_MISC(warn, "dynamic_modules: removed cached file failing SHA256 verification: {}",
+                     verify_status.message());
+      // Fall through to the fetch logic below.
+    } else {
+      auto dynamic_module =
+          newDynamicModule(cached_path, config.do_not_close(), config.load_globally());
+      if (dynamic_module.ok()) {
+        BackgroundFetchManager::singleton(context.singletonManager())->erase(sha256);
+        return DynamicModuleLoadResult{std::move(dynamic_module.value()), nullptr};
+      }
+      // File exists, hash matches, but failed to load — re-fetching the same SHA256 would
+      // produce identical bytes, so there is no point in falling through.
+      return absl::InvalidArgumentError("Cached remote module failed to load: " +
+                                        std::string(dynamic_module.status().message()));
+    }
+  }
+
+  // In NACK mode, reject the config and kick off a background fetch. The control
+  // plane will retry, and the next attempt picks up the cached file above.
+  if (config.nack_on_cache_miss()) {
+    BackgroundFetchManager::singleton(context.singletonManager())
+        ->fetchIfNeeded(sha256, context.clusterManager(), config.module().remote());
+    return absl::InvalidArgumentError(
+        "Remote module not cached; background fetch in progress. SHA256: " + std::string(sha256));
+  }
+
+  // No cached file — need async fetch, which requires init_manager.
+  if (!init_manager.has_value()) {
+    return absl::InvalidArgumentError("Remote module sources require an init manager");
+  }
+
+  // No on_loaded callback means the caller does not support asynchronous loading, so reject the
+  // config rather than silently failing to load the module.
+  if (!on_loaded) {
+    return absl::InvalidArgumentError("Remote module sources require an on_loaded callback");
+  }
+
+  // Shared state holding the RemoteAsyncDataProvider (to keep the fetch alive for its duration,
+  // including retries) and the on_loaded callback invoked once the module is loaded.
+  auto async_state = std::make_shared<AsyncLoadingState>();
+  async_state->on_loaded = std::move(on_loaded);
+
+  // Use a weak_ptr in the callback to break the reference cycle:
+  // async_state -> remote_provider -> callback -> async_state.
+  std::weak_ptr<AsyncLoadingState> weak_state = async_state;
+
+  async_state->remote_provider = std::make_unique<RemoteAsyncDataProvider>(
+      context.clusterManager(), *init_manager, config.module().remote(),
+      context.mainThreadDispatcher(), context.api().randomGenerator(),
+      /*allow_empty=*/true, [weak_state, config](const std::string& data) {
+        auto state = weak_state.lock();
+        if (!state) {
+          return;
+        }
+        if (data.empty()) {
+          ENVOY_LOG_TO_LOGGER(
+              Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+              "Remote dynamic module fetch returned empty data; module will not be loaded");
+          return;
+        }
+        auto module_or_error = newDynamicModuleFromBytes(
+            data, config.module().remote().sha256(), config.do_not_close(), config.load_globally());
+        if (!module_or_error.ok()) {
+          ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules),
+                              error, "Failed to load remote dynamic module from bytes: {}",
+                              module_or_error.status().message());
+          return;
+        }
+        if (state->on_loaded) {
+          state->on_loaded(std::move(module_or_error.value()));
+        }
+      });
+
+  return DynamicModuleLoadResult{nullptr, std::move(async_state)};
 }
 
 } // namespace DynamicModules

--- a/source/extensions/dynamic_modules/dynamic_modules.h
+++ b/source/extensions/dynamic_modules/dynamic_modules.h
@@ -1,8 +1,15 @@
 #pragma once
 
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <string>
+
+#include "envoy/extensions/dynamic_modules/v3/dynamic_modules.pb.h"
+#include "envoy/init/manager.h"
+#include "envoy/server/factory_context.h"
+
+#include "source/extensions/common/wasm/remote_async_datasource.h"
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
@@ -10,6 +17,8 @@
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
+
+using ProtoDynamicModuleConfig = envoy::extensions::dynamic_modules::v3::DynamicModuleConfig;
 
 /**
  * A class for loading and managing dynamic modules. This corresponds to a single dlopen handle
@@ -162,6 +171,56 @@ std::filesystem::path moduleTempPath(absl::string_view sha256);
  */
 absl::Status verifyFileSha256(const std::filesystem::path& path,
                               absl::string_view expected_sha256_hex);
+
+/**
+ * Holds the state required to keep an in-flight asynchronous remote module fetch alive. This is
+ * returned (inside DynamicModuleLoadResult) when newDynamicModuleByConfig() needs to fetch the
+ * module from a remote source. The caller must keep this object alive until the fetch completes.
+ */
+struct AsyncLoadingState {
+  // Keeps the remote data provider alive for the duration of the fetch (including retries).
+  RemoteAsyncDataProviderPtr remote_provider;
+  // Invoked on the main thread with the loaded module once the remote fetch succeeds. This is the
+  // on_loaded callback that was passed to newDynamicModuleByConfig().
+  std::function<void(DynamicModulePtr)> on_loaded;
+};
+using AsyncLoadingStateSharedPtr = std::shared_ptr<AsyncLoadingState>;
+
+/**
+ * The result of newDynamicModuleByConfig(). Exactly one of the two members is populated:
+ *  - loaded_ is set when the module was loaded synchronously (local file, by name, or remote
+ *    cache hit). The caller takes ownership of the module and can use it immediately.
+ *  - async_ is set when the module is being fetched asynchronously from a remote source. The
+ *    on_loaded callback supplied to newDynamicModuleByConfig() is invoked once the fetch
+ *    completes; the caller must keep async_ alive until then.
+ */
+struct DynamicModuleLoadResult {
+  DynamicModulePtr loaded_;
+  AsyncLoadingStateSharedPtr async_;
+};
+
+/**
+ * Loads a dynamic module described by the given configuration. This consolidates all the module
+ * sourcing strategies (local file, statically linked by name, and remote HTTP source with on-disk
+ * caching and optional asynchronous fetch) behind a single entry point.
+ *
+ * @param config the dynamic module configuration describing where to source the module from.
+ * @param context the server factory context, used to access the singleton, cluster, dispatcher and
+ * random generator needed for remote fetches and background caching.
+ * @param init_manager the init manager used to register the asynchronous remote fetch target. May
+ * be nullptr; in that case a remote source that is not already cached is rejected with an error.
+ * @param on_loaded invoked on the main thread with the loaded module once an asynchronous remote
+ * fetch completes successfully. Only used for the asynchronous remote path; ignored for the
+ * synchronous paths (where the module is returned directly via DynamicModuleLoadResult::loaded_).
+ * May be empty if the caller does not support asynchronous loading.
+ * @return the load result on success, or an error status if the configuration is invalid or the
+ * module failed to load.
+ */
+absl::StatusOr<DynamicModuleLoadResult>
+newDynamicModuleByConfig(const ProtoDynamicModuleConfig& config,
+                         Server::Configuration::ServerFactoryContext& context,
+                         OptRef<Init::Manager> init_manager = {},
+                         std::function<void(DynamicModulePtr)> on_loaded = nullptr);
 
 } // namespace DynamicModules
 } // namespace Extensions

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -38,8 +38,6 @@ envoy_cc_library(
         ":abi_impl",
         ":filter_config_lib",
         ":filter_lib",
-        "//source/extensions/common/wasm:remote_async_datasource_lib",
-        "//source/extensions/dynamic_modules:background_fetch_manager_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
         "@envoy_api//envoy/extensions/filters/http/dynamic_modules/v3:pkg_cc_proto",

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -1,12 +1,7 @@
 #include "source/extensions/filters/http/dynamic_modules/factory.h"
 
-#include <filesystem>
-#include <system_error>
-
 #include "source/common/common/logger.h"
 #include "source/common/runtime/runtime_features.h"
-#include "source/extensions/common/wasm/remote_async_datasource.h"
-#include "source/extensions/dynamic_modules/background_fetch_manager.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
@@ -21,7 +16,6 @@ namespace {
 // Extracted because both the synchronous path and the remote fetch callback need it.
 absl::StatusOr<Http::FilterFactoryCb> buildFilterFactoryCallback(
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, const FilterConfig& proto_config,
-    const envoy::extensions::dynamic_modules::v3::DynamicModuleConfig& module_config,
     Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
 
   std::string config;
@@ -33,9 +27,9 @@ absl::StatusOr<Http::FilterFactoryCb> buildFilterFactoryCallback(
 
   // Use configured metrics namespace or fall back to the default.
   const std::string metrics_namespace =
-      module_config.metrics_namespace().empty()
+      proto_config.dynamic_module_config().metrics_namespace().empty()
           ? std::string(Extensions::DynamicModules::HttpFilters::DefaultMetricsNamespace)
-          : module_config.metrics_namespace();
+          : proto_config.dynamic_module_config().metrics_namespace();
 
   absl::StatusOr<
       Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilterConfigSharedPtr>
@@ -83,156 +77,59 @@ absl::StatusOr<Http::FilterFactoryCb> buildFilterFactoryCallback(
 absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFactory(
     const FilterConfig& proto_config, const std::string&,
     Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
-    Init::Manager* init_manager) {
+    OptRef<Init::Manager> init_manager) {
 
   const auto& module_config = proto_config.dynamic_module_config();
 
-  // Load the module: local file, remote HTTP source, or by name.
-  absl::StatusOr<Extensions::DynamicModules::DynamicModulePtr> dynamic_module;
-  if (module_config.has_module()) {
-    if (module_config.module().has_remote()) {
-      const auto& sha256 = module_config.module().remote().sha256();
-
-      // Check if a previously fetched module with the same SHA256 already exists on disk.
-      // newDynamicModuleFromBytes writes to a deterministic path based on SHA256, so the
-      // filesystem itself acts as the cache.
-      auto cached_path = Extensions::DynamicModules::moduleTempPath(sha256);
-      if (std::filesystem::exists(cached_path)) {
-        // Re-verify SHA256 of the cached file before dlopen. The cache path is in /tmp, which
-        // may be writable by other processes (co-tenant containers, shared hosts); without this
-        // check, an attacker who pre-populates ``/tmp/envoy_dynamic_module_<expected_sha>.so``
-        // with a malicious shared object turns the cache-hit fast path into arbitrary code
-        // execution. The fetch path that wrote the cached file already verified the hash, but
-        // we cannot trust that the file was not replaced between writes.
-        const auto verify_status =
-            Extensions::DynamicModules::verifyFileSha256(cached_path, sha256);
-        if (!verify_status.ok()) {
-          // Tampered or corrupted cache entry — remove it and fall through to the fetch path
-          // below so the legitimate remote source can re-supply correct bytes.
-          std::error_code ec;
-          std::filesystem::remove(cached_path, ec);
-          ENVOY_LOG_MISC(warn,
-                         "dynamic_modules: removed cached file failing SHA256 verification: {}",
-                         verify_status.message());
-          // Fall through to the fetch logic below.
-        } else {
-          dynamic_module = Extensions::DynamicModules::newDynamicModule(
-              cached_path, module_config.do_not_close(), module_config.load_globally());
-          if (dynamic_module.ok()) {
-            Extensions::DynamicModules::BackgroundFetchManager::singleton(
-                context.singletonManager())
-                ->erase(sha256);
-            return buildFilterFactoryCallback(std::move(dynamic_module.value()), proto_config,
-                                              module_config, context, scope);
-          }
-          // File exists, hash matches, but failed to load — re-fetching the same SHA256 would
-          // produce identical bytes, so there is no point in falling through.
-          return absl::InvalidArgumentError("Cached remote module failed to load: " +
-                                            std::string(dynamic_module.status().message()));
-        }
-      }
-
-      // In NACK mode, reject the config and kick off a background fetch. The control
-      // plane will retry, and the next attempt picks up the cached file above.
-      if (module_config.nack_on_cache_miss()) {
-        Extensions::DynamicModules::BackgroundFetchManager::singleton(context.singletonManager())
-            ->fetchIfNeeded(sha256, context.clusterManager(), module_config.module().remote());
-        return absl::InvalidArgumentError(
-            "Remote module not cached; background fetch in progress. SHA256: " + sha256);
-      }
-
-      // No cached file — need async fetch, which requires init_manager.
-      if (init_manager == nullptr) {
-        return absl::InvalidArgumentError("Remote module sources require an init manager");
-      }
-      return createFilterFactoryFromRemoteSource(proto_config, module_config, context, scope,
-                                                 *init_manager);
-    }
-    if (!module_config.module().has_local() || !module_config.module().local().has_filename()) {
-      return absl::InvalidArgumentError(
-          "Only local file path or remote HTTP source is supported for module sources");
-    }
-    dynamic_module = Extensions::DynamicModules::newDynamicModule(
-        module_config.module().local().filename(), module_config.do_not_close(),
-        module_config.load_globally());
-  } else {
-    if (module_config.name().empty()) {
-      return absl::InvalidArgumentError(
-          "Either 'name' or 'module' must be specified in dynamic_module_config");
-    }
-    dynamic_module = Extensions::DynamicModules::newDynamicModuleByName(
-        module_config.name(), module_config.do_not_close(), module_config.load_globally());
-  }
-  if (!dynamic_module.ok()) {
-    return absl::InvalidArgumentError("Failed to load dynamic module: " +
-                                      std::string(dynamic_module.status().message()));
-  }
-
-  return buildFilterFactoryCallback(std::move(dynamic_module.value()), proto_config, module_config,
-                                    context, scope);
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
-DynamicModuleConfigFactory::createFilterFactoryFromRemoteSource(
-    const FilterConfig& proto_config,
-    const envoy::extensions::dynamic_modules::v3::DynamicModuleConfig& module_config,
-    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
-    Init::Manager& init_manager) {
-
-  // Shared state: the filter factory callback is populated asynchronously after the remote fetch
-  // completes, then used by per-request lambda below. The RemoteAsyncDataProvider is stored here
-  // to keep it alive for the duration of the fetch (including retries).
+  // Shared state for the asynchronous remote-fetch path: the filter factory callback is populated
+  // after the fetch completes and then used by the per-request lambda below. The loading_state
+  // (which owns the RemoteAsyncDataProvider) is held here to keep the fetch alive for its duration,
+  // including retries.
   struct AsyncState {
     Http::FilterFactoryCb filter_factory_cb;
-    RemoteAsyncDataProviderPtr remote_provider;
+    Extensions::DynamicModules::AsyncLoadingStateSharedPtr loading_state;
   };
   auto async_state = std::make_shared<AsyncState>();
 
   // Use a weak_ptr in the callback to break the reference cycle:
-  // async_state -> remote_provider -> callback -> async_state.
+  // async_state -> loading_state -> on_loaded -> async_state.
   std::weak_ptr<AsyncState> weak_state = async_state;
 
-  async_state->remote_provider = std::make_unique<RemoteAsyncDataProvider>(
-      context.clusterManager(), init_manager, module_config.module().remote(),
-      context.mainThreadDispatcher(), context.api().randomGenerator(),
-      /*allow_empty=*/true,
-      [weak_state, proto_config_copy = proto_config, module_config_copy = module_config, &context,
-       &scope](const std::string& data) {
-        auto state = weak_state.lock();
-        if (!state) {
-          return;
-        }
-        if (data.empty()) {
-          ENVOY_LOG_TO_LOGGER(
-              Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
-              "Remote dynamic module fetch returned empty data; filter will not be installed");
-          return;
-        }
-        auto module_or_error = Extensions::DynamicModules::newDynamicModuleFromBytes(
-            data, module_config_copy.module().remote().sha256(), module_config_copy.do_not_close(),
-            module_config_copy.load_globally());
-        if (!module_or_error.ok()) {
-          ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules),
-                              error, "Failed to load remote dynamic module from bytes: {}",
-                              module_or_error.status().message());
-          return;
-        }
+  // Invoked on the main thread once an asynchronously fetched module finishes loading.
+  auto on_loaded = [weak_state, proto_config, &context,
+                    &scope](Extensions::DynamicModules::DynamicModulePtr dynamic_module) {
+    auto state = weak_state.lock();
+    if (!state) {
+      return;
+    }
+    auto cb_or_error =
+        buildFilterFactoryCallback(std::move(dynamic_module), proto_config, context, scope);
+    if (!cb_or_error.ok()) {
+      ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules),
+                          error, "Failed to create filter config from remote module: {}",
+                          cb_or_error.status().message());
+      return;
+    }
+    state->filter_factory_cb = cb_or_error.value();
+  };
 
-        auto cb_or_error =
-            buildFilterFactoryCallback(std::move(module_or_error.value()), proto_config_copy,
-                                       module_config_copy, context, scope);
-        if (!cb_or_error.ok()) {
-          ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules),
-                              error, "Failed to create filter config from remote module: {}",
-                              cb_or_error.status().message());
-          return;
-        }
-        state->filter_factory_cb = cb_or_error.value();
-      });
+  auto load_result = Extensions::DynamicModules::newDynamicModuleByConfig(
+      module_config, context, init_manager, std::move(on_loaded));
+  RETURN_IF_NOT_OK_REF(load_result.status());
 
-  // Note: if the remote fetch fails (network error, bad data, etc.), filter_factory_cb remains
-  // empty and this lambda becomes a no-op — the filter is not installed and requests pass through.
-  // This is fail-open, consistent with how Wasm remote data providers handle fetch failures.
+  // Synchronous load (local file, by name, or remote cache hit): build the factory now.
+  if (load_result->loaded_ != nullptr) {
+    return buildFilterFactoryCallback(std::move(load_result->loaded_), proto_config, context,
+                                      scope);
+  }
+
+  ASSERT(load_result->async_ != nullptr, "Async loading state must be populated for async loads");
+
+  // Asynchronous remote fetch in progress: keep the loading state alive and return a fail-open
+  // factory that becomes active once the fetch completes. If the fetch fails (network error, bad
+  // data, etc.), filter_factory_cb remains empty and this lambda is a no-op — the filter is not
+  // installed and requests pass through, consistent with how Wasm remote data providers behave.
+  async_state->loading_state = std::move(load_result->async_);
   return [async_state](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     if (async_state->filter_factory_cb) {
       async_state->filter_factory_cb(callbacks);

--- a/source/extensions/filters/http/dynamic_modules/factory.h
+++ b/source/extensions/filters/http/dynamic_modules/factory.h
@@ -24,7 +24,7 @@ public:
                                     const std::string& stat_prefix, DualInfo dual_info,
                                     Server::Configuration::ServerFactoryContext& context) override {
     return createFilterFactory(proto_config, stat_prefix, context, dual_info.scope,
-                               &dual_info.init_manager);
+                               dual_info.init_manager);
   }
   Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
       const FilterConfig& proto_config, const std::string& stat_prefix,
@@ -33,7 +33,7 @@ public:
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const FilterConfig& proto_config, const std::string& stat_prefix,
                       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
-                      Init::Manager* init_manager = nullptr);
+                      OptRef<Init::Manager> init_manager = absl::nullopt);
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,
@@ -46,13 +46,6 @@ public:
                                     Server::Configuration::ServerFactoryContext&) override {
     return proto_config.terminal_filter();
   }
-
-private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromRemoteSource(
-      const FilterConfig& proto_config,
-      const envoy::extensions::dynamic_modules::v3::DynamicModuleConfig& module_config,
-      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
-      Init::Manager& init_manager);
 };
 using UpstreamDynamicModuleConfigFactory = DynamicModuleConfigFactory;
 

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -21,7 +21,7 @@ envoy_cc_test(
         "//source/common/crypto:utility_lib",
         "//source/common/http:message_lib",
         "//source/common/stats:isolated_store_lib",
-        "//source/extensions/dynamic_modules:background_fetch_manager_lib",
+        "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/http/dynamic_modules:factory_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/http:http_mocks",

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -446,7 +446,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheHitAfterFetch) {
   DynamicModuleConfigFactory factory2;
   auto result2 =
       factory2.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
-                                   /*init_manager=*/nullptr);
+                                   /*init_manager=*/absl::nullopt);
   EXPECT_TRUE(result2.ok()) << result2.status().message();
 
   // Verify the cache-loaded factory callback installs the filter.
@@ -635,7 +635,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchPopulatesCache) {
   // so the background fetch writes the module to disk before we return.
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result1.ok());
   EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
 
@@ -644,7 +644,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchPopulatesCache) {
 
   // Second call finds the cached file and succeeds.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_TRUE(result2.ok()) << result2.status().message();
 
   // Clean up.
@@ -674,7 +674,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchFailure) {
   // Cluster is not initialized, so the fetch fails immediately.
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result1.ok());
   EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
 
@@ -684,7 +684,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchFailure) {
 
   // Second call cleans up the completed (failed) entry and starts a new fetch.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result2.ok());
   EXPECT_THAT(result2.status().message(), testing::HasSubstr("not cached"));
 }
@@ -710,7 +710,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeWithoutInitManager) {
 
   DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                            stats_scope_, /*init_manager=*/nullptr);
+                                            stats_scope_, /*init_manager=*/absl::nullopt);
   EXPECT_FALSE(result.ok());
   EXPECT_THAT(result.status().message(), testing::HasSubstr("not cached"));
   EXPECT_THAT(result.status().message(), testing::Not(testing::HasSubstr("init manager")));
@@ -753,7 +753,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeInFlightDedup) {
 
   // First call: starts a background fetch.
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result1.ok());
   EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
   EXPECT_NE(captured_cb, nullptr);
@@ -761,7 +761,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeInFlightDedup) {
   // Second call while the fetch is still in-flight: no new send_ expected (WillOnce above
   // would fail if a second call happened).
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result2.ok());
   EXPECT_THAT(result2.status().message(), testing::HasSubstr("not cached"));
 
@@ -818,7 +818,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchBadModule) {
 
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result1.ok());
   EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
 
@@ -828,7 +828,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchBadModule) {
 
   // Next config push finds the cached file, tries to load it, and gets a load error.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
-                                             stats_scope_, &init_manager_);
+                                             stats_scope_, init_manager_);
   EXPECT_FALSE(result2.ok());
   EXPECT_THAT(result2.status().message(),
               testing::HasSubstr("Cached remote module failed to load"));
@@ -898,7 +898,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheInvalidationOnMissingFile) {
   // Second call with init_manager=nullptr: file is gone, so it needs an init manager.
   auto result2 =
       factory.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
-                                  /*init_manager=*/nullptr);
+                                  /*init_manager=*/absl::nullopt);
   EXPECT_FALSE(result2.ok());
   EXPECT_THAT(result2.status().message(),
               testing::HasSubstr("Remote module sources require an init manager"));


### PR DESCRIPTION
Commit Message: dym: make the file/async data source loading as common method
Additional Description:

We added `module` API before to support data source based (local or remote data source) DYM, but only HTTP supported it. This PR split the data source loading logic out of HTTP source code to make it's possible to reuse that to support data source based DYM.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.