### PR TITLE
http: WebTransport over HTTP/3 core interfaces and extended-CONNECT handling

### DIFF
--- a/changelogs/current/minor_behavior_changes/http__webtransport-upgrade-coercion.rst
+++ b/changelogs/current/minor_behavior_changes/http__webtransport-upgrade-coercion.rst
@@ -1,0 +1,5 @@
+When the runtime guard ``envoy.reloadable_features.web_transport`` is enabled, a ``CONNECT``
+request with ``:protocol`` set to ``webtransport`` is no longer coerced into an HTTP/1 ``Upgrade``
+(the single-bytestream tunneling form used for WebSocket and other extended ``CONNECT`` protocols),
+since that model cannot represent a WebTransport session. This behavior is gated by the guard,
+which defaults to ``false``.

--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -71,6 +71,16 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "web_transport_interface",
+    hdrs = ["web_transport.h"],
+    deps = [
+        "//envoy/common:pure_lib",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
+    ],
+)
+
+envoy_cc_library(
     name = "codes_interface",
     hdrs = ["codes.h"],
     deps = ["//envoy/stats:stats_interface"],

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -40,6 +40,7 @@ struct CodecStats;
 
 class Stream;
 class RequestDecoder;
+class WebTransportSession;
 
 class RequestDecoderHandle {
 public:
@@ -110,6 +111,12 @@ public:
    * absl::nullopt.
    */
   virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
+
+  /**
+   * Return the WebTransport session for this stream, or nullopt if the stream is not a
+   * WebTransport session. Defaulted so only the HTTP/3 stream overrides it.
+   */
+  virtual OptRef<WebTransportSession> webTransport() { return {}; }
 };
 
 /**

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -525,6 +525,12 @@ public:
   virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
 
   /**
+   * Return the WebTransport session associated with the stream, or nullopt if there is none.
+   * Defaulted so existing filters need no change.
+   */
+  virtual OptRef<WebTransportSession> webTransport() { return {}; }
+
+  /**
    * Return a handle to the upstream callbacks. This is valid for upstream HTTP filters, and nullopt
    * for downstream HTTP filters.
    */

--- a/envoy/http/web_transport.h
+++ b/envoy/http/web_transport.h
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "envoy/common/pure.h"
+
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+
+namespace Envoy {
+namespace Http {
+
+/**
+ * Result of a read from a WebTransport stream.
+ */
+struct WebTransportStreamReadResult {
+  size_t bytes_read;
+  bool end_stream;
+};
+
+/**
+ * Application callbacks for a single WebTransport stream.
+ */
+class WebTransportStreamCallbacks {
+public:
+  virtual ~WebTransportStreamCallbacks() = default;
+
+  /**
+   * Called when the stream has data to read or has reached its end.
+   */
+  virtual void onWebTransportStreamData() PURE;
+
+  /**
+   * Called when the stream can accept writes again after a blocked write.
+   */
+  virtual void onWebTransportStreamCanWrite() PURE;
+
+  /**
+   * Called when the peer reset the stream with the given error code.
+   */
+  virtual void onWebTransportStreamReset(uint32_t error_code) PURE;
+
+  /**
+   * Called when the peer asked to stop sending with the given error code.
+   */
+  virtual void onWebTransportStreamStopSending(uint32_t error_code) PURE;
+};
+
+/**
+ * Application surface for a single WebTransport stream. The QUIC layer adapts the vendored QUICHE
+ * stream so consumers avoid QUICHE headers. The session owns the handle and it is valid until the
+ * stream closes.
+ */
+class WebTransportStream {
+public:
+  virtual ~WebTransportStream() = default;
+
+  /**
+   * Whether the stream is bidirectional.
+   */
+  virtual bool bidirectional() const PURE;
+
+  /**
+   * Registers stream-event callbacks. A nullptr detaches the consumer.
+   */
+  virtual void setWebTransportStreamCallbacks(WebTransportStreamCallbacks* callbacks) PURE;
+
+  /**
+   * Reads up to buffer.size() bytes into buffer. The result reports the byte count read and whether
+   * the end of the stream was reached.
+   */
+  virtual WebTransportStreamReadResult readWebTransportStream(absl::Span<char> buffer) PURE;
+
+  /**
+   * Writes the data, optionally ending the stream. Returns false if the stream cannot accept it
+   * now, in which case the caller retries after onWebTransportStreamCanWrite().
+   */
+  virtual bool writeWebTransportStream(absl::string_view data, bool end_stream) PURE;
+
+  /**
+   * Whether the stream can accept a write now.
+   */
+  virtual bool canWriteWebTransportStream() const PURE;
+
+  /**
+   * Resets the write side with the given error code.
+   */
+  virtual void resetWebTransportStream(uint32_t error_code) PURE;
+
+  /**
+   * Asks the peer to stop sending with the given error code.
+   */
+  virtual void stopSendingWebTransportStream(uint32_t error_code) PURE;
+};
+
+/**
+ * Application callbacks for a terminated WebTransport session. Implemented by the HTTP filter.
+ */
+class WebTransportSessionCallbacks {
+public:
+  virtual ~WebTransportSessionCallbacks() = default;
+
+  /**
+   * Called once the session is ready. Delivered synchronously while the accepting response is
+   * encoded.
+   */
+  virtual void onWebTransportSessionReady() PURE;
+
+  /**
+   * Called for each received datagram. The view is valid only during the call.
+   */
+  virtual void onWebTransportDatagram(absl::string_view datagram) PURE;
+
+  /**
+   * Called once when the session closes. No further callbacks or calls are valid afterward.
+   */
+  virtual void onWebTransportSessionClosed() PURE;
+
+  /**
+   * Called when the peer opened a stream. The handle is owned by the session.
+   */
+  virtual void onWebTransportStreamIncoming(WebTransportStream& stream, bool bidirectional) PURE;
+
+  /**
+   * Called when a new outgoing stream of the given kind can be opened after a flow control block.
+   */
+  virtual void onCanCreateWebTransportStream(bool bidirectional) PURE;
+};
+
+/**
+ * Application surface for a terminated WebTransport session. The QUIC layer adapts the vendored
+ * QUICHE session so consumers avoid QUICHE headers. Owned by the codec stream and valid until
+ * onWebTransportSessionClosed() or filter destruction.
+ */
+class WebTransportSession {
+public:
+  virtual ~WebTransportSession() = default;
+
+  /**
+   * Whether the connection is already at its WebTransport session limit. A consumer must reject the
+   * request instead of claiming the session when this is true.
+   */
+  virtual bool sessionLimitExceeded() const PURE;
+
+  /**
+   * Registers session-event callbacks. A nullptr detaches the consumer.
+   */
+  virtual void setWebTransportSessionCallbacks(WebTransportSessionCallbacks* callbacks) PURE;
+
+  /**
+   * Sends a datagram on the session. Datagrams are unreliable and may be dropped.
+   */
+  virtual void sendWebTransportDatagram(absl::string_view datagram) PURE;
+
+  /**
+   * Whether a new outgoing stream of the given kind can be opened now.
+   */
+  virtual bool canOpenWebTransportStream(bool bidirectional) const PURE;
+
+  /**
+   * Opens an outgoing stream, or returns nullptr if flow control blocks it. The session owns the
+   * returned handle.
+   */
+  virtual WebTransportStream* openWebTransportStream(bool bidirectional) PURE;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -2575,6 +2575,10 @@ Http1StreamEncoderOptionsOptRef ConnectionManagerImpl::ActiveStream::http1Stream
   return response_encoder_->http1StreamEncoderOptions();
 }
 
+OptRef<WebTransportSession> ConnectionManagerImpl::ActiveStream::webTransport() {
+  return response_encoder_->webTransport();
+}
+
 void ConnectionManagerImpl::ActiveStream::onResponseDataTooLarge() {
   connection_manager_.stats_.named_.rs_too_large_.inc();
 }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -304,6 +304,7 @@ private:
     void onResponseDataTooLarge() override;
     void onRequestDataTooLarge() override;
     Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
+    OptRef<WebTransportSession> webTransport() override;
     void onLocalReply(Code code) override;
     OptRef<const Tracing::Config> tracingConfig() const override;
     const ScopeTrackedObject& scope() override;

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -345,6 +345,10 @@ Http1StreamEncoderOptionsOptRef ActiveStreamFilterBase::http1StreamEncoderOption
   return parent_.filter_manager_callbacks_.http1StreamEncoderOptions();
 }
 
+OptRef<WebTransportSession> ActiveStreamFilterBase::webTransport() {
+  return parent_.filter_manager_callbacks_.webTransport();
+}
+
 OptRef<DownstreamStreamFilterCallbacks> ActiveStreamFilterBase::downstreamCallbacks() {
   return parent_.filter_manager_callbacks_.downstreamCallbacks();
 }
@@ -1695,12 +1699,23 @@ FilterManager::UpgradeResult
 FilterManager::createUpgradeFilterChain(const FilterChainFactory& filter_chain_factory,
                                         FilterChainFactoryCallbacksImpl& callbacks) {
   const HeaderEntry* upgrade = nullptr;
+  absl::string_view upgrade_type;
   if (filter_manager_callbacks_.requestHeaders()) {
-    upgrade = filter_manager_callbacks_.requestHeaders()->Upgrade();
-
-    // Treat CONNECT requests as a special upgrade case.
-    if (!upgrade && HeaderUtility::isConnect(*filter_manager_callbacks_.requestHeaders())) {
-      upgrade = filter_manager_callbacks_.requestHeaders()->Method();
+    RequestHeaderMap& headers = *filter_manager_callbacks_.requestHeaders();
+    upgrade = headers.Upgrade();
+    if (upgrade != nullptr) {
+      upgrade_type = upgrade->value().getStringView();
+    } else if (HeaderUtility::isConnect(headers)) {
+      // Treat CONNECT requests as a special upgrade case.
+      upgrade = headers.Method();
+      upgrade_type = upgrade->value().getStringView();
+      // A non-coerced WebTransport CONNECT keys on its :protocol so a route opts in with an
+      // upgrade_configs entry of type webtransport.
+      if (headers.Protocol() != nullptr &&
+          headers.getProtocolValue() == Headers::get().ProtocolValues.WebTransport &&
+          Runtime::runtimeFeatureEnabled("envoy.reloadable_features.web_transport")) {
+        upgrade_type = headers.getProtocolValue();
+      }
     }
   }
 
@@ -1710,8 +1725,7 @@ FilterManager::createUpgradeFilterChain(const FilterChainFactory& filter_chain_f
   }
 
   const Router::RouteEntry::UpgradeMap* upgrade_map = filter_manager_callbacks_.upgradeMap();
-  return filter_chain_factory.createUpgradeFilterChain(upgrade->value().getStringView(),
-                                                       upgrade_map, callbacks)
+  return filter_chain_factory.createUpgradeFilterChain(upgrade_type, upgrade_map, callbacks)
              ? UpgradeResult::UpgradeAccepted
              : UpgradeResult::UpgradeRejected;
 }

--- a/source/common/http/filter_manager.h
+++ b/source/common/http/filter_manager.h
@@ -166,6 +166,7 @@ struct ActiveStreamFilterBase : public virtual StreamFilterCallbacks,
   const Router::RouteSpecificFilterConfig* mostSpecificPerFilterConfig() const override;
   Router::RouteSpecificFilterConfigs perFilterConfigs() const override;
   Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() override;
+  OptRef<WebTransportSession> webTransport() override;
   OptRef<DownstreamStreamFilterCallbacks> downstreamCallbacks() override;
   OptRef<UpstreamStreamFilterCallbacks> upstreamCallbacks() override;
   absl::string_view filterConfigName() const override { return filter_context_.config_name; }
@@ -565,6 +566,12 @@ public:
    * Returns the Http1StreamEncoderOptions associated with the response encoder.
    */
   virtual Http1StreamEncoderOptionsOptRef http1StreamEncoderOptions() PURE;
+
+  /**
+   * Returns the WebTransport session associated with the response encoder, or nullopt if there is
+   * none. Defaulted so non-HTTP/3 callbacks need not override it.
+   */
+  virtual OptRef<WebTransportSession> webTransport() { return {}; }
 
   /**
    * Returns the UpstreamStreamFilterCallbacks for upstream HTTP filters.

--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -250,6 +250,11 @@ bool HeaderUtility::isConnectUdpRequest(const RequestHeaderMap& headers) {
                                                      Http::Headers::get().UpgradeValues.ConnectUdp);
 }
 
+bool HeaderUtility::isWebTransportConnectRequest(const RequestHeaderMap& headers) {
+  return headers.getMethodValue() == Http::Headers::get().MethodValues.Connect &&
+         headers.getProtocolValue() == Http::Headers::get().ProtocolValues.WebTransport;
+}
+
 bool HeaderUtility::isConnectUdpResponse(const ResponseHeaderMap& headers) {
   // In connect-udp case, Envoy will transform the H2 headers to H1 upgrade headers.
   // A valid response should have SwitchingProtocol status and connect-udp upgrade.

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -380,6 +380,11 @@ public:
   static bool isConnectUdpRequest(const RequestHeaderMap& headers);
 
   /**
+   * @brief a helper function to determine if the headers represent a WebTransport CONNECT request.
+   */
+  static bool isWebTransportConnectRequest(const RequestHeaderMap& headers);
+
+  /**
    * @brief a helper function to determine if the headers represent a CONNECT-UDP response.
    */
   static bool isConnectUdpResponse(const ResponseHeaderMap& headers);

--- a/source/common/http/headers.h
+++ b/source/common/http/headers.h
@@ -338,6 +338,8 @@ public:
   struct {
     // per https://tools.ietf.org/html/draft-kinnear-httpbis-http2-transport-02
     const std::string Bytestream{"bytestream"};
+    // per https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/
+    const std::string WebTransport{"webtransport"};
   } ProtocolValues;
 
   struct {

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -676,7 +676,11 @@ bool Utility::isUpgrade(const RequestOrResponseHeaderMap& headers) {
 bool Utility::isH2UpgradeRequest(const RequestHeaderMap& headers) {
   return headers.getMethodValue() == Http::Headers::get().MethodValues.Connect &&
          headers.Protocol() && !headers.Protocol()->value().empty() &&
-         headers.Protocol()->value() != Headers::get().ProtocolValues.Bytestream;
+         headers.Protocol()->value() != Headers::get().ProtocolValues.Bytestream &&
+         // WebTransport multiplexes streams and datagrams in one session, which the bytestream
+         // upgrade model cannot represent, so exempt it from coercion like bytestream.
+         !(Runtime::runtimeFeatureEnabled("envoy.reloadable_features.web_transport") &&
+           headers.Protocol()->value() == Headers::get().ProtocolValues.WebTransport);
 }
 
 bool Utility::isH3UpgradeRequest(const RequestHeaderMap& headers) {

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -135,6 +135,8 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_test_feature_false);
 // descriptor_value fields by default.
 FALSE_RUNTIME_GUARD(
     envoy_reloadable_features_enable_formatter_for_ratelimit_action_descriptor_value);
+// TODO(RyanTheOptimist) flip to true once WebTransport over HTTP/3 termination is complete.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_web_transport);
 // TODO(adisuissa) reset to true to enable unified mux by default
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_unified_mux);
 // Used to track if runtime is initialized.

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -1127,6 +1127,20 @@ TEST(HeaderIsValidTest, IsConnectUdpRequest) {
   EXPECT_FALSE(HeaderUtility::isConnectUdpRequest(Http::TestRequestHeaderMapImpl{}));
 }
 
+TEST(HeaderIsValidTest, IsWebTransportConnectRequest) {
+  EXPECT_TRUE(HeaderUtility::isWebTransportConnectRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":protocol", "webtransport"}}));
+  // A different extended CONNECT protocol is not WebTransport.
+  EXPECT_FALSE(HeaderUtility::isWebTransportConnectRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}, {":protocol", "connect-udp"}}));
+  // A plain CONNECT without a protocol is not WebTransport.
+  EXPECT_FALSE(HeaderUtility::isWebTransportConnectRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "CONNECT"}}));
+  EXPECT_FALSE(HeaderUtility::isWebTransportConnectRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"}, {":protocol", "webtransport"}}));
+  EXPECT_FALSE(HeaderUtility::isWebTransportConnectRequest(Http::TestRequestHeaderMapImpl{}));
+}
+
 TEST(HeaderIsValidTest, IsConnectResponse) {
   RequestHeaderMapPtr connect_request{new TestRequestHeaderMapImpl{{":method", "CONNECT"}}};
   RequestHeaderMapPtr get_request{new TestRequestHeaderMapImpl{{":method", "GET"}}};

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -422,6 +422,29 @@ TEST(HttpUtility, H1H2H1Request) {
   ASSERT_EQ(converted_headers, original_headers);
 }
 
+// With the WebTransport runtime guard enabled, a webtransport extended CONNECT is exempted from
+// the HTTP/1 upgrade coercion like bytestream, since the bytestream upgrade model cannot represent
+// a WebTransport session.
+TEST(HttpUtility, WebTransportExtendedConnectIsNotUpgradeWhenEnabled) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.web_transport", "true"}});
+
+  TestRequestHeaderMapImpl headers = {{":method", "CONNECT"}, {":protocol", "webtransport"}};
+  EXPECT_FALSE(Utility::isH2UpgradeRequest(headers));
+  EXPECT_FALSE(Utility::isH3UpgradeRequest(headers));
+}
+
+// With the runtime guard disabled, a webtransport extended CONNECT keeps the legacy behavior and is
+// coerced like any other (non-bytestream) extended CONNECT.
+TEST(HttpUtility, WebTransportExtendedConnectIsUpgradeWhenDisabled) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.web_transport", "false"}});
+
+  TestRequestHeaderMapImpl headers = {{":method", "CONNECT"}, {":protocol", "webtransport"}};
+  EXPECT_TRUE(Utility::isH2UpgradeRequest(headers));
+  EXPECT_TRUE(Utility::isH3UpgradeRequest(headers));
+}
+
 // Start with H2 style websocket request headers. Transform to H1 and back.
 TEST(HttpUtility, H2H1H2Request) {
   TestRequestHeaderMapImpl converted_headers = {{":method", "CONNECT"}, {":protocol", "websocket"}};

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -302,6 +302,38 @@ TEST_F(Http2HeaderValidatorTest, RequestExtendedConnect) {
   EXPECT_EQ(headers.getProtocolValue(), "");
 }
 
+// A webtransport extended CONNECT is coerced to an HTTP/1 upgrade like any other extended CONNECT
+// when the WebTransport runtime guard is disabled (the default).
+TEST_F(Http2HeaderValidatorTest, RequestWebTransportExtendedConnectCoercedWhenDisabled) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.web_transport", "false"}});
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{
+      {":scheme", "https"},  {":method", "CONNECT"},      {":protocol", "webtransport"},
+      {":path", "/foo/bar"}, {":authority", "envoy.com"}, {"x-foo", "bar"}};
+  auto uhv = createH2ServerUhv(empty_config);
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_ACCEPT(uhv->transformRequestHeaders(headers));
+  EXPECT_EQ(headers.getMethodValue(), "GET");
+  EXPECT_EQ(headers.getUpgradeValue(), "webtransport");
+  EXPECT_EQ(headers.getConnectionValue(), "upgrade");
+  EXPECT_EQ(headers.getProtocolValue(), "");
+}
+
+// With the WebTransport runtime guard enabled, a webtransport extended CONNECT is exempted from the
+// upgrade coercion and the pseudo-headers are preserved for the WebTransport path.
+TEST_F(Http2HeaderValidatorTest, RequestWebTransportExtendedConnectPreservedWhenEnabled) {
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.web_transport", "true"}});
+  ::Envoy::Http::TestRequestHeaderMapImpl headers{
+      {":scheme", "https"},  {":method", "CONNECT"},      {":protocol", "webtransport"},
+      {":path", "/foo/bar"}, {":authority", "envoy.com"}, {"x-foo", "bar"}};
+  auto uhv = createH2ServerUhv(empty_config);
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(headers));
+  EXPECT_ACCEPT(uhv->transformRequestHeaders(headers));
+  EXPECT_EQ(headers.getMethodValue(), "CONNECT");
+  EXPECT_EQ(headers.getProtocolValue(), "webtransport");
+  EXPECT_EQ(headers.getPathValue(), "/foo/bar");
+  EXPECT_EQ(headers.Upgrade(), nullptr);
+}
+
 TEST_F(Http2HeaderValidatorTest, RequestExtendedConnectNoScheme) {
   ::Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "CONNECT"},
                                                   {":protocol", "websocket"},

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -283,6 +283,7 @@ public:
   MOCK_METHOD(const Router::RouteSpecificFilterConfig*, mostSpecificPerFilterConfig, (), (const));
   MOCK_METHOD(Router::RouteSpecificFilterConfigs, perFilterConfigs, (), (const));
   MOCK_METHOD(Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
+  MOCK_METHOD(OptRef<WebTransportSession>, webTransport, ());
   MOCK_METHOD(OptRef<DownstreamStreamFilterCallbacks>, downstreamCallbacks, ());
   MOCK_METHOD(OptRef<UpstreamStreamFilterCallbacks>, upstreamCallbacks, ());
   MOCK_METHOD(absl::string_view, filterConfigName, (), (const override));

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1620,6 +1620,7 @@ wakeups
 wamr
 wasmtime
 websocket
+webtransport
 wepoll
 whitespace
 whitespaces


### PR DESCRIPTION
## Description

This PR introduces a new `Http::WebTransport` application interface and the core plumbing for `WebTransport` over HTTP/3.

For now the behavior is gated behind the `envoy.reloadable_features.web_transport` runtime guard, which defaults to `false`.

This is 1 of the 3 changes. The negotiation and termination would follow in later changes.

---

**Commit Message:** http: WebTransport over HTTP/3 core interfaces and extended-CONNECT handling
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added