### PR TITLE
dynamic_modules: add transport socket fd and writable ABI callbacks

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -12359,6 +12359,19 @@ void envoy_dynamic_module_callback_transport_socket_io_shutdown_write(
     envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr);
 
 /**
+ * envoy_dynamic_module_callback_transport_socket_get_fd returns the native OS file descriptor of
+ * the underlying socket. A module that performs raw socket operations such as installing kernel TLS
+ * with setsockopt uses this descriptor. It is only meaningful for transports backed by an OS
+ * socket. The descriptor is owned by Envoy and is only valid while the connection is open, so the
+ * module must not close it or use it after the connection closes.
+ *
+ * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
+ * @return the native file descriptor, or -1 if it is unavailable.
+ */
+int envoy_dynamic_module_callback_transport_socket_get_fd(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr);
+
+/**
  * envoy_dynamic_module_callback_transport_socket_read_buffer_add appends data to the connection
  * read buffer.
  *
@@ -12397,6 +12410,16 @@ void envoy_dynamic_module_callback_transport_socket_write_buffer_get_slices(
     envoy_dynamic_module_type_envoy_buffer* slices, size_t* slices_count);
 
 /**
+ * envoy_dynamic_module_callback_transport_socket_write_buffer_length returns the number of bytes
+ * currently queued in the connection write buffer.
+ *
+ * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
+ * @return the length of the write buffer in bytes, or zero when there is no active write buffer.
+ */
+size_t envoy_dynamic_module_callback_transport_socket_write_buffer_length(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr);
+
+/**
  * envoy_dynamic_module_callback_transport_socket_raise_event raises a connection event on the
  * connection (e.g., Connected after TLS handshake). Raising a close event can synchronously
  * re-enter the module through on_close, so the caller must not rely on any state after this
@@ -12426,6 +12449,17 @@ bool envoy_dynamic_module_callback_transport_socket_should_drain_read_buffer(
  * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
  */
 void envoy_dynamic_module_callback_transport_socket_set_is_readable(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_transport_socket_set_is_writable schedules another write on a
+ * future event loop iteration. A module calls this when it defers buffered bytes for its own
+ * reasons rather than because the socket reported it would block. After a write reports it would
+ * block, Envoy re-arms the writable notification on its own, so this call is not needed then.
+ *
+ * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
+ */
+void envoy_dynamic_module_callback_transport_socket_set_is_writable(
     envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr);
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -3409,6 +3409,13 @@ __attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_io_shu
                "not implemented in this context");
 }
 
+__attribute__((weak)) int envoy_dynamic_module_callback_transport_socket_get_fd(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_transport_socket_get_fd: "
+               "not implemented in this context");
+  return -1;
+}
+
 __attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_read_buffer_add(
     envoy_dynamic_module_type_transport_socket_envoy_ptr, const char*, size_t) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_transport_socket_read_buffer_add: "
@@ -3428,6 +3435,13 @@ __attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_write_
                "not implemented in this context");
 }
 
+__attribute__((weak)) size_t envoy_dynamic_module_callback_transport_socket_write_buffer_length(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_transport_socket_write_buffer_length: "
+               "not implemented in this context");
+  return 0;
+}
+
 __attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_raise_event(
     envoy_dynamic_module_type_transport_socket_envoy_ptr,
     envoy_dynamic_module_type_network_connection_event) {
@@ -3445,6 +3459,12 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_transport_socket_should
 __attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_set_is_readable(
     envoy_dynamic_module_type_transport_socket_envoy_ptr) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_transport_socket_set_is_readable: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_transport_socket_set_is_writable(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_transport_socket_set_is_writable: "
                "not implemented in this context");
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -7530,3 +7530,72 @@ fn test_mock_envoy_transport_socket_do_read() {
   let mut socket = EchoTransportSocket;
   assert_eq!(socket.on_do_read(&mut mock), IoResult::keep_open(5, false));
 }
+
+#[test]
+fn test_mock_envoy_transport_socket_fd_and_write_rearm() {
+  // Exercises the raw socket callbacks a transport such as kTLS relies on. It reads the descriptor
+  // on connect and, when it defers buffered bytes for its own reasons, re-arms the writable
+  // notification so the write is retried later.
+  struct ProbeTransportSocket {
+    fd: Option<i32>,
+  }
+  impl TransportSocket<transport_socket::MockEnvoyTransportSocket> for ProbeTransportSocket {
+    fn on_set_callbacks(&mut self, _envoy: &mut transport_socket::MockEnvoyTransportSocket) {}
+    fn on_connected(&mut self, envoy: &mut transport_socket::MockEnvoyTransportSocket) {
+      self.fd = envoy.get_fd();
+    }
+    fn on_do_read(&mut self, _envoy: &mut transport_socket::MockEnvoyTransportSocket) -> IoResult {
+      IoResult::keep_open(0, false)
+    }
+    fn on_do_write(
+      &mut self,
+      envoy: &mut transport_socket::MockEnvoyTransportSocket,
+      _end_stream: bool,
+    ) -> IoResult {
+      // A transport that defers the buffered bytes re-arms instead of sending, so it is driven
+      // again on a later iteration.
+      if envoy.write_buffer_length() > 0 {
+        envoy.set_is_writable();
+      }
+      IoResult::keep_open(0, false)
+    }
+    fn on_close(
+      &mut self,
+      _envoy: &mut transport_socket::MockEnvoyTransportSocket,
+      _event: ConnectionEvent,
+      _abort_reset: bool,
+    ) {
+    }
+    fn get_protocol(&self, _envoy: &mut transport_socket::MockEnvoyTransportSocket) -> String {
+      String::new()
+    }
+    fn get_failure_reason(
+      &self,
+      _envoy: &mut transport_socket::MockEnvoyTransportSocket,
+    ) -> String {
+      String::new()
+    }
+    fn can_flush_close(&self, _envoy: &mut transport_socket::MockEnvoyTransportSocket) -> bool {
+      true
+    }
+    fn start_secure_transport(
+      &mut self,
+      _envoy: &mut transport_socket::MockEnvoyTransportSocket,
+    ) -> bool {
+      false
+    }
+  }
+
+  let mut mock = transport_socket::MockEnvoyTransportSocket::new();
+  mock.expect_get_fd().times(1).returning(|| Some(7));
+  mock.expect_write_buffer_length().times(1).returning(|| 3);
+  mock.expect_set_is_writable().times(1).returning(|| ());
+
+  let mut socket = ProbeTransportSocket { fd: None };
+  socket.on_connected(&mut mock);
+  assert_eq!(socket.fd, Some(7));
+  assert_eq!(
+    socket.on_do_write(&mut mock, false),
+    IoResult::keep_open(0, false)
+  );
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/transport_socket.rs
@@ -171,18 +171,27 @@ pub trait EnvoyTransportSocket {
   fn io_write(&self, data: &[u8]) -> (IoStatus, usize);
   /// Shuts down the write side of the underlying socket so the peer observes end of stream.
   fn io_shutdown_write(&self);
+  /// Returns the native OS file descriptor of the underlying socket, or `None` when unavailable.
+  /// The descriptor is owned by Envoy and is only valid while the connection is open, so the module
+  /// must not close it.
+  fn get_fd(&self) -> Option<i32>;
   /// Appends `data` to the read buffer.
   fn read_buffer_add(&self, data: &[u8]);
   /// Appends the current contents of the write buffer to `out`.
   fn copy_write_buffer(&self, out: &mut Vec<u8>);
   /// Drains `length` bytes from the start of the write buffer.
   fn write_buffer_drain(&self, length: usize);
+  /// Returns the number of bytes currently queued in the write buffer.
+  fn write_buffer_length(&self) -> usize;
   /// Raises `event` on the underlying connection.
   fn raise_event(&self, event: ConnectionEvent);
   /// Returns whether Envoy expects the read buffer to be drained for flow-control reasons.
   fn should_drain_read_buffer(&self) -> bool;
   /// Requests that a future event-loop iteration schedules a read.
   fn set_is_readable(&self);
+  /// Schedules a write on a future event-loop iteration. A module calls this when it defers
+  /// buffered bytes for its own reasons rather than because the socket reported it would block.
+  fn set_is_writable(&self);
   /// Requests that the connection flush its write buffer, for example after queuing handshake
   /// bytes outside of a write step.
   fn flush_write_buffer(&self);
@@ -260,6 +269,15 @@ impl EnvoyTransportSocket for EnvoyTransportSocketImpl {
     }
   }
 
+  fn get_fd(&self) -> Option<i32> {
+    let fd = unsafe { abi::envoy_dynamic_module_callback_transport_socket_get_fd(self.raw) };
+    if fd < 0 {
+      None
+    } else {
+      Some(fd)
+    }
+  }
+
   fn read_buffer_add(&self, data: &[u8]) {
     if data.is_empty() {
       return;
@@ -315,6 +333,10 @@ impl EnvoyTransportSocket for EnvoyTransportSocketImpl {
     }
   }
 
+  fn write_buffer_length(&self) -> usize {
+    unsafe { abi::envoy_dynamic_module_callback_transport_socket_write_buffer_length(self.raw) }
+  }
+
   fn raise_event(&self, event: ConnectionEvent) {
     let abi_event: abi::envoy_dynamic_module_type_network_connection_event = event.into();
     unsafe {
@@ -331,6 +353,12 @@ impl EnvoyTransportSocket for EnvoyTransportSocketImpl {
   fn set_is_readable(&self) {
     unsafe {
       abi::envoy_dynamic_module_callback_transport_socket_set_is_readable(self.raw);
+    }
+  }
+
+  fn set_is_writable(&self) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_transport_socket_set_is_writable(self.raw);
     }
   }
 

--- a/source/extensions/transport_sockets/dynamic_modules/BUILD
+++ b/source/extensions/transport_sockets/dynamic_modules/BUILD
@@ -37,6 +37,7 @@ envoy_cc_library(
         ":transport_socket_lib",
         "//envoy/api:io_error_interface",
         "//envoy/buffer:buffer_interface",
+        "//envoy/event:file_event_interface",
         "//envoy/network:address_interface",
         "//envoy/network:connection_interface",
         "//envoy/network:transport_socket_interface",

--- a/source/extensions/transport_sockets/dynamic_modules/abi_impl.cc
+++ b/source/extensions/transport_sockets/dynamic_modules/abi_impl.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/api/io_error.h"
 #include "envoy/common/platform.h"
+#include "envoy/event/file_event.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 
@@ -88,6 +89,15 @@ void envoy_dynamic_module_callback_transport_socket_io_shutdown_write(
   callbacks->ioHandle().shutdown(ENVOY_SHUT_WR);
 }
 
+int envoy_dynamic_module_callback_transport_socket_get_fd(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr) {
+  Network::TransportSocketCallbacks* callbacks = toSocket(transport_socket_envoy_ptr)->callbacks();
+  if (callbacks == nullptr) {
+    return -1;
+  }
+  return static_cast<int>(callbacks->ioHandle().fdDoNotUse());
+}
+
 void envoy_dynamic_module_callback_transport_socket_read_buffer_add(
     envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr,
     const char* data, size_t length) {
@@ -129,6 +139,15 @@ void envoy_dynamic_module_callback_transport_socket_write_buffer_get_slices(
   *slices_count = count;
 }
 
+size_t envoy_dynamic_module_callback_transport_socket_write_buffer_length(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr) {
+  Buffer::Instance* buffer = toSocket(transport_socket_envoy_ptr)->currentWriteBuffer();
+  if (buffer == nullptr) {
+    return 0;
+  }
+  return buffer->length();
+}
+
 void envoy_dynamic_module_callback_transport_socket_raise_event(
     envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr,
     envoy_dynamic_module_type_network_connection_event event) {
@@ -168,6 +187,16 @@ void envoy_dynamic_module_callback_transport_socket_set_is_readable(
     return;
   }
   callbacks->setTransportSocketIsReadable();
+}
+
+void envoy_dynamic_module_callback_transport_socket_set_is_writable(
+    envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr) {
+  Network::TransportSocketCallbacks* callbacks = toSocket(transport_socket_envoy_ptr)->callbacks();
+  if (callbacks == nullptr) {
+    return;
+  }
+  // TransportSocketCallbacks has no `writability` setter, so re-arm the write event directly.
+  callbacks->ioHandle().activateFileEvents(Event::FileReadyType::Write);
 }
 
 void envoy_dynamic_module_callback_transport_socket_flush_write_buffer(

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1279,6 +1279,7 @@ WEAK_STUB(TransportSocketIoWrite,
           envoy_dynamic_module_callback_transport_socket_io_write(nullptr, nullptr, 0, nullptr))
 WEAK_STUB(TransportSocketIoShutdownWrite,
           envoy_dynamic_module_callback_transport_socket_io_shutdown_write(nullptr))
+WEAK_STUB(TransportSocketGetFd, envoy_dynamic_module_callback_transport_socket_get_fd(nullptr))
 WEAK_STUB(TransportSocketReadBufferAdd,
           envoy_dynamic_module_callback_transport_socket_read_buffer_add(nullptr, nullptr, 0))
 WEAK_STUB(TransportSocketWriteBufferDrain,
@@ -1286,6 +1287,8 @@ WEAK_STUB(TransportSocketWriteBufferDrain,
 WEAK_STUB(TransportSocketWriteBufferGetSlices,
           envoy_dynamic_module_callback_transport_socket_write_buffer_get_slices(nullptr, nullptr,
                                                                                  nullptr))
+WEAK_STUB(TransportSocketWriteBufferLength,
+          envoy_dynamic_module_callback_transport_socket_write_buffer_length(nullptr))
 WEAK_STUB(TransportSocketRaiseEvent,
           envoy_dynamic_module_callback_transport_socket_raise_event(
               nullptr, envoy_dynamic_module_type_network_connection_event_Connected))
@@ -1293,6 +1296,8 @@ WEAK_STUB(TransportSocketShouldDrainReadBuffer,
           envoy_dynamic_module_callback_transport_socket_should_drain_read_buffer(nullptr))
 WEAK_STUB(TransportSocketSetIsReadable,
           envoy_dynamic_module_callback_transport_socket_set_is_readable(nullptr))
+WEAK_STUB(TransportSocketSetIsWritable,
+          envoy_dynamic_module_callback_transport_socket_set_is_writable(nullptr))
 WEAK_STUB(TransportSocketFlushWriteBuffer,
           envoy_dynamic_module_callback_transport_socket_flush_write_buffer(nullptr))
 WEAK_STUB(TransportSocketGetRemoteAddress,

--- a/test/extensions/dynamic_modules/test_data/rust/transport_socket_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/transport_socket_integration_test.rs
@@ -2,7 +2,8 @@
 //!
 //! It applies a symmetric XOR transform to the raw connection bytes. The same transform runs on
 //! both reads and writes, so a peer that echoes the transformed bytes observes the original
-//! plaintext. A zero key behaves as a passthrough.
+//! plaintext. A zero key behaves as a passthrough. On connect it validates the native socket
+//! descriptor.
 
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 
@@ -71,8 +72,12 @@ impl<ETS: EnvoyTransportSocket> TransportSocket<ETS> for XorTransportSocket {
   fn on_set_callbacks(&mut self, _envoy: &mut ETS) {}
 
   fn on_connected(&mut self, envoy: &mut ETS) {
-    // A real secure transport finishes its handshake here. Mirror that by inspecting the
-    // connection endpoints and flushing any buffered output before signaling readiness.
+    // A real secure transport finishes its handshake here. Mirror that by validating the native
+    // socket descriptor (which a transport such as kTLS needs for setsockopt), inspecting the
+    // connection endpoints, and flushing any buffered output before signaling readiness.
+    if envoy.get_fd().is_none() {
+      self.failure_reason = "missing socket fd".to_string();
+    }
     let (remote, _) = envoy.get_remote_address();
     let (local, _) = envoy.get_local_address();
     if !remote.is_empty() && !local.is_empty() {
@@ -109,15 +114,16 @@ impl<ETS: EnvoyTransportSocket> TransportSocket<ETS> for XorTransportSocket {
   }
 
   fn on_do_write(&mut self, envoy: &mut ETS, end_stream: bool) -> IoResult {
-    // Snapshot and transform the whole write buffer once. The transform is position-independent so
-    // partial writes are handled by draining only the bytes the socket accepted.
+    // Snapshot and transform the whole write buffer once. The transform is byte-for-byte, so the
+    // number of bytes to send equals the length Envoy reports for its write buffer.
+    let pending = envoy.write_buffer_length();
     self.write_scratch.clear();
     envoy.copy_write_buffer(&mut self.write_scratch);
     apply_xor(&mut self.write_scratch, self.key);
 
     let mut written = 0;
     let action = loop {
-      if written == self.write_scratch.len() {
+      if written == pending {
         if end_stream && !self.write_shutdown {
           envoy.io_shutdown_write();
           self.write_shutdown = true;

--- a/test/extensions/transport_sockets/dynamic_modules/BUILD
+++ b/test/extensions/transport_sockets/dynamic_modules/BUILD
@@ -21,6 +21,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.transport_sockets.dynamic_modules"],
     rbe_pool = "6gig",
     deps = [
+        "//envoy/event:file_event_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/network:io_socket_error_lib",
         "//source/common/network:utility_lib",

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/event/file_event.h"
 #include "envoy/extensions/transport_sockets/dynamic_modules/v3/dynamic_modules.pb.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -443,10 +444,12 @@ TEST_F(DynamicModuleTransportSocketTest, ConnectionCallbacksWithoutCallbacksAreS
                                                                     sizeof(buffer), &io_bytes));
   EXPECT_EQ(0, io_bytes);
   envoy_dynamic_module_callback_transport_socket_io_shutdown_write(envoy_ptr);
+  EXPECT_EQ(-1, envoy_dynamic_module_callback_transport_socket_get_fd(envoy_ptr));
   envoy_dynamic_module_callback_transport_socket_raise_event(
       envoy_ptr, envoy_dynamic_module_type_network_connection_event_RemoteClose);
   EXPECT_FALSE(envoy_dynamic_module_callback_transport_socket_should_drain_read_buffer(envoy_ptr));
   envoy_dynamic_module_callback_transport_socket_set_is_readable(envoy_ptr);
+  envoy_dynamic_module_callback_transport_socket_set_is_writable(envoy_ptr);
   envoy_dynamic_module_callback_transport_socket_flush_write_buffer(envoy_ptr);
 
   envoy_dynamic_module_type_envoy_buffer address{nullptr, 0};
@@ -559,8 +562,31 @@ TEST_F(DynamicModuleTransportSocketTest, BufferCallbacksWithoutActiveBufferAreNo
   envoy_dynamic_module_callback_transport_socket_write_buffer_get_slices(envoy_ptr, nullptr,
                                                                          &slices_count);
   EXPECT_EQ(0, slices_count);
+  EXPECT_EQ(0, envoy_dynamic_module_callback_transport_socket_write_buffer_length(envoy_ptr));
 }
 
+TEST_F(DynamicModuleTransportSocketTest, GetFdReturnsNativeDescriptor) {
+  auto socket = createSocket("passthrough");
+  auto* envoy_ptr = static_cast<DynamicModuleTransportSocket*>(socket.get());
+  EXPECT_CALL(io_handle_, fdDoNotUse()).WillOnce(testing::Return(42));
+  EXPECT_EQ(42, envoy_dynamic_module_callback_transport_socket_get_fd(envoy_ptr));
+}
+
+TEST_F(DynamicModuleTransportSocketTest, SetIsWritableActivatesWriteEvent) {
+  auto socket = createSocket("passthrough");
+  auto* envoy_ptr = static_cast<DynamicModuleTransportSocket*>(socket.get());
+  EXPECT_CALL(io_handle_, activateFileEvents(Event::FileReadyType::Write));
+  envoy_dynamic_module_callback_transport_socket_set_is_writable(envoy_ptr);
+}
+
+TEST_F(DynamicModuleTransportSocketTest, OnConnectedRecordsFailureWhenFdUnavailable) {
+  auto socket = createSocket("passthrough");
+  // The reference module records a failure when the socket descriptor is unavailable.
+  EXPECT_CALL(io_handle_, fdDoNotUse()).WillOnce(testing::Return(-1));
+  EXPECT_CALL(callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
+  socket->onConnected();
+  EXPECT_EQ("missing socket fd", socket->failureReason());
+}
 } // namespace
 } // namespace DynamicModules
 } // namespace TransportSockets

--- a/test/extensions/transport_sockets/dynamic_modules/integration_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/integration_test.cc
@@ -145,7 +145,8 @@ TEST_P(DynamicModuleTransportSocketIntegrationTest, UpstreamXorTransform) {
   tcp_client->close();
 }
 
-// Large transfers exercise the read and write loops across multiple I/O operations.
+// Large transfers exercise the read and write loops across multiple I/O operations, including the
+// write buffer length check.
 TEST_P(DynamicModuleTransportSocketIntegrationTest, DownstreamLargeData) {
   initializeWithDownstreamSocket("xor");
 


### PR DESCRIPTION
## Description

This PR adds three new transport-socket ABI callbacks for dynamic modules so a Rust module could perform raw socket work.

The Rust SDK exposes them on the `EnvoyTransportSocket` trait as `get_fd`, `write_buffer_length`, and `set_is_writable`.

---

**Commit Message**: dynamic_modules: add transport socket fd and writable ABI callbacks
**Additional Description:** Added three new transport-socket ABI callbacks for dynamic modules so a Rust module could perform raw socket work.
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes**: Added
**Release Notes**: Added