### PR TITLE
openssl: make RSA_check_fips() and EC_KEY_check_fips() a no-op stubs returning success.

### DIFF
--- a/compat/openssl/source/EC_KEY_check_fips.cc
+++ b/compat/openssl/source/EC_KEY_check_fips.cc
@@ -1,8 +1,8 @@
 #include <openssl/ec_key.h>
 
-#include "log.h"
 
-extern "C" int EC_KEY_check_fips(const EC_KEY* key) {
-  bssl_compat_fatal("%s() NYI", __func__);
-  return 0;
+// OpenSSL's FIPS provider already performs key validation during key operations,
+// making an explicit check here redundant and a performance bottleneck.
+extern "C" int EC_KEY_check_fips(const EC_KEY *key) {
+  return 1;
 }

--- a/compat/openssl/source/RSA_check_fips.cc
+++ b/compat/openssl/source/RSA_check_fips.cc
@@ -1,8 +1,8 @@
 #include <openssl/rsa.h>
 
-#include "log.h"
 
-extern "C" int RSA_check_fips(RSA* key) {
-  bssl_compat_fatal("%s() NYI", __func__);
-  return 0;
+// OpenSSL's FIPS provider already performs key validation during key operations,
+// making an explicit check here redundant and a performance bottleneck.
+extern "C" int RSA_check_fips(RSA *key) {
+  return 1;
 }


### PR DESCRIPTION
Commit Message: openssl: make RSA_check_fips() and EC_KEY_check_fips() a no-op stubs returning success.
Additional Description:
This is a backport of
https://github.com/envoyproxy/envoy-openssl/pull/527.

Returning 1 (always succeed) is safe because OpenSSL's FIPS provider already performs pairwise consistency tests and key validation internally during key generation and import. By the time Envoy calls these functions, OpenSSL has already validated the key through FIPS-compliant code paths. These BoringSSL-specific FIPS self-test functions are redundant in an OpenSSL context and were causing a measurable performance decrease.

Risk Level: XS
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
