### PR TITLE
upstream connection ID in passthrough state

### DIFF
--- a/source/extensions/io_socket/user_space/BUILD
+++ b/source/extensions/io_socket/user_space/BUILD
@@ -22,6 +22,14 @@ envoy_cc_extension(
 )
 
 envoy_cc_library(
+    name = "filter_state_keys_lib",
+    hdrs = ["filter_state_keys.h"],
+    deps = [
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+envoy_cc_library(
     name = "io_handle_lib",
     hdrs = ["io_handle.h"],
     deps = [
@@ -57,9 +65,11 @@ envoy_cc_library(
     ],
     deps = [
         ":file_event_lib",
+        ":filter_state_keys_lib",
         ":io_handle_lib",
         "//source/common/event:dispatcher_includes",
         "//source/common/network:address_lib",
         "//source/common/network:default_socket_interface_lib",
+        "//source/common/stream_info:uint64_accessor_lib",
     ],
 )

--- a/source/extensions/io_socket/user_space/filter_state_keys.h
+++ b/source/extensions/io_socket/user_space/filter_state_keys.h
@@ -9,8 +9,7 @@ namespace UserSpace {
 
 // Key under which the originating connection ID is stored in the upstream
 // filter state.
-constexpr absl::string_view ConnectionIdFilterStateKey =
-    "envoy.io_socket.user_space.connection_id";
+constexpr absl::string_view ConnectionIdFilterStateKey = "envoy.io_socket.user_space.connection_id";
 
 } // namespace UserSpace
 } // namespace IoSocket

--- a/source/extensions/io_socket/user_space/filter_state_keys.h
+++ b/source/extensions/io_socket/user_space/filter_state_keys.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace IoSocket {
+namespace UserSpace {
+
+// Key under which the originating connection ID is stored in the upstream
+// filter state.
+constexpr absl::string_view ConnectionIdFilterStateKey =
+    "envoy.io_socket.user_space.connection_id";
+
+} // namespace UserSpace
+} // namespace IoSocket
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/io_socket/user_space/io_handle.h
+++ b/source/extensions/io_socket/user_space/io_handle.h
@@ -21,7 +21,8 @@ public:
    * called at most once before `mergeInto`.
    */
   virtual void initialize(std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                          const StreamInfo::FilterState::Objects& filter_state_objects) PURE;
+                          const StreamInfo::FilterState::Objects& filter_state_objects,
+                          uint64_t connection_id) PURE;
 
   /**
    * Merge the passthrough state into a recipient stream metadata and its

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -7,7 +7,9 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/utility.h"
 #include "source/common/network/address_impl.h"
+#include "source/common/stream_info/uint64_accessor_impl.h"
 #include "source/extensions/io_socket/user_space/file_event_impl.h"
+#include "source/extensions/io_socket/user_space/filter_state_keys.h"
 
 #include "absl/types/optional.h"
 
@@ -371,10 +373,11 @@ Api::SysCallIntResult IoHandleImpl::shutdown(int how) {
 
 void PassthroughStateImpl::initialize(
     std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-    const StreamInfo::FilterState::Objects& filter_state_objects) {
+    const StreamInfo::FilterState::Objects& filter_state_objects, uint64_t connection_id) {
   ASSERT(state_ == State::Created);
   metadata_ = std::move(metadata);
   filter_state_objects_ = filter_state_objects;
+  connection_id_ = connection_id;
   state_ = State::Initialized;
 }
 void PassthroughStateImpl::mergeInto(envoy::config::core::v3::Metadata& metadata,
@@ -388,8 +391,15 @@ void PassthroughStateImpl::mergeInto(envoy::config::core::v3::Metadata& metadata
     filter_state.setData(object.name_, object.data_, StreamInfo::FilterState::LifeSpan::Connection,
                          object.stream_sharing_);
   }
+  if (connection_id_.has_value()) {
+    filter_state.setData(ConnectionIdFilterStateKey,
+                         std::make_shared<StreamInfo::UInt64AccessorImpl>(*connection_id_),
+                         StreamInfo::FilterState::LifeSpan::Connection,
+                         StreamInfo::StreamSharingMayImpactPooling::None);
+  }
   metadata_ = nullptr;
   filter_state_objects_.clear();
+  connection_id_ = absl::nullopt;
   state_ = State::Done;
 }
 

--- a/source/extensions/io_socket/user_space/io_handle_impl.cc
+++ b/source/extensions/io_socket/user_space/io_handle_impl.cc
@@ -371,9 +371,9 @@ Api::SysCallIntResult IoHandleImpl::shutdown(int how) {
   return {0, 0};
 }
 
-void PassthroughStateImpl::initialize(
-    std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-    const StreamInfo::FilterState::Objects& filter_state_objects, uint64_t connection_id) {
+void PassthroughStateImpl::initialize(std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
+                                      const StreamInfo::FilterState::Objects& filter_state_objects,
+                                      uint64_t connection_id) {
   ASSERT(state_ == State::Created);
   metadata_ = std::move(metadata);
   filter_state_objects_ = filter_state_objects;

--- a/source/extensions/io_socket/user_space/io_handle_impl.h
+++ b/source/extensions/io_socket/user_space/io_handle_impl.h
@@ -194,7 +194,8 @@ private:
 class PassthroughStateImpl : public PassthroughState, public Logger::Loggable<Logger::Id::io> {
 public:
   void initialize(std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                  const StreamInfo::FilterState::Objects& filter_state_objects) override;
+                  const StreamInfo::FilterState::Objects& filter_state_objects,
+                  uint64_t connection_id) override;
   void mergeInto(envoy::config::core::v3::Metadata& metadata,
                  StreamInfo::FilterState& filter_state) override;
 
@@ -203,6 +204,7 @@ protected:
   State state_{State::Created};
   std::unique_ptr<envoy::config::core::v3::Metadata> metadata_;
   StreamInfo::FilterState::Objects filter_state_objects_;
+  absl::optional<uint64_t> connection_id_;
 };
 
 using IoHandleImplPtr = std::unique_ptr<IoHandleImpl>;

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
@@ -15,7 +15,8 @@ void InternalSocket::setTransportSocketCallbacks(Network::TransportSocketCallbac
   transport_socket_->setTransportSocketCallbacks(callbacks);
   auto* io_handle = dynamic_cast<IoSocket::UserSpace::IoHandle*>(&callbacks.ioHandle());
   if (io_handle != nullptr && io_handle->passthroughState()) {
-    io_handle->passthroughState()->initialize(std::move(metadata_), filter_state_objects_);
+    io_handle->passthroughState()->initialize(std::move(metadata_), filter_state_objects_,
+                                              callbacks.connection().id());
   }
   metadata_ = nullptr;
   filter_state_objects_.clear();

--- a/test/extensions/io_socket/user_space/BUILD
+++ b/test/extensions/io_socket/user_space/BUILD
@@ -34,9 +34,11 @@ envoy_extension_cc_test(
     extension_names = ["envoy.io_socket.user_space"],
     rbe_pool = "6gig",
     deps = [
+        "//envoy/stream_info:uint64_accessor_interface",
         "//source/common/common:utility_lib",
         "//source/common/network:address_lib",
         "//source/common/stream_info:filter_state_lib",
+        "//source/extensions/io_socket/user_space:filter_state_keys_lib",
         "//source/extensions/io_socket/user_space:io_handle_impl_lib",
         "//test/mocks/event:event_mocks",
     ],

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -1,9 +1,11 @@
 #include "envoy/buffer/buffer.h"
 #include "envoy/event/file_event.h"
+#include "envoy/stream_info/uint64_accessor.h"
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/stream_info/filter_state_impl.h"
+#include "source/extensions/io_socket/user_space/filter_state_keys.h"
 #include "source/extensions/io_socket/user_space/io_handle_impl.h"
 
 #include "test/mocks/event/mocks.h"
@@ -1194,7 +1196,8 @@ TEST_F(IoHandleImplTest, PassthroughState) {
       {object, StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection,
        "object_key"});
   ASSERT_NE(nullptr, io_handle_->passthroughState());
-  io_handle_->passthroughState()->initialize(std::move(source_metadata), source_filter_state);
+  io_handle_->passthroughState()->initialize(std::move(source_metadata), source_filter_state,
+                                             /*connection_id=*/42);
 
   StreamInfo::FilterStateImpl dest_filter_state(StreamInfo::FilterState::LifeSpan::Connection);
   envoy::config::core::v3::Metadata dest_metadata;
@@ -1205,6 +1208,11 @@ TEST_F(IoHandleImplTest, PassthroughState) {
   auto dest_object = dest_filter_state.getDataReadOnly<TestObject>("object_key");
   ASSERT_NE(nullptr, dest_object);
   ASSERT_EQ(object->value_, dest_object->value_);
+
+  const auto* connection_id =
+      dest_filter_state.getDataReadOnly<StreamInfo::UInt64Accessor>(ConnectionIdFilterStateKey);
+  ASSERT_NE(nullptr, connection_id);
+  EXPECT_EQ(42, connection_id->value());
 }
 
 class IoHandleImplNotImplementedTest : public testing::Test {

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -44,7 +44,8 @@ class MockPassthroughState : public PassthroughState {
 public:
   MOCK_METHOD(void, initialize,
               (std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-               const StreamInfo::FilterState::Objects& filter_state_objects));
+               const StreamInfo::FilterState::Objects& filter_state_objects,
+               uint64_t connection_id));
   MOCK_METHOD(void, mergeInto,
               (envoy::config::core::v3::Metadata & metadata,
                StreamInfo::FilterState& filter_state));
@@ -91,9 +92,10 @@ TEST_F(InternalSocketTest, PassthroughStateInjected) {
   auto state = std::make_shared<NiceMock<MockPassthroughState>>();
   NiceMock<MockUserSpaceIoHandle> io_handle;
   EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
-  EXPECT_CALL(*state, initialize(_, _))
+  EXPECT_CALL(*state, initialize(_, _, _))
       .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+                           const StreamInfo::FilterState::Objects& filter_state_objects,
+                           uint64_t) -> void {
         ASSERT_EQ("val",
                   metadata->filter_metadata().at("envoy.test").fields().at("key").string_value());
         ASSERT_EQ(1, filter_state_objects.size());
@@ -109,9 +111,10 @@ TEST_F(InternalSocketTest, EmptyPassthroughState) {
   auto state = std::make_shared<NiceMock<MockPassthroughState>>();
   NiceMock<MockUserSpaceIoHandle> io_handle;
   EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
-  EXPECT_CALL(*state, initialize(_, _))
+  EXPECT_CALL(*state, initialize(_, _, _))
       .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+                           const StreamInfo::FilterState::Objects& filter_state_objects,
+                           uint64_t) -> void {
         ASSERT_EQ(nullptr, metadata);
         ASSERT_EQ(0, filter_state_objects.size());
       }));


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Introduces upstream connection ID in internal socket filter state.

Additional Description: 

This allows for upstream and downstream filters sitting on both sides of an internal connection to use the referred connection ID as a common key for communication using thread local storage. The connection ID is transparently obtained during the internal socket creation. An upstream network filter (initiating the internal connection) will have access to that ID from its own stream information. A downstream filter (on the listener side of the internal connection) can now obtain the ID from filter state and use it as a common key to exchange data with the upstream network filter.

Solutions we've tried:
 - **Using the downstream ID connection**. We tried this using "set_filter_state", but that doesn't work as there's cases where the ID is not necessarily unique. For example, when a HTTP2 connection generates multiple upstream connections due to its multiplexing behaviour. The downstream connection ID is the same for all the connections created in upstream.
 - **Creating a ClientConnectionFactory**. One of the suggestions in Slack was to create our own implementation of ClientConnectionFactory so we can create our own implementation of PassthroughState. That would require a lot of boilerplate code and replication. Also, it still requires configuration change as the client connection factory needs to be specified whenever a filter needs the unique key for upstream/downstream communication.
 - **IternalSocket extension**. We're also investigating the use of an extension of InternalSocket. Though, InternalSocket doesn't seem to be so friendly to be extended, as it stores a copy of filter state (used to store the unique ID) during construction time privately, and it doesn't offer any interfaces for it to be modified.
 
Risk Level: Low
Testing: Unit test added
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
