### PR TITLE
[bp/v1.38] tls: disable brotli certificate compression by default (#45618)

### DIFF
--- a/changelogs/current/minor_behavior_changes/tls__certificate-compression-brotli-disabled-by-default.rst
+++ b/changelogs/current/minor_behavior_changes/tls__certificate-compression-brotli-disabled-by-default.rst
@@ -1,0 +1,3 @@
+Runtime guard ``envoy.reloadable_features.tls_certificate_compression_brotli`` is now disabled by
+default. When disabled, QUIC retains zlib-only certificate compression and TCP TLS performs no
+certificate compression. It can be re-enabled by setting the runtime guard to ``true``.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -101,7 +101,6 @@ RUNTIME_GUARD(envoy_reloadable_features_skip_pending_overflow_count_on_active_rq
 RUNTIME_GUARD(envoy_reloadable_features_strict_stats_matcher_unpacked);
 RUNTIME_GUARD(envoy_reloadable_features_tcp_proxy_odcds_over_ads_fix);
 RUNTIME_GUARD(envoy_reloadable_features_test_feature_true);
-RUNTIME_GUARD(envoy_reloadable_features_tls_certificate_compression_brotli);
 RUNTIME_GUARD(envoy_reloadable_features_trace_refresh_after_route_refresh);
 RUNTIME_GUARD(envoy_reloadable_features_udp_set_do_not_fragment);
 RUNTIME_GUARD(envoy_reloadable_features_uhv_allow_malformed_url_encoding);
@@ -240,6 +239,11 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_strict_chunk_parsing);
 
 // Enable histograms of HTTP/2 header sizes, including cookie size.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);
+
+// TODO: Flip back to true once TLS certificate compression with brotli (RFC 8879) has been
+// validated in production. When disabled, QUIC retains zlib-only compression while TCP TLS has
+// no certificate compression.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_tls_certificate_compression_brotli);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -8236,6 +8236,30 @@ TEST_P(SslSocketTest, CertificateCompressionDisabled) {
   testUtilV2(test_options);
 }
 
+// Test that TLS handshakes succeed under the production default, without any runtime override.
+// The brotli certificate compression runtime flag defaults to disabled, so this verifies that
+// the default (no override) code path produces a working handshake and guards against an
+// accidental re-flip of the runtime guard.
+TEST_P(SslSocketTest, CertificateCompressionDefaultBehavior) {
+  envoy::config::listener::v3::Listener listener;
+  envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext server_tls_context;
+  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* server_cert =
+      server_tls_context.mutable_common_tls_context()->add_tls_certificates();
+  server_cert->mutable_certificate_chain()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_cert.pem"));
+  server_cert->mutable_private_key()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_key.pem"));
+
+  updateFilterChain(server_tls_context, *filter_chain);
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client_tls_context;
+
+  // TLS handshake should succeed using the default (brotli compression disabled) configuration.
+  TestUtilOptionsV2 test_options(listener, client_tls_context, /*expect_success=*/true, version_);
+  testUtilV2(test_options);
+}
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -574,6 +574,10 @@ tcp_logs:
 TEST_P(TcpGrpcAccessLogIntegrationTest, SslTerminatedWithJA3) {
   setupTlsInspectorFilter(/*ssl_terminate=*/true,
                           /*enable_`ja3`_fingerprinting=*/true);
+  // The fingerprint includes the certificate compression extension, which is opt-in, so enable
+  // the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   initialize();
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setSni("sni");
@@ -640,6 +644,10 @@ tcp_logs:
 TEST_P(TcpGrpcAccessLogIntegrationTest, SslNotTerminated) {
   setupTlsInspectorFilter(/*ssl_terminate=*/false,
                           /*enable_`ja3`_fingerprinting=*/false);
+  // The forwarded client hello byte count includes the certificate compression extension, which
+  // is opt-in, so enable the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   initialize();
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setSni("sni");
@@ -692,6 +700,10 @@ tcp_logs:
 TEST_P(TcpGrpcAccessLogIntegrationTest, SslNotTerminatedWithJA3) {
   setupTlsInspectorFilter(/*ssl_terminate=*/false,
                           /*enable_`ja3`_fingerprinting=*/true);
+  // The fingerprint and forwarded byte count include the certificate compression extension, which
+  // is opt-in, so enable the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   initialize();
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setSni("sni");
@@ -747,6 +759,10 @@ tcp_logs:
 TEST_P(TcpGrpcAccessLogIntegrationTest, SslNotTerminatedWithJA3NoSNI) {
   setupTlsInspectorFilter(/*ssl_terminate=*/false,
                           /*enable_`ja3`_fingerprinting=*/true);
+  // The fingerprint and forwarded byte count include the certificate compression extension, which
+  // is opt-in, so enable the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   initialize();
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -303,6 +303,10 @@ TEST_P(TlsInspectorIntegrationTest, JA3FingerprintIsSet) {
   // MD5 hash:
   //   `c68cd85633d6847f599328eb2df750b7` (BoringSSL)
   //   `bcab080434778b813a3903a51fdc90fc` (OpenSSL)
+  // The fingerprint includes the certificate compression extension, which is opt-in, so enable
+  // the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
@@ -332,6 +336,10 @@ TEST_P(TlsInspectorIntegrationTest, JA4FingerprintIsSet) {
   // `JA4` fingerprint:
   //   `t12i0108en_f06271c2b022_91d8455748bc` (BoringSSL)
   //   `t12i0108en_f06271c2b022_322a62d02564` (OpenSSL)
+  // The fingerprint includes the certificate compression extension, which is opt-in, so enable
+  // the runtime guard explicitly to keep the client hello deterministic.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -100,6 +100,10 @@ TEST_P(QuicHttpIntegrationTest, RuntimeEnableDraft29) {
 }
 
 TEST_P(QuicHttpIntegrationTest, CertCompressionEnabled) {
+  // Brotli certificate compression is opt-in, so enable the runtime guard explicitly to exercise
+  // the brotli compression path.
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.tls_certificate_compression_brotli",
+                                    "true");
   initialize();
 
   EXPECT_LOG_CONTAINS_ALL_OF(


### PR DESCRIPTION
## Description

This PR flips the
`envoy.reloadable_features.tls_certificate_compression_brotli` runtime guard to `false` by default. We are seeing a 50x increase in the CPU after this change to services that terminate high number of TCP connections.

---

**Commit Message:** tls: disable brotli certificate compression by default
**Additional Description:** Flipped the
`envoy.reloadable_features.tls_certificate_compression_brotli` runtime guard to `false` by default
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** Added
