### PR TITLE
http: notify load balancers of connection lifecycle events via pool callbacks

### DIFF
--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -62,17 +62,26 @@ public:
    * @param hash_key the hash key used for this connection.
    * @param connection newly open connection.
    */
-  virtual void onConnectionOpen(Instance& pool, std::vector<uint8_t>& hash_key,
+  virtual void onConnectionOpen(Instance& pool, const std::vector<uint8_t>& hash_key,
                                 const Network::Connection& connection) PURE;
 
   /**
    * Called when a connection is draining and may no longer be used for requests.
    * @param pool which the connection is associated with.
    * @param hash_key the hash key used for this connection.
-   * @param connection newly open connection.
+   * @param connection the draining connection.
    */
-  virtual void onConnectionDraining(Instance& pool, std::vector<uint8_t>& hash_key,
+  virtual void onConnectionDraining(Instance& pool, const std::vector<uint8_t>& hash_key,
                                     const Network::Connection& connection) PURE;
+
+  /**
+   * Called when a connection is closed and may no longer be used for requests.
+   * @param pool which the connection is associated with.
+   * @param hash_key the hash key used for this connection.
+   * @param connection the closed connection.
+   */
+  virtual void onConnectionClosed(Instance& pool, const std::vector<uint8_t>& hash_key,
+                                  const Network::Connection& connection) PURE;
 };
 
 /**
@@ -119,6 +128,9 @@ public:
    * @return absl::string_view a protocol description for logging.
    */
   virtual absl::string_view protocolDescription() const PURE;
+
+  virtual void setLifetimeCallbacks(std::weak_ptr<ConnectionLifetimeCallbacks> callbacks,
+                                    std::vector<uint8_t> hash_key) PURE;
 };
 
 using InstancePtr = std::unique_ptr<Instance>;

--- a/envoy/upstream/load_balancer.h
+++ b/envoy/upstream/load_balancer.h
@@ -246,7 +246,8 @@ public:
    * will return nullopt.
    * @return optional lifetime callbacks for this load balancer.
    */
-  virtual OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() PURE;
+  virtual std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() PURE;
 
   /**
    * Returns a specific pool and existing connection to be used for the specified host.

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -155,6 +155,8 @@ public:
 
   bool connectCalled() const { return connect_called_; }
 
+  const Network::Connection& connection() const { return *connection_; }
+
 protected:
   /**
    * Create a codec client and connect to a remote host/port.

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -104,6 +104,31 @@ void HttpConnPoolImplBase::onPoolReady(Envoy::ConnectionPool::ActiveClient& clie
                         http_client->codec_client_->protocol());
 }
 
+void HttpConnPoolImplBase::setLifetimeCallbacks(
+    std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> callbacks,
+    std::vector<uint8_t> hash_key) {
+  lifetime_callbacks_ = callbacks;
+  hash_key_ = std::move(hash_key);
+}
+
+void HttpConnPoolImplBase::onConnectionOpen(const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionOpen(*this, hash_key_, connection);
+  }
+}
+
+void HttpConnPoolImplBase::onConnectionDraining(const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionDraining(*this, hash_key_, connection);
+  }
+}
+
+void HttpConnPoolImplBase::onConnectionClose(const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionClosed(*this, hash_key_, connection);
+  }
+}
+
 // All streams are 2^31. Client streams are half that, minus stream 0. Just to be on the safe
 // side we do 2^29.
 constexpr uint32_t DEFAULT_MAX_STREAMS = 1U << 29;
@@ -115,6 +140,7 @@ void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
     if (codec_client_->numActiveRequests() == 0) {
       codec_client_->close();
     } else {
+      parent().onConnectionDraining(codec_client_->connection());
       parent_.transitionActiveClientState(*this, ActiveClient::State::Draining);
     }
   }
@@ -223,6 +249,22 @@ RequestEncoder& MultiplexedActiveClientBase::newStreamEncoder(ResponseDecoder& r
 RequestEncoder&
 MultiplexedActiveClientBase::newStreamEncoder(ResponseDecoderHandlePtr response_decoder_handle) {
   return codec_client_->newStream(std::move(response_decoder_handle));
+}
+
+void MultiplexedActiveClientBase::onEvent(Network::ConnectionEvent event) {
+  // Lifetime callbacks must fire synchronously before ActiveClient::onEvent, because that call
+  // triggers deferred deletion of this client (and its connection).
+  if (event == Network::ConnectionEvent::Connected &&
+      state() == Envoy::ConnectionPool::ActiveClient::State::Connecting) {
+    parent().onConnectionOpen(codec_client_->connection());
+  } else if (event == Network::ConnectionEvent::ConnectedZeroRtt) {
+    parent().onConnectionOpen(codec_client_->connection());
+  } else if (event == Network::ConnectionEvent::LocalClose ||
+             event == Network::ConnectionEvent::RemoteClose) {
+    parent().onConnectionClose(codec_client_->connection());
+  }
+
+  ActiveClient::onEvent(event);
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -98,6 +98,13 @@ public:
   virtual absl::optional<HttpServerPropertiesCache::Origin>& origin() { return origin_; }
   virtual Http::HttpServerPropertiesCacheSharedPtr cache() { return nullptr; }
 
+  void setLifetimeCallbacks(std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> callbacks,
+                            std::vector<uint8_t> hash_key) override;
+
+  void onConnectionOpen(const Network::Connection& connection);
+  void onConnectionDraining(const Network::Connection& connection);
+  void onConnectionClose(const Network::Connection& connection);
+
 protected:
   friend class ActiveClient;
 
@@ -107,6 +114,8 @@ protected:
 
 private:
   absl::optional<HttpServerPropertiesCache::Origin> origin_;
+  std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks_;
+  std::vector<uint8_t> hash_key_;
 };
 
 // An implementation of Envoy::ConnectionPool::ActiveClient for HTTP/1.1 and HTTP/2
@@ -241,6 +250,8 @@ public:
   // Http::ConnectionCallbacks
   void onGoAway(Http::GoAwayErrorCode error_code) override;
   void onSettings(ReceivedSettings& settings) override;
+
+  void onEvent(Network::ConnectionEvent event) override;
 
 private:
   bool closed_with_active_rq_{};

--- a/source/common/http/conn_pool_grid.cc
+++ b/source/common/http/conn_pool_grid.cc
@@ -428,6 +428,7 @@ ConnectionPool::InstancePtr ConnectivityGrid::createHttp3Pool(bool attempt_alter
 
 void ConnectivityGrid::setupPool(ConnectionPool::Instance& pool) {
   pool.addIdleCallback([this]() { onIdleReceived(); });
+  pool.setLifetimeCallbacks(receiver_, hash_key_);
 }
 
 bool ConnectivityGrid::hasActiveConnections() const {
@@ -619,6 +620,47 @@ void ConnectivityGrid::onHandshakeComplete() {
 void ConnectivityGrid::onZeroRttHandshakeFailed() {
   ENVOY_LOG(trace, "Marking HTTP/3 failed for host '{}'.", host_->hostname());
   getHttp3StatusTracker().markHttp3FailedRecently();
+}
+
+void ConnectionLifetimeCallbacksReceiver::onConnectionOpen(ConnectionPool::Instance& pool,
+                                                           const std::vector<uint8_t>& hash_key,
+                                                           const Network::Connection& connection) {
+  parent_.onConnectionOpen(pool, hash_key, connection);
+}
+
+void ConnectionLifetimeCallbacksReceiver::onConnectionDraining(
+    ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+    const Network::Connection& connection) {
+  parent_.onConnectionDraining(pool, hash_key, connection);
+}
+
+void ConnectionLifetimeCallbacksReceiver::onConnectionClosed(
+    ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+    const Network::Connection& connection) {
+  parent_.onConnectionClosed(pool, hash_key, connection);
+}
+
+void ConnectivityGrid::onConnectionOpen(ConnectionPool::Instance& pool, const std::vector<uint8_t>&,
+                                        const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionOpen(pool, hash_key_, connection);
+  }
+}
+
+void ConnectivityGrid::onConnectionDraining(ConnectionPool::Instance& pool,
+                                            const std::vector<uint8_t>&,
+                                            const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionDraining(pool, hash_key_, connection);
+  }
+}
+
+void ConnectivityGrid::onConnectionClosed(ConnectionPool::Instance& pool,
+                                          const std::vector<uint8_t>&,
+                                          const Network::Connection& connection) {
+  if (auto callbacks = lifetime_callbacks_.lock()) {
+    callbacks->onConnectionClosed(pool, hash_key_, connection);
+  }
 }
 
 } // namespace Http

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -13,6 +13,23 @@
 namespace Envoy {
 namespace Http {
 
+class ConnectivityGrid;
+
+class ConnectionLifetimeCallbacksReceiver : public ConnectionPool::ConnectionLifetimeCallbacks {
+public:
+  ConnectionLifetimeCallbacksReceiver(ConnectivityGrid& parent) : parent_(parent) {}
+
+  void onConnectionOpen(ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+                        const Network::Connection& connection) override;
+  void onConnectionDraining(ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+                            const Network::Connection& connection) override;
+  void onConnectionClosed(ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+                          const Network::Connection& connection) override;
+
+private:
+  ConnectivityGrid& parent_;
+};
+
 // An HTTP connection pool which handles HTTP/3 failing over to HTTP/2
 //
 // The ConnectivityGrid wraps an inner HTTP/3 and HTTP/2 pool.
@@ -228,6 +245,19 @@ public:
   void onHandshakeComplete() override;
   void onZeroRttHandshakeFailed() override;
 
+  void setLifetimeCallbacks(std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> callbacks,
+                            std::vector<uint8_t> hash_key) override {
+    lifetime_callbacks_ = callbacks;
+    hash_key_ = std::move(hash_key);
+  }
+
+  void onConnectionOpen(Instance& pool, const std::vector<uint8_t>& hash_key,
+                        const Network::Connection& connection);
+  void onConnectionDraining(Instance& pool, const std::vector<uint8_t>& hash_key,
+                            const Network::Connection& connection);
+  void onConnectionClosed(Instance& pool, const std::vector<uint8_t>& hash_key,
+                          const Network::Connection& connection);
+
 protected:
   // Set the required idle callback on the pool.
   void setupPool(ConnectionPool::Instance& pool);
@@ -308,6 +338,14 @@ private:
   bool deferred_deleting_{};
 
   OptRef<Quic::EnvoyQuicNetworkObserverRegistry> network_observer_registry_;
+
+  std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks_;
+  // The hash_key identifies this pool in the cluster manager's pool map. It encodes protocol,
+  // socket options, and transport-socket options. Inner pools snapshot this value at creation
+  // time, so setLifetimeCallbacks() must be called before any inner pool is created.
+  std::vector<uint8_t> hash_key_;
+  std::shared_ptr<ConnectionLifetimeCallbacksReceiver> receiver_{
+      std::make_shared<ConnectionLifetimeCallbacksReceiver>(*this)};
 };
 
 } // namespace Http

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -2022,6 +2022,8 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::httpConnPoolImp
         pool->addIdleCallback([&parent = parent_, host, priority, hash_key]() {
           parent.httpConnPoolIsIdle(host, priority, hash_key);
         });
+        ASSERT(lb_ != nullptr);
+        pool->setLifetimeCallbacks(lb_->lifetimeCallbacks(), hash_key);
 
         return pool;
       });

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -197,7 +197,7 @@ AggregateClusterLoadBalancer::selectExistingConnection(Upstream::LoadBalancerCon
   return absl::nullopt;
 }
 
-OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
 AggregateClusterLoadBalancer::lifetimeCallbacks() {
   if (load_balancer_) {
     return load_balancer_->lifetimeCallbacks();

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -88,7 +88,8 @@ public:
   selectExistingConnection(Upstream::LoadBalancerContext* /*context*/,
                            const Upstream::Host& /*host*/,
                            std::vector<uint8_t>& /*hash_key*/) override;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override;
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override;
 
 private:
   // Use inner class to extend LoadBalancerBase. When initializing AggregateClusterLoadBalancer, the
@@ -115,7 +116,8 @@ private:
                              std::vector<uint8_t>& /*hash_key*/) override {
       return {};
     }
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
 

--- a/source/extensions/clusters/composite/cluster.cc
+++ b/source/extensions/clusters/composite/cluster.cc
@@ -170,7 +170,7 @@ CompositeClusterLoadBalancer::selectExistingConnection(Upstream::LoadBalancerCon
   return cluster->loadBalancer().selectExistingConnection(&composite_context, host, hash_key);
 }
 
-OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
 CompositeClusterLoadBalancer::lifetimeCallbacks() {
   // Return empty for now. Could be enhanced to aggregate callbacks from sub-clusters.
   return {};

--- a/source/extensions/clusters/composite/cluster.h
+++ b/source/extensions/clusters/composite/cluster.h
@@ -65,7 +65,8 @@ public:
   absl::optional<Upstream::SelectedPoolAndConnection>
   selectExistingConnection(Upstream::LoadBalancerContext* context, const Upstream::Host& host,
                            std::vector<uint8_t>& hash_key) override;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override;
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override;
 
   // Extract retry attempt count from LoadBalancerContext.
   uint32_t getAttemptCount(Upstream::LoadBalancerContext* context) const;

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -356,6 +356,24 @@ void Cluster::onDnsHostRemove(const std::string& host) {
   updatePriorityState({}, hosts_removed);
 }
 
+void Cluster::LifetimeCallbacksReceiver::onConnectionOpen(
+    Envoy::Http::ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+    const Network::Connection& connection) {
+  parent_.onConnectionOpen(pool, hash_key, connection);
+}
+
+void Cluster::LifetimeCallbacksReceiver::onConnectionDraining(
+    Envoy::Http::ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+    const Network::Connection& connection) {
+  parent_.onConnectionDraining(pool, hash_key, connection);
+}
+
+void Cluster::LifetimeCallbacksReceiver::onConnectionClosed(
+    Envoy::Http::ConnectionPool::Instance& pool, const std::vector<uint8_t>& hash_key,
+    const Network::Connection& connection) {
+  parent_.onConnectionClosed(pool, hash_key, connection);
+}
+
 Upstream::HostSelectionResponse
 Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   if (!context) {
@@ -542,19 +560,19 @@ Cluster::LoadBalancer::selectExistingConnection(Upstream::LoadBalancerContext* /
   return absl::nullopt;
 }
 
-OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
 Cluster::LoadBalancer::lifetimeCallbacks() {
   if (auto cluster = cluster_.lock()) {
     if (!cluster->allowCoalescedConnections()) {
       return {};
     }
-    return makeOptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>(*this);
+    return lifetime_callbacks_receiver_;
   }
   return {};
 }
 
 void Cluster::LoadBalancer::onConnectionOpen(Envoy::Http::ConnectionPool::Instance& pool,
-                                             std::vector<uint8_t>& hash_key,
+                                             const std::vector<uint8_t>& hash_key,
                                              const Network::Connection& connection) {
   // Only coalesce connections that are over TLS.
   if (!connection.ssl()) {
@@ -571,16 +589,33 @@ void Cluster::LoadBalancer::onConnectionOpen(Envoy::Http::ConnectionPool::Instan
   connection_info_map_[key].push_back(info);
 }
 
-void Cluster::LoadBalancer::onConnectionDraining(Envoy::Http::ConnectionPool::Instance& pool,
-                                                 std::vector<uint8_t>& hash_key,
-                                                 const Network::Connection& connection) {
+void Cluster::LoadBalancer::removeConnection(Envoy::Http::ConnectionPool::Instance& pool,
+                                             const std::vector<uint8_t>& hash_key,
+                                             const Network::Connection& connection) {
   const LookupKey key = {hash_key, *connection.connectionInfoProvider().remoteAddress()};
-  connection_info_map_[key].erase(
-      std::remove_if(connection_info_map_[key].begin(), connection_info_map_[key].end(),
-                     [&pool, &connection](const ConnectionInfo& info) {
-                       return (info.pool_ == &pool && info.connection_ == &connection);
-                     }),
-      connection_info_map_[key].end());
+  auto it = connection_info_map_.find(key);
+  if (it == connection_info_map_.end()) {
+    return;
+  }
+
+  std::erase_if(it->second, [&pool, &connection](const ConnectionInfo& info) {
+    return (info.pool_ == &pool && info.connection_ == &connection);
+  });
+  if (it->second.empty()) {
+    connection_info_map_.erase(it);
+  }
+}
+
+void Cluster::LoadBalancer::onConnectionDraining(Envoy::Http::ConnectionPool::Instance& pool,
+                                                 const std::vector<uint8_t>& hash_key,
+                                                 const Network::Connection& connection) {
+  removeConnection(pool, hash_key, connection);
+}
+
+void Cluster::LoadBalancer::onConnectionClosed(Envoy::Http::ConnectionPool::Instance& pool,
+                                               const std::vector<uint8_t>& hash_key,
+                                               const Network::Connection& connection) {
+  removeConnection(pool, hash_key, connection);
 }
 
 absl::StatusOr<std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>>

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -91,10 +91,29 @@ private:
   using HostInfoMap = absl::flat_hash_map<std::string, HostInfo>;
 
   class DFPHostSelectionHandle;
+  class LoadBalancer;
+
+  class LifetimeCallbacksReceiver
+      : public Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks {
+  public:
+    LifetimeCallbacksReceiver(LoadBalancer& parent) : parent_(parent) {}
+
+    void onConnectionOpen(Envoy::Http::ConnectionPool::Instance& pool,
+                          const std::vector<uint8_t>& hash_key,
+                          const Network::Connection& connection) override;
+    void onConnectionDraining(Envoy::Http::ConnectionPool::Instance& pool,
+                              const std::vector<uint8_t>& hash_key,
+                              const Network::Connection& connection) override;
+    void onConnectionClosed(Envoy::Http::ConnectionPool::Instance& pool,
+                            const std::vector<uint8_t>& hash_key,
+                            const Network::Connection& connection) override;
+
+  private:
+    LoadBalancer& parent_;
+  };
 
   class LoadBalancer : public Upstream::LoadBalancer,
-                       public Extensions::Common::DynamicForwardProxy::DfpLb,
-                       public Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks {
+                       public Extensions::Common::DynamicForwardProxy::DfpLb {
   public:
     LoadBalancer(std::weak_ptr<const Cluster> cluster) : cluster_(cluster) {}
     ~LoadBalancer() override;
@@ -110,18 +129,25 @@ private:
     absl::optional<Upstream::SelectedPoolAndConnection>
     selectExistingConnection(Upstream::LoadBalancerContext* context, const Upstream::Host& host,
                              std::vector<uint8_t>& hash_key) override;
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override;
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override;
 
-    // Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks
     void onConnectionOpen(Envoy::Http::ConnectionPool::Instance& pool,
-                          std::vector<uint8_t>& hash_key,
-                          const Network::Connection& connection) override;
+                          const std::vector<uint8_t>& hash_key,
+                          const Network::Connection& connection);
 
     void onConnectionDraining(Envoy::Http::ConnectionPool::Instance& pool,
-                              std::vector<uint8_t>& hash_key,
-                              const Network::Connection& connection) override;
+                              const std::vector<uint8_t>& hash_key,
+                              const Network::Connection& connection);
+
+    void onConnectionClosed(Envoy::Http::ConnectionPool::Instance& pool,
+                            const std::vector<uint8_t>& hash_key,
+                            const Network::Connection& connection);
 
   private:
+    void removeConnection(Envoy::Http::ConnectionPool::Instance& pool,
+                          const std::vector<uint8_t>& hash_key,
+                          const Network::Connection& connection);
     struct ConnectionInfo {
       Envoy::Http::ConnectionPool::Instance* pool_; // Not a ref to allow assignment in remove().
       const Network::Connection* connection_;       // Not a ref to allow assignment in remove().
@@ -142,6 +168,8 @@ private:
     absl::flat_hash_map<LookupKey, std::vector<ConnectionInfo>, LookupKeyHash> connection_info_map_;
     absl::flat_hash_set<DFPHostSelectionHandle*> pending_host_selection_handles_;
     std::weak_ptr<const Cluster> cluster_;
+    std::shared_ptr<LifetimeCallbacksReceiver> lifetime_callbacks_receiver_{
+        std::make_shared<LifetimeCallbacksReceiver>(*this)};
   };
 
   // This acts as the bridge for asynchronous host lookup. If the host is not

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -568,7 +568,8 @@ public:
                            std::vector<uint8_t>&) override {
     return absl::nullopt;
   }
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override {
     return {};
   }
 

--- a/source/extensions/clusters/original_dst/original_dst_cluster.h
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.h
@@ -111,7 +111,8 @@ public:
       return absl::nullopt;
     }
     // Lifetime tracking not implemented for OriginalDstCluster
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
 

--- a/source/extensions/clusters/redis/redis_cluster_lb.h
+++ b/source/extensions/clusters/redis/redis_cluster_lb.h
@@ -286,7 +286,8 @@ private:
       return absl::nullopt;
     }
     // Lifetime tracking not implemented.
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
 

--- a/source/extensions/clusters/reverse_connection/reverse_connection.h
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.h
@@ -168,7 +168,8 @@ public:
     }
 
     // Lifetime tracking not implemented.
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
 

--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.h
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.h
@@ -153,7 +153,8 @@ public:
     return absl::nullopt;
   }
   // Lifetime tracking not implemented.
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override {
     return {};
   }
 

--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.h
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.h
@@ -106,7 +106,8 @@ public:
     return absl::nullopt;
   }
   // Lifetime tracking not implemented.
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override {
     return {};
   }
 
@@ -142,7 +143,8 @@ private:
                              std::vector<uint8_t>& /*hash_key*/) override {
       return absl::nullopt;
     }
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
 

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.cc
@@ -74,7 +74,7 @@ DynamicModuleLoadBalancer::peekAnotherHost(Upstream::LoadBalancerContext*) {
   return nullptr;
 }
 
-OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
 DynamicModuleLoadBalancer::lifetimeCallbacks() {
   return {};
 }

--- a/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
+++ b/source/extensions/load_balancing_policies/dynamic_modules/load_balancer.h
@@ -25,7 +25,8 @@ public:
   // Upstream::LoadBalancer
   Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;
   Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext* context) override;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override;
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override;
   absl::optional<Upstream::SelectedPoolAndConnection>
   selectExistingConnection(Upstream::LoadBalancerContext* context, const Upstream::Host& host,
                            std::vector<uint8_t>& hash_key) override;

--- a/source/extensions/load_balancing_policies/override_host/load_balancer.h
+++ b/source/extensions/load_balancing_policies/override_host/load_balancer.h
@@ -136,7 +136,8 @@ private:
 
     HostSelectionResponse chooseHost(LoadBalancerContext* context) override;
 
-    OptRef<Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       // TODO(yavlasov): Check if this is needed by the fallback LB.
       return {};
     }

--- a/source/extensions/load_balancing_policies/subset/subset_lb.h
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.h
@@ -53,7 +53,8 @@ public:
     return absl::nullopt;
   }
   // Lifetime tracking not implemented.
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+  std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+  lifetimeCallbacks() override {
     return {};
   }
 

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -85,6 +85,12 @@ public:
 
   void createHttp3AlternatePool() {
     ConnectionPool::MockInstance* instance = new NiceMock<ConnectionPool::MockInstance>();
+    EXPECT_CALL(*instance, setLifetimeCallbacks(_, _))
+        .WillRepeatedly(
+            Invoke([this, instance](std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> cb,
+                                    std::vector<uint8_t> key) {
+              captured_lifetime_callbacks_[instance] = {cb.lock(), std::move(key)};
+            }));
     setupPool(*instance);
     http3_alternate_pool_.reset(instance);
     pools_.push_back(instance);
@@ -120,6 +126,12 @@ public:
               return cancel_;
             }));
     EXPECT_CALL(*instance, protocolDescription()).Times(AnyNumber()).WillRepeatedly(Return(type));
+    EXPECT_CALL(*instance, setLifetimeCallbacks(_, _))
+        .WillRepeatedly(
+            Invoke([this, instance](std::weak_ptr<ConnectionPool::ConnectionLifetimeCallbacks> cb,
+                                    std::vector<uint8_t> key) {
+              captured_lifetime_callbacks_[instance] = {cb.lock(), std::move(key)};
+            }));
     return absl::WrapUnique(instance);
   }
 
@@ -148,6 +160,28 @@ public:
     return http3_status_tracker.isHttp3Confirmed();
   }
 
+  void simulateConnectionOpen(ConnectionPool::Instance& pool,
+                              const Network::Connection& connection) {
+    auto it = captured_lifetime_callbacks_.find(&pool);
+    ASSERT_TRUE(it != captured_lifetime_callbacks_.end());
+    ASSERT_TRUE(it->second.callbacks != nullptr);
+    it->second.callbacks->onConnectionOpen(pool, it->second.hash_key, connection);
+  }
+  void simulateConnectionDraining(ConnectionPool::Instance& pool,
+                                  const Network::Connection& connection) {
+    auto it = captured_lifetime_callbacks_.find(&pool);
+    ASSERT_TRUE(it != captured_lifetime_callbacks_.end());
+    ASSERT_TRUE(it->second.callbacks != nullptr);
+    it->second.callbacks->onConnectionDraining(pool, it->second.hash_key, connection);
+  }
+  void simulateConnectionClosed(ConnectionPool::Instance& pool,
+                                const Network::Connection& connection) {
+    auto it = captured_lifetime_callbacks_.find(&pool);
+    ASSERT_TRUE(it != captured_lifetime_callbacks_.end());
+    ASSERT_TRUE(it->second.callbacks != nullptr);
+    it->second.callbacks->onConnectionClosed(pool, it->second.hash_key, connection);
+  }
+
   StreamInfo::MockStreamInfo* info_;
   NiceMock<MockRequestEncoder>* encoder_;
   void setDestroying() { destroying_ = true; }
@@ -160,6 +194,12 @@ public:
 
   bool alternate_immediate_{true};
   bool alternate_failure_{true};
+
+  struct CapturedCallbacks {
+    std::shared_ptr<ConnectionPool::ConnectionLifetimeCallbacks> callbacks;
+    std::vector<uint8_t> hash_key;
+  };
+  absl::flat_hash_map<ConnectionPool::Instance*, CapturedCallbacks> captured_lifetime_callbacks_;
 };
 
 namespace {
@@ -1899,6 +1939,187 @@ TEST_F(ConnectivityGridTest, DestroyGridWithActiveH2Attempts) {
 }
 
 #endif
+
+// --- ConnectionLifetimeCallbacks tests ---
+
+TEST_F(ConnectivityGridTest, PoolsWorkWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  grid_->immediate_success_ = true;
+  auto* cancel = grid_->newStream(decoder_, callbacks_,
+                                  {/*can_send_early_data_=*/false, /*can_use_http3_=*/true});
+  EXPECT_EQ(cancel, nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+  grid_->simulateConnectionClosed(*grid_->http3Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, H2PoolWorksWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false, /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  grid_->immediate_success_ = true;
+  grid_->callbacks()->onPoolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure,
+                                    "reason", host_);
+  EXPECT_NE(grid_->http2Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->http2Pool(), connection);
+  grid_->simulateConnectionDraining(*grid_->http2Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, H3AltPoolWorksWithoutLifetimeCallbacks) {
+  initialize();
+  addHttp3AlternateProtocol();
+  grid_->createHttp3AlternatePool();
+
+  EXPECT_NE(grid_->alternate(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->alternate(), connection);
+  grid_->simulateConnectionDraining(*grid_->alternate(), connection);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3Only) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  grid_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false, /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_->http3Pool()), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_->http3Pool()),
+                                   testing::ContainerEq(hash_key), testing::Ref(connection)));
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*grid_->http3Pool()), testing::ContainerEq(hash_key),
+                                 testing::Ref(connection)));
+  grid_->simulateConnectionClosed(*grid_->http3Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3AndH2) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  grid_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false, /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  grid_->callbacks()->onPoolFailure(ConnectionPool::PoolFailureReason::LocalConnectionFailure,
+                                    "reason", host_);
+  EXPECT_NE(grid_->http2Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> h3_conn;
+  NiceMock<Network::MockConnection> h2_conn;
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_->http3Pool()), testing::ContainerEq(hash_key),
+                               testing::Ref(h3_conn)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), h3_conn);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_->http2Pool()), testing::ContainerEq(hash_key),
+                               testing::Ref(h2_conn)));
+  grid_->simulateConnectionOpen(*grid_->http2Pool(), h2_conn);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_->http2Pool()),
+                                   testing::ContainerEq(hash_key), testing::Ref(h2_conn)));
+  grid_->simulateConnectionDraining(*grid_->http2Pool(), h2_conn);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksH3Alt) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {9, 10};
+  grid_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  grid_->createHttp3AlternatePool();
+  EXPECT_NE(grid_->alternate(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_->alternate()), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->alternate(), connection);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksSetAfterPoolCreation) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false, /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {11, 12};
+  grid_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  NiceMock<Network::MockConnection> connection;
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*grid_->http3Pool()), testing::ContainerEq(hash_key),
+                               testing::Ref(connection)));
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*grid_->http3Pool()),
+                                   testing::ContainerEq(hash_key), testing::Ref(connection)));
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+}
+
+TEST_F(ConnectivityGridTest, LifetimeCallbacksExpiredWeakPtrNoCrash) {
+  initialize();
+  addHttp3AlternateProtocol();
+
+  {
+    auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+    std::vector<uint8_t> hash_key = {1};
+    grid_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+  }
+  // lifetime_callbacks is destroyed; weak_ptr should be expired.
+
+  EXPECT_NE(grid_->newStream(decoder_, callbacks_,
+                             {/*can_send_early_data_=*/false, /*can_use_http3_=*/true}),
+            nullptr);
+  EXPECT_NE(grid_->http3Pool(), nullptr);
+
+  NiceMock<Network::MockConnection> connection;
+  grid_->simulateConnectionOpen(*grid_->http3Pool(), connection);
+  grid_->simulateConnectionDraining(*grid_->http3Pool(), connection);
+}
 
 } // namespace
 } // namespace Http

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -68,6 +68,7 @@ envoy_cc_test(
         "//test/common/http:common_lib",
         "//test/common/upstream:utility_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/http:conn_pool_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/http:http_server_properties_cache_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -11,6 +11,7 @@
 #include "test/common/http/common.h"
 #include "test/common/upstream/utility.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/conn_pool.h"
 #include "test/mocks/http/http_server_properties_cache.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
@@ -2151,6 +2152,190 @@ TEST_F(Http2ConnPoolImplTest, ReentrancySynchronousResetInPoolReady) {
   EXPECT_CALL(*this, onClientDestroy());
   test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
   dispatcher_.clearDeferredDeleteList();
+}
+
+// --- ConnectionLifetimeCallbacks tests ---
+
+TEST_F(Http2ConnPoolImplTest, ConnectionLifecycleNoopsWithoutCallbacks) {
+  InSequence s;
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  completeRequestCloseUpstream(0, r1);
+}
+
+TEST_F(Http2ConnPoolImplTest, ConnectedEventFiresOpenCallback) {
+  InSequence s;
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                               testing::Ref(*test_clients_[0].connection_)));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                 testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, RemoteCloseFiresClosedCallback) {
+  InSequence s;
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                 testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, LocalCloseFiresClosedCallback) {
+  InSequence s;
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {4, 5, 6};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                 testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::LocalClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, GoAwayWithActiveStreamFiresDrainingCallback) {
+  InSequence s;
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {7, 8, 9};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  EXPECT_CALL(r1.inner_encoder_, encodeHeaders(_, true));
+  EXPECT_TRUE(
+      r1.callbacks_.outer_encoder_
+          ->encodeHeaders(TestRequestHeaderMapImpl{{":path", "/"}, {":method", "GET"}}, true)
+          .ok());
+
+  // GOAWAY with active request fires draining from the goaway handler.
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionDraining(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                   testing::Ref(*test_clients_[0].connection_)));
+  test_clients_[0].codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
+
+  // Completing the request triggers close which fires onConnectionClosed.
+  EXPECT_CALL(*lifetime_callbacks, onConnectionClosed(_, _, _));
+  EXPECT_CALL(r1.decoder_, decodeHeaders_(_, true));
+  EXPECT_CALL(*this, onClientDestroy());
+  r1.inner_decoder_->decodeHeaders(
+      ResponseHeaderMapPtr{new TestResponseHeaderMapImpl{{":status", "200"}}}, true);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, GoAwayIdleConnectionFiresClosedDueToClose) {
+  InSequence s;
+
+  auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {10, 11, 12};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*lifetime_callbacks, onConnectionOpen(_, _, _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  // GOAWAY on idle connection closes it immediately -> fires onConnectionClosed.
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key),
+                                 testing::Ref(*test_clients_[0].connection_)));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].codec_client_->raiseGoAway(Http::GoAwayErrorCode::NoError);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, SetLifetimeCallbacksReplacesExisting) {
+  InSequence s;
+
+  auto first_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  auto second_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {1};
+
+  pool_->setLifetimeCallbacks(first_callbacks, hash_key);
+  pool_->setLifetimeCallbacks(second_callbacks, hash_key);
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+
+  EXPECT_CALL(*first_callbacks, onConnectionOpen(_, _, _)).Times(0);
+  EXPECT_CALL(*second_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key), _));
+  expectClientConnect(0, r1);
+
+  completeRequest(r1);
+
+  EXPECT_CALL(*first_callbacks, onConnectionClosed(_, _, _)).Times(0);
+  EXPECT_CALL(*second_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key), _));
+  EXPECT_CALL(*this, onClientDestroy());
+  test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::RemoteClose);
+  dispatcher_.clearDeferredDeleteList();
+}
+
+TEST_F(Http2ConnPoolImplTest, ExpiredCallbacksNoCrash) {
+  InSequence s;
+
+  {
+    auto lifetime_callbacks = std::make_shared<ConnectionPool::MockConnectionLifetimeCallbacks>();
+    std::vector<uint8_t> hash_key = {1};
+    pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+  }
+  // lifetime_callbacks destroyed, weak_ptr expired.
+
+  expectClientCreate();
+  ActiveTestRequest r1(*this, 0, false);
+  expectClientConnect(0, r1);
+  completeRequestCloseUpstream(0, r1);
 }
 
 } // namespace Http2

--- a/test/common/http/http3/BUILD
+++ b/test/common/http/http3/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
         "//test/common/quic:test_utils_lib",
         "//test/common/upstream:utility_lib",
         "//test/mocks/event:event_mocks",
+        "//test/mocks/http:conn_pool_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <memory>
 
+#include "source/common/http/conn_pool_base.h"
 #include "source/common/http/http3/conn_pool.h"
 #include "source/common/quic/quic_client_transport_socket_factory.h"
 
@@ -9,6 +10,7 @@
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/http/conn_pool.h"
 #include "test/mocks/server/overload_manager.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/ssl/mocks.h"
@@ -304,6 +306,60 @@ TEST_F(Http3ConnPoolImplTest, GetNetworkChangeEvents) {
   observers_.onNetworkConnected(-1);
   observers_.onNetworkMadeDefault(-1);
   observers_.onNetworkDisconnected(-1);
+}
+
+// --- ConnectionLifetimeCallbacks tests ---
+
+TEST_F(Http3ConnPoolImplTest, LifetimeCallbackOpenAndGoAwayDraining) {
+  EXPECT_CALL(mockHost(), address()).WillRepeatedly(Return(test_address_));
+  initialize();
+
+  auto lifetime_callbacks =
+      std::make_shared<Http::ConnectionPool::MockConnectionLifetimeCallbacks>();
+  std::vector<uint8_t> hash_key = {1, 2, 3};
+  pool_->setLifetimeCallbacks(lifetime_callbacks, hash_key);
+
+  MockResponseDecoder decoder;
+  ConnPoolCallbacks callbacks;
+  mockHost().cluster_.cluster_socket_options_ = std::make_shared<Network::Socket::Options>();
+  std::shared_ptr<Network::MockSocketOption> cluster_socket_option{new Network::MockSocketOption()};
+  mockHost().cluster_.cluster_socket_options_->push_back(cluster_socket_option);
+  EXPECT_CALL(*mockHost().cluster_.upstream_local_address_selector_,
+              getUpstreamLocalAddressImpl(_, _))
+      .WillOnce(Invoke(
+          [&](const Network::Address::InstanceConstSharedPtr& address,
+              OptRef<const Network::TransportSocketOptions>) -> Upstream::UpstreamLocalAddress {
+            EXPECT_EQ(address, test_address_);
+            Network::ConnectionSocket::OptionsSharedPtr options =
+                std::make_shared<Network::ConnectionSocket::Options>();
+            Network::Socket::appendOptions(options, mockHost().cluster_.cluster_socket_options_);
+            return Upstream::UpstreamLocalAddress({nullptr, options});
+          }));
+  EXPECT_CALL(*cluster_socket_option, setOption(_, _)).Times(3u);
+  EXPECT_CALL(*socket_option_, setOption(_, _)).Times(3u);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+  auto* async_connect_callback = new NiceMock<Event::MockSchedulableCallback>(&dispatcher_);
+  ConnectionPool::Cancellable* cancellable = pool_->newStream(
+      decoder, callbacks, {/*can_send_early_data_=*/false, /*can_use_http3_=*/true});
+  EXPECT_NE(nullptr, cancellable);
+  async_connect_callback->invokeCallback();
+
+  std::list<Envoy::ConnectionPool::ActiveClientPtr>& clients =
+      Http3ConnPoolImplPeer::connectingClients(*pool_);
+  EXPECT_EQ(1u, clients.size());
+  auto* client = static_cast<MultiplexedActiveClientBase*>(clients.front().get());
+
+  // ConnectedZeroRtt event fires onConnectionOpen.
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionOpen(testing::Ref(*pool_), testing::ContainerEq(hash_key), testing::_));
+  client->onEvent(Network::ConnectionEvent::ConnectedZeroRtt);
+
+  // GOAWAY on idle connection -> closes -> LocalClose -> onConnectionClosed.
+  EXPECT_CALL(*lifetime_callbacks,
+              onConnectionClosed(testing::Ref(*pool_), testing::ContainerEq(hash_key), testing::_));
+  EXPECT_CALL(dispatcher_, deferredDelete_(_));
+  client->onGoAway(Http::GoAwayErrorCode::NoError);
+  dispatcher_.to_delete_.clear();
 }
 
 } // namespace Http3

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -1736,6 +1736,31 @@ TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsPassedToConnPool) {
   EXPECT_TRUE(opt_cp.has_value());
 }
 
+TEST_F(ClusterManagerImplTest, LifetimeCallbacksPassedToConnPool) {
+  createWithBasicStaticCluster();
+  NiceMock<MockLoadBalancerContext> context;
+
+  Http::ConnectionPool::MockInstance* to_create =
+      new NiceMock<Http::ConnectionPool::MockInstance>();
+
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(to_create));
+  EXPECT_CALL(*to_create, setLifetimeCallbacks(_, _))
+      .WillOnce(Invoke([](std::weak_ptr<Http::ConnectionPool::ConnectionLifetimeCallbacks> cb,
+                          std::vector<uint8_t> hash_key) {
+        // RoundRobin LB does not implement coalescing, so the weak_ptr should be expired.
+        EXPECT_TRUE(cb.expired());
+        // The hash_key encodes protocol and socket options; must be non-empty.
+        EXPECT_FALSE(hash_key.empty());
+      }));
+
+  auto opt_cp =
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->httpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, Http::Protocol::Http11, &context);
+  EXPECT_TRUE(opt_cp.has_value());
+}
+
 TEST_F(ClusterManagerImplTest, UpstreamSocketOptionsUsedInConnPoolHash) {
   NiceMock<MockLoadBalancerContext> context1;
   NiceMock<MockLoadBalancerContext> context2;
@@ -1825,6 +1850,7 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
 
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(pool_mock));
   EXPECT_CALL(*pool_mock, addIdleCallback(_));
+  EXPECT_CALL(*pool_mock, setLifetimeCallbacks(_, _));
 
   auto opt_cp =
       cluster_manager_->getThreadLocalCluster("cluster_1")
@@ -2288,6 +2314,7 @@ TEST_F(ClusterManagerImplTest, ConnectionPoolPerDownstreamConnection) {
   for (size_t i = 0; i < 3; ++i) {
     conn_pool_vector.push_back(new Http::ConnectionPool::MockInstance());
     EXPECT_CALL(*conn_pool_vector.back(), addIdleCallback(_));
+    EXPECT_CALL(*conn_pool_vector.back(), setLifetimeCallbacks(_, _));
     EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
         .WillOnce(Return(conn_pool_vector.back()));
     EXPECT_CALL(downstream_connection, hashKey)
@@ -2368,6 +2395,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
   auto* pool = new Http::ConnectionPool::MockInstance();
   Quic::EnvoyQuicNetworkObserverRegistry* created_registry = nullptr;
   EXPECT_CALL(*pool, addIdleCallback(_));
+  EXPECT_CALL(*pool, setLifetimeCallbacks(_, _));
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry_ptr = &created_registry](
@@ -2386,6 +2414,7 @@ TEST_F(ClusterManagerImplTest, PassDownNetworkObserverRegistryToConnectionPool) 
 
   pool = new Http::ConnectionPool::MockInstance();
   EXPECT_CALL(*pool, addIdleCallback(_));
+  EXPECT_CALL(*pool, setLifetimeCallbacks(_, _));
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _))
       .WillOnce(testing::WithArg<5>(
           Invoke([pool, created_registry](

--- a/test/common/upstream/cluster_manager_lifecycle_test.cc
+++ b/test/common/upstream/cluster_manager_lifecycle_test.cc
@@ -742,6 +742,7 @@ TEST_P(ClusterManagerLifecycleTest, DynamicAddRemove) {
   Http::ConnectionPool::Instance::IdleCb idle_cb;
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(cp));
   EXPECT_CALL(*cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&idle_cb));
+  EXPECT_CALL(*cp, setLifetimeCallbacks(_, _));
   EXPECT_EQ(
       cp,
       HttpPoolDataPeer::getPool(
@@ -1941,6 +1942,7 @@ TEST_P(ClusterManagerLifecycleTest, ConnPoolDestroyWithDraining) {
   Http::ConnectionPool::Instance::IdleCb drained_cb;
   EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(mock_cp));
   EXPECT_CALL(*mock_cp, addIdleCallback(_)).WillOnce(SaveArg<0>(&drained_cb));
+  EXPECT_CALL(*mock_cp, setLifetimeCallbacks(_, _));
   EXPECT_CALL(*mock_cp, drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainAndDelete));
 
   MockTcpConnPoolWithDestroy* mock_tcp = new NiceMock<MockTcpConnPoolWithDestroy>();

--- a/test/common/upstream/cluster_manager_misc_test.cc
+++ b/test/common/upstream/cluster_manager_misc_test.cc
@@ -194,7 +194,8 @@ private:
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
     absl::optional<Upstream::SelectedPoolAndConnection>

--- a/test/extensions/clusters/aggregate/cluster_test.cc
+++ b/test/extensions/clusters/aggregate/cluster_test.cc
@@ -185,9 +185,7 @@ TEST_F(AggregateClusterTest, LoadBalancerTest) {
     EXPECT_CALL(random_, random()).WillRepeatedly(Return(i));
     EXPECT_TRUE(lb_->peekAnotherHost(nullptr) == nullptr);
     Upstream::HostConstSharedPtr target = lb_->chooseHost(nullptr).host;
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-        lb_->lifetimeCallbacks();
-    EXPECT_FALSE(lifetime_callbacks.has_value());
+    EXPECT_TRUE(lb_->lifetimeCallbacks().expired());
     std::vector<uint8_t> hash_key = {1, 2, 3};
     absl::optional<Upstream::SelectedPoolAndConnection> selection =
         lb_->selectExistingConnection(nullptr, *host, hash_key);

--- a/test/extensions/clusters/composite/cluster_test.cc
+++ b/test/extensions/clusters/composite/cluster_test.cc
@@ -216,7 +216,7 @@ cluster_type:
 
   EXPECT_EQ(nullptr, lb.peekAnotherHost(&context));
   EXPECT_EQ(absl::nullopt, lb.selectExistingConnection(&context, host, hash_key));
-  EXPECT_FALSE(lb.lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb.lifetimeCallbacks().expired());
 }
 
 // Test cluster update callbacks.

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -403,17 +403,13 @@ TEST_F(ClusterTest, PopulatedCache) {
 TEST_F(ClusterTest, LoadBalancer_LifetimeCallbacksWithoutCoalescing) {
   initialize(default_yaml_config_, false);
 
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_FALSE(lifetime_callbacks.has_value());
+  ASSERT_TRUE(lb_->lifetimeCallbacks().expired());
 }
 
 TEST_F(ClusterTest, LoadBalancer_LifetimeCallbacksWithCoalescing) {
   initialize(coalesce_connection_config_, false);
 
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  ASSERT_FALSE(lb_->lifetimeCallbacks().expired());
 }
 
 TEST_F(ClusterTest, LoadBalancer_SelectPoolNoConnections) {
@@ -446,9 +442,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolMatchingConnection) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
 
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
@@ -479,9 +474,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolMatchingConnectionHttp3) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
 
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h3"));
@@ -512,9 +506,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolNoMatchingConnectionAfterDraining) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
 
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
@@ -522,7 +515,7 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolNoMatchingConnectionAfterDraining) {
   EXPECT_CALL(connection, ssl()).WillRepeatedly(Return(ssl_info));
   lifetime_callbacks->onConnectionOpen(pool, hash_key, connection);
 
-  // Drain the connection then no verify that no connection is subsequently selected.
+  // Drain the connection then verify that no connection is subsequently selected.
   lifetime_callbacks->onConnectionDraining(pool, hash_key, connection);
 
   absl::optional<Upstream::SelectedPoolAndConnection> selection =
@@ -544,9 +537,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolInvalidAlpn) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
 
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("hello"));
@@ -573,9 +565,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolSanMismatch) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
   auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
@@ -603,9 +594,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolHashMismatch) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
   auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
@@ -632,9 +622,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolIpMismatch) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
   auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
@@ -662,9 +651,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolEmptyHostname) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
   auto ssl_info = std::make_shared<Ssl::MockConnectionInfo>();
@@ -696,9 +684,8 @@ TEST_F(ClusterTest, LoadBalancer_SelectPoolNoSSSL) {
 
   Envoy::Http::ConnectionPool::MockInstance pool;
   Envoy::Network::MockConnection connection;
-  OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetime_callbacks =
-      lb_->lifetimeCallbacks();
-  ASSERT_TRUE(lifetime_callbacks.has_value());
+  auto lifetime_callbacks = lb_->lifetimeCallbacks().lock();
+  ASSERT_TRUE(lifetime_callbacks != nullptr);
   EXPECT_CALL(connection, connectionInfoProvider()).Times(testing::AnyNumber());
   EXPECT_CALL(connection, nextProtocol()).WillRepeatedly(Return("h2"));
   auto ssl_info = nullptr;

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -353,7 +353,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerLifecycle) {
   EXPECT_FALSE(existing.has_value());
 
   // lifetimeCallbacks should return empty (not supported).
-  EXPECT_FALSE(lb->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb->lifetimeCallbacks().expired());
 
   // Clean up.
   cluster->removeHosts(dummy_hosts);

--- a/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
+++ b/test/extensions/clusters/original_dst/original_dst_cluster_test.cc
@@ -198,7 +198,7 @@ TEST_F(OriginalDstClusterTest, NoContext) {
     EXPECT_EQ(host, nullptr);
 
     EXPECT_EQ(nullptr, lb.peekAnotherHost(nullptr));
-    EXPECT_FALSE(lb.lifetimeCallbacks().has_value());
+    EXPECT_TRUE(lb.lifetimeCallbacks().expired());
     std::vector<uint8_t> hash_key;
     auto mock_host = std::make_shared<NiceMock<MockHost>>();
     EXPECT_FALSE(lb.selectExistingConnection(nullptr, *mock_host, hash_key).has_value());

--- a/test/extensions/clusters/redis/redis_cluster_lb_test.cc
+++ b/test/extensions/clusters/redis/redis_cluster_lb_test.cc
@@ -137,7 +137,7 @@ TEST_F(RedisClusterLoadBalancerTest, LoadBalancerStubMethods) {
   EXPECT_EQ(absl::nullopt, lb->selectExistingConnection(nullptr, *hosts[0], hash_key));
 
   // lifetimeCallbacks is not implemented and returns empty OptRef.
-  EXPECT_FALSE(lb->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb->lifetimeCallbacks().expired());
 }
 
 // Works correctly with empty context

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_test.cc
@@ -1079,11 +1079,8 @@ TEST_F(ReverseConnectionClusterTest, LoadBalancerNoopMethods) {
     EXPECT_FALSE(selected_connection.has_value());
   }
 
-  // Test lifetimeCallbacks. It should return an empty OptRef.
-  {
-    auto lifetime_callbacks = lb.lifetimeCallbacks();
-    EXPECT_FALSE(lifetime_callbacks.has_value());
-  }
+  // Test lifetimeCallbacks. It should return an expired weak_ptr.
+  { EXPECT_TRUE(lb.lifetimeCallbacks().expired()); }
 }
 
 // UpstreamReverseConnectionAddress tests

--- a/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
+++ b/test/extensions/load_balancing_policies/common/load_balancer_impl_base_test.cc
@@ -596,7 +596,7 @@ TEST_F(ZoneAwareLoadBalancerBaseTest, SourceTypeMethods) {
 }
 
 TEST_F(ZoneAwareLoadBalancerBaseTest, BaseMethods) {
-  EXPECT_FALSE(lb_.lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb_.lifetimeCallbacks().expired());
   std::vector<uint8_t> hash_key;
   auto mock_host = std::make_shared<NiceMock<MockHost>>();
   EXPECT_FALSE(lb_.selectExistingConnection(nullptr, *mock_host, hash_key).has_value());
@@ -675,7 +675,7 @@ TEST(ZoneAwareLbCoalesceDisabledTest, FallbackPathExercised) {
   host_set.healthy_hosts_ = host_set.hosts_;
   host_set.runCallbacks({}, {});
 
-  EXPECT_FALSE(lb.lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb.lifetimeCallbacks().expired());
 }
 
 // Exercises the coalescing branch of ZoneAwareLoadBalancerBase: PriorityUpdateCb stages dirty
@@ -703,7 +703,7 @@ TEST(ZoneAwareLbCoalesceEnabledTest, CoalescedPathExercised) {
   host_set.healthy_hosts_ = host_set.hosts_;
   host_set.runCallbacks({}, {});
 
-  EXPECT_FALSE(lb.lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb.lifetimeCallbacks().expired());
 }
 
 } // namespace

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -485,7 +485,7 @@ TEST_F(DynamicModulesLoadBalancerTest, LifetimeCallbacks) {
   ASSERT_NE(lb, nullptr);
 
   // lifetimeCallbacks should return empty optional.
-  EXPECT_FALSE(lb->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb->lifetimeCallbacks().expired());
 }
 
 TEST_F(DynamicModulesLoadBalancerTest, SelectExistingConnection) {

--- a/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
+++ b/test/extensions/load_balancing_policies/override_host/load_balancer_test.cc
@@ -211,7 +211,7 @@ TEST_F(OverrideHostLoadBalancerTest, NoMetadataOrHeaders) {
   HostConstSharedPtr host = load_balancer_->chooseHost(&load_balancer_context_).host;
   EXPECT_EQ(host->address()->asString(), "127.0.0.1:80");
 
-  EXPECT_FALSE(load_balancer_->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(load_balancer_->lifetimeCallbacks().expired());
   std::vector<uint8_t> out_value;
   EXPECT_FALSE(load_balancer_->selectExistingConnection(&load_balancer_context_, *host, out_value)
                    .has_value());

--- a/test/extensions/load_balancing_policies/override_host/test_lb.cc
+++ b/test/extensions/load_balancing_policies/override_host/test_lb.cc
@@ -62,7 +62,7 @@ private:
       return {hosts[0]};
     }
 
-    OptRef<Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
       return {};
     }
 

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -122,7 +122,7 @@ TEST_P(RingHashLoadBalancerTest, NoHost) {
   EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->chooseHost(nullptr).host);
 
   EXPECT_EQ(nullptr, lb_->factory()->create(lb_params_)->peekAnotherHost(nullptr));
-  EXPECT_FALSE(lb_->factory()->create(lb_params_)->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb_->factory()->create(lb_params_)->lifetimeCallbacks().expired());
   std::vector<uint8_t> hash_key;
   auto mock_host = std::make_shared<NiceMock<MockHost>>();
   EXPECT_FALSE(lb_->factory()
@@ -134,7 +134,7 @@ TEST_P(RingHashLoadBalancerTest, NoHost) {
 TEST_P(RingHashLoadBalancerTest, BaseMethods) {
   init();
   EXPECT_EQ(nullptr, lb_->peekAnotherHost(nullptr));
-  EXPECT_FALSE(lb_->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb_->lifetimeCallbacks().expired());
   std::vector<uint8_t> hash_key;
   auto mock_host = std::make_shared<NiceMock<MockHost>>();
   EXPECT_FALSE(lb_->selectExistingConnection(nullptr, *mock_host, hash_key).has_value());

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -746,7 +746,7 @@ TEST_F(SubsetLoadBalancerTest, NoFallback) {
   EXPECT_EQ(0U, stats_.lb_subsets_selected_.value());
 
   EXPECT_EQ(nullptr, lb_->peekAnotherHost(nullptr));
-  EXPECT_FALSE(lb_->lifetimeCallbacks().has_value());
+  EXPECT_TRUE(lb_->lifetimeCallbacks().expired());
   std::vector<uint8_t> hash_key;
   auto mock_host = std::make_shared<NiceMock<MockHost>>();
   EXPECT_FALSE(lb_->selectExistingConnection(nullptr, *mock_host, hash_key).has_value());

--- a/test/integration/load_balancers/custom_lb_policy.h
+++ b/test/integration/load_balancers/custom_lb_policy.h
@@ -29,7 +29,8 @@ private:
     Upstream::HostConstSharedPtr peekAnotherHost(Upstream::LoadBalancerContext*) override {
       return nullptr;
     }
-    OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks> lifetimeCallbacks() override {
+    std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
+    lifetimeCallbacks() override {
       return {};
     }
     absl::optional<Upstream::SelectedPoolAndConnection>

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -39,9 +39,25 @@ public:
   MOCK_METHOD(bool, maybePreconnect, (float));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
   MOCK_METHOD(absl::string_view, protocolDescription, (), (const));
+  MOCK_METHOD(void, setLifetimeCallbacks,
+              (std::weak_ptr<ConnectionLifetimeCallbacks> callbacks,
+               std::vector<uint8_t> hash_key));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;
   IdleCb idle_cb_;
+};
+
+class MockConnectionLifetimeCallbacks : public ConnectionLifetimeCallbacks {
+public:
+  MOCK_METHOD(void, onConnectionOpen,
+              (Instance & pool, const std::vector<uint8_t>& hash_key,
+               const Network::Connection& connection));
+  MOCK_METHOD(void, onConnectionDraining,
+              (Instance & pool, const std::vector<uint8_t>& hash_key,
+               const Network::Connection& connection));
+  MOCK_METHOD(void, onConnectionClosed,
+              (Instance & pool, const std::vector<uint8_t>& hash_key,
+               const Network::Connection& connection));
 };
 
 } // namespace ConnectionPool

--- a/test/mocks/upstream/load_balancer.h
+++ b/test/mocks/upstream/load_balancer.h
@@ -20,8 +20,8 @@ public:
   MOCK_METHOD(absl::optional<Upstream::SelectedPoolAndConnection>, selectExistingConnection,
               (Upstream::LoadBalancerContext * context, const Upstream::Host& host,
                std::vector<uint8_t>& hash_key));
-  MOCK_METHOD(OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>, lifetimeCallbacks,
-              ());
+  MOCK_METHOD(std::weak_ptr<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>,
+              lifetimeCallbacks, ());
 
   std::shared_ptr<MockHost> host_{new NiceMock<MockHost>()};
 };


### PR DESCRIPTION
## Commit Message
http: notify load balancers of connection lifecycle events via pool callbacks
## Additional Description
Adds plumbing so that `ConnectionPool::Instance` notifies a `ConnectionLifetimeCallbacks` observer (held via `weak_ptr`) whenever a pooled connection is opened, enters draining, or is closed. 

Reimpl of: #43702 
Used std::weak_ptr as discussed. Also added onConnectionClosed instead of plumbing closes via the onConnectionDraining itself. This caused redefs for all overriding load balancers.

## Risk Level
Medium: Strictly additive only dfp should be seeing callbacks but tests validate that no issue should be caused.
## Testing
New unit tests for HTTP/2, HTTP/3, and ConnectivityGrid pools covering open/draining/closed callbacks, replacement, expired weak_ptr safety, and no-op without callbacks. Updated cluster manager tests to verify wiring.
Existing tests updated for `OptRef` → `weak_ptr` migration.