### PR TITLE
dynamic_modules: add numeric and bool access logger metadata getters

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -741,6 +741,23 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(
   return ContextAccessor::getDynamicMetadata(*logger->stream_info_, filter_name, path, result);
 }
 
+bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, double* result) {
+  auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  return ContextAccessor::getDynamicMetadataNumber(*logger->stream_info_, filter_name, path,
+                                                   result);
+}
+
+bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, bool* result) {
+  auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
+  return ContextAccessor::getDynamicMetadataBool(*logger->stream_info_, filter_name, path, result);
+}
+
 bool envoy_dynamic_module_callback_access_logger_get_filter_state(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* result) {

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -7001,6 +7001,34 @@ bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(
     envoy_dynamic_module_type_module_buffer path, envoy_dynamic_module_type_envoy_buffer* result);
 
 /**
+ * Get a number value from dynamic metadata by filter name and key path.
+ *
+ * @param logger_envoy_ptr is the pointer to the log context.
+ * @param filter_name is the filter namespace in dynamic metadata.
+ * @param path is the key path within the filter namespace (can be nested with dots).
+ * @param result receives the number value. Only number-typed metadata is returned.
+ * @return true if a number value exists at the path, false otherwise.
+ */
+bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, double* result);
+
+/**
+ * Get a bool value from dynamic metadata by filter name and key path.
+ *
+ * @param logger_envoy_ptr is the pointer to the log context.
+ * @param filter_name is the filter namespace in dynamic metadata.
+ * @param path is the key path within the filter namespace (can be nested with dots).
+ * @param result receives the bool value. Only bool-typed metadata is returned.
+ * @return true if a bool value exists at the path, false otherwise.
+ */
+bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_name,
+    envoy_dynamic_module_type_module_buffer path, bool* result);
+
+/**
  * Get a value from filter state by key.
  *
  * @param logger_envoy_ptr is the pointer to the log context.

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -55,6 +55,18 @@ bool getUpstreamSslAttribute(
   return true;
 }
 
+// Resolve a dynamic metadata value by filter name and dotted key path. Returns an unset value
+// when the path is absent.
+const Protobuf::Value& dynamicMetadataValue(const StreamInfo::StreamInfo& stream_info,
+                                            envoy_dynamic_module_type_module_buffer filter_name,
+                                            envoy_dynamic_module_type_module_buffer path) {
+  std::string filter_name_str(filter_name.ptr, filter_name.length);
+  std::string path_str(path.ptr, path.length);
+  std::vector<std::string> path_parts = absl::StrSplit(path_str, '.');
+  const auto& metadata = stream_info.dynamicMetadata();
+  return Envoy::Config::Metadata::metadataValue(&metadata, filter_name_str, path_parts);
+}
+
 } // namespace
 
 HeadersMapOptConstRef
@@ -474,26 +486,37 @@ bool ContextAccessor::getDynamicMetadata(const StreamInfo::StreamInfo& stream_in
                                          envoy_dynamic_module_type_module_buffer filter_name,
                                          envoy_dynamic_module_type_module_buffer path,
                                          envoy_dynamic_module_type_envoy_buffer* result) {
-  std::string filter_name_str(filter_name.ptr, filter_name.length);
-  std::string path_str(path.ptr, path.length);
-  std::vector<std::string> path_parts = absl::StrSplit(path_str, '.');
-
-  const auto& metadata = stream_info.dynamicMetadata();
-  const auto& value =
-      Envoy::Config::Metadata::metadataValue(&metadata, filter_name_str, path_parts);
-
-  if (value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
-    return false;
-  }
-
-  // Note: Currently only string values are supported. Complex types would require serialization
-  // to a buffer, but the ABI uses zero-copy pointers to Envoy memory.
+  // String values are returned zero-copy here. Numbers and bools have dedicated typed accessors.
+  const auto& value = dynamicMetadataValue(stream_info, filter_name, path);
   if (value.kind_case() == Protobuf::Value::kStringValue) {
     const auto& str = value.string_value();
     *result = {const_cast<char*>(str.data()), str.size()};
     return true;
   }
+  return false;
+}
 
+bool ContextAccessor::getDynamicMetadataNumber(const StreamInfo::StreamInfo& stream_info,
+                                               envoy_dynamic_module_type_module_buffer filter_name,
+                                               envoy_dynamic_module_type_module_buffer path,
+                                               double* result) {
+  const auto& value = dynamicMetadataValue(stream_info, filter_name, path);
+  if (value.kind_case() == Protobuf::Value::kNumberValue) {
+    *result = value.number_value();
+    return true;
+  }
+  return false;
+}
+
+bool ContextAccessor::getDynamicMetadataBool(const StreamInfo::StreamInfo& stream_info,
+                                             envoy_dynamic_module_type_module_buffer filter_name,
+                                             envoy_dynamic_module_type_module_buffer path,
+                                             bool* result) {
+  const auto& value = dynamicMetadataValue(stream_info, filter_name, path);
+  if (value.kind_case() == Protobuf::Value::kBoolValue) {
+    *result = value.bool_value();
+    return true;
+  }
   return false;
 }
 

--- a/source/extensions/dynamic_modules/abi_context_accessors.h
+++ b/source/extensions/dynamic_modules/abi_context_accessors.h
@@ -57,12 +57,25 @@ public:
   static bool getAttributeBool(const StreamInfo::StreamInfo& stream_info,
                                envoy_dynamic_module_type_attribute_id attribute_id, bool* result);
 
-  // Get a value from dynamic metadata by filter name and dotted key path. Only string values are
-  // returned, matching the zero-copy ABI contract.
+  // Get a string value from dynamic metadata by filter name and dotted key path. Returns false
+  // when the path is absent or the value is not a string.
   static bool getDynamicMetadata(const StreamInfo::StreamInfo& stream_info,
                                  envoy_dynamic_module_type_module_buffer filter_name,
                                  envoy_dynamic_module_type_module_buffer path,
                                  envoy_dynamic_module_type_envoy_buffer* result);
+
+  // Get a number value from dynamic metadata by filter name and dotted key path. Returns false
+  // when the path is absent or the value is not a number.
+  static bool getDynamicMetadataNumber(const StreamInfo::StreamInfo& stream_info,
+                                       envoy_dynamic_module_type_module_buffer filter_name,
+                                       envoy_dynamic_module_type_module_buffer path,
+                                       double* result);
+
+  // Get a bool value from dynamic metadata by filter name and dotted key path. Returns false when
+  // the path is absent or the value is not a bool.
+  static bool getDynamicMetadataBool(const StreamInfo::StreamInfo& stream_info,
+                                     envoy_dynamic_module_type_module_buffer filter_name,
+                                     envoy_dynamic_module_type_module_buffer path, bool* result);
 
   // Get the local reply body from the formatting context. Returns false when there is no body.
   static bool getLocalReplyBody(const Formatter::Context& context,

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -2228,6 +2228,22 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_access_logger_get_dynam
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+    envoy_dynamic_module_type_access_logger_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, double*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number: not "
+               "implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+    envoy_dynamic_module_type_access_logger_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool: not "
+               "implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) bool envoy_dynamic_module_callback_access_logger_get_filter_state(
     envoy_dynamic_module_type_access_logger_envoy_ptr, envoy_dynamic_module_type_module_buffer,
     envoy_dynamic_module_type_envoy_buffer*) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -636,8 +636,10 @@ impl LogContext {
   /// * `key` - The key within the filter namespace (e.g., "rbac_policy").
   ///
   /// # Returns
-  /// The string value if it exists, None otherwise.
-  /// Note: Only string values are currently supported.
+  /// The string value if it exists and is string-typed, None otherwise. Use
+  /// [`get_dynamic_metadata_number`](Self::get_dynamic_metadata_number) or
+  /// [`get_dynamic_metadata_bool`](Self::get_dynamic_metadata_bool) for number- and bool-typed
+  /// values.
   pub fn get_dynamic_metadata(&self, filter_name: &str, key: &str) -> Option<EnvoyBuffer<'_>> {
     let filter_buf = abi::envoy_dynamic_module_type_module_buffer {
       ptr: filter_name.as_ptr() as *const _,
@@ -660,6 +662,70 @@ impl LogContext {
       )
     } {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const u8, result.length) })
+    } else {
+      None
+    }
+  }
+
+  /// Get a number value from dynamic metadata.
+  ///
+  /// # Arguments
+  /// * `filter_name` - The filter namespace (e.g., "envoy.filters.http.dynamic_module").
+  /// * `key` - The key within the filter namespace (e.g., "handshake_state").
+  ///
+  /// # Returns
+  /// The number value if it exists and is number-typed, None otherwise.
+  pub fn get_dynamic_metadata_number(&self, filter_name: &str, key: &str) -> Option<f64> {
+    let filter_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: filter_name.as_ptr() as *const _,
+      length: filter_name.len(),
+    };
+    let key_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: key.as_ptr() as *const _,
+      length: key.len(),
+    };
+    let mut result: f64 = 0.0;
+    if unsafe {
+      abi::envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+        self.envoy_ptr,
+        filter_buf,
+        key_buf,
+        &mut result,
+      )
+    } {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  /// Get a bool value from dynamic metadata.
+  ///
+  /// # Arguments
+  /// * `filter_name` - The filter namespace (e.g., "envoy.filters.http.dynamic_module").
+  /// * `key` - The key within the filter namespace (e.g., "tls_enabled").
+  ///
+  /// # Returns
+  /// The bool value if it exists and is bool-typed, None otherwise.
+  pub fn get_dynamic_metadata_bool(&self, filter_name: &str, key: &str) -> Option<bool> {
+    let filter_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: filter_name.as_ptr() as *const _,
+      length: filter_name.len(),
+    };
+    let key_buf = abi::envoy_dynamic_module_type_module_buffer {
+      ptr: key.as_ptr() as *const _,
+      length: key.len(),
+    };
+    let mut result: bool = false;
+    if unsafe {
+      abi::envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+        self.envoy_ptr,
+        filter_buf,
+        key_buf,
+        &mut result,
+      )
+    } {
+      Some(result)
     } else {
       None
     }

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -1674,6 +1674,156 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNonStringValue) {
                                                                                 key, &result));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNumber) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["handshake_state"] = ValueUtil::numberValue(3.0);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"handshake_state", 15};
+  double result = 0;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+      env_ptr, filter, key, &result));
+  EXPECT_DOUBLE_EQ(3.0, result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNumberZero) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["handshake_state"] = ValueUtil::numberValue(0.0);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"handshake_state", 15};
+  // Initialize to a sentinel to prove that a stored zero is written, not absence.
+  double result = 999.0;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+      env_ptr, filter, key, &result));
+  EXPECT_DOUBLE_EQ(0.0, result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNumberNestedPath) {
+  Protobuf::Struct struct_obj;
+  auto& nested = *(*struct_obj.mutable_fields())["nested"].mutable_struct_value();
+  (*nested.mutable_fields())["handshake_state"] = ValueUtil::numberValue(2.0);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"nested.handshake_state", 22};
+  double result = 0;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+      env_ptr, filter, key, &result));
+  EXPECT_DOUBLE_EQ(2.0, result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNumberNotSet) {
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"handshake_state", 15};
+  double result = 0;
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+      env_ptr, filter, key, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNonNumberValue) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["handshake_state"] = ValueUtil::stringValue("not_a_number");
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"handshake_state", 15};
+  double result = 0;
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+      env_ptr, filter, key, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataBool) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["tls_enabled"] = ValueUtil::boolValue(true);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"tls_enabled", 11};
+  bool result = false;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(env_ptr, filter,
+                                                                                    key, &result));
+  EXPECT_TRUE(result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataBoolFalse) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["tls_enabled"] = ValueUtil::boolValue(false);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"tls_enabled", 11};
+  // Initialize to true to prove that a stored false is written, not absence.
+  bool result = true;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(env_ptr, filter,
+                                                                                    key, &result));
+  EXPECT_FALSE(result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataBoolNotSet) {
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"tls_enabled", 11};
+  bool result = false;
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+      env_ptr, filter, key, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNonBoolValue) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["tls_enabled"] = ValueUtil::numberValue(1.0);
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {"tls_enabled", 11};
+  bool result = false;
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+      env_ptr, filter, key, &result));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, GetRequestId) {
   auto provider = std::make_shared<NiceMock<MockStreamIdProvider>>();
   ON_CALL(*provider, toStringView())

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -798,6 +798,12 @@ WEAK_STUB(AccessLoggerGetDownstreamTransportFailureReason,
 WEAK_STUB(AccessLoggerGetDynamicMetadata,
           envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(nullptr, {nullptr, 0},
                                                                            {nullptr, 0}, nullptr))
+WEAK_STUB(AccessLoggerGetDynamicMetadataNumber,
+          envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number(
+              nullptr, {nullptr, 0}, {nullptr, 0}, nullptr))
+WEAK_STUB(AccessLoggerGetDynamicMetadataBool,
+          envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_bool(
+              nullptr, {nullptr, 0}, {nullptr, 0}, nullptr))
 WEAK_STUB(AccessLoggerGetFilterState,
           envoy_dynamic_module_callback_access_logger_get_filter_state(nullptr, {nullptr, 0},
                                                                        nullptr))

--- a/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
@@ -140,6 +140,11 @@ impl AccessLogger for TestAccessLogger {
     let _request_id = ctx.request_id();
     let _filter_state = ctx.get_filter_state("test_key");
 
+    // Test typed dynamic metadata accessors.
+    let _dm_string = ctx.get_dynamic_metadata("test_filter", "string_key");
+    let _dm_number = ctx.get_dynamic_metadata_number("test_filter", "handshake_state");
+    let _dm_bool = ctx.get_dynamic_metadata_bool("test_filter", "tls_enabled");
+
     // Test tracing (stubs that always return None).
     let _trace_id = ctx.get_trace_id();
     let _span_id = ctx.get_span_id();


### PR DESCRIPTION
## Description

Today, the access logger dynamic modules ABI only surfaced string dynamic metadata. Numeric and bool values returned `false`, so a module reading a numeric field receives `None` and could not classify it correctly.

This PR adds a new `envoy_dynamic_module_callback_access_logger_get_dynamic_metadata_number` and `_bool` callbacks plus matching Rust SDK wrappers, mirroring the existing network and listener typed getters. 

---

**Commit Message:** dynamic_modules: add numeric and bool access logger metadata getters
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** Added