### PR TITLE
udp_proxy: populate upstream host and address info for access logs

### DIFF
--- a/changelogs/current/bug_fixes/udp_proxy__fixed-attempted-upstream-host-tracking-in-tunneling.rst
+++ b/changelogs/current/bug_fixes/udp_proxy__fixed-attempted-upstream-host-tracking-in-tunneling.rst
@@ -1,0 +1,8 @@
+Fixed missing attempted upstream host tracking in the
+:ref:`UDP proxy <config_udp_listener_filters_udp_proxy>` tunneling path.
+``TunnelingConnectionPoolImpl`` now records the upstream host via
+``StreamInfo::UpstreamInfo::addUpstreamHostAttempted`` on both pool ready and pool
+failure, so the ``%UPSTREAM_HOSTS_ATTEMPTED%``,
+``%UPSTREAM_HOST_NAMES_ATTEMPTED_WITHOUT_PORT%`` and related access log formatters are
+populated for tunneled (UDP-over-HTTP) sessions, matching the behavior of the
+non-tunneling UDP proxy and TCP proxy.

--- a/changelogs/current/bug_fixes/udp_proxy__fixed-upstream-address-logging-in-non-tunneling-path.rst
+++ b/changelogs/current/bug_fixes/udp_proxy__fixed-upstream-address-logging-in-non-tunneling-path.rst
@@ -1,0 +1,6 @@
+Fixed the :ref:`UDP proxy <config_udp_listener_filters_udp_proxy>` not populating the upstream
+local and remote addresses on the session stream info. As a result the ``%UPSTREAM_LOCAL_ADDRESS%``
+and ``%UPSTREAM_REMOTE_ADDRESS%`` (and their ``_WITHOUT_PORT`` / port variants) access log
+formatters were always empty for non-tunneling UDP -> UDP sessions, unlike TCP proxy. The upstream
+remote address is now recorded when the upstream host is selected, and the upstream local address
+once the socket is bound after the first datagram is sent upstream.

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -568,6 +568,15 @@ void UdpProxyFilter::UdpActiveSession::writeUpstream(Network::UdpRecvData& data)
   } else {
     cluster_->cluster_stats_.sess_tx_datagrams_.inc();
     cluster_->cluster_info_->trafficStats()->upstream_cx_tx_bytes_total_.add(tx_buffer_length);
+
+    // The local ephemeral address is only bound after the first successful send, so populate the
+    // upstream local address for access logging once it becomes available.
+    if (udp_session_info_.upstreamInfo()->upstreamLocalAddress() == nullptr) {
+      auto local_address = udp_socket_->ioHandle().localAddress();
+      if (local_address.ok()) {
+        udp_session_info_.upstreamInfo()->setUpstreamLocalAddress(*local_address);
+      }
+    }
   }
 }
 
@@ -629,6 +638,7 @@ bool UdpProxyFilter::UdpActiveSession::createUpstream() {
   // Track attempted hosts for access logging
   udp_session_info_.upstreamInfo()->addUpstreamHostAttempted(host_);
   udp_session_info_.upstreamInfo()->setUpstreamHost(host_);
+  udp_session_info_.upstreamInfo()->setUpstreamRemoteAddress(host_->address());
   cluster_->addSession(host_.get(), this);
   createUdpSocket(host_);
   return true;
@@ -962,6 +972,7 @@ void TunnelingConnectionPoolImpl::onPoolFailure(Http::ConnectionPool::PoolFailur
   upstream_handle_ = nullptr;
   // Writing to downstream_info_ before calling onStreamFailure, as the session could be potentially
   // removed by onStreamFailure, which will cause downstream_info_ to be freed.
+  downstream_info_.upstreamInfo()->addUpstreamHostAttempted(host);
   downstream_info_.upstreamInfo()->setUpstreamHost(host);
   downstream_info_.upstreamInfo()->setUpstreamTransportFailureReason(failure_reason);
   callbacks_->onStreamFailure(reason, failure_reason, *host);
@@ -983,6 +994,7 @@ void TunnelingConnectionPoolImpl::onPoolReady(Http::RequestEncoder& request_enco
   bool is_ssl = upstream_host->transportSocketFactory().implementsSecureTransport();
   upstream_->setRequestEncoder(request_encoder, is_ssl);
   upstream_->setTunnelCreationCallbacks(*this);
+  downstream_info_.upstreamInfo()->addUpstreamHostAttempted(upstream_host);
   downstream_info_.upstreamInfo()->setUpstreamHost(upstream_host);
   downstream_info_.setUpstreamBytesMeter(request_encoder.getStream().bytesMeter());
   downstream_info_.upstreamInfo()->setUpstreamConnectionId(upstream_connection_id);

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -197,6 +197,12 @@ public:
                     }
                   }));
         }
+        // After the first successful write the upstream socket's ephemeral local address becomes
+        // available and is captured for access logging. Allow the lookup in any flow.
+        EXPECT_CALL(*socket_->io_handle_, localAddress())
+            .Times(testing::AnyNumber())
+            .WillRepeatedly(
+                Return(Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.1:12345")));
       }
     }
 
@@ -585,6 +591,38 @@ upstream_socket_config:
 
   EXPECT_TRUE(std::regex_match(output_[0], std::regex(session_access_log_regex)));
   EXPECT_TRUE(std::regex_match(output_[1], std::regex(session_access_log_regex)));
+}
+
+// The non-tunneling UDP proxy session records the upstream remote and local addresses so they are
+// available to access loggers, matching TCP proxy behavior.
+TEST_F(UdpProxyFilterTest, UpstreamAddressAccessLog) {
+  InSequence s;
+
+  const std::string session_access_log_format =
+      "%UPSTREAM_REMOTE_ADDRESS% %UPSTREAM_LOCAL_ADDRESS%";
+
+  setup(accessLogConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+  )EOF",
+                        session_access_log_format, ""),
+        true, false);
+
+  expectSessionCreate(upstream_address_);
+  // The local ephemeral address is only bound after the first successful send to the upstream;
+  // expectWriteToUpstream stubs it to 127.0.0.1:12345.
+  test_sessions_[0].expectWriteToUpstream("hello", 0, nullptr, true);
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+
+  filter_.reset();
+  ASSERT_EQ(output_.size(), 1);
+  EXPECT_EQ(output_[0], "20.0.0.1:443 127.0.0.1:12345");
 }
 
 // Route with source IP.
@@ -2586,6 +2624,8 @@ TEST_F(TunnelingConnectionPoolImplTest, PoolFailure) {
   pool_->onPoolFailure(Http::ConnectionPool::PoolFailureReason::Timeout, "reason", upstream_host_);
   EXPECT_EQ(stream_info_.upstreamInfo()->upstreamHost()->hostname(), upstream_host_name);
   EXPECT_EQ(stream_info_.upstreamInfo()->upstreamTransportFailureReason(), "reason");
+  ASSERT_EQ(stream_info_.upstreamInfo()->upstreamHostsAttempted().size(), 1);
+  EXPECT_EQ(stream_info_.upstreamInfo()->upstreamHostsAttempted()[0], upstream_host_);
 }
 
 TEST_F(TunnelingConnectionPoolImplTest, PoolReady) {
@@ -2598,6 +2638,8 @@ TEST_F(TunnelingConnectionPoolImplTest, PoolReady) {
   EXPECT_CALL(stream_callbacks_, resetIdleTimer());
   pool_->onPoolReady(request_encoder_, upstream_host_, stream_info_, absl::nullopt);
   EXPECT_EQ(stream_info_.upstreamInfo()->upstreamHost()->hostname(), upstream_host_name);
+  ASSERT_EQ(stream_info_.upstreamInfo()->upstreamHostsAttempted().size(), 1);
+  EXPECT_EQ(stream_info_.upstreamInfo()->upstreamHostsAttempted()[0], upstream_host_);
 }
 
 TEST_F(TunnelingConnectionPoolImplTest, OnStreamFailure) {


### PR DESCRIPTION
Commit Message: udp_proxy: populate upstream host and address info for access logs

Additional Description:
The UDP proxy did not populate all upstream information on the session `StreamInfo` that access loggers expect, so several `%UPSTREAM_*%` access log formatters were always empty for UDP sessions, unlike TCP proxy. This PR fixes two distinct gaps:

1. **Non-tunneling UDP → UDP path (#44153):** the upstream local and remote addresses were never set, so `%UPSTREAM_LOCAL_ADDRESS%` and `%UPSTREAM_REMOTE_ADDRESS%` (and their `_WITHOUT_PORT` / port variants) were always empty. The remote address is now recorded when the upstream host is selected in `createUpstream()`, and the local address once the socket is bound after the first datagram is sent upstream in `writeUpstream()`.

2. **Tunneling (UDP-over-HTTP) path:** the attempted-upstream-host tracking added in #43215 (HTTP router, TCP proxy and the non-tunneling UDP path) was not wired into `TunnelingConnectionPoolImpl`, so `%UPSTREAM_HOSTS_ATTEMPTED%` / `%UPSTREAM_HOST_NAMES_ATTEMPTED_WITHOUT_PORT%` were always empty for tunneled sessions even though `%UPSTREAM_HOST%` was populated. `addUpstreamHostAttempted()` is now called alongside `setUpstreamHost()` on both pool ready and pool failure.

Risk Level: Low (only adds population of existing StreamInfo upstream fields; no behavior change to the data path).
Testing: Added unit tests in `udp_proxy_filter_test` covering both paths (`UdpProxyFilterTest.UpstreamAddressAccessLog`, and `upstreamHostsAttempted()` assertions in `TunnelingConnectionPoolImplTest.PoolReady` / `PoolFailure`).
Docs Changes: N/A
Release Notes: Added (two `changelogs/current/bug_fixes` entries).
Fixes #44153
