### PR TITLE
dynamic_modules: streamline stat sink hot path and enforce thread contract

### DIFF
--- a/source/extensions/stat_sinks/dynamic_modules/sink.cc
+++ b/source/extensions/stat_sinks/dynamic_modules/sink.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/stat_sinks/dynamic_modules/sink.h"
 
+#include <vector>
+
 #include "source/common/common/assert.h"
 #include "source/extensions/stat_sinks/dynamic_modules/flush_context.h"
 
@@ -22,8 +24,16 @@ void DynamicModuleStatsSink::onHistogramComplete(const Stats::Histogram& histogr
   // The config members are written once during config creation on the main thread
   // before any worker thread starts, so reading them here needs no synchronization.
   ASSERT(config_->on_histogram_complete_ != nullptr);
-  const std::string name = histogram.name();
-  envoy_dynamic_module_type_envoy_buffer name_buf = {.ptr = name.data(), .length = name.size()};
+  thread_local std::vector<char> histogram_name_buffer;
+  const size_t required_size =
+      histogram.constSymbolTable().serializeToBuffer(histogram.statName(), nullptr, 0);
+  if (histogram_name_buffer.size() < required_size) {
+    histogram_name_buffer.resize(required_size);
+  }
+  histogram.constSymbolTable().serializeToBuffer(histogram.statName(), histogram_name_buffer.data(),
+                                                 histogram_name_buffer.size());
+  envoy_dynamic_module_type_envoy_buffer name_buf = {.ptr = histogram_name_buffer.data(),
+                                                     .length = required_size};
   config_->on_histogram_complete_(config_->in_module_config_, name_buf, value);
 }
 

--- a/source/extensions/stat_sinks/dynamic_modules/sink_config.cc
+++ b/source/extensions/stat_sinks/dynamic_modules/sink_config.cc
@@ -26,7 +26,12 @@ DynamicModuleStatsSinkConfig::~DynamicModuleStatsSinkConfig() {
 
 envoy_dynamic_module_type_metrics_result
 DynamicModuleStatsSinkConfig::defineGauge(absl::string_view name, size_t* gauge_id_out) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  // Defining a gauge mutates shared storage, so reject calls from other threads.
+  if (!Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_stat_sink_config_define_gauge must be called on "
+                 "the main thread");
+    return envoy_dynamic_module_type_metrics_result_Frozen;
+  }
   // Acquire-load pairs with the release-store in newDynamicModuleStatsSinkConfig(). See the header
   // for the memory-order contract.
   if (stat_creation_frozen_.load(std::memory_order_acquire)) {
@@ -42,7 +47,12 @@ DynamicModuleStatsSinkConfig::defineGauge(absl::string_view name, size_t* gauge_
 
 envoy_dynamic_module_type_metrics_result DynamicModuleStatsSinkConfig::setGauge(size_t gauge_id,
                                                                                 uint64_t value) {
-  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  // Setting a gauge writes shared state, so reject calls from other threads.
+  if (!Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_stat_sink_config_set_gauge must be called on the "
+                 "main thread");
+    return envoy_dynamic_module_type_metrics_result_MetricNotFound;
+  }
   if (gauge_id == 0 || gauge_id > gauges_.size()) {
     return envoy_dynamic_module_type_metrics_result_MetricNotFound;
   }

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -144,6 +144,24 @@ sink_config:
   ASSERT_TRUE(sink_or_error.ok()) << sink_or_error.status().message();
 }
 
+// A sink_config Any that claims to be a StringValue but carries truncated wire bytes makes
+// knownAnyToBytes fail after the module loads, surfacing a clear parse error. This must be set
+// programmatically because a sink_config parsed from YAML is always valid.
+TEST_F(DynamicModuleStatsSinkFactoryTest, MalformedSinkConfig) {
+  envoy::extensions::stat_sinks::dynamic_modules::v3::DynamicModuleStatsSink proto_config;
+  proto_config.mutable_dynamic_module_config()->set_name("stat_sink_no_op");
+  proto_config.mutable_dynamic_module_config()->set_do_not_close(true);
+  proto_config.set_sink_name("test_sink");
+  auto* any = proto_config.mutable_sink_config();
+  any->set_type_url("type.googleapis.com/google.protobuf.StringValue");
+  any->set_value("\x0a");
+
+  auto sink_or_error = factory_.createStatsSink(proto_config, context_);
+  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(std::string(sink_or_error.status().message()),
+              testing::HasSubstr("Failed to parse sink config"));
+}
+
 // A bogus module name produces a clear "Failed to load dynamic module" error.
 TEST_F(DynamicModuleStatsSinkFactoryTest, InvalidModule) {
   const std::string yaml = R"EOF(

--- a/test/extensions/dynamic_modules/stat_sink/sink_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/sink_test.cc
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/stat_sinks/dynamic_modules/flush_context.h"
 #include "source/extensions/stat_sinks/dynamic_modules/sink.h"
@@ -179,8 +181,8 @@ TEST_F(DynamicModuleStatsSinkTest, FlushPassesSnapshotContext) {
   g_recorder = nullptr;
 }
 
-// onHistogramComplete must bind the histogram name to a local std::string so the
-// buffer stays valid for the module call, since Metric::name() returns by value.
+// onHistogramComplete serializes the histogram name into a thread-local buffer before handing it
+// to the module, so repeated calls reuse the buffer and still report the full name.
 TEST_F(DynamicModuleStatsSinkTest, OnHistogramCompletePassesNameAndValue) {
   CallRecorder recorder;
   g_recorder = &recorder;
@@ -274,6 +276,44 @@ TEST_F(DynamicModuleStatsSinkGaugeTest, SetGaugeInvalidIdIsRejected) {
 
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_MetricNotFound, config->setGauge(0, 1));
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_MetricNotFound, config->setGauge(2, 1));
+}
+
+// defineGauge fails closed when invoked off the main thread, so a misbehaving module cannot mutate
+// the gauge storage from a worker thread.
+TEST_F(DynamicModuleStatsSinkGaugeTest, DefineGaugeOffMainThreadFailsClosed) {
+  auto config = makeConfig();
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          size_t id = 0;
+          EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
+                    config->defineGauge("off_thread", &id));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_stat_sink_config_define_gauge must be called on the main "
+      "thread");
+  EXPECT_EQ(nullptr, TestUtility::findGauge(context_.store_, "off_thread"));
+}
+
+// setGauge fails closed when invoked off the main thread, leaving the gauge value untouched.
+TEST_F(DynamicModuleStatsSinkGaugeTest, SetGaugeOffMainThreadFailsClosed) {
+  auto config = makeConfig();
+  size_t id = 0;
+  ASSERT_EQ(envoy_dynamic_module_type_metrics_result_Success, config->defineGauge("g", &id));
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_EQ(envoy_dynamic_module_type_metrics_result_MetricNotFound,
+                    config->setGauge(id, 99));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_stat_sink_config_set_gauge must be called on the main thread");
+  auto gauge = TestUtility::findGauge(context_.store_, "g");
+  ASSERT_NE(nullptr, gauge);
+  EXPECT_EQ(0u, gauge->value());
 }
 
 // onScheduled is a no-op when the module does not implement the scheduled hook.


### PR DESCRIPTION
## Description

Serialize the histogram name into a thread local buffer on the worker path to avoid a symbol table lock and per observation allocations, and add release mode main thread guards to the gauge define and set entry points.

---

**Commit Message:** dynamic_modules: streamline stat sink hot path and enforce thread contract
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A