### PR TITLE
mobile: part 1 of supporting multiple API listeners

### DIFF
--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -302,6 +302,12 @@ public:
    */
   virtual ApiListenerOptRef apiListener() PURE;
 
+  /**
+   * @return the server's API Listener by name if it exists, nullopt if it does
+   * not.
+   */
+  virtual ApiListenerOptRef apiListener(absl::string_view) { return apiListener(); }
+
   /*
    * @return TRUE if the worker has started or FALSE if not.
    */

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -28,6 +28,7 @@ struct EnvoyLogger {
 };
 
 inline constexpr absl::string_view ENVOY_EVENT_TRACKER_API_NAME = "event_tracker_api";
+inline constexpr absl::string_view DEFAULT_API_LISTENER_NAME = "base_api_listener";
 
 /** The callbacks for Envoy Event Tracker. */
 struct EnvoyEventTracker {

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/BUILD
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/BUILD
@@ -18,6 +18,7 @@ envoy_cc_extension(
     ],
     repository = "@envoy",
     deps = [
+        "//library/common:engine_types_lib",
         "//library/common/event:provisional_dispatcher_lib",
         "//library/common/http:client_lib",
         "@envoy//envoy/server:api_listener_interface",

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.cc
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.cc
@@ -1,13 +1,24 @@
 #include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
 
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "envoy/server/listener_manager.h"
+#include "source/common/common/logger.h"
+
+#include "absl/synchronization/notification.h"
 #include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/network/listener.h"
 #include "envoy/server/api_listener.h"
-
+#include "library/common/engine_types.h"
 #include "source/common/common/assert.h"
 #include "source/common/common/fmt.h"
 #include "source/common/config/utility.h"
-#include "absl/synchronization/notification.h"
 
 namespace Envoy {
 namespace Server {
@@ -21,19 +32,25 @@ ApiListenerWorker::ApiListenerWorker(Instance& server)
 
 ApiListenerWorker::~ApiListenerWorker() {}
 
-void ApiListenerWorker::addListener(ApiListenerOptRef api_listener, std::function<void()> cb) {
-  dispatcher_->post([this, api_listener, cb]() {
-    api_listener_ = api_listener;
-    if (api_listener_.has_value()) {
-      auto api_listener_impl = api_listener_->get().createHttpApiListener(*dispatcher_);
+void ApiListenerWorker::addListener(const std::string& name,
+                                    std::shared_ptr<ApiListener> api_listener,
+                                    std::function<void()> cb) {
+  dispatcher_->post([this, name, api_listener, cb]() {
+    if (api_listener != nullptr) {
+      auto it = http_clients_.find(name);
+      if (it != http_clients_.end()) {
+        it->second->shutdownApiListener();
+        http_clients_.erase(it);
+      }
+      auto api_listener_impl = api_listener->createHttpApiListener(*dispatcher_);
       ASSERT(api_listener_impl != nullptr);
-      http_client_ = std::make_unique<Http::Client>(
+      http_clients_[name] = std::make_unique<Http::Client>(
           std::move(api_listener_impl), *provisional_dispatcher_,
           server_.serverFactoryContext().scope(), server_.api().randomGenerator());
-      ENVOY_LOG_MISC(info, "Created API listener.");
+      ENVOY_LOG_MISC(info, "Created API listener {}.", name);
       if (shutdown_notification_.HasBeenNotified()) {
-        ENVOY_LOG_MISC(info, "Shutting down API listener.");
-        http_client_->shutdownApiListener();
+        ENVOY_LOG_MISC(info, "Shutting down API listener {}.", name);
+        http_clients_[name]->shutdownApiListener();
       }
     }
     if (cb) {
@@ -58,6 +75,9 @@ void ApiListenerWorker::initializeStats(Stats::Scope& scope) {
 
 void ApiListenerWorker::stop() {
   if (thread_) {
+    if (!shutdown_notification_.HasBeenNotified()) {
+      stopListener();
+    }
     shutdown_notification_.WaitForNotification();
     ENVOY_LOG_MISC(info, "Listener has been shutdown, exiting the event loop.");
     dispatcher_->exit();
@@ -67,9 +87,14 @@ void ApiListenerWorker::stop() {
 }
 
 void ApiListenerWorker::stopListener() {
+  if (stop_posted_.exchange(true)) {
+    return;
+  }
   dispatcher_->post([this]() {
-    if (http_client_) {
-      http_client_->shutdownApiListener();
+    for (auto& [name, client] : http_clients_) {
+      if (client) {
+        client->shutdownApiListener();
+      }
     }
     shutdown_notification_.Notify();
   });
@@ -106,6 +131,40 @@ ApiListenerManagerImpl::~ApiListenerManagerImpl() {
   }
 }
 
+ApiListenerOptRef ApiListenerManagerImpl::apiListener() {
+  auto it = api_listeners_.find(DEFAULT_API_LISTENER_NAME);
+  if (it != api_listeners_.end()) {
+    return ApiListenerOptRef(std::ref(*it->second));
+  }
+  if (api_listeners_.empty()) {
+    return absl::nullopt;
+  }
+  // Fall back to the first listener if the default one is not found but we have
+  // one.
+  return ApiListenerOptRef(std::ref(*api_listeners_.begin()->second));
+}
+
+ApiListenerOptRef ApiListenerManagerImpl::apiListener(absl::string_view name) {
+  auto it = api_listeners_.find(name);
+  if (it != api_listeners_.end()) {
+    return ApiListenerOptRef(std::ref(*it->second));
+  }
+  return absl::nullopt;
+}
+
+Http::Client* ApiListenerManagerImpl::httpClient(const std::string& name) {
+  if (worker_) {
+    return worker_->httpClient(name);
+  }
+  ASSERT(api_listeners_.size() <= 1);
+  if (!name.empty() && !api_listeners_.empty()) {
+    if (name != api_listeners_.begin()->first) {
+      return nullptr;
+    }
+  }
+  return http_client_.get();
+}
+
 absl::StatusOr<bool>
 ApiListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::Listener& config,
                                             const std::string&, bool added_via_api) {
@@ -114,21 +173,16 @@ ApiListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::L
   if (!config.name().empty()) {
     name = config.name();
   } else {
-    // TODO (soulxu): The random uuid name is bad for logging. We can use listening addresses in
-    // the log to improve that.
     name = server_.api().randomGenerator().uuid();
   }
 
-  // TODO(junr03): currently only one ApiListener can be installed via bootstrap to avoid having to
-  // build a collection of listeners, and to have to be able to warm and drain the listeners. In the
-  // future allow multiple ApiListeners, and allow them to be created via LDS as well as bootstrap.
   if (config.has_api_listener()) {
     if (config.has_internal_listener()) {
       return absl::InvalidArgumentError(fmt::format(
           "error adding listener named '{}': api_listener and internal_listener cannot be both set",
           name));
     }
-    if (!api_listener_ && !added_via_api) {
+    if (!added_via_api) {
       auto* api_listener_factory =
           Registry::FactoryRegistry<Server::ApiListenerFactory>::getFactory(
               "envoy.http_api_listener");
@@ -136,13 +190,44 @@ ApiListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::L
         return absl::InvalidArgumentError(fmt::format(
             "error adding listener named '{}': missing the API listener extension", name));
       }
-      auto listener_or_error = api_listener_factory->create(config, server_, config.name());
+      auto listener_or_error = api_listener_factory->create(config, server_, name);
       RETURN_IF_NOT_OK(listener_or_error.status());
-      api_listener_ = std::move(listener_or_error.value());
+
+      // TODO(junr03): support warming and draining of API listeners when
+      // multiple are installed.
+      bool is_update = (api_listeners_.find(name) != api_listeners_.end());
+
+      // If there is no worker thread, we only support a single API listener.
+      // We check if this is an update to the existing one, or if we are trying
+      // to add a new one when we already have one.
+      if (!worker_ && !is_update && !api_listeners_.empty()) {
+        return absl::InvalidArgumentError(
+            "Multiple ApiListeners are not supported when worker thread is "
+            "disabled.");
+      }
+
+      if (is_update && worker_started_ && !worker_) {
+        if (http_client_) {
+          http_client_->shutdownApiListener();
+          http_client_.reset();
+        }
+      }
+
+      api_listeners_[name] = std::move(listener_or_error.value());
+
+      if (worker_started_) {
+        if (!worker_) {
+          setupClient();
+        } else {
+          worker_->addListener(name, api_listeners_[name], nullptr);
+        }
+      }
       return true;
     } else {
-      ENVOY_LOG(warn, "listener {} can not be added because currently only one ApiListener is "
-                      "allowed, and it can only be added via bootstrap configuration");
+      ENVOY_LOG(warn,
+                "listener {} can not be added because it can only be added via "
+                "bootstrap configuration",
+                name);
       return false;
     }
   }
@@ -151,43 +236,79 @@ ApiListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::L
 
 absl::Status ApiListenerManagerImpl::startWorkers(OptRef<GuardDog> guard_dog,
                                                   std::function<void()> callback) {
-  if (!worker_) {
+  if (worker_started_.exchange(true)) {
     if (callback) {
       callback();
     }
     return absl::OkStatus();
   }
 
-  if (worker_started_.load()) {
+  if (!worker_) {
+    setupClient();
+    if (provisional_dispatcher_) {
+      provisional_dispatcher_->drain(server_.dispatcher());
+    }
+    if (callback) {
+      callback();
+    }
     return absl::OkStatus();
   }
 
-  ASSERT(api_listener_ != nullptr, "api_listener_ is null in startWorkers!");
-  worker_->addListener(api_listener_ ? ApiListenerOptRef(std::ref(*api_listener_)) : absl::nullopt,
-                       callback);
+  if (api_listeners_.empty()) {
+    if (callback) {
+      callback();
+    }
+    return absl::OkStatus();
+  }
+
+  size_t remaining = api_listeners_.size();
+  size_t i = 0;
+  for (auto& [name, listener] : api_listeners_) {
+    bool is_last = (i == remaining - 1);
+    worker_->addListener(name, listener, is_last ? callback : nullptr);
+    i++;
+  }
+
   absl::Notification worker_started_notification;
-  worker_->start(guard_dog, [&worker_started_notification, this]() {
-    worker_started_.store(true);
-    worker_started_notification.Notify();
-  });
+  worker_->start(guard_dog,
+                 [&worker_started_notification]() { worker_started_notification.Notify(); });
   worker_started_notification.WaitForNotification();
   ENVOY_LOG_MISC(info, "Worker thread has been started");
-
-  // The client should be available at this point.
-  worker_->httpClient();
 
   return absl::OkStatus();
 }
 
 void ApiListenerManagerImpl::stopListeners(StopListenersType,
                                            const Network::ExtraShutdownListenerOptions&) {
-  worker_->stopListener();
+  if (worker_) {
+    worker_->stopListener();
+  } else {
+    if (http_client_) {
+      http_client_->shutdownApiListener();
+    }
+  }
 }
 
 void ApiListenerManagerImpl::stopWorkers() {
-  if (worker_started_.load()) {
+  if (worker_started_.load() && worker_) {
     worker_->stop();
   }
+}
+
+void ApiListenerManagerImpl::setupClient() {
+  ASSERT(!worker_);
+  ASSERT(api_listeners_.size() <= 1);
+  if (api_listeners_.empty()) {
+    return;
+  }
+  auto& name = api_listeners_.begin()->first;
+  if (!provisional_dispatcher_) {
+    provisional_dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
+  }
+  auto api_listener_impl = api_listeners_[name]->createHttpApiListener(server_.dispatcher());
+  http_client_ = std::make_unique<Http::Client>(
+      std::move(api_listener_impl), *provisional_dispatcher_,
+      server_.serverFactoryContext().scope(), server_.api().randomGenerator());
 }
 
 REGISTER_FACTORY(ApiListenerManagerFactoryImpl, ListenerManagerFactory);

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
@@ -2,18 +2,17 @@
 
 #include <memory>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/notification.h"
-
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.validate.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/listener_manager.h"
-#include "envoy/config/bootstrap/v3/bootstrap.pb.validate.h"
-
-#include "source/server/listener_manager_factory.h"
-
 #include "envoy/thread/thread.h"
 #include "library/common/event/provisional_dispatcher.h"
 #include "library/common/http/client.h"
+#include "library/common/engine_types.h"
+#include "source/server/listener_manager_factory.h"
 
 namespace Envoy {
 namespace Server {
@@ -23,15 +22,26 @@ public:
   ApiListenerWorker(Instance& server);
   ~ApiListenerWorker();
 
-  void addListener(ApiListenerOptRef api_listener, std::function<void()> cb);
+  void addListener(const std::string& name, std::shared_ptr<ApiListener> api_listener,
+                   std::function<void()> cb);
   void start(OptRef<GuardDog> guard_dog, const std::function<void()>& cb);
   void initializeStats(Stats::Scope& scope);
   void stop();
   void stopListener();
 
-  Http::Client& httpClient() {
-    RELEASE_ASSERT(http_client_ != nullptr, "http_client_ is null!");
-    return *http_client_;
+  Http::Client* httpClient(const std::string& name = "") {
+    std::string target_name = name;
+    if (target_name.empty()) {
+      if (http_clients_.size() == 1) {
+        return http_clients_.begin()->second.get();
+      }
+      target_name = std::string(DEFAULT_API_LISTENER_NAME);
+    }
+    auto it = http_clients_.find(target_name);
+    if (it != http_clients_.end()) {
+      return it->second.get();
+    }
+    return nullptr;
   }
   Event::Dispatcher& dispatcher() { return *dispatcher_; }
 
@@ -39,14 +49,14 @@ private:
   void threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb);
 
   Instance& server_;
-  ApiListenerOptRef api_listener_;
   Thread::ThreadPtr thread_;
   Event::DispatcherPtr dispatcher_;
   // Wraps above dispatcher_ for the http client.
   std::unique_ptr<Event::ProvisionalDispatcher> provisional_dispatcher_;
-  std::unique_ptr<Http::Client> http_client_;
+  absl::flat_hash_map<std::string, Http::ClientPtr> http_clients_;
   WatchDogSharedPtr watch_dog_;
   absl::Notification shutdown_notification_;
+  std::atomic<bool> stop_posted_{false};
 };
 
 /**
@@ -76,17 +86,13 @@ public:
   void endListenerUpdate(FailureStates&&) override {}
   bool isWorkerStarted() override { return worker_started_.load(); }
   Http::Context& httpContext() { return server_.httpContext(); }
-  ApiListenerOptRef apiListener() override {
-    return api_listener_ ? ApiListenerOptRef(std::ref(*api_listener_)) : absl::nullopt;
-  }
+  ApiListenerOptRef apiListener() override;
+  ApiListenerOptRef apiListener(absl::string_view name) override;
   ListenerUpdateCallbacksHandlePtr addListenerUpdateCallbacks(ListenerUpdateCallbacks&) override {
     return std::make_unique<ListenerUpdateCallbacksNopHandle>();
   }
 
-  Http::Client& httpClient() {
-    ASSERT(worker_ != nullptr, "httpClient() called when worker_ is null!");
-    return worker_->httpClient();
-  }
+  Http::Client* httpClient(const std::string& name = "");
 
   Event::Dispatcher& httpClientDispatcher() {
     ASSERT(worker_ != nullptr, "httpClientDispatcher() called when worker_ is null!");
@@ -96,10 +102,14 @@ public:
 private:
   struct ListenerUpdateCallbacksNopHandle : public ListenerUpdateCallbacksHandle {};
   Instance& server_;
-  ApiListenerPtr api_listener_;
+  absl::flat_hash_map<std::string, std::shared_ptr<ApiListener>> api_listeners_;
 
   std::atomic<bool> worker_started_{false};
+  std::unique_ptr<Event::ProvisionalDispatcher> provisional_dispatcher_;
+  Http::ClientPtr http_client_;
   std::unique_ptr<ApiListenerWorker> worker_;
+
+  void setupClient();
 };
 
 class ApiListenerManagerFactoryImpl : public ListenerManagerFactory {

--- a/mobile/library/common/internal_engine.cc
+++ b/mobile/library/common/internal_engine.cc
@@ -1,21 +1,28 @@
 #include "library/common/internal_engine.h"
 
+#include <memory>
+#include <utility>
+
 #include <sys/resource.h>
 
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/notification.h"
+#include "envoy/network/connection_handler.h"
+#include "library/common/engine_types.h"
+#include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
+#include "library/common/http/client.h"
+#include "library/common/mobile_process_wide.h"
+#include "library/common/network/network_types.h"
+#include "library/common/network/proxy_api.h"
+#include "library/common/stats/utility.h"
+#include "library/common/types/c_types.h"
 #include "source/common/api/os_sys_calls_impl.h"
+#include "source/common/common/assert.h"
 #include "source/common/common/lock_guard.h"
 #include "source/common/common/utility.h"
 #include "source/common/http/http_server_properties_cache_manager_impl.h"
 #include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/runtime/runtime_features.h"
-
-#include "absl/strings/string_view.h"
-#include "absl/synchronization/notification.h"
-#include "library/common/mobile_process_wide.h"
-#include "library/common/network/network_types.h"
-#include "library/common/network/proxy_api.h"
-#include "library/common/stats/utility.h"
-#include "library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h"
 
 namespace Envoy {
 namespace {
@@ -111,10 +118,57 @@ envoy_stream_t InternalEngine::initStream() { return current_stream_handle_++; }
 
 envoy_status_t InternalEngine::startStream(envoy_stream_t stream,
                                            EnvoyStreamCallbacks&& stream_callbacks,
-                                           bool explicit_flow_control) {
-  return requestDispatcher().post([this, stream, stream_callbacks = std::move(stream_callbacks),
-                                   explicit_flow_control]() mutable {
-    http_client_handle_->startStream(stream, std::move(stream_callbacks), explicit_flow_control);
+                                           bool explicit_flow_control,
+                                           absl::string_view listener_name) {
+  EnvoyStreamCallbacks wrapped_callbacks;
+  wrapped_callbacks.on_headers_ = std::move(stream_callbacks.on_headers_);
+  wrapped_callbacks.on_data_ = std::move(stream_callbacks.on_data_);
+  wrapped_callbacks.on_trailers_ = std::move(stream_callbacks.on_trailers_);
+  wrapped_callbacks.on_send_window_available_ =
+      std::move(stream_callbacks.on_send_window_available_);
+
+  wrapped_callbacks.on_complete_ =
+      [this, stream, on_complete = std::move(stream_callbacks.on_complete_)](
+          envoy_stream_intel stream_intel, envoy_final_stream_intel final_stream_intel) mutable {
+        removeActiveStream(stream);
+        if (on_complete) {
+          on_complete(stream_intel, final_stream_intel);
+        }
+      };
+  wrapped_callbacks.on_error_ = [this, stream, on_error = std::move(stream_callbacks.on_error_)](
+                                    const EnvoyError& error, envoy_stream_intel stream_intel,
+                                    envoy_final_stream_intel final_stream_intel) mutable {
+    removeActiveStream(stream);
+    if (on_error) {
+      on_error(error, stream_intel, final_stream_intel);
+    }
+  };
+  wrapped_callbacks.on_cancel_ = [this, stream, on_cancel = std::move(stream_callbacks.on_cancel_)](
+                                     envoy_stream_intel stream_intel,
+                                     envoy_final_stream_intel final_stream_intel) mutable {
+    removeActiveStream(stream);
+    if (on_cancel) {
+      on_cancel(stream_intel, final_stream_intel);
+    }
+  };
+
+  return requestDispatcher().post([this, stream, wrapped_callbacks = std::move(wrapped_callbacks),
+                                   explicit_flow_control,
+                                   name = std::string(listener_name)]() mutable {
+    auto* api_mgr = dynamic_cast<Server::ApiListenerManagerImpl*>(&server_->listenerManager());
+    ASSERT(api_mgr != nullptr);
+    Http::Client* client = api_mgr->httpClient(name);
+    if (client == nullptr) {
+      EnvoyError error;
+      error.error_code_ = ENVOY_STREAM_RESET;
+      error.message_ = "Listener not found: " + name;
+      envoy_stream_intel stream_intel{};
+      envoy_final_stream_intel final_stream_intel{};
+      wrapped_callbacks.on_error_(error, stream_intel, final_stream_intel);
+      return;
+    }
+    active_streams_[stream] = client;
+    client->startStream(stream, std::move(wrapped_callbacks), explicit_flow_control);
   });
 }
 
@@ -122,31 +176,54 @@ envoy_status_t InternalEngine::sendHeaders(envoy_stream_t stream, Http::RequestH
                                            bool end_stream, bool idempotent) {
   return requestDispatcher().post(
       [this, stream, headers = std::move(headers), end_stream, idempotent]() mutable {
-        http_client_handle_->sendHeaders(stream, std::move(headers), end_stream, idempotent);
+        auto it = active_streams_.find(stream);
+        if (it != active_streams_.end()) {
+          it->second->sendHeaders(stream, std::move(headers), end_stream, idempotent);
+        }
       });
 }
 
 envoy_status_t InternalEngine::readData(envoy_stream_t stream, size_t bytes_to_read) {
-  return requestDispatcher().post(
-      [this, stream, bytes_to_read]() { http_client_handle_->readData(stream, bytes_to_read); });
+  return requestDispatcher().post([this, stream, bytes_to_read]() {
+    auto it = active_streams_.find(stream);
+    if (it != active_streams_.end()) {
+      it->second->readData(stream, bytes_to_read);
+    }
+  });
 }
 
 envoy_status_t InternalEngine::sendData(envoy_stream_t stream, Buffer::InstancePtr buffer,
                                         bool end_stream) {
   return requestDispatcher().post([this, stream, buffer = std::move(buffer), end_stream]() mutable {
-    http_client_handle_->sendData(stream, std::move(buffer), end_stream);
+    auto it = active_streams_.find(stream);
+    if (it != active_streams_.end()) {
+      it->second->sendData(stream, std::move(buffer), end_stream);
+    }
   });
 }
 
 envoy_status_t InternalEngine::sendTrailers(envoy_stream_t stream,
                                             Http::RequestTrailerMapPtr trailers) {
   return requestDispatcher().post([this, stream, trailers = std::move(trailers)]() mutable {
-    http_client_handle_->sendTrailers(stream, std::move(trailers));
+    auto it = active_streams_.find(stream);
+    if (it != active_streams_.end()) {
+      it->second->sendTrailers(stream, std::move(trailers));
+    }
   });
 }
 
 envoy_status_t InternalEngine::cancelStream(envoy_stream_t stream) {
-  return requestDispatcher().post([this, stream]() { http_client_handle_->cancelStream(stream); });
+  return requestDispatcher().post([this, stream]() {
+    auto it = active_streams_.find(stream);
+    if (it != active_streams_.end()) {
+      it->second->cancelStream(stream);
+    }
+  });
+}
+
+void InternalEngine::removeActiveStream(envoy_stream_t stream) {
+  ASSERT(requestDispatcher().isThreadSafe());
+  active_streams_.erase(stream);
 }
 
 // This function takes a `std::shared_ptr` instead of `std::unique_ptr` because `std::function` is a
@@ -200,7 +277,6 @@ envoy_status_t InternalEngine::main(std::shared_ptr<OptionsImplBase> options) {
           auto* api_mgr =
               dynamic_cast<Server::ApiListenerManagerImpl*>(&server_->listenerManager());
           ASSERT(api_mgr != nullptr);
-          http_client_handle_ = &api_mgr->httpClient();
           request_dispatcher_->drain(api_mgr->httpClientDispatcher());
         }
       });
@@ -271,16 +347,7 @@ envoy_status_t InternalEngine::main(std::shared_ptr<OptionsImplBase> options) {
           // on-the-fly without risking contention on system with lots of threads.
           // It also comes with ease of programming.
           stat_name_set_ = client_scope_->symbolTable().makeSet("pulse");
-          if (!use_worker_thread_) {
-            auto api_listener =
-                server_->listenerManager().apiListener()->get().createHttpApiListener(
-                    server_->dispatcher());
-            ASSERT(api_listener != nullptr);
-            http_client_ = std::make_unique<Http::Client>(
-                std::move(api_listener), *main_dispatcher_, server_->serverFactoryContext().scope(),
-                server_->api().randomGenerator());
-            http_client_handle_ = http_client_.get();
-          }
+
           main_dispatcher_->drain(server_->dispatcher());
           engine_running_.Notify();
           callbacks_->on_engine_running_();
@@ -293,10 +360,6 @@ envoy_status_t InternalEngine::main(std::shared_ptr<OptionsImplBase> options) {
 
   // Ensure destructors run on Envoy's main thread.
   postinit_callback_handler_.reset(nullptr);
-  if (http_client_) {
-    http_client_.reset();
-    http_client_handle_ = nullptr;
-  }
   connectivity_manager_.reset();
   client_scope_.reset();
   stat_name_set_.reset();
@@ -340,16 +403,16 @@ envoy_status_t InternalEngine::terminate() {
 
     ASSERT(event_dispatcher_);
     ASSERT(main_dispatcher_);
-    if (!use_worker_thread_) {
-      main_dispatcher_->post([this]() { http_client_->shutdownApiListener(); });
-    }
-
-    // Exit the event loop and finish up in Engine::run(...)
     if (thread_factory_->currentPthreadId() == main_thread_->pthreadId()) {
       // TODO(goaway): figure out some way to support this.
       PANIC("Terminating the engine from its own main thread is currently unsupported.");
     } else {
-      if (use_worker_thread_) {
+      if (!use_worker_thread_) {
+        main_dispatcher_->post([this]() {
+          server_->listenerManager().stopListeners(Server::ListenerManager::StopListenersType::All,
+                                                   Network::ExtraShutdownListenerOptions{});
+        });
+      } else {
         server_->listenerManager().stopListeners(Server::ListenerManager::StopListenersType::All,
                                                  Network::ExtraShutdownListenerOptions{});
       }

--- a/mobile/library/common/internal_engine.h
+++ b/mobile/library/common/internal_engine.h
@@ -75,7 +75,7 @@ public:
   // to http client functions of the same name after doing a dispatcher post
   // (thread context switch)
   envoy_status_t startStream(envoy_stream_t stream, EnvoyStreamCallbacks&& stream_callbacks,
-                             bool explicit_flow_control);
+                             bool explicit_flow_control, absl::string_view listener_name = "");
 
   /**
    * Send the headers over an open HTTP stream. This function can be invoked
@@ -241,6 +241,8 @@ private:
   // Called when it's been determined that the default network has changed.
   void resetHttpPropertiesAndDrainHosts(bool has_ipv6_connectivity);
 
+  void removeActiveStream(envoy_stream_t stream);
+
   Event::ProvisionalDispatcher& requestDispatcher() const {
     return use_worker_thread_ ? *request_dispatcher_ : *main_dispatcher_;
   }
@@ -258,7 +260,7 @@ private:
   Assert::ActionRegistrationPtr bug_handler_registration_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
-  Http::ClientPtr http_client_;
+  absl::flat_hash_map<envoy_stream_t, Http::Client*> active_streams_;
   Network::ConnectivityManagerImplSharedPtr connectivity_manager_;
   Event::ProvisionalDispatcherPtr main_dispatcher_;
   // Used by the cerr logger to ensure logs don't overwrite each other.
@@ -276,9 +278,6 @@ private:
   Network::Address::InstanceConstSharedPtr prev_local_addr_{nullptr};
   bool enable_logger_{true};
   bool use_worker_thread_{false};
-  // If use_worker_thread_ is true, http_client_handle_ will point to the http_client_ in the
-  // ApiListenerWorker. Otherwise, it will point to http_client_.
-  Http::Client* http_client_handle_{nullptr};
   // If use_worker_thread_ is true, request_dispatcher_ will point to the dispatcher_ in the
   // ApiListenerWorker. Otherwise, it will be null.
   Event::ProvisionalDispatcherPtr request_dispatcher_;

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -552,36 +552,29 @@ TEST_F(InternalEngineTest, MultipleListenersStream) {
   options->setLogLevel(static_cast<spdlog::level::level_enum>(LOG_LEVEL));
   engine->run(std::move(options));
 
-  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(
-      absl::Seconds(10)));
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
   // Start stream on first listener.
   {
     absl::Notification on_complete_notification;
     EnvoyStreamCallbacks stream_callbacks;
     stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
-                                       bool /* end_stream */,
-                                       envoy_stream_intel) {
+                                       bool /* end_stream */, envoy_stream_intel) {
       EXPECT_EQ(headers.Status()->value().getStringView(), "200");
     };
-    stream_callbacks.on_complete_ = [&](envoy_stream_intel,
-                                        envoy_final_stream_intel) {
+    stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
       on_complete_notification.Notify();
     };
 
     envoy_stream_t stream = engine->initStream();
     // Explicitly specify "base_api_listener"
-    engine->startStream(stream, std::move(stream_callbacks), false,
-                        "base_api_listener");
+    engine->startStream(stream, std::move(stream_callbacks), false, "base_api_listener");
 
-    engine->sendHeaders(
-        stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
-    engine->sendData(
-        stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
+    engine->sendHeaders(stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
+    engine->sendData(stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
     engine->sendTrailers(stream, Http::Utility::createRequestTrailerMapPtr());
 
-    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(
-        absl::Seconds(10)));
+    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(absl::Seconds(10)));
   }
 
   // Start stream on second listener.
@@ -589,35 +582,28 @@ TEST_F(InternalEngineTest, MultipleListenersStream) {
     absl::Notification on_complete_notification;
     EnvoyStreamCallbacks stream_callbacks;
     stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
-                                       bool /* end_stream */,
-                                       envoy_stream_intel) {
+                                       bool /* end_stream */, envoy_stream_intel) {
       EXPECT_EQ(headers.Status()->value().getStringView(), "200");
     };
-    stream_callbacks.on_complete_ = [&](envoy_stream_intel,
-                                        envoy_final_stream_intel) {
+    stream_callbacks.on_complete_ = [&](envoy_stream_intel, envoy_final_stream_intel) {
       on_complete_notification.Notify();
     };
 
     envoy_stream_t stream = engine->initStream();
     // Explicitly specify "second_api_listener"
-    engine->startStream(stream, std::move(stream_callbacks), false,
-                        "second_api_listener");
+    engine->startStream(stream, std::move(stream_callbacks), false, "second_api_listener");
 
-    engine->sendHeaders(
-        stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
-    engine->sendData(
-        stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
+    engine->sendHeaders(stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
+    engine->sendData(stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
     engine->sendTrailers(stream, Http::Utility::createRequestTrailerMapPtr());
 
-    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(
-        absl::Seconds(10)));
+    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(absl::Seconds(10)));
   }
 
   test_server.shutdown();
   engine->terminate();
 
-  ASSERT_TRUE(
-      test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
+  ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
 } // namespace Envoy

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -1,4 +1,5 @@
 #include <sys/resource.h>
+#include <memory>
 
 #include <atomic>
 
@@ -13,6 +14,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/notification.h"
+#include "absl/types/optional.h"
 #include "gtest/gtest.h"
 #include "test/cc/engine_builder_test_shim.h"
 #include "library/common/api/external.h"
@@ -517,6 +519,105 @@ TEST_F(ThreadPriorityInternalEngineTest, SetOutOfRangeThreadPriority) {
   // could be system dependent, we just verify that the thread priority that gets set is not the
   // out-of-range one that we initialized the engine with.
   EXPECT_NE(actual_thread_priority, expected_thread_priority);
+}
+
+TEST_F(InternalEngineTest, MultipleListenersStream) {
+  TestServer test_server;
+  test_server.start(TestServerType::HTTP1_WITHOUT_TLS);
+
+  EngineTestContext test_context{};
+  std::unique_ptr<InternalEngine> engine = std::make_unique<InternalEngine>(
+      createDefaultEngineCallbacks(test_context), /*logger=*/nullptr,
+      /*event_tracker=*/nullptr, /*thread_priority=*/absl::nullopt,
+      /*high_watermark=*/absl::nullopt, /*enable_logger=*/true,
+      /*use_worker_thread=*/true);
+
+  Platform::EngineBuilder builder;
+  builder.enableWorkerThread(true);
+  auto bootstrap = builder.generateBootstrap();
+
+  // Add a second listener by cloning the first one and renaming it.
+  ASSERT_GT(bootstrap->static_resources().listeners_size(), 0);
+  auto* listener1 = bootstrap->mutable_static_resources()->mutable_listeners(0);
+  // Ensure it has the expected name.
+  ASSERT_EQ(listener1->name(), "base_api_listener");
+
+  auto* listener2 = bootstrap->mutable_static_resources()->add_listeners();
+  listener2->CopyFrom(*listener1);
+  listener2->set_name("second_api_listener");
+
+  // Run engine with mutated bootstrap.
+  auto options = std::make_shared<Envoy::OptionsImplBase>();
+  options->setConfigProto(std::move(bootstrap));
+  options->setLogLevel(static_cast<spdlog::level::level_enum>(LOG_LEVEL));
+  engine->run(std::move(options));
+
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(
+      absl::Seconds(10)));
+
+  // Start stream on first listener.
+  {
+    absl::Notification on_complete_notification;
+    EnvoyStreamCallbacks stream_callbacks;
+    stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                       bool /* end_stream */,
+                                       envoy_stream_intel) {
+      EXPECT_EQ(headers.Status()->value().getStringView(), "200");
+    };
+    stream_callbacks.on_complete_ = [&](envoy_stream_intel,
+                                        envoy_final_stream_intel) {
+      on_complete_notification.Notify();
+    };
+
+    envoy_stream_t stream = engine->initStream();
+    // Explicitly specify "base_api_listener"
+    engine->startStream(stream, std::move(stream_callbacks), false,
+                        "base_api_listener");
+
+    engine->sendHeaders(
+        stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
+    engine->sendData(
+        stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
+    engine->sendTrailers(stream, Http::Utility::createRequestTrailerMapPtr());
+
+    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(
+        absl::Seconds(10)));
+  }
+
+  // Start stream on second listener.
+  {
+    absl::Notification on_complete_notification;
+    EnvoyStreamCallbacks stream_callbacks;
+    stream_callbacks.on_headers_ = [&](const Http::ResponseHeaderMap& headers,
+                                       bool /* end_stream */,
+                                       envoy_stream_intel) {
+      EXPECT_EQ(headers.Status()->value().getStringView(), "200");
+    };
+    stream_callbacks.on_complete_ = [&](envoy_stream_intel,
+                                        envoy_final_stream_intel) {
+      on_complete_notification.Notify();
+    };
+
+    envoy_stream_t stream = engine->initStream();
+    // Explicitly specify "second_api_listener"
+    engine->startStream(stream, std::move(stream_callbacks), false,
+                        "second_api_listener");
+
+    engine->sendHeaders(
+        stream, createLocalhostRequestHeaders(test_server.getAddress()), false);
+    engine->sendData(
+        stream, std::make_unique<Buffer::OwnedImpl>("request body"), false);
+    engine->sendTrailers(stream, Http::Utility::createRequestTrailerMapPtr());
+
+    ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(
+        absl::Seconds(10)));
+  }
+
+  test_server.shutdown();
+  engine->terminate();
+
+  ASSERT_TRUE(
+      test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
 
 } // namespace Envoy

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -242,6 +242,7 @@ public:
   void endListenerUpdate(FailureStates&& failure_state) override;
   bool isWorkerStarted() override { return workers_started_; }
   Http::Context& httpContext() { return server_.httpContext(); }
+  using ListenerManager::apiListener;
   ApiListenerOptRef apiListener() override;
   ListenerUpdateCallbacksHandlePtr
   addListenerUpdateCallbacks(ListenerUpdateCallbacks& callbacks) override;

--- a/test/mocks/server/listener_manager.h
+++ b/test/mocks/server/listener_manager.h
@@ -29,6 +29,7 @@ public:
   MOCK_METHOD(void, stopWorkers, ());
   MOCK_METHOD(void, beginListenerUpdate, ());
   MOCK_METHOD(void, endListenerUpdate, (ListenerManager::FailureStates&&));
+  using ListenerManager::apiListener;
   MOCK_METHOD(ApiListenerOptRef, apiListener, ());
   MOCK_METHOD(bool, isWorkerStarted, ());
 


### PR DESCRIPTION
Commit Message: mobile: Part 1 of supporting multiple API listeners.
Additional Description: part1 in a sequence of PRs to enable running multiple API listeners within a single Envoy Engine, supporting diverse use cases (different routing, filters, and timeouts) in a single process. Note that due to singletons in Envoy, you can't run multiple Envoy Engines in a single process.
Risk Level: low
Testing: unit testing; integration testing coming in part 2 or 3.
Docs Changes: to come in later PR
Release Notes: to come in later PR.
