### PR TITLE
dynamic_modules: track per-direction continue state in the HTTP filter

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__fixed-per-direction-continue-flags.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__fixed-per-direction-continue-flags.rst
@@ -1,0 +1,6 @@
+Fixed a bug in the HTTP filter where the decode and encode directions shared a single continue
+flag, so a request body that continued the decode direction while an upstream response was held at
+``encodeHeaders`` turned the later ``continueEncoding()`` into a silent no-op and wedged the held
+response. Because the flag was shared, one resume could never continue both directions. The decode
+and encode continue states are now tracked independently so a continue in one direction never
+suppresses a resume in the other.

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -84,7 +84,8 @@ void DynamicModuleHttpFilter::destroy() {
 FilterHeadersStatus DynamicModuleHttpFilter::decodeHeaders(RequestHeaderMap&, bool end_of_stream) {
   const envoy_dynamic_module_type_on_http_filter_request_headers_status status =
       config_->on_http_filter_request_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
-  in_continue_ = status == envoy_dynamic_module_type_on_http_filter_request_headers_status_Continue;
+  decode_in_continue_ =
+      status == envoy_dynamic_module_type_on_http_filter_request_headers_status_Continue;
   return static_cast<FilterHeadersStatus>(status);
 };
 
@@ -93,27 +94,28 @@ FilterDataStatus DynamicModuleHttpFilter::decodeData(Buffer::Instance& chunk, bo
   const envoy_dynamic_module_type_on_http_filter_request_body_status status =
       config_->on_http_filter_request_body_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   current_request_body_ = nullptr;
-  in_continue_ = status == envoy_dynamic_module_type_on_http_filter_request_body_status_Continue;
+  decode_in_continue_ =
+      status == envoy_dynamic_module_type_on_http_filter_request_body_status_Continue;
   return static_cast<FilterDataStatus>(status);
 };
 
 FilterTrailersStatus DynamicModuleHttpFilter::decodeTrailers(RequestTrailerMap&) {
   const envoy_dynamic_module_type_on_http_filter_request_trailers_status status =
       config_->on_http_filter_request_trailers_(thisAsVoidPtr(), in_module_filter_);
-  in_continue_ =
+  decode_in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_request_trailers_status_Continue;
   return static_cast<FilterTrailersStatus>(status);
 }
 
 FilterMetadataStatus DynamicModuleHttpFilter::decodeMetadata(MetadataMap&) {
-  in_continue_ = true;
+  decode_in_continue_ = true;
   return FilterMetadataStatus::Continue;
 }
 
 void DynamicModuleHttpFilter::decodeComplete() {}
 
 Filter1xxHeadersStatus DynamicModuleHttpFilter::encode1xxHeaders(ResponseHeaderMap&) {
-  in_continue_ = true;
+  encode_in_continue_ = true;
   return Filter1xxHeadersStatus::Continue;
 }
 
@@ -123,7 +125,7 @@ FilterHeadersStatus DynamicModuleHttpFilter::encodeHeaders(ResponseHeaderMap&, b
   }
   const envoy_dynamic_module_type_on_http_filter_response_headers_status status =
       config_->on_http_filter_response_headers_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
-  in_continue_ =
+  encode_in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_headers_status_Continue;
   return static_cast<FilterHeadersStatus>(status);
 };
@@ -136,7 +138,8 @@ FilterDataStatus DynamicModuleHttpFilter::encodeData(Buffer::Instance& chunk, bo
   const envoy_dynamic_module_type_on_http_filter_response_body_status status =
       config_->on_http_filter_response_body_(thisAsVoidPtr(), in_module_filter_, end_of_stream);
   current_response_body_ = nullptr;
-  in_continue_ = status == envoy_dynamic_module_type_on_http_filter_response_body_status_Continue;
+  encode_in_continue_ =
+      status == envoy_dynamic_module_type_on_http_filter_response_body_status_Continue;
   return static_cast<FilterDataStatus>(status);
 };
 
@@ -146,13 +149,13 @@ FilterTrailersStatus DynamicModuleHttpFilter::encodeTrailers(ResponseTrailerMap&
   }
   const envoy_dynamic_module_type_on_http_filter_response_trailers_status status =
       config_->on_http_filter_response_trailers_(thisAsVoidPtr(), in_module_filter_);
-  in_continue_ =
+  encode_in_continue_ =
       status == envoy_dynamic_module_type_on_http_filter_response_trailers_status_Continue;
   return static_cast<FilterTrailersStatus>(status);
 };
 
 FilterMetadataStatus DynamicModuleHttpFilter::encodeMetadata(MetadataMap&) {
-  in_continue_ = true;
+  encode_in_continue_ = true;
   return FilterMetadataStatus::Continue;
 }
 
@@ -281,16 +284,16 @@ void DynamicModuleHttpFilter::onScheduled(uint64_t event_id) {
 }
 
 void DynamicModuleHttpFilter::continueDecoding() {
-  if (decoder_callbacks_ && !in_continue_) {
+  if (decoder_callbacks_ && !decode_in_continue_) {
     decoder_callbacks_->continueDecoding();
-    in_continue_ = true;
+    decode_in_continue_ = true;
   }
 }
 
 void DynamicModuleHttpFilter::continueEncoding() {
-  if (encoder_callbacks_ && !in_continue_) {
+  if (encoder_callbacks_ && !encode_in_continue_) {
     encoder_callbacks_->continueEncoding();
-    in_continue_ = true;
+    encode_in_continue_ = true;
   }
 }
 

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -261,9 +261,11 @@ private:
    */
   void maybeRegisterDownstreamWatermarkCallbacks();
 
-  // True if the filter is in the continue state. This is to avoid prohibited calls to
-  // continueDecoding() or continueEncoding() multiple times.
-  bool in_continue_ = false;
+  // True when the decode or encode direction is in the continue state. Tracked per direction to
+  // avoid prohibited repeat continueDecoding() or continueEncoding() calls, and so a continue in
+  // one direction never suppresses a resume in the other.
+  bool decode_in_continue_ = false;
+  bool encode_in_continue_ = false;
 
   // This helps to avoid reentering the module when sending a local reply. For example, if
   // sendLocalReply() is called, encodeHeaders and encodeData will be called again inline on top of

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -2902,6 +2902,79 @@ TEST(DynamicModulesTest, StartHttpStreamCannotCreateRequest) {
   filter->onDestroy();
 }
 
+// Verifies that the decode and encode continue states are tracked independently. A request body
+// that returns Continue marks only the decode direction as continued, so a paused encode phase can
+// still be resumed via continueEncoding(). A single shared flag used to suppress this resume.
+TEST(DynamicModulesTest, PerDirectionContinueDecodeDoesNotBlockEncode) {
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
+  EXPECT_TRUE(dynamic_module.ok());
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
+  EXPECT_TRUE(filter_config_or_status.ok());
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable(), 0);
+  filter->initializeInModuleFilter();
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+  filter->setDecoderFilterCallbacks(decoder_callbacks);
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
+
+  // A request body chunk returns Continue, marking only the decode direction as continued.
+  Buffer::OwnedImpl data;
+  EXPECT_EQ(FilterDataStatus::Continue, filter->decodeData(data, false));
+
+  // The encode direction was never continued, so it must still be resumable. A repeat
+  // continueDecoding() stays a no-op because the decode direction is already continued.
+  EXPECT_CALL(decoder_callbacks, continueDecoding()).Times(0);
+  EXPECT_CALL(encoder_callbacks, continueEncoding());
+  filter->continueDecoding();
+  filter->continueEncoding();
+
+  filter->onDestroy();
+}
+
+// The symmetric case. A response body that returns Continue marks only the encode direction as
+// continued, so a paused decode phase can still be resumed via continueDecoding().
+TEST(DynamicModulesTest, PerDirectionContinueEncodeDoesNotBlockDecode) {
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
+  EXPECT_TRUE(dynamic_module.ok());
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::IsolatedStoreImpl stats_store;
+  auto stats_scope = stats_store.createScope("");
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+          *stats_scope, context);
+  EXPECT_TRUE(filter_config_or_status.ok());
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_scope->symbolTable(), 0);
+  filter->initializeInModuleFilter();
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+  filter->setDecoderFilterCallbacks(decoder_callbacks);
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
+
+  // A response body chunk returns Continue, marking only the encode direction as continued.
+  Buffer::OwnedImpl data;
+  EXPECT_EQ(FilterDataStatus::Continue, filter->encodeData(data, false));
+
+  // The decode direction was never continued, so it must still be resumable. A repeat
+  // continueEncoding() stays a no-op because the encode direction is already continued.
+  EXPECT_CALL(encoder_callbacks, continueEncoding()).Times(0);
+  EXPECT_CALL(decoder_callbacks, continueDecoding());
+  filter->continueEncoding();
+  filter->continueDecoding();
+
+  filter->onDestroy();
+}
+
 } // namespace HttpFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -511,6 +511,48 @@ TEST_P(DynamicModulesIntegrationTest, Scheduler) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 }
 
+// Regression test for the shared continue-flag wedge. The upstream replies complete at headers
+// while the client is still uploading. The module holds the response at on_response_headers, a
+// request body chunk continues the decode direction, and the held response is then resumed via
+// continue_encoding. With a single shared continue flag the decode-side continue suppressed the
+// resume and the response never reached the client.
+TEST_P(DynamicModulesIntegrationTest, EarlyResponseDuringUpload) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "Early response during upload test only runs for Rust";
+  }
+  // The upstream half-closes its response while the request keeps uploading, so the router must
+  // keep decoding request data instead of resetting the stream.
+  config_helper_.addRuntimeOverride(
+      "envoy.reloadable_features.allow_multiplexed_upstream_half_close", "true");
+  initializeFilter("early_response_during_upload");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "POST"}, {":path", "/test"}, {":scheme", "http"}, {":authority", "host"}};
+  auto encoder_decoder = codec_client_->startRequest(request_headers);
+  auto& request_encoder = encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // The request is still open, so wait for the upstream stream without requiring its end of stream.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+
+  // Reply complete at headers, for example an early 403, while the client is still uploading.
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  upstream_request_->encodeHeaders(response_headers, true);
+
+  // Wait until the module has held the response at on_response_headers before uploading more, so
+  // the request body continue is interleaved after the encode direction is paused.
+  test_server_->waitForCounter("dynamicmodulescustom.response_pause_total", testing::Ge(1));
+
+  // The request body continues the decode direction, then on_scheduled resumes the held response.
+  codec_client_->sendData(request_encoder, "upload", true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("403", response->headers().Status()->value().getStringView());
+}
+
 TEST_P(DynamicModulesIntegrationTest, FakeExternalCache) {
   initializeFilter("fake_external_cache");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -41,6 +41,11 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     })),
     "send_response" => Some(Box::new(SendResponseHttpFilterConfig::new(config))),
     "http_filter_scheduler" => Some(Box::new(HttpFilterSchedulerConfig {})),
+    "early_response_during_upload" => Some(Box::new(EarlyResponseDuringUploadConfig {
+      response_pause_total: envoy_filter_config
+        .define_counter("response_pause_total")
+        .unwrap(),
+    })),
     "fake_external_cache" => Some(Box::new(FakeExternalCachingFilterConfig {})),
     "stats_callbacks" => {
       let config = String::from_utf8(config.to_owned()).unwrap();
@@ -1010,6 +1015,65 @@ impl Drop for HttpFilterScheduler {
     assert_eq!(self.thread_handles.len(), 2);
     for thread in self.thread_handles.drain(..) {
       thread.join().expect("Failed to join thread");
+    }
+  }
+}
+
+const EVENT_RESUME_ENCODING: u64 = 1;
+
+struct EarlyResponseDuringUploadConfig {
+  response_pause_total: EnvoyCounterId,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for EarlyResponseDuringUploadConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(EarlyResponseDuringUploadFilter {
+      response_pause_total: self.response_pause_total,
+      resume_scheduled: false,
+    })
+  }
+}
+
+/// Reproduces the early-response-during-upload wedge. The upstream response is held at
+/// on_response_headers while the client keeps uploading. A request body chunk then continues the
+/// decode direction, after which the held response is resumed from on_scheduled via
+/// continue_encoding. A single shared continue flag let the decode-side continue suppress that
+/// resume and wedge the held response.
+struct EarlyResponseDuringUploadFilter {
+  response_pause_total: EnvoyCounterId,
+  resume_scheduled: bool,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for EarlyResponseDuringUploadFilter {
+  fn on_request_body(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_request_body_status {
+    // Post the resume instead of calling it inline so it runs after this body returns Continue and
+    // the decode direction is marked continued. An inline resume would not reproduce the wedge.
+    if !self.resume_scheduled {
+      self.resume_scheduled = true;
+      envoy_filter.new_scheduler().commit(EVENT_RESUME_ENCODING);
+    }
+    envoy_dynamic_module_type_on_http_filter_request_body_status::Continue
+  }
+
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    // Hold the response so the test can interleave a request body continue before it is resumed.
+    envoy_filter
+      .increment_counter(self.response_pause_total, 1)
+      .unwrap();
+    envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration
+  }
+
+  fn on_scheduled(&mut self, envoy_filter: &mut EHF, event_id: u64) {
+    if event_id == EVENT_RESUME_ENCODING {
+      envoy_filter.continue_encoding();
     }
   }
 }


### PR DESCRIPTION
## Description

Today, the HTTP filter shares a single `in_continue_` flag across the decode and encode directions. With an upstream response held at `encodeHeaders` while the client was still uploading, a request body `Continue` flipped the shared
flag and turned a later `continueEncoding()` into a silent no-op, wedging the held response. Because the flag was shared, one resume could never continue both directions.

In this PR, we split `in_continue_` into per-direction `decode_in_continue_` and `encode_in_continue_` so a continue in one direction never suppresses a resume in the other.

---

**Commit Message:** dynamic_modules: track per-direction continue state in the HTTP filter
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** Added