### PR TITLE
dynamic_modules: hold host metadata snapshot for stable lifetime

### DIFF
--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -246,6 +246,7 @@ const envoy::config::core::v3::Metadata*
 getMetadata(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
             envoy_dynamic_module_type_metadata_source metadata_source) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  filter->last_metadata_snapshot_.reset();
   auto* callbacks = filter->callbacks();
   if (!callbacks) {
     ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
@@ -277,9 +278,9 @@ getMetadata(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     if (upstreamInfo) {
       Upstream::HostDescriptionConstSharedPtr hostInfo = upstreamInfo->upstreamHost();
       if (hostInfo) {
-        Upstream::MetadataConstSharedPtr md = hostInfo->metadata();
-        if (md) {
-          return md.get();
+        filter->last_metadata_snapshot_ = hostInfo->metadata();
+        if (filter->last_metadata_snapshot_) {
+          return filter->last_metadata_snapshot_.get();
         }
       }
     }
@@ -290,9 +291,9 @@ getMetadata(envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     if (upstreamInfo) {
       Upstream::HostDescriptionConstSharedPtr hostInfo = upstreamInfo->upstreamHost();
       if (hostInfo) {
-        Upstream::MetadataConstSharedPtr md = hostInfo->localityMetadata();
-        if (md) {
-          return md.get();
+        filter->last_metadata_snapshot_ = hostInfo->localityMetadata();
+        if (filter->last_metadata_snapshot_) {
+          return filter->last_metadata_snapshot_.get();
         }
       }
     }

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -97,6 +97,10 @@ public:
   // get_filter_state_typed. Valid until the end of the current event hook.
   absl::optional<std::string> last_serialized_filter_state_;
 
+  // Temporary holder for host metadata snapshots returned by host metadata getters.
+  // Valid until the next metadata getter call on this filter.
+  Upstream::MetadataConstSharedPtr last_metadata_snapshot_;
+
   /**
    * Helper to get the correct callbacks.
    */

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -905,11 +905,22 @@ TEST(ABIImpl, metadata) {
       &result_number));
 
   // lbEndpoints metadata.
+  const std::string host_key = "host_key";
+  const std::string host_value = "host_value";
   const std::string lbendpoint_key = "lbendpoint_key";
   const std::string lbendpoint_value = "lbendpoint_value";
   auto upstream_info = std::make_shared<StreamInfo::MockUpstreamInfo>();
   auto upstream_host = std::make_shared<Upstream::MockHostDescription>();
   EXPECT_CALL(*upstream_info, upstreamHost).WillRepeatedly(testing::Return(upstream_host));
+  auto host_metadata = std::make_shared<envoy::config::core::v3::Metadata>();
+  host_metadata->mutable_filter_metadata()->insert({namespace_str, Protobuf::Struct()});
+  Protobuf::Value host_value_proto;
+  host_value_proto.set_string_value(host_value);
+  host_metadata->mutable_filter_metadata()
+      ->at(namespace_str)
+      .mutable_fields()
+      ->insert({host_key, host_value_proto});
+  EXPECT_CALL(*upstream_host, metadata()).WillRepeatedly(testing::Return(host_metadata));
   auto locality_metadata = std::make_shared<envoy::config::core::v3::Metadata>();
   locality_metadata->mutable_filter_metadata()->insert({namespace_str, Protobuf::Struct()});
   Protobuf::Value lbendpoint_value_proto;
@@ -921,6 +932,11 @@ TEST(ABIImpl, metadata) {
   EXPECT_CALL(*upstream_host, localityMetadata())
       .WillRepeatedly(testing::Return(locality_metadata));
   EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(upstream_info));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
+      &filter, envoy_dynamic_module_type_metadata_source_Host,
+      {namespace_str.data(), namespace_str.size()}, {host_key.data(), host_key.size()},
+      &result_buffer));
+  EXPECT_EQ(absl::string_view(result_buffer.ptr, result_buffer.length), host_value);
   EXPECT_TRUE(envoy_dynamic_module_callback_http_get_metadata_string(
       &filter, envoy_dynamic_module_type_metadata_source_HostLocality,
       {namespace_str.data(), namespace_str.size()}, {lbendpoint_key.data(), lbendpoint_key.size()},


### PR DESCRIPTION
## Description

This PR retains the host metadata shared pointer on the filter so that the pointer returned to the module stays valid for the entire duration of the call.

---

**Commit Message:** dynamic_modules: hold host metadata snapshot for stable lifetime
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A