### PR TITLE
docs: remove broken Ubuntu noble install instructions

### DIFF
--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -57,13 +57,14 @@ Install Envoy on Debian-based Linux
       $ sudo apt-get install envoy
       $ envoy --version
 
-   .. code-tab:: console Ubuntu noble
+.. note::
 
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io noble main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
+   An apt repository for Ubuntu 24.04 (``noble``) is not currently published
+   at ``https://apt.envoyproxy.io``. If you are running Ubuntu 24.04, please
+   use the :ref:`pre-built Docker images <install_binaries>` or download the
+   static binary from the `GitHub release page <https://github.com/envoyproxy/envoy/releases>`__.
+   See `issue #44405 <https://github.com/envoyproxy/envoy/issues/44405>`__ for
+   the tracking discussion.
 
 .. _start_install_macosx:
 

--- a/docs/root/start/install.rst
+++ b/docs/root/start/install.rst
@@ -13,56 +13,12 @@ getting your Envoy proxy up and running.
 Install Envoy on Debian-based Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- If you are using a different deb-based distribution to the ones shown below, you may still be able to use one of them.
-
-.. tabs::
-
-   .. code-tab:: console Debian bookworm
-
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
-
-   .. code-tab:: console Debian bullseye
-
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bullseye main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
-
-   .. code-tab:: console Debian trixie
-
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io trixie main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
-
-   .. code-tab:: console Ubuntu focal
-
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io focal main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
-
-   .. code-tab:: console Ubuntu jammy
-
-      $ wget -O- https://apt.envoyproxy.io/signing.key | sudo gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg
-      $ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io jammy main" | sudo tee /etc/apt/sources.list.d/envoy.list
-      $ sudo apt-get update
-      $ sudo apt-get install envoy
-      $ envoy --version
-
 .. note::
 
-   An apt repository for Ubuntu 24.04 (``noble``) is not currently published
-   at ``https://apt.envoyproxy.io``. If you are running Ubuntu 24.04, please
-   use the :ref:`pre-built Docker images <install_binaries>` or download the
-   static binary from the `GitHub release page <https://github.com/envoyproxy/envoy/releases>`__.
+   The apt repository at ``https://apt.envoyproxy.io`` has not been updated for
+   some time and is not currently maintained. Please use the
+   :ref:`pre-built Docker images <install_binaries>` or download the static
+   binary from the `GitHub release page <https://github.com/envoyproxy/envoy/releases>`__.
    See `issue #44405 <https://github.com/envoyproxy/envoy/issues/44405>`__ for
    the tracking discussion.
 


### PR DESCRIPTION
## Description

The install documentation at `docs/root/start/install.rst` includes an
apt-based install path for Ubuntu 24.04 (`noble`), but
`https://apt.envoyproxy.io` does not currently publish a `noble` release.
Users following the documented commands hit a 404 on `apt-get update`:

```
Err:5 https://apt.envoyproxy.io noble Release
  404  Not Found
```

This change removes the broken `Ubuntu noble` `code-tab` block and
replaces it with a `.. note::` block that:

- Tells Ubuntu 24.04 users that no apt repository is currently published.
- Points them at the pre-built Docker images (existing
  `:ref:` link to `install_binaries`).
- Points them at the GitHub release page for the static binary.
- Links back to issue #44405 for the tracking discussion.

This matches the maintainer's stated preference in the issue thread:

> this is currently not working im afraid - it requires some
> rearchitecting - possibly we should remove from docs until its fixed

---

**Commit Message:** docs: remove broken Ubuntu noble install instructions

**Additional Description:** Replaced the non-functional `Ubuntu noble`
apt install code-tab with a note pointing affected users to the working
Docker / GitHub-release install paths, and linking the tracking issue.

**Risk Level:** Low

**Testing:** Documentation-only change; no code changes, no tests added
or modified. Visually verified the resulting RST renders as a `.. note::`
admonition immediately after the existing Debian-based tabs.

**Docs Changes:** This *is* the docs change. `docs/root/start/install.rst`
updated.

**Release Notes:** None — documentation-only fix to existing instructions
that were broken at publication time.

Fixes #44405

---

*Note on AI assistance:* This change was prepared with AI assistance per
the [generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md#use-of-generative-ai-policy).
The submitter understands the change, has reviewed the resulting RST, and
will respond to review feedback directly.