### PR TITLE
router: add experimental HTTP/1.1 kTLS body-splice fast path

### DIFF
--- a/changelogs/current/new_features/router__added-http1-ktls-body-splice.rst
+++ b/changelogs/current/new_features/router__added-http1-ktls-body-splice.rst
@@ -1,4 +1,4 @@
 Added an experimental HTTP/1.1 kTLS body-splice fast path, guarded by
 ``envoy.reloadable_features.http1_ktls_body_splice`` and disabled by default. When eligible, a
 Content-Length request or response body is relayed with in-kernel ``splice()`` and exposed through
-``cluster.<name>.http1_ktls_splice.{engaged,abandoned,completed,truncated}`` counters.
+``cluster.<name>.http1_ktls_splice_{engaged,abandoned,completed,truncated}`` counters.

--- a/changelogs/current/new_features/router__added-http1-ktls-body-splice.rst
+++ b/changelogs/current/new_features/router__added-http1-ktls-body-splice.rst
@@ -1,0 +1,4 @@
+Added an experimental HTTP/1.1 kTLS body-splice fast path, guarded by
+``envoy.reloadable_features.http1_ktls_body_splice`` and disabled by default. When eligible, a
+Content-Length request or response body is relayed with in-kernel ``splice()`` and exposed through
+``cluster.<name>.http1_ktls_splice.{engaged,abandoned,completed,truncated}`` counters.

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -52,6 +52,10 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_cx_http1_total, Counter, Total HTTP/1.1 connections
   upstream_cx_http2_total, Counter, Total HTTP/2 connections
   upstream_cx_http3_total, Counter, Total HTTP/3 connections
+  http1_ktls_splice.engaged, Counter, Total HTTP/1.1 kTLS body-splices that engaged
+  http1_ktls_splice.abandoned, Counter, Total HTTP/1.1 kTLS body-splices abandoned before engage
+  http1_ktls_splice.completed, Counter, Total HTTP/1.1 kTLS body-splices completed
+  http1_ktls_splice.truncated, Counter, Total HTTP/1.1 kTLS body-splices truncated
   upstream_cx_connect_fail, Counter, Total connection failures
   upstream_cx_connect_timeout, Counter, Total connection connect timeouts
   upstream_cx_connect_with_0_rtt, Counter, Total connections able to send 0-rtt requests (early data).

--- a/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
+++ b/docs/root/configuration/upstream/cluster_manager/cluster_stats.rst
@@ -52,10 +52,10 @@ Every cluster has a statistics tree rooted at *cluster.<name>.* with the followi
   upstream_cx_http1_total, Counter, Total HTTP/1.1 connections
   upstream_cx_http2_total, Counter, Total HTTP/2 connections
   upstream_cx_http3_total, Counter, Total HTTP/3 connections
-  http1_ktls_splice.engaged, Counter, Total HTTP/1.1 kTLS body-splices that engaged
-  http1_ktls_splice.abandoned, Counter, Total HTTP/1.1 kTLS body-splices abandoned before engage
-  http1_ktls_splice.completed, Counter, Total HTTP/1.1 kTLS body-splices completed
-  http1_ktls_splice.truncated, Counter, Total HTTP/1.1 kTLS body-splices truncated
+  http1_ktls_splice_engaged, Counter, Total HTTP/1.1 kTLS body-splices that engaged
+  http1_ktls_splice_abandoned, Counter, Total HTTP/1.1 kTLS body-splices abandoned before engage
+  http1_ktls_splice_completed, Counter, Total HTTP/1.1 kTLS body-splices completed
+  http1_ktls_splice_truncated, Counter, Total HTTP/1.1 kTLS body-splices truncated
   upstream_cx_connect_fail, Counter, Total connection failures
   upstream_cx_connect_timeout, Counter, Total connection connect timeouts
   upstream_cx_connect_with_0_rtt, Counter, Total connections able to send 0-rtt requests (early data).

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -22,6 +22,10 @@
 #include "source/common/http/status.h"
 
 namespace Envoy {
+namespace Network {
+class Connection;
+} // namespace Network
+
 namespace Http {
 
 enum class CodecType { HTTP1, HTTP2, HTTP3 };
@@ -137,6 +141,12 @@ public:
    * Enable TCP Tunneling.
    */
   virtual void enableTcpTunneling() PURE;
+
+  /**
+   * Finalize a Content-Length response body relayed by kTLS body-splice.
+   * @param response_body_bytes the number of body bytes spliced.
+   */
+  virtual void completeSplicedResponse(uint64_t /* response_body_bytes */) {}
 };
 
 /**
@@ -196,6 +206,12 @@ public:
                                        Http::ResponseHeaderMapConstSharedPtr response_header_map,
                                        Http::ResponseTrailerMapConstSharedPtr response_trailer_map,
                                        StreamInfo::StreamInfo& stream_info) PURE;
+
+  /**
+   * Finalize a Content-Length request body relayed by kTLS body-splice.
+   * @param request_body_bytes the number of body bytes spliced.
+   */
+  virtual void completeSplicedRequest(uint64_t /* request_body_bytes */) {}
 };
 
 class ResponseDecoder;
@@ -440,6 +456,15 @@ public:
    * associated with the stream.
    */
   virtual const Network::ConnectionInfoProvider& connectionInfoProvider() PURE;
+
+  /**
+   * @return OptRef<Network::Connection> the underlying network connection when this stream is the
+   * sole user of a non-multiplexed connection whose socket can be borrowed for the kTLS body-splice
+   * fast path. Implemented only by the HTTP/1.1 codec. Multiplexed codecs (HTTP/2 and HTTP/3) and
+   * the default return absl::nullopt so a raw-socket splice is never attempted where it would
+   * corrupt framing.
+   */
+  virtual OptRef<Network::Connection> connectionForSplice() { return {}; }
 
   /**
    * Set the flush timeout for the stream. At the codec level this is used to bound the amount of

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -408,6 +408,17 @@ public:
    */
   virtual void
   requestRouteConfigUpdate(RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) PURE;
+
+  /**
+   * @return downstream HTTP/1.1 connection available for kTLS body-splice, or empty.
+   */
+  virtual OptRef<Network::Connection> downstreamConnectionForSplice() { return {}; }
+
+  /**
+   * Finalize a Content-Length request body relayed by kTLS body-splice.
+   * @param request_body_bytes the number of body bytes spliced.
+   */
+  virtual void completeSplicedRequest(uint64_t /* request_body_bytes */) {}
 };
 
 /**

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -317,9 +317,10 @@ public:
   virtual void reinstallFileEvents() {}
 
   /**
-   * Drains pending write-buffer bytes so body-splice can emit them before the spliced body.
+   * Moves pending write-buffer bytes into `dst` so body-splice can emit them before the spliced
+   * body. Defaults to a no-op.
    */
-  virtual std::string extractPendingWriteForSplice() { return {}; }
+  virtual void extractPendingWriteForSplice(Buffer::Instance&) {}
 
   /**
    * @return requested server name (e.g. SNI in TLS), if any.

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -23,6 +23,8 @@ class Dispatcher;
 
 namespace Network {
 
+struct KtlsBytestreamInfo;
+
 /**
  * Events that occur on a connection.
  */
@@ -303,6 +305,21 @@ public:
    */
   // TODO(snowp): Remove this in favor of StreamInfo::downstreamSslConnection.
   virtual Ssl::ConnectionInfoConstSharedPtr ssl() const PURE;
+
+  /**
+   * @return kTLS bytestream info for direct socket splice, or empty.
+   */
+  virtual OptRef<const KtlsBytestreamInfo> ktlsBytestreamInfo() const { return {}; }
+
+  /**
+   * Re-arm the read/write file event after kTLS body-splice detaches it.
+   */
+  virtual void reinstallFileEvents() {}
+
+  /**
+   * Drains pending write-buffer bytes so body-splice can emit them before the spliced body.
+   */
+  virtual std::string extractPendingWriteForSplice() { return {}; }
 
   /**
    * @return requested server name (e.g. SNI in TLS), if any.

--- a/envoy/network/transport_socket.h
+++ b/envoy/network/transport_socket.h
@@ -36,6 +36,12 @@ namespace Network {
 class Connection;
 enum class ConnectionEvent;
 
+// Reports whether kTLS is installed and trusted for body-splice.
+struct KtlsBytestreamInfo {
+  bool installed{false};
+  bool trusted_peer{false};
+};
+
 /**
  * Result of each I/O event.
  */
@@ -190,6 +196,13 @@ public:
    * @return the const SSL connection data if this is an SSL connection, or nullptr if it is not.
    */
   virtual Ssl::ConnectionInfoConstSharedPtr ssl() const PURE;
+
+  /**
+   * @return kTLS bytestream info (installed plus trusted-peer state) if this transport socket has
+   * installed kernel TLS and can be spliced on directly, otherwise an empty OptRef. The base
+   * returns empty.
+   */
+  virtual OptRef<const KtlsBytestreamInfo> ktlsBytestreamInfo() const { return {}; }
 
   /**
    * Instructs a transport socket to start using secure transport.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1680,6 +1680,17 @@ public:
    * Get the bytes meter for this stream.
    */
   virtual const StreamInfo::BytesMeterSharedPtr& bytesMeter() PURE;
+
+  /**
+   * @return upstream HTTP/1.1 connection available for kTLS body-splice, or empty.
+   */
+  virtual OptRef<Network::Connection> upstreamConnectionForSplice() { return {}; }
+
+  /**
+   * Finalize a Content-Length response body relayed by kTLS body-splice.
+   * @param response_body_bytes the number of body bytes spliced.
+   */
+  virtual void completeSplicedResponse(uint64_t /* response_body_bytes */) {}
 };
 
 /*

--- a/envoy/router/router_filter_interface.h
+++ b/envoy/router/router_filter_interface.h
@@ -131,6 +131,21 @@ public:
   virtual FilterConfig& config() PURE;
 
   /*
+   * Disables any further retries for this stream. Used by the kTLS body-splice fast path. Once an
+   * upload splice streams the request body raw off the downstream socket (past the router's
+   * retry-buffer accounting), a retry could only replay the buffered prefix (a short, corrupt
+   * request), and a truncated splice leaves the downstream parser desynced, so retries must stop.
+   */
+  virtual void disableRetries() PURE;
+
+  /*
+   * Whether a streaming shadow or mirror is active for this stream. An engaged upload splice reads
+   * the request body raw off the downstream socket and never runs it through `decodeData`, so the
+   * coordinator skips the splice when this is true and lets the buffered path feed the shadows.
+   */
+  virtual bool shadowStreamsActive() const PURE;
+
+  /*
    * @returns the various timeouts for this stream.
    */
   virtual TimeoutData timeout() PURE;

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -730,6 +730,10 @@ public:
  */
 #define ALL_CLUSTER_TRAFFIC_STATS(COUNTER, GAUGE, HISTOGRAM, TEXT_READOUT, STATNAME)               \
   COUNTER(bind_errors)                                                                             \
+  COUNTER(http1_ktls_splice_abandoned)                                                             \
+  COUNTER(http1_ktls_splice_completed)                                                             \
+  COUNTER(http1_ktls_splice_engaged)                                                               \
+  COUNTER(http1_ktls_splice_truncated)                                                             \
   COUNTER(original_dst_host_invalid)                                                               \
   COUNTER(retry_or_shadow_abandoned)                                                               \
   COUNTER(upstream_cx_close_notify)                                                                \

--- a/source/common/http/codec_wrappers.h
+++ b/source/common/http/codec_wrappers.h
@@ -167,6 +167,13 @@ public:
     return inner_encoder_->http1StreamEncoderOptions();
   }
 
+  // The RequestEncoder default no-ops, so forward it or a spliced response never finalizes and the
+  // next keep-alive request on the connection wedges.
+  void completeSplicedResponse(uint64_t response_body_bytes) override {
+    ASSERT(inner_encoder_);
+    inner_encoder_->completeSplicedResponse(response_body_bytes);
+  }
+
 protected:
   RequestEncoderWrapper(RequestEncoder* inner) : inner_encoder_(inner) {}
 

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -318,6 +318,15 @@ private:
     void refreshRouteCluster() override;
     void requestRouteConfigUpdate(
         Http::RouteConfigUpdatedCallbackSharedPtr route_config_updated_cb) override;
+    OptRef<Network::Connection> downstreamConnectionForSplice() override {
+      return response_encoder_ != nullptr ? response_encoder_->getStream().connectionForSplice()
+                                          : OptRef<Network::Connection>{};
+    }
+    void completeSplicedRequest(uint64_t request_body_bytes) override {
+      if (response_encoder_ != nullptr) {
+        response_encoder_->completeSplicedRequest(request_body_bytes);
+      }
+    }
 
     void setVirtualHostRoute(Router::VirtualHostRoute route);
     // Set cached route. This method should never be called directly. This is only called in the

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -401,6 +401,10 @@ const Network::ConnectionInfoProvider& StreamEncoderImpl::connectionInfoProvider
   return connection_.connection().connectionInfoProvider();
 }
 
+OptRef<Network::Connection> StreamEncoderImpl::connectionForSplice() {
+  return makeOptRef(connection_.connection());
+}
+
 static constexpr absl::string_view RESPONSE_PREFIX = "HTTP/1.1 ";
 static constexpr absl::string_view HTTP_10_RESPONSE_PREFIX = "HTTP/1.0 ";
 
@@ -509,6 +513,20 @@ Status RequestEncoderImpl::encodeHeaders(const RequestHeaderMap& headers, bool e
   encodeHeadersBase(headers, absl::nullopt, end_stream,
                     HeaderUtility::requestShouldHaveNoBody(headers));
   return okStatus();
+}
+
+void RequestEncoderImpl::completeSplicedResponse(uint64_t response_body_bytes) {
+  // A RequestEncoderImpl is only ever created by ClientConnectionImpl::newStream (it lives inside
+  // PendingResponse), so its connection is always a ClientConnectionImpl. Dispatch to the
+  // connection that owns the response parser and pending response.
+  static_cast<ClientConnectionImpl&>(connection_).completeSplicedResponse(response_body_bytes);
+}
+
+void ResponseEncoderImpl::completeSplicedRequest(uint64_t request_body_bytes) {
+  // A ResponseEncoderImpl is only ever created by ServerConnectionImpl (it lives inside
+  // ActiveRequest), so its connection is always a ServerConnectionImpl. Dispatch to the connection
+  // that owns the request parser and active request.
+  static_cast<ServerConnectionImpl&>(connection_).completeSplicedRequest(request_body_bytes);
 }
 
 CallbackResult ConnectionImpl::setAndCheckCallbackStatus(Status&& status) {
@@ -1654,6 +1672,72 @@ CallbackResult ClientConnectionImpl::onMessageCompleteBase() {
 
   // Pause the parser after a response is complete. Any remaining data indicates an error.
   return parser_->pause();
+}
+
+void ClientConnectionImpl::completeSplicedResponse(uint64_t response_body_bytes) {
+  ENVOY_CONN_LOG(trace, "splice complete: {} response body bytes relayed out-of-band", connection_,
+                 response_body_bytes);
+  // The fast path only engages on a Content-Length response after the request has finished
+  // encoding, so there is always an active, not-yet-complete pending response and no deferred
+  // headers or trailer state to flush.
+  ASSERT(pending_response_.has_value() && !pending_response_done_);
+  ASSERT(!deferred_end_stream_headers_ && !processing_trailers_);
+  ASSERT(encode_complete_);
+  // The spliced bytes bypassed the network connection's read accounting, so attribute them to the
+  // response here.
+  getBytesMeter().addWireBytesReceived(response_body_bytes);
+
+  PendingResponse& response = pending_response_.value();
+  // After delivering end stream below we can no longer reset, so latch completion first.
+  pending_response_done_ = true;
+  ResponseDecoder* decoder = response.decoder_handle_->get().ptr();
+  ENVOY_BUG(decoder != nullptr, "ResponseDecoder is null in completeSplicedResponse");
+  if (decoder != nullptr) {
+    Buffer::OwnedImpl empty;
+    decoder->decodeData(empty, true);
+  }
+  // Reset to ensure no information from one request persists to the next.
+  pending_response_.reset();
+  headers_or_trailers_.emplace<ResponseHeaderMapPtr>(nullptr);
+
+  // The spliced body never reached the parser, leaving it stuck mid-body. Rebuild it so the next
+  // response on this keep-alive connection parses from a clean state, equivalent to the
+  // ready-for-next-message state a normal onMessageComplete leaves via parser_->pause() and the
+  // resume() that the next dispatch performs.
+  parser_ = std::make_unique<BalsaParser>(MessageType::Response, this, max_headers_kb_ * 1024,
+                                          enableTrailers(), codec_settings_.allow_custom_methods_);
+}
+
+void ServerConnectionImpl::completeSplicedRequest(uint64_t request_body_bytes) {
+  ENVOY_CONN_LOG(trace, "splice complete: {} request body bytes relayed out-of-band", connection_,
+                 request_body_bytes);
+  // The fast path only engages on a Content-Length request body, so there is always an active,
+  // not-yet-complete request and no deferred header or trailer state to flush.
+  ASSERT(active_request_ != nullptr && !active_request_->remote_complete_);
+  ASSERT(!deferred_end_stream_headers_ && !processing_trailers_);
+  // The spliced bytes bypassed the network connection's read accounting, so attribute them to the
+  // request here.
+  getBytesMeter().addWireBytesReceived(request_body_bytes);
+
+  // Mirror onMessageCompleteBase() for a Content-Length body. Latch completion, then deliver the
+  // terminal end-of-stream to the request decoder, which finalizes the upstream request and readies
+  // the downstream stream for its response.
+  active_request_->remote_complete_ = true;
+  RequestDecoder* decoder = active_request_->request_decoder_handle_->get().ptr();
+  ENVOY_BUG(decoder != nullptr, "RequestDecoder is null in completeSplicedRequest");
+  if (decoder != nullptr) {
+    Buffer::OwnedImpl empty;
+    decoder->decodeData(empty, true);
+  }
+  // Reset to ensure no information from one request persists to the next.
+  headers_or_trailers_.emplace<RequestHeaderMapPtr>(nullptr);
+
+  // The spliced body never reached the parser, leaving it stuck mid-body. Rebuild it so the next
+  // request on this keep-alive connection parses from a clean state, equivalent to the
+  // ready-for-next-message state a normal onMessageComplete leaves via parser_->pause() and the
+  // resume() that the next dispatch performs.
+  parser_ = std::make_unique<BalsaParser>(MessageType::Request, this, max_headers_kb_ * 1024,
+                                          enableTrailers(), codec_settings_.allow_custom_methods_);
 }
 
 void ClientConnectionImpl::onResetStream(StreamResetReason reason) {

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -68,6 +68,10 @@ public:
   uint32_t bufferLimit() const override;
   absl::string_view responseDetails() override { return details_; }
   const Network::ConnectionInfoProvider& connectionInfoProvider() override;
+  // HTTP/1.1 owns its connection one stream at a time, so the backing socket can be borrowed for
+  // the kTLS body-splice fast path. Defined out-of-line because it dereferences the
+  // forward-declared ConnectionImpl.
+  OptRef<Network::Connection> connectionForSplice() override;
   void setFlushTimeout(std::chrono::milliseconds) override {
     // HTTP/1 has one stream per connection, thus any data encoded is immediately written to the
     // connection, invoking any watermarks as necessary. There is no internal buffering that would
@@ -178,6 +182,9 @@ public:
   // TODO(paulsohn): Enable H/1 codec to get a pointer to the new
   // request decoder on recreateStream, here or elsewhere.
   void setRequestDecoder(Http::RequestDecoder& /*decoder*/) override {}
+  // Defined out-of-line because it dispatches to the owning ServerConnectionImpl, which is declared
+  // later in this header.
+  void completeSplicedRequest(uint64_t request_body_bytes) override;
 
   // Http1::StreamEncoderImpl
   void resetStream(StreamResetReason reason) override;
@@ -202,6 +209,9 @@ public:
   Status encodeHeaders(const RequestHeaderMap& headers, bool end_stream) override;
   void encodeTrailers(const RequestTrailerMap& trailers) override { encodeTrailersBase(trailers); }
   void enableTcpTunneling() override { is_tcp_tunneling_ = true; }
+  // Defined out-of-line because it dispatches to the owning ClientConnectionImpl, which is declared
+  // later in this header.
+  void completeSplicedResponse(uint64_t response_body_bytes) override;
 
 private:
   bool upgrade_request_{};
@@ -463,6 +473,12 @@ public:
                        Server::OverloadManager& overload_manager);
   bool supportsHttp10() override { return codec_settings_.accept_http_10_; }
 
+  // Finalizes a request whose Content-Length body was relayed out-of-band by the kTLS body-splice
+  // fast path. Mirrors onMessageCompleteBase() for a Content-Length body, then rebuilds the parser
+  // (which is otherwise stuck mid-body because the spliced bytes bypassed it) so the connection can
+  // carry the next keep-alive request.
+  void completeSplicedRequest(uint64_t request_body_bytes);
+
 protected:
   /**
    * An active HTTP/1.1 request.
@@ -584,6 +600,12 @@ public:
                        bool passing_through_proxy = false);
   // Http::ClientConnection
   RequestEncoder& newStream(ResponseDecoder& response_decoder) override;
+
+  // Finalizes a response whose Content-Length body was relayed out-of-band by the kTLS body-splice
+  // fast path. Mirrors onMessageCompleteBase() for a Content-Length body, then rebuilds the parser
+  // (which is otherwise stuck mid-body because the spliced bytes bypassed it) so the connection can
+  // carry the next keep-alive response.
+  void completeSplicedResponse(uint64_t response_body_bytes);
 
 private:
   struct PendingResponse {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -115,15 +115,13 @@ void ConnectionImpl::initializeReadWriteFileEvent() {
       trigger, Event::FileReadyType::Read | Event::FileReadyType::Write);
 }
 
-std::string ConnectionImpl::extractPendingWriteForSplice() {
+void ConnectionImpl::extractPendingWriteForSplice(Buffer::Instance& dst) {
   // Hand the kTLS body-splice the bytes already accepted for write but not yet flushed, so the pump
-  // emits them before the spliced body. Detaching them from the write buffer is safe because the
+  // emits them before the spliced body. Moving them out of the write buffer is safe because the
   // splice now drives this socket's output and re-arms the connection when it completes. The splice
   // calls this with only the (small) response headers buffered, well below the high watermark, so
   // the drain does not cross the low watermark or fire a watermark callback.
-  std::string pending = write_buffer_->toString();
-  write_buffer_->drain(write_buffer_->length());
-  return pending;
+  dst.move(*write_buffer_);
 }
 
 void ConnectionImpl::reinstallFileEvents() {

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -91,6 +91,17 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
     connecting_ = true;
   }
 
+  initializeReadWriteFileEvent();
+
+  transport_socket_->setTransportSocketCallbacks(*this);
+
+  // TODO(soulxu): generate the connection id inside the addressProvider directly,
+  // then we don't need a setter or any of the optional stuff.
+  socket_->connectionInfoProvider().setConnectionID(id());
+  socket_->connectionInfoProvider().setSslConnection(transport_socket_->ssl());
+}
+
+void ConnectionImpl::initializeReadWriteFileEvent() {
   Event::FileTriggerType trigger = Event::PlatformDefaultTriggerType;
 
   // We never ask for both early close and read at the same time. If we are reading, we want to
@@ -102,13 +113,27 @@ ConnectionImpl::ConnectionImpl(Event::Dispatcher& dispatcher, ConnectionSocketPt
         return absl::OkStatus();
       },
       trigger, Event::FileReadyType::Read | Event::FileReadyType::Write);
+}
 
-  transport_socket_->setTransportSocketCallbacks(*this);
+std::string ConnectionImpl::extractPendingWriteForSplice() {
+  // Hand the kTLS body-splice the bytes already accepted for write but not yet flushed, so the pump
+  // emits them before the spliced body. Detaching them from the write buffer is safe because the
+  // splice now drives this socket's output and re-arms the connection when it completes. The splice
+  // calls this with only the (small) response headers buffered, well below the high watermark, so
+  // the drain does not cross the low watermark or fire a watermark callback.
+  std::string pending = write_buffer_->toString();
+  write_buffer_->drain(write_buffer_->length());
+  return pending;
+}
 
-  // TODO(soulxu): generate the connection id inside the addressProvider directly,
-  // then we don't need a setter or any of the optional stuff.
-  socket_->connectionInfoProvider().setConnectionID(id());
-  socket_->connectionInfoProvider().setSslConnection(transport_socket_->ssl());
+void ConnectionImpl::reinstallFileEvents() {
+  // The kTLS body-splice borrows this connection's socket and detaches its file event via
+  // getSocket()->ioHandle().resetFileEvents() for the duration of the bounded transfer. Re-create
+  // the identical read/write registration so Envoy resumes driving I/O for the next keep-alive
+  // message once the splice completes. Read readiness is still gated by read_disable_count_ in
+  // onReadReady(), so re-registering Read is safe even if reads were disabled before the splice.
+  ASSERT(socket_->isOpen());
+  initializeReadWriteFileEvent();
 }
 
 ConnectionImpl::~ConnectionImpl() {

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -100,7 +100,7 @@ public:
     return transport_socket_->ktlsBytestreamInfo();
   }
   void reinstallFileEvents() override;
-  std::string extractPendingWriteForSplice() override;
+  void extractPendingWriteForSplice(Buffer::Instance& dst) override;
   State state() const override;
   bool connecting() const override {
     ENVOY_CONN_LOG_EVENT(debug, "connection_connecting_state", "current connecting state: {}",

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -96,6 +96,11 @@ public:
     // SSL info may be overwritten by a filter in the provider.
     return socket_->connectionInfoProvider().sslConnection();
   }
+  OptRef<const KtlsBytestreamInfo> ktlsBytestreamInfo() const override {
+    return transport_socket_->ktlsBytestreamInfo();
+  }
+  void reinstallFileEvents() override;
+  std::string extractPendingWriteForSplice() override;
   State state() const override;
   bool connecting() const override {
     ENVOY_CONN_LOG_EVENT(debug, "connection_connecting_state", "current connecting state: {}",
@@ -230,6 +235,9 @@ private:
   friend class Envoy::RandomPauseFilter;
   friend class Envoy::TestPauseFilter;
 
+  // Installs the read/write file event on the socket's IoHandle. Shared by the constructor and
+  // reinstallFileEvents() so the kTLS body-splice can re-arm with the exact same registration.
+  void initializeReadWriteFileEvent();
   void onFileEvent(uint32_t events);
   void onRead(uint64_t read_buffer_size);
   void onReadReady();

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -220,8 +220,8 @@ OptRef<const KtlsBytestreamInfo> MultiConnectionBaseImpl::ktlsBytestreamInfo() c
 // bounded splice completes.
 void MultiConnectionBaseImpl::reinstallFileEvents() { connections_[0]->reinstallFileEvents(); }
 
-std::string MultiConnectionBaseImpl::extractPendingWriteForSplice() {
-  return connections_[0]->extractPendingWriteForSplice();
+void MultiConnectionBaseImpl::extractPendingWriteForSplice(Buffer::Instance& dst) {
+  connections_[0]->extractPendingWriteForSplice(dst);
 }
 
 Connection::State MultiConnectionBaseImpl::state() const {

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -207,6 +207,23 @@ Ssl::ConnectionInfoConstSharedPtr MultiConnectionBaseImpl::ssl() const {
   return connections_[0]->ssl();
 }
 
+// Delegate to the active connection so the kTLS body-splice can discover the inner kTLS socket and
+// splice() on its fd. Without this the Happy Eyeballs wrapper used for DNS clusters reports the
+// base default "not kTLS" and the splice never engages on a hostname upstream.
+OptRef<const KtlsBytestreamInfo> MultiConnectionBaseImpl::ktlsBytestreamInfo() const {
+  return connections_[0]->ktlsBytestreamInfo();
+}
+
+// Delegate to the active connection so the kTLS body-splice re-arms the inner socket it borrowed
+// (getSocket() and ktlsBytestreamInfo() above resolve to the same connection). Without this a
+// Happy Eyeballs (DNS-cluster) upstream would keep the base no-op and never resume reads after a
+// bounded splice completes.
+void MultiConnectionBaseImpl::reinstallFileEvents() { connections_[0]->reinstallFileEvents(); }
+
+std::string MultiConnectionBaseImpl::extractPendingWriteForSplice() {
+  return connections_[0]->extractPendingWriteForSplice();
+}
+
 Connection::State MultiConnectionBaseImpl::state() const {
   if (!connect_finished_) {
     ASSERT(connections_[0]->state() == Connection::State::Open);

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -118,7 +118,7 @@ public:
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
   OptRef<const KtlsBytestreamInfo> ktlsBytestreamInfo() const override;
   void reinstallFileEvents() override;
-  std::string extractPendingWriteForSplice() override;
+  void extractPendingWriteForSplice(Buffer::Instance& dst) override;
   State state() const override;
   bool connecting() const override;
   uint32_t bufferLimit() const override;

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -116,6 +116,9 @@ public:
   absl::optional<UnixDomainSocketPeerCredentials> unixSocketPeerCredentials() const override;
   // Note, this might change before connect finishes.
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
+  OptRef<const KtlsBytestreamInfo> ktlsBytestreamInfo() const override;
+  void reinstallFileEvents() override;
+  std::string extractPendingWriteForSplice() override;
   State state() const override;
   bool connecting() const override;
   uint32_t bufferLimit() const override;
@@ -137,7 +140,13 @@ public:
   void hashKey(std::vector<uint8_t>& hash_key) const override;
   void dumpState(std::ostream& os, int indent_level) const override;
 
-  const Network::ConnectionSocketPtr& getSocket() const override { PANIC("not implemented"); }
+  // After connect, connections_ holds only the selected connection (same invariant ssl() and
+  // nextProtocol() rely on above), so its socket is well-defined. The kTLS body-splice queries this
+  // post-connect to splice() on the upstream kTLS fd. Without it the splice would panic on a Happy
+  // Eyeballs (DNS-cluster) upstream.
+  const Network::ConnectionSocketPtr& getSocket() const override {
+    return connections_[0]->getSocket();
+  }
 
 private:
   // ConnectionCallbacks which will be set on an ClientConnection which

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -371,10 +371,12 @@ envoy_cc_library(
     name = "router_lib",
     srcs = [
         "router.cc",
+        "splice_coordinator.cc",
         "upstream_request.cc",
     ],
     hdrs = [
         "router.h",
+        "splice_coordinator.h",
         "upstream_request.h",
     ],
     deps = [
@@ -393,6 +395,7 @@ envoy_cc_library(
         "//envoy/http:filter_factory_interface",
         "//envoy/http:filter_interface",
         "//envoy/local_info:local_info_interface",
+        "//envoy/network:address_interface",
         "//envoy/router:router_filter_interface",
         "//envoy/router:shadow_writer_interface",
         "//envoy/runtime:runtime_interface",
@@ -423,7 +426,9 @@ envoy_cc_library(
         "//source/common/network:upstream_socket_options_filter_state_lib",
         "//source/common/orca:orca_load_metrics_lib",
         "//source/common/orca:orca_parser",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/stream_info:uint32_accessor_lib",
+        "//source/common/tcp_proxy:splice_pump_lib",
         "//source/common/upstream:load_balancer_context_base_lib",
         "//source/common/upstream:upstream_factory_context_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -527,6 +527,11 @@ public:
   Http::StreamDecoderFilterCallbacks* callbacks() override { return callbacks_; }
   Upstream::ClusterInfoConstSharedPtr cluster() override { return cluster_; }
   FilterConfig& config() override { return *config_; }
+  // Disable all further retries for this stream (kTLS body-splice upload engage). Resetting
+  // retry_state_ makes maybeRetryReset / shouldRetryHeaders short-circuit, so no retry can replay a
+  // request whose body was streamed raw past the retry buffer.
+  void disableRetries() override { retry_state_.reset(); }
+  bool shadowStreamsActive() const override { return !shadow_streams_.empty(); }
   TimeoutData timeout() override { return timeout_; }
   absl::optional<std::chrono::milliseconds> dynamicMaxStreamDuration() const override {
     return dynamic_max_stream_duration_;

--- a/source/common/router/splice_coordinator.cc
+++ b/source/common/router/splice_coordinator.cc
@@ -1,0 +1,518 @@
+#include "source/common/router/splice_coordinator.h"
+
+#include "envoy/http/header_map.h"
+#include "envoy/network/address.h"
+#include "envoy/stats/scope.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/router/router.h"
+#include "source/common/router/upstream_request.h"
+#include "source/common/runtime/runtime_features.h"
+
+#include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
+
+namespace Envoy {
+namespace Router {
+
+namespace {
+
+// Returns the OS fd that backs the splice.
+absl::optional<os_fd_t> spliceableFd(Network::Connection& connection) {
+  if (connection.state() != Network::Connection::State::Open) {
+    return absl::nullopt;
+  }
+  // An internal-listener connection has no kernel fd to splice on.
+  if (connection.connectionInfoProvider().localAddress()->type() ==
+      Network::Address::Type::EnvoyInternal) {
+    return absl::nullopt;
+  }
+  const os_fd_t fd = connection.getSocket()->ioHandle().fdDoNotUse();
+  if (fd == INVALID_SOCKET) {
+    return absl::nullopt;
+  }
+  return fd;
+}
+
+} // namespace
+
+SpliceCoordinator::SpliceCoordinator(UpstreamRequest& upstream_request)
+    : upstream_request_(upstream_request) {}
+
+SpliceCoordinator::~SpliceCoordinator() = default;
+
+bool SpliceCoordinator::maybeArmForResponse(const Http::ResponseHeaderMap& headers,
+                                            bool end_stream) {
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_ktls_body_splice")) {
+    return false;
+  }
+  // A header-only response has no body to splice.
+  if (end_stream) {
+    return false;
+  }
+  // The request encoder must be done before the upstream connection can be borrowed.
+  if (!upstream_request_.encodeComplete()) {
+    return false;
+  }
+  // The splice needs a fixed body boundary.
+  const Http::HeaderEntry* content_length_header = headers.ContentLength();
+  if (content_length_header == nullptr) {
+    return false;
+  }
+  uint64_t content_length = 0;
+  if (!absl::SimpleAtoi(content_length_header->value().getStringView(), &content_length) ||
+      content_length < MinSpliceBodyBytes) {
+    return false;
+  }
+  // Both legs must be single, non-multiplexed HTTP/1.1 sockets.
+  OptRef<Network::Connection> upstream = upstreamConnection();
+  OptRef<Network::Connection> downstream = downstreamConnection();
+  if (!upstream.has_value() || !downstream.has_value()) {
+    return false;
+  }
+  // Upstream kTLS reads yield decrypted plaintext.
+  OptRef<const Network::KtlsBytestreamInfo> ktls = upstream->ktlsBytestreamInfo();
+  if (!ktls.has_value() || !ktls->installed || !ktls->trusted_peer) {
+    return false;
+  }
+  // Raw writes are safe only to plaintext or installed-kTLS sockets.
+  if (!sinkLegIsRawOrKtls(downstream.ref())) {
+    return false;
+  }
+
+  content_length_ = content_length;
+  direction_ = Direction::Download;
+  engage_polls_ = 0;
+  completion_status_ = TcpProxy::SpliceCompletion::Closed;
+  armed_ = true;
+  ENVOY_LOG(debug, "kTLS body-splice armed for {}-byte response body", content_length_);
+  return true;
+}
+
+bool SpliceCoordinator::maybeArmForRequest(const Http::RequestHeaderMap& headers, bool end_stream) {
+  if (!Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_ktls_body_splice")) {
+    return false;
+  }
+  // A body-less request has nothing to splice.
+  if (end_stream) {
+    return false;
+  }
+  // The splice needs a fixed body boundary.
+  const Http::HeaderEntry* content_length_header = headers.ContentLength();
+  if (content_length_header == nullptr) {
+    return false;
+  }
+  uint64_t content_length = 0;
+  if (!absl::SimpleAtoi(content_length_header->value().getStringView(), &content_length) ||
+      content_length < MinSpliceBodyBytes) {
+    return false;
+  }
+  // Raw reads are safe only from plaintext or installed-kTLS sockets.
+  OptRef<Network::Connection> downstream = downstreamConnection();
+  if (!downstream.has_value() || !sinkLegIsRawOrKtls(downstream.ref())) {
+    return false;
+  }
+
+  content_length_ = content_length;
+  direction_ = Direction::Upload;
+  engage_polls_ = 0;
+  completion_status_ = TcpProxy::SpliceCompletion::Closed;
+  armed_ = true;
+  // Hold the request body in the kernel until the upstream installs kTLS-TX.
+  downstream->readDisable(true);
+  source_read_disabled_ = true;
+  ENVOY_LOG(debug, "kTLS body-splice armed for {}-byte request body", content_length_);
+  return true;
+}
+
+void SpliceCoordinator::scheduleEngage() {
+  if (!armed_) {
+    return;
+  }
+  if (engage_callback_ == nullptr) {
+    engage_callback_ =
+        upstream_request_.parent_.callbacks()->dispatcher().createSchedulableCallback(
+            [this]() { engage(); });
+  }
+  // Engage after this read unwinds and headers are encoded.
+  engage_callback_->scheduleCallbackCurrentIteration();
+}
+
+bool SpliceCoordinator::bufferPreEngageBody(Buffer::Instance& data, bool end_stream) {
+  ASSERT(armed_ && !engaged());
+  // Stop holding when there is no body left to splice or the in-memory bound is exceeded.
+  if (end_stream || pre_engage_body_.length() + data.length() > MaxHeldBodyBytes) {
+    abandon();
+    return false;
+  }
+  // Hold the body back from the sink codec. Engage emits it ahead of the spliced remainder.
+  pre_engage_body_.move(data);
+  return true;
+}
+
+void SpliceCoordinator::disarm() {
+  armed_ = false;
+  if (engage_callback_ != nullptr) {
+    engage_callback_->cancel();
+  }
+  if (engage_poll_timer_ != nullptr) {
+    engage_poll_timer_->disableTimer();
+  }
+}
+
+void SpliceCoordinator::abandon() {
+  // Held bytes must precede resumed reads on the wire.
+  incSpliceCounter("abandoned");
+  flushPreEngageBody();
+  maybeReadEnableSource();
+  disarm();
+}
+
+bool SpliceCoordinator::sinkLegIsRawOrKtls(Network::Connection& connection) {
+  return TcpProxy::spliceLegIsRawOrKtls(connection);
+}
+
+void SpliceCoordinator::onSpliceProgress() {
+  upstream_request_.resetPerTryIdleTimer();
+  // The codec is bypassed, so byte movement refreshes the HCM stream idle timer.
+  upstream_request_.parent_.callbacks()->resetIdleTimer();
+  // Re-arm the no-progress watchdog.
+  if (progress_watchdog_ != nullptr) {
+    progress_watchdog_->enableTimer(ProgressWatchdogTimeout);
+  }
+}
+
+void SpliceCoordinator::armProgressWatchdog() {
+  if (progress_watchdog_ == nullptr) {
+    progress_watchdog_ = upstream_request_.parent_.callbacks()->dispatcher().createTimer([this]() {
+      // Part of the body may have reached the sink, so a stalled splice cannot recover.
+      ENVOY_LOG(debug, "kTLS body-splice no-progress watchdog fired, resetting");
+      upstream_request_.onResetStream(Http::StreamResetReason::ConnectionTermination,
+                                      "kTLS body-splice stalled");
+    });
+  }
+  progress_watchdog_->enableTimer(ProgressWatchdogTimeout);
+}
+
+void SpliceCoordinator::incSpliceCounter(absl::string_view event) {
+  // Count once per splice decision, never per byte.
+  const Upstream::ClusterInfoConstSharedPtr cluster = upstream_request_.parent_.cluster();
+  if (cluster == nullptr) {
+    return;
+  }
+  cluster->statsScope().counterFromString(absl::StrCat("http1_ktls_splice.", event)).inc();
+}
+
+void SpliceCoordinator::maybeReadEnableSource() {
+  if (!source_read_disabled_) {
+    return;
+  }
+  source_read_disabled_ = false;
+  OptRef<Network::Connection> downstream = downstreamConnection();
+  // readDisable() asserts the connection is open.
+  if (downstream.has_value() && downstream->state() == Network::Connection::State::Open) {
+    // Reinstall before re-enabling a source leg detached by engage().
+    if (legs_detached_) {
+      downstream->reinstallFileEvents();
+    }
+    downstream->readDisable(false);
+  }
+}
+
+void SpliceCoordinator::rescheduleEngage() {
+  if (++engage_polls_ > MaxEngagePolls) {
+    // Fall back if upstream kTLS-TX does not become ready.
+    ENVOY_LOG(debug, "kTLS body-splice skipped: upstream not ready after {} polls", engage_polls_);
+    abandon();
+    return;
+  }
+  if (engage_poll_timer_ == nullptr) {
+    engage_poll_timer_ =
+        upstream_request_.parent_.callbacks()->dispatcher().createTimer([this]() { engage(); });
+  }
+  // Space the poll across connect, handshake, and kTLS-TX install I/O.
+  engage_poll_timer_->enableTimer(std::chrono::milliseconds(2));
+}
+
+void SpliceCoordinator::engage() {
+  if (!armed_) {
+    return;
+  }
+
+  OptRef<Network::Connection> upstream = upstreamConnection();
+  OptRef<Network::Connection> downstream = downstreamConnection();
+
+  // Upload waits until the upstream connects and installs kTLS-TX.
+  if (direction_ == Direction::Upload) {
+    // Shadows need the normal decodeData path to see the request body.
+    if (upstream_request_.parent_.shadowStreamsActive()) {
+      abandon();
+      return;
+    }
+    if (!downstream.has_value()) {
+      abandon();
+      return;
+    }
+    if (!upstream.has_value()) {
+      // Once the upstream stream exists, an empty splice connection means it is not HTTP/1.1.
+      if (upstream_request_.upstream_ != nullptr) {
+        ENVOY_LOG(debug, "kTLS body-splice skipped: upstream is not a borrowable HTTP/1.1 socket");
+        abandon();
+        return;
+      }
+      rescheduleEngage(); // Upstream pool not ready yet.
+      return;
+    }
+    OptRef<const Network::KtlsBytestreamInfo> ktls = upstream->ktlsBytestreamInfo();
+    if (!ktls.has_value()) {
+      // The splice cannot frame TLS records in userspace.
+      abandon();
+      return;
+    }
+    if (!ktls->installed || !ktls->trusted_peer) {
+      rescheduleEngage(); // kTLS-TX still installing.
+      return;
+    }
+  }
+
+  armed_ = false;
+
+  if (!upstream.has_value() || !downstream.has_value()) {
+    ENVOY_LOG(debug, "kTLS body-splice skipped: a leg is no longer borrowable");
+    abandon();
+    return;
+  }
+
+  // Re-validate both legs after the schedulable-callback gap.
+  const bool download = direction_ == Direction::Download;
+  OptRef<const Network::KtlsBytestreamInfo> ktls = upstream->ktlsBytestreamInfo();
+  if (!ktls.has_value() || !ktls->installed || !ktls->trusted_peer ||
+      !sinkLegIsRawOrKtls(downstream.ref())) {
+    abandon();
+    return;
+  }
+  // The sink is downstream for downloads and upstream for uploads.
+  Network::Connection& sink = download ? downstream.ref() : upstream.ref();
+  const absl::optional<os_fd_t> up_fd = spliceableFd(upstream.ref());
+  const absl::optional<os_fd_t> down_fd = spliceableFd(downstream.ref());
+  if (!up_fd.has_value() || !down_fd.has_value()) {
+    abandon();
+    return;
+  }
+  // If the whole body arrived before engage, deliver it normally.
+  const uint64_t buffered = pre_engage_body_.length();
+  if (buffered >= content_length_) {
+    abandon();
+    return;
+  }
+  spliced_body_bytes_ = content_length_ - buffered;
+
+  auto pump = splice_pump_factory_(
+      down_fd.value(), up_fd.value(), /*up_is_ktls=*/true,
+      upstream_request_.parent_.callbacks()->dispatcher(),
+      [this](TcpProxy::SpliceCompletion status) { onSpliceComplete(status); },
+      // Byte movement refreshes liveness timers while the codec is bypassed.
+      [this](uint64_t) { onSpliceProgress(); }, [this](uint64_t) { onSpliceProgress(); });
+
+  // Create pipes before draining the sink write buffer so failure can still fall back.
+  if (!pump->createPipes(/*need_u2d=*/download, /*need_d2u=*/!download)) {
+    ENVOY_LOG(debug, "kTLS body-splice skipped: pipe creation failed, using buffered path");
+    abandon();
+    return;
+  }
+
+  // Preserve wire order by emitting headers and held body before the spliced remainder.
+  std::string pre_engage = sink.extractPendingWriteForSplice();
+  const size_t pending_size = pre_engage.size();
+  pre_engage.resize(pending_size + buffered);
+  pre_engage_body_.copyOut(0, buffered, pre_engage.data() + pending_size);
+  pre_engage_body_.drain(buffered);
+  // The sink write buffer is now drained, so the splice is committed.
+  incSpliceCounter("engaged");
+  // prepare() can fail only after bytes were drained, so failure resets the stream.
+  const bool ok = download ? pump->prepare(std::move(pre_engage), /*initial_d2u=*/"")
+                           : pump->prepare(/*initial_u2d=*/"", std::move(pre_engage));
+  if (!ok) {
+    // Pending output was already drained, so this is a reset, not a fallback.
+    incSpliceCounter("truncated");
+    ENVOY_LOG(warn, "kTLS body-splice setup failed after taking pending output, resetting");
+    upstream_request_.onResetStream(Http::StreamResetReason::ConnectionTermination,
+                                    "kTLS body-splice setup failed");
+    return;
+  }
+  if (download) {
+    pump->setBounds(/*u2d_limit=*/spliced_body_bytes_, /*d2u_limit=*/absl::nullopt);
+  } else {
+    pump->setBounds(/*u2d_limit=*/absl::nullopt, /*d2u_limit=*/spliced_body_bytes_);
+  }
+
+  // Upload retries would replay only the buffered prefix after engage.
+  if (!download) {
+    upstream_request_.parent_.disableRetries();
+  }
+
+  // The pump owns both fd registrations until finalize or reset.
+  upstream->getSocket()->ioHandle().resetFileEvents();
+  downstream->getSocket()->ioHandle().resetFileEvents();
+  legs_detached_ = true;
+  upstream_connection_ = upstream;
+  downstream_connection_ = downstream;
+  splice_pump_ = std::move(pump);
+  splice_pump_->arm();
+  // Reap a stalled splice even while the codec is detached.
+  armProgressWatchdog();
+  ENVOY_LOG(debug, "kTLS body-splice engaged: {} {} body bytes (down_fd={}, up_fd={})",
+            spliced_body_bytes_, download ? "response" : "request", down_fd.value(), up_fd.value());
+}
+
+void SpliceCoordinator::flushPreEngageBody() {
+  if (pre_engage_body_.length() == 0) {
+    return;
+  }
+  // Forward held body so the normal path can resume.
+  if (direction_ == Direction::Download) {
+    // Response body to the downstream encoder.
+    upstream_request_.parent_.onUpstreamData(pre_engage_body_, upstream_request_, false);
+  } else {
+    // Request body to the upstream encoder via the upstream filter chain.
+    upstream_request_.filter_manager_->decodeData(pre_engage_body_, false);
+  }
+}
+
+void SpliceCoordinator::onSpliceComplete(TcpProxy::SpliceCompletion status) {
+  // Defer teardown until the pump callback unwinds.
+  completion_status_ = status;
+  if (finalize_callback_ == nullptr) {
+    finalize_callback_ =
+        upstream_request_.parent_.callbacks()->dispatcher().createSchedulableCallback(
+            [this]() { finalize(); });
+  }
+  finalize_callback_->scheduleCallbackCurrentIteration();
+}
+
+void SpliceCoordinator::finalize() {
+  // Destroy the pump first so its FileEvents are gone. Keep ConnectionImpl events detached while
+  // completeSpliced* finalizes the codec stream, then re-arm each reusable leg.
+  if (progress_watchdog_ != nullptr) {
+    progress_watchdog_->disableTimer();
+  }
+  splice_pump_.reset();
+
+  // completeSpliced* may delete this coordinator, so capture the legs before calling it.
+  OptRef<Network::Connection> up = upstream_connection_;
+  OptRef<Network::Connection> down = downstream_connection_;
+  upstream_connection_ = {};
+  downstream_connection_ = {};
+
+  if (completion_status_ != TcpProxy::SpliceCompletion::BoundsReached) {
+    // A truncated splice cannot recover because part of the body may have reached the sink.
+    incSpliceCounter("truncated");
+    ENVOY_LOG(debug, "kTLS body-splice aborted before the Content-Length boundary, resetting");
+    maybeReadEnableSource();
+    // The upstream NoFlush close cascades into downstream file-event code. Reinstall the download
+    // sink first so that cascade never sees a detached file event.
+    if (direction_ == Direction::Download && legs_detached_ && down.has_value() &&
+        down->state() == Network::Connection::State::Open) {
+      down->reinstallFileEvents();
+    }
+    if (up.has_value() && up->state() == Network::Connection::State::Open) {
+      up->close(Network::ConnectionCloseType::NoFlush);
+    }
+    return;
+  }
+
+  // Count before completeSpliced* can delete this coordinator.
+  incSpliceCounter("completed");
+
+  // The sink codec did not see the body, so account its full Content-Length here.
+  StreamInfo::StreamInfo& downstream_info = upstream_request_.parent_.callbacks()->streamInfo();
+  ENVOY_LOG(debug, "kTLS body-splice complete: {} body bytes relayed", spliced_body_bytes_);
+  if (direction_ == Direction::Download) {
+    if (downstream_info.getDownstreamBytesMeter() != nullptr) {
+      downstream_info.getDownstreamBytesMeter()->addWireBytesSent(content_length_);
+    }
+    downstream_info.addBytesSent(content_length_);
+    upstream_request_.stream_info_.addBytesReceived(spliced_body_bytes_);
+    // Re-arm downstream before completing the response.
+    if (down.has_value() && down->state() == Network::Connection::State::Open) {
+      down->reinstallFileEvents();
+    }
+    // completeSplicedResponse may delete this coordinator.
+    ASSERT(upstream_request_.upstream_ != nullptr);
+    upstream_request_.upstream_->completeSplicedResponse(spliced_body_bytes_);
+    // Re-arm upstream only after the codec stream is finalized.
+    if (up.has_value() && up->state() == Network::Connection::State::Open) {
+      up->reinstallFileEvents();
+    }
+    return;
+  }
+
+  // Upload reuses both legs and then awaits the response.
+  if (up.has_value() && up->state() == Network::Connection::State::Open) {
+    up->reinstallFileEvents();
+  }
+  maybeReadEnableSource();
+  if (downstream_info.getUpstreamBytesMeter() != nullptr) {
+    downstream_info.getUpstreamBytesMeter()->addWireBytesSent(content_length_);
+  }
+  downstream_info.addBytesReceived(spliced_body_bytes_);
+  upstream_request_.stream_info_.addBytesSent(content_length_);
+  // completeSplicedRequest may delete this coordinator.
+  auto downstream_callbacks = upstream_request_.parent_.callbacks()->downstreamCallbacks();
+  if (downstream_callbacks.has_value()) {
+    downstream_callbacks->completeSplicedRequest(spliced_body_bytes_);
+  }
+}
+
+void SpliceCoordinator::reset() {
+  armed_ = false;
+  if (engage_callback_ != nullptr) {
+    engage_callback_->cancel();
+  }
+  if (engage_poll_timer_ != nullptr) {
+    engage_poll_timer_->disableTimer();
+  }
+  if (finalize_callback_ != nullptr) {
+    finalize_callback_->cancel();
+  }
+  if (progress_watchdog_ != nullptr) {
+    progress_watchdog_->disableTimer();
+  }
+  // reset() runs from UpstreamRequest teardown, not from inside a pump callback.
+  if (splice_pump_ != nullptr) {
+    // Count an in-flight splice once when teardown beats finalize().
+    incSpliceCounter(completion_status_ == TcpProxy::SpliceCompletion::BoundsReached ? "completed"
+                                                                                     : "truncated");
+  }
+  splice_pump_.reset();
+  maybeReadEnableSource();
+  // Match finalize's truncation ordering when teardown wins the race.
+  if (direction_ == Direction::Download && legs_detached_ && downstream_connection_.has_value() &&
+      downstream_connection_->state() == Network::Connection::State::Open) {
+    downstream_connection_->reinstallFileEvents();
+  }
+  if (upstream_connection_.has_value() &&
+      upstream_connection_->state() == Network::Connection::State::Open) {
+    // NoFlush close re-enters UpstreamRequest::onResetStream inline.
+    upstream_request_.on_reset_stream_in_progress_ = true;
+    upstream_connection_->close(Network::ConnectionCloseType::NoFlush);
+  }
+  upstream_connection_ = {};
+  downstream_connection_ = {};
+  legs_detached_ = false;
+}
+
+OptRef<Network::Connection> SpliceCoordinator::upstreamConnection() {
+  return upstream_request_.upstream_ != nullptr
+             ? upstream_request_.upstream_->upstreamConnectionForSplice()
+             : OptRef<Network::Connection>{};
+}
+
+OptRef<Network::Connection> SpliceCoordinator::downstreamConnection() {
+  auto downstream_callbacks = upstream_request_.parent_.callbacks()->downstreamCallbacks();
+  return downstream_callbacks.has_value() ? downstream_callbacks->downstreamConnectionForSplice()
+                                          : OptRef<Network::Connection>{};
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/splice_coordinator.cc
+++ b/source/common/router/splice_coordinator.cc
@@ -2,7 +2,6 @@
 
 #include "envoy/http/header_map.h"
 #include "envoy/network/address.h"
-#include "envoy/stats/scope.h"
 
 #include "source/common/common/assert.h"
 #include "source/common/router/router.h"
@@ -10,7 +9,6 @@
 #include "source/common/runtime/runtime_features.h"
 
 #include "absl/strings/numbers.h"
-#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Router {
@@ -162,7 +160,7 @@ void SpliceCoordinator::disarm() {
 
 void SpliceCoordinator::abandon() {
   // Held bytes must precede resumed reads on the wire.
-  incSpliceCounter("abandoned");
+  incSpliceCounter(SpliceCounter::Abandoned);
   flushPreEngageBody();
   maybeReadEnableSource();
   disarm();
@@ -194,13 +192,27 @@ void SpliceCoordinator::armProgressWatchdog() {
   progress_watchdog_->enableTimer(ProgressWatchdogTimeout);
 }
 
-void SpliceCoordinator::incSpliceCounter(absl::string_view event) {
+void SpliceCoordinator::incSpliceCounter(SpliceCounter counter) {
   // Count once per splice decision, never per byte.
   const Upstream::ClusterInfoConstSharedPtr cluster = upstream_request_.parent_.cluster();
   if (cluster == nullptr) {
     return;
   }
-  cluster->statsScope().counterFromString(absl::StrCat("http1_ktls_splice.", event)).inc();
+  auto& stats = cluster->trafficStats();
+  switch (counter) {
+  case SpliceCounter::Engaged:
+    stats->http1_ktls_splice_engaged_.inc();
+    return;
+  case SpliceCounter::Abandoned:
+    stats->http1_ktls_splice_abandoned_.inc();
+    return;
+  case SpliceCounter::Completed:
+    stats->http1_ktls_splice_completed_.inc();
+    return;
+  case SpliceCounter::Truncated:
+    stats->http1_ktls_splice_truncated_.inc();
+    return;
+  }
 }
 
 void SpliceCoordinator::maybeReadEnableSource() {
@@ -230,7 +242,7 @@ void SpliceCoordinator::rescheduleEngage() {
     engage_poll_timer_ =
         upstream_request_.parent_.callbacks()->dispatcher().createTimer([this]() { engage(); });
   }
-  // Space the poll across connect, handshake, and kTLS-TX install I/O.
+  // Poll the brief upstream kTLS-TX install window after the connection is ready.
   engage_poll_timer_->enableTimer(std::chrono::milliseconds(2));
 }
 
@@ -260,7 +272,7 @@ void SpliceCoordinator::engage() {
         abandon();
         return;
       }
-      rescheduleEngage(); // Upstream pool not ready yet.
+      // Pool not ready yet. onPoolReady drives engage once connected, so wait without polling.
       return;
     }
     OptRef<const Network::KtlsBytestreamInfo> ktls = upstream->ktlsBytestreamInfo();
@@ -321,20 +333,20 @@ void SpliceCoordinator::engage() {
     return;
   }
 
-  // Preserve wire order by emitting headers and held body before the spliced remainder.
-  std::string pre_engage = sink.extractPendingWriteForSplice();
-  const size_t pending_size = pre_engage.size();
-  pre_engage.resize(pending_size + buffered);
-  pre_engage_body_.copyOut(0, buffered, pre_engage.data() + pending_size);
-  pre_engage_body_.drain(buffered);
+  // Preserve wire order by emitting headers and held body before the spliced remainder. Both moves
+  // are zero-copy, so the held body (up to the buffered bound) is never copied on the engage path.
+  Buffer::OwnedImpl pre_engage;
+  sink.extractPendingWriteForSplice(pre_engage);
+  pre_engage.move(pre_engage_body_);
   // The sink write buffer is now drained, so the splice is committed.
-  incSpliceCounter("engaged");
+  incSpliceCounter(SpliceCounter::Engaged);
   // prepare() can fail only after bytes were drained, so failure resets the stream.
-  const bool ok = download ? pump->prepare(std::move(pre_engage), /*initial_d2u=*/"")
-                           : pump->prepare(/*initial_u2d=*/"", std::move(pre_engage));
+  Buffer::OwnedImpl no_initial;
+  const bool ok =
+      download ? pump->prepare(pre_engage, no_initial) : pump->prepare(no_initial, pre_engage);
   if (!ok) {
     // Pending output was already drained, so this is a reset, not a fallback.
-    incSpliceCounter("truncated");
+    incSpliceCounter(SpliceCounter::Truncated);
     ENVOY_LOG(warn, "kTLS body-splice setup failed after taking pending output, resetting");
     upstream_request_.onResetStream(Http::StreamResetReason::ConnectionTermination,
                                     "kTLS body-splice setup failed");
@@ -406,7 +418,7 @@ void SpliceCoordinator::finalize() {
 
   if (completion_status_ != TcpProxy::SpliceCompletion::BoundsReached) {
     // A truncated splice cannot recover because part of the body may have reached the sink.
-    incSpliceCounter("truncated");
+    incSpliceCounter(SpliceCounter::Truncated);
     ENVOY_LOG(debug, "kTLS body-splice aborted before the Content-Length boundary, resetting");
     maybeReadEnableSource();
     // The upstream NoFlush close cascades into downstream file-event code. Reinstall the download
@@ -422,7 +434,7 @@ void SpliceCoordinator::finalize() {
   }
 
   // Count before completeSpliced* can delete this coordinator.
-  incSpliceCounter("completed");
+  incSpliceCounter(SpliceCounter::Completed);
 
   // The sink codec did not see the body, so account its full Content-Length here.
   StreamInfo::StreamInfo& downstream_info = upstream_request_.parent_.callbacks()->streamInfo();
@@ -481,8 +493,9 @@ void SpliceCoordinator::reset() {
   // reset() runs from UpstreamRequest teardown, not from inside a pump callback.
   if (splice_pump_ != nullptr) {
     // Count an in-flight splice once when teardown beats finalize().
-    incSpliceCounter(completion_status_ == TcpProxy::SpliceCompletion::BoundsReached ? "completed"
-                                                                                     : "truncated");
+    incSpliceCounter(completion_status_ == TcpProxy::SpliceCompletion::BoundsReached
+                         ? SpliceCounter::Completed
+                         : SpliceCounter::Truncated);
   }
   splice_pump_.reset();
   maybeReadEnableSource();

--- a/source/common/router/splice_coordinator.h
+++ b/source/common/router/splice_coordinator.h
@@ -16,8 +16,6 @@
 #include "source/common/common/logger.h"
 #include "source/common/tcp_proxy/splice_pump.h"
 
-#include "absl/strings/string_view.h"
-
 namespace Envoy {
 namespace Router {
 
@@ -96,8 +94,9 @@ private:
   // Refreshes liveness timers after byte movement.
   void onSpliceProgress();
   void armProgressWatchdog();
-  // Increments the per-cluster splice lifecycle counter.
-  void incSpliceCounter(absl::string_view event);
+  // Per-cluster splice lifecycle counters.
+  enum class SpliceCounter { Engaged, Abandoned, Completed, Truncated };
+  void incSpliceCounter(SpliceCounter counter);
 
   UpstreamRequest& upstream_request_;
   Event::SchedulableCallbackPtr engage_callback_;

--- a/source/common/router/splice_coordinator.h
+++ b/source/common/router/splice_coordinator.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/optref.h"
+#include "envoy/event/schedulable_cb.h"
+#include "envoy/event/timer.h"
+#include "envoy/http/header_map.h"
+#include "envoy/network/connection.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/logger.h"
+#include "source/common/tcp_proxy/splice_pump.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Router {
+
+class UpstreamRequest;
+
+// Coordinates one HTTP/1.1 Content-Length body splice for an UpstreamRequest. Downloads relay from
+// a kTLS upstream to the downstream. Uploads relay from downstream to a kTLS-TX upstream. The pump
+// bypasses userspace buffers and filters, so the runtime guard must only be enabled when no filter
+// mutates the body. Clean completion stops at Content-Length and keeps both sockets reusable.
+// Errors reset the stream and do not reuse the sockets.
+class SpliceCoordinator : public Logger::Loggable<Logger::Id::router> {
+public:
+  explicit SpliceCoordinator(UpstreamRequest& upstream_request);
+  ~SpliceCoordinator();
+
+  // Direction of the body relayed by the splice.
+  enum class Direction {
+    Download, // Upstream (kTLS) to downstream, a response body.
+    Upload,   // Downstream to upstream (kTLS-TX), a request body.
+  };
+
+  // Arms a download splice for the decoded response when eligible.
+  bool maybeArmForResponse(const Http::ResponseHeaderMap& headers, bool end_stream);
+
+  // Arms an upload splice for the request when eligible.
+  bool maybeArmForRequest(const Http::RequestHeaderMap& headers, bool end_stream);
+
+  // Schedules engage after headers are encoded onto the sink leg.
+  void scheduleEngage();
+
+  // Holds body that arrives before engage so it can precede the spliced remainder.
+  bool bufferPreEngageBody(Buffer::Instance& data, bool end_stream);
+
+  // Cancels a pending arm and tears down any in-flight splice.
+  void reset();
+
+  // Direction-specific armed predicates.
+  bool armedForResponse() const { return armed_ && direction_ == Direction::Download; }
+  bool armedForRequest() const { return armed_ && direction_ == Direction::Upload; }
+  bool engaged() const { return splice_pump_ != nullptr; }
+
+  // Builds the pump at engage time.
+  using SplicePumpFactory = std::function<TcpProxy::SplicePumpPtr(
+      os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls, Event::Dispatcher& dispatcher,
+      TcpProxy::SplicePump::CompletionCb on_complete, TcpProxy::SplicePump::BytesCb on_u2d_bytes,
+      TcpProxy::SplicePump::BytesCb on_d2u_bytes)>;
+  void setSplicePumpFactoryForTest(SplicePumpFactory factory) {
+    splice_pump_factory_ = std::move(factory);
+  }
+
+private:
+  // Minimum Content-Length worth splicing.
+  static constexpr uint64_t MinSpliceBodyBytes = 64 * 1024;
+  // Upper bound on body held in memory while waiting to engage.
+  static constexpr uint64_t MaxHeldBodyBytes = 4 * 1024 * 1024;
+  // Defensive bound on upload engage polling.
+  static constexpr uint32_t MaxEngagePolls = 64;
+
+  void engage();
+  void onSpliceComplete(TcpProxy::SpliceCompletion status);
+  void finalize();
+  void disarm();
+  // Gives up an armed splice before it engages.
+  void abandon();
+  // Reschedules engage while upload waits for upstream kTLS-TX.
+  void rescheduleEngage();
+  // Forwards held body back through the normal path.
+  void flushPreEngageBody();
+  // Re-enables upload source reads after they were disabled at arm.
+  void maybeReadEnableSource();
+  // Resolves the single HTTP/1.1 legs borrowed by the splice.
+  OptRef<Network::Connection> upstreamConnection();
+  OptRef<Network::Connection> downstreamConnection();
+  // True if the leg can safely send or receive raw spliced bytes.
+  static bool sinkLegIsRawOrKtls(Network::Connection& connection);
+  // Refreshes liveness timers after byte movement.
+  void onSpliceProgress();
+  void armProgressWatchdog();
+  // Increments the per-cluster splice lifecycle counter.
+  void incSpliceCounter(absl::string_view event);
+
+  UpstreamRequest& upstream_request_;
+  Event::SchedulableCallbackPtr engage_callback_;
+  Event::TimerPtr engage_poll_timer_;
+  Event::SchedulableCallbackPtr finalize_callback_;
+  // Reaps a splice that stalls with zero byte movement.
+  Event::TimerPtr progress_watchdog_;
+  TcpProxy::SplicePumpPtr splice_pump_;
+  // Constructs the real pump unless a test installs a deterministic double.
+  SplicePumpFactory splice_pump_factory_{
+      [](os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls, Event::Dispatcher& dispatcher,
+         TcpProxy::SplicePump::CompletionCb on_complete, TcpProxy::SplicePump::BytesCb on_u2d_bytes,
+         TcpProxy::SplicePump::BytesCb on_d2u_bytes) {
+        return std::make_unique<TcpProxy::SplicePump>(
+            down_fd, up_fd, up_is_ktls, dispatcher, std::move(on_complete), std::move(on_u2d_bytes),
+            std::move(on_d2u_bytes));
+      }};
+  // Borrowed legs held until finalize re-arms their file events.
+  OptRef<Network::Connection> upstream_connection_;
+  OptRef<Network::Connection> downstream_connection_;
+  uint64_t content_length_{0};
+  // Body held before engage so it can precede the spliced remainder.
+  Buffer::OwnedImpl pre_engage_body_;
+  // Bytes the in-kernel splice itself relayed.
+  uint64_t spliced_body_bytes_{0};
+  // No-progress watchdog duration.
+  static constexpr std::chrono::seconds ProgressWatchdogTimeout{30};
+  TcpProxy::SpliceCompletion completion_status_{TcpProxy::SpliceCompletion::Closed};
+  Direction direction_{Direction::Download};
+  uint32_t engage_polls_{0};
+  bool armed_{false};
+  // True when upload source reads are disabled until engage.
+  bool source_read_disabled_{false};
+  // True once engage detached both ConnectionImpl file events.
+  bool legs_detached_{false};
+};
+
+using SpliceCoordinatorPtr = std::unique_ptr<SpliceCoordinator>;
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -34,6 +34,7 @@
 #include "source/common/router/config_impl.h"
 #include "source/common/router/debug_config.h"
 #include "source/common/router/router.h"
+#include "source/common/router/splice_coordinator.h"
 #include "source/common/router/upstream_codec_filter.h"
 #include "source/common/stream_info/uint32_accessor_impl.h"
 #include "source/common/tracing/http_tracer_impl.h"
@@ -196,6 +197,11 @@ void UpstreamRequest::cleanUp() {
   }
   cleaned_up_ = true;
 
+  // Cancel any pending arm and tear down an in-flight splice before the rest of teardown.
+  if (splice_coordinator_ != nullptr) {
+    splice_coordinator_->reset();
+  }
+
   filter_manager_->destroyFilters();
 
   if (span_ != nullptr) {
@@ -331,6 +337,19 @@ void UpstreamRequest::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool e
   maybeHandleDeferredReadDisable();
   ASSERT(headers.get());
 
+  // Arm and schedule before forwarding headers because onUpstreamHeaders may tear this request
+  // down.
+  bool splice_armed = false;
+  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_ktls_body_splice")) {
+    if (splice_coordinator_ == nullptr) {
+      splice_coordinator_ = std::make_unique<SpliceCoordinator>(*this);
+    }
+    splice_armed = splice_coordinator_->maybeArmForResponse(*headers, end_stream);
+    if (splice_armed) {
+      splice_coordinator_->scheduleEngage();
+    }
+  }
+
   parent_.onUpstreamHeaders(response_code, std::move(headers), *this, end_stream);
 }
 
@@ -351,6 +370,16 @@ void UpstreamRequest::decodeData(Buffer::Instance& data, bool end_stream) {
 
   resetPerTryIdleTimer();
   stream_info_.addBytesReceived(data.length());
+  // While a download splice is armed but not yet engaged, hold the response body back from the
+  // downstream encoder so engage can emit it ahead of the spliced remainder. This keeps the
+  // downstream off its write high watermark so the splice reliably engages. bufferPreEngageBody
+  // returns true once it has taken the body (do not forward it). It returns false when the response
+  // ends first, having flushed any held body, so the terminal chunk forwards normally below.
+  if (splice_coordinator_ != nullptr && splice_coordinator_->armedForResponse() &&
+      !splice_coordinator_->engaged() &&
+      splice_coordinator_->bufferPreEngageBody(data, end_stream)) {
+    return;
+  }
   parent_.onUpstreamData(data, *this, end_stream);
 }
 
@@ -471,15 +500,44 @@ void UpstreamRequest::acceptHeadersFromRouter(bool end_stream) {
     resetUpstreamLogFlushTimer();
   }
 
+  // Evaluate the upload (request-body) splice before the request headers enter the upstream filter
+  // chain. When armed, the headers still encode normally and the body is spliced once engage finds
+  // the upstream connected with kTLS-TX installed. CONNECT/WebSocket upgrades are tunnels with no
+  // Content-Length body, so maybeArmForRequest rejects them. The explicit guard keeps that clear.
+  bool splice_armed = false;
+  if (!paused_for_connect_ && !paused_for_websocket_ &&
+      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http1_ktls_body_splice")) {
+    if (splice_coordinator_ == nullptr) {
+      splice_coordinator_ = std::make_unique<SpliceCoordinator>(*this);
+    }
+    splice_armed =
+        splice_coordinator_->maybeArmForRequest(*parent_.downstreamHeaders(), end_stream);
+  }
+
   filter_manager_->requestHeadersInitialized();
   filter_manager_->streamInfo().setRequestHeaders(*parent_.downstreamHeaders());
   filter_manager_->decodeHeaders(*parent_.downstreamHeaders(), end_stream);
+
+  if (splice_armed) {
+    splice_coordinator_->scheduleEngage();
+  }
 }
 
 void UpstreamRequest::acceptDataFromRouter(Buffer::Instance& data, bool end_stream) {
   ASSERT(!router_sent_end_stream_);
-  router_sent_end_stream_ = end_stream;
 
+  // While an upload splice is armed but not yet engaged, hold the request body back from the
+  // upstream encoder so engage can emit it ahead of the spliced remainder, keeping the upstream off
+  // its write high watermark so the splice engages reliably. bufferPreEngageBody returns true once
+  // it has taken the body (do not forward it). It returns false when the request ends first or the
+  // held body exceeds the bound, having flushed any held body, so this data forwards normally.
+  if (splice_coordinator_ != nullptr && splice_coordinator_->armedForRequest() &&
+      !splice_coordinator_->engaged() &&
+      splice_coordinator_->bufferPreEngageBody(data, end_stream)) {
+    return;
+  }
+
+  router_sent_end_stream_ = end_stream;
   filter_manager_->decodeData(data, end_stream);
 }
 
@@ -497,7 +555,18 @@ void UpstreamRequest::acceptMetadataFromRouter(Http::MetadataMapPtr&& metadata_m
 
 void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
                                     absl::string_view transport_failure_reason) {
+  // SpliceCoordinator::reset() force-closes the borrowed upstream inline, whose codec reset cascade
+  // re-enters here. reset() latches on_reset_stream_in_progress_ before that close, so the nested
+  // call returns here and the request leaves the parent list exactly once.
+  if (on_reset_stream_in_progress_) {
+    return;
+  }
   ScopeTrackerScopeState scope(&parent_.callbacks()->scope(), parent_.callbacks()->dispatcher());
+
+  // Tear down an in-flight splice before the connection is reset out from under it.
+  if (splice_coordinator_ != nullptr) {
+    splice_coordinator_->reset();
+  }
 
   if (reason != Http::StreamResetReason::RemoteResetNoError) {
     if (span_ != nullptr) {
@@ -515,6 +584,22 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
 }
 
 void UpstreamRequest::resetStream() {
+  // Tear down an in-flight splice before the upstream stream is reset. reset() is idempotent, so
+  // the re-entrant call from the splice coordinator's own truncation path is a no-op.
+  if (splice_coordinator_ != nullptr) {
+    splice_coordinator_->reset();
+  }
+
+  // reset() force-closes the borrowed upstream for an engaged splice, and that close cascade has
+  // already reset the codec stream and destroyed the request encoder. A normal upstream reset below
+  // would dereference the freed encoder, so finish the teardown here. The guard is set only on that
+  // force-close path, so an armed-but-not-engaged splice still falls through to the normal reset.
+  if (on_reset_stream_in_progress_) {
+    clearRequestEncoder();
+    reset_stream_ = true;
+    return;
+  }
+
   if (conn_pool_->cancelAnyPendingStream()) {
     ENVOY_STREAM_LOG(debug, "canceled pool request", *parent_.callbacks());
     ASSERT(!upstream_);

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -832,6 +832,13 @@ void UpstreamRequest::onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
   for (auto* callback : upstream_callbacks_) {
     callback->onUpstreamConnectionEstablished();
   }
+
+  // Drive an armed upload splice now that the upstream connection is ready. This keeps engage
+  // event-driven instead of polling for the connection during establishment.
+  if (splice_coordinator_ != nullptr && splice_coordinator_->armedForRequest() &&
+      !splice_coordinator_->engaged()) {
+    splice_coordinator_->scheduleEngage();
+  }
 }
 
 UpstreamToDownstream& UpstreamRequest::upstreamToDownstream() { return *upstream_interface_; }

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -34,6 +34,7 @@ namespace Router {
 class GenericUpstream;
 class GenericConnectionPoolCallbacks;
 class RouterFilterInterface;
+class SpliceCoordinator;
 class UpstreamRequest;
 class UpstreamRequestFilterManagerCallbacks;
 class UpstreamFilterManager;
@@ -175,6 +176,11 @@ private:
   friend class UpstreamFilterManager;
   friend class UpstreamCodecFilter;
   friend class UpstreamRequestFilterManagerCallbacks;
+  friend class SpliceCoordinator;
+  // Test-only friend that lets the splice coordinator unit test set the private members the
+  // coordinator reads (upstream_, router_sent_end_stream_) and observe
+  // on_reset_stream_in_progress_.
+  friend class SpliceCoordinatorTest;
   StreamInfo::UpstreamTiming& upstreamTiming() {
     return stream_info_.upstreamInfo()->upstreamTiming();
   }
@@ -224,6 +230,12 @@ private:
   std::unique_ptr<UpstreamRequestFilterManagerCallbacks> filter_manager_callbacks_;
   std::unique_ptr<Http::FilterManager> filter_manager_;
 
+  // Drives the L7 kTLS body-splice fast path for this request in either direction, the response
+  // body (download) or the request body (upload, which read-disables the downstream source while it
+  // waits to engage). Lazily created when a message first becomes splice-eligible. Null on every
+  // connection that never qualifies.
+  std::unique_ptr<SpliceCoordinator> splice_coordinator_;
+
   // The number of outstanding readDisable to be called with parameter value true.
   // When downstream send buffers get above high watermark before response headers arrive, we
   // increment this counter instead of immediately calling readDisable on upstream stream. This is
@@ -252,6 +264,10 @@ private:
   bool paused_for_connect_ : 1 = false;
   bool paused_for_websocket_ : 1 = false;
   bool reset_stream_ : 1 = false;
+  // Guards onResetStream against re-entry. The splice no-progress watchdog calls onResetStream
+  // directly, and reset() force-closes the upstream inline, whose codec reset cascade re-enters
+  // onResetStream. The nested call must be a no-op so the request leaves the parent list once.
+  bool on_reset_stream_in_progress_ : 1 = false;
 
   // Sentinel to indicate if timeout budget tracking is configured for the cluster,
   // and if so, if the per-try histogram should record a value.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -190,6 +190,9 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_disable_quic_rx_queue_overflow_soc
 // TODO(abeyad): Flip to true after prod testing.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_disable_quic_ip_packet_info_socket_options);
 
+// L7 HTTP/1.1 kTLS body-splice fast path, disabled by default.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_http1_ktls_body_splice);
+
 // A flag to set the maximum TLS version for google_grpc client to TLS1.2, when needed for
 // compliance restrictions.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_google_grpc_disable_tls_13);

--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -55,6 +55,7 @@ envoy_cc_library(
         "//envoy/network:connection_interface",
         "//envoy/network:transport_socket_interface",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/common:utility_lib",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/types:optional",
     ],

--- a/source/common/tcp_proxy/BUILD
+++ b/source/common/tcp_proxy/BUILD
@@ -38,6 +38,28 @@ envoy_cc_library(
     ],
 )
 
+# Standalone so the L7 kTLS body-splice (source/common/router) can reuse the in-kernel pump without
+# depending on the whole tcp_proxy network filter (which would form a dependency cycle).
+envoy_cc_library(
+    name = "splice_pump_lib",
+    srcs = [
+        "splice_pump.cc",
+    ],
+    hdrs = [
+        "splice_pump.h",
+    ],
+    deps = [
+        "//envoy/common:base_includes",
+        "//envoy/event:dispatcher_interface",
+        "//envoy/event:file_event_interface",
+        "//envoy/network:connection_interface",
+        "//envoy/network:transport_socket_interface",
+        "//source/common/common:minimal_logger_lib",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/types:optional",
+    ],
+)
+
 envoy_cc_library(
     name = "tcp_proxy",
     srcs = [

--- a/source/common/tcp_proxy/splice_pump.cc
+++ b/source/common/tcp_proxy/splice_pump.cc
@@ -1,0 +1,696 @@
+#include "source/common/tcp_proxy/splice_pump.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+
+// spliceLegIsRawOrKtls dereferences KtlsBytestreamInfo, which envoy/network/connection.h only
+// forward-declares. The full struct lives here.
+#include "envoy/network/transport_socket.h"
+
+#if defined(__linux__)
+#include <fcntl.h>
+#include <linux/tls.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
+
+namespace Envoy {
+namespace TcpProxy {
+
+namespace {
+// TLS record-type bytes for kTLS control-message dispatch.
+constexpr uint8_t kTlsRecordChangeCipherSpec = 20;
+constexpr uint8_t kTlsRecordAlert = 21;
+constexpr uint8_t kTlsRecordHandshake = 22;
+constexpr uint8_t kTlsHandshakeNewSessionTicket = 4;
+constexpr uint8_t kTlsAlertCloseNotify = 0;
+} // namespace
+
+ControlAction classifyKtlsControlRecord(uint8_t record_type, const uint8_t* data, size_t len) {
+  switch (record_type) {
+  case kTlsRecordAlert:
+    if (len >= 2 && data[1] == kTlsAlertCloseNotify) {
+      return ControlAction::Eof;
+    }
+    return ControlAction::Close;
+  case kTlsRecordHandshake: {
+    // Tolerate NewSessionTicket and close on any unsupported post-handshake message.
+    size_t pos = 0;
+    while (pos < len) {
+      if (data[pos] != kTlsHandshakeNewSessionTicket) {
+        return ControlAction::Close;
+      }
+      // Split handshake headers need userspace TLS reassembly, so close instead.
+      if (pos + 4 > len) {
+        return ControlAction::Close;
+      }
+      const size_t msg_len = (static_cast<size_t>(data[pos + 1]) << 16) |
+                             (static_cast<size_t>(data[pos + 2]) << 8) |
+                             static_cast<size_t>(data[pos + 3]);
+      if (msg_len > len - pos - 4) {
+        return ControlAction::Close; // Declared length overruns the record.
+      }
+      pos += 4 + msg_len;
+    }
+    return ControlAction::Retry;
+  }
+  case kTlsRecordChangeCipherSpec:
+    return ControlAction::Retry; // TLS 1.3 middlebox-compat record.
+  default:
+    return ControlAction::Close;
+  }
+}
+
+bool spliceLegIsRawOrKtls(Network::Connection& connection) {
+  if (connection.ssl() != nullptr) {
+    return false;
+  }
+  OptRef<const Network::KtlsBytestreamInfo> info = connection.ktlsBytestreamInfo();
+  if (!info.has_value()) {
+    return true; // Plaintext raw socket.
+  }
+  return info->installed; // kTLS-capable socket.
+}
+
+#if defined(__linux__)
+
+namespace {
+// Pipe capacity. The kernel clamps to /proc/sys/fs/pipe-max-size.
+constexpr size_t kPipeCapacity = 1024 * 1024;
+// Floor used only when the kernel does not report pipe capacity.
+constexpr size_t kFallbackPipeCapacity = 64 * 1024;
+// Upper bound on non-DATA kTLS control records drained in one pump pass.
+constexpr int kMaxControlRecordsPerPass = 1024;
+// TLS 1.3 max record, 16384 plaintext plus AEAD and header overhead.
+constexpr size_t kMaxTlsRecordSize = 16640;
+} // namespace
+
+SplicePump::SplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls,
+                       Event::Dispatcher& dispatcher, CompletionCb on_complete,
+                       BytesCb on_upstream_to_downstream, BytesCb on_downstream_to_upstream)
+    : down_fd_(down_fd), up_fd_(up_fd), up_is_ktls_(up_is_ktls), dispatcher_(dispatcher),
+      on_complete_(std::move(on_complete)), on_u2d_bytes_(std::move(on_upstream_to_downstream)),
+      on_d2u_bytes_(std::move(on_downstream_to_upstream)) {}
+
+SplicePump::~SplicePump() {
+  // Socket fds are borrowed and stay owned by their ConnectionImpls.
+  for (int fd : {u2d_.read_fd, u2d_.write_fd, d2u_.read_fd, d2u_.write_fd}) {
+    if (fd >= 0) {
+      ::close(fd);
+    }
+  }
+}
+
+bool SplicePump::createPipes(bool need_u2d, bool need_d2u) {
+  // Bounded HTTP body splice uses one direction per engage.
+  if (need_u2d && u2d_.read_fd < 0) {
+    int u2d[2];
+    if (::pipe2(u2d, O_NONBLOCK | O_CLOEXEC) != 0) {
+      ENVOY_LOG(warn, "splice pump u2d pipe2 failed, {}", std::strerror(errno));
+      return false;
+    }
+    u2d_.read_fd = u2d[0];
+    u2d_.write_fd = u2d[1];
+  }
+  if (need_d2u && d2u_.read_fd < 0) {
+    int d2u[2];
+    if (::pipe2(d2u, O_NONBLOCK | O_CLOEXEC) != 0) {
+      ENVOY_LOG(warn, "splice pump d2u pipe2 failed, {}", std::strerror(errno));
+      return false;
+    }
+    d2u_.read_fd = d2u[0];
+    d2u_.write_fd = d2u[1];
+  }
+  return true;
+}
+
+bool SplicePump::prepare(std::string initial_u2d, std::string initial_d2u) {
+  // Lazily create both pipes for callers that did not pre-create them.
+  if (u2d_.read_fd < 0 && d2u_.read_fd < 0) {
+    if (!createPipes(/*need_u2d=*/true, /*need_d2u=*/true)) {
+      return false;
+    }
+  }
+
+  // Write the pre-engage upstream chunk before any spliced upstream-to-downstream bytes.
+  if (!initial_u2d.empty()) {
+    size_t off = 0;
+    while (off < initial_u2d.size()) {
+      const ssize_t w = ::write(down_fd_, initial_u2d.data() + off, initial_u2d.size() - off);
+      if (w > 0) {
+        off += static_cast<size_t>(w);
+        on_u2d_bytes_(static_cast<uint64_t>(w));
+      } else if (w < 0 && errno == EINTR) {
+        continue;
+      } else if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        break; // Socket full, stash the rest below.
+      } else {
+        ENVOY_LOG(warn, "splice pump initial downstream write error, {}", std::strerror(errno));
+        if (off == 0) {
+          return false; // Nothing delivered yet.
+        }
+        break; // Some bytes already delivered.
+      }
+    }
+    if (off < initial_u2d.size()) {
+      pending_down_ = std::move(initial_u2d);
+      pending_down_off_ = off;
+    }
+  }
+
+  // Write the pre-engage downstream chunk before any spliced downstream-to-upstream bytes.
+  if (!initial_d2u.empty()) {
+    size_t off = 0;
+    while (off < initial_d2u.size()) {
+      const ssize_t w = ::write(up_fd_, initial_d2u.data() + off, initial_d2u.size() - off);
+      if (w > 0) {
+        off += static_cast<size_t>(w);
+        on_d2u_bytes_(static_cast<uint64_t>(w));
+      } else if (w < 0 && errno == EINTR) {
+        continue;
+      } else if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+        break; // Socket full, stash the rest below.
+      } else {
+        ENVOY_LOG(warn, "splice pump initial upstream write error, {}", std::strerror(errno));
+        if (off == 0) {
+          return false; // Nothing delivered yet.
+        }
+        break;
+      }
+    }
+    if (off < initial_d2u.size()) {
+      pending_up_ = std::move(initial_d2u);
+      pending_up_off_ = off;
+    }
+  }
+  return true;
+}
+
+void SplicePump::setBounds(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit) {
+  bounded_ = true;
+  u2d_limit_ = u2d_limit;
+  d2u_limit_ = d2u_limit;
+}
+
+void SplicePump::arm() {
+  // Trust the kernel-reported pipe capacity, not the requested size.
+  auto size_pipe = [](Pipe& pipe) {
+    if (pipe.write_fd < 0) {
+      return;
+    }
+    const int set = ::fcntl(pipe.write_fd, F_SETPIPE_SZ, static_cast<int>(kPipeCapacity));
+    if (set > 0) {
+      pipe.capacity = static_cast<size_t>(set);
+      return;
+    }
+    const int got = ::fcntl(pipe.write_fd, F_GETPIPE_SZ);
+    pipe.capacity = got > 0 ? static_cast<size_t>(got) : kFallbackPipeCapacity;
+  };
+  size_pipe(u2d_);
+  size_pipe(d2u_);
+
+  up_file_event_ = dispatcher_.createFileEvent(
+      up_fd_, [this](uint32_t events) { return onUpReady(events); }, Event::FileTriggerType::Edge,
+      Event::FileReadyType::Read | Event::FileReadyType::Write | Event::FileReadyType::Closed);
+  down_file_event_ = dispatcher_.createFileEvent(
+      down_fd_, [this](uint32_t events) { return onDownReady(events); },
+      Event::FileTriggerType::Edge,
+      Event::FileReadyType::Read | Event::FileReadyType::Write | Event::FileReadyType::Closed);
+
+  // Assume ready at arm and let EAGAIN clear the latches.
+  up_readable_ = up_writable_ = down_readable_ = down_writable_ = true;
+  ENVOY_LOG(debug, "splice pump armed down_fd={} up_fd={} kTLS={} pending={}", down_fd_, up_fd_,
+            up_is_ktls_, pending_down_.size() - pending_down_off_);
+  pump();
+}
+
+absl::Status SplicePump::onUpReady(uint32_t events) {
+  if (completed_) {
+    return absl::OkStatus();
+  }
+  if (events & Event::FileReadyType::Closed) {
+    up_closed_ = true;
+  }
+  if (events & (Event::FileReadyType::Read | Event::FileReadyType::Closed)) {
+    up_readable_ = true;
+  }
+  if (events & Event::FileReadyType::Write) {
+    up_writable_ = true;
+  }
+  pump();
+  return absl::OkStatus();
+}
+
+absl::Status SplicePump::onDownReady(uint32_t events) {
+  if (completed_) {
+    return absl::OkStatus();
+  }
+  if (events & Event::FileReadyType::Closed) {
+    down_closed_ = true;
+  }
+  if (events & (Event::FileReadyType::Read | Event::FileReadyType::Closed)) {
+    down_readable_ = true;
+  }
+  if (events & Event::FileReadyType::Write) {
+    down_writable_ = true;
+  }
+  pump();
+  return absl::OkStatus();
+}
+
+void SplicePump::pump() {
+  if (completed_) {
+    return;
+  }
+  // Reset the authoritative upstream drain marker each pass.
+  up_eagain_this_pass_ = false;
+  // Re-test write readiness each pass. Edge-triggered EPOLLOUT may not fire again after a
+  // transient EAGAIN if the socket never left writable state.
+  up_writable_ = true;
+  down_writable_ = true;
+  // SPLICE_F_MORE is set only while more bytes are expected in bounded mode.
+  const unsigned base_flags = SPLICE_F_NONBLOCK | SPLICE_F_MOVE;
+  int control_records = 0;
+  bool progress = true;
+  while (progress) {
+    progress = false;
+
+    // Unbounded mode has no message boundary, so it never sets SPLICE_F_MORE.
+    const bool u2d_more_expected =
+        bounded_ && u2d_limit_.has_value() && u2d_read_ < u2d_limit_.value();
+    const bool d2u_more_expected =
+        bounded_ && d2u_limit_.has_value() && d2u_read_ < d2u_limit_.value();
+    const unsigned u2d_out_flags = base_flags | (u2d_more_expected ? SPLICE_F_MORE : 0u);
+    const unsigned d2u_out_flags = base_flags | (d2u_more_expected ? SPLICE_F_MORE : 0u);
+
+    // Flush pre-engage upstream bytes before spliced upstream-to-downstream bytes.
+    while (down_writable_ && pending_down_off_ < pending_down_.size()) {
+      const ssize_t w = ::write(down_fd_, pending_down_.data() + pending_down_off_,
+                                pending_down_.size() - pending_down_off_);
+      if (w > 0) {
+        pending_down_off_ += static_cast<size_t>(w);
+        on_u2d_bytes_(static_cast<uint64_t>(w));
+        progress = true;
+      } else if (w == 0) {
+        complete(SpliceCompletion::Closed);
+        return;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        down_writable_ = false;
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else {
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+
+    // Drain upstream-to-downstream pipe after the pre-engage chunk.
+    while (down_writable_ && u2d_.in_pipe > 0 && pending_down_off_ >= pending_down_.size()) {
+      const ssize_t n =
+          ::splice(u2d_.read_fd, nullptr, down_fd_, nullptr, u2d_.in_pipe, u2d_out_flags);
+      if (n > 0) {
+        u2d_.in_pipe -= static_cast<size_t>(n);
+        on_u2d_bytes_(static_cast<uint64_t>(n));
+        progress = true;
+      } else if (n == 0) {
+        complete(SpliceCompletion::Closed);
+        return;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        down_writable_ = false;
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else {
+        ENVOY_LOG(debug, "splice pump u2d downstream write error, {}", std::strerror(errno));
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+
+    // Fill upstream-to-downstream pipe without reading past its byte budget.
+    while (up_readable_ && !up_read_eof_ && u2d_.in_pipe < u2d_.capacity &&
+           (!bounded_ || (u2d_limit_.has_value() && u2d_read_ < u2d_limit_.value()))) {
+      size_t want = u2d_.capacity - u2d_.in_pipe;
+      if (bounded_) {
+        want = std::min(want, static_cast<size_t>(u2d_limit_.value() - u2d_read_));
+      }
+      const ssize_t n = ::splice(up_fd_, nullptr, u2d_.write_fd, nullptr, want, base_flags);
+      if (n > 0) {
+        u2d_.in_pipe += static_cast<size_t>(n);
+        u2d_read_ += static_cast<uint64_t>(n);
+        progress = true;
+      } else if (n == 0) {
+        up_read_eof_ = true;
+        break;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        // Source EAGAIN proves a drained socket only when the pipe is empty. A full pipe can also
+        // return EAGAIN and must not be promoted to EOF.
+        if (u2d_.in_pipe == 0) {
+          up_readable_ = false;
+          up_eagain_this_pass_ = true;
+          // Closed plus drained read side is the TCP half-close signal.
+          if (up_closed_) {
+            up_read_eof_ = true;
+          }
+        }
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else if (errno == EINVAL && up_is_ktls_) {
+        if (drainUpstreamControlMessage()) {
+          if (++control_records > kMaxControlRecordsPerPass) {
+            ENVOY_LOG(debug, "splice pump too many kTLS control records, closing");
+            complete(SpliceCompletion::Closed);
+            return;
+          }
+          progress = true;
+          continue; // Benign control record consumed.
+        }
+        if (completed_) {
+          return; // Fatal record or error closed the pump.
+        }
+        break; // Stop reading upstream but keep draining downstream-to-upstream bytes.
+      } else {
+        ENVOY_LOG(debug, "splice pump u2d upstream read error, {}", std::strerror(errno));
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+
+    // Flush pre-engage downstream bytes before spliced downstream-to-upstream bytes.
+    while (up_writable_ && pending_up_off_ < pending_up_.size()) {
+      const ssize_t w = ::write(up_fd_, pending_up_.data() + pending_up_off_,
+                                pending_up_.size() - pending_up_off_);
+      if (w > 0) {
+        pending_up_off_ += static_cast<size_t>(w);
+        on_d2u_bytes_(static_cast<uint64_t>(w));
+        progress = true;
+      } else if (w == 0) {
+        complete(SpliceCompletion::Closed);
+        return;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        up_writable_ = false;
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else {
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+
+    // Drain downstream-to-upstream pipe after the pre-engage chunk.
+    while (up_writable_ && d2u_.in_pipe > 0 && pending_up_off_ >= pending_up_.size()) {
+      const ssize_t n =
+          ::splice(d2u_.read_fd, nullptr, up_fd_, nullptr, d2u_.in_pipe, d2u_out_flags);
+      if (n > 0) {
+        d2u_.in_pipe -= static_cast<size_t>(n);
+        on_d2u_bytes_(static_cast<uint64_t>(n));
+        progress = true;
+      } else if (n == 0) {
+        complete(SpliceCompletion::Closed);
+        return;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        up_writable_ = false;
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else {
+        ENVOY_LOG(debug, "splice pump d2u upstream write error, {}", std::strerror(errno));
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+
+    // Fill downstream-to-upstream pipe without reading past its byte budget.
+    while (down_readable_ && !down_read_eof_ && d2u_.in_pipe < d2u_.capacity &&
+           (!bounded_ || (d2u_limit_.has_value() && d2u_read_ < d2u_limit_.value()))) {
+      size_t want = d2u_.capacity - d2u_.in_pipe;
+      if (bounded_) {
+        want = std::min(want, static_cast<size_t>(d2u_limit_.value() - d2u_read_));
+      }
+      const ssize_t n = ::splice(down_fd_, nullptr, d2u_.write_fd, nullptr, want, base_flags);
+      if (n > 0) {
+        d2u_.in_pipe += static_cast<size_t>(n);
+        d2u_read_ += static_cast<uint64_t>(n);
+        progress = true;
+      } else if (n == 0) {
+        down_read_eof_ = true;
+        // Re-check upstream before completing after a downstream EOF.
+        if (!up_read_eof_ && !up_readable_) {
+          up_readable_ = true;
+          progress = true;
+        }
+        break;
+      } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        // Source EAGAIN proves a drained socket only when the pipe is empty. A full pipe can also
+        // return EAGAIN and must not be promoted to EOF.
+        if (d2u_.in_pipe == 0) {
+          down_readable_ = false;
+          // Closed plus drained read side is the TCP half-close signal.
+          if (down_closed_ && !down_read_eof_) {
+            down_read_eof_ = true;
+            if (!up_read_eof_ && !up_readable_) {
+              up_readable_ = true;
+              progress = true;
+            }
+          }
+        }
+        break;
+      } else if (errno == EINTR) {
+        continue;
+      } else {
+        ENVOY_LOG(debug, "splice pump d2u downstream read error, {}", std::strerror(errno));
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+    }
+  }
+  maybeHalfCloseOrComplete();
+}
+
+bool SplicePump::drainUpstreamControlMessage() {
+  // Non-DATA TLS records must be consumed through recvmsg().
+  uint8_t buf[kMaxTlsRecordSize];
+  alignas(struct cmsghdr) char cmsg_space[CMSG_SPACE(sizeof(uint8_t))];
+  struct iovec iov;
+  iov.iov_base = buf;
+  iov.iov_len = sizeof(buf);
+  struct msghdr msg;
+  std::memset(&msg, 0, sizeof(msg));
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_space;
+  msg.msg_controllen = sizeof(cmsg_space);
+
+  ssize_t n;
+  do {
+    n = ::recvmsg(up_fd_, &msg, MSG_DONTWAIT);
+  } while (n < 0 && errno == EINTR);
+
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      up_readable_ = false;
+      up_eagain_this_pass_ = true; // Authoritative upstream drain.
+      return false;
+    }
+    ENVOY_LOG(debug, "splice pump kTLS control recvmsg error, {}", std::strerror(errno));
+    complete(SpliceCompletion::Closed);
+    return false;
+  }
+  if (n == 0) {
+    // Upstream closed its read side.
+    up_read_eof_ = true;
+    maybeHalfCloseOrComplete();
+    return false;
+  }
+  // Oversized or truncated records cannot be classified safely.
+  if (msg.msg_flags & (MSG_TRUNC | MSG_CTRUNC)) {
+    ENVOY_LOG(debug, "splice pump kTLS control record truncated");
+    complete(SpliceCompletion::Closed);
+    return false;
+  }
+
+  uint8_t record_type = 0;
+  for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg); cmsg != nullptr;
+       cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+    if (cmsg->cmsg_level == SOL_TLS && cmsg->cmsg_type == TLS_GET_RECORD_TYPE &&
+        cmsg->cmsg_len >= CMSG_LEN(sizeof(uint8_t))) {
+      record_type = *reinterpret_cast<uint8_t*>(CMSG_DATA(cmsg));
+    }
+  }
+
+  switch (classifyKtlsControlRecord(record_type, buf, static_cast<size_t>(n))) {
+  case ControlAction::Retry:
+    return true;
+  case ControlAction::Eof:
+    ENVOY_LOG(debug, "splice pump upstream close_notify");
+    up_read_eof_ = true;
+    maybeHalfCloseOrComplete();
+    return false;
+  case ControlAction::Close:
+    if (record_type == kTlsRecordAlert) {
+      ENVOY_LOG(debug, "splice pump upstream fatal TLS alert level {} desc {}", buf[0],
+                n >= 2 ? buf[1] : 0xFF);
+    } else {
+      ENVOY_LOG(debug, "splice pump closing on TLS record type {}", record_type);
+    }
+    complete(SpliceCompletion::Closed);
+    return false;
+  }
+  return false; // All ControlActions are handled above.
+}
+
+bool SplicePump::upstreamHasExtraneousData() {
+  // A successful peek means DATA is queued past Content-Length.
+  uint8_t b;
+  ssize_t n;
+  do {
+    n = ::recv(up_fd_, &b, 1, MSG_PEEK | MSG_DONTWAIT);
+  } while (n < 0 && errno == EINTR);
+  return n > 0;
+}
+
+void SplicePump::sendUpstreamCloseNotify() {
+  // Best-effort close_notify for strict kTLS peers.
+  uint8_t alert[2] = {1, kTlsAlertCloseNotify}; // Warning level and close_notify.
+  alignas(struct cmsghdr) char cmsg_space[CMSG_SPACE(sizeof(uint8_t))];
+  struct iovec iov;
+  iov.iov_base = alert;
+  iov.iov_len = sizeof(alert);
+  struct msghdr msg;
+  std::memset(&msg, 0, sizeof(msg));
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_space;
+  msg.msg_controllen = sizeof(cmsg_space);
+  struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+  if (cmsg == nullptr) {
+    return;
+  }
+  cmsg->cmsg_level = SOL_TLS;
+  cmsg->cmsg_type = TLS_SET_RECORD_TYPE;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(uint8_t));
+  *CMSG_DATA(cmsg) = kTlsRecordAlert;
+  ssize_t rc;
+  do {
+    rc = ::sendmsg(up_fd_, &msg, MSG_DONTWAIT);
+  } while (rc < 0 && errno == EINTR);
+  if (rc < 0) {
+    ENVOY_LOG(debug, "splice pump close_notify sendmsg failed, {}", std::strerror(errno));
+  }
+}
+
+void SplicePump::maybeHalfCloseOrComplete() {
+  if (completed_) {
+    return;
+  }
+  if (bounded_) {
+    // Bounded mode never half-closes.
+    if ((u2d_limit_.has_value() && up_read_eof_ && u2d_read_ < u2d_limit_.value()) ||
+        (d2u_limit_.has_value() && down_read_eof_ && d2u_read_ < d2u_limit_.value())) {
+      complete(SpliceCompletion::Closed);
+      return;
+    }
+    // A bounded direction is done once its budget and pending bytes are flushed.
+    const bool u2d_done =
+        !u2d_limit_.has_value() || (u2d_read_ >= u2d_limit_.value() && u2d_.in_pipe == 0 &&
+                                    pending_down_off_ >= pending_down_.size());
+    const bool d2u_done =
+        !d2u_limit_.has_value() || (d2u_read_ >= d2u_limit_.value() && d2u_.in_pipe == 0 &&
+                                    pending_up_off_ >= pending_up_.size());
+    if (u2d_done && d2u_done) {
+      // DATA past Content-Length would be smuggled onto the next pooled stream. kTLS control
+      // records are benign and are drained by the next read.
+      if (u2d_limit_.has_value() && upstreamHasExtraneousData()) {
+        ENVOY_LOG(debug, "splice pump: extraneous upstream data past Content-Length, not reusable");
+        complete(SpliceCompletion::Closed);
+        return;
+      }
+      complete(SpliceCompletion::BoundsReached);
+    }
+    return;
+  }
+  const bool u2d_drained =
+      up_read_eof_ && u2d_.in_pipe == 0 && pending_down_off_ >= pending_down_.size();
+  const bool d2u_drained =
+      down_read_eof_ && d2u_.in_pipe == 0 && pending_up_off_ >= pending_up_.size();
+  // Half-close downstream write after the upstream side drains.
+  if (u2d_drained && !down_write_shutdown_) {
+    ::shutdown(down_fd_, SHUT_WR);
+    down_write_shutdown_ = true;
+  }
+  if (d2u_drained && !up_write_shutdown_) {
+    if (up_is_ktls_) {
+      sendUpstreamCloseNotify();
+    }
+    ::shutdown(up_fd_, SHUT_WR);
+    up_write_shutdown_ = true;
+  }
+  if (u2d_drained && d2u_drained) {
+    complete(SpliceCompletion::Closed);
+    return;
+  }
+  // Once upstream is done, complete after any upload bytes finish draining.
+  if (u2d_drained && down_write_shutdown_ && d2u_.in_pipe == 0 &&
+      pending_up_off_ >= pending_up_.size()) {
+    complete(SpliceCompletion::Closed);
+    return;
+  }
+  // Complete after client EOF only after this pass observes upstream EAGAIN. A stale readable latch
+  // does not prove the RX buffer is empty.
+  if (d2u_drained && up_write_shutdown_ && up_eagain_this_pass_ && u2d_.in_pipe == 0 &&
+      pending_down_off_ >= pending_down_.size()) {
+    complete(SpliceCompletion::Closed);
+  }
+}
+
+void SplicePump::complete(SpliceCompletion status) {
+  if (completed_) {
+    return;
+  }
+  completed_ = true;
+  ENVOY_LOG(debug, "splice pump complete");
+  // Disable FileEvents before completion because we may be inside one of them.
+  if (up_file_event_ != nullptr) {
+    up_file_event_->setEnabled(0);
+  }
+  if (down_file_event_ != nullptr) {
+    down_file_event_->setEnabled(0);
+  }
+  // The owner defers pump destruction through its own callback.
+  on_complete_(status);
+}
+
+#else // !defined(__linux__)
+
+// kTLS and splice() are Linux-only.
+SplicePump::SplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls,
+                       Event::Dispatcher& dispatcher, CompletionCb on_complete,
+                       BytesCb on_upstream_to_downstream, BytesCb on_downstream_to_upstream)
+    : down_fd_(down_fd), up_fd_(up_fd), up_is_ktls_(up_is_ktls), dispatcher_(dispatcher),
+      on_complete_(std::move(on_complete)), on_u2d_bytes_(std::move(on_upstream_to_downstream)),
+      on_d2u_bytes_(std::move(on_downstream_to_upstream)) {}
+
+SplicePump::~SplicePump() = default;
+bool SplicePump::createPipes(bool, bool) { return false; }
+bool SplicePump::prepare(std::string, std::string) { return false; }
+void SplicePump::setBounds(absl::optional<uint64_t>, absl::optional<uint64_t>) {}
+void SplicePump::arm() {}
+absl::Status SplicePump::onUpReady(uint32_t) { return absl::OkStatus(); }
+absl::Status SplicePump::onDownReady(uint32_t) { return absl::OkStatus(); }
+void SplicePump::pump() {}
+bool SplicePump::drainUpstreamControlMessage() { return false; }
+bool SplicePump::upstreamHasExtraneousData() { return false; }
+void SplicePump::sendUpstreamCloseNotify() {}
+void SplicePump::maybeHalfCloseOrComplete() {}
+void SplicePump::complete(SpliceCompletion) {}
+
+#endif
+
+} // namespace TcpProxy
+} // namespace Envoy

--- a/source/common/tcp_proxy/splice_pump.cc
+++ b/source/common/tcp_proxy/splice_pump.cc
@@ -9,6 +9,8 @@
 // forward-declares. The full struct lives here.
 #include "envoy/network/transport_socket.h"
 
+#include "source/common/common/utility.h"
+
 #if defined(__linux__)
 #include <fcntl.h>
 #include <linux/tls.h>
@@ -86,6 +88,19 @@ constexpr size_t kFallbackPipeCapacity = 64 * 1024;
 constexpr int kMaxControlRecordsPerPass = 1024;
 // TLS 1.3 max record, 16384 plaintext plus AEAD and header overhead.
 constexpr size_t kMaxTlsRecordSize = 16640;
+
+// writev a buffer's leading slices to a raw fd, returning the writev() result. The caller loops
+// until the buffer drains, so capping the slice count per call is fine.
+ssize_t writeBufferToFd(os_fd_t fd, Buffer::Instance& buf) {
+  constexpr uint64_t kMaxSlices = 16;
+  const Buffer::RawSliceVector slices = buf.getRawSlices(kMaxSlices);
+  iovec iov[kMaxSlices];
+  for (size_t i = 0; i < slices.size(); i++) {
+    iov[i].iov_base = slices[i].mem_;
+    iov[i].iov_len = slices[i].len_;
+  }
+  return ::writev(fd, iov, static_cast<int>(slices.size()));
+}
 } // namespace
 
 SplicePump::SplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls,
@@ -109,7 +124,7 @@ bool SplicePump::createPipes(bool need_u2d, bool need_d2u) {
   if (need_u2d && u2d_.read_fd < 0) {
     int u2d[2];
     if (::pipe2(u2d, O_NONBLOCK | O_CLOEXEC) != 0) {
-      ENVOY_LOG(warn, "splice pump u2d pipe2 failed, {}", std::strerror(errno));
+      ENVOY_LOG(warn, "splice pump u2d pipe2 failed, {}", errorDetails(errno));
       return false;
     }
     u2d_.read_fd = u2d[0];
@@ -118,7 +133,7 @@ bool SplicePump::createPipes(bool need_u2d, bool need_d2u) {
   if (need_d2u && d2u_.read_fd < 0) {
     int d2u[2];
     if (::pipe2(d2u, O_NONBLOCK | O_CLOEXEC) != 0) {
-      ENVOY_LOG(warn, "splice pump d2u pipe2 failed, {}", std::strerror(errno));
+      ENVOY_LOG(warn, "splice pump d2u pipe2 failed, {}", errorDetails(errno));
       return false;
     }
     d2u_.read_fd = d2u[0];
@@ -127,7 +142,7 @@ bool SplicePump::createPipes(bool need_u2d, bool need_d2u) {
   return true;
 }
 
-bool SplicePump::prepare(std::string initial_u2d, std::string initial_d2u) {
+bool SplicePump::prepare(Buffer::Instance& initial_u2d, Buffer::Instance& initial_d2u) {
   // Lazily create both pipes for callers that did not pre-create them.
   if (u2d_.read_fd < 0 && d2u_.read_fd < 0) {
     if (!createPipes(/*need_u2d=*/true, /*need_d2u=*/true)) {
@@ -136,55 +151,52 @@ bool SplicePump::prepare(std::string initial_u2d, std::string initial_d2u) {
   }
 
   // Write the pre-engage upstream chunk before any spliced upstream-to-downstream bytes.
-  if (!initial_u2d.empty()) {
-    size_t off = 0;
-    while (off < initial_u2d.size()) {
-      const ssize_t w = ::write(down_fd_, initial_u2d.data() + off, initial_u2d.size() - off);
+  if (initial_u2d.length() > 0) {
+    bool delivered = false;
+    while (initial_u2d.length() > 0) {
+      const ssize_t w = writeBufferToFd(down_fd_, initial_u2d);
       if (w > 0) {
-        off += static_cast<size_t>(w);
+        initial_u2d.drain(static_cast<size_t>(w));
         on_u2d_bytes_(static_cast<uint64_t>(w));
+        delivered = true;
       } else if (w < 0 && errno == EINTR) {
         continue;
       } else if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
         break; // Socket full, stash the rest below.
       } else {
-        ENVOY_LOG(warn, "splice pump initial downstream write error, {}", std::strerror(errno));
-        if (off == 0) {
+        ENVOY_LOG(warn, "splice pump initial downstream write error, {}", errorDetails(errno));
+        if (!delivered) {
           return false; // Nothing delivered yet.
         }
         break; // Some bytes already delivered.
       }
     }
-    if (off < initial_u2d.size()) {
-      pending_down_ = std::move(initial_u2d);
-      pending_down_off_ = off;
-    }
+    // Move the unwritten remainder (empty when fully flushed) for pump() to drain.
+    pending_down_.move(initial_u2d);
   }
 
   // Write the pre-engage downstream chunk before any spliced downstream-to-upstream bytes.
-  if (!initial_d2u.empty()) {
-    size_t off = 0;
-    while (off < initial_d2u.size()) {
-      const ssize_t w = ::write(up_fd_, initial_d2u.data() + off, initial_d2u.size() - off);
+  if (initial_d2u.length() > 0) {
+    bool delivered = false;
+    while (initial_d2u.length() > 0) {
+      const ssize_t w = writeBufferToFd(up_fd_, initial_d2u);
       if (w > 0) {
-        off += static_cast<size_t>(w);
+        initial_d2u.drain(static_cast<size_t>(w));
         on_d2u_bytes_(static_cast<uint64_t>(w));
+        delivered = true;
       } else if (w < 0 && errno == EINTR) {
         continue;
       } else if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
         break; // Socket full, stash the rest below.
       } else {
-        ENVOY_LOG(warn, "splice pump initial upstream write error, {}", std::strerror(errno));
-        if (off == 0) {
+        ENVOY_LOG(warn, "splice pump initial upstream write error, {}", errorDetails(errno));
+        if (!delivered) {
           return false; // Nothing delivered yet.
         }
         break;
       }
     }
-    if (off < initial_d2u.size()) {
-      pending_up_ = std::move(initial_d2u);
-      pending_up_off_ = off;
-    }
+    pending_up_.move(initial_d2u);
   }
   return true;
 }
@@ -223,7 +235,7 @@ void SplicePump::arm() {
   // Assume ready at arm and let EAGAIN clear the latches.
   up_readable_ = up_writable_ = down_readable_ = down_writable_ = true;
   ENVOY_LOG(debug, "splice pump armed down_fd={} up_fd={} kTLS={} pending={}", down_fd_, up_fd_,
-            up_is_ktls_, pending_down_.size() - pending_down_off_);
+            up_is_ktls_, pending_down_.length());
   pump();
 }
 
@@ -287,11 +299,10 @@ void SplicePump::pump() {
     const unsigned d2u_out_flags = base_flags | (d2u_more_expected ? SPLICE_F_MORE : 0u);
 
     // Flush pre-engage upstream bytes before spliced upstream-to-downstream bytes.
-    while (down_writable_ && pending_down_off_ < pending_down_.size()) {
-      const ssize_t w = ::write(down_fd_, pending_down_.data() + pending_down_off_,
-                                pending_down_.size() - pending_down_off_);
+    while (down_writable_ && pending_down_.length() > 0) {
+      const ssize_t w = writeBufferToFd(down_fd_, pending_down_);
       if (w > 0) {
-        pending_down_off_ += static_cast<size_t>(w);
+        pending_down_.drain(static_cast<size_t>(w));
         on_u2d_bytes_(static_cast<uint64_t>(w));
         progress = true;
       } else if (w == 0) {
@@ -309,7 +320,7 @@ void SplicePump::pump() {
     }
 
     // Drain upstream-to-downstream pipe after the pre-engage chunk.
-    while (down_writable_ && u2d_.in_pipe > 0 && pending_down_off_ >= pending_down_.size()) {
+    while (down_writable_ && u2d_.in_pipe > 0 && pending_down_.length() == 0) {
       const ssize_t n =
           ::splice(u2d_.read_fd, nullptr, down_fd_, nullptr, u2d_.in_pipe, u2d_out_flags);
       if (n > 0) {
@@ -325,7 +336,7 @@ void SplicePump::pump() {
       } else if (errno == EINTR) {
         continue;
       } else {
-        ENVOY_LOG(debug, "splice pump u2d downstream write error, {}", std::strerror(errno));
+        ENVOY_LOG(debug, "splice pump u2d downstream write error, {}", errorDetails(errno));
         complete(SpliceCompletion::Closed);
         return;
       }
@@ -375,18 +386,17 @@ void SplicePump::pump() {
         }
         break; // Stop reading upstream but keep draining downstream-to-upstream bytes.
       } else {
-        ENVOY_LOG(debug, "splice pump u2d upstream read error, {}", std::strerror(errno));
+        ENVOY_LOG(debug, "splice pump u2d upstream read error, {}", errorDetails(errno));
         complete(SpliceCompletion::Closed);
         return;
       }
     }
 
     // Flush pre-engage downstream bytes before spliced downstream-to-upstream bytes.
-    while (up_writable_ && pending_up_off_ < pending_up_.size()) {
-      const ssize_t w = ::write(up_fd_, pending_up_.data() + pending_up_off_,
-                                pending_up_.size() - pending_up_off_);
+    while (up_writable_ && pending_up_.length() > 0) {
+      const ssize_t w = writeBufferToFd(up_fd_, pending_up_);
       if (w > 0) {
-        pending_up_off_ += static_cast<size_t>(w);
+        pending_up_.drain(static_cast<size_t>(w));
         on_d2u_bytes_(static_cast<uint64_t>(w));
         progress = true;
       } else if (w == 0) {
@@ -404,7 +414,7 @@ void SplicePump::pump() {
     }
 
     // Drain downstream-to-upstream pipe after the pre-engage chunk.
-    while (up_writable_ && d2u_.in_pipe > 0 && pending_up_off_ >= pending_up_.size()) {
+    while (up_writable_ && d2u_.in_pipe > 0 && pending_up_.length() == 0) {
       const ssize_t n =
           ::splice(d2u_.read_fd, nullptr, up_fd_, nullptr, d2u_.in_pipe, d2u_out_flags);
       if (n > 0) {
@@ -420,7 +430,7 @@ void SplicePump::pump() {
       } else if (errno == EINTR) {
         continue;
       } else {
-        ENVOY_LOG(debug, "splice pump d2u upstream write error, {}", std::strerror(errno));
+        ENVOY_LOG(debug, "splice pump d2u upstream write error, {}", errorDetails(errno));
         complete(SpliceCompletion::Closed);
         return;
       }
@@ -464,7 +474,7 @@ void SplicePump::pump() {
       } else if (errno == EINTR) {
         continue;
       } else {
-        ENVOY_LOG(debug, "splice pump d2u downstream read error, {}", std::strerror(errno));
+        ENVOY_LOG(debug, "splice pump d2u downstream read error, {}", errorDetails(errno));
         complete(SpliceCompletion::Closed);
         return;
       }
@@ -498,7 +508,7 @@ bool SplicePump::drainUpstreamControlMessage() {
       up_eagain_this_pass_ = true; // Authoritative upstream drain.
       return false;
     }
-    ENVOY_LOG(debug, "splice pump kTLS control recvmsg error, {}", std::strerror(errno));
+    ENVOY_LOG(debug, "splice pump kTLS control recvmsg error, {}", errorDetails(errno));
     complete(SpliceCompletion::Closed);
     return false;
   }
@@ -558,7 +568,8 @@ bool SplicePump::upstreamHasExtraneousData() {
 void SplicePump::sendUpstreamCloseNotify() {
   // Best-effort close_notify for strict kTLS peers.
   uint8_t alert[2] = {1, kTlsAlertCloseNotify}; // Warning level and close_notify.
-  alignas(struct cmsghdr) char cmsg_space[CMSG_SPACE(sizeof(uint8_t))];
+  // Zero-initialized so no uninitialized padding is handed to sendmsg.
+  alignas(struct cmsghdr) char cmsg_space[CMSG_SPACE(sizeof(uint8_t))] = {};
   struct iovec iov;
   iov.iov_base = alert;
   iov.iov_len = sizeof(alert);
@@ -581,7 +592,7 @@ void SplicePump::sendUpstreamCloseNotify() {
     rc = ::sendmsg(up_fd_, &msg, MSG_DONTWAIT);
   } while (rc < 0 && errno == EINTR);
   if (rc < 0) {
-    ENVOY_LOG(debug, "splice pump close_notify sendmsg failed, {}", std::strerror(errno));
+    ENVOY_LOG(debug, "splice pump close_notify sendmsg failed, {}", errorDetails(errno));
   }
 }
 
@@ -598,11 +609,11 @@ void SplicePump::maybeHalfCloseOrComplete() {
     }
     // A bounded direction is done once its budget and pending bytes are flushed.
     const bool u2d_done =
-        !u2d_limit_.has_value() || (u2d_read_ >= u2d_limit_.value() && u2d_.in_pipe == 0 &&
-                                    pending_down_off_ >= pending_down_.size());
+        !u2d_limit_.has_value() ||
+        (u2d_read_ >= u2d_limit_.value() && u2d_.in_pipe == 0 && pending_down_.length() == 0);
     const bool d2u_done =
-        !d2u_limit_.has_value() || (d2u_read_ >= d2u_limit_.value() && d2u_.in_pipe == 0 &&
-                                    pending_up_off_ >= pending_up_.size());
+        !d2u_limit_.has_value() ||
+        (d2u_read_ >= d2u_limit_.value() && d2u_.in_pipe == 0 && pending_up_.length() == 0);
     if (u2d_done && d2u_done) {
       // DATA past Content-Length would be smuggled onto the next pooled stream. kTLS control
       // records are benign and are drained by the next read.
@@ -615,10 +626,8 @@ void SplicePump::maybeHalfCloseOrComplete() {
     }
     return;
   }
-  const bool u2d_drained =
-      up_read_eof_ && u2d_.in_pipe == 0 && pending_down_off_ >= pending_down_.size();
-  const bool d2u_drained =
-      down_read_eof_ && d2u_.in_pipe == 0 && pending_up_off_ >= pending_up_.size();
+  const bool u2d_drained = up_read_eof_ && u2d_.in_pipe == 0 && pending_down_.length() == 0;
+  const bool d2u_drained = down_read_eof_ && d2u_.in_pipe == 0 && pending_up_.length() == 0;
   // Half-close downstream write after the upstream side drains.
   if (u2d_drained && !down_write_shutdown_) {
     ::shutdown(down_fd_, SHUT_WR);
@@ -636,15 +645,14 @@ void SplicePump::maybeHalfCloseOrComplete() {
     return;
   }
   // Once upstream is done, complete after any upload bytes finish draining.
-  if (u2d_drained && down_write_shutdown_ && d2u_.in_pipe == 0 &&
-      pending_up_off_ >= pending_up_.size()) {
+  if (u2d_drained && down_write_shutdown_ && d2u_.in_pipe == 0 && pending_up_.length() == 0) {
     complete(SpliceCompletion::Closed);
     return;
   }
   // Complete after client EOF only after this pass observes upstream EAGAIN. A stale readable latch
   // does not prove the RX buffer is empty.
   if (d2u_drained && up_write_shutdown_ && up_eagain_this_pass_ && u2d_.in_pipe == 0 &&
-      pending_down_off_ >= pending_down_.size()) {
+      pending_down_.length() == 0) {
     complete(SpliceCompletion::Closed);
   }
 }
@@ -668,17 +676,13 @@ void SplicePump::complete(SpliceCompletion status) {
 
 #else // !defined(__linux__)
 
-// kTLS and splice() are Linux-only.
-SplicePump::SplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls,
-                       Event::Dispatcher& dispatcher, CompletionCb on_complete,
-                       BytesCb on_upstream_to_downstream, BytesCb on_downstream_to_upstream)
-    : down_fd_(down_fd), up_fd_(up_fd), up_is_ktls_(up_is_ktls), dispatcher_(dispatcher),
-      on_complete_(std::move(on_complete)), on_u2d_bytes_(std::move(on_upstream_to_downstream)),
-      on_d2u_bytes_(std::move(on_downstream_to_upstream)) {}
+// kTLS and splice() are Linux-only, so this build stores none of the pump state.
+SplicePump::SplicePump(os_fd_t, os_fd_t, bool, Event::Dispatcher&, CompletionCb, BytesCb, BytesCb) {
+}
 
 SplicePump::~SplicePump() = default;
 bool SplicePump::createPipes(bool, bool) { return false; }
-bool SplicePump::prepare(std::string, std::string) { return false; }
+bool SplicePump::prepare(Buffer::Instance&, Buffer::Instance&) { return false; }
 void SplicePump::setBounds(absl::optional<uint64_t>, absl::optional<uint64_t>) {}
 void SplicePump::arm() {}
 absl::Status SplicePump::onUpReady(uint32_t) { return absl::OkStatus(); }

--- a/source/common/tcp_proxy/splice_pump.h
+++ b/source/common/tcp_proxy/splice_pump.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "envoy/common/platform.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/file_event.h"
+#include "envoy/network/connection.h"
+
+#include "source/common/common/logger.h"
+
+#include "absl/types/optional.h"
+
+namespace Envoy {
+namespace TcpProxy {
+
+// What to do with a non-DATA kTLS record drained from the upstream socket.
+enum class ControlAction {
+  Retry, // benign record consumed (NewSessionTicket or ChangeCipherSpec), retry the splice.
+  Eof,   // peer sent close_notify, treat the upstream read as EOF.
+  Close, // fatal alert or unsupported record, tear the splice down.
+};
+
+// Terminal outcome reported once through the SplicePump completion callback.
+enum class SpliceCompletion {
+  // A bounded transfer moved exactly the configured byte budget in every active direction. The
+  // borrowed sockets are intact and can carry the next keep-alive message, so the caller resumes
+  // the codecs rather than closing.
+  BoundsReached,
+  // The transfer ended because a peer closed or half-closed, an unbounded pump ran a socket to EOF,
+  // or an error occurred. The sockets must not be reused.
+  Closed,
+};
+
+// Classifies a non-DATA TLS record by its record type and bytes. Pure so it can be unit-tested
+// without a kTLS socket. `data` and `len` are the decrypted record payload from recvmsg(). Exposed
+// here for unit testing.
+ControlAction classifyKtlsControlRecord(uint8_t record_type, const uint8_t* data, size_t len);
+
+// True if raw spliced bytes can be sent to or read from the connection without bypassing
+// encryption. Plaintext and installed-kTLS legs pass. Userspace TLS and kTLS-capable legs without
+// installed kTLS fail.
+bool spliceLegIsRawOrKtls(Network::Connection& connection);
+
+// In-kernel splice() pump that moves bytes through pipes while borrowing both socket fds. The
+// caller owns the sockets. The pump owns only its pipes and FileEvents. Each edge-triggered wakeup
+// drains ready directions to EAGAIN without blocking.
+class SplicePump : public Logger::Loggable<Logger::Id::filter> {
+public:
+  using CompletionCb = std::function<void(SpliceCompletion)>;
+  using BytesCb = std::function<void(uint64_t)>;
+
+  SplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls, Event::Dispatcher& dispatcher,
+             CompletionCb on_complete, BytesCb on_upstream_to_downstream,
+             BytesCb on_downstream_to_upstream);
+  // Virtual for deterministic coordinator tests. These methods are not on the byte path.
+  virtual ~SplicePump();
+
+  // Creates only the requested pipe directions before callers do irreversible work.
+  virtual bool createPipes(bool need_u2d, bool need_d2u);
+  // Queues pre-engage chunks before callers detach ConnectionImpl FileEvents.
+  virtual bool prepare(std::string initial_u2d, std::string initial_d2u);
+  // Switches the pump into bounded mode for exact Content-Length bodies.
+  virtual void setBounds(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit);
+  // Installs the pump's FileEvents after callers detach ConnectionImpl FileEvents.
+  virtual void arm();
+
+private:
+  struct Pipe {
+    int read_fd{-1};
+    int write_fd{-1};
+    size_t in_pipe{0};
+    size_t capacity{0};
+  };
+
+  absl::Status onDownReady(uint32_t events);
+  absl::Status onUpReady(uint32_t events);
+  void pump();
+  bool drainUpstreamControlMessage();
+  // Checks if DATA is queued past a bounded download's Content-Length boundary.
+  bool upstreamHasExtraneousData();
+  void sendUpstreamCloseNotify();
+  void maybeHalfCloseOrComplete();
+  void complete(SpliceCompletion status);
+
+  const os_fd_t down_fd_;
+  const os_fd_t up_fd_;
+  const bool up_is_ktls_;
+  Event::Dispatcher& dispatcher_;
+  CompletionCb on_complete_;
+  BytesCb on_u2d_bytes_;
+  BytesCb on_d2u_bytes_;
+
+  // Bounded-mode state for exact Content-Length bodies.
+  bool bounded_{false};
+  absl::optional<uint64_t> u2d_limit_;
+  absl::optional<uint64_t> d2u_limit_;
+  uint64_t u2d_read_{0};
+  uint64_t d2u_read_{0};
+
+  Pipe u2d_; // Upstream to downstream.
+  // Downstream to upstream.
+  Pipe d2u_;
+  Event::FileEventPtr up_file_event_;
+  Event::FileEventPtr down_file_event_;
+
+  // Pre-engage upstream chunk waiting for downstream socket space.
+  std::string pending_down_;
+  size_t pending_down_off_{0};
+  // Pre-engage downstream chunk waiting for upstream socket space.
+  std::string pending_up_;
+  size_t pending_up_off_{0};
+
+  // Readiness latches set by FileEvents and cleared on EAGAIN.
+  bool up_readable_{false};
+  bool up_writable_{false};
+  bool down_readable_{false};
+  bool down_writable_{false};
+  bool up_read_eof_{false};
+  bool down_read_eof_{false};
+  bool down_write_shutdown_{false};
+  bool up_write_shutdown_{false};
+  bool completed_{false};
+  // True only when this pump pass proved the upstream RX buffer is drained.
+  bool up_eagain_this_pass_{false};
+  // Set when the FileEvent reports Closed.
+  bool down_closed_{false};
+  bool up_closed_{false};
+};
+
+using SplicePumpPtr = std::unique_ptr<SplicePump>;
+
+} // namespace TcpProxy
+} // namespace Envoy

--- a/source/common/tcp_proxy/splice_pump.h
+++ b/source/common/tcp_proxy/splice_pump.h
@@ -9,6 +9,7 @@
 #include "envoy/event/file_event.h"
 #include "envoy/network/connection.h"
 
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 
 #include "absl/types/optional.h"
@@ -60,8 +61,9 @@ public:
 
   // Creates only the requested pipe directions before callers do irreversible work.
   virtual bool createPipes(bool need_u2d, bool need_d2u);
-  // Queues pre-engage chunks before callers detach ConnectionImpl FileEvents.
-  virtual bool prepare(std::string initial_u2d, std::string initial_d2u);
+  // Queues pre-engage chunks before callers detach ConnectionImpl FileEvents. The chunks are moved
+  // out of the caller's buffers (zero-copy), so they are left empty on return.
+  virtual bool prepare(Buffer::Instance& initial_u2d, Buffer::Instance& initial_d2u);
   // Switches the pump into bounded mode for exact Content-Length bodies.
   virtual void setBounds(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit);
   // Installs the pump's FileEvents after callers detach ConnectionImpl FileEvents.
@@ -85,6 +87,10 @@ private:
   void maybeHalfCloseOrComplete();
   void complete(SpliceCompletion status);
 
+  // The state below is only used by the Linux splice()/kTLS fast path; the non-Linux build compiles
+  // stub methods that never touch it. Guarding it keeps that build free of unused-private-field
+  // errors.
+#if defined(__linux__)
   const os_fd_t down_fd_;
   const os_fd_t up_fd_;
   const bool up_is_ktls_;
@@ -107,11 +113,9 @@ private:
   Event::FileEventPtr down_file_event_;
 
   // Pre-engage upstream chunk waiting for downstream socket space.
-  std::string pending_down_;
-  size_t pending_down_off_{0};
+  Buffer::OwnedImpl pending_down_;
   // Pre-engage downstream chunk waiting for upstream socket space.
-  std::string pending_up_;
-  size_t pending_up_off_{0};
+  Buffer::OwnedImpl pending_up_;
 
   // Readiness latches set by FileEvents and cleared on EAGAIN.
   bool up_readable_{false};
@@ -128,6 +132,7 @@ private:
   // Set when the FileEvent reports Closed.
   bool down_closed_{false};
   bool up_closed_{false};
+#endif
 };
 
 using SplicePumpPtr = std::unique_ptr<SplicePump>;

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -361,6 +361,10 @@ public:
   Router::FilterConfig& config() override {
     return const_cast<Router::FilterConfig&>(config_.routerFilterConfig());
   }
+  // The L7 kTLS body-splice is a router-only fast path and never engages on a tcp_proxy tunnel, so
+  // these are unused here and exist only to satisfy the interface.
+  void disableRetries() override {}
+  bool shadowStreamsActive() const override { return false; }
   Router::TimeoutData timeout() override { return {}; }
   absl::optional<std::chrono::milliseconds> dynamicMaxStreamDuration() const override {
     return absl::nullopt;

--- a/source/extensions/transport_sockets/common/passthrough.h
+++ b/source/extensions/transport_sockets/common/passthrough.h
@@ -77,6 +77,13 @@ public:
   Network::IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;
   void onConnected() override;
   Ssl::ConnectionInfoConstSharedPtr ssl() const override;
+  // Forward kTLS bytestream info to the wrapped socket so a wrapper (e.g. the upstream
+  // http_11_proxy transport socket) does not hide an inner kTLS socket from a higher layer such as
+  // the kTLS body-splice that wants to splice() on the fd. Without this forward the base default
+  // reports "not kTLS" and the splice never engages on a wrapped upstream.
+  OptRef<const Network::KtlsBytestreamInfo> ktlsBytestreamInfo() const override {
+    return transport_socket_->ktlsBytestreamInfo();
+  }
   // startSecureTransport method should not be called for this transport socket.
   bool startSecureTransport() override { return false; }
   void configureInitialCongestionWindow(uint64_t bandwidth_bits_per_sec,

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -5,6 +5,7 @@
 
 #include "envoy/http/codes.h"
 #include "envoy/http/conn_pool.h"
+#include "envoy/network/connection.h"
 #include "envoy/upstream/thread_local_cluster.h"
 
 #include "source/common/common/assert.h"
@@ -104,6 +105,17 @@ public:
 
   const StreamInfo::BytesMeterSharedPtr& bytesMeter() override {
     return request_encoder_->getStream().bytesMeter();
+  }
+
+  OptRef<Network::Connection> upstreamConnectionForSplice() override {
+    return request_encoder_ != nullptr ? request_encoder_->getStream().connectionForSplice()
+                                       : OptRef<Network::Connection>{};
+  }
+
+  void completeSplicedResponse(uint64_t response_body_bytes) override {
+    if (request_encoder_ != nullptr) {
+      request_encoder_->completeSplicedResponse(response_body_bytes);
+    }
   }
 
 private:

--- a/test/common/http/codec_wrappers_test.cc
+++ b/test/common/http/codec_wrappers_test.cc
@@ -87,6 +87,14 @@ TEST(RequestEncoderWrapper, HeaderOnlyEncode) {
   EXPECT_TRUE(wrapper.encodeComplete());
 }
 
+TEST(RequestEncoderWrapper, CompleteSplicedResponseForwardsToInner) {
+  // The kTLS body-splice finalizes the response through this wrapper stack, so the call must reach
+  // the inner encoder. A silent no-op here would strand the spliced stream.
+  MockRequestEncoderWrapper wrapper;
+  EXPECT_CALL(wrapper.innerEncoder(), completeSplicedResponse(12345));
+  wrapper.completeSplicedResponse(12345);
+}
+
 TEST(RequestEncoderWrapper, HeaderAndBodyEncode) {
   MockRequestEncoderWrapper wrapper;
 

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -1655,6 +1655,51 @@ TEST_F(Http1ServerConnectionImplTest, PostWithContentLength) {
   EXPECT_EQ(0U, buffer.length());
 }
 
+TEST_F(Http1ServerConnectionImplTest, CompleteSplicedRequestFinalizesAndResetsParser) {
+  initialize();
+
+  // Set up both request decoder mocks before the sequence so their getRequestDecoderHandle()
+  // expectations are not themselves sequenced (they fire whenever a stream is created).
+  MockRequestDecoder decoder;
+  MockRequestDecoder second_decoder;
+  setupRequestDecoderMock(decoder);
+  setupRequestDecoderMock(second_decoder);
+
+  InSequence sequence;
+  Http::ResponseEncoder* response_encoder = nullptr;
+  EXPECT_CALL(callbacks_, newStream(_, _))
+      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+        response_encoder = &encoder;
+        return decoder;
+      }));
+
+  // Deliver only the request headers. The 100000-byte body would be spliced out-of-band, so it
+  // never passes through the parser or the decode path.
+  EXPECT_CALL(decoder, decodeHeaders_(_, false));
+  Buffer::OwnedImpl headers_buffer(
+      "POST / HTTP/1.1\r\nhost: host\r\ncontent-length: 100000\r\n\r\n");
+  auto status = codec_->dispatch(headers_buffer);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(0, headers_buffer.length());
+
+  // Finalize the spliced request. The decoder observes the terminal end-of-stream with no body.
+  EXPECT_CALL(decoder, decodeData(_, true));
+  response_encoder->completeSplicedRequest(100000);
+
+  // Send the response to complete the request/response cycle, which clears the active request so
+  // the connection can parse the next pipelined request.
+  TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"content-length", "0"}};
+  response_encoder->encodeHeaders(response_headers, true);
+
+  // The connection is keep-alive ready. A second request parses cleanly on a fresh stream, proving
+  // the parser was rebuilt rather than left stuck mid-body.
+  EXPECT_CALL(callbacks_, newStream(_, _)).WillOnce(ReturnRef(second_decoder));
+  EXPECT_CALL(second_decoder, decodeHeaders_(_, true));
+  Buffer::OwnedImpl second_request("GET /next HTTP/1.1\r\nhost: host\r\n\r\n");
+  status = codec_->dispatch(second_request);
+  EXPECT_TRUE(status.ok());
+}
+
 // Verify that headers and body with content length are processed correctly and data is merged
 // before the decodeData call even if delivered in a buffer that holds 1 byte per slice.
 TEST_F(Http1ServerConnectionImplTest, PostWithContentLengthFragmentedBuffer) {
@@ -2671,6 +2716,41 @@ TEST_F(Http1ClientConnectionImplTest, SimpleGet) {
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/"}};
   EXPECT_TRUE(request_encoder.encodeHeaders(headers, true).ok());
   EXPECT_EQ("GET / HTTP/1.1\r\n\r\n", output);
+}
+
+// completeSplicedResponse() finalizes a Content-Length response whose body was relayed out-of-band
+// by the kTLS body-splice fast path. It delivers the terminal end-of-stream to the decoder and
+// leaves the connection ready to parse the next keep-alive response.
+TEST_F(Http1ClientConnectionImplTest, CompleteSplicedResponseFinalizesAndResetsParser) {
+  initialize();
+
+  NiceMock<MockResponseDecoder> response_decoder;
+  Http::RequestEncoder& request_encoder = codec_->newStream(response_decoder);
+  TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_TRUE(request_encoder.encodeHeaders(request_headers, true).ok());
+
+  // Deliver only the response headers. The 100000-byte body would be spliced out-of-band, so it
+  // never passes through the parser or the decode path.
+  EXPECT_CALL(response_decoder, decodeHeaders_(_, false));
+  Buffer::OwnedImpl headers_buffer("HTTP/1.1 200 OK\r\ncontent-length: 100000\r\n\r\n");
+  auto status = codec_->dispatch(headers_buffer);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(0, headers_buffer.length());
+
+  // Finalize the spliced response. The decoder observes the terminal end-of-stream with no body.
+  EXPECT_CALL(response_decoder, decodeData(_, true));
+  request_encoder.completeSplicedResponse(100000);
+
+  // The connection is keep-alive ready. A second response parses cleanly on a fresh stream, proving
+  // the parser was rebuilt rather than left stuck mid-body.
+  NiceMock<MockResponseDecoder> second_response_decoder;
+  Http::RequestEncoder& second_request_encoder = codec_->newStream(second_response_decoder);
+  EXPECT_TRUE(second_request_encoder.encodeHeaders(request_headers, true).ok());
+  EXPECT_CALL(second_response_decoder, decodeHeaders_(_, true));
+  Buffer::OwnedImpl second_response("HTTP/1.1 204 No Content\r\n\r\n");
+  status = codec_->dispatch(second_response);
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(Http1ClientConnectionImplTest, SimpleGetWithHeaderCasing) {

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -406,6 +406,36 @@ TEST_P(ConnectionImplTest, DrainSkipsRemovedCallbacks) {
   disconnect(true);
 }
 
+// extractPendingWriteForSplice() removes buffered output so the kTLS body-splice can emit it, and
+// reinstallFileEvents() re-arms a leg whose file event the splice detached, restoring I/O.
+TEST_P(ConnectionImplTest, SpliceExtractWriteBufferAndReinstallFileEvents) {
+  setUpBasicConnection();
+  connect();
+
+  // Buffer output on the client, then take it for the splice. The connection no longer sends it.
+  Buffer::OwnedImpl prefix("extracted-prefix");
+  client_connection_->write(prefix, false);
+  EXPECT_EQ("extracted-prefix", client_connection_->extractPendingWriteForSplice());
+
+  // Detach the server's file event the way the splice does, then re-arm it.
+  server_connection_->getSocket()->ioHandle().resetFileEvents();
+  server_connection_->reinstallFileEvents();
+
+  // The server receives only the post-extract write, proving the prefix was taken (not sent) and
+  // that read I/O resumed after re-arm.
+  EXPECT_CALL(*read_filter_, onData(_, false))
+      .WillOnce(Invoke([&](Buffer::Instance& buffer, bool) -> FilterStatus {
+        EXPECT_EQ("reinstalled", buffer.toString());
+        dispatcher_->exit();
+        return FilterStatus::StopIteration;
+      }));
+  Buffer::OwnedImpl data("reinstalled");
+  client_connection_->write(data, false);
+  dispatcher_->run(Event::Dispatcher::RunType::Block);
+
+  disconnect(true);
+}
+
 TEST_P(ConnectionImplTest, CloseDuringConnectCallback) {
   setUpBasicConnection();
 

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -415,7 +415,9 @@ TEST_P(ConnectionImplTest, SpliceExtractWriteBufferAndReinstallFileEvents) {
   // Buffer output on the client, then take it for the splice. The connection no longer sends it.
   Buffer::OwnedImpl prefix("extracted-prefix");
   client_connection_->write(prefix, false);
-  EXPECT_EQ("extracted-prefix", client_connection_->extractPendingWriteForSplice());
+  Buffer::OwnedImpl extracted;
+  client_connection_->extractPendingWriteForSplice(extracted);
+  EXPECT_EQ("extracted-prefix", extracted.toString());
 
   // Detach the server's file event the way the splice does, then re-arm it.
   server_connection_->getSocket()->ioHandle().resetFileEvents();

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -1306,8 +1306,11 @@ TEST_F(MultiConnectionBaseImplTest, SpliceHelpersDelegateAfterConnect) {
   EXPECT_CALL(*createdConnections()[0], reinstallFileEvents());
   impl_->reinstallFileEvents();
 
-  EXPECT_CALL(*createdConnections()[0], extractPendingWriteForSplice()).WillOnce(Return("pending"));
-  EXPECT_EQ("pending", impl_->extractPendingWriteForSplice());
+  EXPECT_CALL(*createdConnections()[0], extractPendingWriteForSplice(testing::_))
+      .WillOnce(testing::Invoke([](Buffer::Instance& dst) { dst.add("pending"); }));
+  Buffer::OwnedImpl pending;
+  impl_->extractPendingWriteForSplice(pending);
+  EXPECT_EQ("pending", pending.toString());
 }
 
 } // namespace Network

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -1279,11 +1279,35 @@ TEST_F(MultiConnectionBaseImplTest, SetSocketOptionFailedTest) {
   EXPECT_FALSE(impl_->setSocketOption(sockopt_name, sockopt_val));
 }
 
-TEST_F(MultiConnectionBaseImplTest, GetSocketPanics) {
+// After connect, getSocket() delegates to the single selected connection so the kTLS body-splice
+// can splice() on the upstream fd of a Happy Eyeballs (DNS-cluster) upstream.
+TEST_F(MultiConnectionBaseImplTest, GetSocketDelegatesAfterConnect) {
   setupMultiConnectionImpl(2);
+  connectFirstAttempt();
 
-  // getSocket() should panic as it's not implemented for MultiConnectionBaseImpl.
-  EXPECT_DEATH(impl_->getSocket(), "not implemented");
+  ConnectionSocketPtr socket;
+  EXPECT_CALL(*createdConnections()[0], getSocket()).WillOnce(ReturnRef(socket));
+  EXPECT_EQ(&socket, &impl_->getSocket());
+}
+
+// The kTLS body-splice helpers delegate to the single selected connection after connect.
+TEST_F(MultiConnectionBaseImplTest, SpliceHelpersDelegateAfterConnect) {
+  setupMultiConnectionImpl(2);
+  connectFirstAttempt();
+
+  KtlsBytestreamInfo info;
+  info.installed = true;
+  EXPECT_CALL(*createdConnections()[0], ktlsBytestreamInfo())
+      .WillOnce(Return(OptRef<const KtlsBytestreamInfo>(info)));
+  OptRef<const KtlsBytestreamInfo> returned = impl_->ktlsBytestreamInfo();
+  ASSERT_TRUE(returned.has_value());
+  EXPECT_TRUE(returned->installed);
+
+  EXPECT_CALL(*createdConnections()[0], reinstallFileEvents());
+  impl_->reinstallFileEvents();
+
+  EXPECT_CALL(*createdConnections()[0], extractPendingWriteForSplice()).WillOnce(Return("pending"));
+  EXPECT_EQ("pending", impl_->extractPendingWriteForSplice());
 }
 
 } // namespace Network

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -579,6 +579,9 @@ envoy_cc_test(
     name = "splice_coordinator_test",
     srcs = ["splice_coordinator_test.cc"],
     rbe_pool = "6gig",
+    # The fixture rebuilds the full UpstreamRequest mock graph per case, which is slow under MSAN;
+    # shard so no single shard exceeds the test timeout.
+    shard_count = 4,
     deps = [
         "//source/common/network:utility_lib",
         "//source/common/router:router_lib",

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -576,6 +576,25 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "splice_coordinator_test",
+    srcs = ["splice_coordinator_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/network:utility_lib",
+        "//source/common/router:router_lib",
+        "//source/common/tcp_proxy:splice_pump_lib",
+        "//test/common/http:common_lib",
+        "//test/mocks:common_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/router:router_filter_interface",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "delegating_route_impl_test",
     srcs = ["delegating_route_impl_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/router/splice_coordinator_test.cc
+++ b/test/common/router/splice_coordinator_test.cc
@@ -1,0 +1,1517 @@
+// Unit tests for Router::SpliceCoordinator. The fixture injects a fake pump so tests can drive arm,
+// engage, complete, finalize, and reset without kernel I/O. The kernel splice path is covered by
+// splice_pump_test.cc.
+
+#include "envoy/network/address.h"
+
+#include "source/common/network/address_impl.h"
+#include "source/common/network/utility.h"
+#include "source/common/router/splice_coordinator.h"
+#include "source/common/router/upstream_request.h"
+#include "source/common/tcp_proxy/splice_pump.h"
+
+#include "test/common/http/common.h"
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/network/connection.h"
+#include "test/mocks/network/io_handle.h"
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/router/router_filter_interface.h"
+#include "test/mocks/ssl/mocks.h"
+#include "test/test_common/test_runtime.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::_;
+using ::testing::AnyNumber;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+namespace Envoy {
+namespace Router {
+namespace {
+
+// Non-invalid fds accepted by spliceableFd.
+constexpr os_fd_t kUpstreamFd = 11;
+constexpr os_fd_t kDownstreamFd = 10;
+// Content-Length above MinSpliceBodyBytes.
+constexpr uint64_t kBodyBytes = 128 * 1024;
+
+// No-I/O SplicePump test double.
+class FakeSplicePump : public TcpProxy::SplicePump {
+public:
+  FakeSplicePump(os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls, Event::Dispatcher& dispatcher,
+                 TcpProxy::SplicePump::CompletionCb on_complete,
+                 TcpProxy::SplicePump::BytesCb on_u2d_bytes,
+                 TcpProxy::SplicePump::BytesCb on_d2u_bytes)
+      : TcpProxy::SplicePump(down_fd, up_fd, up_is_ktls, dispatcher, std::move(on_complete),
+                             std::move(on_u2d_bytes), std::move(on_d2u_bytes)) {}
+
+  bool createPipes(bool need_u2d, bool need_d2u) override {
+    create_pipes_called_ = true;
+    need_u2d_ = need_u2d;
+    need_d2u_ = need_d2u;
+    return create_pipes_result_;
+  }
+  bool prepare(std::string initial_u2d, std::string initial_d2u) override {
+    prepare_called_ = true;
+    prepare_initial_u2d_ = std::move(initial_u2d);
+    prepare_initial_d2u_ = std::move(initial_d2u);
+    return prepare_result_;
+  }
+  void setBounds(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit) override {
+    set_bounds_called_ = true;
+    u2d_limit_ = u2d_limit;
+    d2u_limit_ = d2u_limit;
+  }
+  void arm() override { arm_called_ = true; }
+
+  // Fixture knobs.
+  bool create_pipes_result_{true};
+  bool prepare_result_{true};
+
+  // Observations.
+  bool create_pipes_called_{false};
+  bool prepare_called_{false};
+  bool set_bounds_called_{false};
+  bool arm_called_{false};
+  bool need_u2d_{false};
+  bool need_d2u_{false};
+  std::string prepare_initial_u2d_;
+  std::string prepare_initial_d2u_;
+  absl::optional<uint64_t> u2d_limit_;
+  absl::optional<uint64_t> d2u_limit_;
+};
+
+// GenericUpstream double exposing only the splice seams.
+class TestGenericUpstream : public GenericUpstream {
+public:
+  // Splice seams under test.
+  OptRef<Network::Connection> upstreamConnectionForSplice() override { return splice_connection_; }
+  MOCK_METHOD(void, completeSplicedResponse, (uint64_t response_body_bytes), (override));
+
+  // Unused GenericUpstream surface.
+  void encodeData(Buffer::Instance&, bool) override {}
+  void encodeMetadata(const Http::MetadataMapVector&) override {}
+  Http::Status encodeHeaders(const Http::RequestHeaderMap&, bool) override {
+    return Http::okStatus();
+  }
+  void encodeTrailers(const Http::RequestTrailerMap&) override {}
+  void enableTcpTunneling() override {}
+  void readDisable(bool) override {}
+  void resetStream() override {}
+  void setAccount(Buffer::BufferMemoryAccountSharedPtr) override {}
+  const StreamInfo::BytesMeterSharedPtr& bytesMeter() override { return bytes_meter_; }
+
+  OptRef<Network::Connection> splice_connection_;
+  StreamInfo::BytesMeterSharedPtr bytes_meter_{std::make_shared<StreamInfo::BytesMeter>()};
+};
+
+// Downstream callbacks mock with splice seams.
+class TestDownstreamFilterCallbacks : public Http::MockDownstreamStreamFilterCallbacks {
+public:
+  MOCK_METHOD(OptRef<Network::Connection>, downstreamConnectionForSplice, (), (override));
+  MOCK_METHOD(void, completeSplicedRequest, (uint64_t request_body_bytes), (override));
+};
+
+} // namespace
+
+// The fixture lives in Envoy::Router so UpstreamRequest friendship applies.
+class SpliceCoordinatorTest : public testing::Test {
+public:
+  SpliceCoordinatorTest() {
+    scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_ktls_body_splice", "true"}});
+    HttpTestUtility::addDefaultHeaders(downstream_request_header_map_);
+    ON_CALL(parent_, downstreamHeaders()).WillByDefault(Return(&downstream_request_header_map_));
+  }
+
+protected:
+  // Builds the request, coordinator, mocks, and fake-pump factory.
+  void initialize() {
+    auto conn_pool = std::make_unique<NiceMock<MockGenericConnPool>>();
+    conn_pool_ = conn_pool.get();
+    ON_CALL(*conn_pool_, host()).WillByDefault(Return(host_));
+    upstream_request_ = std::make_unique<UpstreamRequest>(parent_, std::move(conn_pool),
+                                                          /*can_send_early_data=*/false,
+                                                          /*can_use_http3=*/true,
+                                                          /*enable_half_close=*/false);
+
+    coord_ = std::make_unique<SpliceCoordinator>(*upstream_request_);
+
+    // Capture callbacks in coordinator creation order.
+    Event::MockDispatcher& disp = parent_.callbacks_.dispatcher_;
+    ON_CALL(disp, createSchedulableCallback_(_))
+        .WillByDefault(Invoke([this](std::function<void()> cb) -> Event::SchedulableCallback* {
+          auto* sched = new NiceMock<Event::MockSchedulableCallback>(
+              &this->parent_.callbacks_.dispatcher_, cb);
+          if (engage_sched_ == nullptr) {
+            engage_sched_ = sched;
+            engage_cb_ = cb;
+          } else {
+            finalize_sched_ = sched;
+            finalize_cb_ = cb;
+          }
+          return sched;
+        }));
+    // Classify timers by duration because creation order differs by direction.
+    ON_CALL(disp, createTimer_(_)).WillByDefault(Invoke([this](Event::TimerCb cb) -> Event::Timer* {
+      auto* timer = new NiceMock<Event::MockTimer>();
+      timer->callback_ = cb;
+      ON_CALL(*timer, enableTimer(_, _))
+          .WillByDefault(
+              Invoke([this, timer](std::chrono::milliseconds d, const ScopeTrackedObject* scope) {
+                timer->enabled_ = true;
+                timer->scope_ = scope;
+                if (d == std::chrono::milliseconds(2)) {
+                  poll_timer_ = timer;
+                } else {
+                  watchdog_timer_ = timer;
+                }
+              }));
+      return timer;
+    }));
+
+    // Downstream leg resolved through downstream callbacks.
+    ON_CALL(down_cb_, downstreamConnectionForSplice())
+        .WillByDefault(Return(OptRef<Network::Connection>(downstream_conn_)));
+    ON_CALL(parent_.callbacks_, downstreamCallbacks())
+        .WillByDefault(Return(OptRef<Http::DownstreamStreamFilterCallbacks>(down_cb_)));
+
+    // Downstream defaults to plaintext.
+    wireConnection(downstream_conn_, down_socket_, down_io_, down_socket_ptr_, kDownstreamFd);
+    ON_CALL(downstream_conn_, ssl()).WillByDefault(Return(nullptr));
+    ON_CALL(downstream_conn_, ktlsBytestreamInfo())
+        .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>{}));
+
+    // Upstream defaults to trusted kTLS.
+    wireConnection(upstream_conn_, up_socket_, up_io_, up_socket_ptr_, kUpstreamFd);
+    ON_CALL(upstream_conn_, ssl()).WillByDefault(Return(nullptr));
+    up_ktls_.installed = true;
+    up_ktls_.trusted_peer = true;
+    ON_CALL(upstream_conn_, ktlsBytestreamInfo())
+        .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>(up_ktls_)));
+
+    // GenericUpstream resolves to upstream_conn_.
+    auto test_upstream = std::make_unique<NiceMock<TestGenericUpstream>>();
+    test_upstream_ = test_upstream.get();
+    test_upstream_->splice_connection_ = upstream_conn_;
+    upstream_request_->upstream_ = std::move(test_upstream);
+
+    // Pending writes handed to the pump.
+    ON_CALL(upstream_conn_, extractPendingWriteForSplice())
+        .WillByDefault(Return(std::string("UP-HEADERS")));
+    ON_CALL(downstream_conn_, extractPendingWriteForSplice())
+        .WillByDefault(Return(std::string("DOWN-HEADERS")));
+
+    // Capture the fake pump and its callbacks for each test.
+    coord_->setSplicePumpFactoryForTest(
+        [this](os_fd_t down_fd, os_fd_t up_fd, bool up_is_ktls, Event::Dispatcher& dispatcher,
+               TcpProxy::SplicePump::CompletionCb on_complete,
+               TcpProxy::SplicePump::BytesCb on_u2d_bytes,
+               TcpProxy::SplicePump::BytesCb on_d2u_bytes) -> TcpProxy::SplicePumpPtr {
+          factory_called_ = true;
+          factory_down_fd_ = down_fd;
+          factory_up_fd_ = up_fd;
+          factory_up_is_ktls_ = up_is_ktls;
+          completion_cb_ = std::move(on_complete);
+          u2d_bytes_cb_ = std::move(on_u2d_bytes);
+          d2u_bytes_cb_ = std::move(on_d2u_bytes);
+          auto pump = std::make_unique<FakeSplicePump>(
+              down_fd, up_fd, up_is_ktls, dispatcher, completion_cb_, u2d_bytes_cb_, d2u_bytes_cb_);
+          pump->create_pipes_result_ = create_pipes_result_;
+          pump->prepare_result_ = prepare_result_;
+          fake_pump_ = pump.get();
+          return pump;
+        });
+  }
+
+  void TearDown() override {
+    // Release non-owning wrappers around stack mocks.
+    up_socket_ptr_.release();
+    down_socket_ptr_.release();
+  }
+
+  // Wires a connection mock so getSocket()->ioHandle().fdDoNotUse() returns `fd`, resetFileEvents()
+  // is a no-op, and a non-internal local address is present so spliceableFd accepts it.
+  void wireConnection(NiceMock<Network::MockConnection>& c,
+                      NiceMock<Network::MockConnectionSocket>& s,
+                      NiceMock<Network::MockIoHandle>& io, Network::ConnectionSocketPtr& sptr,
+                      os_fd_t fd) {
+    sptr.reset(&s);
+    ON_CALL(c, getSocket()).WillByDefault(ReturnRef(sptr));
+    ON_CALL(s, ioHandle()).WillByDefault(ReturnRef(io));
+    ON_CALL(Const(s), ioHandle()).WillByDefault(ReturnRef(io));
+    ON_CALL(io, fdDoNotUse()).WillByDefault(Return(fd));
+    c.connectionInfoSetter().setLocalAddress(
+        Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.1:80"));
+    // state() defaults Open via initializeMockConnection, readDisable returns a status.
+    ON_CALL(c, readDisable(_))
+        .WillByDefault(Return(Network::Connection::ReadDisableStatus::StillReadDisabled));
+  }
+
+  // Arms a download splice for `cl` bytes. encodeComplete() must already be true (set via the
+  // friend). Returns the arm result.
+  bool armDownload(uint64_t cl = kBodyBytes) {
+    setEncodeComplete(true);
+    Http::TestResponseHeaderMapImpl headers{{":status", "200"},
+                                            {"content-length", absl::StrCat(cl)}};
+    return coord_->maybeArmForResponse(headers, /*end_stream=*/false);
+  }
+
+  // Arms an upload splice for `cl` bytes.
+  bool armUpload(uint64_t cl = kBodyBytes) {
+    Http::TestRequestHeaderMapImpl headers{{":method", "PUT"},
+                                           {":path", "/"},
+                                           {":authority", "host"},
+                                           {"content-length", absl::StrCat(cl)}};
+    return coord_->maybeArmForRequest(headers, /*end_stream=*/false);
+  }
+
+  void fireEngage() {
+    ASSERT_TRUE(engage_cb_ != nullptr);
+    engage_cb_();
+  }
+  void fireFinalize() {
+    ASSERT_TRUE(finalize_cb_ != nullptr);
+    finalize_cb_();
+  }
+
+  uint64_t counter(absl::string_view name) {
+    return parent_.cluster_info_->stats_store_.counter(absl::StrCat("http1_ktls_splice.", name))
+        .value();
+  }
+
+  // Private-member accessors. The fixture class is a friend of UpstreamRequest, but friendship is
+  // not inherited by the per-TEST_F subclasses, so these helpers live here on the fixture and the
+  // tests call them.
+  void setEncodeComplete(bool complete) { upstream_request_->router_sent_end_stream_ = complete; }
+  void clearUpstream() { upstream_request_->upstream_.reset(); }
+  bool onResetStreamInProgress() const { return upstream_request_->on_reset_stream_in_progress_; }
+  // Re-enters onResetStream as the codec reset cascade would when the upstream is force-closed.
+  void reenterOnResetStream() {
+    upstream_request_->onResetStream(Http::StreamResetReason::ConnectionTermination,
+                                     "codec reset cascade");
+  }
+
+  TestScopedRuntime scoped_runtime_;
+  NiceMock<MockRouterFilterInterface> parent_;
+  Http::TestRequestHeaderMapImpl downstream_request_header_map_;
+  MockGenericConnPool* conn_pool_{nullptr};
+  std::shared_ptr<NiceMock<Upstream::MockHostDescription>> host_{
+      new NiceMock<Upstream::MockHostDescription>()};
+  std::unique_ptr<UpstreamRequest> upstream_request_;
+  std::unique_ptr<SpliceCoordinator> coord_;
+
+  NiceMock<Network::MockConnection> upstream_conn_;
+  NiceMock<Network::MockConnection> downstream_conn_;
+  NiceMock<Network::MockConnectionSocket> up_socket_;
+  NiceMock<Network::MockConnectionSocket> down_socket_;
+  NiceMock<Network::MockIoHandle> up_io_;
+  NiceMock<Network::MockIoHandle> down_io_;
+  Network::ConnectionSocketPtr up_socket_ptr_;
+  Network::ConnectionSocketPtr down_socket_ptr_;
+  Network::KtlsBytestreamInfo up_ktls_;
+  Network::KtlsBytestreamInfo down_ktls_;
+
+  NiceMock<TestDownstreamFilterCallbacks> down_cb_;
+  TestGenericUpstream* test_upstream_{nullptr};
+
+  // Captured dispatcher artifacts.
+  std::function<void()> engage_cb_;
+  std::function<void()> finalize_cb_;
+  Event::MockSchedulableCallback* engage_sched_{nullptr};
+  Event::MockSchedulableCallback* finalize_sched_{nullptr};
+  Event::MockTimer* poll_timer_{nullptr};
+  Event::MockTimer* watchdog_timer_{nullptr};
+
+  // Fake pump factory knobs and observations.
+  bool create_pipes_result_{true};
+  bool prepare_result_{true};
+  bool factory_called_{false};
+  os_fd_t factory_down_fd_{0};
+  os_fd_t factory_up_fd_{0};
+  bool factory_up_is_ktls_{false};
+  FakeSplicePump* fake_pump_{nullptr};
+  TcpProxy::SplicePump::CompletionCb completion_cb_;
+  TcpProxy::SplicePump::BytesCb u2d_bytes_cb_;
+  TcpProxy::SplicePump::BytesCb d2u_bytes_cb_;
+};
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadHappy) {
+  initialize();
+  EXPECT_TRUE(armDownload());
+  EXPECT_TRUE(coord_->armedForResponse());
+  EXPECT_FALSE(coord_->armedForRequest());
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(0, counter("abandoned"));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadFlagOff) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_ktls_body_splice", "false"}});
+  initialize();
+  EXPECT_FALSE(armDownload());
+  EXPECT_FALSE(coord_->armedForResponse());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadEndStream) {
+  initialize();
+  setEncodeComplete(true);
+  Http::TestResponseHeaderMapImpl headers{{":status", "200"},
+                                          {"content-length", absl::StrCat(kBodyBytes)}};
+  EXPECT_FALSE(coord_->maybeArmForResponse(headers, /*end_stream=*/true));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadEncodeIncomplete) {
+  initialize();
+  setEncodeComplete(false);
+  Http::TestResponseHeaderMapImpl headers{{":status", "200"},
+                                          {"content-length", absl::StrCat(kBodyBytes)}};
+  EXPECT_FALSE(coord_->maybeArmForResponse(headers, /*end_stream=*/false));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadNoContentLength) {
+  initialize();
+  setEncodeComplete(true);
+  Http::TestResponseHeaderMapImpl headers{{":status", "200"}};
+  EXPECT_FALSE(coord_->maybeArmForResponse(headers, /*end_stream=*/false));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadContentLengthUnparseable) {
+  initialize();
+  setEncodeComplete(true);
+  Http::TestResponseHeaderMapImpl headers{{":status", "200"}, {"content-length", "abc"}};
+  EXPECT_FALSE(coord_->maybeArmForResponse(headers, /*end_stream=*/false));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadContentLengthBelowMin) {
+  initialize();
+  // Well below the 64 KiB minimum.
+  EXPECT_FALSE(armDownload(1024));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadContentLengthAtMin) {
+  initialize();
+  EXPECT_TRUE(armDownload(65536));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadContentLengthJustBelowMin) {
+  initialize();
+  EXPECT_FALSE(armDownload(65535));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadUpstreamNotBorrowable) {
+  initialize();
+  test_upstream_->splice_connection_ = {}; // Upstream connection is empty.
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadDownstreamNotBorrowable) {
+  initialize();
+  ON_CALL(down_cb_, downstreamConnectionForSplice())
+      .WillByDefault(Return(OptRef<Network::Connection>{}));
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadUpstreamNoKtlsInfo) {
+  initialize();
+  ON_CALL(upstream_conn_, ktlsBytestreamInfo())
+      .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>{}));
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadUpstreamKtlsNotInstalled) {
+  initialize();
+  up_ktls_.installed = false;
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadUpstreamKtlsUntrusted) {
+  initialize();
+  up_ktls_.trusted_peer = false;
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadSinkBoringSsl) {
+  initialize();
+  auto ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(downstream_conn_, ssl()).WillByDefault(Return(ssl_info));
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadSinkUserspaceTlsTrap) {
+  initialize();
+  down_ktls_.installed = false;
+  ON_CALL(downstream_conn_, ktlsBytestreamInfo())
+      .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>(down_ktls_)));
+  EXPECT_FALSE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadSinkKtlsInstalled) {
+  initialize();
+  down_ktls_.installed = true;
+  ON_CALL(downstream_conn_, ktlsBytestreamInfo())
+      .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>(down_ktls_)));
+  EXPECT_TRUE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmDownloadSinkPlaintextRaw) {
+  initialize();
+  EXPECT_TRUE(armDownload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadHappy) {
+  initialize();
+  EXPECT_CALL(downstream_conn_, readDisable(true))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::StillReadDisabled));
+  EXPECT_TRUE(armUpload());
+  EXPECT_TRUE(coord_->armedForRequest());
+  EXPECT_FALSE(coord_->armedForResponse());
+  EXPECT_EQ(0, counter("abandoned"));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadFlagOff) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.http1_ktls_body_splice", "false"}});
+  initialize();
+  EXPECT_CALL(downstream_conn_, readDisable(true)).Times(0);
+  EXPECT_FALSE(armUpload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadEndStreamBodyless) {
+  initialize();
+  EXPECT_CALL(downstream_conn_, readDisable(true)).Times(0);
+  Http::TestRequestHeaderMapImpl headers{{":method", "PUT"},
+                                         {":path", "/"},
+                                         {":authority", "host"},
+                                         {"content-length", absl::StrCat(kBodyBytes)}};
+  EXPECT_FALSE(coord_->maybeArmForRequest(headers, /*end_stream=*/true));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadNoContentLength) {
+  initialize();
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "PUT"}, {":path", "/"}, {":authority", "host"}};
+  EXPECT_FALSE(coord_->maybeArmForRequest(headers, /*end_stream=*/false));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadContentLengthUnparseable) {
+  initialize();
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "PUT"}, {":path", "/"}, {":authority", "host"}, {"content-length", "xyz"}};
+  EXPECT_FALSE(coord_->maybeArmForRequest(headers, /*end_stream=*/false));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadContentLengthBelowMin) {
+  initialize();
+  EXPECT_FALSE(armUpload(65535));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadContentLengthAtMin) {
+  initialize();
+  EXPECT_CALL(downstream_conn_, readDisable(true))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::StillReadDisabled));
+  EXPECT_TRUE(armUpload(65536));
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadSourceNotBorrowable) {
+  initialize();
+  ON_CALL(down_cb_, downstreamConnectionForSplice())
+      .WillByDefault(Return(OptRef<Network::Connection>{}));
+  EXPECT_CALL(downstream_conn_, readDisable(true)).Times(0);
+  EXPECT_FALSE(armUpload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadSourceBoringSsl) {
+  initialize();
+  auto ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(downstream_conn_, ssl()).WillByDefault(Return(ssl_info));
+  EXPECT_FALSE(armUpload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadSourceUserspaceTlsTrap) {
+  initialize();
+  down_ktls_.installed = false;
+  ON_CALL(downstream_conn_, ktlsBytestreamInfo())
+      .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>(down_ktls_)));
+  EXPECT_FALSE(armUpload());
+}
+
+TEST_F(SpliceCoordinatorTest, ArmUploadSourceRaw) {
+  initialize();
+  EXPECT_CALL(downstream_conn_, readDisable(true))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::StillReadDisabled));
+  EXPECT_TRUE(armUpload());
+}
+
+TEST_F(SpliceCoordinatorTest, BufferTakeBody) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl data("0123456789");
+  EXPECT_TRUE(coord_->bufferPreEngageBody(data, /*end_stream=*/false));
+  EXPECT_EQ(0, data.length());
+  EXPECT_EQ(0, counter("abandoned"));
+  EXPECT_TRUE(coord_->armedForResponse());
+}
+
+TEST_F(SpliceCoordinatorTest, BufferMessageEndsBeforeEngageDownload) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl held("held");
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  Buffer::OwnedImpl data("final");
+  EXPECT_CALL(parent_, onUpstreamData(_, _, false));
+  EXPECT_FALSE(coord_->bufferPreEngageBody(data, /*end_stream=*/true));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_FALSE(coord_->armedForResponse());
+}
+
+TEST_F(SpliceCoordinatorTest, BufferExceedsMaxHeld) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  // Hold just under the 4 MiB cap, then push it over.
+  Buffer::OwnedImpl held(std::string(4 * 1024 * 1024 - 10, 'x'));
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  Buffer::OwnedImpl data(std::string(20, 'y'));
+  EXPECT_CALL(parent_, onUpstreamData(_, _, false));
+  EXPECT_FALSE(coord_->bufferPreEngageBody(data, /*end_stream=*/false));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, BufferAtMaxHeldBoundary) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl data(std::string(4 * 1024 * 1024, 'z'));
+  EXPECT_TRUE(coord_->bufferPreEngageBody(data, /*end_stream=*/false));
+  EXPECT_EQ(0, data.length());
+  EXPECT_EQ(0, counter("abandoned"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadSuccess) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  // A download must not disable retries.
+  EXPECT_CALL(parent_, disableRetries()).Times(0);
+  fireEngage();
+  EXPECT_TRUE(coord_->engaged());
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(0, counter("abandoned"));
+  ASSERT_NE(nullptr, fake_pump_);
+  // Download uses the u2d pipe only and bounds the u2d direction.
+  EXPECT_TRUE(fake_pump_->need_u2d_);
+  EXPECT_FALSE(fake_pump_->need_d2u_);
+  ASSERT_TRUE(fake_pump_->u2d_limit_.has_value());
+  EXPECT_EQ(kBodyBytes, fake_pump_->u2d_limit_.value());
+  EXPECT_FALSE(fake_pump_->d2u_limit_.has_value());
+  EXPECT_TRUE(fake_pump_->arm_called_);
+  // up_is_ktls is always true on the download upstream leg.
+  EXPECT_TRUE(factory_up_is_ktls_);
+  // Watchdog armed at engage.
+  ASSERT_NE(nullptr, watchdog_timer_);
+  EXPECT_TRUE(watchdog_timer_->enabled_);
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadLegLostAfterSchedule) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  test_upstream_->splice_connection_ = {}; // Upstream leg is now empty.
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadRevalidateKtlsLost) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  up_ktls_.installed = false; // kTLS lost across the schedule gap
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadFdNotSpliceable) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  upstream_conn_.state_ = Network::Connection::State::Closed;
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadWholeBodyBuffered) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl whole(std::string(kBodyBytes, 'b'));
+  ASSERT_TRUE(coord_->bufferPreEngageBody(whole, /*end_stream=*/false));
+  coord_->scheduleEngage();
+  EXPECT_CALL(parent_, onUpstreamData(_, _, false)); // held delivered via flush
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadPipeCreateFails) {
+  initialize();
+  create_pipes_result_ = false;
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  // Pending write is not extracted when pipe creation fails before the irreversible drain.
+  EXPECT_CALL(downstream_conn_, extractPendingWriteForSplice()).Times(0);
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+  ASSERT_NE(nullptr, fake_pump_);
+  EXPECT_TRUE(fake_pump_->create_pipes_called_);
+  EXPECT_FALSE(fake_pump_->prepare_called_);
+}
+
+TEST_F(SpliceCoordinatorTest, EngageDownloadPrepareFailsAfterExtract) {
+  initialize();
+  prepare_result_ = false;
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  EXPECT_CALL(parent_, onUpstreamReset(Http::StreamResetReason::ConnectionTermination,
+                                       "kTLS body-splice setup failed", _));
+  fireEngage();
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(1, counter("truncated"));
+  EXPECT_EQ(0, counter("abandoned"));
+}
+
+// Held bytes reduce the splice bound and follow the sink's pending headers.
+TEST_F(SpliceCoordinatorTest, EngageDownloadPartialPreEngageBuffer) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  constexpr uint64_t kHeld = 4096;
+  Buffer::OwnedImpl held(std::string(kHeld, 'x'));
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  EXPECT_EQ(1, counter("engaged"));
+  ASSERT_NE(nullptr, fake_pump_);
+  // The bound is the Content-Length minus the body already held in memory.
+  ASSERT_TRUE(fake_pump_->u2d_limit_.has_value());
+  EXPECT_EQ(kBodyBytes - kHeld, fake_pump_->u2d_limit_.value());
+  EXPECT_FALSE(fake_pump_->d2u_limit_.has_value());
+  // The download pre-engage chunk is the sink's pending headers followed by the held body.
+  EXPECT_EQ(absl::StrCat("DOWN-HEADERS", std::string(kHeld, 'x')),
+            fake_pump_->prepare_initial_u2d_);
+  EXPECT_TRUE(fake_pump_->prepare_initial_d2u_.empty());
+}
+
+// Sink accounting includes the full Content-Length while source accounting excludes held bytes.
+TEST_F(SpliceCoordinatorTest, FinalizeDownloadAccountsFullContentLength) {
+  initialize();
+  auto meter = std::make_shared<StreamInfo::BytesMeter>();
+  parent_.callbacks_.stream_info_.downstream_bytes_meter_ = meter;
+  ASSERT_TRUE(armDownload());
+  constexpr uint64_t kHeld = 4096;
+  Buffer::OwnedImpl held(std::string(kHeld, 'x'));
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(kBodyBytes - kHeld));
+  fireFinalize();
+  EXPECT_EQ(kBodyBytes, meter->wireBytesSent());
+}
+
+// Upload sink accounting mirrors the download path.
+TEST_F(SpliceCoordinatorTest, FinalizeUploadAccountsFullContentLength) {
+  initialize();
+  auto meter = std::make_shared<StreamInfo::BytesMeter>();
+  parent_.callbacks_.stream_info_.upstream_bytes_meter_ = meter;
+  ASSERT_TRUE(armUpload());
+  constexpr uint64_t kHeld = 4096;
+  Buffer::OwnedImpl held(std::string(kHeld, 'x'));
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(down_cb_, completeSplicedRequest(kBodyBytes - kHeld));
+  fireFinalize();
+  EXPECT_EQ(kBodyBytes, meter->wireBytesSent());
+  EXPECT_EQ(kBodyBytes, upstream_request_->streamInfo().bytesSent());
+}
+
+// A leg with no kernel fd abandons.
+TEST_F(SpliceCoordinatorTest, EngageDownloadFdInvalidSocket) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  ON_CALL(up_io_, fdDoNotUse()).WillByDefault(Return(INVALID_SOCKET));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+}
+
+// An internal-listener leg has no kernel fd to splice on.
+TEST_F(SpliceCoordinatorTest, EngageDownloadLegEnvoyInternal) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  upstream_conn_.connectionInfoSetter().setLocalAddress(
+      std::make_shared<Network::Address::EnvoyInternalInstance>("test_internal"));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+}
+
+// Engage re-validation rejects a sink that changes to userspace TLS.
+TEST_F(SpliceCoordinatorTest, EngageDownloadSinkTlsFlipAfterSchedule) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  auto ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(downstream_conn_, ssl()).WillByDefault(Return(ssl_info));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadShadowActive) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  ON_CALL(parent_, shadowStreamsActive()).WillByDefault(Return(true));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadDownstreamLost) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  ON_CALL(down_cb_, downstreamConnectionForSplice())
+      .WillByDefault(Return(OptRef<Network::Connection>{}));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadPoolNotReadyPoll) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  clearUpstream(); // Pool is not ready.
+  test_upstream_ = nullptr;
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("abandoned"));
+  ASSERT_NE(nullptr, poll_timer_);
+  EXPECT_TRUE(poll_timer_->enabled_); // rescheduled on the 2ms poll timer
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadUpstreamNotHttp1) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  test_upstream_->splice_connection_ = {}; // present but cannot be borrowed
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+  // Did not create a poll timer.
+  EXPECT_EQ(nullptr, poll_timer_);
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadUpstreamNoKtls) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  ON_CALL(upstream_conn_, ktlsBytestreamInfo())
+      .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>{}));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadKtlsInstallingPoll) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  up_ktls_.installed = false; // kTLS-TX still installing
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("abandoned"));
+  ASSERT_NE(nullptr, poll_timer_);
+  EXPECT_TRUE(poll_timer_->enabled_);
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadPollExceedsMax) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  up_ktls_.installed = false; // keep polling forever
+  fireEngage();               // engage_polls_ -> 1, schedules poll timer
+  ASSERT_NE(nullptr, poll_timer_);
+  // Fire the poll timer until the bound is exceeded. The first fireEngage already did poll 1.
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  // Sixty-four more poll-timer fires bring engage_polls_ from 1 to 65, past the bound.
+  for (int i = 0; i < 64; i++) {
+    ASSERT_TRUE(poll_timer_->enabled_);
+    poll_timer_->invokeCallback();
+  }
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, EngageUploadSuccess) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  // Upload must disable retries the moment it engages.
+  EXPECT_CALL(parent_, disableRetries());
+  fireEngage();
+  EXPECT_TRUE(coord_->engaged());
+  EXPECT_EQ(1, counter("engaged"));
+  ASSERT_NE(nullptr, fake_pump_);
+  // Upload uses the d2u pipe only and bounds the d2u direction.
+  EXPECT_FALSE(fake_pump_->need_u2d_);
+  EXPECT_TRUE(fake_pump_->need_d2u_);
+  ASSERT_TRUE(fake_pump_->d2u_limit_.has_value());
+  EXPECT_EQ(kBodyBytes, fake_pump_->d2u_limit_.value());
+  EXPECT_FALSE(fake_pump_->u2d_limit_.has_value());
+  ASSERT_NE(nullptr, watchdog_timer_);
+  EXPECT_TRUE(watchdog_timer_->enabled_);
+}
+
+TEST_F(SpliceCoordinatorTest, EngageNotArmedNoop) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  coord_->reset(); // clears armed_
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_FALSE(factory_called_);
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, CompleteDownloadBoundsReached) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  // onSpliceComplete only schedules finalize. Pump not yet gone.
+  EXPECT_TRUE(coord_->engaged());
+
+  {
+    InSequence seq;
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(*test_upstream_, completeSplicedResponse(kBodyBytes));
+    EXPECT_CALL(upstream_conn_, reinstallFileEvents());
+  }
+  // Neither leg is closed on a clean completion.
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  EXPECT_CALL(downstream_conn_, close(_)).Times(0);
+  fireFinalize();
+  EXPECT_FALSE(coord_->engaged());
+  // Per-engaged invariant, one engaged, then completed or truncated.
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(1, counter("completed"));
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, CompleteUploadBoundsReached) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  {
+    InSequence seq;
+    // Re-arm upload sink before re-enabling the source and completing.
+    EXPECT_CALL(upstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(downstream_conn_, readDisable(false))
+        .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+    EXPECT_CALL(down_cb_, completeSplicedRequest(kBodyBytes));
+  }
+  fireFinalize();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(1, counter("completed"));
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+// Truncation must reinstall the downstream sink before force-closing upstream.
+TEST_F(SpliceCoordinatorTest, CompleteTruncated) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::Closed);
+  {
+    InSequence seq;
+    // The download sink leg is reinstalled before the upstream close cascade can reach it.
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
+  }
+  // The upstream is force-closed and never re-armed for reuse.
+  EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0);
+  fireFinalize();
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(1, counter("truncated"));
+  EXPECT_EQ(0, counter("completed"));
+}
+
+// A closed upstream is not force-closed again, but truncation is still counted.
+TEST_F(SpliceCoordinatorTest, CompleteTruncatedUpstreamAlreadyClosed) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::Closed);
+  upstream_conn_.state_ = Network::Connection::State::Closed;
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  // The downstream is still Open, so it is reinstalled even though the upstream close is skipped.
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+  fireFinalize();
+  EXPECT_EQ(1, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, CompleteErrorRoutesToTruncation) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  // Upload that truncates re-enables the held source before force-closing the upstream.
+  completion_cb_(TcpProxy::SpliceCompletion::Closed);
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
+  fireFinalize();
+  EXPECT_EQ(1, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, CompleteFinalizeDeferred) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  // The completion callback must not destroy the pump inline. engaged() stays true until finalize.
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_TRUE(coord_->engaged());
+  ASSERT_TRUE(finalize_cb_ != nullptr);
+  EXPECT_TRUE(finalize_sched_->enabled_);
+  fireFinalize();
+  EXPECT_FALSE(coord_->engaged());
+}
+
+// reset() also reinstalls the downstream sink before force-closing upstream.
+TEST_F(SpliceCoordinatorTest, ResetWhileEngaged) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  {
+    InSequence seq;
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
+  }
+  coord_->reset();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(1, counter("truncated"));
+  // The latch is set before the close so a re-entrant onResetStream is a no-op.
+  EXPECT_TRUE(onResetStreamInProgress());
+}
+
+// BoundsReached before reset counts completed even when teardown wins the race.
+TEST_F(SpliceCoordinatorTest, ResetAfterBoundsReachedCountsCompleted) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
+  coord_->reset();
+  EXPECT_EQ(1, counter("engaged"));
+  EXPECT_EQ(1, counter("completed"));
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+// Proves the downstream reinstall happens before the upstream close callback.
+TEST_F(SpliceCoordinatorTest, ResetDownloadReinstallsSinkBeforeUpstreamClose) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  bool sink_reinstalled = false;
+  bool reinstalled_before_close = false;
+  ON_CALL(downstream_conn_, reinstallFileEvents()).WillByDefault(Invoke([&]() {
+    sink_reinstalled = true;
+  }));
+  // The sink reinstall must already have run when upstream closes.
+  ON_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).WillByDefault(Invoke([&]() {
+    reinstalled_before_close = sink_reinstalled;
+  }));
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents()).Times(1);
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  // The upstream is force-closed, never re-armed.
+  EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0);
+
+  coord_->reset();
+
+  EXPECT_TRUE(sink_reinstalled);
+  EXPECT_TRUE(reinstalled_before_close);
+  EXPECT_EQ(1, counter("truncated"));
+}
+
+// NoFlush close re-enters onResetStream, which must stop at the reset guard.
+TEST_F(SpliceCoordinatorTest, ResetDoubleFreeGuard) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  bool latch_set_at_close = false;
+  int close_reentries = 0;
+  // Re-enter onResetStream from the close callback to exercise the guard.
+  ON_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).WillByDefault(Invoke([&]() {
+    ++close_reentries;
+    latch_set_at_close = onResetStreamInProgress();
+    reenterOnResetStream();
+  }));
+  // The nested onResetStream must short-circuit at the latch.
+  EXPECT_CALL(parent_, onUpstreamReset(_, _, _)).Times(0);
+  // The upstream is force-closed exactly once.
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+
+  // The latch is clear before reset(), proving reset() itself sets it (not fixture init).
+  EXPECT_FALSE(onResetStreamInProgress());
+  // Drive the in-flight reset, simulating UpstreamRequest teardown reaching the coordinator.
+  coord_->reset();
+
+  // The close fired and re-entered onResetStream exactly once. The cascade really ran.
+  EXPECT_EQ(1, close_reentries);
+  EXPECT_TRUE(latch_set_at_close); // Latch was set before the close.
+  EXPECT_EQ(1, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, ResetNotEngagedNoTruncated) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  fireFinalize(); // Clean completion cleared the pump.
+  ASSERT_EQ(1, counter("completed"));
+
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  coord_->reset();
+  // After a clean finalize the pump is already gone, so reset() does not count a truncation.
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, ResetIdempotent) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  // The download sink is reinstalled exactly once. The first reset clears the connection refs, so
+  // the second reset's reinstall guard is false.
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents()).Times(1);
+  coord_->reset();
+  coord_->reset(); // second reset is a no-op, no second close, no second truncated
+  EXPECT_EQ(1, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, ResetArmedNotEngaged) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  coord_->reset();
+  EXPECT_FALSE(coord_->armedForResponse());
+  EXPECT_EQ(0, counter("truncated"));
+  EXPECT_EQ(0, counter("abandoned"));
+}
+
+TEST_F(SpliceCoordinatorTest, ResetAfterFinalize) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .WillRepeatedly(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  fireFinalize();
+  ASSERT_EQ(1, counter("completed"));
+
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  coord_->reset();
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+// The pump is destroyed (engaged() false) before any leg re-arm.
+TEST_F(SpliceCoordinatorTest, FinalizePumpDestroyedBeforeRearm) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+
+  bool pump_gone_at_first_rearm = false;
+  ON_CALL(downstream_conn_, reinstallFileEvents()).WillByDefault(Invoke([&]() {
+    pump_gone_at_first_rearm = !coord_->engaged();
+  }));
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(_));
+  fireFinalize();
+  EXPECT_TRUE(pump_gone_at_first_rearm);
+}
+
+TEST_F(SpliceCoordinatorTest, FinalizeDownloadRearmOrder) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  {
+    InSequence seq;
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(*test_upstream_, completeSplicedResponse(kBodyBytes));
+    EXPECT_CALL(upstream_conn_, reinstallFileEvents());
+  }
+  fireFinalize();
+}
+
+// Connection members are cleared before completeSpliced* can defer-delete the coordinator.
+TEST_F(SpliceCoordinatorTest, FinalizeCapturesRefsOnStack) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(_)).WillOnce(Invoke([&](uint64_t) {
+    // Simulate teardown re-entering reset() from inside the codec finalize. With the members
+    // already cleared, this must not re-close or re-truncate.
+    coord_->reset();
+  }));
+  // The upstream is re-armed (not closed) on the clean path. The nested reset finds no refs so it
+  // does not close.
+  EXPECT_CALL(upstream_conn_, close(_)).Times(0);
+  fireFinalize();
+  EXPECT_EQ(0, counter("truncated"));
+  EXPECT_EQ(1, counter("completed"));
+}
+
+TEST_F(SpliceCoordinatorTest, FinalizeLegClosedSkipRearm) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+
+  upstream_conn_.state_ = Network::Connection::State::Closed; // captured upstream not Open
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(_));
+  EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0); // closed leg not re-armed
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, FinalizeReadEnableSourceReinstallFirst) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  {
+    InSequence seq;
+    // Upstream sink re-armed first.
+    EXPECT_CALL(upstream_conn_, reinstallFileEvents());
+    // Then the held source is re-enabled by reinstalling the source file event before
+    // readDisable(false).
+    EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+    EXPECT_CALL(downstream_conn_, readDisable(false))
+        .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+    EXPECT_CALL(down_cb_, completeSplicedRequest(_));
+  }
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, WatchdogRearmedOnProgress) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_NE(nullptr, watchdog_timer_);
+
+  // resetIdleTimer on the downstream HCM callbacks is refreshed on progress.
+  EXPECT_CALL(parent_.callbacks_, resetIdleTimer());
+  // The no-progress watchdog is re-armed at its 30-second timeout on every byte callback.
+  EXPECT_CALL(*watchdog_timer_, enableTimer(std::chrono::milliseconds(30000), _));
+  // A byte callback drives onSpliceProgress.
+  ASSERT_TRUE(u2d_bytes_cb_ != nullptr);
+  u2d_bytes_cb_(4096);
+}
+
+TEST_F(SpliceCoordinatorTest, WatchdogFiresOnStall) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_NE(nullptr, watchdog_timer_);
+
+  // The watchdog callback resets the stream with the stall reason. It does not count the truncation
+  // itself. That happens when teardown reaches reset().
+  EXPECT_CALL(parent_, onUpstreamReset(Http::StreamResetReason::ConnectionTermination,
+                                       "kTLS body-splice stalled", _));
+  ASSERT_TRUE(watchdog_timer_->enabled_);
+  watchdog_timer_->invokeCallback();
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+TEST_F(SpliceCoordinatorTest, WatchdogArmedAtEngage) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_NE(nullptr, watchdog_timer_);
+  EXPECT_TRUE(watchdog_timer_->enabled_);
+}
+
+TEST_F(SpliceCoordinatorTest, WatchdogDisabledOnFinalize) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_NE(nullptr, watchdog_timer_);
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(_));
+  EXPECT_CALL(*watchdog_timer_, disableTimer());
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, WatchdogDisabledOnReset) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_NE(nullptr, watchdog_timer_);
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*watchdog_timer_, disableTimer());
+  coord_->reset();
+}
+
+TEST_F(SpliceCoordinatorTest, ReadEnableDownloadNoop) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  fireEngage();
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(*test_upstream_, completeSplicedResponse(_));
+  EXPECT_CALL(downstream_conn_, readDisable(false)).Times(0);
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, ReadEnableUploadOnce) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .Times(1)
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  EXPECT_CALL(down_cb_, completeSplicedRequest(_));
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, ReadEnableSourceClosedSkip) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  downstream_conn_.state_ = Network::Connection::State::Closed;
+  EXPECT_CALL(downstream_conn_, readDisable(false)).Times(0);
+  EXPECT_CALL(down_cb_, completeSplicedRequest(_));
+  fireFinalize();
+}
+
+TEST_F(SpliceCoordinatorTest, ReadEnableNotDetachedNoReinstall) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  // Abandon before engage (message ends), so legs were never detached.
+  Buffer::OwnedImpl data("x");
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents()).Times(0);
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  EXPECT_FALSE(coord_->bufferPreEngageBody(data, /*end_stream=*/true));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, FlushDownloadPath) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl held("held-body");
+  ASSERT_TRUE(coord_->bufferPreEngageBody(held, /*end_stream=*/false));
+  Buffer::OwnedImpl end;
+  EXPECT_CALL(parent_, onUpstreamData(_, _, false));
+  EXPECT_FALSE(coord_->bufferPreEngageBody(end, /*end_stream=*/true));
+}
+
+TEST_F(SpliceCoordinatorTest, FlushEmptyNoop) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  Buffer::OwnedImpl end;
+  EXPECT_CALL(parent_, onUpstreamData(_, _, _)).Times(0);
+  EXPECT_FALSE(coord_->bufferPreEngageBody(end, /*end_stream=*/true));
+  EXPECT_EQ(1, counter("abandoned"));
+  EXPECT_EQ(0, counter("engaged"));
+}
+
+TEST_F(SpliceCoordinatorTest, DisarmCancelsCallbacks) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  ASSERT_NE(nullptr, engage_sched_);
+  EXPECT_CALL(*engage_sched_, cancel());
+  coord_->reset(); // Reaches the disarm-equivalent cancel path.
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_FALSE(factory_called_);
+}
+
+TEST_F(SpliceCoordinatorTest, ScheduleNotArmedNoop) {
+  initialize();
+  // Not armed, so scheduleEngage creates no callback.
+  coord_->scheduleEngage();
+  EXPECT_EQ(nullptr, engage_sched_);
+  EXPECT_FALSE(static_cast<bool>(engage_cb_));
+}
+
+TEST_F(SpliceCoordinatorTest, ScheduleCreatesCallbackOnce) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  ASSERT_NE(nullptr, engage_sched_);
+  Event::MockSchedulableCallback* first = engage_sched_;
+  EXPECT_CALL(*first, scheduleCallbackCurrentIteration()).Times(AnyNumber());
+  coord_->scheduleEngage();
+  // Still the same callback object. No second engage callback was created.
+  EXPECT_EQ(first, engage_sched_);
+}
+
+// Downstream with no kernel fd mirrors the upstream INVALID_SOCKET test.
+TEST_F(SpliceCoordinatorTest, EngageDownloadDownFdInvalidSocket) {
+  initialize();
+  ASSERT_TRUE(armDownload());
+  coord_->scheduleEngage();
+  ON_CALL(down_io_, fdDoNotUse()).WillByDefault(Return(INVALID_SOCKET));
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  EXPECT_EQ(1, counter("abandoned"));
+}
+
+// Installed but untrusted kTLS keeps the upload polling.
+TEST_F(SpliceCoordinatorTest, EngageUploadUntrustedPeerPolls) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  up_ktls_.installed = true;
+  up_ktls_.trusted_peer = false;
+  fireEngage();
+  EXPECT_FALSE(coord_->engaged());
+  EXPECT_EQ(0, counter("abandoned"));
+  ASSERT_NE(nullptr, poll_timer_);
+  EXPECT_TRUE(poll_timer_->enabled_);
+}
+
+// Reset while upload is polling disables the poll timer.
+TEST_F(SpliceCoordinatorTest, ResetDuringPollDisablesTimer) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  up_ktls_.installed = false; // keep polling
+  fireEngage();
+  ASSERT_NE(nullptr, poll_timer_);
+  EXPECT_CALL(*poll_timer_, disableTimer());
+  coord_->reset();
+  EXPECT_FALSE(coord_->engaged());
+  // No splice was in flight, so nothing is counted truncated.
+  EXPECT_EQ(0, counter("truncated"));
+}
+
+// Upload finalize skips completeSplicedRequest when downstream callbacks are gone.
+TEST_F(SpliceCoordinatorTest, CompleteUploadNoDownstreamCallbacks) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  fireEngage();
+  ASSERT_TRUE(coord_->engaged());
+  completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
+  // The downstream callbacks go away before finalize runs.
+  ON_CALL(parent_.callbacks_, downstreamCallbacks())
+      .WillByDefault(Return(OptRef<Http::DownstreamStreamFilterCallbacks>{}));
+  EXPECT_CALL(down_cb_, completeSplicedRequest(_)).Times(0);
+  EXPECT_CALL(downstream_conn_, readDisable(false))
+      .WillRepeatedly(Return(Network::Connection::ReadDisableStatus::NoTransition));
+  fireFinalize();
+  EXPECT_EQ(1, counter("completed"));
+}
+
+} // namespace Router
+} // namespace Envoy

--- a/test/common/router/splice_coordinator_test.cc
+++ b/test/common/router/splice_coordinator_test.cc
@@ -56,10 +56,10 @@ public:
     need_d2u_ = need_d2u;
     return create_pipes_result_;
   }
-  bool prepare(std::string initial_u2d, std::string initial_d2u) override {
+  bool prepare(Buffer::Instance& initial_u2d, Buffer::Instance& initial_d2u) override {
     prepare_called_ = true;
-    prepare_initial_u2d_ = std::move(initial_u2d);
-    prepare_initial_d2u_ = std::move(initial_d2u);
+    prepare_initial_u2d_ = initial_u2d.toString();
+    prepare_initial_d2u_ = initial_d2u.toString();
     return prepare_result_;
   }
   void setBounds(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit) override {
@@ -195,16 +195,13 @@ protected:
         .WillByDefault(Return(OptRef<const Network::KtlsBytestreamInfo>(up_ktls_)));
 
     // GenericUpstream resolves to upstream_conn_.
-    auto test_upstream = std::make_unique<NiceMock<TestGenericUpstream>>();
-    test_upstream_ = test_upstream.get();
-    test_upstream_->splice_connection_ = upstream_conn_;
-    upstream_request_->upstream_ = std::move(test_upstream);
+    reinstallUpstream();
 
     // Pending writes handed to the pump.
-    ON_CALL(upstream_conn_, extractPendingWriteForSplice())
-        .WillByDefault(Return(std::string("UP-HEADERS")));
-    ON_CALL(downstream_conn_, extractPendingWriteForSplice())
-        .WillByDefault(Return(std::string("DOWN-HEADERS")));
+    ON_CALL(upstream_conn_, extractPendingWriteForSplice(_))
+        .WillByDefault(Invoke([](Buffer::Instance& dst) { dst.add("UP-HEADERS"); }));
+    ON_CALL(downstream_conn_, extractPendingWriteForSplice(_))
+        .WillByDefault(Invoke([](Buffer::Instance& dst) { dst.add("DOWN-HEADERS"); }));
 
     // Capture the fake pump and its callbacks for each test.
     coord_->setSplicePumpFactoryForTest(
@@ -280,7 +277,7 @@ protected:
   }
 
   uint64_t counter(absl::string_view name) {
-    return parent_.cluster_info_->stats_store_.counter(absl::StrCat("http1_ktls_splice.", name))
+    return parent_.cluster_info_->stats_store_.counter(absl::StrCat("http1_ktls_splice_", name))
         .value();
   }
 
@@ -289,6 +286,13 @@ protected:
   // tests call them.
   void setEncodeComplete(bool complete) { upstream_request_->router_sent_end_stream_ = complete; }
   void clearUpstream() { upstream_request_->upstream_.reset(); }
+  // Installs a fresh upstream wired to upstream_conn_, as the pool does when it becomes ready.
+  void reinstallUpstream() {
+    auto test_upstream = std::make_unique<NiceMock<TestGenericUpstream>>();
+    test_upstream_ = test_upstream.get();
+    test_upstream_->splice_connection_ = upstream_conn_;
+    upstream_request_->upstream_ = std::move(test_upstream);
+  }
   bool onResetStreamInProgress() const { return upstream_request_->on_reset_stream_in_progress_; }
   // Re-enters onResetStream as the codec reset cascade would when the upstream is force-closed.
   void reenterOnResetStream() {
@@ -632,7 +636,7 @@ TEST_F(SpliceCoordinatorTest, EngageDownloadRevalidateKtlsLost) {
   initialize();
   ASSERT_TRUE(armDownload());
   coord_->scheduleEngage();
-  up_ktls_.installed = false; // kTLS lost across the schedule gap
+  up_ktls_.installed = false; // kTLS lost across the schedule gap.
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
   EXPECT_EQ(0, counter("engaged"));
@@ -657,7 +661,7 @@ TEST_F(SpliceCoordinatorTest, EngageDownloadWholeBodyBuffered) {
   Buffer::OwnedImpl whole(std::string(kBodyBytes, 'b'));
   ASSERT_TRUE(coord_->bufferPreEngageBody(whole, /*end_stream=*/false));
   coord_->scheduleEngage();
-  EXPECT_CALL(parent_, onUpstreamData(_, _, false)); // held delivered via flush
+  EXPECT_CALL(parent_, onUpstreamData(_, _, false)); // held delivered via flush.
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
   EXPECT_EQ(0, counter("engaged"));
@@ -671,15 +675,17 @@ TEST_F(SpliceCoordinatorTest, EngageDownloadPipeCreateFails) {
   ASSERT_TRUE(armDownload());
   coord_->scheduleEngage();
   // Pending write is not extracted when pipe creation fails before the irreversible drain.
-  EXPECT_CALL(downstream_conn_, extractPendingWriteForSplice()).Times(0);
+  EXPECT_CALL(downstream_conn_, extractPendingWriteForSplice(_)).Times(0);
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
   EXPECT_EQ(0, counter("engaged"));
   EXPECT_EQ(1, counter("abandoned"));
   EXPECT_EQ(0, counter("engaged"));
-  ASSERT_NE(nullptr, fake_pump_);
-  EXPECT_TRUE(fake_pump_->create_pipes_called_);
-  EXPECT_FALSE(fake_pump_->prepare_called_);
+  // createPipes() failed, so engage abandoned and destroyed the pump before extracting pending
+  // output or calling prepare(). The pump is gone, so the created-then-abandoned path is proven by
+  // factory_called_ and the extractPendingWriteForSplice() expectation above rather than by reading
+  // the freed pump.
+  EXPECT_TRUE(factory_called_);
 }
 
 TEST_F(SpliceCoordinatorTest, EngageDownloadPrepareFailsAfterExtract) {
@@ -817,7 +823,8 @@ TEST_F(SpliceCoordinatorTest, EngageUploadDownstreamLost) {
   EXPECT_EQ(0, counter("engaged"));
 }
 
-TEST_F(SpliceCoordinatorTest, EngageUploadPoolNotReadyPoll) {
+// Pool not ready waits for onPoolReady instead of polling during connection establishment.
+TEST_F(SpliceCoordinatorTest, EngageUploadPoolNotReadyWaits) {
   initialize();
   ASSERT_TRUE(armUpload());
   coord_->scheduleEngage();
@@ -825,16 +832,54 @@ TEST_F(SpliceCoordinatorTest, EngageUploadPoolNotReadyPoll) {
   test_upstream_ = nullptr;
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
+  // Still armed and not abandoned, with no pump built and no poll timer created.
+  EXPECT_TRUE(coord_->armedForRequest());
+  EXPECT_FALSE(factory_called_);
   EXPECT_EQ(0, counter("abandoned"));
-  ASSERT_NE(nullptr, poll_timer_);
-  EXPECT_TRUE(poll_timer_->enabled_); // rescheduled on the 2ms poll timer
+  EXPECT_EQ(nullptr, poll_timer_);
+}
+
+// Once the pool becomes ready, the onPoolReady reschedule drives engage to completion.
+TEST_F(SpliceCoordinatorTest, EngageUploadEngagesWhenPoolBecomesReady) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  clearUpstream(); // Pool is not ready.
+  test_upstream_ = nullptr;
+  fireEngage();
+  ASSERT_TRUE(coord_->armedForRequest());
+  ASSERT_FALSE(coord_->engaged());
+  EXPECT_EQ(nullptr, poll_timer_);
+
+  // onPoolReady installs the upstream and reschedules engage.
+  reinstallUpstream();
+  coord_->scheduleEngage();
+  EXPECT_CALL(parent_, disableRetries());
+  fireEngage();
+  EXPECT_TRUE(coord_->engaged());
+  EXPECT_EQ(1, counter("engaged"));
+}
+
+// With no cluster the lifecycle counter increment is skipped and the splice still engages.
+TEST_F(SpliceCoordinatorTest, IncSpliceCounterNoClusterNoop) {
+  initialize();
+  ASSERT_TRUE(armUpload());
+  coord_->scheduleEngage();
+  // The cluster is absent when engage tries to increment the counter, so the increment is skipped.
+  ON_CALL(parent_, cluster()).WillByDefault(Return(nullptr));
+  EXPECT_CALL(parent_, disableRetries());
+  fireEngage();
+  EXPECT_TRUE(coord_->engaged());
+  EXPECT_EQ(0, counter("engaged"));
+  // Restore the cluster before teardown; UpstreamRequest::cleanUp dereferences it for stats.
+  ON_CALL(parent_, cluster()).WillByDefault(Return(parent_.cluster_info_));
 }
 
 TEST_F(SpliceCoordinatorTest, EngageUploadUpstreamNotHttp1) {
   initialize();
   ASSERT_TRUE(armUpload());
   coord_->scheduleEngage();
-  test_upstream_->splice_connection_ = {}; // present but cannot be borrowed
+  test_upstream_->splice_connection_ = {}; // present but cannot be borrowed.
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
   EXPECT_EQ(1, counter("abandoned"));
@@ -859,7 +904,7 @@ TEST_F(SpliceCoordinatorTest, EngageUploadKtlsInstallingPoll) {
   initialize();
   ASSERT_TRUE(armUpload());
   coord_->scheduleEngage();
-  up_ktls_.installed = false; // kTLS-TX still installing
+  up_ktls_.installed = false; // kTLS-TX still installing.
   fireEngage();
   EXPECT_FALSE(coord_->engaged());
   EXPECT_EQ(0, counter("abandoned"));
@@ -871,8 +916,8 @@ TEST_F(SpliceCoordinatorTest, EngageUploadPollExceedsMax) {
   initialize();
   ASSERT_TRUE(armUpload());
   coord_->scheduleEngage();
-  up_ktls_.installed = false; // keep polling forever
-  fireEngage();               // engage_polls_ -> 1, schedules poll timer
+  up_ktls_.installed = false; // keep polling forever.
+  fireEngage();               // engage_polls_ -> 1, schedules poll timer.
   ASSERT_NE(nullptr, poll_timer_);
   // Fire the poll timer until the bound is exceeded. The first fireEngage already did poll 1.
   EXPECT_CALL(downstream_conn_, readDisable(false))
@@ -1095,8 +1140,8 @@ TEST_F(SpliceCoordinatorTest, ResetDownloadReinstallsSinkBeforeUpstreamClose) {
   ON_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).WillByDefault(Invoke([&]() {
     reinstalled_before_close = sink_reinstalled;
   }));
-  EXPECT_CALL(downstream_conn_, reinstallFileEvents()).Times(1);
-  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents());
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
   // The upstream is force-closed, never re-armed.
   EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0);
 
@@ -1126,7 +1171,7 @@ TEST_F(SpliceCoordinatorTest, ResetDoubleFreeGuard) {
   // The nested onResetStream must short-circuit at the latch.
   EXPECT_CALL(parent_, onUpstreamReset(_, _, _)).Times(0);
   // The upstream is force-closed exactly once.
-  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
 
   // The latch is clear before reset(), proving reset() itself sets it (not fixture init).
   EXPECT_FALSE(onResetStreamInProgress());
@@ -1161,12 +1206,12 @@ TEST_F(SpliceCoordinatorTest, ResetIdempotent) {
   fireEngage();
   ASSERT_TRUE(coord_->engaged());
 
-  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush)).Times(1);
+  EXPECT_CALL(upstream_conn_, close(Network::ConnectionCloseType::NoFlush));
   // The download sink is reinstalled exactly once. The first reset clears the connection refs, so
   // the second reset's reinstall guard is false.
-  EXPECT_CALL(downstream_conn_, reinstallFileEvents()).Times(1);
+  EXPECT_CALL(downstream_conn_, reinstallFileEvents());
   coord_->reset();
-  coord_->reset(); // second reset is a no-op, no second close, no second truncated
+  coord_->reset(); // second reset is a no-op, no second close, no second truncated.
   EXPECT_EQ(1, counter("truncated"));
 }
 
@@ -1261,10 +1306,10 @@ TEST_F(SpliceCoordinatorTest, FinalizeLegClosedSkipRearm) {
   ASSERT_TRUE(coord_->engaged());
   completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
 
-  upstream_conn_.state_ = Network::Connection::State::Closed; // captured upstream not Open
+  upstream_conn_.state_ = Network::Connection::State::Closed; // captured upstream not Open.
   EXPECT_CALL(downstream_conn_, reinstallFileEvents());
   EXPECT_CALL(*test_upstream_, completeSplicedResponse(_));
-  EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0); // closed leg not re-armed
+  EXPECT_CALL(upstream_conn_, reinstallFileEvents()).Times(0); // closed leg not re-armed.
   fireFinalize();
 }
 
@@ -1371,7 +1416,6 @@ TEST_F(SpliceCoordinatorTest, ReadEnableUploadOnce) {
   fireEngage();
   completion_cb_(TcpProxy::SpliceCompletion::BoundsReached);
   EXPECT_CALL(downstream_conn_, readDisable(false))
-      .Times(1)
       .WillOnce(Return(Network::Connection::ReadDisableStatus::NoTransition));
   EXPECT_CALL(down_cb_, completeSplicedRequest(_));
   fireFinalize();
@@ -1485,7 +1529,7 @@ TEST_F(SpliceCoordinatorTest, ResetDuringPollDisablesTimer) {
   initialize();
   ASSERT_TRUE(armUpload());
   coord_->scheduleEngage();
-  up_ktls_.installed = false; // keep polling
+  up_ktls_.installed = false; // keep polling.
   fireEngage();
   ASSERT_NE(nullptr, poll_timer_);
   EXPECT_CALL(*poll_timer_, disableTimer());

--- a/test/common/tcp_proxy/BUILD
+++ b/test/common/tcp_proxy/BUILD
@@ -82,6 +82,18 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "splice_pump_test",
+    srcs = ["splice_pump_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/api:api_lib",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/tcp_proxy:splice_pump_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "upstream_test",
     srcs = ["upstream_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/tcp_proxy/splice_pump_test.cc
+++ b/test/common/tcp_proxy/splice_pump_test.cc
@@ -2,10 +2,19 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#ifdef __linux__
+#include <arpa/inet.h>
+#include <linux/tls.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/uio.h>
+#endif
+
 #include <string>
 #include <vector>
 
 #include "source/common/api/api_impl.h"
+#include "source/common/buffer/buffer_impl.h"
 #include "source/common/event/dispatcher_impl.h"
 #include "source/common/tcp_proxy/splice_pump.h"
 
@@ -40,12 +49,12 @@ std::vector<uint8_t> newSessionTickets(int count, uint8_t body_len) {
 }
 
 TEST(ClassifyKtlsControlRecord, CloseNotifyAlertIsEof) {
-  const uint8_t alert[] = {1, 0}; // warning, close_notify
+  const uint8_t alert[] = {1, 0}; // warning, close_notify.
   EXPECT_EQ(ControlAction::Eof, classifyKtlsControlRecord(kAlert, alert, sizeof(alert)));
 }
 
 TEST(ClassifyKtlsControlRecord, FatalAlertIsClose) {
-  const uint8_t alert[] = {2, 50}; // fatal, decode_error
+  const uint8_t alert[] = {2, 50}; // fatal, decode_error.
   EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kAlert, alert, sizeof(alert)));
 }
 
@@ -71,13 +80,13 @@ TEST(ClassifyKtlsControlRecord, CoalescedNewSessionTicketsAreRetry) {
 }
 
 TEST(ClassifyKtlsControlRecord, NonTicketHandshakeIsClose) {
-  const uint8_t hs[] = {1, 0, 0, 0}; // ClientHello, not serviceable post-kTLS
+  const uint8_t hs[] = {1, 0, 0, 0}; // ClientHello, not serviceable post-kTLS.
   EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kHandshake, hs, sizeof(hs)));
 }
 
 TEST(ClassifyKtlsControlRecord, TicketThenRekeyIsClose) {
   std::vector<uint8_t> hs = newSessionTickets(1, 4);
-  hs.push_back(kKeyUpdate); // must force a close
+  hs.push_back(kKeyUpdate); // must force a close.
   hs.push_back(0);
   hs.push_back(0);
   hs.push_back(1);
@@ -116,7 +125,9 @@ public:
   }
 
   ~SplicePumpIoTest() override {
-    for (int fd : {down_.test_end, up_.test_end}) {
+    // Release the pump before closing the borrowed socket fds it was registered on.
+    pump_.reset();
+    for (int fd : {down_.test_end, down_.pump_end, up_.test_end, up_.pump_end}) {
       if (fd >= 0) {
         ::close(fd);
       }
@@ -137,15 +148,19 @@ public:
     p.pump_end = fds[1];
   }
 
-  void buildAndArm(const std::string& initial_downstream = "") {
+  // Builds an unbounded pump. up_is_ktls selects the kTLS upstream path, the only mode that
+  // emits an upstream close_notify alert when the downstream half-closes.
+  void buildAndArm(const std::string& initial_downstream = "", bool up_is_ktls = false) {
     pump_ = std::make_unique<SplicePump>(
-        down_.pump_end, up_.pump_end, /*up_is_ktls=*/false, *dispatcher_,
+        down_.pump_end, up_.pump_end, up_is_ktls, *dispatcher_,
         [this](SpliceCompletion status) {
           completed_ = true;
           completion_ = status;
         },
         [this](uint64_t n) { u2d_bytes_ += n; }, [this](uint64_t n) { d2u_bytes_ += n; });
-    ASSERT_TRUE(pump_->prepare(initial_downstream, /*initial_d2u=*/""));
+    Buffer::OwnedImpl initial_u2d, initial_d2u;
+    initial_u2d.add(initial_downstream);
+    ASSERT_TRUE(pump_->prepare(initial_u2d, initial_d2u));
     pump_->arm();
   }
 
@@ -162,7 +177,10 @@ public:
           completion_ = status;
         },
         [this](uint64_t n) { u2d_bytes_ += n; }, [this](uint64_t n) { d2u_bytes_ += n; });
-    ASSERT_TRUE(pump_->prepare(initial_u2d, initial_d2u));
+    Buffer::OwnedImpl initial_u2d_buf, initial_d2u_buf;
+    initial_u2d_buf.add(initial_u2d);
+    initial_d2u_buf.add(initial_d2u);
+    ASSERT_TRUE(pump_->prepare(initial_u2d_buf, initial_d2u_buf));
     pump_->setBounds(u2d_limit, d2u_limit);
     pump_->arm();
   }
@@ -521,7 +539,7 @@ TEST_F(SplicePumpIoTest, BoundedCompletionLeavesSocketsOpen) {
 TEST_F(SplicePumpIoTest, BoundedDownloadPrematureCloseCompletesClosed) {
   buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(8192),
                      /*d2u_limit=*/absl::nullopt);
-  const std::string body(4096, 'q'); // fewer than the budget
+  const std::string body(4096, 'q'); // fewer than the budget.
   ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
   ::close(up_.test_end);
   up_.test_end = -1;
@@ -586,8 +604,228 @@ TEST_F(SplicePumpIoTest, BoundedDownloadLargerThanPipeTransfersInFull) {
   ASSERT_TRUE(completion_.has_value());
   EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
   EXPECT_EQ(kBody, received.size());
-  EXPECT_EQ(body, received); // byte-exact, no truncation or reorder
+  EXPECT_EQ(body, received); // byte-exact, no truncation or reorder.
   EXPECT_EQ(kBody, u2d_bytes_);
+}
+
+// On a downstream half-close, the pump relays the buffered request to an unbounded kTLS upstream,
+// sends a best-effort close_notify, half-closes the upstream write side, and completes. A real kTLS
+// socket encrypts the record-type control message into a close_notify alert record; this plaintext
+// loopback ignores the control message and delivers the two alert bytes inline after the request.
+TEST_F(SplicePumpIoTest, KtlsUpstreamCloseNotifyOnDownstreamHalfClose) {
+  buildAndArm(/*initial_downstream=*/"", /*up_is_ktls=*/true);
+  const std::string request = "PUT /upload HTTP/1.1\r\n\r\n";
+  ASSERT_EQ(static_cast<ssize_t>(request.size()),
+            ::write(down_.test_end, request.data(), request.size()));
+  ::shutdown(down_.test_end, SHUT_WR);
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return completed_;
+  });
+  received += readAll(up_.test_end);
+  EXPECT_TRUE(completed_);
+  // The warning-level close_notify alert (bytes 0x01, 0x00) trails the request inline, confirming
+  // the best-effort close_notify was sent. It goes out via sendmsg, not the relay, so it is not
+  // counted as a body byte.
+  EXPECT_EQ(request + std::string("\x01\x00", 2), received);
+  EXPECT_EQ(request.size(), d2u_bytes_);
+}
+
+// A plain (non-kTLS) upstream takes the same downstream half-close path but sends no close_notify,
+// so the upstream receives exactly the request with no trailing alert bytes.
+TEST_F(SplicePumpIoTest, PlainUpstreamNoCloseNotifyOnDownstreamHalfClose) {
+  buildAndArm();
+  const std::string request = "PUT /upload HTTP/1.1\r\n\r\n";
+  ASSERT_EQ(static_cast<ssize_t>(request.size()),
+            ::write(down_.test_end, request.data(), request.size()));
+  ::shutdown(down_.test_end, SHUT_WR);
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return completed_;
+  });
+  received += readAll(up_.test_end);
+  EXPECT_TRUE(completed_);
+  EXPECT_EQ(request, received);
+  EXPECT_EQ(request.size(), d2u_bytes_);
+}
+
+// Exercises the kTLS control-message path. The plaintext `socketpair` above cannot produce non-DATA
+// TLS records, which is what makes splice() return EINVAL and routes the pump into
+// drainUpstreamControlMessage(), so these tests stand up a real AES-128-GCM kTLS upstream on a
+// loopback TCP pair and skip when the kernel lacks the TLS `ULP`. The fixture reuses
+// SplicePumpIoTest for the dispatcher, the plaintext downstream pair, and the run/read helpers.
+class SplicePumpKtlsIoTest : public SplicePumpIoTest {
+public:
+  ~SplicePumpKtlsIoTest() override {
+    // Release the pump before closing the kTLS fds it was registered on. The base destructor closes
+    // the (unused here) plaintext upstream pair and the downstream pair.
+    pump_.reset();
+    for (int fd : {up_tls_tx_, up_tls_rx_}) {
+      if (fd >= 0) {
+        ::close(fd);
+      }
+    }
+  }
+
+  // Connects a loopback TCP pair and installs AES-128-GCM kTLS. up_tls_tx_ encrypts (the upstream
+  // peer) and up_tls_rx_ decrypts (the pump's upstream leg). Returns false if the kernel lacks the
+  // TLS `ULP` so the caller can skip.
+  bool setupKtlsUpstream() {
+    const int listener = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listener < 0) {
+      return false;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (::bind(listener, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 ||
+        ::listen(listener, 1) != 0) {
+      ::close(listener);
+      return false;
+    }
+    socklen_t len = sizeof(addr);
+    ::getsockname(listener, reinterpret_cast<sockaddr*>(&addr), &len);
+    up_tls_tx_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    const bool connected =
+        up_tls_tx_ >= 0 &&
+        ::connect(up_tls_tx_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+    up_tls_rx_ = connected ? ::accept(listener, nullptr, nullptr) : -1;
+    ::close(listener);
+    if (up_tls_rx_ < 0) {
+      return false;
+    }
+    if (::setsockopt(up_tls_tx_, SOL_TCP, TCP_ULP, "tls", sizeof("tls")) != 0 ||
+        ::setsockopt(up_tls_rx_, SOL_TCP, TCP_ULP, "tls", sizeof("tls")) != 0) {
+      return false; // Kernel without CONFIG_TLS.
+    }
+    // A fixed all-zero key keeps the encrypting and decrypting ends in lockstep. This is test-only
+    // record framing, not real security.
+    tls12_crypto_info_aes_gcm_128 info{};
+    info.info.version = TLS_1_2_VERSION;
+    info.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+    if (::setsockopt(up_tls_tx_, SOL_TLS, TLS_TX, &info, sizeof(info)) != 0 ||
+        ::setsockopt(up_tls_rx_, SOL_TLS, TLS_RX, &info, sizeof(info)) != 0) {
+      return false;
+    }
+    ::fcntl(up_tls_rx_, F_SETFL, O_NONBLOCK);
+    return true;
+  }
+
+  // Sends a non-DATA TLS record of `record_type` carrying `payload` from the encrypting peer.
+  void sendControlRecord(uint8_t record_type, const std::vector<uint8_t>& payload) {
+    alignas(cmsghdr) char cmsg_space[CMSG_SPACE(sizeof(uint8_t))] = {};
+    iovec iov;
+    iov.iov_base = const_cast<uint8_t*>(payload.data());
+    iov.iov_len = payload.size();
+    msghdr msg{};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg_space;
+    msg.msg_controllen = sizeof(cmsg_space);
+    cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+    cmsg->cmsg_level = SOL_TLS;
+    cmsg->cmsg_type = TLS_SET_RECORD_TYPE;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(uint8_t));
+    *CMSG_DATA(cmsg) = record_type;
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()), ::sendmsg(up_tls_tx_, &msg, 0));
+  }
+
+  // Builds an unbounded download pump that reads from the kTLS upstream leg.
+  void buildAndArmKtlsDownload() {
+    pump_ = std::make_unique<SplicePump>(
+        down_.pump_end, up_tls_rx_, /*up_is_ktls=*/true, *dispatcher_,
+        [this](SpliceCompletion status) {
+          completed_ = true;
+          completion_ = status;
+        },
+        [this](uint64_t n) { u2d_bytes_ += n; }, [this](uint64_t n) { d2u_bytes_ += n; });
+    Buffer::OwnedImpl initial_u2d, initial_d2u;
+    ASSERT_TRUE(pump_->prepare(initial_u2d, initial_d2u));
+    pump_->arm();
+  }
+
+  int up_tls_tx_{-1};
+  int up_tls_rx_{-1};
+};
+
+// A benign NewSessionTicket sits between two DATA records. splice() returns EINVAL on it, the pump
+// drains it through recvmsg, and the surrounding plaintext still relays byte-for-byte.
+TEST_F(SplicePumpKtlsIoTest, BenignControlRecordDrainedDataContinues) {
+  if (!setupKtlsUpstream()) {
+    GTEST_SKIP() << "kernel does not support kTLS";
+  }
+  buildAndArmKtlsDownload();
+  const std::string before = "before";
+  const std::string after = "after";
+  ASSERT_EQ(static_cast<ssize_t>(before.size()), ::write(up_tls_tx_, before.data(), before.size()));
+  sendControlRecord(kHandshake, newSessionTickets(/*count=*/1, /*body_len=*/8));
+  ASSERT_EQ(static_cast<ssize_t>(after.size()), ::write(up_tls_tx_, after.data(), after.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return received.size() >= before.size() + after.size();
+  });
+  EXPECT_EQ(before + after, received);
+  EXPECT_EQ(before.size() + after.size(), u2d_bytes_);
+  // A drained benign record does not end the splice.
+  EXPECT_FALSE(completed_);
+}
+
+// A close_notify alert is treated as upstream EOF: the relayed bytes arrive, then the pump
+// half-closes the downstream write side so the downstream peer observes EOF.
+TEST_F(SplicePumpKtlsIoTest, CloseNotifyHalfClosesDownstream) {
+  if (!setupKtlsUpstream()) {
+    GTEST_SKIP() << "kernel does not support kTLS";
+  }
+  buildAndArmKtlsDownload();
+  const std::string body = "payload";
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_tls_tx_, body.data(), body.size()));
+  sendControlRecord(kAlert, {1, 0}); // Warning level, close_notify.
+  std::string received;
+  bool saw_eof = false;
+  runUntil([&]() {
+    char buf[256];
+    const ssize_t n = ::read(down_.test_end, buf, sizeof(buf));
+    if (n > 0) {
+      received.append(buf, static_cast<size_t>(n));
+    } else if (n == 0) {
+      saw_eof = true;
+    }
+    return saw_eof;
+  });
+  EXPECT_EQ(body, received);
+  EXPECT_TRUE(saw_eof);
+}
+
+// A fatal alert tears the splice down with Closed so neither socket is reused.
+TEST_F(SplicePumpKtlsIoTest, FatalAlertCompletesClosed) {
+  if (!setupKtlsUpstream()) {
+    GTEST_SKIP() << "kernel does not support kTLS";
+  }
+  buildAndArmKtlsDownload();
+  sendControlRecord(kAlert, {2, 40}); // Fatal level, handshake_failure.
+  runUntil([&]() { return completed_; });
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::Closed, completion_.value());
+}
+
+// A non-alert control record that is not a benign NewSessionTicket (here a handshake that is not a
+// session ticket) tears the splice down rather than being drained.
+TEST_F(SplicePumpKtlsIoTest, NonTicketHandshakeCompletesClosed) {
+  if (!setupKtlsUpstream()) {
+    GTEST_SKIP() << "kernel does not support kTLS";
+  }
+  buildAndArmKtlsDownload();
+  // Handshake message type 1 (ClientHello) is not a NewSessionTicket: a 3-byte length of 4 then a
+  // 4-byte body.
+  sendControlRecord(kHandshake, {1, 0, 0, 4, 0, 0, 0, 0});
+  runUntil([&]() { return completed_; });
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::Closed, completion_.value());
 }
 #endif
 

--- a/test/common/tcp_proxy/splice_pump_test.cc
+++ b/test/common/tcp_proxy/splice_pump_test.cc
@@ -1,0 +1,596 @@
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "source/common/api/api_impl.h"
+#include "source/common/event/dispatcher_impl.h"
+#include "source/common/tcp_proxy/splice_pump.h"
+
+#include "test/test_common/utility.h"
+
+#include "absl/types/optional.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace TcpProxy {
+namespace {
+
+// TLS record type bytes, mirrored from splice_pump.cc for the classifier tests.
+constexpr uint8_t kChangeCipherSpec = 20;
+constexpr uint8_t kAlert = 21;
+constexpr uint8_t kHandshake = 22;
+constexpr uint8_t kNewSessionTicket = 4;
+constexpr uint8_t kKeyUpdate = 24;
+
+// Builds a handshake record body of `count` NewSessionTicket messages, each with a `body_len`-byte
+// body, so the classifier's coalesced-message walk can be exercised.
+std::vector<uint8_t> newSessionTickets(int count, uint8_t body_len) {
+  std::vector<uint8_t> out;
+  for (int i = 0; i < count; i++) {
+    out.push_back(kNewSessionTicket);
+    out.push_back(0);
+    out.push_back(0);
+    out.push_back(body_len);
+    out.insert(out.end(), body_len, 0xAB);
+  }
+  return out;
+}
+
+TEST(ClassifyKtlsControlRecord, CloseNotifyAlertIsEof) {
+  const uint8_t alert[] = {1, 0}; // warning, close_notify
+  EXPECT_EQ(ControlAction::Eof, classifyKtlsControlRecord(kAlert, alert, sizeof(alert)));
+}
+
+TEST(ClassifyKtlsControlRecord, FatalAlertIsClose) {
+  const uint8_t alert[] = {2, 50}; // fatal, decode_error
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kAlert, alert, sizeof(alert)));
+}
+
+TEST(ClassifyKtlsControlRecord, ShortAlertIsClose) {
+  const uint8_t alert[] = {1};
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kAlert, alert, sizeof(alert)));
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kAlert, nullptr, 0));
+}
+
+TEST(ClassifyKtlsControlRecord, ChangeCipherSpecIsRetry) {
+  const uint8_t ccs[] = {1};
+  EXPECT_EQ(ControlAction::Retry, classifyKtlsControlRecord(kChangeCipherSpec, ccs, sizeof(ccs)));
+}
+
+TEST(ClassifyKtlsControlRecord, SingleNewSessionTicketIsRetry) {
+  const std::vector<uint8_t> hs = newSessionTickets(1, 8);
+  EXPECT_EQ(ControlAction::Retry, classifyKtlsControlRecord(kHandshake, hs.data(), hs.size()));
+}
+
+TEST(ClassifyKtlsControlRecord, CoalescedNewSessionTicketsAreRetry) {
+  const std::vector<uint8_t> hs = newSessionTickets(3, 16);
+  EXPECT_EQ(ControlAction::Retry, classifyKtlsControlRecord(kHandshake, hs.data(), hs.size()));
+}
+
+TEST(ClassifyKtlsControlRecord, NonTicketHandshakeIsClose) {
+  const uint8_t hs[] = {1, 0, 0, 0}; // ClientHello, not serviceable post-kTLS
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kHandshake, hs, sizeof(hs)));
+}
+
+TEST(ClassifyKtlsControlRecord, TicketThenRekeyIsClose) {
+  std::vector<uint8_t> hs = newSessionTickets(1, 4);
+  hs.push_back(kKeyUpdate); // must force a close
+  hs.push_back(0);
+  hs.push_back(0);
+  hs.push_back(1);
+  hs.push_back(0);
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kHandshake, hs.data(), hs.size()));
+}
+
+TEST(ClassifyKtlsControlRecord, UnknownRecordTypeIsClose) {
+  const uint8_t data[] = {0};
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(99, data, sizeof(data)));
+}
+
+TEST(ClassifyKtlsControlRecord, HandshakeWithOverlongLengthIsClose) {
+  // A NewSessionTicket whose declared length (~16M) runs past the 5-byte record is malformed.
+  const uint8_t hs[] = {kNewSessionTicket, 0xFF, 0xFF, 0xFF, 0x00};
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kHandshake, hs, sizeof(hs)));
+}
+
+TEST(ClassifyKtlsControlRecord, HandshakeWithSplitHeaderIsClose) {
+  // A NewSessionTicket type byte whose 4-byte length header is split across records cannot be
+  // classified without cross-record reassembly, so it closes rather than risk frame misalignment.
+  const uint8_t hs[] = {kNewSessionTicket};
+  EXPECT_EQ(ControlAction::Close, classifyKtlsControlRecord(kHandshake, hs, sizeof(hs)));
+}
+
+#ifdef __linux__
+// Real I/O test of the pump's data path. Two AF_UNIX socket pairs stand in for the downstream and
+// upstream sockets. up_is_ktls is false, so the pump runs its plain splice and userspace relay
+// without the kTLS control-message path. The test drives a real dispatcher.
+class SplicePumpIoTest : public testing::Test {
+public:
+  SplicePumpIoTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test_thread")) {
+    makePair(down_);
+    makePair(up_);
+  }
+
+  ~SplicePumpIoTest() override {
+    for (int fd : {down_.test_end, up_.test_end}) {
+      if (fd >= 0) {
+        ::close(fd);
+      }
+    }
+  }
+
+  struct Pair {
+    int test_end{-1};
+    int pump_end{-1};
+  };
+
+  void makePair(Pair& p) {
+    int fds[2];
+    ASSERT_EQ(0, ::socketpair(AF_UNIX, SOCK_STREAM, 0, fds));
+    ::fcntl(fds[0], F_SETFL, O_NONBLOCK);
+    ::fcntl(fds[1], F_SETFL, O_NONBLOCK);
+    p.test_end = fds[0];
+    p.pump_end = fds[1];
+  }
+
+  void buildAndArm(const std::string& initial_downstream = "") {
+    pump_ = std::make_unique<SplicePump>(
+        down_.pump_end, up_.pump_end, /*up_is_ktls=*/false, *dispatcher_,
+        [this](SpliceCompletion status) {
+          completed_ = true;
+          completion_ = status;
+        },
+        [this](uint64_t n) { u2d_bytes_ += n; }, [this](uint64_t n) { d2u_bytes_ += n; });
+    ASSERT_TRUE(pump_->prepare(initial_downstream, /*initial_d2u=*/""));
+    pump_->arm();
+  }
+
+  // Builds a bounded pump (the HTTP body-splice mode). Exactly one direction is usually active. The
+  // pre-engage chunk for the active direction precedes any spliced bytes and is accounted but not
+  // counted against the byte limit.
+  void buildAndArmBounded(absl::optional<uint64_t> u2d_limit, absl::optional<uint64_t> d2u_limit,
+                          const std::string& initial_u2d = "",
+                          const std::string& initial_d2u = "") {
+    pump_ = std::make_unique<SplicePump>(
+        down_.pump_end, up_.pump_end, /*up_is_ktls=*/false, *dispatcher_,
+        [this](SpliceCompletion status) {
+          completed_ = true;
+          completion_ = status;
+        },
+        [this](uint64_t n) { u2d_bytes_ += n; }, [this](uint64_t n) { d2u_bytes_ += n; });
+    ASSERT_TRUE(pump_->prepare(initial_u2d, initial_d2u));
+    pump_->setBounds(u2d_limit, d2u_limit);
+    pump_->arm();
+  }
+
+  // Runs the dispatcher until `pred` holds or the iteration budget is exhausted.
+  void runUntil(const std::function<bool()>& pred, int max_iters = 200) {
+    for (int i = 0; i < max_iters && !pred(); i++) {
+      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+  std::string readAll(int fd) {
+    std::string out;
+    char buf[16384];
+    for (;;) {
+      const ssize_t n = ::read(fd, buf, sizeof(buf));
+      if (n > 0) {
+        out.append(buf, static_cast<size_t>(n));
+      } else {
+        break;
+      }
+    }
+    return out;
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  Pair down_;
+  Pair up_;
+  SplicePumpPtr pump_;
+  uint64_t u2d_bytes_{0};
+  uint64_t d2u_bytes_{0};
+  bool completed_{false};
+  absl::optional<SpliceCompletion> completion_;
+};
+
+// Bytes written on the upstream socket reach the downstream socket (the download path) and are
+// accounted in the u2d byte callback.
+TEST_F(SplicePumpIoTest, UpstreamToDownstream) {
+  buildAndArm();
+  const std::string payload(40000, 'x');
+  ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+            ::write(up_.test_end, payload.data(), payload.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return received.size() >= payload.size();
+  });
+  EXPECT_EQ(payload, received);
+  EXPECT_EQ(payload.size(), u2d_bytes_);
+}
+
+// The pre-engage chunk handed to prepare() is delivered to the downstream socket before any
+// spliced bytes.
+TEST_F(SplicePumpIoTest, PreEngageChunkDeliveredFirst) {
+  buildAndArm("HEADER");
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return received.size() >= 6;
+  });
+  EXPECT_EQ("HEADER", received);
+  EXPECT_EQ(6u, u2d_bytes_);
+}
+
+// Bytes written on the downstream socket reach the upstream socket (the request path) and are
+// accounted in the d2u byte callback.
+TEST_F(SplicePumpIoTest, DownstreamToUpstream) {
+  buildAndArm();
+  const std::string request = "GET /object HTTP/1.1\r\n\r\n";
+  ASSERT_EQ(static_cast<ssize_t>(request.size()),
+            ::write(down_.test_end, request.data(), request.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return received.size() >= request.size();
+  });
+  EXPECT_EQ(request, received);
+  EXPECT_EQ(request.size(), d2u_bytes_);
+}
+
+// A pre-engage chunk larger than the downstream socket send buffer overflows into pending_down_
+// and is fully flushed by the pump ahead of any spliced bytes.
+TEST_F(SplicePumpIoTest, LargePreEngageChunkStashedAndDrained) {
+  const std::string header(2 * 1024 * 1024, 'h');
+  buildAndArm(header);
+  std::string received;
+  runUntil(
+      [&]() {
+        received += readAll(down_.test_end);
+        return received.size() >= header.size();
+      },
+      2000);
+  EXPECT_EQ(header.size(), received.size());
+  EXPECT_EQ(header, received);
+  EXPECT_EQ(header.size(), u2d_bytes_);
+}
+
+// Once the upstream peer closes and its bytes are drained, the pump half-closes the downstream
+// write side so the downstream peer observes EOF.
+TEST_F(SplicePumpIoTest, UpstreamCloseHalfClosesDownstream) {
+  buildAndArm();
+  const std::string payload(8192, 'y');
+  ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+            ::write(up_.test_end, payload.data(), payload.size()));
+  ::close(up_.test_end);
+  up_.test_end = -1;
+  std::string received;
+  bool saw_eof = false;
+  runUntil([&]() {
+    char buf[16384];
+    const ssize_t n = ::read(down_.test_end, buf, sizeof(buf));
+    if (n > 0) {
+      received.append(buf, static_cast<size_t>(n));
+    } else if (n == 0) {
+      saw_eof = true;
+    }
+    return saw_eof;
+  });
+  EXPECT_EQ(payload, received);
+  EXPECT_TRUE(saw_eof);
+}
+
+// Closing both peer ends drives the pump to completion through its on_complete_ callback.
+TEST_F(SplicePumpIoTest, BothPeersCloseCompletes) {
+  buildAndArm();
+  ::close(up_.test_end);
+  up_.test_end = -1;
+  ::close(down_.test_end);
+  down_.test_end = -1;
+  runUntil([&]() { return completed_; });
+  EXPECT_TRUE(completed_);
+}
+
+// Upstream close with downstream still open must deliver the response and complete.
+TEST_F(SplicePumpIoTest, UpstreamCloseCompletesWhileDownstreamStaysOpen) {
+  buildAndArm();
+  const std::string response(8192, 'z');
+  ASSERT_EQ(static_cast<ssize_t>(response.size()),
+            ::write(up_.test_end, response.data(), response.size()));
+  ::close(up_.test_end);
+  up_.test_end = -1;
+  // The downstream end is deliberately left open for the whole test.
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  EXPECT_TRUE(completed_);
+  EXPECT_EQ(response, received);
+}
+
+// Client close must drain buffered upstream bytes before completing.
+TEST_F(SplicePumpIoTest, DownstreamCloseDeliversBufferedUpstreamBytes) {
+  buildAndArm();
+  const std::string response(200000, 'r');
+  ASSERT_EQ(static_cast<ssize_t>(response.size()),
+            ::write(up_.test_end, response.data(), response.size()));
+  ::close(up_.test_end);
+  up_.test_end = -1;
+  // The client closes its connection right after, the typical keep-alive retire.
+  ::shutdown(down_.test_end, SHUT_WR);
+  std::string received;
+  runUntil(
+      [&]() {
+        received += readAll(down_.test_end);
+        return completed_;
+      },
+      2000);
+  EXPECT_TRUE(completed_);
+  EXPECT_EQ(response.size(), received.size());
+  EXPECT_EQ(response, received);
+}
+
+// A keep-alive upstream that never sends EOF. The client sends its request, reads the full
+// response, and closes its connection (retiring it). The pump must complete via the client-close
+// path rather than wait forever for an upstream EOF that a keep-alive peer never sends.
+TEST_F(SplicePumpIoTest, ClientCloseCompletesWithKeepAliveUpstream) {
+  buildAndArm();
+  const std::string response(8192, 'r');
+  ASSERT_EQ(static_cast<ssize_t>(response.size()),
+            ::write(up_.test_end, response.data(), response.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return received.size() >= response.size();
+  });
+  EXPECT_EQ(response, received);
+  // The client closes fully while the upstream stays open (keep-alive).
+  ::close(down_.test_end);
+  down_.test_end = -1;
+  runUntil([&]() { return completed_; });
+  EXPECT_TRUE(completed_);
+}
+
+// Bounded download. The pump reads exactly the Content-Length budget from the upstream and never
+// over-reads (the bytes past the budget stay untouched in the socket). On a download an H1 upstream
+// sends nothing past the response body until asked, so bytes still queued past the budget are
+// extraneous. The pump completes Closed (not BoundsReached) so the connection is not pool-reused.
+// This is the anti-smuggling defense that replaces the H1 client codec's "extraneous data after
+// response complete" check that the splice bypasses.
+TEST_F(SplicePumpIoTest, BoundedDownloadExtraneousDataIsNotReusable) {
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(8192),
+                     /*d2u_limit=*/absl::nullopt);
+  const std::string body(20000, 'b');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  received += readAll(down_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  // 8192 budget bytes were delivered, but the surplus past Content-Length marks the connection
+  // unreusable.
+  EXPECT_EQ(SpliceCompletion::Closed, completion_.value());
+  EXPECT_EQ(8192u, received.size());
+  EXPECT_EQ(body.substr(0, 8192), received);
+  EXPECT_EQ(8192u, u2d_bytes_);
+  // The bytes past the budget were never read by the pump. They stay in the upstream socket.
+  const std::string leftover = readAll(up_.pump_end);
+  EXPECT_EQ(body.size() - 8192, leftover.size());
+}
+
+// Bounded download with exactly Content-Length available completes BoundsReached and leaves both
+// sockets intact for keep-alive reuse (no extraneous data past the boundary).
+TEST_F(SplicePumpIoTest, BoundedDownloadStopsAtLimit) {
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(8192),
+                     /*d2u_limit=*/absl::nullopt);
+  const std::string body(8192, 'b');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  received += readAll(down_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ(8192u, received.size());
+  EXPECT_EQ(body, received);
+  EXPECT_EQ(8192u, u2d_bytes_);
+}
+
+// Bounded upload, symmetric to the download case in the downstream-to-upstream direction.
+TEST_F(SplicePumpIoTest, BoundedUploadStopsAtLimit) {
+  buildAndArmBounded(/*u2d_limit=*/absl::nullopt,
+                     /*d2u_limit=*/absl::make_optional<uint64_t>(8192));
+  const std::string body(20000, 'u');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(down_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return completed_;
+  });
+  received += readAll(up_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ(8192u, received.size());
+  EXPECT_EQ(8192u, d2u_bytes_);
+  const std::string leftover = readAll(down_.pump_end);
+  EXPECT_EQ(body.size() - 8192, leftover.size());
+}
+
+// The pre-engage chunk precedes the spliced body and is delivered in full on top of the byte
+// budget, so the downstream receives chunk + limit bytes in order.
+TEST_F(SplicePumpIoTest, BoundedDownloadDeliversPreEngageThenLimit) {
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(4096), /*d2u_limit=*/absl::nullopt,
+                     /*initial_u2d=*/"PREFIX");
+  const std::string body(4096, 'p');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  received += readAll(down_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ("PREFIX" + body, received);
+  EXPECT_EQ(6u + 4096u, u2d_bytes_);
+}
+
+// The upload mirror. The pre-engage chunk precedes the spliced request body and is delivered in
+// full on top of the byte budget, so the upstream receives chunk plus limit bytes in order. This
+// exercises prepare()'s initial_d2u write and the section (3a) pre-engage flush.
+TEST_F(SplicePumpIoTest, BoundedUploadDeliversPreEngageThenLimit) {
+  buildAndArmBounded(/*u2d_limit=*/absl::nullopt, /*d2u_limit=*/absl::make_optional<uint64_t>(4096),
+                     /*initial_u2d=*/"", /*initial_d2u=*/"PREFIX");
+  const std::string body(4096, 'p');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(down_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return completed_;
+  });
+  received += readAll(up_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ("PREFIX" + body, received);
+  EXPECT_EQ(6u + 4096u, d2u_bytes_);
+}
+
+// A large upload pre-engage chunk overflows into pending_up_ and is fully flushed by the pump ahead
+// of the spliced request body, the upload mirror of the download stash path.
+TEST_F(SplicePumpIoTest, BoundedUploadLargePreEngageStashedAndDrained) {
+  const std::string header(2 * 1024 * 1024, 'h');
+  buildAndArmBounded(/*u2d_limit=*/absl::nullopt, /*d2u_limit=*/absl::make_optional<uint64_t>(4096),
+                     /*initial_u2d=*/"", /*initial_d2u=*/header);
+  const std::string body(4096, 'p');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(down_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil(
+      [&]() {
+        received += readAll(up_.test_end);
+        return completed_;
+      },
+      2000);
+  received += readAll(up_.test_end);
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ(header + body, received);
+  EXPECT_EQ(header.size() + 4096u, d2u_bytes_);
+}
+
+// Bounded completion never half-closes the downstream write side, so a subsequent read observes
+// EAGAIN rather than EOF and the connection can carry the next keep-alive message.
+TEST_F(SplicePumpIoTest, BoundedCompletionLeavesSocketsOpen) {
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(4096),
+                     /*d2u_limit=*/absl::nullopt);
+  const std::string body(4096, 'k');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  received += readAll(down_.test_end);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ(4096u, received.size());
+  char buf[16];
+  const ssize_t n = ::read(down_.test_end, buf, sizeof(buf));
+  EXPECT_EQ(-1, n);
+  EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+// A source EOF before the byte budget is met is a truncated message, so the bounded pump completes
+// with Closed and the caller must reset rather than reuse the connection.
+TEST_F(SplicePumpIoTest, BoundedDownloadPrematureCloseCompletesClosed) {
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(8192),
+                     /*d2u_limit=*/absl::nullopt);
+  const std::string body(4096, 'q'); // fewer than the budget
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(up_.test_end, body.data(), body.size()));
+  ::close(up_.test_end);
+  up_.test_end = -1;
+  std::string received;
+  runUntil([&]() {
+    received += readAll(down_.test_end);
+    return completed_;
+  });
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::Closed, completion_.value());
+}
+
+TEST_F(SplicePumpIoTest, BoundedUploadPrematureCloseCompletesClosed) {
+  buildAndArmBounded(/*u2d_limit=*/absl::nullopt,
+                     /*d2u_limit=*/absl::make_optional<uint64_t>(8192));
+  const std::string body(4096, 'q');
+  ASSERT_EQ(static_cast<ssize_t>(body.size()), ::write(down_.test_end, body.data(), body.size()));
+  ::close(down_.test_end);
+  down_.test_end = -1;
+  std::string received;
+  runUntil([&]() {
+    received += readAll(up_.test_end);
+    return completed_;
+  });
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::Closed, completion_.value());
+  EXPECT_EQ(body, received);
+  EXPECT_EQ(body.size(), d2u_bytes_);
+}
+
+// A body larger than the pipe capacity must transfer fully while the sink is drained incrementally.
+TEST_F(SplicePumpIoTest, BoundedDownloadLargerThanPipeTransfersInFull) {
+  constexpr uint64_t kBody = 3u * 1024 * 1024;
+  buildAndArmBounded(/*u2d_limit=*/absl::make_optional<uint64_t>(kBody),
+                     /*d2u_limit=*/absl::nullopt);
+
+  std::string body(kBody, '\0');
+  for (uint64_t i = 0; i < kBody; i++) {
+    body[i] = static_cast<char>('A' + (i % 26));
+  }
+  std::string received;
+  size_t written = 0;
+  // Feed the source and drain the sink incrementally across dispatcher passes so neither the pipe
+  // nor the sink socket can hold the whole body at once.
+  runUntil(
+      [&]() {
+        if (written < body.size()) {
+          const ssize_t w = ::write(up_.test_end, body.data() + written, body.size() - written);
+          if (w > 0) {
+            written += static_cast<size_t>(w);
+          }
+        }
+        received += readAll(down_.test_end);
+        return completed_;
+      },
+      /*max_iters=*/100000);
+  received += readAll(down_.test_end);
+
+  EXPECT_TRUE(completed_);
+  ASSERT_TRUE(completion_.has_value());
+  EXPECT_EQ(SpliceCompletion::BoundsReached, completion_.value());
+  EXPECT_EQ(kBody, received.size());
+  EXPECT_EQ(body, received); // byte-exact, no truncation or reorder
+  EXPECT_EQ(kBody, u2d_bytes_);
+}
+#endif
+
+} // namespace
+} // namespace TcpProxy
+} // namespace Envoy

--- a/test/coverage.yaml
+++ b/test/coverage.yaml
@@ -19,6 +19,7 @@ directories:
   source/common/network/dns_resolver: 91.4   # A few lines of MacOS code not tested in linux scripts. Tested in MacOS scripts
   source/common/quic: 93.5
   source/common/signal: 87.4  # Death tests don't report LCOV
+  source/common/tcp_proxy: 90.0
   source/common/thread: 0.0  # Death tests don't report LCOV
   source/common/tls: 94.3  # FIPS code paths impossible to trigger on non-FIPS builds and vice versa
   source/common/tls/cert_validator: 95.1

--- a/test/extensions/transport_sockets/common/passthrough_test.cc
+++ b/test/extensions/transport_sockets/common/passthrough_test.cc
@@ -95,6 +95,19 @@ TEST_F(PassthroughTest, SslDefersToInnerSocket) {
   passthrough_socket_->ssl();
 }
 
+// Test ktlsBytestreamInfo method defers to inner socket so a wrapped kTLS socket stays visible.
+TEST_F(PassthroughTest, KtlsBytestreamInfoDefersToInnerSocket) {
+  Network::KtlsBytestreamInfo info;
+  info.installed = true;
+  info.trusted_peer = true;
+  EXPECT_CALL(*inner_socket_, ktlsBytestreamInfo())
+      .WillOnce(testing::Return(OptRef<const Network::KtlsBytestreamInfo>(info)));
+  const auto result = passthrough_socket_->ktlsBytestreamInfo();
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->installed);
+  EXPECT_TRUE(result->trusted_peer);
+}
+
 // Test invoking startSecureTransport.
 TEST_F(PassthroughTest, FailOnStartSecureTransport) {
   EXPECT_FALSE(passthrough_socket_->startSecureTransport());

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -353,6 +353,28 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "ktls_splice_integration_test",
+    size = "large",
+    srcs = [
+        "ktls_splice_integration_test.cc",
+    ],
+    rbe_pool = "6gig",
+    deps = [
+        ":http_integration_lib",
+        ":integration_lib",
+        "//envoy/stats:stats_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/common/network:raw_buffer_socket_lib",
+        "//source/common/protobuf",
+        "//source/extensions/transport_sockets/common:passthrough_lib",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "cluster_filter_integration_test",
     size = "large",
     srcs = ["cluster_filter_integration_test.cc"],

--- a/test/integration/ktls_splice_integration_test.cc
+++ b/test/integration/ktls_splice_integration_test.cc
@@ -183,10 +183,10 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, KtlsSpliceIntegrationTest,
 TEST_P(KtlsSpliceIntegrationTest, DownloadAboveThresholdEngagesSplice) {
   initializeWithFakeKtlsUpstream();
   auto response = runDownload(128 * 1024);
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.completed", testing::Ge(1));
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value());
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_completed", testing::Ge(1));
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice_engaged")->value());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed")->value());
 }
 
 // Below-threshold bodies use the buffered path and do not engage the splice.
@@ -194,7 +194,7 @@ TEST_P(KtlsSpliceIntegrationTest, DownloadBelowThresholdDoesNotEngage) {
   initializeWithFakeKtlsUpstream();
   auto response = runDownload(MinSpliceBodyBytes - 1);
   const Stats::CounterSharedPtr engaged =
-      test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged");
+      test_server_->counter("cluster.cluster_0.http1_ktls_splice_engaged");
   EXPECT_EQ(0, engaged == nullptr ? 0 : engaged->value());
 }
 
@@ -206,17 +206,23 @@ TEST_P(KtlsSpliceIntegrationTest, DownloadBelowThresholdDoesNotEngage) {
 TEST_P(KtlsSpliceIntegrationTest, UploadAboveThresholdEngagesSplice) {
   initializeWithFakeKtlsUpstream();
   auto response = runUpload(128 * 1024);
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.completed", testing::Ge(1));
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value());
-  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_completed", testing::Ge(1));
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice_engaged")->value());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed")->value());
   // A clean upload completes rather than truncates.
   const Stats::CounterSharedPtr truncated =
-      test_server_->counter("cluster.cluster_0.http1_ktls_splice.truncated");
+      test_server_->counter("cluster.cluster_0.http1_ktls_splice_truncated");
   EXPECT_EQ(0, truncated == nullptr ? 0 : truncated->value());
 }
 
-TEST_P(KtlsSpliceIntegrationTest, UploadFullyBufferedBeforeEngageAbandons) {
+// An eligible upload sent with its body inline. Whether the coordinator abandons the splice (the
+// body is fully buffered before engage) or engages it (the body is still arriving) depends on how
+// the request is segmented on the wire relative to the upstream connection, so it is not
+// deterministic at the integration level; splice_coordinator_test covers both decisions directly.
+// Either way the body must reach the upstream byte-for-byte, the armed splice must resolve exactly
+// once, and a clean upload must never truncate.
+TEST_P(KtlsSpliceIntegrationTest, UploadInlineBodyRelayedIntact) {
   initializeWithFakeKtlsUpstream();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   const std::string body = makeBody(128 * 1024);
@@ -234,10 +240,19 @@ TEST_P(KtlsSpliceIntegrationTest, UploadFullyBufferedBeforeEngageAbandons) {
   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.abandoned", testing::Ge(1));
-  const Stats::CounterSharedPtr engaged =
-      test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged");
-  EXPECT_EQ(0, engaged == nullptr ? 0 : engaged->value());
+
+  // The counters are incremented on the worker thread before the response completes above, so they
+  // are settled here. Exactly one of abandon or engage fires for the armed splice, and a clean
+  // upload never truncates.
+  const auto splice_counter = [this](absl::string_view name) -> uint64_t {
+    const Stats::CounterSharedPtr counter =
+        test_server_->counter(absl::StrCat("cluster.cluster_0.", name));
+    return counter == nullptr ? 0 : counter->value();
+  };
+  EXPECT_GE(splice_counter("http1_ktls_splice_abandoned") +
+                splice_counter("http1_ktls_splice_engaged"),
+            1);
+  EXPECT_EQ(0, splice_counter("http1_ktls_splice_truncated"));
 }
 
 // Engaged download truncation force-closes upstream after reinstalling the downstream sink, so
@@ -260,7 +275,7 @@ TEST_P(KtlsSpliceIntegrationTest, EngagedDownloadTruncationDoesNotCrash) {
   response->waitForHeaders();
 
   // Confirm engagement before forcing truncation.
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_engaged", testing::Ge(1));
 
   // Send strictly fewer bytes than the advertised Content-Length (end_stream=false), then close the
   // upstream connection so the body is cut mid-transfer. The pump sees EOF before the bound.
@@ -276,12 +291,12 @@ TEST_P(KtlsSpliceIntegrationTest, EngagedDownloadTruncationDoesNotCrash) {
   EXPECT_FALSE(response->complete());
 
   // Mid-body close counts as truncated after engagement.
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.truncated", testing::Ge(1));
-  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value(), 1);
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_truncated", testing::Ge(1));
+  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice_engaged")->value(), 1);
   EXPECT_EQ(0,
-            test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed") == nullptr
+            test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed") == nullptr
                 ? 0
-                : test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+                : test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed")->value());
 }
 
 TEST_P(KtlsSpliceIntegrationTest, EngagedUploadTruncationDoesNotCrash) {
@@ -299,18 +314,18 @@ TEST_P(KtlsSpliceIntegrationTest, EngagedUploadTruncationDoesNotCrash) {
                  "no upstream connection");
   RELEASE_ASSERT(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_),
                  "no upstream stream");
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_engaged", testing::Ge(1));
 
   codec_client_->sendData(encoder, makeBody(64 * 1024), false);
   codec_client_->close();
 
   ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
-  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.truncated", testing::Ge(1));
-  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value(), 1);
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice_truncated", testing::Ge(1));
+  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice_engaged")->value(), 1);
   EXPECT_EQ(0,
-            test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed") == nullptr
+            test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed") == nullptr
                 ? 0
-                : test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+                : test_server_->counter("cluster.cluster_0.http1_ktls_splice_completed")->value());
 }
 
 } // namespace

--- a/test/integration/ktls_splice_integration_test.cc
+++ b/test/integration/ktls_splice_integration_test.cc
@@ -1,0 +1,319 @@
+#include <string>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/network/transport_socket.h"
+#include "envoy/stats/stats.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/assert.h"
+#include "source/common/network/raw_buffer_socket.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/transport_sockets/common/passthrough.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+
+// The fixture is Linux-only because the fast path uses splice() on loopback fds. Fake kTLS keeps
+// the wire plaintext while reporting installed kTLS to arm the splice.
+#ifdef __linux__
+
+namespace Envoy {
+namespace {
+
+// Test-only upstream socket that wraps raw_buffer but reports trusted kTLS.
+class FakeKtlsSocket : public Extensions::TransportSockets::PassthroughSocket {
+public:
+  FakeKtlsSocket(Network::TransportSocketPtr&& inner_socket)
+      : PassthroughSocket(std::move(inner_socket)) {}
+
+  // Backed by a member so the returned OptRef remains valid.
+  OptRef<const Network::KtlsBytestreamInfo> ktlsBytestreamInfo() const override {
+    info_.installed = true;
+    info_.trusted_peer = true;
+    return info_;
+  }
+
+private:
+  // Backing store for ktlsBytestreamInfo.
+  mutable Network::KtlsBytestreamInfo info_{};
+};
+
+// Wraps an inner raw_buffer upstream factory and produces FakeKtlsSocket instances.
+class FakeKtlsSocketFactory : public Extensions::TransportSockets::PassthroughFactory {
+public:
+  FakeKtlsSocketFactory(Network::UpstreamTransportSocketFactoryPtr&& inner_factory)
+      : PassthroughFactory(std::move(inner_factory)) {}
+
+  Network::TransportSocketPtr
+  createTransportSocket(Network::TransportSocketOptionsConstSharedPtr options,
+                        Upstream::HostDescriptionConstSharedPtr host) const override {
+    auto inner_socket = transport_socket_factory_->createTransportSocket(options, host);
+    if (inner_socket == nullptr) {
+      return nullptr;
+    }
+    return std::make_unique<FakeKtlsSocket>(std::move(inner_socket));
+  }
+};
+
+// Config factory for envoy.transport_sockets.fake_ktls.
+class FakeKtlsConfigFactory : public Server::Configuration::UpstreamTransportSocketConfigFactory {
+public:
+  std::string name() const override { return "envoy.transport_sockets.fake_ktls"; }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+
+  absl::StatusOr<Network::UpstreamTransportSocketFactoryPtr>
+  createTransportSocketFactory(const Protobuf::Message&,
+                               Server::Configuration::TransportSocketFactoryContext&) override {
+    return std::make_unique<FakeKtlsSocketFactory>(
+        std::make_unique<Network::RawBufferSocketFactory>());
+  }
+};
+
+// Builds a deterministic body so the spliced bytes can be asserted byte-for-byte at the client.
+std::string makeBody(uint64_t size) {
+  std::string body;
+  body.reserve(size);
+  for (uint64_t i = 0; i < size; i++) {
+    body.push_back(static_cast<char>('A' + (i % 26)));
+  }
+  return body;
+}
+
+// Minimum body the splice engages on, mirrored from SpliceCoordinator::MinSpliceBodyBytes.
+constexpr uint64_t MinSpliceBodyBytes = 64 * 1024;
+
+class KtlsSpliceIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                  public HttpIntegrationTest {
+public:
+  KtlsSpliceIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void initializeWithFakeKtlsUpstream() {
+    // Enable the dark runtime guard and point cluster_0 at the fake kTLS socket.
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.http1_ktls_body_splice", "true");
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* cluster_transport_socket =
+          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      cluster_transport_socket->set_name("envoy.transport_sockets.fake_ktls");
+      Protobuf::Struct empty;
+      cluster_transport_socket->mutable_typed_config()->PackFrom(empty);
+    });
+    initialize();
+  }
+
+  // Sends headers first so engage can commit before the body arrives.
+  IntegrationStreamDecoderPtr runDownload(uint64_t body_size) {
+    codec_client_ = makeHttpConnection(lookupPort("http"));
+    auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+        {":method", "GET"}, {":path", "/download"}, {":scheme", "http"}, {":authority", "host"}});
+
+    waitForNextUpstreamRequest();
+    upstream_request_->encodeHeaders(
+        Http::TestResponseHeaderMapImpl{{":status", "200"},
+                                        {"content-length", absl::StrCat(body_size)}},
+        false);
+    // Wait for engage to run before sending the body.
+    response->waitForHeaders();
+
+    const std::string body = makeBody(body_size);
+    Buffer::OwnedImpl response_data(body);
+    upstream_request_->encodeData(response_data, true);
+
+    RELEASE_ASSERT(response->waitForEndStream(), "download did not complete");
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+    EXPECT_EQ(body_size, response->body().size());
+    EXPECT_EQ(body, response->body());
+    return response;
+  }
+
+  // Sends request headers first so upload engage can wait for upstream kTLS-TX before the body.
+  IntegrationStreamDecoderPtr runUpload(uint64_t body_size) {
+    codec_client_ = makeHttpConnection(lookupPort("http"));
+    auto encoder_decoder = codec_client_->startRequest(
+        Http::TestRequestHeaderMapImpl{{":method", "PUT"},
+                                       {":path", "/upload"},
+                                       {":scheme", "http"},
+                                       {":authority", "host"},
+                                       {"content-length", absl::StrCat(body_size)}});
+    auto& encoder = encoder_decoder.first;
+    auto response = std::move(encoder_decoder.second);
+
+    // Wait for the upstream stream, not end stream, before sending the body.
+    RELEASE_ASSERT(
+        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_),
+        "no upstream connection");
+    RELEASE_ASSERT(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_),
+                   "no upstream stream");
+
+    const std::string body = makeBody(body_size);
+    codec_client_->sendData(encoder, body, true);
+
+    RELEASE_ASSERT(upstream_request_->waitForEndStream(*dispatcher_), "upload did not complete");
+    // FakeStream::body() drains the accumulated body, so snapshot it once and assert on the copy.
+    const std::string received = upstream_request_->body().toString();
+    EXPECT_EQ(body_size, received.size());
+    EXPECT_EQ(body, received);
+
+    upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+    RELEASE_ASSERT(response->waitForEndStream(), "upload response did not complete");
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+    return response;
+  }
+
+  FakeKtlsConfigFactory config_factory_;
+  Registry::InjectFactory<Server::Configuration::UpstreamTransportSocketConfigFactory>
+      registered_config_factory_{config_factory_};
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, KtlsSpliceIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// A 128 KiB download (>= the 64 KiB floor) over a fake-kTLS upstream engages the splice and the
+// body still arrives byte-for-byte. The engaged counter assertion is what proves the fast-path
+// actually fired rather than the buffered path silently carrying the bytes.
+TEST_P(KtlsSpliceIntegrationTest, DownloadAboveThresholdEngagesSplice) {
+  initializeWithFakeKtlsUpstream();
+  auto response = runDownload(128 * 1024);
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.completed", testing::Ge(1));
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+}
+
+// Below-threshold bodies use the buffered path and do not engage the splice.
+TEST_P(KtlsSpliceIntegrationTest, DownloadBelowThresholdDoesNotEngage) {
+  initializeWithFakeKtlsUpstream();
+  auto response = runDownload(MinSpliceBodyBytes - 1);
+  const Stats::CounterSharedPtr engaged =
+      test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged");
+  EXPECT_EQ(0, engaged == nullptr ? 0 : engaged->value());
+}
+
+// A 128 KiB PUT body (>= the 64 KiB floor) over the fake-kTLS upstream engages the upload splice
+// (downstream source to kTLS-TX upstream sink) and the upstream still receives the body
+// byte-for-byte. The engaged counter assertion is what proves the request-body fast-path actually
+// fired rather than the buffered path silently carrying the bytes. This is the upload mirror of
+// DownloadAboveThresholdEngagesSplice.
+TEST_P(KtlsSpliceIntegrationTest, UploadAboveThresholdEngagesSplice) {
+  initializeWithFakeKtlsUpstream();
+  auto response = runUpload(128 * 1024);
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.completed", testing::Ge(1));
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value());
+  EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+  // A clean upload completes rather than truncates.
+  const Stats::CounterSharedPtr truncated =
+      test_server_->counter("cluster.cluster_0.http1_ktls_splice.truncated");
+  EXPECT_EQ(0, truncated == nullptr ? 0 : truncated->value());
+}
+
+TEST_P(KtlsSpliceIntegrationTest, UploadFullyBufferedBeforeEngageAbandons) {
+  initializeWithFakeKtlsUpstream();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  const std::string body = makeBody(128 * 1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "PUT"},
+                                     {":path", "/upload"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-length", absl::StrCat(body.size())}},
+      body);
+
+  waitForNextUpstreamRequest();
+  const std::string received = upstream_request_->body().toString();
+  EXPECT_EQ(body, received);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.abandoned", testing::Ge(1));
+  const Stats::CounterSharedPtr engaged =
+      test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged");
+  EXPECT_EQ(0, engaged == nullptr ? 0 : engaged->value());
+}
+
+// Engaged download truncation force-closes upstream after reinstalling the downstream sink, so
+// teardown must reset the stream without hitting a detached file event.
+TEST_P(KtlsSpliceIntegrationTest, EngagedDownloadTruncationDoesNotCrash) {
+  initializeWithFakeKtlsUpstream();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/download"}, {":scheme", "http"}, {":authority", "host"}});
+
+  // At/above the 64 KiB floor so the download splice arms and engages. The pump owns the fds once
+  // engage() commits, which is the state the crash fix protects on teardown.
+  constexpr uint64_t content_length = 128 * 1024;
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"},
+                                      {"content-length", absl::StrCat(content_length)}},
+      false);
+  // Wait for headers so scheduled engage can run before body bytes.
+  response->waitForHeaders();
+
+  // Confirm engagement before forcing truncation.
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+
+  // Send strictly fewer bytes than the advertised Content-Length (end_stream=false), then close the
+  // upstream connection so the body is cut mid-transfer. The pump sees EOF before the bound.
+  const std::string partial = makeBody(content_length / 2);
+  Buffer::OwnedImpl partial_data(partial);
+  upstream_request_->encodeData(partial_data, false);
+  RELEASE_ASSERT(fake_upstream_connection_->close(), "failed to close upstream");
+
+  // The downstream stream is reset / left incomplete, no clean end-of-stream with the full body. If
+  // the teardown had aborted on the detached-sink ENVOY_BUG, the process would have crashed before
+  // reaching this point.
+  ASSERT_TRUE(response->waitForAnyTermination());
+  EXPECT_FALSE(response->complete());
+
+  // Mid-body close counts as truncated after engagement.
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.truncated", testing::Ge(1));
+  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value(), 1);
+  EXPECT_EQ(0,
+            test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed") == nullptr
+                ? 0
+                : test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+}
+
+TEST_P(KtlsSpliceIntegrationTest, EngagedUploadTruncationDoesNotCrash) {
+  initializeWithFakeKtlsUpstream();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "PUT"},
+                                                                 {":path", "/upload"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "131072"}});
+  auto& encoder = encoder_decoder.first;
+
+  RELEASE_ASSERT(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_),
+                 "no upstream connection");
+  RELEASE_ASSERT(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_),
+                 "no upstream stream");
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.engaged", testing::Ge(1));
+
+  codec_client_->sendData(encoder, makeBody(64 * 1024), false);
+  codec_client_->close();
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  test_server_->waitForCounter("cluster.cluster_0.http1_ktls_splice.truncated", testing::Ge(1));
+  EXPECT_GE(test_server_->counter("cluster.cluster_0.http1_ktls_splice.engaged")->value(), 1);
+  EXPECT_EQ(0,
+            test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed") == nullptr
+                ? 0
+                : test_server_->counter("cluster.cluster_0.http1_ktls_splice.completed")->value());
+}
+
+} // namespace
+} // namespace Envoy
+
+#endif // __linux__

--- a/test/mocks/http/stream_encoder.h
+++ b/test/mocks/http/stream_encoder.h
@@ -29,6 +29,7 @@ public:
   MOCK_METHOD(Status, encodeHeaders, (const RequestHeaderMap& headers, bool end_stream));
   MOCK_METHOD(void, encodeTrailers, (const RequestTrailerMap& trailers));
   MOCK_METHOD(void, enableTcpTunneling, ());
+  MOCK_METHOD(void, completeSplicedResponse, (uint64_t response_body_bytes));
 
   // Http::StreamEncoder
   MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));
@@ -54,6 +55,7 @@ public:
                Http::ResponseHeaderMapConstSharedPtr response_header_map,
                Http::ResponseTrailerMapConstSharedPtr response_trailer_map,
                StreamInfo::StreamInfo& stream_info));
+  MOCK_METHOD(void, completeSplicedRequest, (uint64_t request_body_bytes));
 
   // Http::StreamEncoder
   MOCK_METHOD(void, encodeData, (Buffer::Instance & data, bool end_stream));

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -82,7 +82,7 @@ public:
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, ssl, (), (const));                                \
   MOCK_METHOD(OptRef<const KtlsBytestreamInfo>, ktlsBytestreamInfo, (), (const));                  \
   MOCK_METHOD(void, reinstallFileEvents, ());                                                      \
-  MOCK_METHOD(std::string, extractPendingWriteForSplice, ());                                      \
+  MOCK_METHOD(void, extractPendingWriteForSplice, (Buffer::Instance&));                            \
   MOCK_METHOD(absl::string_view, requestedServerName, (), (const));                                \
   MOCK_METHOD(absl::string_view, ja3Hash, (), (const));                                            \
   MOCK_METHOD(absl::string_view, ja4Hash, (), (const));                                            \

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -80,6 +80,9 @@ public:
               unixSocketPeerCredentials, (), (const));                                             \
   MOCK_METHOD(void, setConnectionStats, (const ConnectionStats& stats));                           \
   MOCK_METHOD(Ssl::ConnectionInfoConstSharedPtr, ssl, (), (const));                                \
+  MOCK_METHOD(OptRef<const KtlsBytestreamInfo>, ktlsBytestreamInfo, (), (const));                  \
+  MOCK_METHOD(void, reinstallFileEvents, ());                                                      \
+  MOCK_METHOD(std::string, extractPendingWriteForSplice, ());                                      \
   MOCK_METHOD(absl::string_view, requestedServerName, (), (const));                                \
   MOCK_METHOD(absl::string_view, ja3Hash, (), (const));                                            \
   MOCK_METHOD(absl::string_view, ja4Hash, (), (const));                                            \

--- a/test/mocks/network/transport_socket.h
+++ b/test/mocks/network/transport_socket.h
@@ -36,6 +36,7 @@ public:
   MOCK_METHOD(bool, startSecureTransport, ());
   MOCK_METHOD(void, configureInitialCongestionWindow,
               (uint64_t bandwidth_bits_per_sec, std::chrono::microseconds rtt));
+  MOCK_METHOD(OptRef<const KtlsBytestreamInfo>, ktlsBytestreamInfo, (), (const));
 
   TransportSocketCallbacks* callbacks_{};
 };

--- a/test/mocks/router/router_filter_interface.h
+++ b/test/mocks/router/router_filter_interface.h
@@ -41,6 +41,8 @@ public:
   MOCK_METHOD(Envoy::Http::StreamDecoderFilterCallbacks*, callbacks, ());
   MOCK_METHOD(Upstream::ClusterInfoConstSharedPtr, cluster, ());
   MOCK_METHOD(FilterConfig&, config, ());
+  MOCK_METHOD(void, disableRetries, ());
+  MOCK_METHOD(bool, shadowStreamsActive, (), (const));
   MOCK_METHOD(TimeoutData, timeout, ());
   MOCK_METHOD(absl::optional<std::chrono::milliseconds>, dynamicMaxStreamDuration, (), (const));
   MOCK_METHOD(Envoy::Http::RequestHeaderMap*, downstreamHeaders, ());

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1012,6 +1012,7 @@ keepalives
 keyset
 ketama
 keyder
+kTLS
 kqueue
 kubernetes
 kv
@@ -1586,6 +1587,7 @@ useragent
 userdata
 userinfo
 username
+userspace
 usr
 util
 utils
@@ -1720,3 +1722,9 @@ datasets
 smartptr
 JA3
 JA4
+AEAD
+iters
+ktls
+middlebox
+reinstalls
+spliceable


### PR DESCRIPTION
## Description

This PR adds an experimental, disabled-by-default HTTP/1.1 kTLS body-splice fast path. When eligible, Envoy can relay a `Content-Length` request or response body with in-kernel `splice()`, bypassing user-space body buffers and codec filter-chain body processing while preserving HTTP/1.1 keep-alive reuse.

The fast path is guarded by `envoy.reloadable_features.http1_ktls_body_splice` and only engages for single HTTP/1.1 socket legs with trusted upstream kTLS and a plaintext or installed-kTLS peer. Per-cluster lifecycle counters track `engaged`, `abandoned`, `completed`, and `truncated` splice decisions.

---

**Commit Message:** router: add experimental HTTP/1.1 kTLS body-splice fast path
**Additional Description:** Added an experimental, disabled-by-default HTTP/1.1 kTLS body-splice fast path.
**Risk Level:** Low
**Testing:** Added Unit + Integration Tests
**Docs Changes:** Added
**Release Notes:** Added