### PR TITLE
reverse_tunnel: proactively replace draining connections instead of GOAWAY

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -88,6 +88,11 @@ Api::SysCallIntResult DownstreamReverseConnectionIOHandle::shutdown(int how) {
   return Api::SysCallIntResult{0, 0};
 }
 
+void DownstreamReverseConnectionIOHandle::reestablishConnection() {
+  ENVOY_LOG(info, "DownstreamReverseConnectionIOHandle: reestablishing connection for FD: {}", fd_);
+  parent_->onDownstreamConnectionClosed(connection_key_, true);
+}
+
 } // namespace ReverseConnection
 } // namespace Bootstrap
 } // namespace Extensions

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -38,6 +38,13 @@ public:
   Api::IoCallUint64Result close() override;
   Api::SysCallIntResult shutdown(int how) override;
 
+  /**
+   * Trigger immediate reconnection for this reverse connection slot. Called by the
+   * drain-aware HCM when a connection is being gracefully drained but the listener
+   * is still healthy — ensures the reverse tunnel pool stays at target capacity.
+   */
+  void reestablishConnection();
+
   // RPING Interceptor overrides.
   // Send the RPING response from here.
   void onPingMessage() override;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -770,7 +770,8 @@ void ReverseConnectionIOHandle::removeConnectionState(const std::string& host_ad
             connection_key, host_address, cluster_name);
 }
 
-void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key) {
+void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key,
+                                                             bool start_new_connection) {
   ENVOY_LOG(debug, "reverse_tunnel: Downstream connection closed: {}", connection_key);
 
   // Find the host for this connection key.
@@ -805,8 +806,14 @@ void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& 
   // Remove connection state tracking.
   removeConnectionState(host_address, cluster_name, connection_key);
 
-  // The next call to maintainClusterConnections() will detect the missing connection
-  // and re-initiate it automatically.
+  if (start_new_connection) {
+    // Use a 0ms timer to schedule reconnection on the next event loop iteration, avoiding
+    // re-entrant calls into connection setup from within the close path.
+    return rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(0));
+  }
+
+  // No immediate reconnection requested — the next periodic maintainClusterConnections()
+  // call will detect the deficit and re-initiate.
   ENVOY_LOG(debug,
             "reverse_tunnel: Connection closure recorded for host {} in cluster {}. "
             "Next maintenance cycle will re-initiate if needed.",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -286,11 +286,15 @@ public:
                              const std::string& connection_key);
 
   /**
-   * Handle downstream connection closure and update internal maps so that the next
-   * maintenance cycle re-initiates the connection.
+   * Handle downstream connection closure and update internal maps.
    * @param connection_key the unique key identifying the closed connection.
+   * @param start_new_connection if true, immediately schedule reconnection via the retry timer
+   *        (0ms delay) rather than waiting for the next maintenance cycle. Used when a healthy
+   *        connection is being drained for connection-level reasons (e.g. max requests) and the
+   *        pool should stay at capacity.
    */
-  void onDownstreamConnectionClosed(const std::string& connection_key);
+  void onDownstreamConnectionClosed(const std::string& connection_key,
+                                    bool start_new_connection = false);
 
   /**
    * Get reference to the cluster manager.

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
@@ -22,6 +22,7 @@ envoy_cc_extension(
         "//envoy/network:drain_decision_interface",
         "//envoy/server:factory_context_interface",
         "//source/common/http:conn_manager_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "//source/extensions/filters/network/http_connection_manager:config",

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
@@ -30,8 +30,11 @@ Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createCodec(
   // Use the listener-level DrainDecision, NOT serverFactoryContext().drainManager().
   // /drain_listeners fires the listener-level drain decision; the server-wide drain manager
   // only fires on hot-restart / full server shutdown.
-  return std::make_unique<DrainAwareServerConnection>(std::move(codec), connection.dispatcher(),
-                                                      factory_context_.drainDecision());
+  // Pass the HCM drain_timeout so the proactive (idle-connection) drain uses the same graceful
+  // window between shutdownNotice and the final goAway as a normal HCM-driven drain.
+  return std::make_unique<DrainAwareServerConnection>(
+      std::move(codec), factory_context_.drainDecision(), connection.getSocket()->ioHandle(),
+      connection.dispatcher(), drainTimeout());
 }
 
 absl::StatusOr<Network::FilterFactoryCb>

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include "envoy/event/dispatcher.h"
@@ -7,38 +8,103 @@
 #include "envoy/network/drain_decision.h"
 
 #include "source/common/common/logger.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace ReverseTunnel {
 
-// Wraps an Http::ServerConnection and proactively sends an HTTP/2 GOAWAY frame when
-// the listener that owns this connection begins draining. Drain is detected by polling
-// DrainDecision::drainClose() on a short timer; this avoids calling addOnDrainCloseCb()
-// which is intentionally unsupported on PerFilterChainFactoryContextImpl.
+// Wraps an Http::ServerConnection to manage the drain sequence for reverse tunnels.
+//
+// Key idea: we NEVER forward the HCM's phase-1 shutdownNotice() GOAWAY. The only GOAWAY ever put
+// on the wire is the final goAway(), and it is guarded so it is sent at most once. Two bools track
+// the two halves of the sequence: drain_initiated_ (shutdownNotice handled) and
+// drain_goaway_sent_ (final GOAWAY emitted).
+//
+// Two drain triggers:
+//
+// 1. Connection-level drain (max_connection_duration, max_requests, ...): the HCM calls
+//    shutdownNotice() then goAway() after drain_timeout. We swallow shutdownNotice() and instead
+//    proactively establish a REPLACEMENT reverse tunnel (when the listener is healthy), so the
+//    cluster has somewhere to route. The old connection keeps serving during drain_timeout
+//    because no GOAWAY has been sent yet. The HCM's goAway() then sends the single final GOAWAY.
+//
+// 2. Listener-level drain (hot-restart, /drain_listeners, healthcheck fail): the HCM only checks
+//    drainClose() while encoding a response, so it never notices listener drain on an idle
+//    connection. We poll drainClose() on a short timer; on detection we do NOT reconnect (the
+//    listener is dying) and instead arm a timer to send the final goAway() after drain_timeout,
+//    giving any in-flight request time to finish before the connection closes.
+//
+// drain_goaway_sent_ guards goAway() so the two paths (HCM-driven and our proactive timer) can
+// never put a duplicate GOAWAY on the wire.
 class DrainAwareServerConnection : public Http::ServerConnection,
                                    public Logger::Loggable<Logger::Id::filter> {
 public:
-  DrainAwareServerConnection(Http::ServerConnectionPtr inner, Event::Dispatcher& dispatcher,
-                             const Network::DrainDecision& drain_decision)
-      : inner_(std::move(inner)), drain_decision_(drain_decision) {
+  // @param drain_decision listener-level drain decision; polled to detect listener drain.
+  // @param io_handle reference to the connection's IoHandle; used to trigger reconnection on a
+  //        connection-level drain. Lifetime is guaranteed by the Network::Connection that owns
+  //        both this codec wrapper and the IoHandle.
+  // @param dispatcher the connection's dispatcher; owns the drain-poll and proactive-goaway timers.
+  // @param drain_timeout gap between detecting a listener drain and sending the final goAway when
+  //        we drive the sequence ourselves. Mirrors the HCM's drain_timeout so the graceful window
+  //        is identical to a normal HCM-driven drain.
+  DrainAwareServerConnection(Http::ServerConnectionPtr inner,
+                             const Network::DrainDecision& drain_decision,
+                             Network::IoHandle& io_handle, Event::Dispatcher& dispatcher,
+                             std::chrono::milliseconds drain_timeout)
+      : inner_(std::move(inner)), drain_decision_(drain_decision), io_handle_(io_handle),
+        drain_timeout_(drain_timeout) {
     ENVOY_LOG(debug, "drain_aware_hcm: created server connection wrapper, protocol={}",
               static_cast<int>(inner_->protocol()));
     drain_check_timer_ = dispatcher.createTimer([this]() { onDrainCheckTimer(); });
-    drain_check_timer_->enableTimer(std::chrono::milliseconds(100));
-  }
-
-  ~DrainAwareServerConnection() override {
-    if (drain_check_timer_ != nullptr) {
-      drain_check_timer_->disableTimer();
-    }
+    proactive_goaway_timer_ = dispatcher.createTimer([this]() { goAway(); });
+    drain_check_timer_->enableTimer(kDrainPollInterval);
   }
 
   Http::Status dispatch(Buffer::Instance& data) override { return inner_->dispatch(data); }
-  void goAway() override { inner_->goAway(); }
+
+  // Sends the final GOAWAY exactly once. Reached either from the HCM's own drain sequence
+  // (connection-level drain) or from proactive_goaway_timer_ (listener-level drain on an idle
+  // connection). The bool guard makes the two paths mutually idempotent.
+  void goAway() override {
+    if (drain_goaway_sent_) {
+      return;
+    }
+    drain_goaway_sent_ = true;
+    inner_->goAway();
+  }
+
   Http::Protocol protocol() override { return inner_->protocol(); }
-  void shutdownNotice() override { inner_->shutdownNotice(); }
+
+  // The HCM's phase-1 drain notice. We always swallow it (never forward to the inner codec) so no
+  // premature GOAWAY is emitted; instead we set up a replacement tunnel when appropriate.
+  void shutdownNotice() override {
+    if (drain_initiated_) {
+      return;
+    }
+    drain_initiated_ = true;
+
+    if (drain_decision_.drainClose(Network::DrainDirection::All)) {
+      // The listener itself is draining: there is no point opening a replacement connection to a
+      // dying listener. Some other listener/process is responsible for new connections; just give
+      // the in-flight work time to finish and let the final goAway() close this one.
+      return;
+    }
+
+    // Connection-level drain while the listener is healthy. We swallowed the phase-1 GOAWAY above,
+    // so the old connection keeps accepting requests during drain_timeout. Proactively open a
+    // replacement reverse tunnel so the cluster has somewhere to route once this one closes; the
+    // HCM's own goAway() (after drain_timeout) sends the single final GOAWAY.
+    // NOTE: dynamic_cast is used here because IoHandle does not expose a reconnection interface.
+    // This coupling is acceptable since drain_aware_hcm is exclusively used with reverse tunnels.
+    if (auto* io_handle = dynamic_cast<
+            Extensions::Bootstrap::ReverseConnection::DownstreamReverseConnectionIOHandle*>(
+            &io_handle_)) {
+      io_handle->reestablishConnection();
+    }
+  }
+
   bool wantsToWrite() override { return inner_->wantsToWrite(); }
 
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override {
@@ -50,22 +116,44 @@ public:
   }
 
 private:
+  // Poll interval for detecting listener-level drain on idle connections. 100ms is short enough
+  // that an idle reverse tunnel reacts to a hot-restart/drain almost immediately, while being
+  // cheap enough to run per-connection (one timer firing 10x/sec).
+  static constexpr std::chrono::milliseconds kDrainPollInterval{100};
+
+  // Polls the listener drain decision. Only matters for idle connections, where the HCM never
+  // checks drainClose() itself. On detection, schedules the final goAway() after drain_timeout.
   void onDrainCheckTimer() {
-    if (drain_goaway_sent_) {
+    if (drain_initiated_) {
       return;
     }
     if (drain_decision_.drainClose(Network::DrainDirection::All)) {
-      ENVOY_LOG(info, "drain_aware_hcm: drain detected, sending GOAWAY");
-      drain_goaway_sent_ = true;
-      inner_->goAway();
+      ENVOY_LOG(info, "drain_aware_hcm: listener drain detected on idle connection, scheduling "
+                      "graceful goAway");
+      drain_initiated_ = true;
+      // No reconnection (listener is dying). Send the final GOAWAY after drain_timeout so any
+      // in-flight request gets the same graceful window as a normal HCM-driven drain.
+      proactive_goaway_timer_->enableTimer(drain_timeout_);
       return;
     }
-    drain_check_timer_->enableTimer(std::chrono::milliseconds(100));
+    drain_check_timer_->enableTimer(kDrainPollInterval);
   }
 
   Http::ServerConnectionPtr inner_;
   const Network::DrainDecision& drain_decision_;
+  // Underlying IoHandle for the reverse connection. Used to trigger reconnection on a
+  // connection-level drain.
+  Network::IoHandle& io_handle_;
+  // Mirrors the HCM drain_timeout: the gap between detecting a drain and sending the final goAway
+  // when this wrapper drives the sequence itself.
+  const std::chrono::milliseconds drain_timeout_;
   Event::TimerPtr drain_check_timer_;
+  Event::TimerPtr proactive_goaway_timer_;
+
+  // Set once a drain has been initiated (HCM-driven shutdownNotice or polling-detected listener
+  // drain), so the drain sequence is started at most once.
+  bool drain_initiated_{false};
+  // Set once the final GOAWAY has been emitted, so it is never sent twice.
   bool drain_goaway_sent_{false};
 };
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -165,6 +165,32 @@ protected:
                                                                  connection_key);
   }
 
+  // Helpers to access private members via friend access (friend doesn't extend to TEST_F bodies).
+  void injectHostConnectionInfo(const std::string& host_address, const std::string& cluster_name,
+                                const std::string& connection_key,
+                                uint32_t target_connection_count) {
+    ReverseConnectionIOHandle::HostConnectionInfo host_info;
+    host_info.host_address = host_address;
+    host_info.cluster_name = cluster_name;
+    host_info.connection_keys.insert(connection_key);
+    host_info.target_connection_count = target_connection_count;
+    io_handle_->host_to_conn_info_map_[host_address] = host_info;
+  }
+
+  NiceMock<Event::MockTimer>* injectReconnectTimer() {
+    auto* timer = new NiceMock<Event::MockTimer>();
+    io_handle_->rev_conn_retry_timer_.reset(timer);
+    return timer;
+  }
+
+  bool hostHasConnectionKey(const std::string& host_address, const std::string& connection_key) {
+    auto it = io_handle_->host_to_conn_info_map_.find(host_address);
+    if (it == io_handle_->host_to_conn_info_map_.end()) {
+      return false;
+    }
+    return it->second.connection_keys.count(connection_key) > 0;
+  }
+
   // Test fixtures.
   std::unique_ptr<NiceMock<Network::MockConnectionSocket>> mock_socket_;
   NiceMock<Network::MockIoHandle>* mock_io_handle_; // Raw pointer, managed by socket
@@ -611,6 +637,33 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleShutdownCallNoDoubleClose)
   handle.reset();
 
   ::close(fds[1]);
+}
+
+// Verify reestablishConnection() with an unknown key does not crash.
+// The parent's onDownstreamConnectionClosed returns early when the key is not in the map.
+TEST_F(DownstreamReverseConnectionIOHandleTest, ReestablishConnectionUnknownKeyNoCrash) {
+  auto handle = createHandle(io_handle_.get(), "unknown_key");
+  EXPECT_NO_THROW(handle->reestablishConnection());
+}
+
+// Verify reestablishConnection() triggers the reconnect timer when the key exists in the parent.
+TEST_F(DownstreamReverseConnectionIOHandleTest, ReestablishConnectionTriggersReconnectTimer) {
+  const std::string connection_key = "reestablish_test_key";
+  const std::string host_address = "10.0.0.1:8080";
+  const std::string cluster_name = "remote-cluster";
+
+  // Set up the parent's internal state via fixture helpers (uses friend access).
+  injectHostConnectionInfo(host_address, cluster_name, connection_key, 2);
+  auto* reconnect_timer = injectReconnectTimer();
+
+  // Expect the timer to be armed with 0ms (immediate reconnection on next event loop).
+  EXPECT_CALL(*reconnect_timer, enableTimer(std::chrono::milliseconds(0), _));
+
+  auto handle = createHandle(io_handle_.get(), connection_key);
+  handle->reestablishConnection();
+
+  // Verify the connection key was removed from the parent's map.
+  EXPECT_FALSE(hostHasConnectionKey(host_address, connection_key));
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/clusters/reverse_connection/BUILD
+++ b/test/extensions/clusters/reverse_connection/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
     extension_names = [
         "envoy.clusters.reverse_connection",
         "envoy.filters.network.reverse_tunnel",
+        "envoy.filters.network.reverse_tunnel_drain_aware_http_connection_manager",
         "envoy.filters.http.lua",
         "envoy.bootstrap.reverse_tunnel.upstream_socket_interface",
         "envoy.bootstrap.reverse_tunnel.downstream_socket_interface",
@@ -64,6 +65,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/filters/network/reverse_tunnel:config",
+        "//source/extensions/filters/network/reverse_tunnel/drain_aware_hcm:drain_aware_config",
         "//source/extensions/transport_sockets/tls:config",
         "//test/integration:http_integration_lib",
         "//test/integration:integration_lib",

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
@@ -2,6 +2,7 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/extensions/clusters/reverse_connection/v3/reverse_connection.pb.h"
 #include "envoy/extensions/filters/http/lua/v3/lua.pb.h"
+#include "envoy/extensions/filters/network/reverse_tunnel/v3/drain_aware_hcm.pb.h"
 #include "envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.pb.h"
 #include "envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.pb.h"
 #include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
@@ -1269,6 +1270,266 @@ TEST_P(ReverseConnectionClusterIntegrationTest, MultiWorkerEndToEndReverseTunnel
   // Wait for listeners to be fully stopped before test cleanup.
   test_server_->waitForCounter("listener_manager.listener_stopped", Eq(3),
                                std::chrono::milliseconds(5000));
+}
+
+// Test drain-aware HCM reconnection behavior end-to-end:
+// 1. Connection-level drain: max_connection_duration expires while a stream is active. The wrapper
+//    swallows the phase-1 shutdownNotice and calls reestablishConnection(), opening a replacement
+//    tunnel (handshake 1 → 2). After drain_timeout the HCM's goAway() emits the single GOAWAY
+//    (upstream_cx_close_notify 0 → 1). The in-flight request still completes on the old connection.
+// 2. Listener-level drain on an IDLE connection: after probing the replacement tunnel to create
+//    its wrapper, failing health checks makes drainClose() true. The wrapper's poll timer detects
+//    this with no active stream and schedules the final GOAWAY after drain_timeout
+//    (upstream_cx_close_notify 1 → 2) — the case the HCM never notices on its own.
+TEST_P(ReverseConnectionClusterIntegrationTest, DrainAwareHcmReconnectionOnMaxDuration) {
+  DISABLE_IF_ADMIN_DISABLED;
+
+  const uint32_t tunnel_listener_port = tunnelListenerPort();
+  const std::string loopback_addr = loopbackAddress();
+
+  config_helper_.addConfigModifier([tunnel_listener_port, loopback_addr](
+                                       envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    bootstrap.mutable_static_resources()->clear_listeners();
+
+    // --- Tunnel acceptor listener (upstream side) ---
+    auto* tunnel_listener = bootstrap.mutable_static_resources()->add_listeners();
+    tunnel_listener->set_name("tunnel_listener");
+    tunnel_listener->mutable_address()->mutable_socket_address()->set_address(loopback_addr);
+    tunnel_listener->mutable_address()->mutable_socket_address()->set_port_value(
+        tunnel_listener_port);
+
+    auto* tunnel_chain = tunnel_listener->add_filter_chains();
+    auto* rt_filter = tunnel_chain->add_filters();
+    rt_filter->set_name("envoy.filters.network.reverse_tunnel");
+
+    envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel rt_config;
+    rt_config.mutable_ping_interval()->set_seconds(60);
+    rt_config.set_auto_close_connections(true);
+    rt_config.set_request_path("/reverse_connections/request");
+    rt_config.set_request_method(envoy::config::core::v3::GET);
+    rt_filter->mutable_typed_config()->PackFrom(rt_config);
+
+    // --- Egress listener ---
+    auto* egress_listener = bootstrap.mutable_static_resources()->add_listeners();
+    egress_listener->set_name("egress_listener");
+    auto* egress_address = egress_listener->mutable_address()->mutable_socket_address();
+    egress_address->set_address(loopback_addr);
+    egress_address->set_port_value(0);
+
+    auto* egress_chain = egress_listener->add_filter_chains();
+    auto* egress_hcm_filter = egress_chain->add_filters();
+    egress_hcm_filter->set_name("envoy.filters.network.http_connection_manager");
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
+        egress_hcm;
+    egress_hcm.set_stat_prefix("egress_http");
+    egress_hcm.set_codec_type(envoy::extensions::filters::network::http_connection_manager::v3::
+                                  HttpConnectionManager::AUTO);
+
+    auto* egress_route_config = egress_hcm.mutable_route_config();
+    egress_route_config->set_name("local_route");
+    auto* egress_virtual_host = egress_route_config->add_virtual_hosts();
+    egress_virtual_host->set_name("backend");
+    egress_virtual_host->add_domains("*");
+
+    auto* egress_route = egress_virtual_host->add_routes();
+    egress_route->mutable_match()->set_prefix("/");
+    egress_route->mutable_route()->set_cluster("reverse_connection_cluster");
+    egress_route->mutable_route()->mutable_timeout()->set_seconds(30);
+
+    auto* egress_router = egress_hcm.add_http_filters();
+    egress_router->set_name("envoy.filters.http.router");
+    egress_router->mutable_typed_config()->PackFrom(
+        envoy::extensions::filters::http::router::v3::Router());
+
+    egress_hcm_filter->mutable_typed_config()->PackFrom(egress_hcm);
+
+    // --- Initiator listener using DrainAwareHttpConnectionManager ---
+    auto* init_listener = bootstrap.mutable_static_resources()->add_listeners();
+    init_listener->set_name("reverse_conn_listener");
+    init_listener->set_stat_prefix("reverse_conn_listener");
+    init_listener->mutable_listener_filters_timeout()->set_seconds(0);
+
+    auto* init_address = init_listener->mutable_address()->mutable_socket_address();
+    init_address->set_address("rc://test-node-id:test-cluster-id:test-tenant-id@tunnel_cluster:1");
+    init_address->set_port_value(0);
+    init_address->set_resolver_name("envoy.resolvers.reverse_connection");
+
+    auto* init_chain = init_listener->add_filter_chains();
+    auto* init_hcm_filter = init_chain->add_filters();
+    init_hcm_filter->set_name(
+        "envoy.filters.network.reverse_tunnel_drain_aware_http_connection_manager");
+
+    envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager
+        init_hcm;
+    init_hcm.set_stat_prefix("reverse_conn_initiator");
+    init_hcm.set_codec_type(envoy::extensions::filters::network::http_connection_manager::v3::
+                                HttpConnectionManager::AUTO);
+    // 3s max_connection_duration: triggers the drain sequence on the active connection.
+    init_hcm.mutable_common_http_protocol_options()->mutable_max_connection_duration()->set_seconds(
+        3);
+    // 2s drain_timeout: the wrapper swallows the phase-1 shutdownNotice, so the final GOAWAY is
+    // emitted this long after the drain starts. Kept short to keep the test fast.
+    init_hcm.mutable_drain_timeout()->set_seconds(2);
+
+    auto* init_route_config = init_hcm.mutable_route_config();
+    init_route_config->set_name("local_route");
+    auto* init_virtual_host = init_route_config->add_virtual_hosts();
+    init_virtual_host->set_name("backend");
+    init_virtual_host->add_domains("*");
+
+    // Direct response for probe requests — forces the H2 codec (and thus the
+    // DrainAwareServerConnection wrapper + its drain-poll timer) to be created on a tunnel
+    // connection without needing a real upstream.
+    auto* probe_route = init_virtual_host->add_routes();
+    probe_route->mutable_match()->set_prefix("/probe");
+    probe_route->mutable_direct_response()->set_status(200);
+    probe_route->mutable_direct_response()->mutable_body()->set_inline_string("ok");
+
+    auto* init_route = init_virtual_host->add_routes();
+    init_route->mutable_match()->set_prefix("/");
+    init_route->mutable_route()->set_cluster("cluster_0");
+    init_route->mutable_route()->mutable_timeout()->set_seconds(30);
+
+    auto* init_router = init_hcm.add_http_filters();
+    init_router->set_name("envoy.filters.http.router");
+    init_router->mutable_typed_config()->PackFrom(
+        envoy::extensions::filters::http::router::v3::Router());
+
+    envoy::extensions::filters::network::reverse_tunnel::v3::DrainAwareHttpConnectionManager
+        drain_aware_config;
+    *drain_aware_config.mutable_hcm_config() = init_hcm;
+    init_hcm_filter->mutable_typed_config()->PackFrom(drain_aware_config);
+
+    // --- Reverse connection cluster ---
+    auto* rc_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    rc_cluster->set_name("reverse_connection_cluster");
+    rc_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+    rc_cluster->mutable_connect_timeout()->set_seconds(5);
+
+    auto* cluster_type = rc_cluster->mutable_cluster_type();
+    cluster_type->set_name("envoy.clusters.reverse_connection");
+
+    envoy::extensions::clusters::reverse_connection::v3::ReverseConnectionClusterConfig rc_config;
+    rc_config.set_host_id_format("%REQ(x-computed-host-id)%");
+    rc_config.mutable_cleanup_interval()->set_seconds(60);
+    cluster_type->mutable_typed_config()->PackFrom(rc_config);
+
+    envoy::extensions::upstreams::http::v3::HttpProtocolOptions http_options;
+    http_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
+    (*rc_cluster->mutable_typed_extension_protocol_options())
+        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+            .PackFrom(http_options);
+
+    // --- Tunnel cluster ---
+    auto* tunnel_cluster = bootstrap.mutable_static_resources()->add_clusters();
+    tunnel_cluster->set_name("tunnel_cluster");
+    tunnel_cluster->set_type(envoy::config::cluster::v3::Cluster::STATIC);
+    tunnel_cluster->mutable_connect_timeout()->set_seconds(5);
+    tunnel_cluster->mutable_load_assignment()->set_cluster_name("tunnel_cluster");
+
+    auto* tunnel_locality = tunnel_cluster->mutable_load_assignment()->add_endpoints();
+    auto* tunnel_lb_endpoint = tunnel_locality->add_lb_endpoints();
+    auto* tunnel_endpoint = tunnel_lb_endpoint->mutable_endpoint();
+    auto* tunnel_addr = tunnel_endpoint->mutable_address()->mutable_socket_address();
+    tunnel_addr->set_address(loopback_addr);
+    tunnel_addr->set_port_value(tunnel_listener_port);
+  });
+
+  // Immediate drain strategy + zero drain time so that, once health checks fail, the listener's
+  // drainClose() returns true right away (no probabilistic gradual-drain delay).
+  drain_strategy_ = Server::DrainStrategy::Immediate;
+  setDrainTime(std::chrono::seconds(0));
+
+  initialize();
+  registerTestServerPorts({"tunnel_listener", "egress_listener"});
+
+  // --- Phase 1: Wait for the initial tunnel to establish. ---
+  ENVOY_LOG_MISC(info, "Phase 1: Waiting for initial reverse tunnel connection.");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1),
+                               std::chrono::milliseconds(5000));
+  test_server_->waitForCounter("listener.reverse_conn_listener.downstream_cx_total", Ge(1),
+                               std::chrono::milliseconds(5000));
+  test_server_->waitForGauge("reverse_tunnel_acceptor.nodes.test-node-id", Ge(1));
+
+  // --- Phase 2: Send a long-running request that outlasts max_connection_duration (3s). ---
+  // When max_connection_duration fires while this stream is active, the HCM starts
+  // startDrainSequence() → shutdownNotice() → GOAWAY sent to responder.
+  ENVOY_LOG_MISC(info, "Phase 2: Sending long-running request to hold connection active past "
+                       "max_connection_duration (3s).");
+  codec_client_ = makeHttpConnection(lookupPort("egress_listener"));
+
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/slow"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-computed-host-id", "test-node-id"}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+  // Wait for the request to arrive at the fake upstream (but DON'T respond yet).
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  ENVOY_LOG_MISC(info, "Request in-flight. Waiting for max_connection_duration drain to fire.");
+
+  // max_connection_duration (3s) fires → HCM drain → shutdownNotice (GOAWAY) sent →
+  // upstream_cx_close_notify increments.
+  test_server_->waitForCounter("cluster.reverse_connection_cluster.upstream_cx_close_notify", Ge(1),
+                               std::chrono::milliseconds(10000));
+
+  ENVOY_LOG_MISC(info, "upstream_cx_close_notify=1. reestablishConnection() should have "
+                       "triggered a new tunnel handshake.");
+
+  // Verify a new connection was established (handshake count 1 → 2).
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2),
+                               std::chrono::milliseconds(10000));
+  ENVOY_LOG_MISC(info, "New tunnel established (handshake_accepted >= 2).");
+
+  // Complete the in-flight request — it should still succeed on the old (draining) connection.
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  ENVOY_LOG_MISC(info, "In-flight request completed successfully on draining connection.");
+
+  // --- Phase 3: Force the new (replacement) tunnel to create its H2 codec. ---
+  // The DrainAwareServerConnection wrapper (and its drain-poll timer) only exists once the H2
+  // codec is created, which happens lazily on first traffic. Send a probe (direct_response) so the
+  // wrapper exists on the new connection, then let the connection go idle again.
+  ENVOY_LOG_MISC(info, "Phase 3: Probing new tunnel to instantiate the drain-aware wrapper.");
+  auto probe_response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/probe"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-computed-host-id", "test-node-id"}});
+  ASSERT_TRUE(probe_response->waitForEndStream());
+  EXPECT_TRUE(probe_response->complete());
+  EXPECT_EQ("200", probe_response->headers().getStatusValue());
+
+  // --- Phase 4: Drain the listener while the replacement connection is idle. ---
+  // The wrapper's drain-poll timer detects the listener drain (drainClose()==true) even though no
+  // stream is active, and schedules the final GOAWAY after drain_timeout (2s). This proves an idle
+  // reverse tunnel is drained gracefully — the case the HCM itself never notices.
+  ENVOY_LOG_MISC(info, "Phase 4: Failing health check to drain the idle replacement connection.");
+  BufferingStreamDecoderPtr hc_fail_response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/healthcheck/fail", "", Http::CodecType::HTTP1, GetParam());
+  EXPECT_TRUE(hc_fail_response->complete());
+  EXPECT_EQ("200", hc_fail_response->headers().getStatusValue());
+
+  // The idle connection's GOAWAY arrives after drain_timeout (2s) — bump from 1 to 2. Allow a
+  // generous window (poll interval + drain_timeout + propagation).
+  test_server_->waitForCounter("cluster.reverse_connection_cluster.upstream_cx_close_notify", Ge(2),
+                               std::chrono::milliseconds(8000));
+
+  ENVOY_LOG_MISC(info, "Drain-aware HCM reconnection test completed successfully.");
+
+  // Cleanup: close test client, then close fake upstream from Phase 2.
+  codec_client_->close();
+  if (fake_upstream_connection_) {
+    ASSERT_TRUE(fake_upstream_connection_->close());
+  }
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
@@ -2,6 +2,7 @@
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/network/io_handle.h"
 #include "test/mocks/network/mocks.h"
 
 #include "gmock/gmock.h"
@@ -17,135 +18,163 @@ namespace NetworkFilters {
 namespace ReverseTunnel {
 namespace {
 
+constexpr std::chrono::milliseconds kDrainTimeout{5000};
+constexpr std::chrono::milliseconds kPollInterval{100};
+
 class DrainAwareServerConnectionTest : public testing::Test {
 protected:
   DrainAwareServerConnectionTest() {
-    // MockTimer(dispatcher) registers itself as the next timer returned by createTimer_.
-    timer_ = new Event::MockTimer(&dispatcher_);
+    // The wrapper's constructor calls createTimer twice: first for the drain-poll timer, then for
+    // the proactive-goaway timer. MockTimer expectations are matched LIFO, so declare the
+    // proactive mock first and the poll mock second to map them to the right createTimer calls.
+    proactive_goaway_timer_ = new Event::MockTimer(&dispatcher_);
+    drain_check_timer_ = new Event::MockTimer(&dispatcher_);
     inner_ = std::make_unique<NiceMock<Http::MockServerConnection>>();
     inner_ptr_ = inner_.get();
     ON_CALL(*inner_ptr_, protocol()).WillByDefault(Return(Http::Protocol::Http2));
   }
 
-  // Creates the connection, consuming inner_. Expects the 100ms timer arm from the constructor.
   std::unique_ptr<DrainAwareServerConnection> makeConnection() {
-    EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(100), _));
-    return std::make_unique<DrainAwareServerConnection>(std::move(inner_), dispatcher_,
-                                                        drain_decision_);
-  }
-
-  // Destroy conn cleanly, satisfying the disableTimer() call from the destructor.
-  void destroyConnection(std::unique_ptr<DrainAwareServerConnection>& conn) {
-    EXPECT_CALL(*timer_, disableTimer());
-    conn.reset();
+    EXPECT_CALL(*drain_check_timer_, enableTimer(kPollInterval, _));
+    return std::make_unique<DrainAwareServerConnection>(std::move(inner_), drain_decision_,
+                                                        io_handle_, dispatcher_, kDrainTimeout);
   }
 
   NiceMock<Event::MockDispatcher> dispatcher_;
   NiceMock<Network::MockDrainDecision> drain_decision_;
-  Event::MockTimer* timer_{nullptr};
+  NiceMock<Network::MockIoHandle> io_handle_;
+  Event::MockTimer* drain_check_timer_{nullptr};
+  Event::MockTimer* proactive_goaway_timer_{nullptr};
   std::unique_ptr<NiceMock<Http::MockServerConnection>> inner_;
   NiceMock<Http::MockServerConnection>* inner_ptr_{nullptr};
 };
 
-// Constructor arms the 100ms drain-check timer.
-TEST_F(DrainAwareServerConnectionTest, ConstructorStartsTimer) {
-  auto conn = makeConnection();
-  destroyConnection(conn);
-}
+// --- Delegation ---
 
-// Destructor disables the timer.
-TEST_F(DrainAwareServerConnectionTest, DestructorDisablesTimer) {
-  auto conn = makeConnection();
-  EXPECT_CALL(*timer_, disableTimer());
-  conn.reset();
-}
-
-// All delegating methods forward to the inner connection.
 TEST_F(DrainAwareServerConnectionTest, DelegatesDispatch) {
   auto conn = makeConnection();
   Buffer::OwnedImpl data("hello");
   EXPECT_CALL(*inner_ptr_, dispatch(testing::Ref(data)));
   auto status = conn->dispatch(data);
   EXPECT_TRUE(status.ok());
-  destroyConnection(conn);
-}
-
-TEST_F(DrainAwareServerConnectionTest, DelegatesGoAway) {
-  auto conn = makeConnection();
-  EXPECT_CALL(*inner_ptr_, goAway());
-  conn->goAway();
-  destroyConnection(conn);
 }
 
 TEST_F(DrainAwareServerConnectionTest, DelegatesProtocol) {
   auto conn = makeConnection();
   EXPECT_CALL(*inner_ptr_, protocol()).WillOnce(Return(Http::Protocol::Http2));
   EXPECT_EQ(Http::Protocol::Http2, conn->protocol());
-  destroyConnection(conn);
-}
-
-TEST_F(DrainAwareServerConnectionTest, DelegatesShutdownNotice) {
-  auto conn = makeConnection();
-  EXPECT_CALL(*inner_ptr_, shutdownNotice());
-  conn->shutdownNotice();
-  destroyConnection(conn);
 }
 
 TEST_F(DrainAwareServerConnectionTest, DelegatesWantsToWrite) {
   auto conn = makeConnection();
   EXPECT_CALL(*inner_ptr_, wantsToWrite()).WillOnce(Return(true));
   EXPECT_TRUE(conn->wantsToWrite());
-  destroyConnection(conn);
 }
 
 TEST_F(DrainAwareServerConnectionTest, DelegatesAboveWriteBufferHighWatermark) {
   auto conn = makeConnection();
   EXPECT_CALL(*inner_ptr_, onUnderlyingConnectionAboveWriteBufferHighWatermark());
   conn->onUnderlyingConnectionAboveWriteBufferHighWatermark();
-  destroyConnection(conn);
 }
 
 TEST_F(DrainAwareServerConnectionTest, DelegatesBelowWriteBufferLowWatermark) {
   auto conn = makeConnection();
   EXPECT_CALL(*inner_ptr_, onUnderlyingConnectionBelowWriteBufferLowWatermark());
   conn->onUnderlyingConnectionBelowWriteBufferLowWatermark();
-  destroyConnection(conn);
 }
 
-// Timer fires when the listener is not draining: re-arms the timer, no GOAWAY.
-TEST_F(DrainAwareServerConnectionTest, TimerFiresNoDrain) {
+// --- goAway() guard ---
+
+// goAway() forwards to the inner codec exactly once; subsequent calls are no-ops.
+TEST_F(DrainAwareServerConnectionTest, GoAwayForwardsOnce) {
+  auto conn = makeConnection();
+  EXPECT_CALL(*inner_ptr_, goAway());
+  conn->goAway();
+  conn->goAway();
+}
+
+// --- shutdownNotice(): always swallowed (never forwarded to inner) ---
+
+// Connection-level drain (listener healthy): swallow phase-1 GOAWAY and reconnect. With
+// MockIoHandle the dynamic_cast yields nullptr, so reconnection is a no-op (and must not crash).
+TEST_F(DrainAwareServerConnectionTest, ShutdownNoticeConnectionDrainSwallowsAndReconnects) {
+  auto conn = makeConnection();
+  EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(false));
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
+  conn->shutdownNotice();
+}
+
+// Listener-level drain: swallow phase-1 GOAWAY and do NOT reconnect (listener is dying).
+TEST_F(DrainAwareServerConnectionTest, ShutdownNoticeListenerDrainSwallowsNoReconnect) {
+  auto conn = makeConnection();
+  EXPECT_CALL(drain_decision_, drainClose(Network::DrainDirection::All)).WillOnce(Return(true));
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
+  conn->shutdownNotice();
+}
+
+// shutdownNotice() is idempotent: the second call short-circuits before querying drainClose().
+TEST_F(DrainAwareServerConnectionTest, ShutdownNoticeIsIdempotent) {
+  auto conn = makeConnection();
+  EXPECT_CALL(drain_decision_, drainClose(_)).WillOnce(Return(false));
+  conn->shutdownNotice();
+  conn->shutdownNotice();
+}
+
+// --- Polling path (listener-level drain on an idle connection) ---
+
+// Timer fires, listener not draining: re-arm the poll timer, take no drain action.
+TEST_F(DrainAwareServerConnectionTest, PollTimerNoDrainReArms) {
   auto conn = makeConnection();
   ON_CALL(drain_decision_, drainClose(_)).WillByDefault(Return(false));
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
   EXPECT_CALL(*inner_ptr_, goAway()).Times(0);
-  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(100), _));
-  timer_->invokeCallback();
-  destroyConnection(conn);
+  EXPECT_CALL(*drain_check_timer_, enableTimer(kPollInterval, _));
+  drain_check_timer_->invokeCallback();
 }
 
-// Timer fires when the listener is draining: sends GOAWAY once, stops re-arming.
-TEST_F(DrainAwareServerConnectionTest, TimerFiresDrainDetected) {
+// Timer fires, listener draining: arm the proactive-goaway timer for drain_timeout and stop
+// re-arming the poll timer. No GOAWAY yet; reconnection is not attempted.
+TEST_F(DrainAwareServerConnectionTest, PollTimerDrainDetectedSchedulesGoAway) {
   auto conn = makeConnection();
   ON_CALL(drain_decision_, drainClose(_)).WillByDefault(Return(true));
+
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
+  EXPECT_CALL(*inner_ptr_, goAway()).Times(0);
+  EXPECT_CALL(*drain_check_timer_, enableTimer(_, _)).Times(0);
+  EXPECT_CALL(*proactive_goaway_timer_, enableTimer(kDrainTimeout, _));
+  drain_check_timer_->invokeCallback();
+
+  // When the proactive timer fires, the final GOAWAY is sent.
   EXPECT_CALL(*inner_ptr_, goAway());
-  EXPECT_CALL(*timer_, enableTimer(_, _)).Times(0);
-  timer_->invokeCallback();
-  destroyConnection(conn);
+  proactive_goaway_timer_->invokeCallback();
 }
 
-// After GOAWAY is sent, subsequent timer fires are complete no-ops.
-TEST_F(DrainAwareServerConnectionTest, TimerFiresAfterGoAwaySentIsNoop) {
+// Once a drain has been initiated, a subsequent poll-timer fire is a no-op.
+TEST_F(DrainAwareServerConnectionTest, PollTimerAfterDrainInitiatedIsNoop) {
   auto conn = makeConnection();
-  // First fire: drain detected, GOAWAY sent. enabled_ is now false (no re-arm).
+  ON_CALL(drain_decision_, drainClose(_)).WillByDefault(Return(false));
+  conn->shutdownNotice(); // sets drain_initiated_
+
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
+  EXPECT_CALL(*drain_check_timer_, enableTimer(_, _)).Times(0);
+  // The poll timer was last enabled by the constructor; invoke its callback directly.
+  drain_check_timer_->invokeCallback();
+}
+
+// The goAway guard prevents a duplicate GOAWAY across both paths: if the HCM sends goAway and the
+// proactive timer later fires (or vice versa), the inner codec only sees a single GOAWAY.
+TEST_F(DrainAwareServerConnectionTest, GoAwayDedupAcrossHcmAndProactiveTimer) {
+  auto conn = makeConnection();
   ON_CALL(drain_decision_, drainClose(_)).WillByDefault(Return(true));
-  timer_->invokeCallback();
 
-  // Second fire: drain_goaway_sent_ == true, early return before any calls.
-  // MockTimer::invokeCallback() asserts enabled_ == true, so manually call the callback.
-  EXPECT_CALL(*inner_ptr_, goAway()).Times(0);
-  EXPECT_CALL(*timer_, enableTimer(_, _)).Times(0);
-  timer_->callback_();
+  // Poll detects listener drain → proactive-goaway timer armed.
+  EXPECT_CALL(*proactive_goaway_timer_, enableTimer(kDrainTimeout, _));
+  drain_check_timer_->invokeCallback();
 
-  destroyConnection(conn);
+  // The inner codec must see exactly one goAway across both triggers.
+  EXPECT_CALL(*inner_ptr_, goAway());
+  conn->goAway();                            // e.g. HCM-driven
+  proactive_goaway_timer_->invokeCallback(); // proactive timer
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -226,6 +226,9 @@ filter_chains:
         stat_prefix: reverse_connection_hcm
         codec_type: HTTP2
         http2_protocol_options: {{}}
+        # Small drain_timeout so the wrapper's proactive goAway (sent drain_timeout after the
+        # listener drain is detected) fires promptly, well before the 1s listener drain completes.
+        drain_timeout: 0.1s
         route_config:
           name: local_route
           virtual_hosts:


### PR DESCRIPTION
## Commit Message
reverse_tunnel: proactively replace draining connections instead of GOAWAY

## Description
Reworks the drain-aware HTTP connection manager used by reverse tunnels so that draining a connection no longer creates a window where the cluster has nowhere to route.

Why this change:
The HCM drains an HTTP/2 connection in two phases — shutdownNotice() (a graceful GOAWAY that stops new streams) followed by goAway() after drain_timeout. The problem for reverse tunnels: the moment a GOAWAY is observed, the responder's upstream nghttp2/oghttp2 adapter marks the connection Draining and refuses new streams on it. If no replacement tunnel exists yet, requests fail (503s) until a fresh tunnel is independently established.

What we do now:
- DrainAwareServerConnection wraps the server codec and swallows the phase-1 shutdownNotice() so no premature GOAWAY is emitted. The only GOAWAY ever put on the wire is the single, guarded final goAway().
- There are two drain triggers, both handled:
  1. Connection-level drain (max_connection_duration, max_requests, ...): the HCM drives it. We swallow shutdownNotice() and instead call reestablishConnection() to bring up a REPLACEMENT reverse tunnel while the old connection keeps serving
during drain_timeout. The HCM's own goAway() then closes the old connection, by which point the cluster already has the new tunnel to route to.
  2. Listener-level drain (hot-restart, /drain_listeners, healthcheck fail): the HCM only checks drainClose() while encoding a response, so it never notices a drain on an idle connection. We poll drainClose() on a 100ms timer and, on detection, schedule the final goAway() after drain_timeout (no reconnect as the listener is dying), giving any in-flight request the same graceful window.
- A bool guard ensures the final GOAWAY is sent at most once across both paths.
Net effect: earlier, a GOAWAY made both client and server stop using the connection immediately, opening a connectivity gap. Now the server brings up a new tunnel first and only sends the GOAWAY once a replacement is ready, so the cluster transparently shifts to the new connection.

## Future
Need to find some way of passing the info of draining to the cluster without preventing adapter from rejecting new stream creation which will allow us to notify the client consumers in advance to not "prefer" this tunnel.

## Testing
Unit and Integ tests.
