### PR TITLE
dns: add dns_min_refresh_rate to DnsCluster

### DIFF
--- a/api/envoy/extensions/clusters/dns/v3/dns_cluster.proto
+++ b/api/envoy/extensions/clusters/dns/v3/dns_cluster.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for DNS discovery clusters.
 // [#extension: envoy.clusters.dns]
 
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message DnsCluster {
   message RefreshRate {
     // Specifies the base interval between refreshes. This parameter is required and must be greater
@@ -89,4 +89,12 @@ message DnsCluster {
   // semantics. Otherwise, each address is considered to be a separate endpoint, which maps to
   // :ref:`strict DNS discovery <arch_overview_service_discovery_types_strict_dns>` semantics.
   bool all_addresses_in_single_endpoint = 9;
+
+  // When :ref:`respect_dns_ttl <envoy_v3_api_field_extensions.clusters.dns.v3.DnsCluster.respect_dns_ttl>`
+  // is enabled, this field specifies a minimum value for the TTL-derived DNS refresh rate.
+  // DNS records with TTLs shorter than this value will be refreshed at this rate instead. If not
+  // set, the TTL from the DNS response is used directly with no minimum floor.
+  // The value must be at least 1 second.
+  google.protobuf.Duration dns_min_refresh_rate = 10
+      [(validate.rules).duration = {gte {seconds: 1}}];
 }

--- a/changelogs/current/new_features/dns_cluster__dns_min_refresh_rate.rst
+++ b/changelogs/current/new_features/dns_cluster__dns_min_refresh_rate.rst
@@ -1,0 +1,6 @@
+Added ``dns_min_refresh_rate`` field to
+:ref:`DnsCluster <envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.
+When :ref:`respect_dns_ttl <envoy_v3_api_field_extensions.clusters.dns.v3.DnsCluster.respect_dns_ttl>`
+is enabled, this sets a minimum floor on the TTL-derived refresh interval. DNS records with TTLs
+shorter than this value will be refreshed at this rate instead, preventing excessively frequent
+re-resolution for low-TTL records.

--- a/source/extensions/clusters/dns/dns_cluster.cc
+++ b/source/extensions/clusters/dns/dns_cluster.cc
@@ -157,6 +157,8 @@ DnsClusterImpl::DnsClusterImpl(const envoy::config::cluster::v3::Cluster& cluste
       local_info_(context.serverFactoryContext().localInfo()), dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_refresh_rate, 5000))),
+      dns_min_refresh_rate_ms_(std::chrono::milliseconds(
+          PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_min_refresh_rate, 0))),
       dns_jitter_ms_(PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_jitter, 0)),
       respect_dns_ttl_(dns_cluster.respect_dns_ttl()),
       dns_lookup_family_(
@@ -422,7 +424,8 @@ void DnsClusterImpl::ResolveTarget::startResolve() {
 
           if (!response.empty() && parent_.respect_dns_ttl_ &&
               new_hosts.ttl_refresh_rate != std::chrono::seconds(0)) {
-            final_refresh_rate = new_hosts.ttl_refresh_rate;
+            final_refresh_rate = std::max(std::chrono::milliseconds(new_hosts.ttl_refresh_rate),
+                                          parent_.dns_min_refresh_rate_ms_);
             ASSERT(new_hosts.ttl_refresh_rate != std::chrono::seconds::max() &&
                    final_refresh_rate.count() > 0);
           }

--- a/source/extensions/clusters/dns/dns_cluster.h
+++ b/source/extensions/clusters/dns/dns_cluster.h
@@ -115,6 +115,7 @@ private:
   Network::DnsResolverSharedPtr dns_resolver_;
   std::list<ResolveTargetPtr> resolve_targets_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
+  const std::chrono::milliseconds dns_min_refresh_rate_ms_;
   const std::chrono::milliseconds dns_jitter_ms_;
   BackOffStrategyPtr failure_backoff_strategy_;
   const bool respect_dns_ttl_;

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.cc
@@ -87,6 +87,8 @@ LogicalDnsCluster::LogicalDnsCluster(
     : ClusterImplBase(cluster, context, creation_status), dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_refresh_rate, 5000))),
+      dns_min_refresh_rate_ms_(std::chrono::milliseconds(
+          PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_min_refresh_rate, 0))),
       dns_jitter_ms_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_jitter, 0))),
       respect_dns_ttl_(dns_cluster.respect_dns_ttl()),
@@ -188,7 +190,8 @@ void LogicalDnsCluster::startResolve() {
           failure_backoff_strategy_->reset();
 
           if (respect_dns_ttl_ && addrinfo.ttl_ != std::chrono::seconds(0)) {
-            final_refresh_rate = addrinfo.ttl_;
+            final_refresh_rate =
+                std::max(std::chrono::milliseconds(addrinfo.ttl_), dns_min_refresh_rate_ms_);
           }
           if (dns_jitter_ms_.count() != 0) {
             // Note that `random_.random()` returns a uint64 while

--- a/source/extensions/clusters/logical_dns/logical_dns_cluster.h
+++ b/source/extensions/clusters/logical_dns/logical_dns_cluster.h
@@ -77,6 +77,7 @@ private:
 
   Network::DnsResolverSharedPtr dns_resolver_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
+  const std::chrono::milliseconds dns_min_refresh_rate_ms_;
   const std::chrono::milliseconds dns_jitter_ms_;
   BackOffStrategyPtr failure_backoff_strategy_;
   const bool respect_dns_ttl_;

--- a/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
+++ b/source/extensions/clusters/strict_dns/strict_dns_cluster.cc
@@ -38,6 +38,8 @@ StrictDnsClusterImpl::StrictDnsClusterImpl(
       local_info_(context.serverFactoryContext().localInfo()), dns_resolver_(dns_resolver),
       dns_refresh_rate_ms_(std::chrono::milliseconds(
           PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_refresh_rate, 5000))),
+      dns_min_refresh_rate_ms_(std::chrono::milliseconds(
+          PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_min_refresh_rate, 0))),
       dns_jitter_ms_(PROTOBUF_GET_MS_OR_DEFAULT(dns_cluster, dns_jitter, 0)),
       respect_dns_ttl_(dns_cluster.respect_dns_ttl()),
       dns_lookup_family_(
@@ -200,7 +202,8 @@ void StrictDnsClusterImpl::ResolveTarget::startResolve() {
 
           if (!response.empty() && parent_.respect_dns_ttl_ &&
               ttl_refresh_rate != std::chrono::seconds(0)) {
-            final_refresh_rate = ttl_refresh_rate;
+            final_refresh_rate = std::max(std::chrono::milliseconds(ttl_refresh_rate),
+                                          parent_.dns_min_refresh_rate_ms_);
             ASSERT(ttl_refresh_rate != std::chrono::seconds::max() &&
                    final_refresh_rate.count() > 0);
           }

--- a/source/extensions/clusters/strict_dns/strict_dns_cluster.h
+++ b/source/extensions/clusters/strict_dns/strict_dns_cluster.h
@@ -73,6 +73,7 @@ private:
   Network::DnsResolverSharedPtr dns_resolver_;
   std::list<ResolveTargetPtr> resolve_targets_;
   const std::chrono::milliseconds dns_refresh_rate_ms_;
+  const std::chrono::milliseconds dns_min_refresh_rate_ms_;
   const std::chrono::milliseconds dns_jitter_ms_;
   BackOffStrategyPtr failure_backoff_strategy_;
   const bool respect_dns_ttl_;

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -1665,6 +1665,62 @@ TEST_P(StrictDnsClusterImplParamTest, TtlAsDnsRefreshRateNoJitter) {
                          TestUtility::makeDnsResponse({}, std::chrono::seconds(5)));
 }
 
+TEST_P(StrictDnsClusterImplParamTest, TtlAsDnsRefreshRateWithMinRefreshRate) {
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.enable_new_dns_implementation", GetParam()}});
+
+  ResolverData resolver(*dns_resolver_, server_context_.dispatcher_);
+
+  // dns_min_refresh_rate: 10s, dns_refresh_rate: 4s, respect_dns_ttl: true
+  // TTL < min → use min; TTL > min → use TTL
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    cluster_type:
+      name: envoy.cluster.dns
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+        dns_refresh_rate: 4s
+        respect_dns_ttl: true
+        dns_min_refresh_rate: 10s
+        all_addresses_in_single_endpoint: false
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost1
+                    port_value: 11001
+  )EOF";
+
+  envoy::config::cluster::v3::Cluster cluster_config = parseClusterFromV3Yaml(yaml);
+
+  Envoy::Upstream::ClusterFactoryContextImpl factory_context(
+      server_context_, [dns_resolver = this->dns_resolver_]() { return dns_resolver; }, nullptr,
+      false);
+
+  auto cluster = *createStrictDnsCluster(cluster_config, factory_context, dns_resolver_);
+
+  MockPriorityUpdateCallback priority_update_cb;
+  auto priority_update_handle =
+      cluster->prioritySet().addPriorityUpdateCb(priority_update_cb.AsStdFunction());
+
+  cluster->initialize([] { return absl::OkStatus(); });
+
+  // TTL (5s) < dns_min_refresh_rate (10s) → refresh rate floored to 10s
+  EXPECT_CALL(priority_update_cb, Call).WillOnce(Return(absl::OkStatus()));
+  EXPECT_CALL(*resolver.timer_, enableTimer(std::chrono::milliseconds(10000), _));
+  resolver.dns_callback_(Network::DnsResolver::ResolutionStatus::Completed, "",
+                         TestUtility::makeDnsResponse({"192.168.1.1"}, std::chrono::seconds(5)));
+
+  // TTL (30s) > dns_min_refresh_rate (10s) → refresh rate uses TTL (30s); same IP, no rebuild
+  EXPECT_CALL(*resolver.timer_, enableTimer(std::chrono::milliseconds(30000), _));
+  resolver.dns_callback_(Network::DnsResolver::ResolutionStatus::Completed, "",
+                         TestUtility::makeDnsResponse({"192.168.1.1"}, std::chrono::seconds(30)));
+}
+
 TEST_P(StrictDnsClusterImplParamTest, NegativeDnsJitter) {
   scoped_runtime.mergeValues(
       {{"envoy.reloadable_features.enable_new_dns_implementation", GetParam()}});

--- a/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
+++ b/test/extensions/clusters/logical_dns/logical_dns_cluster_test.cc
@@ -491,6 +491,50 @@ TEST_P(LogicalDnsImplementationsTest, TtlAsDnsRefreshRate) {
                 TestUtility::makeDnsResponse({}, std::chrono::seconds(5)));
 }
 
+TEST_P(LogicalDnsImplementationsTest, TtlAsDnsRefreshRateWithMinRefreshRate) {
+  scoped_runtime_.mergeValues(
+      {{"envoy.reloadable_features.enable_new_dns_implementation", GetParam()}});
+
+  // dns_min_refresh_rate: 10s, dns_refresh_rate: 4s, respect_dns_ttl: true
+  // TTL < min → use min; TTL > min → use TTL
+  const std::string yaml = R"EOF(
+  name: name
+  connect_timeout: 0.25s
+  cluster_type:
+    name: envoy.cluster.dns
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster
+      dns_refresh_rate: 4s
+      respect_dns_ttl: true
+      dns_min_refresh_rate: 10s
+      dns_lookup_family: V4_ONLY
+  lb_policy: ROUND_ROBIN
+  load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                     address: foo.bar.com
+                     port_value: 443
+  )EOF";
+
+  expectResolve(Network::DnsLookupFamily::V4Only, "foo.bar.com");
+  setupFromV3Yaml(yaml);
+
+  // TTL (5s) < dns_min_refresh_rate (10s) → refresh rate floored to 10s
+  EXPECT_CALL(membership_updated_, ready());
+  EXPECT_CALL(initialized_, ready());
+  EXPECT_CALL(*resolve_timer_, enableTimer(std::chrono::milliseconds(10000), _));
+  dns_callback_(Network::DnsResolver::ResolutionStatus::Completed, "",
+                TestUtility::makeDnsResponse({"127.0.0.1"}, std::chrono::seconds(5)));
+
+  // TTL (30s) > dns_min_refresh_rate (10s) → refresh rate uses TTL (30s)
+  EXPECT_CALL(*resolve_timer_, enableTimer(std::chrono::milliseconds(30000), _));
+  dns_callback_(Network::DnsResolver::ResolutionStatus::Completed, "",
+                TestUtility::makeDnsResponse({"127.0.0.1"}, std::chrono::seconds(30)));
+}
+
 TEST_P(LogicalDnsImplementationsTest, BadConfig) {
   scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.enable_new_dns_implementation", GetParam()}});


### PR DESCRIPTION
**Commit Message:**
dns: add dns_min_refresh_rate to DnsCluster

Add a `dns_min_refresh_rate` field (field 10) to the `DnsCluster` extension proto. When `respect_dns_ttl` is enabled, DNS records with TTLs shorter than this value are refreshed at this rate instead. This prevents excessively frequent re-resolution for low-TTL records (e.g. a 1s TTL record would otherwise trigger DNS queries every second without this floor).

The field mirrors `DnsCacheConfig.dns_min_refresh_rate` and uses the same `>= 1s` validation constraint. The floor is applied in all three DNS cluster implementations: `StrictDnsClusterImpl`, `LogicalDnsCluster`, and `DnsClusterImpl` (the unified impl behind the `enable_new_dns_implementation` runtime flag).

**Risk Level:**
Low

**Testing:**
Added `TtlAsDnsRefreshRateWithMinRefreshRate` tests to both `StrictDnsClusterImplParamTest` (in `upstream_impl_test.cc`) and `LogicalDnsImplementationsTest` (in `logical_dns_cluster_test.cc`). Both tests are parameterized to cover the legacy and new DNS implementations. Each test verifies that TTLs below the minimum are floored, and TTLs above pass through.

**Docs Changes:**
Changelog entry added at `changelogs/current/new_features/dns_cluster__dns_min_refresh_rate.rst`.

**Release Notes:**
Included

**[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):**
New optional field on `DnsCluster`. Defaults to unset (no-op), fully backwards-compatible. Only active when `respect_dns_ttl: true` and the field is explicitly configured.