### PR TITLE
lb: fix crash in validateEndpoints with non-contiguous EDS priorities

### DIFF
--- a/changelogs/current/bug_fixes/load_balancer__fixed-crash-in-validateendpoints-with-non.rst
+++ b/changelogs/current/bug_fixes/load_balancer__fixed-crash-in-validateendpoints-with-non.rst
@@ -1,0 +1,5 @@
+Fixed a crash in the ``ring_hash`` and ``maglev`` load balancers when an EDS
+ClusterLoadAssignment uses non-contiguous priorities (e.g. priorities ``0`` and
+``5`` with ``1``-``4`` absent). ``TypedHashLbConfigBase::validateEndpoints`` now
+skips the null host-list entries that ``PriorityStateManager`` leaves in the gap
+slots instead of dereferencing them.

--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
@@ -393,6 +393,10 @@ TypedHashLbConfigBase::TypedHashLbConfigBase(absl::Span<const HashPolicyProto* c
 absl::Status TypedHashLbConfigBase::validateEndpoints(const PriorityState& priorities) const {
 
   for (const auto& [hosts, locality_weights_map] : priorities) {
+    // Non-contiguous EDS priorities leave gap slots with a null host list; skip them.
+    if (hosts == nullptr) {
+      continue;
+    }
     // Sum should be at most uint32_t max value, so we can validate it by accumulating into uint64_t
     // and making sure there was no overflow.
     uint64_t host_sum = 0;

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -1251,6 +1251,31 @@ TEST(RingHashMidBatchInitializeCrashTest, NoOobOnNewPriority) {
   EXPECT_NE(nullptr, worker_lb);
 }
 
+// Regression test for #44349: non-contiguous EDS priorities leave null host
+// entries in PriorityState that validateEndpoints must not dereference.
+TEST(TypedHashLbConfigValidateEndpoints, ToleratesNullHostsInPriorityGaps) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash config;
+  absl::Status creation_status;
+  TypedRingHashLbConfig typed_config(config, context.regex_engine_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+
+  PriorityState priorities;
+  auto hosts_p0 = std::make_unique<HostVector>();
+  hosts_p0->push_back(makeTestHost(info, "tcp://127.0.0.1:80"));
+  priorities.emplace_back(std::move(hosts_p0), LocalityWeightsMap{});
+  for (int i = 0; i < 4; ++i) {
+    priorities.emplace_back(nullptr, LocalityWeightsMap{});
+  }
+  auto hosts_p5 = std::make_unique<HostVector>();
+  hosts_p5->push_back(makeTestHost(info, "tcp://127.0.0.1:81"));
+  priorities.emplace_back(std::move(hosts_p5), LocalityWeightsMap{});
+
+  EXPECT_TRUE(typed_config.validateEndpoints(priorities).ok());
+}
+
 } // namespace
 } // namespace Upstream
 } // namespace Envoy


### PR DESCRIPTION
TypedHashLbConfigBase::validateEndpoints iterates the PriorityState and dereferences each entry's host list without checking for null. When an EDS ClusterLoadAssignment uses non-contiguous priorities (e.g. only priorities 0 and 5 are present), PriorityStateManager::initializePriorityFor resizes the priority vector and leaves the gap slots as default-constructed pairs with a null HostListPtr, crashing ring_hash and maglev clusters during secondary cluster initialization.

The eds.cc update loop already guards the same access with `if (priority_state[i].first != nullptr)`; mirror that guard inside validateEndpoints so the gap slots are skipped rather than dereferenced.

Fixes #44349

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->


