### PR TITLE
[bp 1.37] http2: limit the size of the re-assembled cookie header

### DIFF
--- a/changelogs/current/new_features/http2__limit_total_cookie_size.rst
+++ b/changelogs/current/new_features/http2__limit_total_cookie_size.rst
@@ -1,0 +1,2 @@
+Added ``envoy.reloadable_features.http2_max_cookies_size_in_kb`` runtime value to set the limit on the contents
+of the re-assembled ``cookie`` header. By default there is no limit on the cookie size.

--- a/docs/root/configuration/http/http_conn_man/stats.rst
+++ b/docs/root/configuration/http/http_conn_man/stats.rst
@@ -163,6 +163,7 @@ On the upstream side all http2 statistics are rooted at ``cluster.<name>.http2.`
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
+   ``cookies_total_bytes_too_large``, Counter, Total number of streams reset due to the re-assembled ``cookie`` header exceeding the ``envoy.reloadable_features.http2_max_cookies_size_in_kb`` runtime value.
    ``dropped_headers_with_underscores``, Counter, Total number of dropped headers with names containing underscores. This action is configured by setting the :ref:`headers_with_underscores_action config setting <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.headers_with_underscores_action>`.
    ``goaway_sent``, Counter, Total number ``GOAWAY`` frames that have been submitted to the codec to send.
    ``header_overflow``, Counter, Total number of connections reset due to the headers being larger than the :ref:`configured value <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.max_request_headers_kb>`.

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -65,12 +65,12 @@ ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
     uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
         headers_with_underscores_action,
-    Server::OverloadManager& overload_manager) {
+    Server::OverloadManager& overload_manager, Runtime::Loader& runtime) {
   if (determineNextProtocol(connection, data) == Utility::AlpnNames::get().Http2) {
     Http2::CodecStats& stats = Http2::CodecStats::atomicGet(http2_codec_stats, scope);
     return std::make_unique<Http2::ServerConnectionImpl>(
         connection, callbacks, stats, random, http2_options, max_request_headers_kb,
-        max_request_headers_count, headers_with_underscores_action, overload_manager);
+        max_request_headers_count, headers_with_underscores_action, overload_manager, runtime);
   } else {
     Http1::CodecStats& stats = Http1::CodecStats::atomicGet(http1_codec_stats, scope);
     return std::make_unique<Http1::ServerConnectionImpl>(

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -5,6 +5,7 @@
 
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/tracing/trace_reason.h"
 
 #include "source/common/http/conn_manager_impl.h"
@@ -46,7 +47,7 @@ public:
                   uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
                   envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                       headers_with_underscores_action,
-                  Server::OverloadManager& overload_manager);
+                  Server::OverloadManager& overload_manager, Runtime::Loader& runtime);
 
   /* The result after calling mutateRequestHeaders(), containing the final remote address. Note that
    * an extension used for detecting the original IP of the request might decide it should be

--- a/source/common/http/http2/BUILD
+++ b/source/common/http/http2/BUILD
@@ -39,6 +39,7 @@ envoy_cc_library(
         "//envoy/http:codes_interface",
         "//envoy/http:header_map_interface",
         "//envoy/network:connection_interface",
+        "//envoy/runtime:runtime_interface",
         "//envoy/server/overload:overload_manager_interface",
         "//envoy/stats:stats_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -10,6 +10,7 @@
 #include "envoy/http/codes.h"
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
+#include "envoy/runtime/runtime.h"
 
 #include "source/common/common/assert.h"
 #include "source/common/common/cleanup.h"
@@ -139,6 +140,7 @@ public:
   const absl::string_view too_many_headers = "http2.too_many_headers";
   // The total size of headers exceeded the configured limits
   const absl::string_view header_list_size_too_large = "http2.header_list_size_too_large";
+  const absl::string_view cookies_total_bytes_too_large = "http2.cookies_total_bytes_too_large";
   // Envoy detected an HTTP/2 frame flood from the server.
   const absl::string_view outbound_frame_flood = "http2.outbound_frames_flood";
   // Envoy detected an inbound HTTP/2 frame flood.
@@ -981,12 +983,18 @@ void ConnectionImpl::StreamImpl::setAccount(Buffer::BufferMemoryAccountSharedPtr
 ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stats,
                                Random::RandomGenerator& random_generator,
                                const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
-                               const uint32_t max_headers_kb, const uint32_t max_headers_count)
+                               const uint32_t max_headers_kb, const uint32_t max_headers_count,
+                               OptRef<Runtime::Loader> runtime)
     : stats_(stats), connection_(connection), max_headers_kb_(max_headers_kb),
       max_headers_count_(max_headers_count),
       per_stream_buffer_limit_(http2_options.initial_stream_window_size().value()),
       stream_error_on_invalid_http_messaging_(
           http2_options.override_stream_error_on_invalid_http_message().value()),
+      max_cookie_size_bytes_(
+          runtime.has_value() ? runtime->snapshot().getInteger(
+                                    "envoy.reloadable_features.http2_max_cookies_size_in_kb", 0) *
+                                    1024
+                              : 0),
       protocol_constraints_(stats, http2_options), dispatching_(false), raised_goaway_(false),
       random_(random_generator),
       last_received_data_time_(connection_.dispatcher().timeSource().monotonicTime()) {
@@ -1665,6 +1673,12 @@ int ConnectionImpl::saveHeader(int32_t stream_id, HeaderString&& name, HeaderStr
   }
 
   stream->saveHeader(std::move(name), std::move(value));
+  const uint64_t total_cookie_size = stream->cookies_.size();
+  if (max_cookie_size_bytes_ > 0 && total_cookie_size > max_cookie_size_bytes_) {
+    stream->setDetails(Http2ResponseCodeDetails::get().cookies_total_bytes_too_large);
+    stats_.cookies_total_bytes_too_large_.inc();
+    return ERR_TEMPORAL_CALLBACK_FAILURE;
+  }
   uint64_t headers_size = stream->headers().byteSize();
   uint64_t headers_count = stream->headers().size();
 
@@ -2380,9 +2394,9 @@ ServerConnectionImpl::ServerConnectionImpl(
     const uint32_t max_request_headers_kb, const uint32_t max_request_headers_count,
     envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
         headers_with_underscores_action,
-    Server::OverloadManager& overload_manager)
+    Server::OverloadManager& overload_manager, OptRef<Runtime::Loader> runtime)
     : ConnectionImpl(connection, stats, random_generator, http2_options, max_request_headers_kb,
-                     max_request_headers_count),
+                     max_request_headers_count, runtime),
       callbacks_(callbacks), headers_with_underscores_action_(headers_with_underscores_action),
       should_send_go_away_on_dispatch_(overload_manager.getLoadShedPoint(
           Server::LoadShedPointName::get().H2ServerGoAwayOnDispatch)),

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -15,6 +15,7 @@
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/connection.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/server/overload/overload_manager.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -151,7 +152,8 @@ public:
   ConnectionImpl(Network::Connection& connection, CodecStats& stats,
                  Random::RandomGenerator& random_generator,
                  const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
-                 const uint32_t max_headers_kb, const uint32_t max_headers_count);
+                 const uint32_t max_headers_kb, const uint32_t max_headers_count,
+                 OptRef<Runtime::Loader> runtime = absl::nullopt);
 
   ~ConnectionImpl() override;
 
@@ -734,6 +736,7 @@ protected:
   bool allow_metadata_;
   uint64_t max_metadata_size_;
   const bool stream_error_on_invalid_http_messaging_;
+  const uint64_t max_cookie_size_bytes_{0};
 
   // Status for any errors encountered by the nghttp2 callbacks.
   // nghttp2 library uses single return code to indicate callback failure and
@@ -860,7 +863,8 @@ public:
                        const uint32_t max_request_headers_count,
                        envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                            headers_with_underscores_action,
-                       Server::OverloadManager& overload_manager);
+                       Server::OverloadManager& overload_manager,
+                       OptRef<Runtime::Loader> runtime = absl::nullopt);
 
 private:
   // ConnectionImpl

--- a/source/common/http/http2/codec_stats.h
+++ b/source/common/http/http2/codec_stats.h
@@ -14,6 +14,7 @@ namespace Http2 {
  * All stats for the HTTP/2 codec. @see stats_macros.h
  */
 #define ALL_HTTP2_CODEC_STATS(COUNTER, GAUGE)                                                      \
+  COUNTER(cookies_total_bytes_too_large)                                                           \
   COUNTER(dropped_headers_with_underscores)                                                        \
   COUNTER(goaway_sent)                                                                             \
   COUNTER(header_overflow)                                                                         \

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -754,7 +754,7 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
         Http::Http2::CodecStats::atomicGet(http2_codec_stats_, context_.scope()),
         context_.serverFactoryContext().api().randomGenerator(), http2_options_,
         maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
-        overload_manager);
+        overload_manager, context_.serverFactoryContext().runtime());
   case CodecType::HTTP3:
 #ifdef ENVOY_ENABLE_QUIC
     return Config::Utility::getAndCheckFactoryByName<QuicHttpServerConnectionFactory>(
@@ -774,7 +774,8 @@ Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(
         connection, data, callbacks, context_.scope(),
         context_.serverFactoryContext().api().randomGenerator(), http1_codec_stats_,
         http2_codec_stats_, http1_settings_, http2_options_, maxRequestHeadersKb(),
-        maxRequestHeadersCount(), headersWithUnderscoresAction(), overload_manager);
+        maxRequestHeadersCount(), headersWithUnderscoresAction(), overload_manager,
+        context_.serverFactoryContext().runtime());
   }
   PANIC_DUE_TO_CORRUPT_ENUM;
 }

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -294,7 +294,7 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
           envoy::config::core::v3::Http2ProtocolOptions())
           .value(),
       maxRequestHeadersKb(), maxRequestHeadersCount(), headersWithUnderscoresAction(),
-      overload_manager);
+      overload_manager, server_.runtime());
 }
 
 bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,

--- a/test/common/http/http2/BUILD
+++ b/test/common/http/http2/BUILD
@@ -54,6 +54,7 @@ envoy_cc_test_library(
     deps = [
         "//source/common/http/http2:codec_lib",
         "//test/mocks:common_lib",
+        "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:overload_manager_mocks",
         "@com_github_google_quiche//:http2_adapter",
         "@com_google_absl//absl/types:optional",

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -247,7 +247,7 @@ public:
     server_ = std::make_unique<TestServerConnectionImpl>(
         server_connection_, server_callbacks_, *server_stats_store_.rootScope(),
         server_http2_options_, random_, max_request_headers_kb_, max_request_headers_count_,
-        headers_with_underscores_action_);
+        headers_with_underscores_action_, runtime_);
     server_wrapper_ = std::make_unique<ConnectionWrapper>(server_.get());
     createHeaderValidator();
     request_encoder_ = &client_->newStream(response_decoder_);
@@ -429,6 +429,7 @@ public:
 #endif
   }
 
+  NiceMock<Runtime::MockLoader> runtime_;
   TestScopedRuntime scoped_runtime_;
   absl::optional<const Http2SettingsTuple> client_settings_;
   absl::optional<const Http2SettingsTuple> server_settings_;
@@ -5006,6 +5007,27 @@ TEST(CodecChoiceTest, ProtocolOptionNotSpecified) {
       max_request_headers_kb, max_response_headers_count, ProdNghttp2SessionFactory::get());
 
   EXPECT_FALSE(client2->useOghttp2Library());
+}
+
+TEST_P(Http2CodecImplTest, DownstreamRequestCookieSizeLimit) {
+  EXPECT_CALL(runtime_.snapshot_,
+              getInteger("envoy.reloadable_features.http2_max_cookies_size_in_kb", 0))
+      .WillRepeatedly(Return(1)); // 1 KB limit
+  initialize();
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  request_headers.addCopy("cookie", std::string(1025, 'a')); // Exceeds 1KB
+
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
+  EXPECT_CALL(server_codec_event_callbacks_, onCodecLowLevelReset());
+
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  if (http2_implementation_ != Http2Impl::Oghttp2) {
+    EXPECT_EQ(1, server_stats_store_.counter("http2.cookies_total_bytes_too_large").value());
+  }
 }
 
 #ifdef NDEBUG

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -7,6 +7,7 @@
 #include "source/common/http/utility.h"
 
 #include "test/mocks/common.h"
+#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/overload_manager.h"
 
 #include "quiche/http2/adapter/http2_adapter.h"
@@ -91,11 +92,12 @@ public:
       Random::RandomGenerator& random, uint32_t max_request_headers_kb,
       uint32_t max_request_headers_count,
       envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
-          headers_with_underscores_action)
+          headers_with_underscores_action,
+      OptRef<Runtime::Loader> runtime = absl::nullopt)
       : TestCodecStatsProvider(scope),
         ServerConnectionImpl(connection, callbacks, http2CodecStats(), random, http2_options,
                              max_request_headers_kb, max_request_headers_count,
-                             headers_with_underscores_action, overload_manager_) {}
+                             headers_with_underscores_action, overload_manager_, runtime) {}
 
   http2::adapter::Http2Adapter* adapter() { return adapter_.get(); }
   using ServerConnectionImpl::getStream;

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2377,6 +2377,26 @@ TEST_P(DownstreamProtocolIntegrationTest, CookiesAreSubjectToHeaderMapSizeLimit)
   }
 }
 
+TEST_P(DownstreamProtocolIntegrationTest, DownstreamCookieSizeLimit) {
+  if (downstreamProtocol() != Http::CodecType::HTTP2) {
+    return;
+  }
+  useAccessLog("%RESPONSE_CODE_DETAILS%");
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.http2_max_cookies_size_in_kb", "1");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "sni.lyft.com"},
+                                                 {"cookie", std::string(1025, 'a')}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+  ASSERT_TRUE(response->waitForReset());
+  EXPECT_EQ(Http::StreamResetReason::RemoteReset, response->resetReason());
+  EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("http2.cookies_total_bytes_too_large"));
+}
+
 TEST_P(DownstreamProtocolIntegrationTest, CookiesAreSubjectToHeaderMapCountLimit) {
   useAccessLog("%RESPONSE_CODE_DETAILS%");
   uint32_t max_count = 2010;


### PR DESCRIPTION
Backport for https://github.com/envoyproxy/envoy/pull/45476
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
