### PR TITLE
dynamic_modules: skip host-set republish when addHosts adds no new hosts

### DIFF
--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -453,6 +453,13 @@ bool DynamicModuleCluster::addHosts(
     result_hosts.emplace_back(std::move(host_result.value()));
   }
 
+  // Every incoming address was already present in the host set, so there is nothing to add. Return
+  // without rebuilding and republishing the unchanged host set, which would otherwise fan out a
+  // no-op membership update to every worker.
+  if (result_hosts.empty()) {
+    return true;
+  }
+
   {
     absl::WriterMutexLock lock(host_map_lock_);
     for (const auto& host : result_hosts) {

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -337,12 +337,28 @@ TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
   EXPECT_EQ(3, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
   EXPECT_EQ(3, cluster->prioritySet().hostSetsPerPriority()[0]->hosts().size());
 
-  // A batch of only existing addresses adds nothing but still succeeds.
+  // Capture the host-set partition identity before a no-op push. A rebuild would replace these
+  // shared_ptrs (partitionHosts allocates new vectors), so identity is a precise "did we rebuild"
+  // signal. Also subscribe a membership callback: a republish fires it even with a (0,0) diff.
+  const auto* hosts_ptr_before = cluster->prioritySet().hostSetsPerPriority()[0]->hostsPtr().get();
+  const auto* healthy_ptr_before =
+      cluster->prioritySet().hostSetsPerPriority()[0]->healthyHostsPtr().get();
+  int membership_updates = 0;
+  auto cb_handle = cluster->prioritySet().addMemberUpdateCb(
+      [&](const Upstream::HostVector&, const Upstream::HostVector&) { ++membership_updates; });
+
+  // A batch of only existing addresses adds nothing but still succeeds, and must not rebuild or
+  // republish the host set.
   std::vector<Upstream::HostSharedPtr> hosts3;
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10003"}, {1, 1}, hosts3));
   EXPECT_EQ(0, hosts3.size());
   EXPECT_EQ(3, DynamicModuleClusterTestPeer::getHostMapSize(*cluster));
   EXPECT_EQ(3, cluster->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+  // No rebuild: the partition shared_ptrs are unchanged and no membership callback fired.
+  EXPECT_EQ(hosts_ptr_before, cluster->prioritySet().hostSetsPerPriority()[0]->hostsPtr().get());
+  EXPECT_EQ(healthy_ptr_before,
+            cluster->prioritySet().hostSetsPerPriority()[0]->healthyHostsPtr().get());
+  EXPECT_EQ(0, membership_updates);
 }
 
 // Test that invalid addresses cause the entire batch to fail.


### PR DESCRIPTION
**Commit Message:** dynamic_modules: skip host-set republish when addHosts adds no new hosts

**Additional Description:**

A dynamic module cluster re-applies its full host set from the control plane periodically. addHosts already skips
addresses already present in the cluster, but when a batch contains only such addresses (eg., a control plane re-send
on reconnect), it still rebuilds and republishes the unchanged host set: it copies the whole host vector, re-partitions
every host, rebuilds per-locality, and calls updateHosts, which fans out to every worker and fires a (0, 0)
membership update. In a cluster with millions of hosts that is a full O(N) rebuild and cross-thread publish for zero
membership change.

This returns early from addHosts when no new hosts remain after filtering, so a no-op re-send does no per-worker republish. 

Risk Level: Low
Testing: Unit Test
Docs Changes: N.A
Release Notes: N.A
Platform Specific Features: N.A