### PR TITLE
ratelimit: add support for Ratelimit.override per route

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -2715,9 +2715,13 @@ message RateLimit {
   // <config_http_filters_rate_limit_rate_limit_override>` for more information.
   //
   // .. note::
-  //   This is not supported if the rate limit action is configured in the ``typed_per_filter_config`` like
-  //   :ref:`VirtualHost.typed_per_filter_config<envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>` or
-  //   :ref:`Route.typed_per_filter_config<envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>`, etc.
+  //   For the global HTTP :ref:`rate limit filter
+  //   <config_http_filters_rate_limit>`, this is supported both at the route/virtual host
+  //   level and when the rate limit configuration is supplied via the filter's
+  //   ``rate_limits`` field or the ``typed_per_filter_config``
+  //   (:ref:`RateLimitPerRoute <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimitPerRoute>`).
+  //   This is not supported by the :ref:`local rate limit filter
+  //   <config_http_filters_local_rate_limit>`.
   Override limit = 4;
 
   // An optional hits addend to be appended to the descriptor produced by this rate limit

--- a/changelogs/current/new_features/ratelimit__per_route_limit_override.rst
+++ b/changelogs/current/new_features/ratelimit__per_route_limit_override.rst
@@ -1,0 +1,8 @@
+The HTTP :ref:`rate limit filter <config_http_filters_rate_limit>` now supports the
+:ref:`limit <envoy_v3_api_field_config.route.v3.RateLimit.limit>` override (including the
+``dynamic_metadata`` source) when the rate limit configuration is supplied via the filter's
+``rate_limits`` field or the per-route
+:ref:`RateLimitPerRoute <envoy_v3_api_msg_extensions.filters.http.ratelimit.v3.RateLimitPerRoute>`.
+This allows the per-descriptor limit override and the per-request
+:ref:`hits_addend <envoy_v3_api_field_config.route.v3.RateLimit.hits_addend>` to be used
+together on the same rule.

--- a/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
+++ b/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/extensions/common/ratelimit/v3/ratelimit.pb.h"
 
+#include "source/common/common/assert.h"
 #include "source/common/config/utility.h"
 #include "source/common/http/matching/data_impl.h"
 #include "source/common/matcher/matcher.h"
@@ -58,6 +59,14 @@ RateLimitPolicy::RateLimitPolicy(const ProtoRateLimit& config,
     if (no_limit) {
       creation_status = absl::InvalidArgumentError("'limit' field is not supported");
       return;
+    }
+    switch (config.limit().override_specifier_case()) {
+    case ProtoRateLimit::Override::OverrideSpecifierCase::kDynamicMetadata:
+      limit_override_.emplace(
+          new Envoy::Router::DynamicMetadataRateLimitOverride(config.limit().dynamic_metadata()));
+      break;
+    case ProtoRateLimit::Override::OverrideSpecifierCase::OVERRIDE_SPECIFIER_NOT_SET:
+      PANIC_DUE_TO_CORRUPT_ENUM;
     }
   }
 
@@ -225,6 +234,11 @@ void RateLimitPolicy::populateDescriptors(const Http::RequestHeaderMap& headers,
 
   // Populate is_negative.
   descriptor.is_negative_hits_ = is_negative_hits_;
+
+  // Populate the limit override if configured.
+  if (limit_override_) {
+    limit_override_.value()->populateOverride(descriptor, &stream_info.dynamicMetadata());
+  }
 
   // Populate enable_x_rate_limit_headers.
   descriptor.x_ratelimit_option_ = x_ratelimit_option_;

--- a/source/extensions/filters/common/ratelimit_config/ratelimit_config.h
+++ b/source/extensions/filters/common/ratelimit_config/ratelimit_config.h
@@ -37,6 +37,7 @@ private:
   absl::optional<uint64_t> hits_addend_;
   bool is_negative_hits_ = false;
   std::vector<Envoy::RateLimit::DescriptorProducerPtr> actions_;
+  absl::optional<Envoy::Router::RateLimitOverrideActionPtr> limit_override_ = absl::nullopt;
 };
 
 class RateLimitConfig : Logger::Loggable<Envoy::Logger::Id::config> {

--- a/source/extensions/filters/http/ratelimit/ratelimit.h
+++ b/source/extensions/filters/http/ratelimit/ratelimit.h
@@ -87,7 +87,7 @@ public:
     SET_AND_RETURN_IF_NOT_OK(response_headers_parser_or_.status(), creation_status);
     response_headers_parser_ = std::move(response_headers_parser_or_.value());
     rate_limit_config_ = std::make_unique<Filters::Common::RateLimit::RateLimitConfig>(
-        config.rate_limits(), context, creation_status);
+        config.rate_limits(), context, creation_status, /*no_limit=*/false);
   }
 
   const std::string& domain() const { return domain_; }
@@ -189,7 +189,7 @@ public:
       : local_info_(context.localInfo()), vh_rate_limits_(config.vh_rate_limits()),
         domain_(config.domain()) {
     rate_limit_config_ = std::make_unique<Filters::Common::RateLimit::RateLimitConfig>(
-        config.rate_limits(), context, creation_status);
+        config.rate_limits(), context, creation_status, /*no_limit=*/false);
   }
 
   envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute::VhRateLimitsOptions

--- a/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
+++ b/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
@@ -506,8 +506,8 @@ filter_metadata:
   EXPECT_THAT(expected_descriptors, testing::ContainerEq(descriptors));
 }
 
-// The key regression for envoyproxy/envoy#45611: the per-descriptor limit override and the
-// per-request hits_addend can be used together on the same rule.
+// The key regression: the per-descriptor limit override and the per-request hits_addend can
+// be used together on the same rule. See https://github.com/envoyproxy/envoy/issues/45611.
 TEST_F(RateLimitConfigTest, LimitOverrideWithHitsAddend) {
   const std::string yaml = R"EOF(
   rate_limits:

--- a/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
+++ b/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
@@ -76,11 +76,11 @@ actions:
 
 class RateLimitConfigTest : public testing::Test {
 public:
-  void setupTest(const std::string& yaml) {
+  void setupTest(const std::string& yaml, bool no_limit = true) {
     test::extensions::filters::common::ratelimit_config::TestRateLimitConfig proto_config;
     TestUtility::loadFromYaml(yaml, proto_config);
     config_ = std::make_unique<Envoy::Extensions::Filters::Common::RateLimit::RateLimitConfig>(
-        proto_config.rate_limits(), factory_context_, creation_status_);
+        proto_config.rate_limits(), factory_context_, creation_status_, no_limit);
     stream_info_.downstream_connection_info_provider_->setRemoteAddress(default_remote_address_);
     stream_info_.route_ = route_;
   }
@@ -467,6 +467,119 @@ TEST_F(RateLimitConfigTest, MultiplePoliciesAndMultipleActionsAndIsNegative) {
   EXPECT_TRUE(descriptors[0].is_negative_hits_);
   EXPECT_EQ(3, descriptors[1].hits_addend_.value());
   EXPECT_TRUE(descriptors[1].is_negative_hits_);
+}
+
+// When the limit override is allowed (no_limit = false), it is parsed from dynamic metadata
+// and applied to the generated descriptor.
+TEST_F(RateLimitConfigTest, LimitOverrideApplied) {
+  const std::string yaml = R"EOF(
+  rate_limits:
+  - actions:
+    - generic_key:
+        descriptor_value: limited_fake_key
+    limit:
+      dynamic_metadata:
+        metadata_key:
+          key: test.filter.key
+          path:
+          - key: test
+  )EOF";
+
+  setupTest(yaml, /*no_limit=*/false);
+  ASSERT_TRUE(creation_status_.ok());
+
+  const std::string metadata_yaml = R"EOF(
+filter_metadata:
+  test.filter.key:
+    test:
+      requests_per_unit: 42
+      unit: HOUR
+  )EOF";
+  TestUtility::loadFromYaml(metadata_yaml, stream_info_.dynamicMetadata());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  config_->populateDescriptors(headers_, stream_info_, "", descriptors);
+
+  std::vector<Envoy::RateLimit::Descriptor> expected_descriptors = {
+      {{{"generic_key", "limited_fake_key"}}}};
+  expected_descriptors[0].limit_ = {42, envoy::type::v3::RateLimitUnit::HOUR};
+  EXPECT_THAT(expected_descriptors, testing::ContainerEq(descriptors));
+}
+
+// The key regression for envoyproxy/envoy#45611: the per-descriptor limit override and the
+// per-request hits_addend can be used together on the same rule.
+TEST_F(RateLimitConfigTest, LimitOverrideWithHitsAddend) {
+  const std::string yaml = R"EOF(
+  rate_limits:
+  - actions:
+    - generic_key:
+        descriptor_value: limited_fake_key
+    hits_addend:
+      format: "%DYNAMIC_METADATA(test.filter.key:tokens)%"
+    limit:
+      dynamic_metadata:
+        metadata_key:
+          key: test.filter.key
+          path:
+          - key: test
+  )EOF";
+
+  setupTest(yaml, /*no_limit=*/false);
+  ASSERT_TRUE(creation_status_.ok());
+
+  const std::string metadata_yaml = R"EOF(
+filter_metadata:
+  test.filter.key:
+    tokens: 7
+    test:
+      requests_per_unit: 42
+      unit: HOUR
+  )EOF";
+  TestUtility::loadFromYaml(metadata_yaml, stream_info_.dynamicMetadata());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  config_->populateDescriptors(headers_, stream_info_, "", descriptors);
+
+  ASSERT_EQ(1, descriptors.size());
+  // Both the cost (hits_addend) and the per-descriptor limit override are present.
+  EXPECT_EQ(7, descriptors[0].hits_addend_.value());
+  ASSERT_TRUE(descriptors[0].limit_.has_value());
+  EXPECT_EQ(42, descriptors[0].limit_->requests_per_unit_);
+  EXPECT_EQ(envoy::type::v3::RateLimitUnit::HOUR, descriptors[0].limit_->unit_);
+}
+
+// When the override metadata is missing, the descriptor is still produced without a limit.
+TEST_F(RateLimitConfigTest, LimitOverrideNotFound) {
+  const std::string yaml = R"EOF(
+  rate_limits:
+  - actions:
+    - generic_key:
+        descriptor_value: limited_fake_key
+    limit:
+      dynamic_metadata:
+        metadata_key:
+          key: unknown.key
+          path:
+          - key: test
+  )EOF";
+
+  setupTest(yaml, /*no_limit=*/false);
+  ASSERT_TRUE(creation_status_.ok());
+
+  const std::string metadata_yaml = R"EOF(
+filter_metadata:
+  test.filter.key:
+    test:
+      requests_per_unit: 42
+      unit: HOUR
+  )EOF";
+  TestUtility::loadFromYaml(metadata_yaml, stream_info_.dynamicMetadata());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  config_->populateDescriptors(headers_, stream_info_, "", descriptors);
+
+  ASSERT_EQ(1, descriptors.size());
+  EXPECT_FALSE(descriptors[0].limit_.has_value());
 }
 
 class RateLimitPolicyTest : public testing::Test {

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -64,6 +64,47 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
   }
 }
 
+// The filter-level ``rate_limits`` field also accepts a ``limit`` override alongside
+// ``hits_addend`` (envoyproxy/envoy#45611), exercising the FilterConfig (no_limit=false) path.
+TEST(RateLimitFilterConfigTest, FilterLevelRateLimitsWithLimitOverride) {
+  const std::string yaml = R"EOF(
+  domain: test
+  rate_limit_service:
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ratelimit_cluster
+  rate_limits:
+    - actions:
+      - remote_address: {}
+      hits_addend:
+        number: 1234
+      limit:
+        dynamic_metadata:
+          metadata_key:
+            key: test.filter.key
+            path:
+            - key: test
+  )EOF";
+
+  envoy::extensions::filters::http::ratelimit::v3::RateLimit proto_config{};
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
+  EXPECT_CALL(context.server_factory_context_.cluster_manager_.async_client_manager_,
+              getOrCreateRawAsyncClientWithHashKey(_, _, _))
+      .WillOnce(Invoke([](const Grpc::GrpcServiceConfigWithHashKey&, Stats::Scope&, bool) {
+        return std::make_unique<NiceMock<Grpc::MockAsyncClient>>();
+      }));
+
+  RateLimitFilterConfig factory;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   NiceMock<Server::MockInstance> instance;
@@ -96,6 +137,37 @@ TEST(RateLimitFilterConfigTest, PerRouteRateLimits) {
       - remote_address: {}
       hits_addend:
         number: 1234
+  )EOF";
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;
+  envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute proto_config{};
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  RateLimitFilterConfig factory;
+  auto status_or_error = factory.createRouteSpecificFilterConfig(
+      proto_config, factory_context,
+      factory_context.validation_context_.static_validation_visitor_);
+  EXPECT_TRUE(status_or_error.ok());
+  EXPECT_NE(nullptr, status_or_error.value());
+}
+
+// A per-route ``rate_limits`` rule may carry both a per-request ``hits_addend`` and a
+// per-descriptor ``limit`` override together (envoyproxy/envoy#45611). Previously the
+// override was rejected with "'limit' field is not supported".
+TEST(RateLimitFilterConfigTest, PerRouteRateLimitsWithLimitOverride) {
+  const std::string yaml = R"EOF(
+  domain: test
+  rate_limits:
+    - actions:
+      - remote_address: {}
+      hits_addend:
+        number: 1234
+      limit:
+        dynamic_metadata:
+          metadata_key:
+            key: test.filter.key
+            path:
+            - key: test
   )EOF";
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> factory_context;

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -65,7 +65,8 @@ TEST(RateLimitFilterConfigTest, RatelimitCorrectProto) {
 }
 
 // The filter-level ``rate_limits`` field also accepts a ``limit`` override alongside
-// ``hits_addend`` (envoyproxy/envoy#45611), exercising the FilterConfig (no_limit=false) path.
+// ``hits_addend``, exercising the FilterConfig (no_limit=false) path. See
+// https://github.com/envoyproxy/envoy/issues/45611.
 TEST(RateLimitFilterConfigTest, FilterLevelRateLimitsWithLimitOverride) {
   const std::string yaml = R"EOF(
   domain: test
@@ -152,8 +153,8 @@ TEST(RateLimitFilterConfigTest, PerRouteRateLimits) {
 }
 
 // A per-route ``rate_limits`` rule may carry both a per-request ``hits_addend`` and a
-// per-descriptor ``limit`` override together (envoyproxy/envoy#45611). Previously the
-// override was rejected with "'limit' field is not supported".
+// per-descriptor ``limit`` override together. Previously the override was rejected with
+// "'limit' field is not supported". See https://github.com/envoyproxy/envoy/issues/45611.
 TEST(RateLimitFilterConfigTest, PerRouteRateLimitsWithLimitOverride) {
   const std::string yaml = R"EOF(
   domain: test


### PR DESCRIPTION
**Commit Message:** ratelimit: support the `RateLimit.limit` override on the `RateLimitConfig` path

**Additional Description:**

The `RateLimitConfig` path (HTTP rate limit filter's `rate_limits` and per-route `RateLimitPerRoute`) supported `hits_addend` but rejected the `limit` override, so the two couldn't be used on the same rule. This adds override support to that path, matching `Router::RateLimitPolicyEntryImpl`.

- `RateLimitPolicy` now parses `RateLimit.Override` (when `no_limit == false`) into the existing `Router::DynamicMetadataRateLimitOverride` and applies it in `populateDescriptors` from dynamic metadata.
- Both `FilterConfig` (filter-level `rate_limits`) and `FilterConfigPerRoute` construct `RateLimitConfig` with `no_limit=false`. The local rate limit filter keeps `no_limit=true` (the override is only meaningful for the gRPC RLS descriptor).

**Risk Level:** Low — opt-in (only on `limit`, which previously errored), reuses the existing override impl, no change to existing descriptor output.

**Testing:** New unit tests for override applied, override + `hits_addend` together, and missing-metadata; config tests for both the per-route and filter-level wiring. `ratelimit_config_test` and `config_test` pass locally.

**Docs Changes:** Updated the `RateLimit.limit` field comment in `route_components.proto`.

**Release Notes:** Added a `new_features` changelog entry.

**Platform Specific Features:** None.

Fixes https://github.com/envoyproxy/envoy/issues/45611
