### PR TITLE
reverse_tunnel: fix connection and read-filter teardown during handshake

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -94,7 +94,7 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
   http1_parse_connection_ = http1_client_codec_.get();
 
   // Add a tiny read filter to feed bytes into the codec for response parsing.
-  connection_->addReadFilter(Network::ReadFilterSharedPtr{new SimpleConnReadFilter(this)});
+  connection_->addReadFilter(read_filter_);
 
   // Build HTTP handshake headers with identifiers.
   absl::string_view tenant_id = src_tenant_id;
@@ -210,6 +210,16 @@ ReverseTunnelInitiatorExtension* RCConnectionWrapper::getDownstreamExtension() c
   return parent_.getDownstreamExtension();
 }
 
+Network::ClientConnectionPtr RCConnectionWrapper::releaseConnection() {
+  if (!connection_) {
+    return nullptr;
+  }
+
+  connection_->removeConnectionCallbacks(*this);
+  connection_->removeReadFilter(read_filter_);
+  return std::move(connection_);
+}
+
 void RCConnectionWrapper::onHandshakeSuccess() {
   std::string message = "reverse connection accepted";
   ENVOY_LOG(debug, "handshake succeeded: {}", message);
@@ -257,9 +267,10 @@ void RCConnectionWrapper::shutdown() {
             static_cast<int>(state));
 
   connection_->removeConnectionCallbacks(*this);
-  connection_.reset();
-  ENVOY_LOG(debug, "RCConnectionWrapper: Connection cleared after shutdown");
-  ENVOY_LOG(debug, "RCConnectionWrapper: Shutdown completed");
+  connection_->removeReadFilter(read_filter_);
+
+  // Defer the deletion of the connection and the codec.
+  connection_->dispatcher().deferredDelete(std::move(connection_));
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -168,7 +168,7 @@ public:
    * Release ownership of the connection.
    * @return the connection pointer (ownership transferred to caller)
    */
-  Network::ClientConnectionPtr releaseConnection() { return std::move(connection_); }
+  Network::ClientConnectionPtr releaseConnection();
 
   /**
    * Process HTTP response from upstream.
@@ -230,6 +230,7 @@ private:
   std::unique_ptr<Http::Http1::ClientConnectionImpl> http1_client_codec_;
   // Base interface pointer used to call dispatch via public API.
   Http::Connection* http1_parse_connection_{nullptr};
+  std::shared_ptr<SimpleConnReadFilter> read_filter_{std::make_shared<SimpleConnReadFilter>(this)};
 };
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -1109,9 +1109,6 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
               connection_key);
   }
 
-  // Get connection pointer for safe access in success/failure handling.
-  connection = wrapper->getConnection();
-
   // Process connection result safely.
   bool is_success = (error == "reverse connection accepted" || error == "success" ||
                      error == "handshake successful" || error == "connection established");
@@ -1139,6 +1136,8 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
   } else {
     // Handle connection success.
     ENVOY_LOG(debug, "reverse_tunnel: Connection succeeded for host {}", host_address);
+    auto released_conn = wrapper->releaseConnection();
+    ASSERT(released_conn != nullptr, "Connection should not be null after success");
 
     resetHostBackoff(host_address);
     updateConnectionState(host_address, cluster_name, connection_key,
@@ -1146,21 +1145,9 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
 
     emitAccessLog("handshake_success", host_address, cluster_name, connection_key, "");
 
-    // Only proceed if connection is still valid.
-    if (!connection) {
-      ENVOY_LOG(error, "reverse_tunnel: Cannot complete successful handshake - connection is null");
-      return;
-    }
-
     ENVOY_LOG(info, "reverse_tunnel: Transferring tunnel socket for "
                     "reverse_conn_listener consumption");
-
-    // Reset file events safely.
-    if (connection->getSocket()) {
-      ENVOY_LOG(debug, "reverse_tunnel: Removing connection callbacks and resetting file events");
-      connection->removeConnectionCallbacks(*wrapper);
-      connection->getSocket()->ioHandle().resetFileEvents();
-    }
+    released_conn->getSocket()->ioHandle().resetFileEvents();
 
     // Update host connection tracking safely.
     auto host_it = host_to_conn_info_map_.find(host_address);
@@ -1172,29 +1159,25 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
 
     // Set quiet shutdown since we are duplicating the socket and closing the original socket. When
     // the original socket is closed, a TLS close_notify alert is otherwise sent.
-    ReverseConnectionUtility::applySslQuietClose(*connection);
+    ReverseConnectionUtility::applySslQuietClose(*released_conn);
 
-    Network::ClientConnectionPtr released_conn = wrapper->releaseConnection();
+    ENVOY_LOG(info, "reverse_tunnel: Connection will be consumed by "
+                    "reverse_conn_listener for HTTP processing");
 
-    if (released_conn) {
-      ENVOY_LOG(info, "reverse_tunnel: Connection will be consumed by "
-                      "reverse_conn_listener for HTTP processing");
+    // Move connection to established queue for reverse_conn_listener to consume.
+    established_connections_.push(std::move(released_conn));
 
-      // Move connection to established queue for reverse_conn_listener to consume.
-      established_connections_.push(std::move(released_conn));
-
-      // Trigger accept mechanism safely.
-      if (isTriggerPipeReady()) {
-        char trigger_byte = 1;
-        ssize_t bytes_written = ::write(trigger_pipe_write_fd_, &trigger_byte, 1);
-        if (bytes_written == 1) {
-          ENVOY_LOG(info,
-                    "reverse_tunnel: Successfully triggered reverse_conn_listener "
-                    "accept() for host {}",
-                    host_address);
-        } else {
-          ENVOY_LOG(error, "reverse_tunnel: Failed to write trigger byte: {}", errorDetails(errno));
-        }
+    // Trigger accept mechanism safely.
+    if (isTriggerPipeReady()) {
+      char trigger_byte = 1;
+      ssize_t bytes_written = ::write(trigger_pipe_write_fd_, &trigger_byte, 1);
+      if (bytes_written == 1) {
+        ENVOY_LOG(info,
+                  "reverse_tunnel: Successfully triggered reverse_conn_listener "
+                  "accept() for host {}",
+                  host_address);
+      } else {
+        ENVOY_LOG(error, "reverse_tunnel: Failed to write trigger byte: {}", errorDetails(errno));
       }
     }
   }

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1109,7 +1109,7 @@ TEST_F(RCConnectionWrapperTest, ConnectEmitsUpgradeHeaders) {
   upgrade_config.use_http_upgrade = true;
   auto upgrade_io_handle = createTestIOHandle(upgrade_config);
 
-  auto mock_connection = std::make_unique<NiceMock<Network::MockClientConnection>>();
+  auto mock_connection = getDeletableConn(dispatcher_);
   std::string written;
   EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
   EXPECT_CALL(*mock_connection, addReadFilter(_));
@@ -1211,6 +1211,49 @@ TEST_F(RCConnectionWrapperTest, ReleaseConnection) {
   EXPECT_EQ(wrapper.getConnection(), nullptr);
 }
 
+// releaseConnection() must detach the wrapper's connection callbacks and read filter before
+// transferring ownership, so the handed-off connection no longer references the soon-to-be-deleted
+// wrapper. A second call must be a safe no-op (no double detach).
+TEST_F(RCConnectionWrapperTest, ReleaseConnectionDetachesCallbacksAndReadFilter) {
+  auto mock_connection = setupMockConnection();
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, removeReadFilter(_));
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+
+  auto released_connection = wrapper.releaseConnection();
+  EXPECT_NE(released_connection, nullptr);
+  EXPECT_EQ(wrapper.getConnection(), nullptr);
+
+  // Releasing again returns null and does not re-detach (the EXPECT_CALLs above are Times(1)).
+  EXPECT_EQ(wrapper.releaseConnection(), nullptr);
+}
+
+// shutdown() must detach the connection callbacks and read filter and hand the connection to the
+// dispatcher's deferred-delete queue instead of closing/destroying it inline. Deferring ensures the
+// connection (and the wrapper that owns the codec/read filter) outlives the active dispatch.
+TEST_F(RCConnectionWrapperTest, ShutdownDetachesAndDefersConnectionDeletion) {
+  auto mock_connection = setupMockConnection();
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, removeReadFilter(_));
+  EXPECT_CALL(*mock_connection, close(_)).Times(0);
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(4242));
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+
+  const size_t deferred_before = dispatcher_.to_delete_.size();
+  wrapper.shutdown();
+
+  // Connection ownership transferred to the deferred-delete queue, not destroyed inline.
+  EXPECT_EQ(wrapper.getConnection(), nullptr);
+  EXPECT_EQ(dispatcher_.to_delete_.size(), deferred_before + 1);
+}
+
 // Test RCConnectionWrapper::getConnection method.
 TEST_F(RCConnectionWrapperTest, GetConnection) {
   // Create a mock connection with proper socket setup.
@@ -1297,10 +1340,12 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
     auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
 
     // Set up connection expectations for closed connection.
+    EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state())
         .WillRepeatedly(Return(Network::Connection::State::Closed));
-    EXPECT_CALL(*mock_connection, close(_))
-        .Times(0); // Should not call close on already closed connection
+    // shutdown() defers destruction of the connection via the dispatcher rather than
+    // closing it explicitly, so close() is never invoked here.
+    EXPECT_CALL(*mock_connection, close(_)).Times(0);
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12346));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
@@ -1319,8 +1364,9 @@ TEST_F(RCConnectionWrapperTest, Shutdown) {
     EXPECT_CALL(*mock_connection, removeConnectionCallbacks(_));
     EXPECT_CALL(*mock_connection, state())
         .WillRepeatedly(Return(Network::Connection::State::Closing));
-    EXPECT_CALL(*mock_connection, close(_))
-        .Times(0); // Should not call close on already closing connection
+    // shutdown() defers destruction of the connection via the dispatcher rather than
+    // closing it explicitly, so close() is never invoked here.
+    EXPECT_CALL(*mock_connection, close(_)).Times(0);
     EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12347));
 
     RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");


### PR DESCRIPTION
## Commit Message 
reverse_tunnel: fix connection and read-filter teardown during handshake

## Description
The reverse-tunnel handshake wrapper tore its connection down synchronously inside its own callbacks and owned its read filter only via a raw pointer, making teardown ordering fragile.
This gives the read filter a single owner, detaches callbacks/read filter before the connection is handed off or destroyed, and defers connection + wrapper destruction so they always outlive the active dispatch.

## Testing
Added unit tests + existing integ tests.