### PR TITLE
http: support DS_CX_BEG/DS_CX_END in COMMON_DURATION

### DIFF
--- a/changelogs/current/new_features/http__common-duration-downstream-connection.rst
+++ b/changelogs/current/new_features/http__common-duration-downstream-connection.rst
@@ -1,0 +1,5 @@
+Added support for the ``DS_CX_BEG`` and ``DS_CX_END`` :ref:`COMMON_DURATION
+<config_access_log_format_common_duration>` time points for HTTP. ``DS_CX_BEG`` reflects the
+downstream connection begin and repeats for all requests on a connection, while ``DS_CX_END`` is
+populated for requests that are active when the downstream connection closes and otherwise renders
+as ``"-"``.

--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -357,6 +357,8 @@ Current supported substitution commands include:
     The ``START`` and ``END`` time points are specified by the following values (all values
     here are case-sensitive):
 
+    * ``DS_CX_BEG``: The time point of the downstream connection begin.
+    * ``DS_CX_END``: The time point of the downstream connection end.
     * ``DS_RX_BEG``: The time point of the downstream request receiving begin.
     * ``DS_RX_END``: The time point of the downstream request receiving end.
     * ``US_CX_BEG``: The time point of the upstream TCP connect begin.
@@ -375,6 +377,12 @@ Current supported substitution commands include:
 
       Upstream connection establishment time points (``US_CX_*``, ``US_HS_END``) repeat for all requests
       in a given connection.
+
+    .. note::
+
+      The ``DS_CX_BEG`` time point reflects the downstream connection begin and repeats for all
+      requests on a given connection. The ``DS_CX_END`` time point is only populated for requests
+      that are active when the downstream connection closes and renders as ``"-"`` otherwise.
 
     The ``PRECISION`` is specified by the following values (all values here are case-sensitive):
 

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -443,7 +443,10 @@ struct DownstreamTiming {
     ASSERT(!last_downstream_header_rx_byte_received_);
     last_downstream_header_rx_byte_received_ = time_source.monotonicTime();
   }
-  void setDownstreamConnectionBegin(MonotonicTime time) { downstream_connection_begin_ = time; }
+  void setDownstreamConnectionBegin(MonotonicTime time) {
+    ASSERT(!downstream_connection_begin_);
+    downstream_connection_begin_ = time;
+  }
   void onDownstreamConnectionEnd(TimeSource& time_source) {
     // Record only the first close so the connection duration is not inflated.
     if (!downstream_connection_end_) {

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -412,6 +412,9 @@ struct DownstreamTiming {
   absl::optional<MonotonicTime> lastDownstreamHeaderRxByteReceived() const {
     return last_downstream_header_rx_byte_received_;
   }
+  absl::optional<MonotonicTime> downstreamConnectionBegin() const {
+    return downstream_connection_begin_;
+  }
   absl::optional<MonotonicTime> downstreamConnectionEnd() const {
     return downstream_connection_end_;
   }
@@ -440,6 +443,7 @@ struct DownstreamTiming {
     ASSERT(!last_downstream_header_rx_byte_received_);
     last_downstream_header_rx_byte_received_ = time_source.monotonicTime();
   }
+  void setDownstreamConnectionBegin(MonotonicTime time) { downstream_connection_begin_ = time; }
   void onDownstreamConnectionEnd(TimeSource& time_source) {
     // Record only the first close so the connection duration is not inflated.
     if (!downstream_connection_end_) {
@@ -460,6 +464,8 @@ struct DownstreamTiming {
   absl::optional<MonotonicTime> last_downstream_ack_received_;
   // The time when the last header byte was received.
   absl::optional<MonotonicTime> last_downstream_header_rx_byte_received_;
+  // The time the downstream connection was established.
+  absl::optional<MonotonicTime> downstream_connection_begin_;
   // The time the downstream connection was closed.
   absl::optional<MonotonicTime> downstream_connection_end_;
 };

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -374,6 +374,13 @@ const absl::flat_hash_map<absl::string_view, CommonDurationFormatter::TimePointG
          }},
         {DownstreamConnectionBegin,
          [](const StreamInfo::StreamInfo& stream_info) -> absl::optional<MonotonicTime> {
+           const auto downstream_timing = stream_info.downstreamTiming();
+           if (downstream_timing.has_value()) {
+             const auto connection_begin = downstream_timing->downstreamConnectionBegin();
+             if (connection_begin.has_value()) {
+               return connection_begin;
+             }
+           }
            return stream_info.startTimeMonotonic();
          }},
         {DownstreamConnectionEnd,

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -687,6 +687,11 @@ void ConnectionManagerImpl::doConnectionClose(
 
     stats_.named_.downstream_cx_destroy_active_rq_.inc();
     user_agent_.onConnectionDestroy(event, true);
+    // Record the downstream connection end time point for COMMON_DURATION access logging.
+    for (auto& stream : streams_) {
+      stream->filter_manager_.streamInfo().downstreamTiming().onDownstreamConnectionEnd(
+          time_source_);
+    }
     // Note that resetAllStreams() does not actually write anything to the wire. It just resets
     // all upstream streams and their filter stacks. Thus, there are no issues around recursive
     // entry.
@@ -928,6 +933,10 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
 
   filter_manager_.streamInfo().setShouldSchemeMatchUpstream(
       connection_manager.config_->shouldSchemeMatchUpstream());
+
+  // Record the downstream connection begin time point for COMMON_DURATION access logging.
+  filter_manager_.streamInfo().downstreamTiming().setDownstreamConnectionBegin(
+      connection_manager_.read_callbacks_->connection().streamInfo().startTimeMonotonic());
 
   // TODO(chaoqin-li1123): can this be moved to the on demand filter?
   auto factory = Envoy::Config::Utility::getFactoryByName<RouteConfigUpdateRequesterFactory>(

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1837,6 +1837,26 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
     EXPECT_THAT(duration_format.formatValue({}, stream_info),
                 ProtoEq(ValueUtil::numberValue(3000)));
   }
+
+  {
+    // DS_CX_BEG uses the downstream connection begin time point when set, instead of the stream
+    // start time, so the connection duration reflects the whole connection for HTTP.
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    MockTimeSystem time_system;
+
+    stream_info.start_time_monotonic_ = MonotonicTime(std::chrono::nanoseconds(1000000));
+    stream_info.downstream_timing_.setDownstreamConnectionBegin(
+        MonotonicTime(std::chrono::nanoseconds(500000)));
+
+    EXPECT_CALL(time_system, monotonicTime)
+        .WillOnce(Return(MonotonicTime(std::chrono::nanoseconds(4000000))));
+    stream_info.downstream_timing_.onDownstreamConnectionEnd(time_system);
+
+    StreamInfoFormatter duration_format("COMMON_DURATION", "DS_CX_BEG:DS_CX_END:us");
+    EXPECT_EQ("3500", duration_format.format({}, stream_info));
+    EXPECT_THAT(duration_format.formatValue({}, stream_info),
+                ProtoEq(ValueUtil::numberValue(3500)));
+  }
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {

--- a/test/common/http/conn_manager_impl_test_3.cc
+++ b/test/common/http/conn_manager_impl_test_3.cc
@@ -2638,6 +2638,123 @@ TEST_F(HttpConnectionManagerImplTest, DownstreamTimingsRecordWhenRequestHeaderPr
   filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
 }
 
+// The COMMON_DURATION downstream connection time points are populated for HTTP. DS_CX_BEG reflects
+// the downstream connection begin and DS_CX_END is recorded when the connection closes with an
+// active stream.
+TEST_F(HttpConnectionManagerImplTest, CommonDurationDownstreamConnectionTimePoints) {
+  std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
+  access_logs_ = {handler};
+  setup();
+
+  // The downstream connection begins at 5ms, before the stream is created.
+  const MonotonicTime connection_begin(std::chrono::milliseconds(5));
+  filter_callbacks_.connection_.stream_info_.start_time_monotonic_ = connection_begin;
+
+  absl::optional<MonotonicTime> logged_connection_begin;
+  absl::optional<MonotonicTime> logged_connection_end;
+  EXPECT_CALL(*handler, log(_, _))
+      .WillOnce(Invoke([&](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        auto timing = stream_info.downstreamTiming();
+        ASSERT_TRUE(timing.has_value());
+        logged_connection_begin = timing->downstreamConnectionBegin();
+        logged_connection_end = timing->downstreamConnectionEnd();
+      }));
+
+  Buffer::OwnedImpl fake_input("input");
+  conn_manager_->createCodec(fake_input);
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
+    // Create the stream at 20ms, later than the downstream connection begin.
+    test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(20)));
+    decoder_ = &conn_manager_->newStream(response_encoder_);
+    RequestHeaderMapPtr headers{
+        new TestRequestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+    decoder_->decodeHeaders(std::move(headers), /*end_stream=*/false);
+    return Http::okStatus();
+  }));
+
+  conn_manager_->onData(fake_input, /*end_stream=*/false);
+
+  // DS_CX_BEG reflects the connection begin, not the later stream start.
+  auto begin = decoder_->streamInfo().downstreamTiming().downstreamConnectionBegin();
+  ASSERT_TRUE(begin.has_value());
+  EXPECT_EQ(connection_begin, begin.value());
+
+  // Close the connection at 30ms while the stream is active.
+  test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(30)));
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  ASSERT_TRUE(logged_connection_begin.has_value());
+  EXPECT_EQ(connection_begin, logged_connection_begin.value());
+  ASSERT_TRUE(logged_connection_end.has_value());
+  EXPECT_EQ(MonotonicTime(std::chrono::milliseconds(30)), logged_connection_end.value());
+}
+
+// The COMMON_DURATION downstream connection time points are shared by all streams on a connection.
+// Every concurrent stream reports the same DS_CX_BEG, and every stream active when the connection
+// closes records DS_CX_END.
+TEST_F(HttpConnectionManagerImplTest, CommonDurationDownstreamConnectionTimePointsMultipleStreams) {
+  std::shared_ptr<AccessLog::MockInstance> handler(new NiceMock<AccessLog::MockInstance>());
+  access_logs_ = {handler};
+  setup();
+
+  // The downstream connection begins at 5ms, before any stream is created.
+  const MonotonicTime connection_begin(std::chrono::milliseconds(5));
+  filter_callbacks_.connection_.stream_info_.start_time_monotonic_ = connection_begin;
+
+  std::vector<absl::optional<MonotonicTime>> logged_connection_ends;
+  EXPECT_CALL(*handler, log(_, _))
+      .Times(2)
+      .WillRepeatedly(
+          Invoke([&](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+            auto timing = stream_info.downstreamTiming();
+            ASSERT_TRUE(timing.has_value());
+            logged_connection_ends.push_back(timing->downstreamConnectionEnd());
+          }));
+
+  std::vector<NiceMock<MockResponseEncoder>> response_encoders(2);
+  for (auto& encoder : response_encoders) {
+    EXPECT_CALL(encoder, getStream()).WillRepeatedly(ReturnRef(encoder.stream_));
+  }
+
+  std::vector<RequestDecoder*> decoders;
+  Buffer::OwnedImpl fake_input("input");
+  conn_manager_->createCodec(fake_input);
+
+  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> Http::Status {
+    // Create both streams at 20ms, later than the downstream connection begin.
+    test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(20)));
+    for (auto& encoder : response_encoders) {
+      RequestDecoder* decoder = &conn_manager_->newStream(encoder);
+      RequestHeaderMapPtr headers{
+          new TestRequestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
+      decoder->decodeHeaders(std::move(headers), /*end_stream=*/false);
+      decoders.push_back(decoder);
+    }
+    return Http::okStatus();
+  }));
+
+  conn_manager_->onData(fake_input, /*end_stream=*/false);
+
+  // Both streams share the same DS_CX_BEG, reflecting the single downstream connection begin.
+  for (RequestDecoder* decoder : decoders) {
+    auto begin = decoder->streamInfo().downstreamTiming().downstreamConnectionBegin();
+    ASSERT_TRUE(begin.has_value());
+    EXPECT_EQ(connection_begin, begin.value());
+  }
+
+  // Close the connection at 30ms while both streams are active.
+  test_time_.timeSystem().setMonotonicTime(MonotonicTime(std::chrono::milliseconds(30)));
+  filter_callbacks_.connection_.raiseEvent(Network::ConnectionEvent::RemoteClose);
+
+  // Both active streams record DS_CX_END at the connection close.
+  ASSERT_EQ(2, logged_connection_ends.size());
+  for (const auto& end : logged_connection_ends) {
+    ASSERT_TRUE(end.has_value());
+    EXPECT_EQ(MonotonicTime(std::chrono::milliseconds(30)), end.value());
+  }
+}
+
 TEST_F(HttpConnectionManagerImplTest, PassMatchUpstreamSchemeHintToStreamInfo) {
   setup(SetupOpts().setTracing(false));
   scheme_match_upstream_ = true;

--- a/test/common/stream_info/stream_info_impl_test.cc
+++ b/test/common/stream_info/stream_info_impl_test.cc
@@ -43,11 +43,11 @@ protected:
   void assertStreamInfoSize(StreamInfoImpl stream_info) {
     ASSERT_TRUE(
         // with --config=docker-msan
-        sizeof(stream_info) == 736 ||
+        sizeof(stream_info) == 752 ||
         // with --config=docker-clang
-        sizeof(stream_info) == 760 ||
+        sizeof(stream_info) == 776 ||
         // with --config=docker-clang-libc++
-        sizeof(stream_info) == 712)
+        sizeof(stream_info) == 728)
         << "If adding fields to StreamInfoImpl, please check to see if you "
            "need to add them to setFromForRecreateStream or setFrom! Current size "
         << sizeof(stream_info);
@@ -121,6 +121,17 @@ TEST_F(StreamInfoImplTest, TimingTest) {
   EXPECT_FALSE(info.requestComplete());
   info.onRequestComplete();
   dur = checkDuration(dur, info.requestComplete());
+}
+
+// downstreamConnectionBegin is empty until set.
+TEST(DownstreamTimingTest, ConnectionBeginSet) {
+  DownstreamTiming timing;
+  EXPECT_FALSE(timing.downstreamConnectionBegin().has_value());
+
+  const MonotonicTime begin(std::chrono::milliseconds(5));
+  timing.setDownstreamConnectionBegin(begin);
+  ASSERT_TRUE(timing.downstreamConnectionBegin().has_value());
+  EXPECT_EQ(begin, timing.downstreamConnectionBegin().value());
 }
 
 // onDownstreamConnectionEnd records only the first close so the duration is not inflated.

--- a/test/integration/access_log_integration_test.cc
+++ b/test/integration/access_log_integration_test.cc
@@ -7,6 +7,7 @@
 
 #include "gtest/gtest.h"
 
+using testing::ContainsRegex;
 using testing::HasSubstr;
 
 namespace Envoy {
@@ -104,6 +105,34 @@ TEST_P(AccessLogIntegrationTest, DownstreamDetectedCloseType) {
   testRouterDownstreamDisconnectBeforeRequestComplete();
   std::string log = waitForAccessLog(access_log_name_);
   EXPECT_THAT(log, HasSubstr("CLOSE_TYPE=Normal"));
+}
+
+// COMMON_DURATION populates the downstream connection time points for HTTP. When the connection
+// closes with an active stream, DS_CX_END is recorded so the connection duration renders as a
+// number instead of "-".
+TEST_P(AccessLogIntegrationTest, CommonDurationDownstreamConnectionActiveAtClose) {
+  useAccessLog("cx=%COMMON_DURATION(DS_CX_BEG:DS_CX_END:us)%");
+  testRouterDownstreamDisconnectBeforeRequestComplete();
+  std::string log = waitForAccessLog(access_log_name_);
+  EXPECT_THAT(log, ContainsRegex("cx=[0-9]+"));
+}
+
+// COMMON_DURATION DS_CX_BEG is populated for completed HTTP requests, while DS_CX_END renders as
+// "-" until the downstream connection closes.
+TEST_P(AccessLogIntegrationTest, CommonDurationDownstreamConnectionCompletedRequest) {
+  useAccessLog("rq=%COMMON_DURATION(DS_CX_BEG:DS_RX_END:us)% "
+               "cx=%COMMON_DURATION(DS_CX_BEG:DS_CX_END:us)%");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  std::string log = waitForAccessLog(access_log_name_);
+  EXPECT_THAT(log, ContainsRegex("rq=[0-9]+"));
+  EXPECT_THAT(log, HasSubstr("cx=-"));
 }
 
 TEST_P(AccessLogIntegrationTest, ShouldReplaceInvalidUtf8) {


### PR DESCRIPTION
## Description

This is a follow up to #45449 which added `COMMON_DURATION` `DS_CX_BEG` and `DS_CX_END` for the TCP proxy. 

This extends the same two downstream connection time points to HTTP access logs. Unlike TCP which has one `StreamInfo` per connection, HTTP `StreamInfo` is per-stream, so connection-level timing is propagated into each stream's `DownstreamTiming`.

---

**Commit Message**: http: support DS_CX_BEG/DS_CX_END in COMMON_DURATION
**Additional Description:** Added `COMMON_DURATION` `DS_CX_BEG` and `DS_CX_END` for HTTP
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes**: Added
**Release Notes**: Added