### PR TITLE
http: add per-cluster upstream client codec factory seam

### DIFF
--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -70,6 +70,10 @@ envoy_cc_library(
     hdrs = ["client_codec_factory.h"],
     deps = [
         ":codec_interface",
+        "//envoy/common:random_generator_interface",
+        "//envoy/network:connection_interface",
+        "//envoy/network:transport_socket_interface",
+        "//envoy/upstream:upstream_interface",
     ],
 )
 

--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -66,6 +66,14 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "client_codec_factory_interface",
+    hdrs = ["client_codec_factory.h"],
+    deps = [
+        ":codec_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "stream_reset_handler_interface",
     hdrs = ["stream_reset_handler.h"],
 )

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "envoy/common/pure.h"
 #include "envoy/http/codec.h"
 
@@ -7,6 +9,7 @@ namespace Envoy {
 
 namespace Network {
 class Connection;
+class TransportSocketOptions;
 } // namespace Network
 
 namespace Random {
@@ -42,6 +45,9 @@ public:
     const Upstream::ClusterInfo& cluster;
     // Random generator for codecs that need it (e.g. HTTP/2).
     Random::RandomGenerator& random;
+    // The transport socket options for the connection, if any. Used e.g. by the HTTP/1 codec to
+    // detect a proxied connection (http11ProxyInfo()).
+    const std::shared_ptr<const Network::TransportSocketOptions>& options;
   };
 
   /**

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <functional>
+
+#include "envoy/http/codec.h"
+
+namespace Envoy {
+
+namespace Network {
+class Connection;
+} // namespace Network
+
+namespace Random {
+class RandomGenerator;
+} // namespace Random
+
+namespace Upstream {
+class ClusterInfo;
+} // namespace Upstream
+
+namespace Http {
+
+/**
+ * Per-cluster factory for the upstream (client) HTTP codec. An implementation is attached to a
+ * cluster via typed_extension_protocol_options and surfaced through
+ * ClusterInfo::upstreamHttpClientCodecFactory().
+ */
+class ClientCodecFactory {
+public:
+  virtual ~ClientCodecFactory() = default;
+
+  /**
+   * Builds the stock client codec that CodecClientProd would otherwise build for this connection.
+   */
+  using CreateDefaultCodecCb = std::function<ClientConnectionPtr()>;
+
+  /**
+   * Everything CodecClientProd hands the stock codecs, so that a fresh codec can be constructed.
+   */
+  struct Context {
+    // The negotiated codec type for this connection.
+    CodecType type;
+    // The underlying network connection the codec runs over.
+    Network::Connection& connection;
+    // The codec connection callbacks (the owning CodecClient).
+    ConnectionCallbacks& callbacks;
+    // The cluster the upstream host belongs to (source of stats, protocol options, header limits).
+    const Upstream::ClusterInfo& cluster;
+    // Random generator for codecs that need it (e.g. HTTP/2).
+    Random::RandomGenerator& random;
+  };
+
+  /**
+   * @param context supplies the materials needed to build a fresh codec.
+   * @param create_default builds the stock codec, for implementations that prefer to decorate.
+   * @return the codec to use for this connection. Returning create_default() is a valid no-op.
+   */
+  virtual ClientConnectionPtr
+  createClientCodec(const Context& context, const CreateDefaultCodecCb& create_default) const PURE;
+};
+
+} // namespace Http
+} // namespace Envoy

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include "envoy/common/pure.h"
 #include "envoy/http/codec.h"
 
 namespace Envoy {

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -3,23 +3,13 @@
 #include <memory>
 
 #include "envoy/common/pure.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/http/codec.h"
+#include "envoy/network/connection.h"
+#include "envoy/network/transport_socket.h"
+#include "envoy/upstream/upstream.h"
 
 namespace Envoy {
-
-namespace Network {
-class Connection;
-class TransportSocketOptions;
-} // namespace Network
-
-namespace Random {
-class RandomGenerator;
-} // namespace Random
-
-namespace Upstream {
-class ClusterInfo;
-} // namespace Upstream
-
 namespace Http {
 
 /**

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-
 #include "envoy/common/pure.h"
 #include "envoy/http/codec.h"
 
@@ -31,11 +29,6 @@ public:
   virtual ~ClientCodecFactory() = default;
 
   /**
-   * Builds the stock client codec that CodecClientProd would otherwise build for this connection.
-   */
-  using CreateDefaultCodecCb = std::function<ClientConnectionPtr()>;
-
-  /**
    * Everything CodecClientProd hands the stock codecs, so that a fresh codec can be constructed.
    */
   struct Context {
@@ -53,11 +46,13 @@ public:
 
   /**
    * @param context supplies the materials needed to build a fresh codec.
-   * @param create_default builds the stock codec, for implementations that prefer to decorate.
-   * @return the codec to use for this connection. Returning create_default() is a valid no-op.
+   * @return the client codec to use for this connection, or nullptr to indicate that the stock
+   *         codec CodecClientProd would otherwise build should be used. An implementation that
+   *         wants to decorate the stock behavior constructs its own codec from @p context (the
+   *         stock codec cannot be wrapped after construction, because intercepting inbound events
+   *         such as GOAWAY requires owning the ConnectionCallbacks at construction time).
    */
-  virtual ClientConnectionPtr
-  createClientCodec(const Context& context, const CreateDefaultCodecCb& create_default) const PURE;
+  virtual ClientConnectionPtr createClientCodec(const Context& context) const PURE;
 };
 
 } // namespace Http

--- a/envoy/http/client_codec_factory.h
+++ b/envoy/http/client_codec_factory.h
@@ -57,6 +57,14 @@ public:
    *         wants to decorate the stock behavior constructs its own codec from @p context (the
    *         stock codec cannot be wrapped after construction, because intercepting inbound events
    *         such as GOAWAY requires owning the ConnectionCallbacks at construction time).
+   *
+   *         An implementation that returns a non-null codec takes over the full construction the
+   *         stock path would otherwise perform. In particular, for an HTTP/3 connection it must
+   *         initialize the QUIC session itself (dynamic_cast context.connection to
+   *         EnvoyQuicClientSession and call Initialize()), since CodecClientProd only does so on
+   *         the stock path. Returning nullptr for unsupported codec types defers to the stock
+   *         codec (e.g. the reverse-tunnel codec handles only HTTP/2 and returns nullptr
+   *         otherwise).
    */
   virtual ClientConnectionPtr createClientCodec(const Context& context) const PURE;
 };

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -917,6 +917,15 @@ using ClusterTimeoutBudgetStatsOptRef =
 class ProtocolOptionsConfig {
 public:
   virtual ~ProtocolOptionsConfig() = default;
+
+  /**
+   * @return an optional upstream (client) HTTP codec factory provided by this options object.
+   *         Defaults to none. An options extension attached via typed_extension_protocol_options
+   *         can override this to make CodecClientProd build a custom or decorated client codec.
+   */
+  virtual OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const {
+    return {};
+  }
 };
 using ProtocolOptionsConfigConstSharedPtr = std::shared_ptr<const ProtocolOptionsConfig>;
 

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -922,6 +922,9 @@ public:
    * @return an optional upstream (client) HTTP codec factory provided by this options object.
    *         Defaults to none. An options extension attached via typed_extension_protocol_options
    *         can override this to make CodecClientProd build a custom or decorated client codec.
+   *         The returned factory's lifetime must be owned by this options object (e.g. by being
+   *         the object itself or a member of it): ClusterInfoImpl pins it with a shared_ptr
+   *         aliasing the options object, so a factory owned elsewhere would dangle.
    */
   virtual OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const {
     return {};

--- a/envoy/upstream/upstream.h
+++ b/envoy/upstream/upstream.h
@@ -34,6 +34,7 @@
 
 namespace Envoy {
 namespace Http {
+class ClientCodecFactory;
 class FilterChainManager;
 class HashPolicy;
 } // namespace Http
@@ -1092,6 +1093,15 @@ public:
   template <class Derived>
   std::shared_ptr<const Derived> extensionProtocolOptionsTyped(const std::string& name) const {
     return std::dynamic_pointer_cast<const Derived>(extensionProtocolOptions(name));
+  }
+
+  /**
+   * @return OptRef<const Http::ClientCodecFactory> a per-cluster factory for the upstream (client)
+   *         HTTP codec, if one was attached via typed_extension_protocol_options. When empty, the
+   *         stock codec is used. Non-pure so that only ClusterInfoImpl has to provide it.
+   */
+  virtual OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const {
+    return {};
   }
 
   /**

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -97,6 +97,7 @@ envoy_cc_library(
         ":status_lib",
         ":utility_lib",
         "//envoy/event:deferred_deletable",
+        "//envoy/http:client_codec_factory_interface",
         "//envoy/http:codec_interface",
         "//envoy/http:header_validator_interface",
         "//envoy/network:connection_interface",

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -292,35 +292,43 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
                                  const Network::TransportSocketOptionsConstSharedPtr& options,
                                  bool should_connect)
     : CodecClient(type, std::move(connection), host, dispatcher) {
-  bool create_default_invoked = false;
-  auto create_default_codec = [&]() -> ClientConnectionPtr {
-    RELEASE_ASSERT(!create_default_invoked,
-                   "upstream codec factory called create_default more than once");
-    create_default_invoked = true;
+  // A per-cluster upstream codec factory (configured via typed_extension_protocol_options) may
+  // build a custom client codec for this connection. It returns nullptr to defer to the stock
+  // codec built below. The stock codec is only constructed when no custom codec is used, because
+  // constructing it has immediate side effects on the connection (e.g. the HTTP/2 codec writes
+  // SETTINGS), so building one we would discard could corrupt the connection.
+  if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
+    codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{
+        type, *connection_, *this, host->cluster(), random_generator});
+  }
+
+  if (codec_ == nullptr) {
     switch (type) {
     case CodecType::HTTP1: {
-      // If the transport socket indicates this is being proxied, inform the HTTP/1.1 codec. It
-      // will send fully qualified URLs iff the underlying transport is plaintext.
+      // If the transport socket indicates this is being proxied, inform the HTTP/1.1 codec. It will
+      // send fully qualified URLs iff the underlying transport is plaintext.
       bool proxied = false;
       if (options && options->http11ProxyInfo().has_value()) {
         proxied = true;
       }
-      return std::make_unique<Http1::ClientConnectionImpl>(
+      codec_ = std::make_unique<Http1::ClientConnectionImpl>(
           *connection_, host->cluster().http1CodecStats(), *this,
           host->cluster().httpProtocolOptions().http1Settings(),
           host->cluster().maxResponseHeadersKb(), host->cluster().maxResponseHeadersCount(),
           proxied);
+      break;
     }
     case CodecType::HTTP2:
-      return std::make_unique<Http2::ClientConnectionImpl>(
+      codec_ = std::make_unique<Http2::ClientConnectionImpl>(
           *connection_, *this, host->cluster().http2CodecStats(), random_generator,
           host->cluster().httpProtocolOptions().http2Options(),
           host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
           host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
+      break;
     case CodecType::HTTP3: {
 #ifdef ENVOY_ENABLE_QUIC
       auto& quic_session = dynamic_cast<Quic::EnvoyQuicClientSession&>(*connection_);
-      auto codec = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
+      codec_ = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
           quic_session, *this, host->cluster().http3CodecStats(),
           host->cluster().httpProtocolOptions().http3Options(),
           host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
@@ -328,27 +336,13 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
       // Initialize the session after max request header size is changed in above http client
       // connection creation.
       quic_session.Initialize();
-      return codec;
+      break;
 #else
       // Should be blocked by configuration checking at an earlier point.
       PANIC("unexpected");
 #endif
     }
     }
-
-    PANIC("unexpected");
-  };
-
-  // A per-cluster upstream codec factory (configured via typed_extension_protocol_options) may
-  // decorate or replace the stock codec built above; create_default hands over that stock codec.
-  if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
-    codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{type, *connection_, *this,
-                                                                          host->cluster(),
-                                                                          random_generator},
-                                        create_default_codec);
-    RELEASE_ASSERT(codec_ != nullptr, "upstream codec factory returned null client codec");
-  } else {
-    codec_ = create_default_codec();
   }
 
   if (should_connect) {

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -299,7 +299,7 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
   // SETTINGS), so building one we would discard could corrupt the connection.
   if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
     codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{
-        type, *connection_, *this, host->cluster(), random_generator});
+        type, *connection_, *this, host->cluster(), random_generator, options});
   }
 
   if (codec_ == nullptr) {

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -335,10 +335,15 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
   // A per-cluster upstream codec factory (configured via typed_extension_protocol_options) may
   // decorate or replace the stock codec built above; create_default hands over that stock codec.
   if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
-    codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{type, *connection_, *this,
-                                                                          host->cluster(),
-                                                                          random_generator},
-                                        [this]() { return std::move(codec_); });
+    codec_ = factory->createClientCodec(
+        Http::ClientCodecFactory::Context{type, *connection_, *this, host->cluster(),
+                                          random_generator},
+        [this]() {
+          RELEASE_ASSERT(codec_ != nullptr, "upstream codec factory called create_default "
+                                            "more than once");
+          return std::move(codec_);
+        });
+    RELEASE_ASSERT(codec_ != nullptr, "upstream codec factory returned null client codec");
   }
 
   if (should_connect) {

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "envoy/http/client_codec_factory.h"
 #include "envoy/http/codec.h"
 
 #include "source/common/common/enum_to_int.h"
@@ -330,6 +331,16 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
 #endif
   }
   }
+
+  // A per-cluster upstream codec factory (configured via typed_extension_protocol_options) may
+  // decorate or replace the stock codec built above; create_default hands over that stock codec.
+  if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
+    codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{type, *connection_, *this,
+                                                                          host->cluster(),
+                                                                          random_generator},
+                                        [this]() { return std::move(codec_); });
+  }
+
   if (should_connect) {
     connect();
   }

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -292,58 +292,63 @@ CodecClientProd::CodecClientProd(CodecType type, Network::ClientConnectionPtr&& 
                                  const Network::TransportSocketOptionsConstSharedPtr& options,
                                  bool should_connect)
     : CodecClient(type, std::move(connection), host, dispatcher) {
-  switch (type) {
-  case CodecType::HTTP1: {
-    // If the transport socket indicates this is being proxied, inform the HTTP/1.1 codec. It will
-    // send fully qualified URLs iff the underlying transport is plaintext.
-    bool proxied = false;
-    if (options && options->http11ProxyInfo().has_value()) {
-      proxied = true;
+  bool create_default_invoked = false;
+  auto create_default_codec = [&]() -> ClientConnectionPtr {
+    RELEASE_ASSERT(!create_default_invoked,
+                   "upstream codec factory called create_default more than once");
+    create_default_invoked = true;
+    switch (type) {
+    case CodecType::HTTP1: {
+      // If the transport socket indicates this is being proxied, inform the HTTP/1.1 codec. It
+      // will send fully qualified URLs iff the underlying transport is plaintext.
+      bool proxied = false;
+      if (options && options->http11ProxyInfo().has_value()) {
+        proxied = true;
+      }
+      return std::make_unique<Http1::ClientConnectionImpl>(
+          *connection_, host->cluster().http1CodecStats(), *this,
+          host->cluster().httpProtocolOptions().http1Settings(),
+          host->cluster().maxResponseHeadersKb(), host->cluster().maxResponseHeadersCount(),
+          proxied);
     }
-    codec_ = std::make_unique<Http1::ClientConnectionImpl>(
-        *connection_, host->cluster().http1CodecStats(), *this,
-        host->cluster().httpProtocolOptions().http1Settings(),
-        host->cluster().maxResponseHeadersKb(), host->cluster().maxResponseHeadersCount(), proxied);
-    break;
-  }
-  case CodecType::HTTP2:
-    codec_ = std::make_unique<Http2::ClientConnectionImpl>(
-        *connection_, *this, host->cluster().http2CodecStats(), random_generator,
-        host->cluster().httpProtocolOptions().http2Options(),
-        host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
-        host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
-    break;
-  case CodecType::HTTP3: {
+    case CodecType::HTTP2:
+      return std::make_unique<Http2::ClientConnectionImpl>(
+          *connection_, *this, host->cluster().http2CodecStats(), random_generator,
+          host->cluster().httpProtocolOptions().http2Options(),
+          host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
+          host->cluster().maxResponseHeadersCount(), Http2::ProdNghttp2SessionFactory::get());
+    case CodecType::HTTP3: {
 #ifdef ENVOY_ENABLE_QUIC
-    auto& quic_session = dynamic_cast<Quic::EnvoyQuicClientSession&>(*connection_);
-    codec_ = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
-        quic_session, *this, host->cluster().http3CodecStats(),
-        host->cluster().httpProtocolOptions().http3Options(),
-        host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
-        host->cluster().maxResponseHeadersCount());
-    // Initialize the session after max request header size is changed in above http client
-    // connection creation.
-    quic_session.Initialize();
-    break;
+      auto& quic_session = dynamic_cast<Quic::EnvoyQuicClientSession&>(*connection_);
+      auto codec = std::make_unique<Quic::QuicHttpClientConnectionImpl>(
+          quic_session, *this, host->cluster().http3CodecStats(),
+          host->cluster().httpProtocolOptions().http3Options(),
+          host->cluster().maxResponseHeadersKb().value_or(Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
+          host->cluster().maxResponseHeadersCount());
+      // Initialize the session after max request header size is changed in above http client
+      // connection creation.
+      quic_session.Initialize();
+      return codec;
 #else
-    // Should be blocked by configuration checking at an earlier point.
-    PANIC("unexpected");
+      // Should be blocked by configuration checking at an earlier point.
+      PANIC("unexpected");
 #endif
-  }
-  }
+    }
+    }
+
+    PANIC("unexpected");
+  };
 
   // A per-cluster upstream codec factory (configured via typed_extension_protocol_options) may
   // decorate or replace the stock codec built above; create_default hands over that stock codec.
   if (auto factory = host->cluster().upstreamHttpClientCodecFactory(); factory.has_value()) {
-    codec_ = factory->createClientCodec(
-        Http::ClientCodecFactory::Context{type, *connection_, *this, host->cluster(),
-                                          random_generator},
-        [this]() {
-          RELEASE_ASSERT(codec_ != nullptr, "upstream codec factory called create_default "
-                                            "more than once");
-          return std::move(codec_);
-        });
+    codec_ = factory->createClientCodec(Http::ClientCodecFactory::Context{type, *connection_, *this,
+                                                                          host->cluster(),
+                                                                          random_generator},
+                                        create_default_codec);
     RELEASE_ASSERT(codec_ != nullptr, "upstream codec factory returned null client codec");
+  } else {
+    codec_ = create_default_codec();
   }
 
   if (should_connect) {

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -469,6 +469,7 @@ envoy_cc_library(
         ":upstream_factory_context_lib",
         "//envoy/event:timer_interface",
         "//envoy/filter:config_provider_manager_interface",
+        "//envoy/http:client_codec_factory_interface",
         "//envoy/local_info:local_info_interface",
         "//envoy/network:dns_interface",
         "//envoy/runtime:runtime_interface",

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1,5 +1,6 @@
 #include "source/common/upstream/upstream_impl.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <limits>
@@ -143,11 +144,19 @@ parseExtensionProtocolOptions(
 
 // Recovers a per-cluster upstream (client) codec factory from the parsed extension protocol
 // options: an options object that also implements Http::ClientCodecFactory is treated as the
-// factory. At most one is expected; the first match wins.
+// factory. At most one is expected.
 std::shared_ptr<const Http::ClientCodecFactory> findUpstreamHttpClientCodecFactory(
     const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>& options) {
+  std::vector<std::string> option_names;
+  option_names.reserve(options.size());
   for (const auto& entry : options) {
-    if (auto factory = std::dynamic_pointer_cast<const Http::ClientCodecFactory>(entry.second);
+    option_names.push_back(entry.first);
+  }
+  std::sort(option_names.begin(), option_names.end());
+
+  for (const auto& name : option_names) {
+    const auto& option = options.at(name);
+    if (auto factory = std::dynamic_pointer_cast<const Http::ClientCodecFactory>(option);
         factory != nullptr) {
       return factory;
     }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -141,6 +141,20 @@ parseExtensionProtocolOptions(
   return options;
 }
 
+// Recovers a per-cluster upstream (client) codec factory from the parsed extension protocol
+// options: an options object that also implements Http::ClientCodecFactory is treated as the
+// factory. At most one is expected; the first match wins.
+std::shared_ptr<const Http::ClientCodecFactory> findUpstreamHttpClientCodecFactory(
+    const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>& options) {
+  for (const auto& entry : options) {
+    if (auto factory = std::dynamic_pointer_cast<const Http::ClientCodecFactory>(entry.second);
+        factory != nullptr) {
+      return factory;
+    }
+  }
+  return nullptr;
+}
+
 // Updates the EDS health flags for an existing host to match the new host.
 // @param updated_host the new host to read health flag values from.
 // @param existing_host the host to update.
@@ -1148,6 +1162,8 @@ ClusterInfoImpl::ClusterInfoImpl(
               : nullptr),
       extension_protocol_options_(THROW_OR_RETURN_VALUE(
           parseExtensionProtocolOptions(config, factory_context), ProtocolOptionsHashMap)),
+      upstream_client_codec_factory_(
+          findUpstreamHttpClientCodecFactory(extension_protocol_options_)),
       http_protocol_options_(THROW_OR_RETURN_VALUE(
           createOptions(config,
                         extensionProtocolOptionsTyped<HttpProtocolOptionsConfigImpl>(

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -159,7 +159,7 @@ absl::StatusOr<std::shared_ptr<const Http::ClientCodecFactory>> findUpstreamHttp
           "typed_extension_protocol_options; at most one is allowed");
     }
     // Aliasing shared_ptr: shares ownership with the options object (the factory and the options
-    // object are the same instance) while pointing at the ClientCodecFactory subobject.
+    // object are the same instance) while exposing it as a ClientCodecFactory.
     found = std::shared_ptr<const Http::ClientCodecFactory>(option, &factory.ref());
   }
   return found;

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -142,26 +142,27 @@ parseExtensionProtocolOptions(
   return options;
 }
 
-// Recovers a per-cluster upstream (client) codec factory from the parsed extension protocol
-// options: an options object that also implements Http::ClientCodecFactory is treated as the
-// factory. At most one is expected.
-std::shared_ptr<const Http::ClientCodecFactory> findUpstreamHttpClientCodecFactory(
+// Recovers the per-cluster upstream (client) codec factory from the parsed protocol options. Any
+// options object may expose one via ProtocolOptionsConfig::upstreamHttpClientCodecFactory(); at
+// most one is allowed across all configured options.
+absl::StatusOr<std::shared_ptr<const Http::ClientCodecFactory>> findUpstreamHttpClientCodecFactory(
     const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>& options) {
-  std::vector<std::string> option_names;
-  option_names.reserve(options.size());
-  for (const auto& entry : options) {
-    option_names.push_back(entry.first);
-  }
-  std::sort(option_names.begin(), option_names.end());
-
-  for (const auto& name : option_names) {
-    const auto& option = options.at(name);
-    if (auto factory = std::dynamic_pointer_cast<const Http::ClientCodecFactory>(option);
-        factory != nullptr) {
-      return factory;
+  std::shared_ptr<const Http::ClientCodecFactory> found;
+  for (const auto& [name, option] : options) {
+    OptRef<const Http::ClientCodecFactory> factory = option->upstreamHttpClientCodecFactory();
+    if (!factory.has_value()) {
+      continue;
     }
+    if (found != nullptr) {
+      return absl::InvalidArgumentError(
+          "multiple upstream HTTP client codec factories configured on a single cluster via "
+          "typed_extension_protocol_options; at most one is allowed");
+    }
+    // Aliasing shared_ptr: shares ownership with the options object (the factory and the options
+    // object are the same instance) while pointing at the ClientCodecFactory subobject.
+    found = std::shared_ptr<const Http::ClientCodecFactory>(option, &factory.ref());
   }
-  return nullptr;
+  return found;
 }
 
 // Updates the EDS health flags for an existing host to match the new host.
@@ -1172,7 +1173,8 @@ ClusterInfoImpl::ClusterInfoImpl(
       extension_protocol_options_(THROW_OR_RETURN_VALUE(
           parseExtensionProtocolOptions(config, factory_context), ProtocolOptionsHashMap)),
       upstream_client_codec_factory_(
-          findUpstreamHttpClientCodecFactory(extension_protocol_options_)),
+          THROW_OR_RETURN_VALUE(findUpstreamHttpClientCodecFactory(extension_protocol_options_),
+                                std::shared_ptr<const Http::ClientCodecFactory>)),
       http_protocol_options_(THROW_OR_RETURN_VALUE(
           createOptions(config,
                         extensionProtocolOptionsTyped<HttpProtocolOptionsConfigImpl>(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -23,6 +23,7 @@
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
 #include "envoy/config/typed_metadata.h"
 #include "envoy/event/timer.h"
+#include "envoy/http/client_codec_factory.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/network/dns.h"
 #include "envoy/network/filter.h"
@@ -906,6 +907,9 @@ public:
                                    Server::Configuration::ServerFactoryContext& context);
   ProtocolOptionsConfigConstSharedPtr
   extensionProtocolOptions(const std::string& name) const override;
+  OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const override {
+    return makeOptRefFromPtr(upstream_client_codec_factory_.get());
+  }
   envoy::config::cluster::v3::Cluster::DiscoveryType type() const override { return type_; }
 
   OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>
@@ -1090,6 +1094,10 @@ private:
   const std::unique_ptr<const std::string> eds_service_name_;
   const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>
       extension_protocol_options_;
+  // Per-cluster upstream (client) codec factory, recovered from extension_protocol_options_ (an
+  // options entry that also implements the factory interface). Held to pin lifetime;
+  // upstreamHttpClientCodecFactory() returns a view into it.
+  const std::shared_ptr<const Http::ClientCodecFactory> upstream_client_codec_factory_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
   const std::shared_ptr<const TcpProtocolOptionsConfigImpl> tcp_protocol_options_;
   const uint32_t max_requests_per_connection_;

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test(
         "//source/common/event:dispatcher_lib",
         "//source/common/http:codec_client_lib",
         "//source/common/http:exception_lib",
+        "//source/common/network:transport_socket_options_lib",
         "//source/common/network:utility_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -67,6 +67,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         ":common_lib",
+        "//envoy/http:client_codec_factory_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/event:dispatcher_lib",
         "//source/common/http:codec_client_lib",

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -140,14 +140,12 @@ TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {
 
 class MockClientCodecFactory : public ClientCodecFactory {
 public:
-  MOCK_METHOD(ClientConnectionPtr, createClientCodec,
-              (const Context& context, const CreateDefaultCodecCb& create_default), (const));
+  MOCK_METHOD(ClientConnectionPtr, createClientCodec, (const Context& context), (const));
 };
 
-// When a cluster exposes an upstream ClientCodecFactory, CodecClientProd consults it, hands it a
-// thunk that yields the stock codec, and installs the codec the factory returns. Uses a bare
-// fixture-less test because it constructs a real CodecClientProd rather than the fixture's
-// CodecClientForTest.
+// When a cluster exposes an upstream ClientCodecFactory, CodecClientProd consults it and installs
+// the codec the factory returns (the stock codec is not built). Uses a bare fixture-less test
+// because it constructs a real CodecClientProd rather than the fixture's CodecClientForTest.
 TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsed) {
   NiceMock<Event::MockDispatcher> dispatcher;
   NiceMock<Random::MockRandomGenerator> random;
@@ -159,24 +157,44 @@ TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsed) {
   ON_CALL(*cluster, upstreamHttpClientCodecFactory())
       .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
 
-  bool stock_codec_built = false;
-  EXPECT_CALL(*factory, createClientCodec(_, _))
-      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context,
-                           const ClientCodecFactory::CreateDefaultCodecCb& create_default)
-                           -> ClientConnectionPtr {
+  // The factory returns its own codec; CodecClientProd must install it verbatim. Use a sentinel
+  // protocol (HTTP/2) distinct from the stock HTTP/1 codec to prove the returned codec is used.
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context) -> ClientConnectionPtr {
         EXPECT_EQ(CodecType::HTTP1, context.type);
         EXPECT_EQ(cluster.get(), &context.cluster);
-        // The thunk hands over the stock codec CodecClientProd already built.
-        ClientConnectionPtr stock = create_default();
-        stock_codec_built = (stock != nullptr);
-        return std::make_unique<NiceMock<MockClientConnection>>();
+        auto codec = std::make_unique<NiceMock<MockClientConnection>>();
+        ON_CALL(*codec, protocol()).WillByDefault(Return(Protocol::Http2));
+        return codec;
       }));
 
   auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
   CodecClientProd client(CodecType::HTTP1, std::move(connection), host, dispatcher, random, nullptr,
                          /*should_connect=*/false);
 
-  EXPECT_TRUE(stock_codec_built);
+  EXPECT_EQ(Protocol::Http2, client.protocol());
+}
+
+// A factory that returns nullptr defers to the stock codec, which CodecClientProd then builds.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryNullptrUsesStockCodec) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke(
+          [](const ClientCodecFactory::Context&) -> ClientConnectionPtr { return nullptr; }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP1, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+  // The factory declined, so the stock HTTP/1 codec is installed.
+  EXPECT_EQ(Protocol::Http11, client.protocol());
 }
 
 // With no factory configured (the default), CodecClientProd builds the stock codec.

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -1,5 +1,7 @@
 #include <memory>
 
+#include "envoy/http/client_codec_factory.h"
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/event/dispatcher_impl.h"
 #include "source/common/http/codec_client.h"
@@ -134,6 +136,62 @@ TEST_F(CodecClientTest, BasicHeaderOnlyResponse) {
   ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
   EXPECT_CALL(outer_decoder, decodeHeaders_(Pointee(Ref(*response_headers)), true));
   inner_decoder->decodeHeaders(std::move(response_headers), true);
+}
+
+class MockClientCodecFactory : public ClientCodecFactory {
+public:
+  MOCK_METHOD(ClientConnectionPtr, createClientCodec,
+              (const Context& context, const CreateDefaultCodecCb& create_default), (const));
+};
+
+// When a cluster exposes an upstream ClientCodecFactory, CodecClientProd consults it, hands it a
+// thunk that yields the stock codec, and installs the codec the factory returns. Uses a bare
+// fixture-less test because it constructs a real CodecClientProd rather than the fixture's
+// CodecClientForTest.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsed) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+
+  bool stock_codec_built = false;
+  EXPECT_CALL(*factory, createClientCodec(_, _))
+      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context,
+                           const ClientCodecFactory::CreateDefaultCodecCb& create_default)
+                           -> ClientConnectionPtr {
+        EXPECT_EQ(CodecType::HTTP1, context.type);
+        EXPECT_EQ(cluster.get(), &context.cluster);
+        // The thunk hands over the stock codec CodecClientProd already built.
+        ClientConnectionPtr stock = create_default();
+        stock_codec_built = (stock != nullptr);
+        return std::make_unique<NiceMock<MockClientConnection>>();
+      }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP1, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+
+  EXPECT_TRUE(stock_codec_built);
+}
+
+// With no factory configured (the default), CodecClientProd builds the stock codec.
+TEST(CodecClientProdTest, NoUpstreamClientCodecFactoryUsesStockCodec) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP1, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+  // No factory consulted; the stock HTTP/1 codec is installed.
+  EXPECT_EQ(Protocol::Http11, client.protocol());
 }
 
 TEST_F(CodecClientTest, BasicResponseWithBody) {

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -163,6 +163,7 @@ TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsed) {
       .WillOnce(Invoke([&](const ClientCodecFactory::Context& context) -> ClientConnectionPtr {
         EXPECT_EQ(CodecType::HTTP1, context.type);
         EXPECT_EQ(cluster.get(), &context.cluster);
+        EXPECT_EQ(nullptr, context.options);
         auto codec = std::make_unique<NiceMock<MockClientConnection>>();
         ON_CALL(*codec, protocol()).WillByDefault(Return(Protocol::Http2));
         return codec;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -248,6 +248,34 @@ TEST(CodecClientProdTest, UpstreamClientCodecFactoryNullptrUsesStockCodecHttp2) 
   EXPECT_EQ(Protocol::Http2, client.protocol());
 }
 
+// For HTTP/3 the factory is consulted and owns full construction. The factory returns its own codec
+// without touching the connection, so the stock QUIC path (which would dynamic_cast the connection
+// to EnvoyQuicClientSession and call Initialize()) is skipped; that this runs against a plain mock
+// connection without crashing is the proof the stock path was not taken.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsedHttp3) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context) -> ClientConnectionPtr {
+        EXPECT_EQ(CodecType::HTTP3, context.type);
+        auto codec = std::make_unique<NiceMock<MockClientConnection>>();
+        ON_CALL(*codec, protocol()).WillByDefault(Return(Protocol::Http3));
+        return codec;
+      }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP3, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+  EXPECT_EQ(Protocol::Http3, client.protocol());
+}
+
 // The transport socket options are forwarded to the factory verbatim.
 TEST(CodecClientProdTest, UpstreamClientCodecFactoryReceivesTransportSocketOptions) {
   NiceMock<Event::MockDispatcher> dispatcher;

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -8,6 +8,7 @@
 #include "source/common/http/exception.h"
 #include "source/common/network/listen_socket_impl.h"
 #include "source/common/network/tcp_listener_impl.h"
+#include "source/common/network/transport_socket_options_impl.h"
 #include "source/common/network/utility.h"
 #include "source/common/stream_info/stream_info_impl.h"
 #include "source/common/upstream/upstream_impl.h"
@@ -196,6 +197,80 @@ TEST(CodecClientProdTest, UpstreamClientCodecFactoryNullptrUsesStockCodec) {
                          /*should_connect=*/false);
   // The factory declined, so the stock HTTP/1 codec is installed.
   EXPECT_EQ(Protocol::Http11, client.protocol());
+}
+
+// The factory is consulted for HTTP/2 connections as well; the returned codec is installed.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryIsUsedHttp2) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+
+  // Sentinel protocol HTTP/1 (distinct from the stock HTTP/2 codec) proves the returned codec is
+  // installed verbatim rather than the stock one being built.
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context) -> ClientConnectionPtr {
+        EXPECT_EQ(CodecType::HTTP2, context.type);
+        auto codec = std::make_unique<NiceMock<MockClientConnection>>();
+        ON_CALL(*codec, protocol()).WillByDefault(Return(Protocol::Http11));
+        return codec;
+      }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP2, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+  EXPECT_EQ(Protocol::Http11, client.protocol());
+}
+
+// A factory that returns nullptr for an HTTP/2 connection defers to the stock HTTP/2 codec.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryNullptrUsesStockCodecHttp2) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke(
+          [](const ClientCodecFactory::Context&) -> ClientConnectionPtr { return nullptr; }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP2, std::move(connection), host, dispatcher, random, nullptr,
+                         /*should_connect=*/false);
+  EXPECT_EQ(Protocol::Http2, client.protocol());
+}
+
+// The transport socket options are forwarded to the factory verbatim.
+TEST(CodecClientProdTest, UpstreamClientCodecFactoryReceivesTransportSocketOptions) {
+  NiceMock<Event::MockDispatcher> dispatcher;
+  NiceMock<Random::MockRandomGenerator> random;
+  auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  Upstream::HostDescriptionConstSharedPtr host =
+      Upstream::makeTestHostDescription(cluster, "tcp://127.0.0.1:80");
+
+  auto factory = std::make_shared<NiceMock<MockClientCodecFactory>>();
+  ON_CALL(*cluster, upstreamHttpClientCodecFactory())
+      .WillByDefault(Return(OptRef<const ClientCodecFactory>(*factory)));
+
+  Network::TransportSocketOptionsConstSharedPtr transport_options =
+      std::make_shared<Network::TransportSocketOptionsImpl>();
+  EXPECT_CALL(*factory, createClientCodec(_))
+      .WillOnce(Invoke([&](const ClientCodecFactory::Context& context) -> ClientConnectionPtr {
+        EXPECT_EQ(transport_options.get(), context.options.get());
+        return std::make_unique<NiceMock<MockClientConnection>>();
+      }));
+
+  auto connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  CodecClientProd client(CodecType::HTTP1, std::move(connection), host, dispatcher, random,
+                         transport_options, /*should_connect=*/false);
 }
 
 // With no factory configured (the default), CodecClientProd builds the stock codec.

--- a/test/common/upstream/BUILD
+++ b/test/common/upstream/BUILD
@@ -585,6 +585,7 @@ envoy_cc_test(
         ":test_local_address_selector",
         ":utility_lib",
         "//envoy/api:api_interface",
+        "//envoy/http:client_codec_factory_interface",
         "//envoy/http:codec_interface",
         "//envoy/upstream:cluster_manager_interface",
         "//source/common/config:metadata_lib",

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -12,6 +12,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/health_check.pb.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
+#include "envoy/http/client_codec_factory.h"
 #include "envoy/http/codec.h"
 #include "envoy/network/address.h"
 #include "envoy/stats/scope.h"
@@ -5441,6 +5442,78 @@ public:
   TestFilterConfigFactoryBase& parent_;
 };
 struct TestFilterProtocolOptionsConfig : public Upstream::ProtocolOptionsConfig {};
+
+// A protocol options object that also exposes an upstream client codec factory via the
+// ProtocolOptionsConfig hook. Used to verify that configuring more than one such factory on a
+// single cluster is rejected.
+struct TestCodecFactoryProtocolOptions : public Upstream::ProtocolOptionsConfig,
+                                         public Http::ClientCodecFactory {
+  OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const override {
+    return *this;
+  }
+  Http::ClientConnectionPtr createClientCodec(const Context&) const override { return nullptr; }
+};
+
+// A network filter config factory (registered under a configurable name) whose protocol options
+// object implements ClientCodecFactory.
+class TestCodecFactoryConfigFactory
+    : public Server::Configuration::NamedNetworkFilterConfigFactory {
+public:
+  explicit TestCodecFactoryConfigFactory(std::string name) : name_(std::move(name)) {}
+
+  absl::StatusOr<Network::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message&,
+                               Server::Configuration::FactoryContext&) override {
+    PANIC("not implemented");
+  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override { PANIC("not implemented"); }
+  ProtobufTypes::MessagePtr createEmptyProtocolOptionsProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+  absl::StatusOr<Upstream::ProtocolOptionsConfigConstSharedPtr>
+  createProtocolOptionsConfig(const Protobuf::Message&,
+                              Server::Configuration::ProtocolOptionsFactoryContext&) override {
+    return std::make_shared<TestCodecFactoryProtocolOptions>();
+  }
+  std::string name() const override { return name_; }
+  std::set<std::string> configTypes() override { return {}; };
+
+  const std::string name_;
+};
+
+// Configuring two protocol options objects that both expose a ClientCodecFactory on the same
+// cluster is a misconfiguration and must be rejected deterministically.
+TEST_F(ClusterInfoImplTest, MultipleUpstreamClientCodecFactoriesRejected) {
+  TestCodecFactoryConfigFactory factory_a("envoy.test.codec_a");
+  TestCodecFactoryConfigFactory factory_b("envoy.test.codec_b");
+  Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> registry_a(
+      factory_a);
+  Registry::InjectFactory<Server::Configuration::NamedNetworkFilterConfigFactory> registry_b(
+      factory_b);
+
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: foo.bar.com
+                    port_value: 443
+    typed_extension_protocol_options:
+      envoy.test.codec_a: { "@type": type.googleapis.com/google.protobuf.Struct }
+      envoy.test.codec_b: { "@type": type.googleapis.com/google.protobuf.Struct }
+  )EOF";
+
+  EXPECT_THROW_WITH_MESSAGE(
+      makeCluster(yaml), EnvoyException,
+      "multiple upstream HTTP client codec factories configured on a single cluster via "
+      "typed_extension_protocol_options; at most one is allowed");
+}
 
 // Cluster extension protocol options fails validation when configured for filter that does not
 // support options.

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -131,6 +131,7 @@ public:
   MOCK_METHOD(envoy::config::cluster::v3::Cluster::DiscoveryType, type, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>, clusterType, (),
               (const));
+  MOCK_METHOD(OptRef<const Http::ClientCodecFactory>, upstreamHttpClientCodecFactory, (), (const));
   MOCK_METHOD(OptRef<const envoy::config::core::v3::TypedExtensionConfig>, upstreamConfig, (),
               (const));
   MOCK_METHOD(bool, maintenanceMode, (), (const));


### PR DESCRIPTION
Commit Message: http: add per-cluster upstream client codec factory seam

Additional Description:
Adds `Http::ClientCodecFactory`, an optional per-cluster extension point for building the upstream
(client) HTTP codec. It is discovered from `typed_extension_protocol_options` and surfaced via a new
non-pure `ClusterInfo::upstreamHttpClientCodecFactory()` accessor that defaults to empty.
`CodecClientProd` invokes the factory when present, handing it a thunk that builds the stock codec,
so an implementation can either decorate the stock codec or return a fresh one. With no factory
configured the stock codec is built exactly as before and behavior is unchanged.

Motivating use case: reverse tunnels invert the HTTP roles -- the connection is dialed from the
downstream to the upstream, but HTTP requests then flow from the upstream to the downstream over
that tunnel, so the upstream is the HTTP/2 client and the downstream is the HTTP/2 server. Graceful
drain of such a tunnel needs cooperation in both directions and both land on the upstream (client)
codec: when the upstream is draining it must signal the downstream to dial a replacement connection
while in-flight requests finish; when the downstream is draining it must tell the upstream to stop
sending new requests and let the downstream re-establish, again finishing in-flight requests.
Neither is expressible with the stock upstream codec, and Envoy currently has no per-cluster hook to
substitute the upstream (client) codec (`CodecClientProd` hard-codes it by protocol). This change
adds that hook generically; the reverse-tunnel codec that uses it is a follow-up change.

Reverse-tunnel implementation that uses this seam (in the ivpr/envoy fork): the upstream drain-aware client codec (https://github.com/ivpr/envoy/pull/4) and the downstream drain-aware HCM that dials a replacement tunnel (https://github.com/ivpr/envoy/pull/5).

## Reverse-tunnel graceful drain (sequence diagram)

```mermaid
sequenceDiagram
    autonumber
    participant D as Downstream
    participant U as Upstream

    Note over D,U: Reverse tunnel setup - unlike a normal hop, the downstream dials OUT to the upstream
    D->>U: open TCP connection and initiate reverse tunnel
    U-->>D: tunnel established
    Note over D,U: On the established tunnel the upstream is the HTTP/2 client and the downstream is the HTTP/2 server, so requests flow from upstream to downstream
    U->>D: request over tunnel
    D-->>U: 200

    Note over D,U: Upstream graceful drain
    U->>D: GOAWAY - drain signal toward downstream
    D->>D: dial a replacement tunnel to a healthy upstream
    U->>D: in-flight request continues on the old tunnel
    D-->>U: 200
    Note over D,U: old tunnel closes once idle, new requests use the replacement

    Note over D,U: Downstream graceful drain
    D->>U: GOAWAY - tell upstream to stop sending new requests
    U->>U: drain pool, route new requests to the replacement tunnel
    U->>D: in-flight request continues on the old tunnel
    D-->>U: 200
    Note over D,U: downstream re-establishes, old tunnel closes once idle
```

Risk Level: Low -- new, opt-in per-cluster extension point. When no factory is configured the stock
codec is used and there is no behavior change.

Testing: `//test/common/http:codec_client_test` covers the unchanged no-factory path. A dedicated
unit test for the factory-injection path is a planned follow-up.

Docs Changes: None (the new interface is documented inline in `envoy/http/client_codec_factory.h`).

Release Notes: None (extension point only; no user-facing behavior change on its own).

Platform Specific Features: None.

Runtime guard: None (this PR adds no runtime-guarded behavior).

API Considerations: No xDS/proto API changes. Adds one new C++ extension interface
(`envoy/http/client_codec_factory.h`) and a non-pure `ClusterInfo::upstreamHttpClientCodecFactory()`
accessor that defaults to empty, so existing `ClusterInfo` implementations are unaffected.
