### PR TITLE
dynamic_modules: tie module data buffers to owning object lifetime

### DIFF
--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 
 #include "envoy/network/listen_socket.h"
@@ -48,7 +49,7 @@ bool envoy_dynamic_module_callback_listener_filter_drain_buffer(
     return false;
   }
 
-  buffer->drain(length);
+  buffer->drain(std::min<size_t>(length, buffer->rawSlice().len_));
   return true;
 }
 

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -118,13 +118,14 @@ Network::FilterStatus DynamicModuleNetworkFilter::onWrite(Buffer::Instance& data
   if (in_module_filter_ == nullptr) {
     return Network::FilterStatus::Continue;
   }
-  // Set the current write buffer for ABI callbacks. The buffer pointer is kept after the callback
-  // returns so that modules can access buffered data outside of on_write (e.g., in on_scheduled).
-  // The buffer is the connection's persistent write buffer and remains valid for the lifetime of
-  // the connection.
+  // The write buffer is only valid for the duration of this call. The connection reuses or moves it
+  // after on_write returns, so the pointer is restored when the call returns rather than cached for
+  // asynchronous access.
+  Buffer::Instance* previous_write_buffer = current_write_buffer_;
   current_write_buffer_ = &data;
   auto status = config_->on_network_filter_write_(thisAsVoidPtr(), in_module_filter_, data.length(),
                                                   end_stream);
+  current_write_buffer_ = previous_write_buffer;
   return toEnvoyFilterStatus(status);
 }
 

--- a/source/extensions/filters/network/dynamic_modules/filter.h
+++ b/source/extensions/filters/network/dynamic_modules/filter.h
@@ -180,9 +180,11 @@ private:
   Network::ReadFilterCallbacks* read_callbacks_ = nullptr;
   Network::WriteFilterCallbacks* write_callbacks_ = nullptr;
 
-  // Current buffers. Set on the first on_read/on_write callback and kept for the lifetime of the
-  // connection so that modules can access buffered data outside of on_read/on_write callbacks.
+  // The connection read buffer, set on the first on_read callback and kept for the lifetime of the
+  // connection so modules can access buffered read data outside of on_read.
   Buffer::Instance* current_read_buffer_ = nullptr;
+  // The write buffer for the active on_write callback only. The connection reuses or moves it after
+  // on_write, so it is restored when the call returns rather than cached.
   Buffer::Instance* current_write_buffer_ = nullptr;
 
   bool destroyed_ = false;

--- a/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/udp/dynamic_modules/abi_impl.cc
@@ -70,7 +70,7 @@ bool envoy_dynamic_module_callback_udp_listener_filter_set_datagram_data(
     envoy_dynamic_module_type_module_buffer data) {
   auto* filter = static_cast<DynamicModuleUdpListenerFilter*>(filter_envoy_ptr);
   auto* current_data = filter->currentData();
-  if (!current_data) {
+  if (!current_data || !current_data->buffer_) {
     return false;
   }
 

--- a/source/extensions/upstreams/http/dynamic_modules/upstream_request.cc
+++ b/source/extensions/upstreams/http/dynamic_modules/upstream_request.cc
@@ -171,12 +171,12 @@ void HttpTcpBridge::encodeData(Buffer::Instance& data, bool end_stream) {
   }
   downstream_complete_ = end_stream;
 
-  // Move into a local buffer so the module reads from a stable copy. The module is expected
-  // to forward the data via send_upstream_data, which writes to the connection and drains
+  // Move into the owned request buffer so the module reads from a stable copy whose lifetime is
+  // tied to this object. Draining first scopes the buffer to the current call. The module is
+  // expected to forward the data via send_upstream_data, which writes to the connection and drains
   // naturally.
-  Buffer::OwnedImpl local_buffer;
-  local_buffer.move(data);
-  request_buffer_ = &local_buffer;
+  request_buffer_.drain(request_buffer_.length());
+  request_buffer_.move(data);
 
   // The module callback may trigger decodeData with end_stream=true (e.g., via sendResponse),
   // which can cause the router to destroy this object. Do not access any member variables after
@@ -211,15 +211,14 @@ void HttpTcpBridge::onUpstreamData(Buffer::Instance& data, bool end_stream) {
     return;
   }
 
-  // Move data into a local buffer before calling the module. The module callback may trigger
-  // downstream processing that re-enables upstream reads, causing a re-entrant onUpstreamData
-  // call. Moving the data first ensures the connection's read buffer is empty, preventing the
-  // same data from being delivered twice.
-  Buffer::OwnedImpl local_buffer;
-  local_buffer.move(data);
-
-  response_buffer_ = &local_buffer;
-  bytes_meter_->addWireBytesReceived(local_buffer.length());
+  // Move data into the owned response buffer before calling the module. The module callback may
+  // trigger downstream processing that re-enables upstream reads, causing a re-entrant
+  // onUpstreamData call. Moving the data first ensures the connection's read buffer is empty,
+  // preventing the same data from being delivered twice. The owned buffer is tied to this object so
+  // the pointer never outlives its storage. Draining first scopes the buffer to the current call.
+  response_buffer_.drain(response_buffer_.length());
+  response_buffer_.move(data);
+  bytes_meter_->addWireBytesReceived(response_buffer_.length());
 
   // The module callback may trigger decodeData with end_stream=true, which can cause the router
   // to call resetStream() and ultimately destroy this object. Do not access any member variables

--- a/source/extensions/upstreams/http/dynamic_modules/upstream_request.h
+++ b/source/extensions/upstreams/http/dynamic_modules/upstream_request.h
@@ -137,8 +137,8 @@ public:
 
   // Accessors for ABI callbacks.
   const Envoy::Http::RequestHeaderMap* requestHeaders() const { return request_headers_; }
-  Buffer::Instance* requestBuffer() { return request_buffer_; }
-  Buffer::Instance* responseBuffer() { return response_buffer_; }
+  Buffer::Instance* requestBuffer() { return &request_buffer_; }
+  Buffer::Instance* responseBuffer() { return &response_buffer_; }
 
   // Called by ABI callbacks to send data upstream.
   void sendUpstreamData(absl::string_view data, bool end_stream);
@@ -174,8 +174,11 @@ private:
   bool downstream_complete_ = false;
 
   const Envoy::Http::RequestHeaderMap* request_headers_ = nullptr;
-  Buffer::Instance* request_buffer_ = nullptr;
-  Buffer::Instance* response_buffer_ = nullptr;
+  // Owned copies of the data passed to the module so the buffer pointer never outlives its storage.
+  // The module may destroy this bridge during the encode callbacks, so these are members rather
+  // than call scoped locals and are never written after the module call returns.
+  Buffer::OwnedImpl request_buffer_;
+  Buffer::OwnedImpl response_buffer_;
 
   StreamInfo::BytesMeterSharedPtr bytes_meter_{std::make_shared<StreamInfo::BytesMeter>()};
 };

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -60,9 +60,11 @@ TEST_F(DynamicModuleNetworkFilterTest, BasicDataFlow) {
   EXPECT_EQ(Network::FilterStatus::Continue, filter->onWrite(write_data, false));
   EXPECT_EQ(Network::FilterStatus::Continue, filter->onWrite(write_data, true));
 
-  // Verify buffers persist after callbacks for access from on_scheduled and other callbacks.
+  // The read buffer is the connection buffer and persists for access from on_scheduled and other
+  // callbacks. The write buffer is only valid during on_write, so it is cleared once the call
+  // returns.
   EXPECT_NE(nullptr, filter->currentReadBuffer());
-  EXPECT_NE(nullptr, filter->currentWriteBuffer());
+  EXPECT_EQ(nullptr, filter->currentWriteBuffer());
 }
 
 TEST_F(DynamicModuleNetworkFilterTest, AllConnectionEvents) {

--- a/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/extensions/upstreams/http/dynamic_modules/config.h"
@@ -201,6 +203,50 @@ TEST_F(HttpTcpBridgeTest, OnUpstreamDataNoOp) {
 
   Buffer::OwnedImpl data("response data");
   bridge_->onUpstreamData(data, false);
+}
+
+TEST_F(HttpTcpBridgeTest, RequestBufferRemainsReadableAfterEncodeData) {
+  Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
+  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+
+  Buffer::OwnedImpl data("hello");
+  bridge_->encodeData(data, false);
+
+  // Reading the request buffer after encodeData returns must not touch freed storage.
+  auto* envoy_ptr =
+      static_cast<envoy_dynamic_module_type_upstream_http_tcp_bridge_envoy_ptr>(bridge_.get());
+  size_t chunks =
+      envoy_dynamic_module_callback_upstream_http_tcp_bridge_get_request_buffer_chunks_size(
+          envoy_ptr);
+  ASSERT_EQ(1, chunks);
+  std::vector<envoy_dynamic_module_type_envoy_buffer> result(chunks);
+  size_t result_length = 0;
+  envoy_dynamic_module_callback_upstream_http_tcp_bridge_get_request_buffer(
+      envoy_ptr, result.data(), &result_length);
+  ASSERT_EQ(1, result_length);
+  EXPECT_EQ("hello", absl::string_view(result[0].ptr, result[0].length));
+}
+
+TEST_F(HttpTcpBridgeTest, ResponseBufferRemainsReadableAfterOnUpstreamData) {
+  Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
+  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+
+  Buffer::OwnedImpl data("world");
+  bridge_->onUpstreamData(data, false);
+
+  // Reading the response buffer after onUpstreamData returns must not touch freed storage.
+  auto* envoy_ptr =
+      static_cast<envoy_dynamic_module_type_upstream_http_tcp_bridge_envoy_ptr>(bridge_.get());
+  size_t chunks =
+      envoy_dynamic_module_callback_upstream_http_tcp_bridge_get_response_buffer_chunks_size(
+          envoy_ptr);
+  ASSERT_EQ(1, chunks);
+  std::vector<envoy_dynamic_module_type_envoy_buffer> result(chunks);
+  size_t result_length = 0;
+  envoy_dynamic_module_callback_upstream_http_tcp_bridge_get_response_buffer(
+      envoy_ptr, result.data(), &result_length);
+  ASSERT_EQ(1, result_length);
+  EXPECT_EQ("world", absl::string_view(result[0].ptr, result[0].length));
 }
 
 TEST_F(HttpTcpBridgeTest, OnUpstreamConnectionClose) {


### PR DESCRIPTION
## Description

This PR adds support for holding the upstream bridge request and response data in owned buffers so the pointer handed to the module never outlives its storage. It also restores the network filter write buffer when `on_write` returns since the connection reuses it, clamp the listener drain length to the available bytes, and guard the UDP datagram setter against a missing buffer.

---

**Commit Message:** dynamic_modules: tie module data buffers to owning object lifetime
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A