### PR TITLE
reverse tunnel: add downstream circuit breaker toggle and configurable maintenance interval

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -5,7 +5,10 @@ package envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3
 import "envoy/config/accesslog/v3/accesslog.proto";
 import "envoy/config/core/v3/base.proto";
 
+import "google/protobuf/duration.proto";
+
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3";
 option java_outer_classname = "DownstreamReverseConnectionSocketInterfaceProto";
@@ -19,6 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for the downstream reverse connection socket interface.
 // This interface initiates reverse connections to upstream Envoys and provides
 // them as socket connections for downstream requests.
+// [#next-free-field: 7]
 message DownstreamReverseConnectionSocketInterface {
   // HTTP handshake settings for initiator envoy initiated reverse tunnels.
   message HttpHandshakeConfig {
@@ -53,4 +57,16 @@ message DownstreamReverseConnectionSocketInterface {
   // Reverse tunnel metadata (``node_id``, ``cluster_id``, ``tenant_id``, upstream cluster, etc.)
   // is available via ``%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:*)%`` substitutions.
   repeated config.accesslog.v3.AccessLog access_log = 4;
+
+  // Disable circuit breaker for reverse connections.
+  // When enabled, the initiator envoy will not place a cluster in backoff when reverse
+  // connection attempts fail.
+  // Defaults to ``false`` i.e. circuit breaker is enabled.
+  bool disable_circuit_breaker = 5;
+
+  // Interval between reverse-connection maintenance passes. On each pass the initiator
+  // re-attempts any missing reverse connections to the configured upstream tunnel hosts.
+  // Defaults to 10s. Must be greater than or equal to 1ms.
+  google.protobuf.Duration maintenance_interval = 6
+      [(validate.rules).duration = {gte {nanos: 1000000}}];
 }

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -891,11 +891,17 @@ void ReverseConnectionIOHandle::maintainReverseConnections() {
 
   // Enable the retry timer to periodically check for missing connections (like maintainConnCount)
   if (rev_conn_retry_timer_) {
-    // TODO(basundhara-c): Make the retry timeout configurable.
-    const std::chrono::milliseconds retry_timeout(10000); // 10 seconds
+    auto retry_timeout = maintenanceInterval();
     rev_conn_retry_timer_->enableTimer(retry_timeout);
-    ENVOY_LOG(debug, "Enabled retry timer for next connection check in 10 seconds.");
+    ENVOY_LOG(debug, "Enabled retry timer for next connection check in {} ms.",
+              retry_timeout.count());
   }
+}
+
+const std::chrono::milliseconds ReverseConnectionIOHandle::maintenanceInterval() const {
+  return extension_ ? extension_->maintenanceInterval()
+                    : std::chrono::milliseconds(
+                          ReverseTunnelInitiatorExtension::DefaultMaintenanceIntervalMs);
 }
 
 bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& cluster_name,

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -311,6 +311,19 @@ public:
   const std::string& requestPath() const { return config_.request_path; }
 
   /**
+   * @return whether per-host failure backoff (the reverse connection circuit breaker) is active for
+   * this handle. When false, connection attempts are never suppressed regardless of prior failures.
+   */
+  bool circuitBreakerEnabled() const { return config_.enable_circuit_breaker; }
+
+  /**
+   * @return the interval between reverse-connection maintenance passes, sourced from the bootstrap
+   * extension's ``maintenance_interval`` (or the default when no extension is wired). Drives the
+   * cadence of the retry timer that re-attempts missing reverse connections.
+   */
+  const std::chrono::milliseconds maintenanceInterval() const;
+
+  /**
    * @return reference to the additional headers for the handshake request.
    */
   const std::vector<envoy::config::core::v3::HeaderValueOption>& additionalHeaders() const {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
@@ -129,6 +129,7 @@ ReverseTunnelInitiator::socket(Envoy::Network::Socket::Type socket_type,
       socket_config.request_path = extension_->handshakeRequestPath();
       socket_config.additional_headers = extension_->handshakeAdditionalHeaders();
       socket_config.use_http_upgrade = extension_->handshakeUsesHttpUpgrade();
+      socket_config.enable_circuit_breaker = !extension_->disableCircuitBreaker();
     }
 
     // Pass config directly to helper method.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -24,7 +24,9 @@ ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
     Server::Configuration::ServerFactoryContext& context,
     const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
         DownstreamReverseConnectionSocketInterface& config)
-    : context_(context), config_(config) {
+    : context_(context), config_(config),
+      maintenance_interval_(
+          PROTOBUF_GET_MS_OR_DEFAULT(config, maintenance_interval, DefaultMaintenanceIntervalMs)) {
   stat_prefix_ = PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_initiator");
   // Configure detailed stats flag (defaults to false).
   enable_detailed_stats_ = config.enable_detailed_stats();

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -151,6 +152,19 @@ public:
     tls_slot_ = std::move(slot);
   }
 
+  // Default reverse-connection maintenance interval (in milliseconds) applied when the optional
+  // ``maintenance_interval`` field is unset on the bootstrap extension. Kept at 10s to bound
+  // reconnect latency without churning connections to the upstream tunnel when a host is
+  // unreachable; override via ``maintenance_interval`` for tighter reconnect loops (e.g. tests) or
+  // to back off harder in production.
+  static constexpr uint32_t DefaultMaintenanceIntervalMs = 10000;
+
+  bool disableCircuitBreaker() const { return config_.disable_circuit_breaker(); }
+
+  // @return the reverse-connection maintenance interval. Drives how frequently the initiator
+  // re-attempts missing reverse connections (see ReverseConnectionIOHandle::maintenanceInterval).
+  std::chrono::milliseconds maintenanceInterval() const { return maintenance_interval_; }
+
 private:
   Server::Configuration::ServerFactoryContext& context_;
   const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
@@ -162,6 +176,7 @@ private:
   std::vector<envoy::config::core::v3::HeaderValueOption> additional_headers_;
   bool use_http_upgrade_{false};
   AccessLog::InstanceSharedPtrVector access_logs_;
+  std::chrono::milliseconds maintenance_interval_{DefaultMaintenanceIntervalMs};
 
   /**
    * Update per-worker connection stats for debugging purposes.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -790,6 +790,78 @@ TEST_F(ReverseConnectionIOHandleTest, ShouldAttemptConnectionToHostValidHost) {
   EXPECT_TRUE(io_handle_disabled->shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
 }
 
+// When the circuit breaker is disabled, repeated connection failures must never put a host into
+// backoff: shouldAttemptConnectionToHost stays true no matter how many failures are recorded. This
+// mirrors the production behavior selected by disable_circuit_breaker on the bootstrap extension.
+TEST_F(ReverseConnectionIOHandleTest, CircuitBreakerDisabledIsNotRespected) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.enable_circuit_breaker = false;
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  // Wire up a thread local cluster with a single host so the host mapping is populated.
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  RemoteClusterConnectionConfig cluster_config("test-cluster", 2);
+  maintainClusterConnections("test-cluster", cluster_config);
+
+  // Even after many consecutive failures, the host is never suppressed.
+  for (int i = 0; i < 5; ++i) {
+    trackConnectionFailure("192.168.1.1", "test-cluster");
+    EXPECT_TRUE(shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
+  }
+}
+
+// The handle's maintenance interval is sourced from the bootstrap extension's configured
+// maintenance_interval, which drives how often the retry timer re-attempts missing reverse
+// connections.
+TEST_F(ReverseConnectionIOHandleTest, MaintenanceIntervalDelegatesToExtension) {
+  auto custom_config = config_;
+  custom_config.mutable_maintenance_interval()->set_nanos(250 * 1000 * 1000); // 250ms
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config, custom_extension.get());
+  ASSERT_NE(io_handle_, nullptr);
+  EXPECT_EQ(io_handle_->maintenanceInterval(), std::chrono::milliseconds(250));
+}
+
+// With maintenance_interval unset on the extension, the handle falls back to the default interval.
+TEST_F(ReverseConnectionIOHandleTest, MaintenanceIntervalDefaultsFromExtension) {
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+  EXPECT_EQ(
+      io_handle_->maintenanceInterval(),
+      std::chrono::milliseconds(ReverseTunnelInitiatorExtension::DefaultMaintenanceIntervalMs));
+}
+
+// A handle created without a bootstrap extension still resolves a sane maintenance interval via the
+// documented default rather than dereferencing a null extension.
+TEST_F(ReverseConnectionIOHandleTest, MaintenanceIntervalDefaultsWithoutExtension) {
+  auto config = createDefaultTestConfig();
+  int test_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  ASSERT_GE(test_fd, 0);
+  io_handle_ = std::make_unique<ReverseConnectionIOHandle>(test_fd, config, cluster_manager_,
+                                                           /*extension=*/nullptr, *stats_scope_);
+  ASSERT_NE(io_handle_, nullptr);
+  EXPECT_EQ(
+      io_handle_->maintenanceInterval(),
+      std::chrono::milliseconds(ReverseTunnelInitiatorExtension::DefaultMaintenanceIntervalMs));
+}
+
 // Test trackConnectionFailure puts host in backoff.
 TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailurePutsHostInBackoff) {
   // Set up thread local slot first so stats can be properly tracked.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -177,6 +177,38 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, AdditionalHeadersOverride) {
             envoy::config::core::v3::HeaderValueOption::APPEND_IF_EXISTS_OR_ADD);
 }
 
+// The circuit breaker is enabled by default, so disableCircuitBreaker() reflects the proto default
+// of false.
+TEST_F(ReverseTunnelInitiatorExtensionTest, DisableCircuitBreakerDefaults) {
+  EXPECT_FALSE(extension_->disableCircuitBreaker());
+}
+
+// Setting disable_circuit_breaker on the proto is surfaced through the accessor used to populate
+// the per-socket config.
+TEST_F(ReverseTunnelInitiatorExtensionTest, DisableCircuitBreakerOverride) {
+  auto custom_config = config_;
+  custom_config.set_disable_circuit_breaker(true);
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+  EXPECT_TRUE(custom_extension->disableCircuitBreaker());
+}
+
+// When maintenance_interval is unset, maintenanceInterval() returns the documented default.
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaintenanceIntervalDefaults) {
+  EXPECT_EQ(
+      extension_->maintenanceInterval(),
+      std::chrono::milliseconds(ReverseTunnelInitiatorExtension::DefaultMaintenanceIntervalMs));
+}
+
+// Setting the maintenance_interval duration overrides the value surfaced by maintenanceInterval().
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaintenanceIntervalOverride) {
+  auto custom_config = config_;
+  custom_config.mutable_maintenance_interval()->set_nanos(250 * 1000 * 1000); // 250ms
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+  EXPECT_EQ(custom_extension->maintenanceInterval(), std::chrono::milliseconds(250));
+}
+
 TEST_F(ReverseTunnelInitiatorExtensionTest, OnServerInitialized) {
   // This should be a no-op.
   extension_->onServerInitialized(server_);

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
@@ -261,6 +261,51 @@ TEST_F(ReverseTunnelInitiatorTest, SocketUsesCustomHandshakeRequestPathFromExten
   EXPECT_EQ(reverse_handle->requestPath(), "/custom/handshake");
 }
 
+// By default the initiator wires the per-socket circuit breaker on, so reverse connection attempts
+// honor per-host failure backoff.
+TEST_F(ReverseTunnelInitiatorTest, SocketEnablesCircuitBreakerByDefault) {
+  setupThreadLocalSlot();
+
+  ReverseConnectionAddress::ReverseConnectionConfig config;
+  config.src_cluster_id = "test-cluster";
+  config.src_node_id = "test-node";
+  config.src_tenant_id = "test-tenant";
+  config.remote_cluster = "remote-cluster";
+  config.connection_count = 1;
+
+  auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
+  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
+                                          Network::SocketCreationOptions{});
+  ASSERT_NE(socket, nullptr);
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  ASSERT_NE(reverse_handle, nullptr);
+  EXPECT_TRUE(reverse_handle->circuitBreakerEnabled());
+}
+
+// When disable_circuit_breaker is set on the bootstrap extension, sockets created through the
+// production socket() path are wired with the circuit breaker off, so the per-host backoff is not
+// respected.
+TEST_F(ReverseTunnelInitiatorTest, SocketDisablesCircuitBreakerFromExtension) {
+  config_.set_disable_circuit_breaker(true);
+  extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
+  setupThreadLocalSlot();
+
+  ReverseConnectionAddress::ReverseConnectionConfig config;
+  config.src_cluster_id = "test-cluster";
+  config.src_node_id = "test-node";
+  config.src_tenant_id = "test-tenant";
+  config.remote_cluster = "remote-cluster";
+  config.connection_count = 1;
+
+  auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
+  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
+                                          Network::SocketCreationOptions{});
+  ASSERT_NE(socket, nullptr);
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  ASSERT_NE(reverse_handle, nullptr);
+  EXPECT_FALSE(reverse_handle->circuitBreakerEnabled());
+}
+
 TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketStreamIPv4) {
   // Test createReverseConnectionSocket for stream IPv4 with TLS registry setup.
   setupThreadLocalSlot();

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
@@ -48,12 +48,27 @@ typed_config:
   enable_detailed_stats: true
 )EOF");
 
-    config_helper_.addBootstrapExtension(R"EOF(
+    // The circuit breaker is enabled by default; tests that need to exercise the disabled
+    // path flip downstream_disable_circuit_breaker_ before calling initialize(). Tests that need a
+    // faster reverse-connection retry cadence set downstream_maintenance_interval_ms_ to shrink the
+    // maintenance interval (the proto default of 10s keeps existing tests unchanged).
+    std::string maintenance_interval_line;
+    if (downstream_maintenance_interval_ms_.has_value()) {
+      const uint32_t ms = *downstream_maintenance_interval_ms_;
+      // maintenance_interval is a google.protobuf.Duration; render the ms value as a duration
+      // string (e.g. 250 -> "0.250s").
+      maintenance_interval_line =
+          fmt::format("\n  maintenance_interval: {}.{:03d}s", ms / 1000, ms % 1000);
+    }
+    config_helper_.addBootstrapExtension(fmt::format(
+        R"EOF(
 name: envoy.bootstrap.reverse_tunnel.downstream_socket_interface
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3.DownstreamReverseConnectionSocketInterface
   enable_detailed_stats: true
-)EOF");
+  disable_circuit_breaker: {}{}
+)EOF",
+        downstream_disable_circuit_breaker_ ? "true" : "false", maintenance_interval_line));
 
     // Call parent initialize to complete setup.
     HttpIntegrationTest::initialize();
@@ -61,6 +76,15 @@ typed_config:
 
 protected:
   LogLevelSetter log_level_setter_ = LogLevelSetter(spdlog::level::debug);
+
+  // Overridable hook controlling the downstream socket interface's circuit breaker. Tests set this
+  // to true to verify that reverse-connection retries are not suppressed after repeated failures.
+  bool downstream_disable_circuit_breaker_{false};
+
+  // Overridable hook for the downstream socket interface's reverse-connection maintenance interval
+  // (maintenance_interval), expressed in milliseconds. Unset leaves the proto default (10s); tests
+  // set a small value to drive a faster retry cadence and keep wall-clock runtime low.
+  absl::optional<uint32_t> downstream_maintenance_interval_ms_;
 
   uint32_t tunnelListenerPort() const {
     return GetParam() == Network::Address::IpVersion::v4 ? 15000 : 15001;
@@ -1269,6 +1293,67 @@ TEST_P(ReverseConnectionClusterIntegrationTest, MultiWorkerEndToEndReverseTunnel
   // Wait for listeners to be fully stopped before test cleanup.
   test_server_->waitForCounter("listener_manager.listener_stopped", Eq(3),
                                std::chrono::milliseconds(5000));
+}
+
+// Verifies that with the circuit breaker disabled, the initiator keeps retrying reverse-connection
+// attempts to an unreachable tunnel host instead of backing off after the first failure. The
+// counterpart (circuit breaker enabled, where backoff suppresses attempts) is covered by the
+// downstream socket interface unit tests; here we assert the end-to-end disabled behaviour via
+// cluster connect-failure stats.
+TEST_P(ReverseConnectionClusterIntegrationTest,
+       CircuitBreakerDisabledKeepsRetryingUnreachableHost) {
+  DISABLE_IF_ADMIN_DISABLED; // Cleanup drains listeners via the admin interface.
+
+  const uint32_t tunnel_listener_port = tunnelListenerPort();
+  const std::string loopback_addr = loopbackAddress();
+
+  // Disable the circuit breaker so failed attempts never place the host in backoff.
+  downstream_disable_circuit_breaker_ = true;
+  downstream_maintenance_interval_ms_ = 250;
+
+  config_helper_.addConfigModifier([this, tunnel_listener_port, loopback_addr](
+                                       envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    // Point the tunnel cluster at an unreachable endpoint (port 1) so every reverse-connection
+    // attempt fails with connection refused. This mirrors the unreachable-endpoint pattern used by
+    // other integration tests (e.g. tcp_proxy_integration_test.cc).
+    TunnelClusterModifier unreachable_modifier =
+        [](envoy::config::cluster::v3::Cluster* tunnel_cluster) {
+          tunnel_cluster->mutable_load_assignment()
+              ->mutable_endpoints(0)
+              ->mutable_lb_endpoints(0)
+              ->mutable_endpoint()
+              ->mutable_address()
+              ->mutable_socket_address()
+              ->set_port_value(1);
+        };
+    configureReverseTunnelSetup(bootstrap, loopback_addr, tunnel_listener_port, "test-node-id",
+                                "test-cluster-id", "test-tenant-id", unreachable_modifier);
+  });
+
+  initialize();
+
+  // Each reverse-connection attempt to the unreachable host transitions through the "failed" state,
+  // which increments this accumulating initiator gauge. With the circuit breaker disabled, a failed
+  // attempt does not place the host in backoff, so the initiator keeps re-attempting (every
+  // timeout_ms) and the failure count climbs well past one. Reaching several failures is therefore
+  // proof that retries are not being suppressed.
+  test_server_->waitForGauge("reverse_tunnel_initiator.cluster.tunnel_cluster.failed", Ge(3),
+                             std::chrono::milliseconds(15000));
+
+  // Drain listeners via the admin interface so in-flight reverse connection sockets are torn down
+  // and the initiator stops re-attempting before the workers are destroyed (matches the cleanup
+  // performed by the other tunnel tests).
+  BufferingStreamDecoderPtr drain_response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/drain_listeners", "", Http::CodecType::HTTP1, GetParam());
+  EXPECT_TRUE(drain_response->complete());
+  EXPECT_EQ("200", drain_response->headers().getStatusValue());
+
+  // Sanity check: the host is genuinely unreachable, so no reverse tunnel handshake ever completed
+  // on the responder side. Guard against a missing counter so the read is safe regardless of stat
+  // creation timing.
+  if (auto accepted = test_server_->counter("reverse_tunnel.handshake.accepted")) {
+    EXPECT_EQ(accepted->value(), 0);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Commit Message
reverse tunnel: add downstream circuit breaker toggle and configurable maintenance interval

## Description
The downstream reverse tunnel initiator previously hard-coded its reconnection behavior: a per-host failure circuit breaker was always on, and the maintenance/retry pass ran on a fixed 10s timer.

This adds two fields to DownstreamReverseConnectionSocketInterface:
- disable_circuit_breaker: when true, failed reverse-connection attempts never place a host in backoff, so the initiator keeps retrying.
- maintenance_interval (Duration, default 10s, >= 1ms): controls how often the initiator re-attempts missing reverse connections.

## Testing
Unit and Integration tests.