### PR TITLE
dynamic_modules: allocate cluster worker slot during construction

### DIFF
--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -213,6 +213,8 @@ DynamicModuleCluster::DynamicModuleCluster(const envoy::config::cluster::v3::Clu
 
   // Initialize the priority set with an empty host set at priority 0.
   priority_set_.getOrCreateHostSet(0);
+  // Allocate and seed the worker slot before worker threads can observe this cluster.
+  ensureWorkerSlot();
 
   registerLifecycleCallbacks();
 }

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -455,7 +455,7 @@ private:
     DynamicModuleClusterConfigSharedPtr config_;
   };
 
-  // Allocates worker_slot_ lazily on first use.
+  // Allocates worker_slot_ and seeds a null payload.
   void ensureWorkerSlot();
 
   uint64_t getNextCalloutId() { return next_callout_id_++; }
@@ -479,7 +479,6 @@ private:
   Server::ServerLifecycleNotifier::HandlePtr server_initialized_handle_;
 
   // Thread-local slot backing both the worker fan-out and the worker_slot_set/get pattern.
-  // Allocated lazily on first use.
   ThreadLocal::TypedSlotPtr<WorkerSlotData> worker_slot_;
 
   // HTTP callout tracking.


### PR DESCRIPTION
## Description

This PR allocates and seeds the worker slot in the cluster constructor so that the worker threads always observe an initialized slot instead of relying on the lazy allocation.

---

**Commit Message:** dynamic_modules: allocate cluster worker slot during construction
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A