### PR TITLE
dynamic_modules: harden module loader and background fetch lifecycle

### DIFF
--- a/source/extensions/dynamic_modules/background_fetch_manager.cc
+++ b/source/extensions/dynamic_modules/background_fetch_manager.cc
@@ -1,6 +1,9 @@
 #include "source/extensions/dynamic_modules/background_fetch_manager.h"
 
+#include "source/common/common/assert.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
+
+#include "absl/algorithm/container.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -16,16 +19,17 @@ BackgroundFetchManager::singleton(Singleton::Manager& manager) {
       /*pin=*/true);
 }
 
-void BackgroundFetchManager::erase(absl::string_view sha256) { background_fetches_.erase(sha256); }
+void BackgroundFetchManager::erase(absl::string_view sha256) {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  background_fetches_.erase(sha256);
+}
 
 void BackgroundFetchManager::fetchIfNeeded(
     absl::string_view sha256, Upstream::ClusterManager& cm,
     const envoy::config::core::v3::RemoteDataSource& source) {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  absl::erase_if(background_fetches_, [](const auto& entry) { return entry.second->completed_; });
   auto it = background_fetches_.find(sha256);
-  if (it != background_fetches_.end() && it->second->completed_) {
-    background_fetches_.erase(it);
-    it = background_fetches_.end();
-  }
   if (it == background_fetches_.end()) {
     background_fetches_.emplace(sha256, std::make_unique<BackgroundFetchState>(cm, source));
   }

--- a/source/extensions/dynamic_modules/dynamic_modules.cc
+++ b/source/extensions/dynamic_modules/dynamic_modules.cc
@@ -229,7 +229,8 @@ absl::Status writeDynamicModuleBytesToDisk(const absl::string_view module_bytes,
         continue;
       }
       close(fd);
-      std::filesystem::remove(staging_template);
+      std::error_code cleanup_ec;
+      std::filesystem::remove(staging_template, cleanup_ec);
       return absl::InternalError(
           absl::StrCat("Failed to write to staging file for dynamic module: ", staging_template));
     }
@@ -238,9 +239,24 @@ absl::Status writeDynamicModuleBytesToDisk(const absl::string_view module_bytes,
   close(fd);
 
   std::filesystem::path staging_path(staging_template);
+  std::error_code ec;
   std::filesystem::permissions(staging_path, std::filesystem::perms::owner_all,
-                               std::filesystem::perm_options::replace);
-  std::filesystem::rename(staging_path, temp_file_path);
+                               std::filesystem::perm_options::replace, ec);
+  if (ec) {
+    std::error_code cleanup_ec;
+    std::filesystem::remove(staging_path, cleanup_ec);
+    return absl::InternalError(absl::StrCat(
+        "Failed to set permissions for dynamic module staging file: ", staging_path.string(), ": ",
+        ec.message()));
+  }
+  std::filesystem::rename(staging_path, temp_file_path, ec);
+  if (ec) {
+    std::error_code cleanup_ec;
+    std::filesystem::remove(staging_path, cleanup_ec);
+    return absl::InternalError(absl::StrCat(
+        "Failed to move dynamic module staging file to cache path: ", temp_file_path.string(), ": ",
+        ec.message()));
+  }
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
## Description

In this PR, we are using the non throwing `std::filesystem` overload with explicit error handling and staging cleanup when writing a cached module to disk, asserting main thread access in the background fetch manager, and purging the completed fetch entries on the next fetch so that the map does not grow without bound.

---

**Commit Message:** dynamic_modules: harden module loader and background fetch lifecycle
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A