### PR TITLE
mobile: Support connection pool isolation in Python transport and a few other fixes

### DIFF
--- a/mobile/library/python/envoy_mobile/async_client_transport.py
+++ b/mobile/library/python/envoy_mobile/async_client_transport.py
@@ -6,7 +6,7 @@ from typing import AsyncIterable, Dict, List, Optional, Union
 import httpx
 from . import envoy_engine
 from .async_client.executor import AsyncioExecutor
-from .httpx_utils import get_envoy_headers, map_envoy_error
+from .httpx_utils import get_envoy_headers, map_envoy_error, get_next_socket_tag
 
 
 class AsyncEnvoyStream(httpx.AsyncByteStream):
@@ -61,7 +61,7 @@ class AsyncResponseHandler:
         self.data_queue: asyncio.Queue = asyncio.Queue()
         self.stream_complete = asyncio.Event()
         self.status_code: Optional[int] = None
-        self.headers: Dict[str, Union[str, List[str]]] = {}
+        self.headers: List[tuple] = []
         self.trailers: Dict[str, Union[str, List[str]]] = {}
 
     def on_headers(
@@ -79,9 +79,11 @@ class AsyncResponseHandler:
 
         for key, value in headers.items():
             if not key.startswith(":"):
-                self.headers[key] = (
-                    value[0] if isinstance(value, list) and len(value) == 1 else value
-                )
+                if isinstance(value, list):
+                    for val in value:
+                        self.headers.append((key, val))
+                else:
+                    self.headers.append((key, value))
 
         if not self.headers_future.done():
             self.headers_future.set_result(True)
@@ -146,11 +148,12 @@ class AsyncEnvoyClientTransport(httpx.AsyncBaseTransport):
         self._engine = engine
         self._listener_name = listener_name
         self._executor = AsyncioExecutor()
+        self._transport_tag = get_next_socket_tag()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         # Map headers
         timeout = request.extensions.get("timeout", {}).get("read")
-        envoy_headers = get_envoy_headers(request, timeout=timeout)
+        envoy_headers = get_envoy_headers(request, timeout=timeout, socket_tag=self._transport_tag)
 
         # Create handler
         handler = AsyncResponseHandler(self._executor)
@@ -188,7 +191,7 @@ class AsyncEnvoyClientTransport(httpx.AsyncBaseTransport):
 
         # Iterate through the request stream and send all data chunks.
         async for chunk in request.stream:
-            stream.send_data(chunk, False)
+            stream.send_data(chunk)
 
         # Finalize the request. Sending an empty string with `stream.close()`
         # signals `end_stream=True` to Envoy, completing the request side of the stream.

--- a/mobile/library/python/envoy_mobile/httpx_utils.py
+++ b/mobile/library/python/envoy_mobile/httpx_utils.py
@@ -1,5 +1,6 @@
 """Utilities for mapping httpx requests and responses to Envoy Mobile."""
 
+import itertools
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 import httpx
@@ -9,10 +10,18 @@ from .async_client.utils import (
     normalize_timeout_to_ms,
 )
 
+_tag_generator = itertools.count(1)
+
+
+def get_next_socket_tag() -> int:
+    """Generate a unique 32-bit socket tag for connection pool isolation."""
+    return next(_tag_generator) & 0xFFFFFFFF
+
 
 def get_envoy_headers(
     request: httpx.Request,
     timeout: Optional[Union[int, float]] = None,
+    socket_tag: Optional[int] = None,
 ) -> Dict[str, Union[str, List[str]]]:
     """Map an httpx.Request to Envoy-compatible headers.
 
@@ -46,10 +55,25 @@ def get_envoy_headers(
 
     # Add normalized user headers
     for key, values in norm_headers.items():
-        # Avoid overriding pseudo-headers
-        if key.startswith(":"):
+        # Avoid overriding pseudo-headers and avoid duplicate host headers.
+        # Envoy Mobile automatically sets the correct upstream authority/host headers.
+        if key.startswith(":") or key.lower() == "host":
+            continue
+        # Avoid HTTP/1.1 connection-specific headers, which are forbidden in HTTP/2.
+        # Envoy Mobile will handle and set corresponding upstream connection headers properly on its own.
+        if key.lower() in {
+            "connection",
+            "keep-alive",
+            "proxy-connection",
+            "transfer-encoding",
+            "upgrade",
+        }:
             continue
         header_dict[key] = values if len(values) > 1 else values[0]
+
+    # Add socket tag header if specified
+    if socket_tag is not None:
+        header_dict["x-envoy-mobile-socket-tag"] = f"0,{socket_tag}"
 
     return header_dict
 

--- a/mobile/library/python/envoy_mobile/sync_client_transport.py
+++ b/mobile/library/python/envoy_mobile/sync_client_transport.py
@@ -6,7 +6,7 @@ from typing import Dict, Iterable, List, Optional, Union
 
 import httpx
 from . import envoy_engine
-from .httpx_utils import get_envoy_headers, map_envoy_error
+from .httpx_utils import get_envoy_headers, map_envoy_error, get_next_socket_tag
 
 
 class SyncEnvoyStream(httpx.SyncByteStream):
@@ -55,7 +55,7 @@ class SyncResponseHandler:
         self.data_queue: queue.Queue = queue.Queue()
         self.stream_complete = threading.Event()
         self.status_code: Optional[int] = None
-        self.headers: Dict[str, Union[str, List[str]]] = {}
+        self.headers: List[tuple] = []
         self.trailers: Dict[str, Union[str, List[str]]] = {}
         self.exception: Optional[Exception] = None
 
@@ -74,9 +74,11 @@ class SyncResponseHandler:
 
         for key, value in headers.items():
             if not key.startswith(":"):
-                self.headers[key] = (
-                    value[0] if isinstance(value, list) and len(value) == 1 else value
-                )
+                if isinstance(value, list):
+                    for val in value:
+                        self.headers.append((key, val))
+                else:
+                    self.headers.append((key, value))
 
         self.headers_event.set()
 
@@ -137,11 +139,12 @@ class EnvoyClientTransport(httpx.BaseTransport):
     def __init__(self, engine: envoy_engine.Engine, listener_name: str = "") -> None:
         self._engine = engine
         self._listener_name = listener_name
+        self._transport_tag = get_next_socket_tag()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         # Map headers
         timeout = request.extensions.get("timeout", {}).get("read")
-        envoy_headers = get_envoy_headers(request, timeout=timeout)
+        envoy_headers = get_envoy_headers(request, timeout=timeout, socket_tag=self._transport_tag)
 
         # Create handler
         handler = SyncResponseHandler()
@@ -177,7 +180,7 @@ class EnvoyClientTransport(httpx.BaseTransport):
 
         # Iterate through the request stream and send all data chunks.
         for chunk in request.stream:
-            stream.send_data(chunk, False)
+            stream.send_data(chunk)
 
         # Finalize the request. Sending an empty string with `stream.close()`
         # signals `end_stream=True` to Envoy, completing the request side of the stream.

--- a/mobile/library/python/envoy_mobile/transport_factory.py
+++ b/mobile/library/python/envoy_mobile/transport_factory.py
@@ -42,8 +42,17 @@ class EnvoyTransportFactory:
                 if builder is None:
                     builder = envoy_engine.EngineBuilder()
 
+                # Wait for the engine to be fully running before returning.
+                # This ensures DNS and other subsystems are initialized.
+                running_event = threading.Event()
+                builder.set_on_engine_running(running_event.set)
+
                 # Build and start the engine
                 cls._engine = builder.build()
+
+                # Timeout after 10 seconds to avoid infinite hang if it fails.
+                if not running_event.wait(timeout=10.0):
+                    raise RuntimeError("Envoy Mobile engine failed to start within 10 seconds")
 
             return cls._engine
 

--- a/mobile/test/python/test_httpx_transport.py
+++ b/mobile/test/python/test_httpx_transport.py
@@ -122,11 +122,102 @@ class TestEnvoyClientTransport(unittest.TestCase):
         self.mock_stream.send_headers.assert_called_once_with(unittest.mock.ANY, False)
         self.mock_stream.send_data.assert_has_calls(
             [
-                call(b"chunk1", False),
-                call(b"chunk2", False),
+                call(b"chunk1"),
+                call(b"chunk2"),
             ]
         )
         self.mock_stream.close.assert_called_once_with(b"")
+
+    def test_handle_request_duplicate_headers(self):
+        """Verify that duplicate headers are correctly preserved in sync transport."""
+        request = httpx.Request("GET", "https://example.com")
+
+        def side_effect(*args, **kwargs):
+            on_headers = kwargs.get("on_headers")
+            on_headers(
+                {
+                    ":status": "200",
+                    "content-type": "application/json",
+                    "set-cookie": ["cookie1", "cookie2"],
+                },
+                False,
+                None,
+            )
+            on_data = kwargs.get("on_data")
+            on_data(b"ok", 2, True, None)
+            return self.mock_stream
+
+        self.mock_prototype.start.side_effect = side_effect
+
+        response = self.transport.handle_request(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/json")
+        self.assertEqual(response.headers.get_list("set-cookie"), ["cookie1", "cookie2"])
+
+    def test_handle_request_socket_tag(self):
+        """Verify that the transport tag is injected into the Envoy headers in sync transport."""
+        request = httpx.Request("GET", "https://example.com")
+
+        def side_effect(*args, **kwargs):
+            on_headers = kwargs.get("on_headers")
+            on_headers({":status": "200"}, True, None)
+            return self.mock_stream
+
+        self.mock_prototype.start.side_effect = side_effect
+
+        # We can inspect the transport's tag before running the request
+        expected_tag = self.transport._transport_tag
+        expected_header_value = f"0,{expected_tag}"
+
+        self.transport.handle_request(request)
+
+        # Verify send_headers was called
+        self.mock_stream.send_headers.assert_called_once()
+
+        # Extract the headers passed to Envoy
+        sent_headers = self.mock_stream.send_headers.call_args[0][0]
+
+        # Verify the socket tag header is present and has the correct value
+        self.assertIn("x-envoy-mobile-socket-tag", sent_headers)
+        self.assertEqual(sent_headers["x-envoy-mobile-socket-tag"], expected_header_value)
+
+    def test_handle_request_filtered_headers(self):
+        """Verify that HTTP/1.1 connection-specific headers (forbidden in H2) and duplicate host headers are filtered out."""
+        request = httpx.Request(
+            "GET",
+            "https://example.com/path",
+            headers={
+                "connection": "upgrade",
+                "keep-alive": "timeout=5",
+                "host": "another-host.com",
+                "custom-header": "custom-value",
+            },
+        )
+
+        def side_effect(*args, **kwargs):
+            on_headers = kwargs.get("on_headers")
+            on_headers({":status": "200"}, True, None)
+            return self.mock_stream
+
+        self.mock_prototype.start.side_effect = side_effect
+
+        self.transport.handle_request(request)
+
+        # Verify send_headers was called
+        self.mock_stream.send_headers.assert_called_once()
+        sent_headers = self.mock_stream.send_headers.call_args[0][0]
+
+        # Verify pseudo-headers are present
+        self.assertEqual(sent_headers[":authority"], "example.com")
+
+        # Verify custom headers are preserved
+        self.assertEqual(sent_headers["custom-header"], "custom-value")
+
+        # Verify forbidden headers are filtered out
+        self.assertNotIn("connection", sent_headers)
+        self.assertNotIn("keep-alive", sent_headers)
+        self.assertNotIn("host", sent_headers)
 
 
 class TestAsyncEnvoyClientTransport(unittest.IsolatedAsyncioTestCase):
@@ -163,7 +254,7 @@ class TestAsyncEnvoyClientTransport(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await response.aread(), b"created")
 
         self.mock_stream.send_headers.assert_called_once_with(unittest.mock.ANY, False)
-        self.mock_stream.send_data.assert_called_once_with(b"body", False)
+        self.mock_stream.send_data.assert_called_once_with(b"body")
         self.mock_stream.close.assert_called_with(b"")
 
     async def test_handle_async_request_error(self):
@@ -210,11 +301,68 @@ class TestAsyncEnvoyClientTransport(unittest.IsolatedAsyncioTestCase):
         self.mock_stream.send_headers.assert_called_once_with(unittest.mock.ANY, False)
         self.mock_stream.send_data.assert_has_calls(
             [
-                call(b"chunk1", False),
-                call(b"chunk2", False),
+                call(b"chunk1"),
+                call(b"chunk2"),
             ]
         )
         self.mock_stream.close.assert_called_once_with(b"")
+
+    async def test_handle_async_request_duplicate_headers(self):
+        """Verify that duplicate headers are correctly preserved and exposed via HTTPX."""
+        request = httpx.Request("GET", "https://example.com")
+
+        def side_effect(*args, **kwargs):
+            on_headers = kwargs.get("on_headers")
+            loop = asyncio.get_running_loop()
+            loop.call_soon(
+                on_headers,
+                {
+                    ":status": "200",
+                    "content-type": "application/json",
+                    "set-cookie": ["cookie1", "cookie2"],
+                },
+                False,
+                None,
+            )
+            on_data = kwargs.get("on_data")
+            loop.call_soon(on_data, b"ok", 2, True, None)
+            return self.mock_stream
+
+        self.mock_prototype.start.side_effect = side_effect
+
+        response = await self.transport.handle_async_request(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/json")
+        self.assertEqual(response.headers.get_list("set-cookie"), ["cookie1", "cookie2"])
+
+    async def test_handle_async_request_socket_tag(self):
+        """Verify that the transport tag is injected into the Envoy headers."""
+        request = httpx.Request("GET", "https://example.com")
+
+        def side_effect(*args, **kwargs):
+            on_headers = kwargs.get("on_headers")
+            loop = asyncio.get_running_loop()
+            loop.call_soon(on_headers, {":status": "200"}, True, None)
+            return self.mock_stream
+
+        self.mock_prototype.start.side_effect = side_effect
+
+        # We can inspect the transport's tag before running the request
+        expected_tag = self.transport._transport_tag
+        expected_header_value = f"0,{expected_tag}"
+
+        await self.transport.handle_async_request(request)
+
+        # Verify send_headers was called
+        self.mock_stream.send_headers.assert_called_once()
+
+        # Extract the headers passed to Envoy
+        sent_headers = self.mock_stream.send_headers.call_args[0][0]
+
+        # Verify the socket tag header is present and has the correct value
+        self.assertIn("x-envoy-mobile-socket-tag", sent_headers)
+        self.assertEqual(sent_headers["x-envoy-mobile-socket-tag"], expected_header_value)
 
 
 from envoy_mobile.async_client.executor import AsyncioExecutor

--- a/mobile/test/python/test_transport_factory.py
+++ b/mobile/test/python/test_transport_factory.py
@@ -1,7 +1,6 @@
 """Unit tests for EnvoyTransportFactory."""
 
 import sys
-import threading
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -22,33 +21,12 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         EnvoyTransportFactory._engine = None
         mock_envoy_engine.reset_mock()
 
-        # Track all threading.Event instances to assert they are always waited for
-        self.created_events = []
-        self.simulate_timeout = False
-        self.original_event = threading.Event
-
-        def mocked_event():
-            # Wrap a real event in a MagicMock to track wait calls
-            ev = MagicMock(wraps=self.original_event())
-            if self.simulate_timeout:
-                ev.wait.return_value = False
-            self.created_events.append(ev)
-            return ev
-
-        self.event_patcher = patch("threading.Event", side_effect=mocked_event)
-        self.event_patcher.start()
-
-    def tearDown(self):
-        self.event_patcher.stop()
-        # Always assert that every synchronization event created was indeed waited for!
-        for ev in self.created_events:
-            self.assertTrue(
-                ev.wait.called,
-                "The engine running synchronization event was not waited for",
-            )
-
     def _setup_mock_builder(self, mock_builder, mock_engine, auto_fire_callback=True):
-        """Helper to configure a mock builder."""
+        """Helper to configure a mock builder.
+
+        By default, it simulates the real engine by immediately invoking the
+        registered 'on_engine_running' callback when build() is called.
+        """
         running_callback = None
 
         def set_on_engine_running(callback):
@@ -57,12 +35,7 @@ class TestEnvoyTransportFactory(unittest.TestCase):
             return mock_builder
 
         def build():
-            # Always assert that running_callback is assigned before build() is called
-            self.assertIsNotNone(
-                running_callback,
-                "builder.set_on_engine_running must be called before builder.build()",
-            )
-            if auto_fire_callback:
+            if auto_fire_callback and running_callback:
                 running_callback()
             return mock_engine
 
@@ -117,58 +90,6 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         mock_envoy_engine.EngineBuilder.assert_called_once()
         self.assertEqual(engine, mock_engine)
 
-    def test_get_shared_engine_waits_for_running(self):
-        # Setup mocks
-        mock_engine = MagicMock()
-        mock_builder = MagicMock()
-
-        # Do NOT auto-fire callback during build() so we can manually control the timing
-        self._setup_mock_builder(mock_builder, mock_engine, auto_fire_callback=False)
-
-        # Capture the callback reference during the test
-        engine_running_callback = None
-        original_side_effect = mock_builder.set_on_engine_running.side_effect
-
-        def set_on_engine_running_capture(callback):
-            nonlocal engine_running_callback
-            engine_running_callback = callback
-            return original_side_effect(callback)
-
-        mock_builder.set_on_engine_running.side_effect = set_on_engine_running_capture
-
-        # Run get_shared_engine in a separate thread because it blocks waiting for the callback
-        result = []
-        exception = []
-
-        def target():
-            try:
-                eng = EnvoyTransportFactory.get_shared_engine(mock_builder)
-                result.append(eng)
-            except Exception as e:
-                exception.append(e)
-
-        t = threading.Thread(target=target)
-        t.start()
-
-        # Wait a bit, verify it is still waiting (result is empty)
-        t.join(timeout=0.1)
-        self.assertTrue(t.is_alive())
-        self.assertEqual(len(result), 0)
-
-        # Now manually trigger the callback
-        self.assertIsNotNone(engine_running_callback)
-        engine_running_callback()
-
-        # The thread should now finish successfully
-        t.join(timeout=1.0)
-        self.assertFalse(t.is_alive())
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], mock_engine)
-        self.assertEqual(len(exception), 0)
-
-        mock_builder.set_on_engine_running.assert_called_once()
-        mock_builder.build.assert_called_once()
-
     def test_get_shared_engine_timeout(self):
         # Setup mocks
         mock_engine = MagicMock()
@@ -176,16 +97,14 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         # Disable auto-fire of callback
         self._setup_mock_builder(mock_builder, mock_engine, auto_fire_callback=False)
 
-        # Tell our event patcher to simulate a timeout
-        self.simulate_timeout = True
+        # Patch threading.Event.wait to return False immediately, simulating a timeout
+        with patch("threading.Event.wait", return_value=False):
+            with self.assertRaises(RuntimeError) as context:
+                EnvoyTransportFactory.get_shared_engine(mock_builder)
 
-        with self.assertRaises(RuntimeError) as context:
-            EnvoyTransportFactory.get_shared_engine(mock_builder)
-
-        self.assertIn(
-            "Envoy Mobile engine failed to start within 10 seconds",
-            str(context.exception),
-        )
+            self.assertIn(
+                "Envoy Mobile engine failed to start within 10 seconds", str(context.exception)
+            )
 
         mock_builder.set_on_engine_running.assert_called_once()
         mock_builder.build.assert_called_once()

--- a/mobile/test/python/test_transport_factory.py
+++ b/mobile/test/python/test_transport_factory.py
@@ -1,8 +1,9 @@
 """Unit tests for EnvoyTransportFactory."""
 
 import sys
+import threading
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # Mock envoy_engine before any imports that might use it
 mock_envoy_engine = MagicMock()
@@ -21,11 +22,58 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         EnvoyTransportFactory._engine = None
         mock_envoy_engine.reset_mock()
 
+        # Track all threading.Event instances to assert they are always waited for
+        self.created_events = []
+        self.simulate_timeout = False
+        self.original_event = threading.Event
+
+        def mocked_event():
+            # Wrap a real event in a MagicMock to track wait calls
+            ev = MagicMock(wraps=self.original_event())
+            if self.simulate_timeout:
+                ev.wait.return_value = False
+            self.created_events.append(ev)
+            return ev
+
+        self.event_patcher = patch("threading.Event", side_effect=mocked_event)
+        self.event_patcher.start()
+
+    def tearDown(self):
+        self.event_patcher.stop()
+        # Always assert that every synchronization event created was indeed waited for!
+        for ev in self.created_events:
+            self.assertTrue(
+                ev.wait.called,
+                "The engine running synchronization event was not waited for",
+            )
+
+    def _setup_mock_builder(self, mock_builder, mock_engine, auto_fire_callback=True):
+        """Helper to configure a mock builder."""
+        running_callback = None
+
+        def set_on_engine_running(callback):
+            nonlocal running_callback
+            running_callback = callback
+            return mock_builder
+
+        def build():
+            # Always assert that running_callback is assigned before build() is called
+            self.assertIsNotNone(
+                running_callback,
+                "builder.set_on_engine_running must be called before builder.build()",
+            )
+            if auto_fire_callback:
+                running_callback()
+            return mock_engine
+
+        mock_builder.set_on_engine_running.side_effect = set_on_engine_running
+        mock_builder.build.side_effect = build
+
     def test_get_shared_engine_singleton(self):
         # Setup mocks
         mock_engine = MagicMock()
         mock_builder = MagicMock()
-        mock_builder.build.return_value = mock_engine
+        self._setup_mock_builder(mock_builder, mock_engine)
 
         # Call factory multiple times
         engine1 = EnvoyTransportFactory.get_shared_engine(mock_builder)
@@ -42,7 +90,7 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         # Setup mocks
         mock_engine = MagicMock()
         mock_builder = MagicMock()
-        mock_builder.build.return_value = mock_engine
+        self._setup_mock_builder(mock_builder, mock_engine)
 
         # Get transports
         async_transport = EnvoyTransportFactory.get_async_transport(mock_builder)
@@ -60,7 +108,7 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         mock_builder_instance = MagicMock()
         mock_envoy_engine.EngineBuilder.return_value = mock_builder_instance
         mock_engine = MagicMock()
-        mock_builder_instance.build.return_value = mock_engine
+        self._setup_mock_builder(mock_builder_instance, mock_engine)
 
         # Call without explicit builder
         engine = EnvoyTransportFactory.get_shared_engine()
@@ -68,6 +116,79 @@ class TestEnvoyTransportFactory(unittest.TestCase):
         # Verify default builder was used
         mock_envoy_engine.EngineBuilder.assert_called_once()
         self.assertEqual(engine, mock_engine)
+
+    def test_get_shared_engine_waits_for_running(self):
+        # Setup mocks
+        mock_engine = MagicMock()
+        mock_builder = MagicMock()
+
+        # Do NOT auto-fire callback during build() so we can manually control the timing
+        self._setup_mock_builder(mock_builder, mock_engine, auto_fire_callback=False)
+
+        # Capture the callback reference during the test
+        engine_running_callback = None
+        original_side_effect = mock_builder.set_on_engine_running.side_effect
+
+        def set_on_engine_running_capture(callback):
+            nonlocal engine_running_callback
+            engine_running_callback = callback
+            return original_side_effect(callback)
+
+        mock_builder.set_on_engine_running.side_effect = set_on_engine_running_capture
+
+        # Run get_shared_engine in a separate thread because it blocks waiting for the callback
+        result = []
+        exception = []
+
+        def target():
+            try:
+                eng = EnvoyTransportFactory.get_shared_engine(mock_builder)
+                result.append(eng)
+            except Exception as e:
+                exception.append(e)
+
+        t = threading.Thread(target=target)
+        t.start()
+
+        # Wait a bit, verify it is still waiting (result is empty)
+        t.join(timeout=0.1)
+        self.assertTrue(t.is_alive())
+        self.assertEqual(len(result), 0)
+
+        # Now manually trigger the callback
+        self.assertIsNotNone(engine_running_callback)
+        engine_running_callback()
+
+        # The thread should now finish successfully
+        t.join(timeout=1.0)
+        self.assertFalse(t.is_alive())
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], mock_engine)
+        self.assertEqual(len(exception), 0)
+
+        mock_builder.set_on_engine_running.assert_called_once()
+        mock_builder.build.assert_called_once()
+
+    def test_get_shared_engine_timeout(self):
+        # Setup mocks
+        mock_engine = MagicMock()
+        mock_builder = MagicMock()
+        # Disable auto-fire of callback
+        self._setup_mock_builder(mock_builder, mock_engine, auto_fire_callback=False)
+
+        # Tell our event patcher to simulate a timeout
+        self.simulate_timeout = True
+
+        with self.assertRaises(RuntimeError) as context:
+            EnvoyTransportFactory.get_shared_engine(mock_builder)
+
+        self.assertIn(
+            "Envoy Mobile engine failed to start within 10 seconds",
+            str(context.exception),
+        )
+
+        mock_builder.set_on_engine_running.assert_called_once()
+        mock_builder.build.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add support for generating a unique socket tag in Python and injecting it via the x-envoy-mobile-socket-tag header in both synchronous and asynchronous HTTPX transports to enable connection pool isolation.
- Preserve duplicate response headers (e.g. multiple Set-Cookie headers) by representing received headers as a list of tuples.
- Filter out forbidden HTTP/1.1 connection-specific headers (e.g. Connection, Keep-Alive, Upgrade) and duplicate Host headers to prevent protocol errors in Envoy's HTTP/2 and HTTP/3 engines.
- Ensure Envoy Mobile engine is fully running with a 10-second initialization timeout before returning from EnvoyTransportFactory.

Risk Level: low, python API not in use
Testing: new unit test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
