### PR TITLE
bazel: patch toolchains_llvm to fix stdc++ link order

### DIFF
--- a/bazel/foreign_cc/toolchains_llvm_stdc++.patch
+++ b/bazel/foreign_cc/toolchains_llvm_stdc++.patch
@@ -1,0 +1,15 @@
+# Fix stdc++ link order: place libstdc++.a in link_libs (after objects) instead
+# of link_flags (before objects) to avoid duplicate symbols with tcmalloc.
+# Fixed upstream in toolchains_llvm master; remove this patch on v1.8.0+.
+diff --git a/toolchain/cc_toolchain_config.bzl b/toolchain/cc_toolchain_config.bzl
+--- a/toolchain/cc_toolchain_config.bzl
++++ b/toolchain/cc_toolchain_config.bzl
+@@ -334,7 +334,7 @@
+             "-stdlib=libstdc++",
+         ]
+
+-        link_flags.extend([
++        link_libs.extend([
+             "-l:libstdc++.a",
+         ])
+     elif stdlib == "libc":

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -955,7 +955,10 @@ def _toolchains_llvm():
     external_http_archive(
         name = "toolchains_llvm",
         patch_args = ["-p1"],
-        patches = ["@envoy_toolshed//:patches/toolchains_llvm.patch"],
+        patches = [
+            "@envoy_toolshed//:patches/toolchains_llvm.patch",
+            "@envoy//bazel/foreign_cc:toolchains_llvm_stdc++.patch",
+        ],
     )
 
 def _wasmtime():


### PR DESCRIPTION
With `stdlib=stdc++`, toolchains_llvm v1.7.0 places `-l:libstdc++.a` in `link_flags` (before object files), causing duplicate symbol errors with tcmalloc which overrides operator new/delete. Move it to `link_libs` (after object files) so tcmalloc's definitions take precedence.

This is already fixed upstream in `toolchains_llvm` master; the patch can be removed when upgrading to v1.8.0+.
