### PR TITLE
mcp_transcoder: add local response support for tools/list

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -177,7 +177,6 @@ message ServerInfo {
   google.protobuf.StringValue fallback_protocol_version = 3;
 }
 
-// [#not-implemented-hide:]
 // Configuration for sending locally-generated responses to tools/list requests.
 message ToolsListLocal {
 }
@@ -203,14 +202,12 @@ message ServerToolConfig {
     // https://modelcontextprotocol.io/specification/2025-11-25/schema#listtoolsresult
     HttpRule tool_list_http_rule = 3;
 
-    // [#not-implemented-hide:]
     // If provided: The extension sends a local response, according to each tool's
     // ToolsListSpecificConfig.
     ToolsListLocal tool_list_local = 4;
   }
 }
 
-// [#not-implemented-hide:]
 // Configuration for a tool's entry in tools/list responses.
 message ToolsListSpecificConfig {
   // Optional, human-readable name of the tool for display purposes.
@@ -242,7 +239,6 @@ message ToolConfig {
   // The HTTP configuration rules that apply to the normal backend.
   HttpRule http_rule = 2;
 
-  // [#not-implemented-hide:]
   // Config for this tool's entry in a local tools/list response. Used when tool_list_local is set
   // in the ServerToolConfig.
   ToolsListSpecificConfig tool_list_config = 3;

--- a/changelogs/current/new_features/mcp_transcoder__tools_list_local.rst
+++ b/changelogs/current/new_features/mcp_transcoder__tools_list_local.rst
@@ -1,0 +1,4 @@
+Added local response handling for the ``tools/list`` JSON-RPC method in the MCP JSON REST bridge
+filter. Configuring ``tools_list_local`` will cause the filter to directly generate and serve the
+available tools list response without sending a request upstream. This may be configured on a
+per-route basis.

--- a/source/extensions/filters/http/mcp_json_rest_bridge/BUILD
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/BUILD
@@ -18,6 +18,8 @@ envoy_cc_library(
         ":trace_context_lib",
         "//envoy/http:filter_interface",
         "//envoy/server:filter_config_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/common/http:headers_lib",
         "//source/common/protobuf",

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -7,7 +7,9 @@
 #include "envoy/http/header_map.h"
 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/assert.h"
 #include "source/common/common/json_escape_string.h"
+#include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
@@ -323,8 +325,9 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
 
   if (mcp_operation_ == McpOperation::Initialization ||
       mcp_operation_ == McpOperation::InitializationAck ||
-      mcp_operation_ == McpOperation::OperationFailed) {
-    // sendLocalReply was called in handleMcpMethod for these operations.
+      mcp_operation_ == McpOperation::OperationFailed ||
+      mcp_operation_ == McpOperation::ToolsListLocal) {
+    // sendLocalReply/encodeHeaders was called in handleMcpMethod for these operations.
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
@@ -340,6 +343,8 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
   // The response for InitializedNotification is empty body so we don't need
   // to modify the response headers.
   case McpOperation::InitializationAck:
+  // ToolsListLocal sends a local reply, so the headers are already correct.
+  case McpOperation::ToolsListLocal:
     return Http::FilterHeadersStatus::Continue;
   default:
     break;
@@ -367,10 +372,12 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
 
 Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& data,
                                                            bool end_stream) {
-  // No need to encode the response body for Initialization and InitializationAck.
+  // No need to encode the response body for Initialization and InitializationAck. ToolsListLocal is
+  // a local response, and the response body is already encoded.
   if (mcp_operation_ == McpOperation::Unspecified ||
       mcp_operation_ == McpOperation::Initialization ||
-      mcp_operation_ == McpOperation::InitializationAck) {
+      mcp_operation_ == McpOperation::InitializationAck ||
+      mcp_operation_ == McpOperation::ToolsListLocal) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -480,6 +487,88 @@ void McpJsonRestBridgeFilter::buildStreamingPrefixAndSuffix(bool is_error) {
   streaming_json_suffix_ = ref_json.substr(pos + marker.size() - 1);
 }
 
+// Send a local reply for a tools/list call. Construct the response body directly instead of
+// building a JSON object, to minimize copying.
+void McpJsonRestBridgeFilter::serveToolsListLocal(
+    const nlohmann::json& json_rpc, const McpJsonRestBridgePerRouteConfig* per_route_config) {
+  std::string request_id_json = "null";
+  if (json_rpc.contains("id")) {
+    request_id_json = json_rpc["id"].dump();
+  } else {
+    ASSERT(false, "serveToolsListLocal requires an RPC ID");
+  }
+
+  const auto& tools =
+      per_route_config ? per_route_config->toolConfig().tools() : config_->toolConfig().tools();
+
+  size_t reserve_size = sizeof("{\"jsonrpc\":\"2.0\",\"id\":") - 1 + request_id_json.size() +
+                        sizeof(",\"result\":{\"tools\":[") - 1 + sizeof("]}}") - 1;
+
+  for (const auto& tool_proto : tools) {
+    const auto* tool = &tool_proto;
+    reserve_size += sizeof("{\"name\":") - 1 + nlohmann::json(tool->name()).dump().size();
+
+    if (!tool->tool_list_config().title().empty()) {
+      reserve_size += sizeof(",\"title\":") - 1 +
+                      nlohmann::json(tool->tool_list_config().title()).dump().size();
+    }
+
+    reserve_size += sizeof(",\"description\":") - 1 +
+                    nlohmann::json(tool->tool_list_config().description()).dump().size() +
+                    sizeof(",\"inputSchema\":") - 1;
+
+    if (!tool->tool_list_config().input_schema().empty()) {
+      reserve_size += tool->tool_list_config().input_schema().size();
+    } else {
+      reserve_size += sizeof("{\"type\":\"object\"}") - 1;
+    }
+    reserve_size += sizeof("}") - 1 + sizeof(",") - 1;
+  }
+
+  std::string response_data;
+  response_data.reserve(reserve_size);
+  absl::StrAppend(&response_data, "{\"jsonrpc\":\"2.0\",\"id\":", request_id_json,
+                  ",\"result\":{\"tools\":[");
+
+  bool first_tool = true;
+  for (const auto& tool_proto : tools) {
+    const auto* tool = &tool_proto;
+    if (!first_tool) {
+      absl::StrAppend(&response_data, ",");
+    }
+    first_tool = false;
+
+    absl::StrAppend(&response_data, "{\"name\":", nlohmann::json(tool->name()).dump());
+
+    if (!tool->tool_list_config().title().empty()) {
+      absl::StrAppend(&response_data,
+                      ",\"title\":", nlohmann::json(tool->tool_list_config().title()).dump());
+    }
+
+    absl::StrAppend(&response_data, ",\"description\":",
+                    nlohmann::json(tool->tool_list_config().description()).dump(),
+                    ",\"inputSchema\":");
+
+    // WARNING: assumes input_schema is trusted to be a valid JSON fragment. Does not validate.
+    if (!tool->tool_list_config().input_schema().empty()) {
+      absl::StrAppend(&response_data, tool->tool_list_config().input_schema());
+    } else {
+      absl::StrAppend(&response_data, "{\"type\":\"object\"}");
+    }
+
+    absl::StrAppend(&response_data, "}");
+  }
+
+  absl::StrAppend(&response_data, "]}}");
+
+  decoder_callbacks_->sendLocalReply(
+      Http::Code::OK, response_data,
+      [](Http::ResponseHeaderMap& headers) {
+        headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
+      },
+      Grpc::Status::WellKnownGrpcStatus::Ok, "mcp_json_rest_bridge_tools_list");
+}
+
 void McpJsonRestBridgeFilter::handleMcpMethod(
     const nlohmann::json& json_rpc, Http::RequestHeaderMapOptRef request_headers,
     const McpJsonRestBridgePerRouteConfig* per_route_config) {
@@ -501,8 +590,10 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
     setDynamicMetadata(method, json_rpc);
   }
 
-  // TODO(guoyilin42): Consider supporting local response for tools/list in addition to the GET.
   if (method == McpConstants::Methods::TOOLS_LIST) {
+    bool has_tool_list_local = per_route_config
+                                   ? per_route_config->toolConfig().has_tool_list_local()
+                                   : config_->toolConfig().has_tool_list_local();
     absl::StatusOr<envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule> http_rule =
         (per_route_config == nullptr) ? config_->getToolsListHttpRule()
                                       : per_route_config->getToolsListHttpRule();
@@ -523,12 +614,17 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
       if (decoder_callbacks_->downstreamCallbacks().has_value()) {
         decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
       }
-    } else {
-      // TODO(guoyilin42): Handle this more elegantly to avoid an unnecessary copy here. This can
-      // be addressed later when the JSON parser is updated.
-      mcp_operation_ = McpOperation::Unspecified;
-      request_body_str_ = json_rpc.dump();
+      return;
+    } else if (has_tool_list_local) {
+      mcp_operation_ = McpOperation::ToolsListLocal;
+      serveToolsListLocal(json_rpc, per_route_config);
+      return;
     }
+
+    // TODO(guoyilin42): Handle this more elegantly to avoid an unnecessary copy here. This can
+    // be addressed later when the JSON parser is updated.
+    mcp_operation_ = McpOperation::Unspecified;
+    request_body_str_ = json_rpc.dump();
   } else if (method == McpConstants::Methods::INITIALIZE) {
     mcp_operation_ = McpOperation::Initialization;
     if (json_rpc.contains(McpConstants::PARAMS_FIELD) &&

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -50,6 +50,11 @@ public:
     return proto_config_.request_storage_mode();
   }
 
+  const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
+  toolConfig() const {
+    return proto_config_.tool_config();
+  }
+
   bool textContentStreamingEnabled(absl::string_view tool_name) const;
 
   bool traceContextExtraction() const { return proto_config_.has_trace_context_extraction(); }
@@ -81,6 +86,11 @@ public:
   getHttpRule(absl::string_view tool_name) const;
   absl::StatusOr<envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule>
   getToolsListHttpRule() const;
+
+  const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
+  toolConfig() const {
+    return proto_config_.tool_config();
+  }
 
   bool textContentStreamingEnabled(absl::string_view tool_name) const;
 
@@ -119,6 +129,10 @@ private:
   void handleMcpMethod(const nlohmann::json& json_rpc, Http::RequestHeaderMapOptRef request_headers,
                        const McpJsonRestBridgePerRouteConfig* per_route_config);
 
+  // Serves a local tools/list response using tools' ToolsListSpecificConfig.
+  void serveToolsListLocal(const nlohmann::json& json_rpc,
+                           const McpJsonRestBridgePerRouteConfig* per_route_config);
+
   // Modifies the response from upstream into JSON-RPC response.
   void encodeJsonRpcData(Http::ResponseHeaderMapOptRef response_headers);
 
@@ -151,10 +165,12 @@ private:
     InitializationAck = 3,
     // Clients send a tools/list request to discover available tools.
     ToolsList = 4,
+    // Clients send a tools/list request that is handled locally.
+    ToolsListLocal = 5,
     // Clients send a tools/call request to invoke a tool.
-    ToolsCall = 5,
+    ToolsCall = 6,
     // MCP operation failed.
-    OperationFailed = 6,
+    OperationFailed = 7,
   };
   McpOperation mcp_operation_ = McpOperation::Unspecified;
   absl::optional<nlohmann::json> session_id_;

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -1833,6 +1833,131 @@ TEST_P(McpHttpMethodFilterTest, NonPostMethodsReturnMethodNotAllowed) {
       StrEq("POST"));
 }
 
+TEST_F(McpJsonRestBridgeFilterTest, ToolsListPerRouteConfig) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
+
+  auto* static_tool = proto_config.mutable_tool_config()->add_tools();
+  static_tool->set_name("static_tool");
+  static_tool->mutable_tool_list_config()->set_title("Static Tool");
+  static_tool->mutable_tool_list_config()->set_description("This should be overridden.");
+
+  auto config = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  filter_ = std::make_unique<McpJsonRestBridgeFilter>(config);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
+      override_config;
+
+  auto* tool1 = override_config.mutable_tool_config()->add_tools();
+  tool1->set_name("simple_tool");
+  tool1->mutable_tool_list_config()->set_title("My Tool");
+  tool1->mutable_tool_list_config()->set_description("Does something.");
+  tool1->mutable_tool_list_config()->set_input_schema("");
+
+  auto* tool2 = override_config.mutable_tool_config()->add_tools();
+  tool2->set_name("complex_tool");
+  tool2->mutable_tool_list_config()->set_title("Complex \"Tool\"");
+  tool2->mutable_tool_list_config()->set_description("Has\\nspecial \"chars\" & \\t stuff.");
+  tool2->mutable_tool_list_config()->set_input_schema(
+      R"({"type": "object", "properties": {"a": {"type": "string"}}})");
+
+  override_config.mutable_tool_config()->mutable_tool_list_local();
+
+  McpJsonRestBridgePerRouteConfig override(override_config);
+
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig)
+      .WillByDefault(testing::Return(&override));
+
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(Http::RequestHeaderMapOptRef(request_headers_)));
+
+  request_headers_.setMethod("POST");
+  request_headers_.setPath("/mcp");
+  request_headers_.setContentType("application/json");
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "tools/list", "id": "req-1"})";
+  Buffer::OwnedImpl data(json);
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Eq(Http::Code::OK), _, _, Eq(Grpc::Status::WellKnownGrpcStatus::Ok),
+                             StrEq("mcp_json_rest_bridge_tools_list")))
+      .WillOnce(
+          testing::Invoke([](Http::Code, absl::string_view body,
+                             std::function<void(Http::ResponseHeaderMap&)> modify_headers,
+                             const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
+            auto parsed_response = nlohmann::json::parse(body);
+
+            EXPECT_EQ(parsed_response["jsonrpc"], "2.0");
+            EXPECT_EQ(parsed_response["id"], "req-1");
+
+            auto tools = parsed_response["result"]["tools"];
+            EXPECT_EQ(tools.size(), 2);
+
+            EXPECT_EQ(tools[0]["name"], "simple_tool");
+            EXPECT_EQ(tools[0]["title"], "My Tool");
+            EXPECT_EQ(tools[0]["description"], "Does something.");
+            EXPECT_EQ(tools[0]["inputSchema"]["type"], "object");
+
+            EXPECT_EQ(tools[1]["name"], "complex_tool");
+            EXPECT_EQ(tools[1]["title"], "Complex \"Tool\"");
+            EXPECT_EQ(tools[1]["description"], "Has\\nspecial \"chars\" & \\t stuff.");
+            EXPECT_EQ(tools[1]["inputSchema"]["type"], "object");
+            EXPECT_EQ(tools[1]["inputSchema"]["properties"]["a"]["type"], "string");
+
+            Http::TestResponseHeaderMapImpl headers;
+            modify_headers(headers);
+            EXPECT_EQ("application/json", headers.getContentTypeValue());
+          }));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data, true));
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, ToolsListLocalEmpty) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
+  proto_config.mutable_tool_config()->mutable_tool_list_local();
+  auto config = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  filter_ = std::make_unique<McpJsonRestBridgeFilter>(config);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(Http::RequestHeaderMapOptRef(request_headers_)));
+
+  request_headers_.setMethod("POST");
+  request_headers_.setPath("/mcp");
+  request_headers_.setContentType("application/json");
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "tools/list", "id": "req-1"})";
+  Buffer::OwnedImpl data(json);
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Eq(Http::Code::OK), _, _, Eq(Grpc::Status::WellKnownGrpcStatus::Ok),
+                             StrEq("mcp_json_rest_bridge_tools_list")))
+      .WillOnce(
+          testing::Invoke([](Http::Code, absl::string_view body,
+                             std::function<void(Http::ResponseHeaderMap&)> modify_headers,
+                             const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
+            auto parsed_response = nlohmann::json::parse(body);
+
+            EXPECT_EQ(parsed_response["jsonrpc"], "2.0");
+            EXPECT_EQ(parsed_response["id"], "req-1");
+
+            auto tools = parsed_response["result"]["tools"];
+            EXPECT_TRUE(tools.empty());
+
+            Http::TestResponseHeaderMapImpl headers;
+            modify_headers(headers);
+            EXPECT_EQ("application/json", headers.getContentTypeValue());
+          }));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data, true));
+}
 TEST_F(McpJsonRestBridgeFilterTest, ToolsCallPerRouteConfig) {
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
   auto* static_tool = proto_config.mutable_tool_config()->add_tools();
@@ -1940,6 +2065,71 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListPerRouteConfigOverridesStaticConfig
             Http::FilterDataStatus::Continue);
   EXPECT_THAT(request_headers_.getPathValue(), StrEq("/override/path"));
   EXPECT_THAT(request_headers_.getMethodValue(), StrEq("GET"));
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, EncodeTrailersReturnsContinue) {
+  Http::TestResponseTrailerMapImpl response_trailers;
+  EXPECT_EQ(filter_->encodeTrailers(response_trailers), Http::FilterTrailersStatus::Continue);
+}
+
+TEST_F(McpJsonRestBridgeFilterTest, ToolsListLocalPerRouteConfig) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
+  auto config = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  filter_ = std::make_unique<McpJsonRestBridgeFilter>(config);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
+      override_config;
+  override_config.mutable_tool_config()->mutable_tool_list_local();
+  auto* tool = override_config.mutable_tool_config()->add_tools();
+  tool->set_name("my_local_tool");
+  tool->mutable_tool_list_config()->set_title("My Local Tool");
+  tool->mutable_tool_list_config()->set_description("Does a local thing.");
+  tool->mutable_tool_list_config()->set_input_schema(R"({"type":"object"})");
+
+  McpJsonRestBridgePerRouteConfig override(override_config);
+
+  ON_CALL(*decoder_callbacks_.route_, mostSpecificPerFilterConfig)
+      .WillByDefault(testing::Return(&override));
+
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(Http::RequestHeaderMapOptRef(request_headers_)));
+
+  request_headers_.setMethod("POST");
+  request_headers_.setPath("/mcp");
+  request_headers_.setContentType("application/json");
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "tools/list", "id": "req-2"})";
+  Buffer::OwnedImpl data(json);
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Eq(Http::Code::OK), _, _, Eq(Grpc::Status::WellKnownGrpcStatus::Ok),
+                             StrEq("mcp_json_rest_bridge_tools_list")))
+      .WillOnce(
+          testing::Invoke([](Http::Code, absl::string_view body,
+                             std::function<void(Http::ResponseHeaderMap&)> modify_headers,
+                             const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
+            auto parsed_response = nlohmann::json::parse(body);
+
+            EXPECT_EQ(parsed_response["jsonrpc"], "2.0");
+            EXPECT_EQ(parsed_response["id"], "req-2");
+            auto tools = parsed_response["result"]["tools"];
+            EXPECT_EQ(tools.size(), 1);
+            EXPECT_EQ(tools[0]["name"], "my_local_tool");
+            EXPECT_EQ(tools[0]["title"], "My Local Tool");
+            EXPECT_EQ(tools[0]["description"], "Does a local thing.");
+            EXPECT_EQ(tools[0]["inputSchema"]["type"], "object");
+
+            Http::TestResponseHeaderMapImpl headers;
+            modify_headers(headers);
+            EXPECT_EQ("application/json", headers.getContentTypeValue());
+          }));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data, true));
 }
 
 } // namespace

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/network/address.h"
 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/protobuf/utility.h"
 
 #include "test/integration/http_integration.h"
 #include "test/test_common/environment.h"
@@ -631,19 +632,29 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallStreamingTranscoding) {
   EXPECT_EQ(nlohmann::json::parse(response->body()), nlohmann::json::parse(expected_rpc_response));
 }
 
-TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallStreamingErrorResponse) {
+TEST_P(McpJsonRestBridgeIntegrationTest, ToolsListLocalResponse) {
   const std::string config = R"EOF(
     name: envoy.filters.http.mcp_json_rest_bridge
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_json_rest_bridge.v3.McpJsonRestBridge
-      tool_config:
-        tools:
-          - name: "create_api_key"
-            http_rule:
-              post: "/v1/{parent=projects/*}/keys"
-              body: "key"
-            text_content_streaming_enabled: true
   )EOF";
+
+  config_helper_.addConfigModifier([](envoy::extensions::filters::network::http_connection_manager::
+                                          v3::HttpConnectionManager& hcm) {
+    auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
+    envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute per_route;
+    per_route.mutable_tool_config()->mutable_tool_list_local();
+    auto* tool = per_route.mutable_tool_config()->add_tools();
+    tool->set_name("my_local_tool");
+    tool->mutable_tool_list_config()->set_title("My Local Tool");
+    tool->mutable_tool_list_config()->set_description("Does a local thing.");
+    tool->mutable_tool_list_config()->set_input_schema(R"({"type":"object"})");
+
+    Protobuf::Any per_route_any;
+    MessageUtil::packFrom(per_route_any, per_route);
+    route->mutable_typed_per_filter_config()->insert(
+        {"envoy.filters.http.mcp_json_rest_bridge", per_route_any});
+  });
 
   initializeFilter(config);
 
@@ -651,17 +662,8 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallStreamingErrorResponse) {
 
   const std::string request_body = R"({
     "jsonrpc": "2.0",
-    "id": 42,
-    "method": "tools/call",
-    "params": {
-      "name": "create_api_key",
-      "arguments": {
-        "parent": "projects/foo",
-        "key": {
-          "displayName": "bar"
-        }
-      }
-    }
+    "id": 123,
+    "method": "tools/list"
   })";
 
   auto response = codec_client_->makeRequestWithBody(
@@ -672,35 +674,24 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallStreamingErrorResponse) {
                                      {"content-type", "application/json"}},
       request_body);
 
-  waitForNextUpstreamRequest();
-
-  Http::TestResponseHeaderMapImpl response_headers;
-  response_headers.setStatus(500);
-  response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
-  upstream_request_->encodeHeaders(response_headers, false);
-
-  Buffer::OwnedImpl response_data;
-  response_data.add("Internal Server Error");
-  upstream_request_->encodeData(response_data, true);
-
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_TRUE(upstream_request_->complete());
-
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("500"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
-  EXPECT_THAT(response->headers().getContentLengthValue(), IsEmpty());
 
   const std::string expected_rpc_response = R"({
     "jsonrpc": "2.0",
-    "id": 42,
+    "id": 123,
     "result": {
-      "content": [
+      "tools": [
         {
-          "type": "text",
-          "text": "Internal Server Error"
+          "name": "my_local_tool",
+          "title": "My Local Tool",
+          "description": "Does a local thing.",
+          "inputSchema": {
+            "type": "object"
+          }
         }
-      ],
-      "isError": true
+      ]
     }
   })";
   EXPECT_EQ(nlohmann::json::parse(response->body()), nlohmann::json::parse(expected_rpc_response));
@@ -958,6 +949,81 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallTraceContextExtractionDisabled
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
+}
+
+TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallStreamingErrorResponse) {
+  const std::string config = R"EOF(
+    name: envoy.filters.http.mcp_json_rest_bridge
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp_json_rest_bridge.v3.McpJsonRestBridge
+      tool_config:
+        tools:
+          - name: "create_api_key"
+            http_rule:
+              post: "/v1/{parent=projects/*}/keys"
+              body: "key"
+            text_content_streaming_enabled: true
+  )EOF";
+
+  initializeFilter(config);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body = R"({
+    "jsonrpc": "2.0",
+    "id": 42,
+    "method": "tools/call",
+    "params": {
+      "name": "create_api_key",
+      "arguments": {
+        "parent": "projects/foo",
+        "key": {
+          "displayName": "bar"
+        }
+      }
+    }
+  })";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  waitForNextUpstreamRequest();
+
+  Http::TestResponseHeaderMapImpl response_headers;
+  response_headers.setStatus(500);
+  response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  Buffer::OwnedImpl response_data;
+  response_data.add("Internal Server Error");
+  upstream_request_->encodeData(response_data, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("500"));
+  EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
+  EXPECT_THAT(response->headers().getContentLengthValue(), IsEmpty());
+
+  const std::string expected_rpc_response = R"({
+    "jsonrpc": "2.0",
+    "id": 42,
+    "result": {
+      "content": [
+        {
+          "type": "text",
+          "text": "Internal Server Error"
+        }
+      ],
+      "isError": true
+    }
+  })";
+  EXPECT_EQ(nlohmann::json::parse(response->body()), nlohmann::json::parse(expected_rpc_response));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: mcp_transcoder: add local response support for tools/list
Additional Description: Serve tools/list calls via local reply from McpJsonRestBridgeFilter. Tools can specify title, description, and input/output schema via ToolsListSpecificConfig. Input and output schemas are provided via serialized JSON strings instead of structured objects for efficiency of encoding, because this config is only used for tools/list.
Risk Level: Low. Config-guarded, default off.
Testing: Unit and integration tests
Docs Changes: n/a
Release Notes: yes
Platform Specific Features: n/a

Generative AI was used to create this change. I have manually reviewed the code and fully understand it.