### PR TITLE
dynamic_modules: skip hosts already present in the cluster host set

### DIFF
--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -311,6 +311,10 @@ bool DynamicModuleCluster::addHosts(
 
   auto cluster_info = info();
 
+  // Cross-priority address map maintained by the priority set; used to skip addresses already in
+  // the cluster without copying the host set.
+  const auto existing_hosts = priority_set_.crossPriorityHostMap();
+
   for (size_t i = 0; i < addresses.size(); ++i) {
     if (weights[i] == 0 || weights[i] > 128) {
       ENVOY_LOG(error, "Invalid weight {} for host {}.", weights[i], addresses[i]);
@@ -322,6 +326,11 @@ bool DynamicModuleCluster::addHosts(
     if (resolved_address == nullptr) {
       ENVOY_LOG(error, "Invalid address: {}.", addresses[i]);
       return false;
+    }
+
+    // Skip addresses already in the host set. Within-batch duplicates are not deduplicated.
+    if (existing_hosts != nullptr && existing_hosts->contains(resolved_address->asString())) {
+      continue;
     }
 
     auto locality = std::make_shared<envoy::config::core::v3::Locality>();

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -328,7 +328,7 @@ bool DynamicModuleCluster::addHosts(
       return false;
     }
 
-    // Skip addresses already in the host set. Within-batch duplicates are not deduplicated.
+    // Skip addresses already in the host set. This does not deduplicate within the batch.
     if (existing_hosts != nullptr && existing_hosts->contains(resolved_address->asString())) {
       continue;
     }

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -266,6 +266,37 @@ TEST_F(DynamicModuleClusterTest, BatchRemoveMultipleHosts) {
   EXPECT_EQ(0, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
 }
 
+// Test that addresses already present in the host set are skipped on a subsequent batch.
+TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  // Add two hosts.
+  std::vector<Upstream::HostSharedPtr> hosts;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002"}, {1, 1}, hosts));
+  EXPECT_EQ(2, hosts.size());
+  EXPECT_EQ(2, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
+  EXPECT_EQ(2, cluster->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+
+  // Add a batch with one existing address and one new address. Only the new one is created.
+  std::vector<Upstream::HostSharedPtr> hosts2;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10002", "127.0.0.1:10003"}, {1, 1}, hosts2));
+  EXPECT_EQ(1, hosts2.size());
+  EXPECT_EQ("127.0.0.1:10003", hosts2[0]->address()->asString());
+  EXPECT_EQ(3, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
+  EXPECT_EQ(3, cluster->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+
+  // A batch of only existing addresses adds nothing but still succeeds.
+  std::vector<Upstream::HostSharedPtr> hosts3;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10003"}, {1, 1}, hosts3));
+  EXPECT_EQ(0, hosts3.size());
+  EXPECT_EQ(3, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
+  EXPECT_EQ(3, cluster->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+}
+
 // Test that invalid addresses cause the entire batch to fail.
 TEST_F(DynamicModuleClusterTest, InvalidAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));


### PR DESCRIPTION

Commit Message: 
dynamic_modules: skip duplicate hosts already in the cluster

Additional Description: 

addHosts now checks each incoming address against the cluster's existing
host set and skips any that are already present, so duplicate hosts are no
longer added. The check reuses the priority set's address map, so it adds
no extra copy of the host set.

Risk Level: Low
Testing: Unit Test
Docs Changes: N.A
Release Notes: N.A
Platform Specific Features: N.A