### PR TITLE
dynamic_modules: scope cert validator call state and guard bootstrap cluster access

### DIFF
--- a/source/extensions/bootstrap/dynamic_modules/extension_config.cc
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.cc
@@ -52,6 +52,10 @@ bool DynamicModuleBootstrapExtensionConfig::enableClusterLifecycle() {
   if (cluster_lifecycle_enabled_) {
     return false;
   }
+  if (!server_initialized_) {
+    ENVOY_LOG(error, "cannot enable cluster lifecycle before server is initialized");
+    return false;
+  }
   cluster_lifecycle_enabled_ = true;
   cluster_update_callbacks_handle_ =
       context_.clusterManager().addThreadLocalClusterUpdateCallbacks(*this);
@@ -121,6 +125,11 @@ DynamicModuleBootstrapExtensionConfig::sendHttpCallout(uint64_t* callout_id_out,
                                                        absl::string_view cluster_name,
                                                        Http::RequestMessagePtr&& message,
                                                        uint64_t timeout_milliseconds) {
+  // The cluster manager is not available during bootstrap extension creation, so accessing it
+  // before the server is initialized would dereference a null cluster manager in release builds.
+  if (!server_initialized_) {
+    return envoy_dynamic_module_type_http_callout_init_result_ClusterNotFound;
+  }
   // Access cluster manager lazily since it's not available during bootstrap extension creation.
   Upstream::ThreadLocalCluster* cluster =
       context_.clusterManager().getThreadLocalCluster(cluster_name);

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -146,10 +146,12 @@ public:
 
   /**
    * Sets the listener manager reference. Must be called during onServerInitialized before
-   * the module can enable listener lifecycle events.
+   * the module can enable listener lifecycle events. Marks the server as initialized so the
+   * cluster manager can be accessed safely.
    */
   void setListenerManager(Server::ListenerManager& listener_manager) {
     listener_manager_ = &listener_manager;
+    server_initialized_ = true;
   }
 
   /**
@@ -456,6 +458,10 @@ private:
   // Handle for the shutdown lifecycle callback that cleans up cluster_update_callbacks_handle_.
   Server::ServerLifecycleNotifier::HandlePtr cluster_lifecycle_shutdown_handle_;
   bool cluster_lifecycle_enabled_ = false;
+
+  // True once the server is initialized, set when the listener manager is provided during
+  // onServerInitialized. The cluster manager is only safe to access after this point.
+  bool server_initialized_ = false;
 
   // Listener manager pointer. Set during onServerInitialized via setListenerManager().
   // Not available during bootstrap extension creation.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -10655,9 +10655,10 @@ bool envoy_dynamic_module_callback_matcher_get_header_value(
 // =============================================================================
 
 /**
- * envoy_dynamic_module_type_cert_validator_config_envoy_ptr is a pointer to the
- * DynamicModuleCertValidatorConfig object in Envoy. This is passed to the module during config
- * creation and cert chain verification.
+ * envoy_dynamic_module_type_cert_validator_config_envoy_ptr is an opaque Envoy pointer for cert
+ * validator hooks. During config creation it identifies the cert validator configuration. During
+ * cert chain verification it identifies the active verification call and must be passed back to the
+ * cert validator callbacks. It is valid only for the duration of the hook that provides it.
  *
  * OWNERSHIP: Envoy owns this object.
  */
@@ -10755,7 +10756,8 @@ void envoy_dynamic_module_on_cert_validator_config_destroy(
  * The certs array and its buffer contents are owned by Envoy and are valid only for the duration
  * of this event hook call.
  *
- * @param config_envoy_ptr is the pointer to the DynamicModuleCertValidatorConfig object.
+ * @param config_envoy_ptr identifies this verification call and must be passed back to the cert
+ *        validator callbacks.
  * @param config_module_ptr is the pointer to the in-module cert validator configuration.
  * @param certs is an array of DER-encoded certificate buffers.
  * @param certs_count is the number of certificates in the array.
@@ -10811,7 +10813,7 @@ void envoy_dynamic_module_on_cert_validator_update_digest(
  *
  * This must only be called from within the do_verify_cert_chain event hook.
  *
- * @param config_envoy_ptr is the pointer to the DynamicModuleCertValidatorConfig object.
+ * @param config_envoy_ptr is the verification call pointer provided to do_verify_cert_chain.
  * @param error_details is the error details string owned by the module.
  */
 void envoy_dynamic_module_callback_cert_validator_set_error_details(
@@ -10825,7 +10827,7 @@ void envoy_dynamic_module_callback_cert_validator_set_error_details(
  * set a string value in filter state with Connection life span. This must only be called from
  * within the do_verify_cert_chain event hook.
  *
- * @param config_envoy_ptr is the pointer to the DynamicModuleCertValidatorConfig object.
+ * @param config_envoy_ptr is the verification call pointer provided to do_verify_cert_chain.
  * @param key is the key string owned by the module.
  * @param value is the value string owned by the module.
  * @return true if the operation was successful, false otherwise (e.g. no connection context
@@ -10840,7 +10842,7 @@ bool envoy_dynamic_module_callback_cert_validator_set_filter_state(
  * get a string value from filter state. This must only be called from within the
  * do_verify_cert_chain event hook.
  *
- * @param config_envoy_ptr is the pointer to the DynamicModuleCertValidatorConfig object.
+ * @param config_envoy_ptr is the verification call pointer provided to do_verify_cert_chain.
  * @param key is the key string owned by the module.
  * @param value_out is the output buffer where the value owned by Envoy will be stored.
  * @return true if the value was found, false otherwise.

--- a/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.cc
@@ -18,29 +18,29 @@ extern "C" {
 void envoy_dynamic_module_callback_cert_validator_set_error_details(
     envoy_dynamic_module_type_cert_validator_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer error_details) {
-  auto* config = static_cast<
-      Envoy::Extensions::TransportSockets::Tls::DynamicModules::DynamicModuleCertValidatorConfig*>(
+  auto* call_context = static_cast<
+      Envoy::Extensions::TransportSockets::Tls::DynamicModules::CertValidatorCallContext*>(
       config_envoy_ptr);
   if (error_details.ptr != nullptr && error_details.length > 0) {
-    config->last_error_details_ = std::string(error_details.ptr, error_details.length);
+    call_context->error_details = std::string(error_details.ptr, error_details.length);
   }
 }
 
 bool envoy_dynamic_module_callback_cert_validator_set_filter_state(
     envoy_dynamic_module_type_cert_validator_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
-  auto* config = static_cast<
-      Envoy::Extensions::TransportSockets::Tls::DynamicModules::DynamicModuleCertValidatorConfig*>(
+  auto* call_context = static_cast<
+      Envoy::Extensions::TransportSockets::Tls::DynamicModules::CertValidatorCallContext*>(
       config_envoy_ptr);
 
-  if (config->current_callbacks_ == nullptr || key.ptr == nullptr || value.ptr == nullptr) {
+  if (call_context->callbacks == nullptr || key.ptr == nullptr || value.ptr == nullptr) {
     return false;
   }
 
   std::string key_str(key.ptr, key.length);
   std::string value_str(value.ptr, value.length);
 
-  config->current_callbacks_->connection().streamInfo().filterState()->setData(
+  call_context->callbacks->connection().streamInfo().filterState()->setData(
       key_str, std::make_shared<Envoy::Router::StringAccessorImpl>(value_str),
       Envoy::StreamInfo::FilterState::LifeSpan::Connection);
   return true;
@@ -50,18 +50,18 @@ bool envoy_dynamic_module_callback_cert_validator_get_filter_state(
     envoy_dynamic_module_type_cert_validator_config_envoy_ptr config_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key,
     envoy_dynamic_module_type_envoy_buffer* value_out) {
-  auto* config = static_cast<
-      Envoy::Extensions::TransportSockets::Tls::DynamicModules::DynamicModuleCertValidatorConfig*>(
+  auto* call_context = static_cast<
+      Envoy::Extensions::TransportSockets::Tls::DynamicModules::CertValidatorCallContext*>(
       config_envoy_ptr);
 
-  if (config->current_callbacks_ == nullptr || key.ptr == nullptr) {
+  if (call_context->callbacks == nullptr || key.ptr == nullptr) {
     value_out->ptr = nullptr;
     value_out->length = 0;
     return false;
   }
 
   std::string key_str(key.ptr, key.length);
-  const auto* accessor = config->current_callbacks_->connection()
+  const auto* accessor = call_context->callbacks->connection()
                              .streamInfo()
                              .filterState()
                              ->getDataReadOnly<Envoy::Router::StringAccessor>(key_str);
@@ -197,22 +197,16 @@ ValidationResults DynamicModuleCertValidator::doVerifyCertChain(
 
   envoy_dynamic_module_type_envoy_buffer host_name_buffer = {host_name.data(), host_name.size()};
 
-  // Reset error details before calling the module. The module may set them via the
-  // envoy_dynamic_module_callback_cert_validator_set_error_details callback.
-  config_->last_error_details_.reset();
-
-  // Store the callbacks pointer so that filter state callbacks can access the connection's
-  // stream info during the module's do_verify_cert_chain call. Set immediately before and
-  // reset immediately after to ensure the pointer is only valid during the module call.
-  config_->current_callbacks_ = validation_context.callbacks;
+  // Per-call state lives on the stack so concurrent verification on different worker threads does
+  // not share it. The module receives a pointer to this context as the verify envoy pointer and
+  // passes it back to the error details and filter state callbacks.
+  CertValidatorCallContext call_context;
+  call_context.callbacks = validation_context.callbacks;
 
   // Call the module's verify function.
   auto result = config_->on_do_verify_cert_chain_(
-      static_cast<void*>(config_.get()), config_->in_module_config_, cert_buffers.data(),
+      static_cast<void*>(&call_context), config_->in_module_config_, cert_buffers.data(),
       static_cast<size_t>(num_certs), host_name_buffer, is_server);
-
-  // Reset the callbacks pointer after the module call returns.
-  config_->current_callbacks_ = nullptr;
 
   // Translate the result.
   ValidationResults::ValidationStatus status;
@@ -247,11 +241,11 @@ ValidationResults DynamicModuleCertValidator::doVerifyCertChain(
     tls_alert = result.tls_alert;
   }
 
-  if (config_->last_error_details_.has_value()) {
-    ENVOY_LOG(debug, "verify cert failed: {}", config_->last_error_details_.value());
+  if (call_context.error_details.has_value()) {
+    ENVOY_LOG(debug, "verify cert failed: {}", call_context.error_details.value());
   }
 
-  return {status, detailed_status, tls_alert, config_->last_error_details_};
+  return {status, detailed_status, tls_alert, call_context.error_details};
 }
 
 absl::StatusOr<int>

--- a/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.h
+++ b/source/extensions/transport_sockets/tls/cert_validator/dynamic_modules/config.h
@@ -28,6 +28,19 @@ using OnCertValidatorUpdateDigestType =
     decltype(&envoy_dynamic_module_on_cert_validator_update_digest);
 
 /**
+ * Per-call state for an active do_verify_cert_chain invocation. The validator config is shared
+ * across worker threads, so the module receives a pointer to this call scoped context as the verify
+ * envoy pointer instead of the shared config. It is valid only for the duration of the module call.
+ */
+struct CertValidatorCallContext {
+  // The transport socket callbacks for the connection being verified. Used by the filter state
+  // callbacks to reach the connection stream info.
+  Network::TransportSocketCallbacks* callbacks = nullptr;
+  // Error details set by the module via the set_error_details callback.
+  absl::optional<std::string> error_details;
+};
+
+/**
  * Configuration holding the resolved dynamic module and ABI function pointers
  * for cert validation. This is shared between the factory and the validator.
  */
@@ -50,14 +63,6 @@ public:
 
   const std::string& validatorName() const { return validator_name_; }
   const std::string& validatorConfig() const { return validator_config_; }
-
-  // Stores error details set by the module via the set_error_details callback during
-  // do_verify_cert_chain. Reset before each verification call.
-  absl::optional<std::string> last_error_details_;
-
-  // Stores the transport socket callbacks pointer during do_verify_cert_chain so that
-  // filter state callbacks can access the connection's stream info. Reset after each call.
-  Network::TransportSocketCallbacks* current_callbacks_ = nullptr;
 
 private:
   friend absl::StatusOr<std::shared_ptr<DynamicModuleCertValidatorConfig>>

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -238,6 +238,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock to return nullptr for the cluster lookup.
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("nonexistent_cluster"))
       .WillOnce(testing::Return(nullptr));
@@ -296,6 +299,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -354,6 +360,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -402,6 +411,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -451,6 +463,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -488,6 +503,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -544,6 +562,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -595,6 +616,9 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutWithBody) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Setup mock cluster manager to return a valid cluster.
   testing::NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster;
   EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster("test_cluster"))
@@ -1684,6 +1708,9 @@ TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
   ASSERT_TRUE(config.ok()) << config.status();
+  // Simulate server initialization by setting the listener manager.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config.value()->setListenerManager(listener_manager);
   // Expect the callback registration to go through ClusterManager.
   EXPECT_CALL(context_.cluster_manager_, addThreadLocalClusterUpdateCallbacks_(_))
       .WillOnce(testing::ReturnNew<Upstream::MockClusterUpdateCallbacksHandle>());

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/bootstrap/dynamic_modules/extension_config.h"
 
 #include "test/mocks/event/mocks.h"
+#include "test/mocks/server/listener_manager.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
@@ -299,6 +300,30 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
   EXPECT_FALSE(config.ok());
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_listener_removal"));
+}
+
+TEST_F(ExtensionConfigTest, ClusterAccessRequiresServerInitialized) {
+  auto dynamic_module =
+      Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
+  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  auto config_or = newDynamicModuleBootstrapExtensionConfig(
+      "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
+      context_, context_.store_);
+  ASSERT_TRUE(config_or.ok()) << config_or.status();
+  auto config = config_or.value();
+
+  // Before the server is initialized the cluster manager is unavailable, so cluster access is
+  // refused rather than dereferencing a null cluster manager.
+  EXPECT_FALSE(config->enableClusterLifecycle());
+  uint64_t callout_id = 0;
+  EXPECT_EQ(envoy_dynamic_module_type_http_callout_init_result_ClusterNotFound,
+            config->sendHttpCallout(&callout_id, "some_cluster",
+                                    std::make_unique<Http::RequestMessageImpl>(), 1000));
+
+  // After the server is initialized cluster lifecycle can be enabled.
+  testing::NiceMock<Server::MockListenerManager> listener_manager;
+  config->setListenerManager(listener_manager);
+  EXPECT_TRUE(config->enableClusterLifecycle());
 }
 
 } // namespace DynamicModules

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -514,62 +514,57 @@ typed_config:
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetAndGet) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   // Set up mock transport socket callbacks to provide filter state access.
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   const std::string key = "test.key";
   const std::string value = "test.value";
 
   bool ok = envoy_dynamic_module_callback_cert_validator_set_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()},
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()},
       {const_cast<char*>(value.data()), value.size()});
   EXPECT_TRUE(ok);
 
   // Verify by reading it back.
   envoy_dynamic_module_type_envoy_buffer result_buf;
   ok = envoy_dynamic_module_callback_cert_validator_get_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()}, &result_buf);
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()}, &result_buf);
   EXPECT_TRUE(ok);
   EXPECT_EQ(value.size(), result_buf.length);
   EXPECT_EQ(value, std::string(result_buf.ptr, result_buf.length));
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNonExisting) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   const std::string key = "nonexistent.key";
   envoy_dynamic_module_type_envoy_buffer result_buf;
   bool ok = envoy_dynamic_module_callback_cert_validator_get_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()}, &result_buf);
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()}, &result_buf);
   EXPECT_FALSE(ok);
   EXPECT_EQ(nullptr, result_buf.ptr);
   EXPECT_EQ(0, result_buf.length);
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullCallbacks) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
-  // current_callbacks_ is nullptr by default.
+  // The call context has no callbacks, so filter state is unavailable.
+  CertValidatorCallContext call_context;
   const std::string key = "test.key";
   const std::string value = "test.value";
 
   bool ok = envoy_dynamic_module_callback_cert_validator_set_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()},
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()},
       {const_cast<char*>(value.data()), value.size()});
   EXPECT_FALSE(ok);
 }
@@ -577,13 +572,13 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullCallbacks) {
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullCallbacks) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
-  // current_callbacks_ is nullptr by default.
+  // The call context has no callbacks, so filter state is unavailable.
+  CertValidatorCallContext call_context;
   const std::string key = "test.key";
   envoy_dynamic_module_type_envoy_buffer result_buf;
   bool ok = envoy_dynamic_module_callback_cert_validator_get_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()}, &result_buf);
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()}, &result_buf);
   EXPECT_FALSE(ok);
   EXPECT_EQ(nullptr, result_buf.ptr);
   EXPECT_EQ(0, result_buf.length);
@@ -592,67 +587,61 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullCallbacks) {
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullKey) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   const std::string value = "test.value";
   bool ok = envoy_dynamic_module_callback_cert_validator_set_filter_state(
-      static_cast<void*>(config.get()), {nullptr, 0},
+      static_cast<void*>(&call_context), {nullptr, 0},
       {const_cast<char*>(value.data()), value.size()});
   EXPECT_FALSE(ok);
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullValue) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   const std::string key = "test.key";
   bool ok = envoy_dynamic_module_callback_cert_validator_set_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()}, {nullptr, 0});
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()}, {nullptr, 0});
   EXPECT_FALSE(ok);
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullKey) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   envoy_dynamic_module_type_envoy_buffer result_buf;
   bool ok = envoy_dynamic_module_callback_cert_validator_get_filter_state(
-      static_cast<void*>(config.get()), {nullptr, 0}, &result_buf);
+      static_cast<void*>(&call_context), {nullptr, 0}, &result_buf);
   EXPECT_FALSE(ok);
   EXPECT_EQ(nullptr, result_buf.ptr);
   EXPECT_EQ(0, result_buf.length);
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetEmptyValue) {
   auto config_or_error = createConfig("cert_validator_no_op");
   ASSERT_TRUE(config_or_error.ok());
-  auto& config = config_or_error.value();
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  config->current_callbacks_ = &transport_callbacks;
+  CertValidatorCallContext call_context;
+  call_context.callbacks = &transport_callbacks;
 
   const std::string key = "test.key";
   const std::string empty_value = "";
 
   bool ok = envoy_dynamic_module_callback_cert_validator_set_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()},
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()},
       {const_cast<char*>(empty_value.data()), empty_value.size()});
   // Empty value has a non-null pointer but zero length, so ptr check passes.
   EXPECT_TRUE(ok);
@@ -660,11 +649,9 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetEmptyValue) {
   // Verify by reading it back.
   envoy_dynamic_module_type_envoy_buffer result_buf;
   ok = envoy_dynamic_module_callback_cert_validator_get_filter_state(
-      static_cast<void*>(config.get()), {const_cast<char*>(key.data()), key.size()}, &result_buf);
+      static_cast<void*>(&call_context), {const_cast<char*>(key.data()), key.size()}, &result_buf);
   EXPECT_TRUE(ok);
   EXPECT_EQ(0, result_buf.length);
-
-  config->current_callbacks_ = nullptr;
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateViaDoVerifyCertChain) {
@@ -697,31 +684,6 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateViaDoVerifyCertChain) {
                              ->getDataReadOnly<Router::StringAccessor>("cert_validator.test_key");
   ASSERT_NE(nullptr, accessor);
   EXPECT_EQ("cert_validator.test_value", accessor->asString());
-}
-
-TEST_F(DynamicModuleCertValidatorTest, FilterStateCallbacksResetAfterVerify) {
-  // Verify that current_callbacks_ is reset to nullptr after doVerifyCertChain returns.
-  auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
-
-  DynamicModuleCertValidator validator(config_or_error.value(), stats_);
-
-  bssl::UniquePtr<X509> cert = readCertFromFile(
-      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_cert.pem"));
-
-  bssl::UniquePtr<STACK_OF(X509)> cert_chain(sk_X509_new_null());
-  sk_X509_push(cert_chain.get(), cert.release());
-
-  CSmartPtr<SSL_CTX, SSL_CTX_free> ssl_ctx(SSL_CTX_new(TLS_method()));
-
-  NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
-  CertValidator::ExtraValidationContext validation_context{&transport_callbacks};
-
-  validator.doVerifyCertChain(*cert_chain, nullptr, nullptr, *ssl_ctx, validation_context, false,
-                              "example.com");
-
-  // After the call, current_callbacks_ should be reset.
-  EXPECT_EQ(nullptr, config_or_error.value()->current_callbacks_);
 }
 
 } // namespace


### PR DESCRIPTION
## Description

This PR passes a per-call context to the cert validator verify hook so the callbacks no longer share mutable state on a config that is used across worker threads, and refuse bootstrap cluster lifecycle and HTTP callout requests until the server is initialized so the cluster manager is never accessed before it exists.

---

**Commit Message:** dynamic_modules: scope cert validator call state and guard bootstrap cluster access
**Risk Level**: Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A