### PR TITLE
bazel: add BAZEL_USE_LIBSTDCPP support for building with libstdc++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -164,6 +164,7 @@ common:libc++ --@envoy//bazel:libc++=true
 build:libstdc++ --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
 build:libstdc++ --@envoy//bazel:libc++=false
 build:libstdc++ --@envoy//bazel:libstdc++=true
+build:libstdc++ --repo_env=BAZEL_USE_LIBSTDCPP=True
 
 
 #############################################################################

--- a/bazel/repo.bzl
+++ b/bazel/repo.bzl
@@ -133,12 +133,19 @@ def _envoy_repo_impl(repository_ctx):
     # Starlark file - we should only accept a proper boolean value and nothing else.
     local_sysroot = {"True": True, "False": False}.get(local_sysroot, False)
 
+    # When set to True, the toolchain uses libstdc++ instead of the default
+    # builtin libc++. This is useful on systems where libc++ is not available
+    # (e.g. RHEL/UBI).
+    use_libstdcpp = repository_ctx.os.environ.get("BAZEL_USE_LIBSTDCPP", "False")
+    use_libstdcpp = {"True": True, "False": False}.get(use_libstdcpp, False)
+
     repository_ctx.file("compiler.bzl", """
 LLVM_PATH = '%s'
 LLVM_VERSION_LOCAL = '%s'
 LLVM_LIB_DIR = '%s'
 USE_LOCAL_SYSROOT = %s
-""" % (llvm_path, llvm_version_local, llvm_lib_dir, local_sysroot))
+USE_LIBSTDCPP = %s
+""" % (llvm_path, llvm_version_local, llvm_lib_dir, local_sysroot, use_libstdcpp))
     repository_ctx.file("version.bzl", "VERSION = '%s'\nAPI_VERSION = '%s'" % (version, api_version))
     repository_ctx.file("path.bzl", "PATH = '%s'" % repo_version_path.dirname)
     repository_ctx.file("envoy_repo.py", "PATH = '%s'\nVERSION = '%s'\nAPI_VERSION = '%s'" % (repo_version_path.dirname, version, api_version))
@@ -335,7 +342,7 @@ _envoy_repo = repository_rule(
         "envoy_api_version": attr.label(default = "@envoy//:API_VERSION.txt"),
         "envoy_ci_config": attr.label(default = "@envoy//:.github/config.yml"),
     },
-    environ = ["BAZEL_LLVM_PATH", "BAZEL_USE_HOST_SYSROOT"],
+    environ = ["BAZEL_LLVM_PATH", "BAZEL_USE_HOST_SYSROOT", "BAZEL_USE_LIBSTDCPP"],
 )
 
 def envoy_repo():

--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -1,4 +1,4 @@
-load("@envoy_repo//:compiler.bzl", "LLVM_LIB_DIR", "LLVM_PATH", "LLVM_VERSION_LOCAL", "USE_LOCAL_SYSROOT")
+load("@envoy_repo//:compiler.bzl", "LLVM_LIB_DIR", "LLVM_PATH", "LLVM_VERSION_LOCAL", "USE_LIBSTDCPP", "USE_LOCAL_SYSROOT")
 load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
@@ -71,6 +71,7 @@ def envoy_toolchains():
             "linux-x86_64": "@libcxx_libs_x86_64",
         },
         cxx_standard = {"": "c++20"},
+        stdlib = {"": "stdc++"} if USE_LIBSTDCPP else {},
         sysroot = {} if USE_LOCAL_SYSROOT else {
             "linux-x86_64": "@sysroot_linux_amd64//:sysroot",
             "linux-aarch64": "@sysroot_linux_arm64//:sysroot",


### PR DESCRIPTION
On systems where libc++ is not available (e.g. RHEL/UBI), the LLVM toolchain defaults to builtin-libc++ which fails to find C++ standard library headers. This adds a BAZEL_USE_LIBSTDCPP repo env variable that configures the LLVM toolchain to use libstdc++ instead.

This allows building with clang and libstdc++ by using bazel flags `--config=libstdc++ --config=clang-common`.
