### PR TITLE
dynamic_modules: harden access logger and transport socket ABI surface

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -18,6 +18,14 @@ using Envoy::Extensions::DynamicModules::HeadersMapOptConstRef;
 
 namespace {
 
+bool hasLogContext(const ThreadLocalLogger* logger) {
+  return logger != nullptr && logger->log_context_ != nullptr;
+}
+
+bool hasStreamInfo(const ThreadLocalLogger* logger) {
+  return logger != nullptr && logger->stream_info_ != nullptr;
+}
+
 // Helper to convert MonotonicTime to nanoseconds duration from start time.
 int64_t monotonicTimeToNanos(const absl::optional<MonotonicTime>& time,
                              const MonotonicTime& start_time) {
@@ -39,6 +47,9 @@ size_t envoy_dynamic_module_callback_access_logger_get_headers_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_http_header_type header_type) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    return 0;
+  }
   HeadersMapOptConstRef map = ContextAccessor::headerMapByType(*logger->log_context_, header_type);
   return map.has_value() ? map->size() : 0;
 }
@@ -48,6 +59,9 @@ bool envoy_dynamic_module_callback_access_logger_get_headers(
     envoy_dynamic_module_type_http_header_type header_type,
     envoy_dynamic_module_type_envoy_http_header* result_headers) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    return false;
+  }
   return ContextAccessor::getHeaders(
       ContextAccessor::headerMapByType(*logger->log_context_, header_type), result_headers);
 }
@@ -58,6 +72,15 @@ bool envoy_dynamic_module_callback_access_logger_get_header_value(
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* result,
     size_t index, size_t* total_count_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    if (result != nullptr) {
+      *result = {.ptr = nullptr, .length = 0};
+    }
+    if (total_count_out != nullptr) {
+      *total_count_out = 0;
+    }
+    return false;
+  }
   return ContextAccessor::getHeaderValue(
       ContextAccessor::headerMapByType(*logger->log_context_, header_type), key, result, index,
       total_count_out);
@@ -385,6 +408,9 @@ int64_t envoy_dynamic_module_callback_access_logger_get_upstream_peer_cert_v_end
 size_t envoy_dynamic_module_callback_access_logger_get_upstream_peer_uri_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return 0;
@@ -396,6 +422,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_peer_uri_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return false;
@@ -411,6 +440,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_peer_uri_san(
 size_t envoy_dynamic_module_callback_access_logger_get_upstream_local_uri_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return 0;
@@ -422,6 +454,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_local_uri_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return false;
@@ -437,6 +472,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_local_uri_san(
 size_t envoy_dynamic_module_callback_access_logger_get_upstream_peer_dns_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return 0;
@@ -448,6 +486,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_peer_dns_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return false;
@@ -463,6 +504,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_peer_dns_san(
 size_t envoy_dynamic_module_callback_access_logger_get_upstream_local_dns_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return 0;
@@ -474,6 +518,9 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_local_dns_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return false;
@@ -628,6 +675,9 @@ int64_t envoy_dynamic_module_callback_access_logger_get_downstream_peer_cert_v_e
 size_t envoy_dynamic_module_callback_access_logger_get_downstream_peer_uri_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return 0;
@@ -639,6 +689,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_peer_uri_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return false;
@@ -654,6 +707,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_peer_uri_san(
 size_t envoy_dynamic_module_callback_access_logger_get_downstream_local_uri_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return 0;
@@ -665,6 +721,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_local_uri_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return false;
@@ -680,6 +739,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_local_uri_san(
 size_t envoy_dynamic_module_callback_access_logger_get_downstream_peer_dns_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return 0;
@@ -691,6 +753,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_peer_dns_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return false;
@@ -706,6 +771,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_peer_dns_san(
 size_t envoy_dynamic_module_callback_access_logger_get_downstream_local_dns_san_size(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger)) {
+    return 0;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return 0;
@@ -717,6 +785,9 @@ bool envoy_dynamic_module_callback_access_logger_get_downstream_local_dns_san(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* sans_out) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || sans_out == nullptr) {
+    return false;
+  }
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return false;
@@ -738,6 +809,9 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(
     envoy_dynamic_module_type_module_buffer filter_name,
     envoy_dynamic_module_type_module_buffer path, envoy_dynamic_module_type_envoy_buffer* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || result == nullptr) {
+    return false;
+  }
   return ContextAccessor::getDynamicMetadata(*logger->stream_info_, filter_name, path, result);
 }
 
@@ -746,6 +820,9 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
     envoy_dynamic_module_type_module_buffer filter_name,
     envoy_dynamic_module_type_module_buffer path, double* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || result == nullptr) {
+    return false;
+  }
   return ContextAccessor::getDynamicMetadataNumber(*logger->stream_info_, filter_name, path,
                                                    result);
 }
@@ -755,6 +832,9 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
     envoy_dynamic_module_type_module_buffer filter_name,
     envoy_dynamic_module_type_module_buffer path, bool* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasStreamInfo(logger) || result == nullptr) {
+    return false;
+  }
   return ContextAccessor::getDynamicMetadataBool(*logger->stream_info_, filter_name, path, result);
 }
 
@@ -773,6 +853,9 @@ bool envoy_dynamic_module_callback_access_logger_get_local_reply_body(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger) || result == nullptr) {
+    return false;
+  }
   return ContextAccessor::getLocalReplyBody(*logger->log_context_, result);
 }
 
@@ -840,6 +923,9 @@ bool envoy_dynamic_module_callback_access_logger_get_ja4_hash(
 uint64_t envoy_dynamic_module_callback_access_logger_get_request_headers_bytes(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    return 0;
+  }
   const auto& headers = logger->log_context_->requestHeaders();
   return headers.has_value() ? headers->byteSize() : 0;
 }
@@ -847,6 +933,9 @@ uint64_t envoy_dynamic_module_callback_access_logger_get_request_headers_bytes(
 uint64_t envoy_dynamic_module_callback_access_logger_get_response_headers_bytes(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    return 0;
+  }
   const auto& headers = logger->log_context_->responseHeaders();
   return headers.has_value() ? headers->byteSize() : 0;
 }
@@ -854,6 +943,9 @@ uint64_t envoy_dynamic_module_callback_access_logger_get_response_headers_bytes(
 uint64_t envoy_dynamic_module_callback_access_logger_get_response_trailers_bytes(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  if (!hasLogContext(logger)) {
+    return 0;
+  }
   const auto& trailers = logger->log_context_->responseTrailers();
   return trailers.has_value() ? trailers->byteSize() : 0;
 }

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -6540,8 +6540,10 @@ void envoy_dynamic_module_on_access_logger_config_destroy(
  * - Return a shared instance if the module handles thread safety internally
  *
  * @param config_module_ptr is the pointer to the in-module configuration.
- * @param logger_envoy_ptr is the pointer to the ThreadLocalLogger object. This can be used
- *        by the module to store a reference for later use in callbacks.
+ * @param logger_envoy_ptr is the pointer to the ThreadLocalLogger object.
+ *        This pointer stays valid for the logger lifetime.
+ *        Stream data exposed through access logger callbacks is only valid during
+ *        envoy_dynamic_module_on_access_logger_log.
  * @return a pointer to the in-module logger instance. Returning nullptr will cause
  *         log events to be silently dropped.
  */
@@ -6608,11 +6610,12 @@ size_t envoy_dynamic_module_callback_access_logger_get_headers_size(
 
 /**
  * Get all headers from the specified header map.
+ * This callback is valid only during envoy_dynamic_module_on_access_logger_log.
  *
  * @param logger_envoy_ptr is the pointer to the log context.
  * @param header_type is the type of header map to access. Supported types are RequestHeader,
  *        ResponseHeader, and ResponseTrailer.
- * @param result_headers is the output array (must be pre-allocated with correct size).
+ * @param result_headers is the output array, pre-allocated with get_headers_size.
  * @return true if successful, false otherwise.
  */
 bool envoy_dynamic_module_callback_access_logger_get_headers(
@@ -12949,6 +12952,8 @@ void envoy_dynamic_module_on_transport_socket_destroy(
  *
  * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
  * @param transport_socket_module_ptr is the pointer to the in-module transport socket.
+ *        A module must not keep read buffer slices across calls that can re-enter
+ *        the connection, including raise_event and flush_write_buffer.
  */
 void envoy_dynamic_module_on_transport_socket_set_callbacks(
     envoy_dynamic_module_type_transport_socket_envoy_ptr transport_socket_envoy_ptr,
@@ -12985,6 +12990,8 @@ envoy_dynamic_module_on_transport_socket_do_read(
  * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
  * @param transport_socket_module_ptr is the pointer to the in-module transport socket.
  * @param end_stream is true if this is the end of the stream (half-close after a full write).
+ *        A module must not keep write buffer slices across calls that can re-enter
+ *        the connection, including raise_event and flush_write_buffer.
  * @return envoy_dynamic_module_type_transport_socket_io_result is the result of the write
  * operation.
  */
@@ -13112,8 +13119,9 @@ void envoy_dynamic_module_callback_transport_socket_io_shutdown_write(
  * envoy_dynamic_module_callback_transport_socket_get_fd returns the native OS file descriptor of
  * the underlying socket. A module that performs raw socket operations such as installing kernel TLS
  * with setsockopt uses this descriptor. It is only meaningful for transports backed by an OS
- * socket. The descriptor is owned by Envoy and is only valid while the connection is open, so the
- * module must not close it or use it after the connection closes.
+ * socket. The descriptor is owned by Envoy and is only valid while the connection is open.
+ * The module must not close it, duplicate it for later use, change file status flags,
+ * or perform blocking I/O on this descriptor.
  *
  * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
  * @return the native file descriptor, or -1 if it is unavailable.
@@ -13171,9 +13179,10 @@ size_t envoy_dynamic_module_callback_transport_socket_write_buffer_length(
 
 /**
  * envoy_dynamic_module_callback_transport_socket_raise_event raises a connection event on the
- * connection (e.g., Connected after TLS handshake). Raising a close event can synchronously
- * re-enter the module through on_close, so the caller must not rely on any state after this
- * returns.
+ * connection (e.g., Connected after TLS handshake).
+ * Raising Connected can synchronously re-enter do_write.
+ * Raising close events can synchronously re-enter on_close.
+ * The caller must not rely on callback local state after this returns.
  *
  * @param transport_socket_envoy_ptr is the pointer to the Envoy transport socket object.
  * @param event is the connection event to raise.

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -86,7 +86,7 @@ ContextAccessor::headerMapByType(const Formatter::Context& context,
 
 bool ContextAccessor::getHeaders(HeadersMapOptConstRef map,
                                  envoy_dynamic_module_type_envoy_http_header* result_headers) {
-  if (!map) {
+  if (!map || result_headers == nullptr) {
     return false;
   }
   size_t i = 0;

--- a/source/extensions/dynamic_modules/abi_context_accessors.h
+++ b/source/extensions/dynamic_modules/abi_context_accessors.h
@@ -30,7 +30,8 @@ public:
                                                envoy_dynamic_module_type_http_header_type type);
 
   // Fill result_headers with all entries of the resolved header map. The array must be
-  // pre-allocated with at least map->size() entries.
+  // pre-allocated with at least map->size() entries. Returns false when the map is unset or
+  // result_headers is null.
   static bool getHeaders(HeadersMapOptConstRef map,
                          envoy_dynamic_module_type_envoy_http_header* result_headers);
 

--- a/source/extensions/transport_sockets/dynamic_modules/transport_socket.cc
+++ b/source/extensions/transport_sockets/dynamic_modules/transport_socket.cc
@@ -205,9 +205,10 @@ Network::IoResult DynamicModuleTransportSocket::doRead(Buffer::Instance& buffer)
   if (in_module_socket_ == nullptr) {
     return {Network::PostIoAction::Close, 0, false};
   }
+  Buffer::Instance* previous_read_buffer = current_read_buffer_;
   current_read_buffer_ = &buffer;
   auto result = config_->on_do_read_(this, in_module_socket_);
-  current_read_buffer_ = nullptr;
+  current_read_buffer_ = previous_read_buffer;
   return {toPostIoAction(result.action), result.bytes_processed, result.end_stream_read};
 }
 
@@ -215,9 +216,10 @@ Network::IoResult DynamicModuleTransportSocket::doWrite(Buffer::Instance& buffer
   if (in_module_socket_ == nullptr) {
     return {Network::PostIoAction::Close, 0, false};
   }
+  Buffer::Instance* previous_write_buffer = current_write_buffer_;
   current_write_buffer_ = &buffer;
   auto result = config_->on_do_write_(this, in_module_socket_, end_stream);
-  current_write_buffer_ = nullptr;
+  current_write_buffer_ = previous_write_buffer;
   // end_stream_read is only meaningful for reads. The connection layer asserts it is never set on a
   // write result, so it is forced to false here regardless of what the module reports.
   return {toPostIoAction(result.action), result.bytes_processed, false};

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -111,6 +111,18 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetHeadersNull) {
       env_ptr, envoy_dynamic_module_type_http_header_type_RequestHeader, nullptr));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, GetHeadersOutsideLogWindowReturnsEmpty) {
+  Formatter::Context log_context(&request_headers_, &response_headers_, &response_trailers_);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  logger_->log_context_ = nullptr;
+
+  EXPECT_EQ(0, envoy_dynamic_module_callback_access_logger_get_headers_size(
+                   env_ptr, envoy_dynamic_module_type_http_header_type_RequestHeader));
+  std::vector<envoy_dynamic_module_type_envoy_http_header> headers(2);
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_headers(
+      env_ptr, envoy_dynamic_module_type_http_header_type_RequestHeader, headers.data()));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, GetHeaderValueFound) {
   Formatter::Context log_context(&request_headers_, &response_headers_, &response_trailers_);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
@@ -195,6 +207,21 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetHeaderValueIndexOutOfBounds) {
   EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_header_value(
       env_ptr, envoy_dynamic_module_type_http_header_type_RequestHeader, key, &result, 1, &count));
   EXPECT_EQ(1, count);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetHeaderValueOutsideLogWindowReturnsEmpty) {
+  Formatter::Context log_context(&request_headers_, &response_headers_, &response_trailers_);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  logger_->log_context_ = nullptr;
+
+  envoy_dynamic_module_type_module_buffer key = {"x-request-id", 12};
+  envoy_dynamic_module_type_envoy_buffer result{"placeholder", 11};
+  size_t count = 7;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_header_value(
+      env_ptr, envoy_dynamic_module_type_http_header_type_RequestHeader, key, &result, 0, &count));
+  EXPECT_EQ(nullptr, result.ptr);
+  EXPECT_EQ(0, result.length);
+  EXPECT_EQ(0, count);
 }
 
 // =============================================================================

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -59,6 +59,51 @@ returnNullTransportSocket(envoy_dynamic_module_type_transport_socket_factory_con
   return nullptr;
 }
 
+// Re-entrancy regression state. The outer do_read or do_write re-enters the socket through a
+// nested call and records the active buffer pointer afterwards, so the test can confirm the outer
+// buffer is restored rather than cleared.
+Buffer::Instance* observed_read_buffer_after_reentry = nullptr;
+Buffer::Instance* observed_write_buffer_after_reentry = nullptr;
+int read_call_depth = 0;
+int write_call_depth = 0;
+
+extern "C" envoy_dynamic_module_type_transport_socket_module_ptr
+returnNonNullTransportSocket(envoy_dynamic_module_type_transport_socket_factory_config_module_ptr,
+                             envoy_dynamic_module_type_transport_socket_envoy_ptr) {
+  static int placeholder = 0;
+  return &placeholder;
+}
+
+extern "C" void noopDestroyTransportSocket(envoy_dynamic_module_type_transport_socket_module_ptr) {}
+
+extern "C" envoy_dynamic_module_type_transport_socket_io_result
+reentrantDoRead(envoy_dynamic_module_type_transport_socket_envoy_ptr envoy_ptr,
+                envoy_dynamic_module_type_transport_socket_module_ptr) {
+  auto* socket = static_cast<DynamicModuleTransportSocket*>(envoy_ptr);
+  read_call_depth++;
+  if (read_call_depth == 1) {
+    Buffer::OwnedImpl nested_buffer;
+    socket->doRead(nested_buffer);
+    observed_read_buffer_after_reentry = socket->currentReadBuffer();
+  }
+  read_call_depth--;
+  return {envoy_dynamic_module_type_transport_socket_post_io_action_KeepOpen, 0, false};
+}
+
+extern "C" envoy_dynamic_module_type_transport_socket_io_result
+reentrantDoWrite(envoy_dynamic_module_type_transport_socket_envoy_ptr envoy_ptr,
+                 envoy_dynamic_module_type_transport_socket_module_ptr, bool) {
+  auto* socket = static_cast<DynamicModuleTransportSocket*>(envoy_ptr);
+  write_call_depth++;
+  if (write_call_depth == 1) {
+    Buffer::OwnedImpl nested_buffer;
+    socket->doWrite(nested_buffer, false);
+    observed_write_buffer_after_reentry = socket->currentWriteBuffer();
+  }
+  write_call_depth--;
+  return {envoy_dynamic_module_type_transport_socket_post_io_action_KeepOpen, 0, false};
+}
+
 // Tests for the upstream and downstream config factories.
 class DynamicModuleTransportSocketConfigTest : public testing::Test {
 public:
@@ -637,6 +682,40 @@ TEST_F(DynamicModuleTransportSocketTest, OnConnectedRecordsFailureWhenFdUnavaila
   EXPECT_CALL(callbacks_, raiseEvent(Network::ConnectionEvent::Connected));
   socket->onConnected();
   EXPECT_EQ("missing socket fd", socket->failureReason());
+}
+
+TEST_F(DynamicModuleTransportSocketTest, DoReadRestoresOuterBufferAfterReentry) {
+  read_call_depth = 0;
+  observed_read_buffer_after_reentry = nullptr;
+  auto config = std::make_shared<DynamicModuleTransportSocketConfig>(false, nullptr);
+  config->on_new_ = returnNonNullTransportSocket;
+  config->on_destroy_ = noopDestroyTransportSocket;
+  config->on_do_read_ = reentrantDoRead;
+  auto socket = std::make_unique<DynamicModuleTransportSocket>(config);
+
+  Buffer::OwnedImpl outer_buffer;
+  socket->doRead(outer_buffer);
+
+  // A re-entrant do_read must leave the outer call's buffer pointer in place.
+  EXPECT_EQ(&outer_buffer, observed_read_buffer_after_reentry);
+  EXPECT_EQ(nullptr, socket->currentReadBuffer());
+}
+
+TEST_F(DynamicModuleTransportSocketTest, DoWriteRestoresOuterBufferAfterReentry) {
+  write_call_depth = 0;
+  observed_write_buffer_after_reentry = nullptr;
+  auto config = std::make_shared<DynamicModuleTransportSocketConfig>(false, nullptr);
+  config->on_new_ = returnNonNullTransportSocket;
+  config->on_destroy_ = noopDestroyTransportSocket;
+  config->on_do_write_ = reentrantDoWrite;
+  auto socket = std::make_unique<DynamicModuleTransportSocket>(config);
+
+  Buffer::OwnedImpl outer_buffer;
+  socket->doWrite(outer_buffer, false);
+
+  // A re-entrant do_write must leave the outer call's buffer pointer in place.
+  EXPECT_EQ(&outer_buffer, observed_write_buffer_after_reentry);
+  EXPECT_EQ(nullptr, socket->currentWriteBuffer());
 }
 } // namespace
 } // namespace DynamicModules


### PR DESCRIPTION
## Description

This PR adds support to guard the access logger header and stream info callbacks against a missing log context or stream info, save and restore the active read and write buffer in the transport socket so a re-entrant call leaves the outer buffer in place, and expand the ABI documentation for the affected entry points.

---

**Commit Message:** dynamic_modules: harden access logger and transport socket ABI surface
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A