### PR TITLE
ratelimit: add static limit override support

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -2646,7 +2646,7 @@ message RateLimit {
       uint32 requests_per_unit = 1;
 
       // The unit of time.
-      type.v3.RateLimitUnit unit = 2 [(validate.rules).enum = {defined_only: true}];
+      type.v3.RateLimitUnit unit = 2;
     }
 
     oneof override_specifier {

--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -16,6 +16,7 @@ import "envoy/type/metadata/v3/metadata.proto";
 import "envoy/type/tracing/v3/custom_tag.proto";
 import "envoy/type/v3/percent.proto";
 import "envoy/type/v3/range.proto";
+import "envoy/type/v3/ratelimit_unit.proto";
 
 import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
@@ -2639,11 +2640,23 @@ message RateLimit {
       type.metadata.v3.MetadataKey metadata_key = 1 [(validate.rules).message = {required: true}];
     }
 
+    // Rate limit to apply to this descriptor.
+    message RateLimitOverride {
+      // The number of requests per unit of time.
+      uint32 requests_per_unit = 1;
+
+      // The unit of time.
+      type.v3.RateLimitUnit unit = 2 [(validate.rules).enum = {defined_only: true}];
+    }
+
     oneof override_specifier {
       option (validate.required) = true;
 
       // Limit override from dynamic metadata.
       DynamicMetadata dynamic_metadata = 1;
+
+      // Static limit override.
+      RateLimitOverride rate_limit = 2;
     }
   }
 

--- a/changelogs/current/new_features/ratelimit__static_limit_override.rst
+++ b/changelogs/current/new_features/ratelimit__static_limit_override.rst
@@ -1,0 +1,4 @@
+Added a static :ref:`rate_limit <envoy_v3_api_field_config.route.v3.RateLimit.Override.rate_limit>`
+source to the rate limit :ref:`limit <envoy_v3_api_field_config.route.v3.RateLimit.limit>` override.
+This allows a fixed ``requests_per_unit``/``unit`` limit override to be attached to a descriptor
+directly from configuration, without requiring the value to be sourced from ``dynamic_metadata``.

--- a/source/common/router/router_ratelimit.cc
+++ b/source/common/router/router_ratelimit.cc
@@ -83,6 +83,12 @@ bool DynamicMetadataRateLimitOverride::populateOverride(
   return false;
 }
 
+bool StaticRateLimitOverride::populateOverride(RateLimit::Descriptor& descriptor,
+                                               const envoy::config::core::v3::Metadata*) const {
+  descriptor.limit_.emplace(RateLimit::RateLimitOverride{requests_per_unit_, unit_});
+  return true;
+}
+
 bool SourceClusterAction::populateDescriptor(RateLimit::DescriptorEntry& descriptor_entry,
                                              const std::string& local_service_cluster,
                                              const Http::RequestHeaderMap&,
@@ -527,6 +533,9 @@ RateLimitPolicyEntryImpl::RateLimitPolicyEntryImpl(
     case envoy::config::route::v3::RateLimit_Override::OverrideSpecifierCase::kDynamicMetadata:
       limit_override_.emplace(
           new DynamicMetadataRateLimitOverride(config.limit().dynamic_metadata()));
+      break;
+    case envoy::config::route::v3::RateLimit_Override::OverrideSpecifierCase::kRateLimit:
+      limit_override_.emplace(new StaticRateLimitOverride(config.limit().rate_limit()));
       break;
     case envoy::config::route::v3::RateLimit_Override::OverrideSpecifierCase::
         OVERRIDE_SPECIFIER_NOT_SET:

--- a/source/common/router/router_ratelimit.h
+++ b/source/common/router/router_ratelimit.h
@@ -43,6 +43,24 @@ private:
 };
 
 /**
+ * Populate rate limit override from a static configuration value.
+ */
+class StaticRateLimitOverride : public RateLimitOverrideAction {
+public:
+  StaticRateLimitOverride(
+      const envoy::config::route::v3::RateLimit::Override::RateLimitOverride& config)
+      : requests_per_unit_(config.requests_per_unit()), unit_(config.unit()) {}
+
+  // Router::RateLimitOverrideAction
+  bool populateOverride(RateLimit::Descriptor& descriptor,
+                        const envoy::config::core::v3::Metadata* metadata) const override;
+
+private:
+  const uint32_t requests_per_unit_;
+  const envoy::type::v3::RateLimitUnit unit_;
+};
+
+/**
  * Action for source cluster rate limiting.
  */
 class SourceClusterAction : public RateLimit::DescriptorProducer {

--- a/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
+++ b/source/extensions/filters/common/ratelimit_config/ratelimit_config.cc
@@ -65,6 +65,10 @@ RateLimitPolicy::RateLimitPolicy(const ProtoRateLimit& config,
       limit_override_.emplace(
           new Envoy::Router::DynamicMetadataRateLimitOverride(config.limit().dynamic_metadata()));
       break;
+    case ProtoRateLimit::Override::OverrideSpecifierCase::kRateLimit:
+      limit_override_.emplace(
+          new Envoy::Router::StaticRateLimitOverride(config.limit().rate_limit()));
+      break;
     case ProtoRateLimit::Override::OverrideSpecifierCase::OVERRIDE_SPECIFIER_NOT_SET:
       PANIC_DUE_TO_CORRUPT_ENUM;
     }

--- a/test/common/router/router_ratelimit_test.cc
+++ b/test/common/router/router_ratelimit_test.cc
@@ -1423,6 +1423,27 @@ filter_metadata:
               testing::ContainerEq(descriptors_));
 }
 
+TEST_F(RateLimitPolicyEntryTest, StaticRateLimitOverride) {
+  const std::string yaml = R"EOF(
+actions:
+- generic_key:
+    descriptor_value: limited_fake_key
+limit:
+ rate_limit:
+   requests_per_unit: 42
+   unit: HOUR
+  )EOF";
+
+  setupTest(yaml);
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "", header_, stream_info_);
+
+  auto descriptors =
+      std::vector<Envoy::RateLimit::Descriptor>({{{{"generic_key", "limited_fake_key"}}}});
+  descriptors[0].limit_ = {42, envoy::type::v3::RateLimitUnit::HOUR};
+  EXPECT_THAT(descriptors, testing::ContainerEq(descriptors_));
+}
+
 const std::string RequestHeaderMatchInputDescriptor = R"EOF(
 actions:
 - extension:

--- a/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
+++ b/test/extensions/filters/common/ratelimit_config/ratelimit_config_test.cc
@@ -506,6 +506,30 @@ filter_metadata:
   EXPECT_THAT(expected_descriptors, testing::ContainerEq(descriptors));
 }
 
+TEST_F(RateLimitConfigTest, StaticLimitOverrideApplied) {
+  const std::string yaml = R"EOF(
+  rate_limits:
+  - actions:
+    - generic_key:
+        descriptor_value: limited_fake_key
+    limit:
+      rate_limit:
+        requests_per_unit: 42
+        unit: HOUR
+  )EOF";
+
+  setupTest(yaml, /*no_limit=*/false);
+  ASSERT_TRUE(creation_status_.ok());
+
+  std::vector<Envoy::RateLimit::Descriptor> descriptors;
+  config_->populateDescriptors(headers_, stream_info_, "", descriptors);
+
+  std::vector<Envoy::RateLimit::Descriptor> expected_descriptors = {
+      {{{"generic_key", "limited_fake_key"}}}};
+  expected_descriptors[0].limit_ = {42, envoy::type::v3::RateLimitUnit::HOUR};
+  EXPECT_THAT(expected_descriptors, testing::ContainerEq(descriptors));
+}
+
 // The key regression: the per-descriptor limit override and the per-request hits_addend can
 // be used together on the same rule. See https://github.com/envoyproxy/envoy/issues/45611.
 TEST_F(RateLimitConfigTest, LimitOverrideWithHitsAddend) {


### PR DESCRIPTION
Commit Message: ratelimit: add static limit override support
Additional Description: 

This may users needn't to touch the RateLimit server and could configure the limit at Envoy's configuration directly which is more straightforward and easy to understand.


Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.