### PR TITLE
vcl: fix `addrlen` computations in `memcpy` calls

### DIFF
--- a/contrib/vcl/source/vcl_io_handle.cc
+++ b/contrib/vcl/source/vcl_io_handle.cc
@@ -48,13 +48,13 @@ void vclEndptCopy(sockaddr* addr, socklen_t* addrlen, const vppcom_endpt_t& ep) 
   if (ep.is_ip4) {
     sockaddr_in* addr4 = reinterpret_cast<sockaddr_in*>(addr);
     addr4->sin_family = AF_INET;
-    *addrlen = std::min(static_cast<unsigned int>(sizeof(struct sockaddr_in)), *addrlen);
+    *addrlen = std::min(static_cast<unsigned int>(sizeof(struct in_addr)), *addrlen);
     memcpy(&addr4->sin_addr, ep.ip, *addrlen); // NOLINT(safe-memcpy)
     addr4->sin_port = ep.port;
   } else {
     sockaddr_in6* addr6 = reinterpret_cast<sockaddr_in6*>(addr);
     addr6->sin6_family = AF_INET6;
-    *addrlen = std::min(static_cast<unsigned int>(sizeof(struct sockaddr_in6)), *addrlen);
+    *addrlen = std::min(static_cast<unsigned int>(sizeof(struct in6_addr)), *addrlen);
     memcpy(&addr6->sin6_addr, ep.ip, *addrlen); // NOLINT(safe-memcpy)
     addr6->sin6_port = ep.port;
   }
@@ -67,13 +67,13 @@ Envoy::Network::Address::InstanceConstSharedPtr vclEndptToAddress(const vppcom_e
 
   if (ep.is_ip4) {
     addr.ss_family = AF_INET;
-    len = sizeof(struct sockaddr_in);
+    len = sizeof(struct in_addr);
     auto in4 = reinterpret_cast<struct sockaddr_in*>(&addr);
     memcpy(&in4->sin_addr, ep.ip, len); // NOLINT(safe-memcpy)
     in4->sin_port = ep.port;
   } else {
     addr.ss_family = AF_INET6;
-    len = sizeof(struct sockaddr_in6);
+    len = sizeof(struct in6_addr);
     auto in6 = reinterpret_cast<struct sockaddr_in6*>(&addr);
     memcpy(&in6->sin6_addr, ep.ip, len); // NOLINT(safe-memcpy)
     in6->sin6_port = ep.port;


### PR DESCRIPTION
Commit Message:
Field `sin_addr` of structure `sockaddr_in` uses type `struct in_addr` (4 bytes), not `struct sockaddr_in`. For `sockaddr_in6`, field `sin6_addr` uses type `struct in6_addr`. Functions `vclEndptCopy` and `vclEndptToAddress` used the wrong structure when preparing the size parameter of `memcpy` calls.

Additional Description:
Before opening this PR, I contacted envoy-security@googlegroups.com to make sure I was not publishing a vulnerability. Someone replied that Envoy code in the `contrib/` directory is not covered by the thread model and is not subject to security release process, thus enabling the creation of this Pull Request.

Risk Level: Low
Testing: compile-tested the change
Docs Changes: N/A
Release Notes: I'm not sure whether this simple fix needs a release note.
Platform Specific Features: nothing new, `struct in_addr` is in some POSIX standard that Linux/Windows/macOS follow (cf. [`man sockaddr_in(3type)`](https://man7.org/linux/man-pages/man3/sockaddr_in.3type.html) and [`man sockaddr_in6(3type)`](https://man7.org/linux/man-pages/man3/sockaddr_in6.3type.html)).