### PR TITLE
mobile/ci: Upgrade to Android NDK r29

### DIFF
--- a/mobile/.bazelrc
+++ b/mobile/.bazelrc
@@ -72,11 +72,13 @@ build:ios --define=envoy_full_protos=enabled
 build:android --define=logger=android
 build:android --java_language_version=8
 build:android --tool_java_language_version=8
+build:android --cxxopt=-Wno-nullability-completeness
 
 # Default flags for Android
 build:mobile-android --config=mobile-clang
 build:mobile-android --java_language_version=8
 build:mobile-android --tool_java_language_version=8
+build:mobile-android --cxxopt=-Wno-nullability-completeness
 test:mobile-android --build_tests_only
 test:mobile-android --define=static_extension_registration=disabled
 

--- a/mobile/ci/linux_ci_setup.sh
+++ b/mobile/ci/linux_ci_setup.sh
@@ -7,6 +7,6 @@ ANDROID_HOME=$ANDROID_SDK_ROOT
 SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
 "${SDKMANAGER}" --install "platform-tools" "platforms;android-30"
 "${SDKMANAGER}" --uninstall "ndk-bundle"
-"${SDKMANAGER}" --install "ndk;26.3.11579264"
+"${SDKMANAGER}" --install "ndk;29.0.14206865"
 "${SDKMANAGER}" --install "build-tools;35.0.0"
-echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/26.3.11579264" >> "$GITHUB_ENV"
+echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/29.0.14206865" >> "$GITHUB_ENV"


### PR DESCRIPTION
NDK r29 supports the vast majority of C++20 features.

Also, this commit adds `--cxxopt=-Wno-nullability-completeness` to the `android` and `mobile-android` build configs to prevent the lack of pointer nullability declarations from failing compilation.