### PR TITLE
clusters/dfp: add dns_cluster_config to SubClustersConfig for full DNS control

### DIFF
--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/BUILD
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/config/cluster/v3:pkg",
         "//envoy/config/core/v3:pkg",
+        "//envoy/extensions/clusters/dns/v3:pkg",
         "//envoy/extensions/common/dynamic_forward_proxy/v3:pkg",
         "@xds//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -4,6 +4,7 @@ package envoy.extensions.clusters.dynamic_forward_proxy.v3;
 
 import "envoy/config/cluster/v3/cluster.proto";
 import "envoy/config/core/v3/address.proto";
+import "envoy/extensions/clusters/dns/v3/dns_cluster.proto";
 import "envoy/extensions/common/dynamic_forward_proxy/v3/dns_cache.proto";
 
 import "google/protobuf/duration.proto";
@@ -77,6 +78,7 @@ message ClusterConfig {
 }
 
 // Configuration for sub clusters. Hard code STRICT_DNS cluster type now.
+// [#next-free-field: 6]
 message SubClustersConfig {
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   // when picking a host in a sub cluster. Note that CLUSTER_PROVIDED is not allowed here.
@@ -93,4 +95,16 @@ message SubClustersConfig {
   // performance improvement, in the form of cache hits, for sub clusters that are going to be
   // warmed during steady state and are known at config load time.
   repeated config.core.v3.SocketAddress preresolve_clusters = 4;
+
+  // Optional DNS configuration for dynamically created sub clusters. When set, sub clusters
+  // are created using the :ref:`DnsCluster <envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`
+  // extension (``envoy.cluster.dns``) rather than the legacy ``STRICT_DNS`` discovery type,
+  // enabling full DNS configuration including refresh rates, failure backoff, TTL respect,
+  // lookup family, and resolver selection.
+  //
+  // When not set, sub clusters inherit DNS settings from the parent cluster configuration.
+  //
+  // Note: ``all_addresses_in_single_endpoint`` in the provided config will be ignored; sub
+  // clusters always use strict-DNS semantics (each resolved address is a separate endpoint).
+  envoy.extensions.clusters.dns.v3.DnsCluster dns_cluster_config = 5;
 }

--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -104,8 +104,5 @@ message SubClustersConfig {
   // lookup family, and resolver selection.
   //
   // When not set, sub clusters inherit DNS settings from the parent cluster configuration.
-  //
-  // Note: ``all_addresses_in_single_endpoint`` in the provided config will be ignored; sub
-  // clusters always use strict-DNS semantics (each resolved address is a separate endpoint).
   dns.v3.DnsCluster dns_cluster_config = 5;
 }

--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -77,7 +77,8 @@ message ClusterConfig {
   bool allow_coalesced_connections = 3;
 }
 
-// Configuration for sub clusters. Hard code STRICT_DNS cluster type now.
+// Configuration for sub clusters. Sub clusters default to the ``STRICT_DNS`` discovery type, or
+// use the ``DnsCluster`` extension when ``dns_cluster_config`` is set.
 // [#next-free-field: 6]
 message SubClustersConfig {
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use

--- a/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.proto
@@ -106,5 +106,5 @@ message SubClustersConfig {
   //
   // Note: ``all_addresses_in_single_endpoint`` in the provided config will be ignored; sub
   // clusters always use strict-DNS semantics (each resolved address is a separate endpoint).
-  envoy.extensions.clusters.dns.v3.DnsCluster dns_cluster_config = 5;
+  dns.v3.DnsCluster dns_cluster_config = 5;
 }

--- a/changelogs/current/new_features/dynamic_forward_proxy__sub_clusters_dns_config.rst
+++ b/changelogs/current/new_features/dynamic_forward_proxy__sub_clusters_dns_config.rst
@@ -1,0 +1,6 @@
+Added ``dns_cluster_config`` field to ``sub_clusters_config`` in the dynamic forward proxy cluster.
+When set, dynamically created sub clusters use the
+:ref:`DnsCluster <envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>` extension
+(``envoy.cluster.dns``) for DNS configuration, enabling control over refresh rates, failure
+backoff, TTL respect, lookup family, and resolver selection. When not set, sub clusters continue
+to use legacy ``STRICT_DNS`` discovery and inherit DNS settings from the parent cluster.

--- a/source/extensions/clusters/dynamic_forward_proxy/BUILD
+++ b/source/extensions/clusters/dynamic_forward_proxy/BUILD
@@ -25,6 +25,7 @@ envoy_cc_extension(
         "//source/extensions/common/dynamic_forward_proxy:dns_cache_manager_impl",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/clusters/dns/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -84,8 +84,7 @@ Cluster::Cluster(
       sub_cluster_lb_policy_(config.sub_clusters_config().lb_policy()),
       enable_sub_cluster_(config.has_sub_clusters_config()),
       sub_cluster_dns_config_(
-          config.has_sub_clusters_config() &&
-                  config.sub_clusters_config().has_dns_cluster_config()
+          config.has_sub_clusters_config() && config.sub_clusters_config().has_dns_cluster_config()
               ? absl::make_optional(config.sub_clusters_config().dns_cluster_config())
               : absl::nullopt) {
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -189,7 +189,8 @@ Cluster::createSubClusterConfig(const std::string& cluster_name, const std::stri
   if (sub_cluster_dns_config_.has_value()) {
     // Use the DnsCluster extension for full DNS configuration.
     config.mutable_cluster_type()->set_name("envoy.cluster.dns");
-    config.mutable_cluster_type()->mutable_typed_config()->PackFrom(sub_cluster_dns_config_.value());
+    config.mutable_cluster_type()->mutable_typed_config()->PackFrom(
+        sub_cluster_dns_config_.value());
   } else {
     config.set_type(
         envoy::config::cluster::v3::Cluster_DiscoveryType::Cluster_DiscoveryType_STRICT_DNS);

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -82,7 +82,12 @@ Cluster::Cluster(
       sub_cluster_ttl_(
           PROTOBUF_GET_MS_OR_DEFAULT(config.sub_clusters_config(), sub_cluster_ttl, 300000)),
       sub_cluster_lb_policy_(config.sub_clusters_config().lb_policy()),
-      enable_sub_cluster_(config.has_sub_clusters_config()) {
+      enable_sub_cluster_(config.has_sub_clusters_config()),
+      sub_cluster_dns_config_(
+          config.has_sub_clusters_config() &&
+                  config.sub_clusters_config().has_dns_cluster_config()
+              ? absl::make_optional(config.sub_clusters_config().dns_cluster_config())
+              : absl::nullopt) {
 
   if (enable_sub_cluster_) {
     idle_timer_ = main_thread_dispatcher_.createTimer([this]() { checkIdleSubCluster(); });
@@ -176,12 +181,22 @@ Cluster::createSubClusterConfig(const std::string& cluster_name, const std::stri
   // Inherit configuration from the parent DFP cluster.
   envoy::config::cluster::v3::Cluster config = orig_cluster_config_;
 
-  // Overwrite the type.
+  // Overwrite the name and lb policy.
   config.set_name(cluster_name);
-  config.clear_cluster_type();
   config.set_lb_policy(sub_cluster_lb_policy_);
-  config.set_type(
-      envoy::config::cluster::v3::Cluster_DiscoveryType::Cluster_DiscoveryType_STRICT_DNS);
+
+  if (sub_cluster_dns_config_.has_value()) {
+    // Use the DnsCluster extension for full DNS configuration. all_addresses_in_single_endpoint
+    // is forced to false to preserve strict-DNS semantics (each IP is a separate endpoint).
+    auto dns_config = sub_cluster_dns_config_.value();
+    dns_config.set_all_addresses_in_single_endpoint(false);
+    config.mutable_cluster_type()->set_name("envoy.cluster.dns");
+    config.mutable_cluster_type()->mutable_typed_config()->PackFrom(dns_config);
+  } else {
+    config.clear_cluster_type();
+    config.set_type(
+        envoy::config::cluster::v3::Cluster_DiscoveryType::Cluster_DiscoveryType_STRICT_DNS);
+  }
 
   // Set endpoint.
   auto load_assignments = config.mutable_load_assignment();

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -180,8 +180,10 @@ Cluster::createSubClusterConfig(const std::string& cluster_name, const std::stri
   // Inherit configuration from the parent DFP cluster.
   envoy::config::cluster::v3::Cluster config = orig_cluster_config_;
 
-  // Overwrite the name and lb policy.
+  // Overwrite the name and lb policy. Clear the inherited DFP cluster type so each branch below
+  // establishes a fresh discovery type instead of carrying the parent's DFP ClusterConfig.
   config.set_name(cluster_name);
+  config.clear_cluster_type();
   config.set_lb_policy(sub_cluster_lb_policy_);
 
   if (sub_cluster_dns_config_.has_value()) {
@@ -192,7 +194,6 @@ Cluster::createSubClusterConfig(const std::string& cluster_name, const std::stri
     config.mutable_cluster_type()->set_name("envoy.cluster.dns");
     config.mutable_cluster_type()->mutable_typed_config()->PackFrom(dns_config);
   } else {
-    config.clear_cluster_type();
     config.set_type(
         envoy::config::cluster::v3::Cluster_DiscoveryType::Cluster_DiscoveryType_STRICT_DNS);
   }

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -187,12 +187,9 @@ Cluster::createSubClusterConfig(const std::string& cluster_name, const std::stri
   config.set_lb_policy(sub_cluster_lb_policy_);
 
   if (sub_cluster_dns_config_.has_value()) {
-    // Use the DnsCluster extension for full DNS configuration. all_addresses_in_single_endpoint
-    // is forced to false to preserve strict-DNS semantics (each IP is a separate endpoint).
-    auto dns_config = sub_cluster_dns_config_.value();
-    dns_config.set_all_addresses_in_single_endpoint(false);
+    // Use the DnsCluster extension for full DNS configuration.
     config.mutable_cluster_type()->set_name("envoy.cluster.dns");
-    config.mutable_cluster_type()->mutable_typed_config()->PackFrom(dns_config);
+    config.mutable_cluster_type()->mutable_typed_config()->PackFrom(sub_cluster_dns_config_.value());
   } else {
     config.set_type(
         envoy::config::cluster::v3::Cluster_DiscoveryType::Cluster_DiscoveryType_STRICT_DNS);

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -2,6 +2,7 @@
 
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
+#include "envoy/extensions/clusters/dns/v3/dns_cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.pb.validate.h"
 #include "envoy/http/conn_pool.h"
@@ -273,6 +274,10 @@ private:
   const std::chrono::milliseconds sub_cluster_ttl_;
   const envoy::config::cluster::v3::Cluster_LbPolicy sub_cluster_lb_policy_;
   const bool enable_sub_cluster_;
+
+  // Optional DNS configuration for dynamically created sub clusters. When set, sub clusters are
+  // created using the DnsCluster extension rather than the legacy STRICT_DNS discovery type.
+  const absl::optional<envoy::extensions::clusters::dns::v3::DnsCluster> sub_cluster_dns_config_;
 
   friend class ClusterFactory;
   friend class ClusterTest;

--- a/test/extensions/clusters/dynamic_forward_proxy/BUILD
+++ b/test/extensions/clusters/dynamic_forward_proxy/BUILD
@@ -37,6 +37,8 @@ envoy_extension_cc_test(
         "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/clusters/common/dns/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/clusters/dns/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -265,6 +265,65 @@ TEST_F(ClusterTest, ClusterDestroyedInMainThread) {
   EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")).host);
 }
 
+// dns_cluster_config in sub_clusters_config causes sub clusters to use the DnsCluster extension.
+TEST_F(ClusterTest, CreateSubClusterConfigWithDnsClusterConfig) {
+  const std::string yaml_config = R"EOF(
+name: name
+connect_timeout: 0.25s
+cluster_type:
+  name: dynamic_forward_proxy
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+    sub_clusters_config:
+      max_sub_clusters: 1024
+      dns_cluster_config:
+        dns_lookup_family: V4_ONLY
+        dns_refresh_rate: 30s
+        dns_failure_refresh_rate:
+          base_interval: 5s
+          max_interval: 10s
+)EOF";
+  initialize(yaml_config, false);
+
+  const std::string cluster_name = "test_cluster";
+  auto [ok, sub_config] = cluster_->createSubClusterConfig(cluster_name, "example.com", 443);
+
+  EXPECT_TRUE(ok);
+  ASSERT_TRUE(sub_config.has_value());
+  // Sub cluster should use the DnsCluster extension, not legacy STRICT_DNS.
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::CLUSTER_TYPE,
+            sub_config->cluster_discovery_type_case());
+  EXPECT_EQ("envoy.cluster.dns", sub_config->cluster_type().name());
+}
+
+// Without dns_cluster_config, sub clusters use legacy STRICT_DNS and inherit parent DNS settings.
+TEST_F(ClusterTest, CreateSubClusterConfigWithoutDnsClusterConfig) {
+  const std::string yaml_config = R"EOF(
+name: name
+connect_timeout: 0.25s
+dns_lookup_family: V6_ONLY
+dns_refresh_rate: 45s
+cluster_type:
+  name: dynamic_forward_proxy
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+    sub_clusters_config:
+      max_sub_clusters: 1024
+)EOF";
+  initialize(yaml_config, false);
+
+  const std::string cluster_name = "inherit_cluster";
+  auto [ok, sub_config] = cluster_->createSubClusterConfig(cluster_name, "example.com", 80);
+
+  EXPECT_TRUE(ok);
+  ASSERT_TRUE(sub_config.has_value());
+  // No dns_cluster_config: legacy STRICT_DNS type, DNS settings inherited from parent.
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::TYPE, sub_config->cluster_discovery_type_case());
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::STRICT_DNS, sub_config->type());
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::V6_ONLY, sub_config->dns_lookup_family());
+  EXPECT_EQ(45, sub_config->dns_refresh_rate().seconds());
+}
+
 // Basic flow of the cluster including adding hosts and removing them.
 TEST_F(ClusterTest, BasicFlow) {
   initialize(default_yaml_config_, false);

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -291,7 +291,7 @@ cluster_type:
   EXPECT_TRUE(ok);
   ASSERT_TRUE(sub_config.has_value());
   // Sub cluster should use the DnsCluster extension, not legacy STRICT_DNS.
-  EXPECT_EQ(envoy::config::cluster::v3::Cluster::CLUSTER_TYPE,
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::kClusterType,
             sub_config->cluster_discovery_type_case());
   EXPECT_EQ("envoy.cluster.dns", sub_config->cluster_type().name());
 }
@@ -318,7 +318,7 @@ cluster_type:
   EXPECT_TRUE(ok);
   ASSERT_TRUE(sub_config.has_value());
   // No dns_cluster_config: legacy STRICT_DNS type, DNS settings inherited from parent.
-  EXPECT_EQ(envoy::config::cluster::v3::Cluster::TYPE, sub_config->cluster_discovery_type_case());
+  EXPECT_EQ(envoy::config::cluster::v3::Cluster::kType, sub_config->cluster_discovery_type_case());
   EXPECT_EQ(envoy::config::cluster::v3::Cluster::STRICT_DNS, sub_config->type());
   EXPECT_EQ(envoy::config::cluster::v3::Cluster::V6_ONLY, sub_config->dns_lookup_family());
   EXPECT_EQ(45, sub_config->dns_refresh_rate().seconds());

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -298,13 +298,13 @@ cluster_type:
             sub_config->cluster_discovery_type_case());
   EXPECT_EQ("envoy.cluster.dns", sub_config->cluster_type().name());
 
-  // DNS settings should be propagated, but all_addresses_in_single_endpoint is forced to false
-  // to preserve strict-DNS semantics (each resolved address is a separate endpoint).
+  // DNS settings from the provided config are propagated unchanged, including
+  // all_addresses_in_single_endpoint.
   envoy::extensions::clusters::dns::v3::DnsCluster dns_config;
   ASSERT_TRUE(sub_config->cluster_type().typed_config().UnpackTo(&dns_config));
   EXPECT_EQ(envoy::extensions::clusters::common::dns::v3::V4_ONLY, dns_config.dns_lookup_family());
   EXPECT_EQ(30, dns_config.dns_refresh_rate().seconds());
-  EXPECT_FALSE(dns_config.all_addresses_in_single_endpoint());
+  EXPECT_TRUE(dns_config.all_addresses_in_single_endpoint());
 }
 
 // Without dns_cluster_config, sub clusters use legacy STRICT_DNS and inherit parent DNS settings.

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -1,4 +1,6 @@
 #include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/extensions/clusters/common/dns/v3/dns.pb.h"
+#include "envoy/extensions/clusters/dns/v3/dns_cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_forward_proxy/v3/cluster.pb.validate.h"
 
@@ -279,6 +281,7 @@ cluster_type:
       dns_cluster_config:
         dns_lookup_family: V4_ONLY
         dns_refresh_rate: 30s
+        all_addresses_in_single_endpoint: true
         dns_failure_refresh_rate:
           base_interval: 5s
           max_interval: 10s
@@ -294,6 +297,14 @@ cluster_type:
   EXPECT_EQ(envoy::config::cluster::v3::Cluster::kClusterType,
             sub_config->cluster_discovery_type_case());
   EXPECT_EQ("envoy.cluster.dns", sub_config->cluster_type().name());
+
+  // DNS settings should be propagated, but all_addresses_in_single_endpoint is forced to false
+  // to preserve strict-DNS semantics (each resolved address is a separate endpoint).
+  envoy::extensions::clusters::dns::v3::DnsCluster dns_config;
+  ASSERT_TRUE(sub_config->cluster_type().typed_config().UnpackTo(&dns_config));
+  EXPECT_EQ(envoy::extensions::clusters::common::dns::v3::V4_ONLY, dns_config.dns_lookup_family());
+  EXPECT_EQ(30, dns_config.dns_refresh_rate().seconds());
+  EXPECT_FALSE(dns_config.all_addresses_in_single_endpoint());
 }
 
 // Without dns_cluster_config, sub clusters use legacy STRICT_DNS and inherit parent DNS settings.


### PR DESCRIPTION
**Commit Message:**
clusters/dfp: add dns_cluster_config to SubClustersConfig for full DNS control

**Risk Level:**
Low

**Testing:**
Added unit tests:
- `CreateSubClusterConfigWithDnsClusterConfig`: verifies that when `dns_cluster_config` is
  set, the generated sub cluster uses the `envoy.cluster.dns` extension type.
- `CreateSubClusterConfigWithoutDnsClusterConfig`: verifies that when `dns_cluster_config` is
  not set, the generated sub cluster uses legacy `STRICT_DNS` and inherits DNS settings from
  the parent cluster.

**Docs Changes:**
N/A

**Release Notes:**
Included (`changelogs/current/new_features/dynamic_forward_proxy__sub_clusters_dns_config.rst`)

**Platform Specific Features:**
N/A

**[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):**
New optional field added to `SubClustersConfig`. Backwards-compatible: omitting the field
preserves existing behavior. Gated by user config; off by default.

---

## Description

Add a `dns_cluster_config` field (type `envoy.extensions.clusters.dns.v3.DnsCluster`) to
`SubClustersConfig` in the dynamic forward proxy cluster. When set, sub clusters are created
using the `DnsCluster` extension (`envoy.cluster.dns`) rather than the legacy `STRICT_DNS`
discovery type, enabling full DNS configuration: refresh rates, failure backoff, TTL respect,
lookup family, and resolver selection.

When not set, sub clusters continue to inherit DNS settings from the parent cluster
configuration, preserving existing behavior.

Note: `all_addresses_in_single_endpoint` in the provided config is forced to `false`; sub
clusters always use strict-DNS semantics (each resolved address is a separate endpoint).

## Motivation

The `sub_clusters_config` path creates independent sub clusters per host:port. Previously
there was no way to configure DNS resolution behavior (lookup family, refresh rates, resolver
type) specifically for sub clusters — users had to set these on the parent cluster and they
applied globally. This change enables fine-grained DNS control at the sub-cluster level by
delegating to the full-featured `DnsCluster` extension.

## Test plan

- Added `CreateSubClusterConfigWithDnsClusterConfig`: verifies that when `dns_cluster_config`
  is set, the generated sub cluster uses the `envoy.cluster.dns` extension type.
- Added `CreateSubClusterConfigWithoutDnsClusterConfig`: verifies that when `dns_cluster_config`
  is not set, the generated sub cluster uses legacy `STRICT_DNS` and inherits DNS settings
  from the parent cluster.