### PR TITLE
reverse_tunnel: add per-node connection cap with tenant-aware enforcement

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/v3/upstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/v3/upstream_reverse_connection_socket_interface.proto
@@ -20,7 +20,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.bootstrap.reverse_tunnel.upstream_socket_interface]
 
 // Configuration for the upstream reverse connection socket interface.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message UpstreamReverseConnectionSocketInterface {
   // Stat prefix for upstream reverse connection socket interface stats.
   string stat_prefix = 1;
@@ -49,4 +49,13 @@ message UpstreamReverseConnectionSocketInterface {
   // Access logs emitted for reverse tunnel lifecycle events. Entries are generated for tunnel setup,
   // socket handoff, tunnel close, and post-handoff HTTP/2 keepalive timeout observations.
   repeated config.accesslog.v3.AccessLog access_log = 6;
+
+  // Maximum number of concurrently accepted reverse connections per node (and per tenant
+  // when tenant isolation is enabled). The cap is only consulted for reverse tunnel network
+  // filters that opt in via ``enable_connection_limit``; filters that leave it disabled ignore it.
+  // The cap is enforced per worker thread, so the effective ceiling is roughly this value
+  // multiplied by the number of workers; it is also only approximate when rebalancing is enabled.
+  // Defaults to 0; combined with ``enable_connection_limit: true`` a value of 0 rejects all
+  // connections, so set a non-zero value whenever a filter enables the limit.
+  uint32 max_connections_per_node = 7;
 }

--- a/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
+++ b/api/envoy/extensions/filters/network/reverse_tunnel/v3/reverse_tunnel.proto
@@ -96,7 +96,7 @@ message Validation {
 // Configuration for the reverse tunnel network filter.
 // This filter handles reverse tunnel connection acceptance and rejection by processing
 // HTTP requests where required identification values are provided via HTTP headers.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message ReverseTunnel {
   // Ping interval for health checks on established reverse tunnel connections.
   // If not specified, defaults to ``2 seconds``.
@@ -145,4 +145,15 @@ message ReverseTunnel {
   // This avoids the cross-worker lock in pickLeastLoadedSocketManager.
   // Default: false (rebalancing enabled).
   bool skip_rebalancing = 8;
+
+  // Enables enforcement of the per-node concurrent connection limit for reverse tunnels accepted
+  // by this filter. When enabled, the filter asks the upstream socket manager whether another
+  // connection can be accepted before completing the handshake; the actual cap
+  // (``max_connections_per_node``) is configured on the
+  // ``UpstreamReverseConnectionSocketInterface`` bootstrap extension, which owns the connection
+  // accounting shared across all filters.
+  // When ``max_connections_per_node`` is left at its default of 0, enabling this rejects every
+  // connection, so set a non-zero cap on the bootstrap extension when turning this on.
+  // Default: false.
+  bool enable_connection_limit = 9;
 }

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
@@ -102,7 +102,8 @@ ReverseTunnelAcceptorExtension::ReverseTunnelAcceptorExtension(
     const envoy::extensions::bootstrap::reverse_tunnel::upstream_socket_interface::v3::
         UpstreamReverseConnectionSocketInterface& config)
     : Envoy::Network::SocketInterfaceExtension(sock_interface), context_(context),
-      socket_interface_(&sock_interface) {
+      socket_interface_(&sock_interface),
+      max_connections_per_node_(config.max_connections_per_node()) {
   stat_prefix_ = PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_acceptor");
   const uint32_t cfg_threshold = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, ping_failure_threshold, 3);
   ping_failure_threshold_ = std::max<uint32_t>(1, cfg_threshold);
@@ -245,6 +246,7 @@ void ReverseTunnelAcceptorExtension::onServerInitialized(Server::Instance&) {
         if (auto* socket_manager = tls->socketManager(); socket_manager != nullptr) {
           socket_manager->setMissThreshold(ping_failure_threshold);
           socket_manager->setTenantIsolationEnabled(enable_tenant_isolation);
+          socket_manager->setMaxConnectionsPerNode(max_connections_per_node_);
         }
         return tls;
       });

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.h
@@ -169,6 +169,11 @@ public:
   bool enableTenantIsolation() const { return enable_tenant_isolation_; }
 
   /**
+   * @return the configured maximum number of concurrently accepted reverse connections per node.
+   */
+  uint32_t maxConnectionsPerNode() const { return max_connections_per_node_; }
+
+  /**
    * @return whether lifecycle access logs are configured.
    */
   bool hasAccessLogs() const { return !access_logs_.empty(); }
@@ -250,6 +255,7 @@ private:
   uint32_t ping_failure_threshold_{3};
   bool enable_detailed_stats_{false};
   bool enable_tenant_isolation_{false};
+  const uint32_t max_connections_per_node_{0};
   AccessLog::InstanceSharedPtrVector access_logs_;
   ReverseTunnelReporterPtr reporter_{nullptr};
 

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -222,6 +222,15 @@ void UpstreamSocketManager::addConnectionSocket(const std::string& node_id,
             scoped_node_id, connectionKey, fd);
 }
 
+bool UpstreamSocketManager::canAcceptConnection(absl::string_view node_id,
+                                                absl::string_view tenant_id) const {
+  const std::string scoped_node_id =
+      maybeBuildTenantScopedIdentifier(tenant_isolation_enabled_, tenant_id, node_id);
+  auto it = node_to_active_fd_count_.find(scoped_node_id);
+  const uint32_t count = it == node_to_active_fd_count_.end() ? 0 : it->second;
+  return count < max_connections_per_node_;
+}
+
 Network::ConnectionSocketPtr
 UpstreamSocketManager::getConnectionSocket(const std::string& node_id) {
 

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
@@ -56,6 +56,15 @@ public:
                            absl::string_view tenant_id = {});
 
   /**
+   * Returns true if a new reverse connection can be accepted for the given node, scoped by tenant
+   * when tenant isolation is enabled.
+   * @param node_id the node ID to check.
+   * @param tenant_id the tenant ID to check.
+   * @return true if a new reverse connection can be accepted, false otherwise.
+   */
+  bool canAcceptConnection(absl::string_view node_id, absl::string_view tenant_id) const;
+
+  /**
    * Hand off a socket to this socket manager's dispatcher.
    * Used for cross-thread rebalancing of reverse connection sockets.
    * @param node_id node_id of initiating node.
@@ -134,6 +143,9 @@ public:
    */
   void setMissThreshold(uint32_t threshold) { miss_threshold_ = std::max<uint32_t>(1, threshold); }
   void setTenantIsolationEnabled(bool enabled) { tenant_isolation_enabled_ = enabled; }
+  void setMaxConnectionsPerNode(uint32_t max_connections_per_node) {
+    max_connections_per_node_ = max_connections_per_node;
+  }
   bool tenantIsolationEnabled() const { return tenant_isolation_enabled_; }
 
   /**
@@ -247,6 +259,7 @@ private:
   absl::flat_hash_map<std::string, int> node_to_conn_count_map_;
 
   bool tenant_isolation_enabled_{false};
+  uint32_t max_connections_per_node_{0};
 
   // Global list of all socket managers across threads for rebalancing.
   static std::vector<UpstreamSocketManager*> socket_managers_;

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -167,11 +167,30 @@ ReverseTunnelFilterConfig::ReverseTunnelFilterConfig(
               : "envoy.filters.network.reverse_tunnel"),
       required_cluster_name_(proto_config.required_cluster_name()),
       use_http_upgrade_(proto_config.use_http_upgrade()),
-      skip_rebalancing_(proto_config.skip_rebalancing()) {}
+      skip_rebalancing_(proto_config.skip_rebalancing()),
+      enable_connection_limit_(proto_config.enable_connection_limit()) {}
+
+bool ReverseTunnelFilterConfig::validateConnectionLimit(absl::string_view node_id,
+                                                        absl::string_view tenant_id) const {
+  if (!enable_connection_limit_) {
+    return true;
+  }
+
+  if (auto socket_manager = getThreadLocalSocketManager()) {
+    return socket_manager->canAcceptConnection(node_id, tenant_id);
+  }
+  return false;
+}
 
 bool ReverseTunnelFilterConfig::validateIdentifiers(
     absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
     const StreamInfo::StreamInfo& stream_info) const {
+
+  if (!validateConnectionLimit(node_id, tenant_id)) {
+    ENVOY_LOG(debug, "reverse_tunnel: connection limit reached. node_id: {}, tenant_id: {}",
+              node_id, tenant_id);
+    return false;
+  }
 
   // If no validation configured, pass validation.
   if (!node_id_formatter_ && !cluster_id_formatter_ && !tenant_id_formatter_) {

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -48,6 +48,10 @@ public:
            tenant_id_formatter_ != nullptr;
   }
 
+  // Returns true if accepting another reverse connection for this node/tenant stays within the
+  // configured per-worker connection cap (or no cap is configured).
+  bool validateConnectionLimit(absl::string_view node_id, absl::string_view tenant_id) const;
+
   // Validates the extracted node_id, cluster_id, and tenant_id against expected values.
   // Returns true if validation passes or no validation is configured.
   bool validateIdentifiers(absl::string_view node_id, absl::string_view cluster_id,
@@ -94,6 +98,10 @@ private:
   const bool use_http_upgrade_{false};
 
   const bool skip_rebalancing_{false};
+
+  // Whether this filter enforces the per-node concurrent connection cap (owned by the upstream
+  // socket interface bootstrap extension) before completing a reverse tunnel handshake.
+  const bool enable_connection_limit_{false};
 };
 
 using ReverseTunnelFilterConfigSharedPtr = std::shared_ptr<ReverseTunnelFilterConfig>;

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
@@ -920,6 +920,51 @@ TEST_F(TestUpstreamSocketManager, NodeToActiveFdCountTracking) {
   EXPECT_EQ(getNodeToActiveFdCount(node_id), 0);
 }
 
+// Exercises the public canAcceptConnection() accessor: it admits while the live per-node socket
+// count is below the configured cap, rejects once the cap is reached, and follows add/death
+// transitions. A cap of 0 (the default) rejects everything, which is why the filter only consults
+// this when rate limiting is explicitly enabled.
+TEST_F(TestUpstreamSocketManager, CanAcceptConnection) {
+  const std::string node_id = "count-node";
+  const std::string cluster_id = "count-cluster";
+  const std::chrono::seconds ping_interval(30);
+
+  // Default cap of 0 rejects every node, even unknown ones.
+  EXPECT_FALSE(socket_manager_->canAcceptConnection("missing-node", ""));
+
+  socket_manager_->setMaxConnectionsPerNode(2);
+
+  // Unknown node is under the cap without inserting a map entry.
+  EXPECT_TRUE(socket_manager_->canAcceptConnection("missing-node", ""));
+
+  socket_manager_->addConnectionSocket(node_id, cluster_id, createMockSocket(201), ping_interval);
+  EXPECT_TRUE(socket_manager_->canAcceptConnection(node_id, "")); // 1 < 2
+
+  socket_manager_->addConnectionSocket(node_id, cluster_id, createMockSocket(202), ping_interval);
+  EXPECT_FALSE(socket_manager_->canAcceptConnection(node_id, "")); // 2 is not < 2
+
+  // Death of a socket frees capacity.
+  socket_manager_->markSocketDead(201);
+  EXPECT_TRUE(socket_manager_->canAcceptConnection(node_id, ""));
+
+  socket_manager_->markSocketDead(202);
+  EXPECT_TRUE(socket_manager_->canAcceptConnection(node_id, ""));
+}
+
+// With tenant isolation enabled the cap must be scoped per tenant, so the same node under a
+// different tenant is tracked independently.
+TEST_F(TestUpstreamSocketManager, CanAcceptConnectionWithTenantIsolation) {
+  socket_manager_->setTenantIsolationEnabled(true);
+  socket_manager_->setMaxConnectionsPerNode(1);
+  const std::chrono::seconds ping_interval(30);
+
+  socket_manager_->addConnectionSocket("node", "cluster", createMockSocket(301), ping_interval,
+                                       false, "tenant-a");
+
+  EXPECT_FALSE(socket_manager_->canAcceptConnection("node", "tenant-a")); // at cap for tenant-a
+  EXPECT_TRUE(socket_manager_->canAcceptConnection("node", "tenant-b"));  // independent tenant
+}
+
 TEST_F(TestUpstreamSocketManager, SendTimerCleanupOnGetConnectionSocket) {
   auto socket = createMockSocket(123);
   const std::string node_id = "test-node";

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -204,6 +204,22 @@ public:
     return req;
   }
 
+  // Builds a mock connection socket with the given fd for populating the upstream socket manager
+  // directly in connection-limit tests (the remote port is derived from the fd to keep keys
+  // distinct).
+  Network::ConnectionSocketPtr createUpstreamSocket(int fd) {
+    auto socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+    auto io_handle = std::make_unique<NiceMock<Network::MockIoHandle>>();
+    EXPECT_CALL(*io_handle, fdDoNotUse()).WillRepeatedly(Return(fd));
+    EXPECT_CALL(*socket, ioHandle()).WillRepeatedly(ReturnRef(*io_handle));
+    socket->io_handle_ = std::move(io_handle);
+    socket->connection_info_provider_->setLocalAddress(
+        Network::Utility::parseInternetAddressNoThrow("127.0.0.1", 8080));
+    socket->connection_info_provider_->setRemoteAddress(
+        Network::Utility::parseInternetAddressNoThrow("127.0.0.1", fd));
+    return socket;
+  }
+
   envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel proto_config_;
   ReverseTunnelFilterConfigSharedPtr config_;
   std::unique_ptr<ReverseTunnelFilter> filter_;
@@ -2191,6 +2207,78 @@ TEST_F(ReverseTunnelFilterUnitTest, FilterConfigLoadsSkipRebalancing) {
   auto config_or_error = ReverseTunnelFilterConfig::create(cfg, factory_context_);
   ASSERT_TRUE(config_or_error.ok());
   EXPECT_TRUE(config_or_error.value()->skipRebalancing());
+}
+
+// enable_connection_limit defaults to false, so the limit check is a no-op and never consults the
+// socket manager; it allows even when no upstream socket interface is wired up.
+TEST_F(ReverseTunnelFilterUnitTest, ConnectionLimitDisabledByDefaultAllows) {
+  EXPECT_EQ(config_->validateConnectionLimit("any-node", ""), true);
+}
+
+// When the filter opts into the connection limit, the bootstrap extension's per-node cap rejects
+// new connections once the live count reaches the limit, and counts are independent across nodes.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ConnectionLimitEnforcedPerNode) {
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  auto cfg = config_or_error.value();
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  // The cap lives on the bootstrap extension; the socket manager mirrors it per worker.
+  socket_manager->setMaxConnectionsPerNode(2);
+
+  const std::string node = "node-cap";
+
+  // No live connections yet: under the cap.
+  EXPECT_TRUE(cfg->validateConnectionLimit(node, ""));
+
+  // One live connection: still under the cap (1 < 2).
+  socket_manager->addConnectionSocket(node, "cluster", createUpstreamSocket(1001),
+                                      std::chrono::seconds(30));
+  EXPECT_TRUE(cfg->validateConnectionLimit(node, ""));
+
+  // Two live connections: at the cap (2 is not < 2) -> rejected.
+  socket_manager->addConnectionSocket(node, "cluster", createUpstreamSocket(1002),
+                                      std::chrono::seconds(30));
+  EXPECT_FALSE(cfg->validateConnectionLimit(node, ""));
+
+  // A different node is unaffected by node-cap's count.
+  EXPECT_TRUE(cfg->validateConnectionLimit("other-node", ""));
+}
+
+// When the connection limit is enabled but the upstream socket manager is unavailable, the check
+// fails closed (rejects).
+TEST_F(ReverseTunnelFilterUnitTest, ConnectionLimitFailsClosedWithoutSocketManager) {
+  // Wire up a live extension but no thread-local registry, so getLocalRegistry() returns nullptr
+  // and the limit cannot be verified.
+  setupUpstreamExtension();
+
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  EXPECT_FALSE(config_or_error.value()->validateConnectionLimit("node", ""));
+}
+
+// With tenant isolation enabled the cap is scoped per tenant: hitting the cap for one tenant does
+// not block a different tenant on the same node.
+TEST_F(ReverseTunnelFilterWithTenantIsolationTest, ConnectionLimitScopedPerTenant) {
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  auto cfg = config_or_error.value();
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  ASSERT_TRUE(socket_manager->tenantIsolationEnabled());
+  socket_manager->setMaxConnectionsPerNode(1);
+
+  // One live connection for tenant-a brings it to the cap.
+  socket_manager->addConnectionSocket("node", "cluster", createUpstreamSocket(2001),
+                                      std::chrono::seconds(30), false, "tenant-a");
+
+  EXPECT_FALSE(cfg->validateConnectionLimit("node", "tenant-a"));
+  EXPECT_TRUE(cfg->validateConnectionLimit("node", "tenant-b"));
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -118,9 +118,17 @@ typed_config:
   void addReverseTunnelFilter(bool auto_close_connections = false,
                               const std::string& request_path = "/reverse_connections/request",
                               const std::string& request_method = "GET",
-                              const std::string& validation_config = "") {
-    const std::string filter_config =
-        fmt::format(R"EOF(
+                              const std::string& validation_config = "",
+                              uint32_t max_connections_per_node = 0) {
+    // The per-node cap now lives on the bootstrap upstream socket interface extension; the filter
+    // only opts into enforcement via enable_connection_limit. A non-zero cap therefore enables
+    // enable_connection_limit on the filter (at request_path indentation) and sets the limit on
+    // the extension below.
+    const std::string connection_limit_config =
+        max_connections_per_node == 0 ? "" : "\n          enable_connection_limit: true";
+
+    const std::string filter_config = fmt::format(
+        R"EOF(
         name: envoy.filters.network.reverse_tunnel
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.network.reverse_tunnel.v3.ReverseTunnel
@@ -128,10 +136,10 @@ typed_config:
             seconds: 300
           auto_close_connections: {}
           request_path: "{}"
-          request_method: {}{}
+          request_method: {}{}{}
 )EOF",
-                    auto_close_connections ? "true" : "false", request_path, request_method,
-                    validation_config.empty() ? "" : "\n" + validation_config);
+        auto_close_connections ? "true" : "false", request_path, request_method,
+        connection_limit_config, validation_config.empty() ? "" : "\n" + validation_config);
 
     config_helper_.addConfigModifier(
         [filter_config](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
@@ -148,6 +156,23 @@ typed_config:
           // Add reverse tunnel filter (either as first filter or after existing filters).
           listener->mutable_filter_chains(0)->add_filters()->Swap(&filter);
         });
+
+    // Configure the per-node cap on the bootstrap extension when rate limiting is requested.
+    if (max_connections_per_node != 0) {
+      config_helper_.addConfigModifier(
+          [max_connections_per_node](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+            for (auto& extension : *bootstrap.mutable_bootstrap_extensions()) {
+              if (extension.name() == "envoy.bootstrap.reverse_tunnel.upstream_socket_interface") {
+                envoy::extensions::bootstrap::reverse_tunnel::upstream_socket_interface::v3::
+                    UpstreamReverseConnectionSocketInterface config;
+                extension.typed_config().UnpackTo(&config);
+                config.set_max_connections_per_node(max_connections_per_node);
+                extension.mutable_typed_config()->PackFrom(config);
+                break;
+              }
+            }
+          });
+    }
   }
 
   std::string createTestPayload(const std::string& node_uuid = "integration-test-node",
@@ -1591,6 +1616,131 @@ cluster_type:
   addReverseTunnelFilter();
   // Should fail to start with validation error.
   EXPECT_DEATH(initialize(), "tenant_id_format must be configured");
+}
+
+// With max_connections_per_node set, accepting beyond the per-node cap is rejected while other
+// nodes remain unaffected. The integration test server runs a single worker (concurrency_ == 1),
+// so the per-worker count is deterministic.
+TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitRejectsBeyondCap) {
+  addReverseTunnelFilter(false, "/reverse_connections/request", "GET", "",
+                         /*max_connections_per_node=*/1);
+  initialize();
+
+  // First connection for the capped node is accepted and registered (count -> 1).
+  std::string req1 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                    "capped-node", "test-cluster", "test-tenant");
+  IntegrationTcpClientPtr client1 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client1->write(req1));
+  client1->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
+
+  // Second connection for the same node exceeds the cap (1 is not < 1) -> rejected with 403.
+  std::string req2 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                    "capped-node", "test-cluster", "test-tenant");
+  IntegrationTcpClientPtr client2 = makeTcpConnection(lookupPort("listener_0"));
+  (void)client2->write(req2);
+  client2->waitForData("HTTP/1.1 403 Forbidden");
+  client2->waitForDisconnect();
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+
+  // A different node has its own independent count and is still accepted.
+  std::string req3 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                    "other-node", "test-cluster", "test-tenant");
+  IntegrationTcpClientPtr client3 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client3->write(req3));
+  client3->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2));
+
+  client1->close();
+  client3->close();
+}
+
+// Connections at or below the per-node cap are all accepted.
+TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitAllowsWithinCap) {
+  addReverseTunnelFilter(false, "/reverse_connections/request", "GET", "",
+                         /*max_connections_per_node=*/2);
+  initialize();
+
+  IntegrationTcpClientPtr client1 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client1->write(createHttpRequestWithRtHeaders(
+      "GET", "/reverse_connections/request", "within-node", "test-cluster", "test-tenant")));
+  client1->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
+
+  IntegrationTcpClientPtr client2 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client2->write(createHttpRequestWithRtHeaders(
+      "GET", "/reverse_connections/request", "within-node", "test-cluster", "test-tenant")));
+  client2->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2));
+
+  client1->close();
+  client2->close();
+}
+
+// With tenant isolation enabled, the per-node cap is scoped per tenant: hitting the cap for one
+// tenant on a node does not block a different tenant on the same node.
+TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitScopedPerTenant) {
+  // Enable tenant isolation on the upstream socket interface and provide a reverse connection
+  // cluster with a tenant_id_format (required when tenant isolation is on).
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    for (auto& extension : *bootstrap.mutable_bootstrap_extensions()) {
+      if (extension.name() == "envoy.bootstrap.reverse_tunnel.upstream_socket_interface") {
+        envoy::extensions::bootstrap::reverse_tunnel::upstream_socket_interface::v3::
+            UpstreamReverseConnectionSocketInterface config;
+        extension.typed_config().UnpackTo(&config);
+        config.mutable_enable_tenant_isolation()->set_value(true);
+        extension.mutable_typed_config()->PackFrom(config);
+        break;
+      }
+    }
+    envoy::config::cluster::v3::Cluster cluster;
+    TestUtility::loadFromYaml(R"EOF(
+name: reverse_connection_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cleanup_interval: 1s
+cluster_type:
+  name: envoy.clusters.reverse_connection
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.reverse_connection.v3.ReverseConnectionClusterConfig
+    cleanup_interval: 10s
+    host_id_format: "%REQ(x-node-id)%"
+    tenant_id_format: "%REQ(x-tenant-id)%"
+)EOF",
+                              cluster);
+    bootstrap.mutable_static_resources()->add_clusters()->CopyFrom(cluster);
+  });
+
+  // Cap of 1 connection per node, scoped per tenant under tenant isolation.
+  addReverseTunnelFilter(false, "/reverse_connections/request", "GET", "",
+                         /*max_connections_per_node=*/1);
+  initialize();
+  test_server_->waitUntilListenersReady();
+
+  // tenant-a brings the (tenant-a, shared-node) scope to the cap.
+  IntegrationTcpClientPtr client_a1 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client_a1->write(createHttpRequestWithRtHeaders(
+      "GET", "/reverse_connections/request", "shared-node", "shared-cluster", "tenant-a")));
+  client_a1->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
+
+  // A second tenant-a connection for the same node exceeds tenant-a's cap -> rejected.
+  IntegrationTcpClientPtr client_a2 = makeTcpConnection(lookupPort("listener_0"));
+  (void)client_a2->write(createHttpRequestWithRtHeaders(
+      "GET", "/reverse_connections/request", "shared-node", "shared-cluster", "tenant-a"));
+  client_a2->waitForData("HTTP/1.1 403 Forbidden");
+  client_a2->waitForDisconnect();
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+
+  // tenant-b on the same node is an independent scope -> accepted.
+  IntegrationTcpClientPtr client_b1 = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(client_b1->write(createHttpRequestWithRtHeaders(
+      "GET", "/reverse_connections/request", "shared-node", "shared-cluster", "tenant-b")));
+  client_b1->waitForData("HTTP/1.1 200 OK");
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2));
+
+  client_a1->close();
+  client_b1->close();
 }
 
 } // namespace


### PR DESCRIPTION
## Commit Message
reverse_tunnel: add per-node connection cap with tenant-aware enforcement

## Description
Add a configurable reverse tunnel connection cap via `max_connections_per_node` to protect workers from excessive accepted reverse connections. Enforce the cap in handshake validation using live upstream socket-manager counts, with tenant-aware scoping when tenant isolation is enabled. 

## Testing
Unit and integ tests which exercise and dont exercise the functionality.