### PR TITLE
fix: remove substitution_formatter_base 

### DIFF
--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -11,7 +11,7 @@
 #include "envoy/config/core/v3/http_uri.pb.h"
 #include "envoy/config/core/v3/protocol.pb.h"
 #include "envoy/config/route/v3/route_components.pb.h"
-#include "envoy/formatter/substitution_formatter_base.h"
+#include "envoy/formatter/substitution_formatter.h"
 #include "envoy/grpc/status.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"

--- a/source/extensions/formatter/dynamic_modules/formatter.h
+++ b/source/extensions/formatter/dynamic_modules/formatter.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <string>
 
-#include "envoy/formatter/substitution_formatter_base.h"
+#include "envoy/formatter/substitution_formatter.h"
 
 #include "source/common/common/statusor.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"


### PR DESCRIPTION
Follow up to https://github.com/envoyproxy/envoy/pull/45369, main is broken

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
