### PR TITLE
[v1.36] http2: add header map stats histograms

### DIFF
--- a/changelogs/current/new_features/http2__add_header_size_histograms.rst
+++ b/changelogs/current/new_features/http2__add_header_size_histograms.rst
@@ -1,0 +1,5 @@
+Added histograms for HTTP/2 header stats, tracking total count of header entries received (including
+individual ``cookie`` headers), total byte size of header map entries, total length of the re-assebled ``cookie``
+header and total count of individual ``cookie`` headers. Histograms are disabled by default and can be enabled by
+setting the runtime guard ``envoy.reloadable_features.http2_record_histograms`` to ``true``.
+The histograms and the runtime guard will be removed in a future release of Envoy.

--- a/docs/root/configuration/http/http_conn_man/stats.rst
+++ b/docs/root/configuration/http/http_conn_man/stats.rst
@@ -163,11 +163,15 @@ On the upstream side all http2 statistics are rooted at ``cluster.<name>.http2.`
    :header: Name, Type, Description
    :widths: 1, 1, 2
 
+   ``cookie_count``, Histogram, Number of individial ``cookie`` headers. Enabled by setting the ``envoy.reloadable_features.http2_record_histograms`` to ``true``.
+   ``cookie_size``, Histogram, Byte size of the re-assebled ``cookie`` header. Enabled by setting the ``envoy.reloadable_features.http2_record_histograms`` to ``true``.
    ``cookies_total_bytes_too_large``, Counter, Total number of streams reset due to the re-assembled ``cookie`` header exceeding the ``envoy.reloadable_features.http2_max_cookies_size_in_kb`` runtime value.
    ``dropped_headers_with_underscores``, Counter, Total number of dropped headers with names containing underscores. This action is configured by setting the :ref:`headers_with_underscores_action config setting <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.headers_with_underscores_action>`.
    ``goaway_sent``, Counter, Total number ``GOAWAY`` frames that have been submitted to the codec to send.
    ``header_overflow``, Counter, Total number of connections reset due to the headers being larger than the :ref:`configured value <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.max_request_headers_kb>`.
    ``headers_cb_no_stream``, Counter, Total number of errors where a header callback is called without an associated stream. This tracks an unexpected occurrence due to an as yet undiagnosed bug
+   ``header_count``, Histogram, Number of headers including individual ``cookie`` headers. Enabled by setting the ``envoy.reloadable_features.http2_record_histograms`` to ``true``.
+   ``header_list_size``, Histogram, Byte size of all headers including ``cookie`` headers. Enabled by setting the ``envoy.reloadable_features.http2_record_histograms`` to ``true``.
    ``inbound_empty_frames_flood``, Counter, Total number of connections terminated for exceeding the limit on consecutive inbound frames with an empty payload and no end stream flag. The limit is configured by setting the :ref:`max_consecutive_inbound_frames_with_empty_payload config setting <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.max_consecutive_inbound_frames_with_empty_payload>`.
    ``inbound_priority_frames_flood``, Counter, Total number of connections terminated for exceeding the limit on inbound frames of type PRIORITY. The limit is configured by setting the :ref:`max_inbound_priority_frames_per_stream config setting <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.max_inbound_priority_frames_per_stream>`.
    ``inbound_window_update_frames_flood``, Counter, Total number of connections terminated for exceeding the limit on inbound frames of type WINDOW_UPDATE. The limit is configured by setting the :ref:`max_inbound_window_updateframes_per_data_frame_sent config setting <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.max_inbound_window_update_frames_per_data_frame_sent>`.

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -203,7 +203,7 @@ ConnectionImpl::StreamImpl::StreamImpl(ConnectionImpl& parent, uint32_t buffer_l
       remote_rst_(false), data_deferred_(false), received_noninformational_headers_(false),
       pending_receive_buffer_high_watermark_called_(false),
       pending_send_buffer_high_watermark_called_(false), reset_due_to_messaging_error_(false),
-      extend_stream_lifetime_flag_(false) {
+      extend_stream_lifetime_flag_(false), histograms_recorded_(false) {
   parent_.stats_.streams_active_.inc();
   if (buffer_limit > 0) {
     setWriteBufferWatermarks(buffer_limit);
@@ -871,6 +871,8 @@ ConnectionImpl::ConnectionImpl(Network::Connection& connection, CodecStats& stat
       per_stream_buffer_limit_(http2_options.initial_stream_window_size().value()),
       stream_error_on_invalid_http_messaging_(
           http2_options.override_stream_error_on_invalid_http_message().value()),
+      record_http2_histograms_(
+          Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_record_histograms")),
       max_cookie_size_bytes_(
           runtime.has_value() ? runtime->snapshot().getInteger(
                                     "envoy.reloadable_features.http2_max_cookies_size_in_kb", 0) *
@@ -1167,6 +1169,7 @@ Status ConnectionImpl::onHeaders(int32_t stream_id, size_t length, uint8_t flags
   stream->bytes_meter_->addHeaderBytesReceived(length + H2_FRAME_HEADER_SIZE);
 
   stream->remote_end_stream_ = flags & FLAG_END_STREAM;
+  recordHistogramsForStream(*stream);
   if (!stream->cookies_.empty()) {
     HeaderString key(Headers::get().Cookie);
     stream->headers().addViaMove(std::move(key), std::move(stream->cookies_));
@@ -1407,6 +1410,8 @@ Status ConnectionImpl::onStreamClose(StreamImpl* stream, uint32_t error_code) {
   if (stream) {
     const int32_t stream_id = stream->stream_id_;
 
+    recordHistogramsForStream(*stream);
+
     // Consume buffered on stream_close.
     if (stream->stream_manager_.buffered_on_stream_close_) {
       stream->stream_manager_.buffered_on_stream_close_ = false;
@@ -1520,6 +1525,26 @@ int ConnectionImpl::onMetadataFrameComplete(int32_t stream_id, bool end_metadata
 
   bool result = stream->getMetadataDecoder().onMetadataFrameComplete(end_metadata);
   return result ? 0 : ERR_CALLBACK_FAILURE;
+}
+
+// This function can be invoked multiple times for a single stream:
+// - Once in onHeaders() for request/response headers (this is when recording happens).
+// - Again in onHeaders() if there are trailers (ignored, trailers are not recorded).
+// - Once in onStreamClose() as a fallback if headers weren't recorded (e.g. early error),
+//   or as a redundant call for successful streams (ignored).
+// The `histograms_recorded_` guard ensures we only record once (only for headers, not trailers).
+void ConnectionImpl::recordHistogramsForStream(StreamImpl& stream) {
+  if (record_http2_histograms_ && !stream.histograms_recorded_) {
+    uint64_t headers_size = stream.headers().byteSize();
+    uint64_t headers_count = stream.headers().size();
+    uint64_t headers_with_cookies_size = headers_size + stream.cookies_.size();
+    uint64_t headers_with_cookies_count = headers_count + stream.cookie_count_;
+    stats_.header_list_size_.recordValue(headers_with_cookies_size);
+    stats_.cookie_size_.recordValue(stream.cookies_.size());
+    stats_.header_count_.recordValue(headers_with_cookies_count);
+    stats_.cookie_count_.recordValue(stream.cookie_count_);
+    stream.histograms_recorded_ = true;
+  }
 }
 
 int ConnectionImpl::saveHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value) {

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -440,6 +440,7 @@ protected:
     bool reset_due_to_messaging_error_ : 1;
     // Latch whether this stream is operating with this flag.
     bool extend_stream_lifetime_flag_ : 1;
+    bool histograms_recorded_ : 1 = false;
     absl::string_view details_;
 
     /**
@@ -644,6 +645,7 @@ protected:
   const StreamImpl* getStreamUnchecked(int32_t stream_id) const;
   StreamImpl* getStreamUnchecked(int32_t stream_id);
   int saveHeader(int32_t stream_id, HeaderString&& name, HeaderString&& value);
+  void recordHistogramsForStream(StreamImpl& stream);
 
   /**
    * Copies any frames pending internally by nghttp2 into outbound buffer.
@@ -724,6 +726,7 @@ protected:
   bool allow_metadata_;
   uint64_t max_metadata_size_;
   const bool stream_error_on_invalid_http_messaging_;
+  const bool record_http2_histograms_;
   const uint64_t max_cookie_size_bytes_{0};
 
   // Status for any errors encountered by the nghttp2 callbacks.

--- a/source/common/http/http2/codec_stats.h
+++ b/source/common/http/http2/codec_stats.h
@@ -13,7 +13,7 @@ namespace Http2 {
 /**
  * All stats for the HTTP/2 codec. @see stats_macros.h
  */
-#define ALL_HTTP2_CODEC_STATS(COUNTER, GAUGE)                                                      \
+#define ALL_HTTP2_CODEC_STATS(COUNTER, GAUGE, HISTOGRAM)                                           \
   COUNTER(cookies_total_bytes_too_large)                                                           \
   COUNTER(dropped_headers_with_underscores)                                                        \
   COUNTER(goaway_sent)                                                                             \
@@ -38,7 +38,12 @@ namespace Http2 {
   GAUGE(pending_send_bytes, Accumulate)                                                            \
   GAUGE(deferred_stream_close, Accumulate)                                                         \
   GAUGE(outbound_frames_active, Accumulate)                                                        \
-  GAUGE(outbound_control_frames_active, Accumulate)
+  GAUGE(outbound_control_frames_active, Accumulate)                                                \
+  HISTOGRAM(cookie_count, Unspecified)                                                             \
+  HISTOGRAM(cookie_size, Bytes)                                                                    \
+  HISTOGRAM(header_count, Unspecified)                                                             \
+  HISTOGRAM(header_list_size, Bytes)
+#define GENERATE_CONSTRUCTOR_HISTOGRAM_PARAM(NAME, ...) Envoy::Stats::Histogram &NAME,
 /**
  * Wrapper struct for the HTTP/2 codec stats. @see stats_macros.h
  */
@@ -46,14 +51,17 @@ struct CodecStats : public ::Envoy::Http::HeaderValidatorStats {
   using AtomicPtr = Thread::AtomicPtr<CodecStats, Thread::AtomicPtrAllocMode::DeleteOnDestruct>;
 
   CodecStats(ALL_HTTP2_CODEC_STATS(GENERATE_CONSTRUCTOR_COUNTER_PARAM,
-                                   GENERATE_CONSTRUCTOR_GAUGE_PARAM)...)
+                                   GENERATE_CONSTRUCTOR_GAUGE_PARAM,
+                                   GENERATE_CONSTRUCTOR_HISTOGRAM_PARAM)...)
       : ::Envoy::Http::HeaderValidatorStats()
-            ALL_HTTP2_CODEC_STATS(GENERATE_CONSTRUCTOR_INIT_LIST, GENERATE_CONSTRUCTOR_INIT_LIST) {}
+            ALL_HTTP2_CODEC_STATS(GENERATE_CONSTRUCTOR_INIT_LIST, GENERATE_CONSTRUCTOR_INIT_LIST,
+                                  GENERATE_CONSTRUCTOR_INIT_LIST) {}
 
   static CodecStats& atomicGet(AtomicPtr& ptr, Stats::Scope& scope) {
     return *ptr.get([&scope]() -> CodecStats* {
       return new CodecStats{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(scope, "http2."),
-                                                  POOL_GAUGE_PREFIX(scope, "http2."))};
+                                                  POOL_GAUGE_PREFIX(scope, "http2."),
+                                                  POOL_HISTOGRAM_PREFIX(scope, "http2."))};
     });
   }
 
@@ -63,7 +71,7 @@ struct CodecStats : public ::Envoy::Http::HeaderValidatorStats {
   }
   void incMessagingError() override { rx_messaging_error_.inc(); }
 
-  ALL_HTTP2_CODEC_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
+  ALL_HTTP2_CODEC_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 } // namespace Http2

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -198,6 +198,9 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_fixed_heap_use_allocated);
 // Replace with a config option (default off) post CVE release.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reject_early_connect_data);
 
+// Enable histograms of HTTP/2 header sizes, including cookie size.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);
+
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT
 ABSL_FLAG(uint64_t, re2_max_program_size_warn_level,            // NOLINT

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -41,6 +41,7 @@ using testing::AnyNumber;
 using testing::AtLeast;
 using testing::ElementsAre;
 using testing::EndsWith;
+using testing::Ge;
 using testing::HasSubstr;
 using testing::InSequence;
 using testing::Invoke;
@@ -4887,6 +4888,107 @@ TEST_P(Http2CodecImplTest, InvalidHeadersFrameInvalid) {
   }
 }
 #endif
+
+TEST_P(Http2CodecImplTest, HeaderListSizeTooLargeHistogram) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_record_histograms", true);
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_include_cookies_in_limits", false);
+  max_request_headers_kb_ = 5;
+  initialize();
+  if (http2_implementation_ == Http2Impl::Oghttp2) {
+    GTEST_SKIP();
+  }
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  for (int i = 0; i < 60; i++) {
+    request_headers.addCopy("cookie", std::string(100, 'a'));
+  }
+
+  // Request should succeed since cookie size is not counted toward size limit.
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  std::vector<uint64_t> header_sizes =
+      server_stats_store_.histogramValues("http2.header_list_size", false);
+  EXPECT_EQ(header_sizes.size(), 1);
+  EXPECT_THAT(header_sizes, ElementsAre(Ge(6000)));
+}
+
+TEST_P(Http2CodecImplTest, CookieSizeHistogram) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_record_histograms", true);
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_include_cookies_in_limits", false);
+  max_request_headers_kb_ = 5;
+  initialize();
+  if (http2_implementation_ == Http2Impl::Oghttp2) {
+    GTEST_SKIP();
+  }
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  for (int i = 0; i < 60; i++) {
+    request_headers.addCopy("cookie", std::string(100, 'a'));
+  }
+
+  // Request should succeed since cookie size is not counted toward size limit.
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  auto cookie_sizes = server_stats_store_.histogramValues("http2.cookie_size", false);
+  EXPECT_EQ(cookie_sizes.size(), 1);
+  EXPECT_THAT(cookie_sizes, ElementsAre(Ge(6000)));
+}
+
+TEST_P(Http2CodecImplTest, TooManyHeadersHistogram) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_record_histograms", true);
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_include_cookies_in_limits", false);
+  max_request_headers_count_ = 10;
+  max_request_headers_kb_ = 100;
+  initialize();
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  for (int i = 0; i < 10; i++) {
+    request_headers.addCopy(absl::StrCat("header", i), "value");
+  }
+
+  EXPECT_CALL(server_stream_callbacks_, onResetStream(StreamResetReason::RemoteReset, _));
+  EXPECT_CALL(server_codec_event_callbacks_, onCodecLowLevelReset());
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  auto header_counts = server_stats_store_.histogramValues("http2.header_count", false);
+  EXPECT_EQ(header_counts.size(), 1);
+  EXPECT_THAT(header_counts, ElementsAre(Ge(10)));
+}
+
+TEST_P(Http2CodecImplTest, TooManyCookiesHistogram) {
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_record_histograms", true);
+  Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.http2_include_cookies_in_limits", false);
+  max_request_headers_count_ = 10;
+  max_request_headers_kb_ = 100;
+  initialize();
+  if (http2_implementation_ == Http2Impl::Oghttp2) {
+    GTEST_SKIP();
+  }
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  for (int i = 0; i < 10; i++) {
+    request_headers.addCopy("cookie", "value");
+  }
+
+  // Request should succeed since cookie size is not counted toward size limit.
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  std::vector<uint64_t> cookie_counts =
+      server_stats_store_.histogramValues("http2.cookie_count", false);
+  EXPECT_EQ(cookie_counts.size(), 1);
+  EXPECT_THAT(cookie_counts, ElementsAre(Ge(10)));
+}
 
 } // namespace Http2
 } // namespace Http


### PR DESCRIPTION
Add histograms for HTTP/2 header map stats.

* header_count - total count of header entries received (including individual ``cookie`` headers)
* header_list_size - total byte size of header map entries, total length of the re-assembled ``cookie``
* cookie_count - count of individual ``cookie`` headers.
* cookie_size - size of re-assembled ``cookie`` headers.

Histograms are disabled by default and can be enabled by setting the runtime guard
``envoy.reloadable_features.http2_record_histograms`` to ``true``.

Risk Level: low
Testing: unit tests
Docs Changes: yes
Release Notes: yes
Platform Specific Features: no
Runtime guard: envoy.reloadable_features.http2_record_histograms
