### PR TITLE
dynamic_modules: read cluster LB host queries from the worker local priority set

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -206,6 +206,14 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr
 envoy_dynamic_module_callback_cluster_find_host_by_address(
     envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
     envoy_dynamic_module_type_module_buffer address) {
+  // This reads the main thread cross-priority host map, so it is main-thread-only. An
+  // `ASSERT_IS_MAIN_OR_TEST_THREAD` would be compiled out under NDEBUG, so guard explicitly and
+  // fail closed.
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_find_host_by_address must be called on the "
+                 "main thread");
+    return nullptr;
+  }
   auto* cluster = getCluster(cluster_envoy_ptr);
   std::string address_str(address.ptr, address.length);
   auto host = cluster->findHostByAddress(address_str);
@@ -1343,6 +1351,20 @@ bool envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address(
   result->ptr = address_str.data();
   result->length = address_str.size();
   return true;
+}
+
+envoy_dynamic_module_type_cluster_host_envoy_ptr
+envoy_dynamic_module_callback_cluster_lb_get_member_update_host(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added) {
+  if (lb_envoy_ptr == nullptr) {
+    return nullptr;
+  }
+  const auto* hosts =
+      is_added ? getLb(lb_envoy_ptr)->hostsAdded() : getLb(lb_envoy_ptr)->hostsRemoved();
+  if (hosts == nullptr || index >= hosts->size()) {
+    return nullptr;
+  }
+  return const_cast<Envoy::Upstream::Host*>((*hosts)[index].get());
 }
 
 } // extern "C"

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -821,7 +821,7 @@ void DynamicModuleAsyncHostSelectionHandle::cancel() {
 }
 
 const Upstream::PrioritySet& DynamicModuleLoadBalancer::prioritySet() const {
-  return handle_->cluster_->prioritySet();
+  return priority_set_;
 }
 
 bool DynamicModuleLoadBalancer::setHostData(uint32_t priority, size_t index, uintptr_t data) {

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -573,7 +573,7 @@ public:
     return {};
   }
 
-  // Access the priority set for lb callbacks.
+  // Worker local priority set used to answer host queries from the lb callbacks.
   const Upstream::PrioritySet& prioritySet() const;
 
   // Access the handle for async host selection completion.
@@ -617,7 +617,8 @@ public:
 
 private:
   const DynamicModuleClusterHandleSharedPtr handle_;
-  // Worker local priority set that backs the membership update subscription.
+  // Worker local priority set that backs the membership update subscription and answers host
+  // queries from the lb callbacks.
   const Upstream::PrioritySet& priority_set_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
 

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -9976,6 +9976,7 @@ envoy_dynamic_module_callback_cluster_http_callout(
  * the cluster's host set.
  *
  * During this callback, the module can call
+ * envoy_dynamic_module_callback_cluster_lb_get_member_update_host to get the host pointers, or
  * envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address to get the addresses of
  * the added or removed hosts by index.
  *
@@ -10012,6 +10013,22 @@ void envoy_dynamic_module_on_cluster_lb_on_host_membership_update(
 bool envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added,
     envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_member_update_host returns the host pointer of an
+ * added or removed host during the on_cluster_lb_on_host_membership_update event hook. This
+ * returns the host directly from the added or removed list without an address lookup, so it is
+ * only valid during envoy_dynamic_module_on_cluster_lb_on_host_membership_update.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy cluster load balancer.
+ * @param index is the index of the host in the added or removed list.
+ * @param is_added is true to get an added host, false to get a removed host.
+ * @return the host pointer if found, or nullptr if the index is out of bounds or the callback is
+ * not active.
+ */
+envoy_dynamic_module_type_cluster_host_envoy_ptr
+envoy_dynamic_module_callback_cluster_lb_get_member_update_host(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, size_t index, bool is_added);
 
 // =============================================================================
 // =============================== Load Balancer ===============================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -501,6 +501,14 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_member_u
   return false;
 }
 
+__attribute__((weak)) envoy_dynamic_module_type_cluster_host_envoy_ptr
+envoy_dynamic_module_callback_cluster_lb_get_member_update_host(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, size_t, bool) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_member_update_host: "
+               "not implemented in this context");
+  return nullptr;
+}
+
 __attribute__((weak)) void envoy_dynamic_module_callback_cluster_pre_init_complete(
     envoy_dynamic_module_type_cluster_envoy_ptr) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_pre_init_complete: "

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -176,8 +176,8 @@ pub trait ClusterLb: Send {
 
   /// Called when the set of hosts in the cluster changes.
   ///
-  /// The `envoy_lb` provides access to the updated host set and to the addresses of hosts
-  /// that were added or removed via
+  /// The `envoy_lb` provides access to the updated host set and to the hosts that were added or
+  /// removed via [`EnvoyClusterLoadBalancer::get_member_update_host`], or their addresses via
   /// [`EnvoyClusterLoadBalancer::get_member_update_host_address`].
   ///
   /// After this callback returns, the standard host query methods reflect the new state.
@@ -645,6 +645,21 @@ pub trait EnvoyClusterLoadBalancer: Send {
   ///
   /// Set `is_added` to `true` to get an added host address, `false` for a removed host address.
   fn get_member_update_host_address(&self, index: usize, is_added: bool) -> Option<String>;
+
+  /// Returns the host pointer of an added or removed host during the
+  /// [`ClusterLb::on_host_membership_update`] callback.
+  ///
+  /// Unlike [`EnvoyClusterLoadBalancer::get_member_update_host_address`], this returns the host
+  /// directly from the added or removed list without an address lookup. It is only valid during
+  /// the `on_host_membership_update` callback.
+  ///
+  /// Set `is_added` to `true` to get an added host, `false` for a removed host. Returns `None`
+  /// when the index is out of bounds or the callback is not active.
+  fn get_member_update_host(
+    &self,
+    index: usize,
+    is_added: bool,
+  ) -> Option<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>;
 }
 
 /// Envoy-side scheduler that dispatches events to the main thread.
@@ -1462,6 +1477,23 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
       })
     } else {
       None
+    }
+  }
+
+  fn get_member_update_host(
+    &self,
+    index: usize,
+    is_added: bool,
+  ) -> Option<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr> {
+    let host = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_member_update_host(
+        self.raw, index, is_added,
+      )
+    };
+    if host.is_null() {
+      None
+    } else {
+      Some(host)
     }
   }
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4251,6 +4251,15 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_member_update_hos
 }
 
 #[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_member_update_host(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  _index: usize,
+  _is_added: bool,
+) -> abi::envoy_dynamic_module_type_cluster_host_envoy_ptr {
+  std::ptr::null_mut()
+}
+
+#[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
   _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
   _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_context_envoy_ptr,
@@ -5258,6 +5267,28 @@ fn test_cluster_lb_get_host_address_none() {
   let mut mock_lb = cluster::MockEnvoyClusterLoadBalancer::new();
   mock_lb.expect_get_host_address().returning(|_, _| None);
   assert!(mock_lb.get_host_address(0, 0).is_none());
+}
+
+#[test]
+fn test_cluster_lb_get_member_update_host() {
+  let mut mock_lb = cluster::MockEnvoyClusterLoadBalancer::new();
+  mock_lb
+    .expect_get_member_update_host()
+    .withf(|index, is_added| *index == 0 && *is_added)
+    .returning(|_, _| Some(0x1234 as abi::envoy_dynamic_module_type_cluster_host_envoy_ptr));
+  assert_eq!(
+    mock_lb.get_member_update_host(0, true).map(|h| h as usize),
+    Some(0x1234)
+  );
+}
+
+#[test]
+fn test_cluster_lb_get_member_update_host_none() {
+  let mut mock_lb = cluster::MockEnvoyClusterLoadBalancer::new();
+  mock_lb
+    .expect_get_member_update_host()
+    .returning(|_, _| None);
+  assert!(mock_lb.get_member_update_host(0, false).is_none());
 }
 
 #[test]

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -64,6 +64,15 @@ public:
   // Simulates the module's on_cluster_lb_new returning nullptr after the LB has already been
   // constructed: clears in_module_lb_ so chooseHost exercises the early-return path.
   static void clearInModuleLb(DynamicModuleLoadBalancer& lb) { lb.in_module_lb_ = nullptr; }
+
+  // Sets the borrowed host vectors that back the member update host accessors. These are only
+  // populated by Envoy during an on_host_membership_update callback, so this lets the accessors
+  // be exercised deterministically from a unit test.
+  static void setMemberUpdateHosts(DynamicModuleLoadBalancer& lb, const Upstream::HostVector* added,
+                                   const Upstream::HostVector* removed) {
+    lb.hosts_added_ = added;
+    lb.hosts_removed_ = removed;
+  }
 };
 
 using ::testing::_;
@@ -434,8 +443,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
 
   auto lb_factory = talb->factory();
   ASSERT_NE(nullptr, lb_factory);
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   ASSERT_NE(nullptr, lb);
 
   // Verify priority set access via the LB.
@@ -444,6 +452,20 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
   const auto& ps = dm_lb->prioritySet();
   EXPECT_EQ(1, ps.hostSetsPerPriority().size());
   EXPECT_EQ(2, ps.hostSetsPerPriority()[0]->healthyHosts().size());
+}
+
+// prioritySet() answers host queries from the worker local set supplied at construction.
+TEST_F(DynamicModuleClusterTest, PrioritySetUsesWorkerLocalSet) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+
+  NiceMock<Upstream::MockPrioritySet> worker_ps;
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, worker_ps);
+
+  EXPECT_EQ(static_cast<const Upstream::PrioritySet*>(&worker_ps), &lb_instance->prioritySet());
+  EXPECT_NE(&cluster->prioritySet(), &lb_instance->prioritySet());
 }
 
 // Test that the cluster initializes with the Primary phase.
@@ -532,8 +554,7 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -572,8 +593,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -815,8 +835,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -2093,8 +2112,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -2120,8 +2138,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -2147,8 +2164,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
   auto& talb = result->second;
   EXPECT_TRUE(talb->initialize().ok());
   auto lb_factory = talb->factory();
-  NiceMock<Upstream::MockPrioritySet> mock_ps;
-  auto lb = lb_factory->create({mock_ps});
+  auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
   ASSERT_NE(nullptr, dm_lb);
 
@@ -2484,6 +2500,49 @@ TEST_F(DynamicModuleClusterTest, LbContextGetHostStatNullPointers) {
                    context_ptr, nullptr, envoy_dynamic_module_type_host_stat_RqActive));
   EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_lb_context_get_host_stat(
                    nullptr, nullptr, envoy_dynamic_module_type_host_stat_RqActive));
+}
+
+// Test that the index-based `get_host_stat` maps each stat enum to the matching `HostStats` field.
+TEST_F(DynamicModuleClusterTest, LbGetHostStatReadsValues) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+
+  std::vector<Upstream::HostSharedPtr> hosts;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001"}, {1}, hosts));
+  ASSERT_EQ(1, hosts.size());
+
+  // Distinct values per field so a mismatched enum mapping is caught.
+  auto& stats = hosts[0]->stats();
+  stats.cx_connect_fail_.add(1);
+  stats.cx_total_.add(2);
+  stats.rq_error_.add(3);
+  stats.rq_success_.add(4);
+  stats.rq_timeout_.add(5);
+  stats.rq_total_.add(6);
+  stats.cx_active_.add(7);
+  stats.rq_active_.add(8);
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+  auto* lb_ptr = static_cast<void*>(lb_instance.get());
+
+  EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxConnectFail));
+  EXPECT_EQ(2, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxTotal));
+  EXPECT_EQ(3, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqError));
+  EXPECT_EQ(4, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqSuccess));
+  EXPECT_EQ(5, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTimeout));
+  EXPECT_EQ(6, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqTotal));
+  EXPECT_EQ(7, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_CxActive));
+  EXPECT_EQ(8, envoy_dynamic_module_callback_cluster_lb_get_host_stat(
+                   lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqActive));
 }
 
 // =================================================================================================
@@ -3284,6 +3343,55 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
       lb_ptr, 0, true, nullptr));
 }
 
+// Test get_member_update_host returns the host pointers borrowed during a membership update.
+TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPointer) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+  auto* lb_ptr = static_cast<void*>(lb_instance.get());
+
+  std::vector<Upstream::HostSharedPtr> hosts;
+  ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002", "127.0.0.1:10003"},
+                             {1, 1, 1}, hosts));
+  ASSERT_EQ(3, hosts.size());
+
+  // Outside a membership update callback the borrowed vectors are null.
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 0, true));
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 0, false));
+
+  // Simulate the vectors that Envoy borrows for the duration of the callback.
+  Upstream::HostVector added{hosts[0], hosts[1]};
+  Upstream::HostVector removed{hosts[2]};
+  DynamicModuleClusterTestPeer::setMemberUpdateHosts(*lb_instance, &added, &removed);
+
+  EXPECT_EQ(hosts[0].get(),
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 0, true));
+  EXPECT_EQ(hosts[1].get(),
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 1, true));
+  EXPECT_EQ(hosts[2].get(),
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 0, false));
+
+  // Out-of-bounds index returns nullptr.
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 2, true));
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 1, false));
+
+  // Null load balancer returns nullptr.
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(nullptr, 0, true));
+
+  // Once the callback ends the borrowed vectors are cleared and lookups return nullptr again.
+  DynamicModuleClusterTestPeer::setMemberUpdateHosts(*lb_instance, nullptr, nullptr);
+  EXPECT_EQ(nullptr,
+            envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_ptr, 0, true));
+}
+
 // Test hosts-per-locality is correctly maintained with locality-aware hosts.
 TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
@@ -3722,6 +3830,28 @@ TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
         t.join();
       },
       "envoy_dynamic_module_callback_cluster_pre_init_complete must be called on the main thread");
+}
+
+// Verifies that `cluster_find_host_by_address` is fail-closed when called off the main thread.
+TEST_F(DynamicModuleClusterTest, FindHostByAddressOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  void* cluster_ptr = cluster.get();
+  envoy_dynamic_module_type_module_buffer addr = {"127.0.0.1:10001", 15};
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_EQ(nullptr,
+                    envoy_dynamic_module_callback_cluster_find_host_by_address(cluster_ptr, addr));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_find_host_by_address must be called on the main "
+      "thread");
 }
 
 // Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -159,6 +159,26 @@ TEST_P(DynamicModuleClusterIntegrationTest, RunOnAllWorkersFiresOnEachWorker) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Exercises the worker local priority set path across multiple workers end to end. Each worker
+// load balancer learns the added host through get_member_update_host, confirms its worker local set
+// agrees, and routes a request to the upstream through that host pointer.
+TEST_P(DynamicModuleClusterIntegrationTest, WorkerLocalPrioritySetRebuild) {
+  concurrency_ = 2;
+  initializeWithDecCluster("worker_local_rebuild");
+
+  // Each worker increments the counter once its worker local set converges, so wait for all of
+  // them before routing.
+  test_server_->waitForCounter("dynamicmodulescustom.membership_hosts_total", testing::Ge(2));
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Verifies that the cluster lifecycle callbacks fire correctly during cluster
 // initialization.
 TEST_P(DynamicModuleClusterIntegrationTest, LifecycleCallbacks) {

--- a/test/extensions/dynamic_modules/test_data/c/cluster_no_op.c
+++ b/test/extensions/dynamic_modules/test_data/c/cluster_no_op.c
@@ -79,24 +79,34 @@ void envoy_dynamic_module_on_cluster_lb_on_host_membership_update(
     size_t num_hosts_removed) {
   (void)lb_module_ptr;
 
-  // Test accessing added host addresses.
+  // Test accessing added hosts by address and by pointer.
   for (size_t i = 0; i < num_hosts_added; i++) {
     envoy_dynamic_module_type_envoy_buffer addr = {NULL, 0};
     envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address(lb_envoy_ptr, i, true,
                                                                            &addr);
+    envoy_dynamic_module_type_cluster_host_envoy_ptr host =
+        envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_envoy_ptr, i, true);
+    (void)host;
   }
 
-  // Test accessing removed host addresses.
+  // Test accessing removed hosts by address and by pointer.
   for (size_t i = 0; i < num_hosts_removed; i++) {
     envoy_dynamic_module_type_envoy_buffer addr = {NULL, 0};
     envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address(lb_envoy_ptr, i, false,
                                                                            &addr);
+    envoy_dynamic_module_type_cluster_host_envoy_ptr host =
+        envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_envoy_ptr, i, false);
+    (void)host;
   }
 
   // Test out-of-bounds index.
   envoy_dynamic_module_type_envoy_buffer oob_result = {NULL, 0};
   envoy_dynamic_module_callback_cluster_lb_get_member_update_host_address(
       lb_envoy_ptr, num_hosts_added, true, &oob_result);
+  envoy_dynamic_module_type_cluster_host_envoy_ptr oob_host =
+      envoy_dynamic_module_callback_cluster_lb_get_member_update_host(lb_envoy_ptr, num_hosts_added,
+                                                                      true);
+  (void)oob_host;
 }
 
 void envoy_dynamic_module_on_cluster_server_initialized(

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -49,6 +49,16 @@ fn new_cluster_config(
         metrics: envoy_cluster_metrics,
       }))
     },
+    "worker_local_rebuild" => {
+      let counter_id = envoy_cluster_metrics
+        .define_counter("membership_hosts_total")
+        .ok();
+      Some(Box::new(WorkerLocalRebuildClusterConfig {
+        upstream_address: config_str.to_string(),
+        counter_id,
+        metrics: envoy_cluster_metrics,
+      }))
+    },
     _ => None,
   }
 }
@@ -466,5 +476,119 @@ impl ClusterLb for RunOnAllWorkersLb {
       return HostSelectionResult::NoHost;
     }
     HostSelectionResult::Selected(hosts.0[0])
+  }
+}
+
+// =============================================================================
+// Worker local priority set rebuild via membership updates.
+// =============================================================================
+//
+// on_init defers the host add through the scheduler so it lands after workers are registered and
+// their load balancers have subscribed to membership updates. on_host_membership_update learns the
+// added hosts directly from get_member_update_host and routes through those pointers, then confirms
+// the worker local priority set agrees on the host count before incrementing a counter so the test
+// can wait for every worker to converge.
+
+const WORKER_LOCAL_REBUILD_ADD_EVENT_ID: u64 = 200;
+
+struct WorkerLocalRebuildClusterConfig {
+  upstream_address: String,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterConfig for WorkerLocalRebuildClusterConfig {
+  fn new_cluster(&self, _envoy_cluster: &dyn EnvoyCluster) -> Box<dyn Cluster> {
+    Box::new(WorkerLocalRebuildCluster {
+      upstream_address: self.upstream_address.clone(),
+      counter_id: self.counter_id,
+      metrics: self.metrics.clone(),
+    })
+  }
+}
+
+struct WorkerLocalRebuildCluster {
+  upstream_address: String,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl Cluster for WorkerLocalRebuildCluster {
+  fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
+    envoy_cluster.pre_init_complete();
+    let scheduler = envoy_cluster.new_scheduler();
+    scheduler.commit(WORKER_LOCAL_REBUILD_ADD_EVENT_ID);
+  }
+
+  fn new_load_balancer(&self, _envoy_lb: &dyn EnvoyClusterLoadBalancer) -> Box<dyn ClusterLb> {
+    Box::new(WorkerLocalRebuildLb {
+      hosts: Vec::new(),
+      index: 0,
+      counter_id: self.counter_id,
+      metrics: self.metrics.clone(),
+    })
+  }
+
+  fn on_scheduled(&self, envoy_cluster: &dyn EnvoyCluster, event_id: u64) {
+    if event_id == WORKER_LOCAL_REBUILD_ADD_EVENT_ID {
+      envoy_cluster.add_hosts(&[self.upstream_address.clone()], &[1u32]);
+    }
+  }
+}
+
+struct WorkerLocalRebuildLb {
+  hosts: Vec<usize>,
+  index: usize,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterLb for WorkerLocalRebuildLb {
+  fn choose_host(
+    &mut self,
+    _context: Option<&dyn ClusterLbContext>,
+    _async_completion: Box<dyn EnvoyAsyncHostSelectionComplete>,
+  ) -> HostSelectionResult {
+    if self.hosts.is_empty() {
+      return HostSelectionResult::NoHost;
+    }
+    let idx = self.index % self.hosts.len();
+    self.index += 1;
+    HostSelectionResult::Selected(
+      self.hosts[idx] as abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+    )
+  }
+
+  fn on_host_membership_update(
+    &mut self,
+    envoy_lb: &dyn EnvoyClusterLoadBalancer,
+    num_hosts_added: usize,
+    num_hosts_removed: usize,
+  ) {
+    // Drop removed hosts resolved directly from the member update.
+    for i in 0..num_hosts_removed {
+      if let Some(host) = envoy_lb.get_member_update_host(i, false) {
+        let addr = host as usize;
+        self.hosts.retain(|&existing| existing != addr);
+      }
+    }
+    // Learn added hosts directly from the member update so routing uses the pointer it returns.
+    for i in 0..num_hosts_added {
+      if let Some(host) = envoy_lb.get_member_update_host(i, true) {
+        self.hosts.push(host as usize);
+      }
+    }
+    // Increment a counter once the out-of-range lookup returns no host and the present host count
+    // agrees with the worker local set, so the test can wait for every worker to converge.
+    let converged = envoy_lb
+      .get_member_update_host(num_hosts_added, true)
+      .is_none()
+      && !self.hosts.is_empty()
+      && envoy_lb.get_hosts_count(0) == self.hosts.len();
+    if converged {
+      if let Some(counter_id) = self.counter_id {
+        let _ = self.metrics.increment_counter(counter_id, 1);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

Today, dynamic module cluster load balancer read host queries from the main thread priority set. This PR switches it to the worker local priority set that the cluster manager keeps in sync per worker, matching the built in thread aware load balancers and keeping worker reads off the main thread set.

---

**Commit Message**: dynamic_modules: read cluster LB host queries from the worker local priority set
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A