### PR TITLE
mobile: Reduce test trace logging to info

### DIFF
--- a/mobile/test/cc/unit/fetch_client_test.cc
+++ b/mobile/test/cc/unit/fetch_client_test.cc
@@ -23,7 +23,7 @@ envoy_status_t fetchUrls(const std::vector<std::string> urls,
                          std::vector<Http::Protocol>* used_protocols) {
   absl::Notification engine_running;
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Envoy::Logger::Logger::trace)
+  engine_builder.setLogLevel(Envoy::Logger::Logger::info)
       .enableLogger(false)
       .addRuntimeGuard("dns_cache_set_ip_version_to_remove", true)
       .addRuntimeGuard("quic_no_tcp_delay", true)

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -95,7 +95,7 @@ public:
     }
     // Integration test starts upstreams before Envoy which can cause a data race.
     builder_.enableLogger(false);
-    builder_.setLogLevel(Logger::Logger::trace);
+    builder_.setLogLevel(Logger::Logger::info);
     builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
     builder_.addRuntimeGuard("quic_no_tcp_delay", true);
     builder_.addRuntimeGuard("mobile_use_network_observer_registry", true);

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -18,6 +18,7 @@
 #include "test/extensions/filters/http/dynamic_forward_proxy/test_resolver.h"
 #include "test/integration/autonomous_upstream.h"
 #include "test/test_common/registry.h"
+#include "source/common/common/logger.h"
 #include "test/test_common/test_random_generator.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
@@ -85,6 +86,10 @@ public:
     // For H2 tests.
     Extensions::TransportSockets::Tls::forceRegisterDefaultCertValidatorFactory();
     builder_.setLogLevel(Logger::Logger::info);
+  }
+
+  ~ClientIntegrationTest() override {
+    Logger::Context::changeAllLogLevels(spdlog::level::info);
   }
 
   void initialize() override {
@@ -308,6 +313,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
 
   builder_.setDisableDnsRefreshOnFailure(true);
   builder_.setLogLevel(Logger::Logger::debug);
+  Logger::Context::changeAllLogLevels(spdlog::level::debug);
   initialize();
 
   default_request_headers_.setHost("doesnotexist");
@@ -335,6 +341,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
       });
   builder_.setDisableDnsRefreshOnNetworkChange(true);
   builder_.setLogLevel(Logger::Logger::debug);
+  Logger::Context::changeAllLogLevels(spdlog::level::debug);
   initialize();
 
   internalEngine()->onDefaultNetworkChanged(1);
@@ -356,6 +363,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
   builder_.setLogLevel(Logger::Logger::debug);
+  Logger::Context::changeAllLogLevels(spdlog::level::debug);
   initialize();
 
   // Set the network type to WIFI. This should trigger a network change.
@@ -417,6 +425,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEventsAndroid) {
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
   builder_.setLogLevel(Logger::Logger::trace);
+  Logger::Context::changeAllLogLevels(spdlog::level::trace);
   initialize();
 
   // A new WIFI network appears and becomes the default network. Even though

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -360,8 +360,8 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-  builder_.setLogLevel(Logger::Logger::debug);
-  Logger::Context::changeAllLogLevels(spdlog::level::debug);
+  builder_.setLogLevel(Logger::Logger::trace);
+  Logger::Context::changeAllLogLevels(spdlog::level::trace);
   initialize();
 
   // Set the network type to WIFI. This should trigger a network change.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -84,6 +84,7 @@ public:
         forceRegisterEnvoyDeterministicConnectionIdGeneratorConfigFactory();
     // For H2 tests.
     Extensions::TransportSockets::Tls::forceRegisterDefaultCertValidatorFactory();
+    builder_.setLogLevel(Logger::Logger::info);
   }
 
   void initialize() override {
@@ -95,7 +96,6 @@ public:
     }
     // Integration test starts upstreams before Envoy which can cause a data race.
     builder_.enableLogger(false);
-    builder_.setLogLevel(Logger::Logger::info);
     builder_.addRuntimeGuard("dns_cache_set_ip_version_to_remove", true);
     builder_.addRuntimeGuard("quic_no_tcp_delay", true);
     builder_.addRuntimeGuard("mobile_use_network_observer_registry", true);
@@ -307,6 +307,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   builder_.setDnsResolver(dns_resolver_config);
 
   builder_.setDisableDnsRefreshOnFailure(true);
+  builder_.setLogLevel(Logger::Logger::debug);
   initialize();
 
   default_request_headers_.setHost("doesnotexist");
@@ -333,6 +334,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(true);
+  builder_.setLogLevel(Logger::Logger::debug);
   initialize();
 
   internalEngine()->onDefaultNetworkChanged(1);
@@ -353,6 +355,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
+  builder_.setLogLevel(Logger::Logger::debug);
   initialize();
 
   // Set the network type to WIFI. This should trigger a network change.
@@ -413,7 +416,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEventsAndroid) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-
+  builder_.setLogLevel(Logger::Logger::trace);
   initialize();
 
   // A new WIFI network appears and becomes the default network. Even though

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -85,12 +85,13 @@ public:
         forceRegisterEnvoyDeterministicConnectionIdGeneratorConfigFactory();
     // For H2 tests.
     Extensions::TransportSockets::Tls::forceRegisterDefaultCertValidatorFactory();
-    builder_.setLogLevel(Logger::Logger::info);
   }
 
   ~ClientIntegrationTest() override { Logger::Context::changeAllLogLevels(spdlog::level::info); }
 
   void initialize() override {
+    builder_.setLogLevel(log_level_);
+    Logger::Context::changeAllLogLevels(static_cast<spdlog::level::level_enum>(log_level_));
     builder_.enableWorkerThread(getUseWorkerThread());
     if (getUseWorkerThread()) {
       // Platform cert validation is disabled when using worker thread. The engine will use the
@@ -215,6 +216,7 @@ public:
   }
 
 protected:
+  Logger::Logger::Levels log_level_ = Logger::Logger::info;
   std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
   bool add_quic_hints_ = false;
   bool add_fake_dns_ = false;
@@ -310,8 +312,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   builder_.setDnsResolver(dns_resolver_config);
 
   builder_.setDisableDnsRefreshOnFailure(true);
-  builder_.setLogLevel(Logger::Logger::debug);
-  Logger::Context::changeAllLogLevels(spdlog::level::debug);
+  log_level_ = Logger::Logger::debug;
   initialize();
 
   default_request_headers_.setHost("doesnotexist");
@@ -338,8 +339,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(true);
-  builder_.setLogLevel(Logger::Logger::debug);
-  Logger::Context::changeAllLogLevels(spdlog::level::debug);
+  log_level_ = Logger::Logger::debug;
   initialize();
 
   internalEngine()->onDefaultNetworkChanged(1);
@@ -360,8 +360,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-  builder_.setLogLevel(Logger::Logger::trace);
-  Logger::Context::changeAllLogLevels(spdlog::level::trace);
+  log_level_ = Logger::Logger::trace;
   initialize();
 
   // Set the network type to WIFI. This should trigger a network change.
@@ -422,8 +421,7 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEventsAndroid) {
         }
       });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-  builder_.setLogLevel(Logger::Logger::trace);
-  Logger::Context::changeAllLogLevels(spdlog::level::trace);
+  log_level_ = Logger::Logger::trace;
   initialize();
 
   // A new WIFI network appears and becomes the default network. Even though

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -88,9 +88,7 @@ public:
     builder_.setLogLevel(Logger::Logger::info);
   }
 
-  ~ClientIntegrationTest() override {
-    Logger::Context::changeAllLogLevels(spdlog::level::info);
-  }
+  ~ClientIntegrationTest() override { Logger::Context::changeAllLogLevels(spdlog::level::info); }
 
   void initialize() override {
     builder_.enableWorkerThread(getUseWorkerThread());

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -38,7 +38,7 @@ public:
     xds_builder.addRuntimeDiscoveryService("some_rtds_resource", /*timeout_in_seconds=*/1)
         .setSslRootCerts(getUpstreamCert());
     builder_.setXds(std::move(xds_builder));
-    builder_.setLogLevel(Logger::Logger::trace);
+    builder_.setLogLevel(Logger::Logger::info);
     builder_.enforceTrustChainVerification(false);
     XdsIntegrationTest::createEnvoy();
   }

--- a/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/mobile/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -47,7 +47,7 @@ public class QuicTestServerTest {
 
     CountDownLatch latch = new CountDownLatch(1);
     engine = new AndroidEngineBuilder(appContext)
-                 .setLogLevel(LogLevel.TRACE)
+                 .setLogLevel(LogLevel.INFO)
                  .setLogger((level, message) -> {
                    System.out.print(message);
                    return null;

--- a/mobile/test/java/org/chromium/net/CronetHttp3Test.java
+++ b/mobile/test/java/org/chromium/net/CronetHttp3Test.java
@@ -120,7 +120,7 @@ public class CronetHttp3Test {
 
     if (setUpLogging) {
       nativeCronetEngineBuilder.setLogger(logger);
-      nativeCronetEngineBuilder.setLogLevel(EnvoyEngine.LogLevel.TRACE);
+      nativeCronetEngineBuilder.setLogLevel(EnvoyEngine.LogLevel.INFO);
     }
     if (useAndroidNetworkMonitorV2) {
       nativeCronetEngineBuilder.setUseV2NetworkMonitor(useAndroidNetworkMonitorV2);

--- a/mobile/test/python/async_client/async_client_fetch_test.py
+++ b/mobile/test/python/async_client/async_client_fetch_test.py
@@ -28,7 +28,7 @@ class TestAsyncClientFetch(unittest.TestCase):
         # factory to keep constructor logic consistent without sharing instances
         builder = (
             EngineBuilder()
-            .set_log_level(LogLevel.trace)
+            .set_log_level(LogLevel.info)
             .add_runtime_guard("getaddrinfo_no_ai_flags", True)
         )
         return builder

--- a/mobile/test/python/fetch_test.py
+++ b/mobile/test/python/fetch_test.py
@@ -34,7 +34,7 @@ class TestFetchRequest(unittest.TestCase):
         engine_running = threading.Event()
         engine = (
             EngineBuilder()
-            .set_log_level(LogLevel.trace)
+            .set_log_level(LogLevel.info)
             .add_runtime_guard("dns_cache_set_ip_version_to_remove", True)
             .add_runtime_guard("getaddrinfo_no_ai_flags", True)
             .set_on_engine_running(lambda: engine_running.set())

--- a/mobile/test/swift/EngineBuilderTests.swift
+++ b/mobile/test/swift/EngineBuilderTests.swift
@@ -27,13 +27,13 @@ final class EngineBuilderTests: XCTestCase {
   func testAddingLogLevelAddsLogLevelWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { _, logLevel in
-      XCTAssertEqual("trace", logLevel)
+      XCTAssertEqual("info", logLevel)
       expectation.fulfill()
     }
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .setLogLevel(.trace)
+      .setLogLevel(.info)
       .build()
     self.waitForExpectations(timeout: 0.01)
   }


### PR DESCRIPTION
`trace` logging produces too much logging on CI and reduces the performance.

Coded with an AI agent