### PR TITLE
mobile: Add the ability to set the request timeout

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -213,6 +213,11 @@ EngineBuilder& EngineBuilder::setPerTryIdleTimeoutSeconds(int per_try_idle_timeo
   return *this;
 }
 
+EngineBuilder& EngineBuilder::setRequestTimeoutMilliseconds(int request_timeout_ms) {
+  request_timeout_ms_ = request_timeout_ms;
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::enableGzipDecompression(bool gzip_decompression_on) {
   gzip_decompression_filter_ = gzip_decompression_on;
   return *this;
@@ -520,7 +525,12 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   route->mutable_per_request_buffer_limit_bytes()->set_value(4096);
   auto* route_to = route->mutable_route();
   route_to->set_cluster_header("x-envoy-mobile-cluster");
-  route_to->mutable_timeout()->set_seconds(0);
+  if (request_timeout_ms_ > 0) {
+    route_to->mutable_timeout()->set_nanos((request_timeout_ms_ % 1000) * 1000000);
+    route_to->mutable_timeout()->set_seconds(request_timeout_ms_ / 1000);
+  } else {
+    route_to->mutable_timeout()->set_seconds(0);
+  }
   route_to->mutable_retry_policy()->mutable_per_try_idle_timeout()->set_seconds(
       per_try_idle_timeout_seconds_);
   auto* backoff = route_to->mutable_retry_policy()->mutable_retry_back_off();

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -61,6 +61,7 @@ public:
   EngineBuilder& setDeviceOs(std::string app_id);
   EngineBuilder& setStreamIdleTimeoutSeconds(int stream_idle_timeout_seconds);
   EngineBuilder& setPerTryIdleTimeoutSeconds(int per_try_idle_timeout_seconds);
+  EngineBuilder& setRequestTimeoutMilliseconds(int request_timeout_ms);
   EngineBuilder& enableGzipDecompression(bool gzip_decompression_on);
   EngineBuilder& enableBrotliDecompression(bool brotli_decompression_on);
   EngineBuilder& enableSocketTagging(bool socket_tagging_on);
@@ -220,6 +221,7 @@ private:
   std::string device_os_ = "unspecified";
   int stream_idle_timeout_seconds_ = 15;
   int per_try_idle_timeout_seconds_ = 15;
+  int request_timeout_ms_ = 0;
   bool gzip_decompression_filter_ = true;
   bool brotli_decompression_filter_ = false;
   bool socket_tagging_filter_ = false;

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -135,6 +135,11 @@ public:
     return static_cast<T&>(*this);
   }
 
+  T& setRequestTimeoutMilliseconds(int request_timeout_ms) {
+    request_timeout_ms_ = request_timeout_ms;
+    return static_cast<T&>(*this);
+  }
+
   T& setPerConnectionBufferLimitBytes(uint32_t per_connection_buffer_limit_bytes) {
     per_connection_buffer_limit_bytes_ = per_connection_buffer_limit_bytes;
     return static_cast<T&>(*this);
@@ -278,6 +283,7 @@ protected:
 
 protected:
   bool useWorkerThread() const { return use_worker_thread_; }
+  int requestTimeoutMs() const { return request_timeout_ms_; }
 
   void setWatchdog(envoy::config::bootstrap::v3::Watchdogs watchdog) {
     watchdog_ = std::move(watchdog);
@@ -364,6 +370,7 @@ private:
   absl::optional<envoy::type::matcher::v3::ListStringMatcher> stats_inclusion_list_;
   uint32_t per_connection_buffer_limit_bytes_ = 10485760;
   int stream_idle_timeout_seconds_ = 15;
+  int request_timeout_ms_ = 0;
   std::vector<std::pair<std::string, bool>> reloadable_runtime_guards_;
   std::vector<std::pair<std::string, bool>> restart_runtime_guards_;
 

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -458,7 +458,12 @@ absl::Status MobileEngineBuilder::configureRouteConfig(
   route->mutable_per_request_buffer_limit_bytes()->set_value(4096);
   auto* route_to = route->mutable_route();
   route_to->set_cluster_header("x-envoy-mobile-cluster");
-  route_to->mutable_timeout()->set_seconds(0);
+  if (requestTimeoutMs() > 0) {
+    route_to->mutable_timeout()->set_nanos((requestTimeoutMs() % 1000) * 1000000);
+    route_to->mutable_timeout()->set_seconds(requestTimeoutMs() / 1000);
+  } else {
+    route_to->mutable_timeout()->set_seconds(0);
+  }
   route_to->mutable_retry_policy()->mutable_per_try_idle_timeout()->set_seconds(
       per_try_idle_timeout_seconds_);
   auto* backoff = route_to->mutable_retry_policy()->mutable_retry_back_off();

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -215,6 +215,17 @@ TEST(TestConfig, StreamIdleTimeout) {
   EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("stream_idle_timeout { seconds: 42 }"));
 }
 
+TEST(TestConfig, RequestTimeout) {
+  EngineBuilder engine_builder;
+
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("timeout { }"));
+
+  engine_builder.setRequestTimeoutMilliseconds(42500);
+  bootstrap = engine_builder.generateBootstrap();
+  EXPECT_THAT(bootstrap->ShortDebugString(), HasSubstr("timeout { seconds: 42 nanos: 500000000 }"));
+}
+
 TEST(TestConfig, PerTryIdleTimeout) {
   EngineBuilder engine_builder;
 


### PR DESCRIPTION
Currently, the request timeout is hard-coded to be disabled. This change enables setting the request timeout, which is the time from when Envoy receives the HTTP request to the time Envoy receives the full HTTP response for that request.