### PR TITLE
Update QUICHE from 6b6a9b743 to 0abb446b2

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-06-05"
+  release_date: "2026-06-11"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "6b6a9b74324ddefa455c1f207788e0a75feeb817",
-        sha256 = "3b0c1f0d078fd61e77788559b53f36e28829da7fc675914a1bc18e33f9c14803",
+        version = "0abb446b2b1d020f2feeada562b920fdf658a9be",
+        sha256 = "15cd2b0d49425958f895e258a0a3332ac71c78c4b518944b110b8708e8b8130e",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/6b6a9b743..0abb446b2

```
$ git log 6b6a9b743..0abb446b2 --date=short --no-merges --format="%ad %al %s"

2026-06-11 asedeno Bump anonymous-tokens dependency in QUICHE.
2026-06-10 ericorth QBONE Server Simulator: Minor shutdown crash fix
2026-06-10 ericorth QBONE Server Simulator: Add generic logic to handle control messages
2026-06-09 ericorth QBONE Server Simulator: Implement open-source BasicQuicServer
2026-06-09 dschinazi Allow expecting multiple errors in OHTTP test client
2026-06-09 asedeno Conditionalize testing of QUIC server padding.
2026-06-09 asedeno Remove protobuf WKT doppleganglers from QUICHE.
2026-06-06 quiche-dev Log request header count in GFE. We will use this for potential log analysis in the context of Sonic Marmot (omg/98169).
2026-06-05 quiche-dev Fix 5 ClangTidyReadability findings: * function 'QuicConnectionIdHasher' has inline specifier but is implicitly inlined. For more info, see go/clang_tidy/checks/readability-redundant-inline-specifier (2 times) * function 'ReviseFirstByteByVersion' has inline specifier but is implicitly inlined. For more info, see go/clang_tidy/checks/readability-redundant-inline-specifier (2 times) * function 'Hash' has inline specifier but is implicitly inlined. For more info, see go/clang_tidy/checks/readability-redundant-inline-specifier
2026-06-05 vasilvv Support the "has first object in the subgroup" bit in the subgroup header.
```

Risk Level: Low
Testing: CI