### PR TITLE
Fix credential provider chain for aws_request_signing filter

### DIFF
--- a/source/extensions/common/aws/credential_provider_chains.cc
+++ b/source/extensions/common/aws/credential_provider_chains.cc
@@ -259,7 +259,7 @@ CredentialsProviderSharedPtr CommonCredentialsProviderChain::createAssumeRoleCre
   auto status = aws_cluster_manager->addManagedCluster(
       cluster_name, envoy::config::cluster::v3::Cluster::LOGICAL_DNS, uri);
 
-  CredentialsProviderChainSharedPtr credentials_provider_chain;
+  std::shared_ptr<CommonCredentialsProviderChain> credentials_provider_chain;
 
   if (assume_role_config.has_credential_provider()) {
     // If a custom chain has been configured in the assume role provider, ensure we do not allow the
@@ -282,6 +282,8 @@ CredentialsProviderSharedPtr CommonCredentialsProviderChain::createAssumeRoleCre
         std::make_shared<Extensions::Common::Aws::CommonCredentialsProviderChain>(context, region,
                                                                                   absl::nullopt);
   }
+
+  credentials_provider_chain->setupSubscriptions();
 
   // Create our own signer specifically for signing AssumeRole API call
   auto signer = std::make_unique<SigV4SignerImpl>(

--- a/test/extensions/common/aws/credential_provider_chains_test.cc
+++ b/test/extensions/common/aws/credential_provider_chains_test.cc
@@ -3,6 +3,7 @@
 #include "test/extensions/common/aws/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/test_runtime.h"
 
@@ -558,6 +559,30 @@ TEST_F(DefaultCredentialsProviderChainTest, WebIdentityPreservesExistingWatchedD
   CommonCredentialsProviderChain chain(context_, "region", credential_provider_config, factories_);
   EXPECT_EQ(filename, "/test/path/token");
   EXPECT_EQ(watched_dir, "/custom/watch/dir");
+}
+
+TEST_F(CustomCredentialsProviderChainTest, AssumeRoleInnerChainSubscriptionsSetup) {
+  envoy::extensions::common::aws::v3::AwsCredentialProvider credential_provider_config = {};
+  credential_provider_config.set_custom_credential_provider_chain(true);
+  auto* assume_role = credential_provider_config.mutable_assume_role_credential_provider();
+  assume_role->set_role_arn("test-role-arn");
+  assume_role->set_role_session_name("test-session");
+  assume_role->mutable_credential_provider()->set_custom_credential_provider_chain(true);
+  assume_role->mutable_credential_provider()->mutable_instance_profile_credential_provider();
+
+  auto chain = Envoy::Extensions::Common::Aws::CommonCredentialsProviderChain::
+      customCredentialsProviderChain(context_, "us-east-1", credential_provider_config);
+
+  EXPECT_TRUE(chain.ok());
+  EXPECT_EQ(1, chain.value()->getNumProviders());
+
+  auto instance_profile_provider =
+      context_.singletonManager().getTyped<Envoy::Extensions::Common::Aws::InstanceProfileCredentialsProvider>(
+          "instance_profile_credentials_provider_singleton");
+  ASSERT_NE(instance_profile_provider, nullptr);
+
+  MetadataCredentialsProviderBaseFriend provider_friend(instance_profile_provider);
+  EXPECT_EQ(1, provider_friend.getSubscribersCount());
 }
 
 } // namespace Aws

--- a/test/extensions/common/aws/credential_provider_chains_test.cc
+++ b/test/extensions/common/aws/credential_provider_chains_test.cc
@@ -1,9 +1,9 @@
 #include "source/extensions/common/aws/credential_provider_chains.h"
+#include "source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h"
 
 #include "test/extensions/common/aws/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_manager.h"
-#include "source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/test_runtime.h"
 
@@ -577,8 +577,9 @@ TEST_F(CustomCredentialsProviderChainTest, AssumeRoleInnerChainSubscriptionsSetu
   EXPECT_EQ(1, chain.value()->getNumProviders());
 
   auto instance_profile_provider =
-      context_.singletonManager().getTyped<Envoy::Extensions::Common::Aws::InstanceProfileCredentialsProvider>(
-          "instance_profile_credentials_provider_singleton");
+      context_.singletonManager()
+          .getTyped<Envoy::Extensions::Common::Aws::InstanceProfileCredentialsProvider>(
+              "instance_profile_credentials_provider_singleton");
   ASSERT_NE(instance_profile_provider, nullptr);
 
   MetadataCredentialsProviderBaseFriend provider_friend(instance_profile_provider);

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -164,6 +164,10 @@ public:
     provider_->setCredentialsToAllThreads(std::move(creds));
   }
   void invalidateStats() { provider_->stats_.reset(); }
+  size_t getSubscribersCount() {
+    Thread::LockGuard lock(provider_->mu_);
+    return provider_->credentials_subscribers_.size();
+  }
 
   std::shared_ptr<MetadataCredentialsProviderBase> provider_;
 };


### PR DESCRIPTION
It's to fix https://github.com/envoyproxy/envoy/issues/45643: AWS AssumeRole provider hangs indefinitely when using WebIdentity source credentials in EKS

Here's the root Cause: 
To fetch the base credentials needed to sign the STS AssumeRole request, `createAssumeRoleCredentialsProvider` instantiates an inner `CommonCredentialsProviderChain`. However, setupSubscriptions() is never called on this newly created inner chain.
Because subscriptions are never set up, the inner chain fails to register its `CredentialSubscriberCallbacks` with any underlying asynchronous metadata providers (like `WebIdentityCredentialsProvider` or `InstanceProfileCredentialsProvider`). When the background metadata fetch eventually succeeds (e.g., STS successfully exchanges the EKS pod's OIDC token for web identity credentials), the base provider fires `onCredentialUpdate()`. But because there are no registered subscribers, the inner chain is never notified.
Consequently, the pending callbacks attached by the SigV4SignerImpl (via `addCallbackIfChainCredentialsPending`) are never executed, and the outbound AWS request is left paused indefinitely waiting for credentials to resolve.

Commit Message:
Additional Description:
Risk Level: low
Testing: Have validated the fix: After applying the change, the aws_request_sigining filter would be able to fetch aws credentials.
Docs Changes:
Release Notes: 
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
