### PR TITLE
[git pre-push] Add explanation for the mysterious nothing outcome

### DIFF
--- a/support/hooks/pre-push
+++ b/support/hooks/pre-push
@@ -19,6 +19,28 @@ if [[ -n "$NO_VERIFY" ]]; then
 fi
 
 DUMMY_SHA=0000000000000000000000000000000000000000
+HOOK_START_SECONDS=$SECONDS
+PRE_PUSH_REMOTE_IDLE_WARNING_SECONDS="${PRE_PUSH_REMOTE_IDLE_WARNING_SECONDS:-300}"
+
+warn_if_remote_may_have_timed_out() {
+  local threshold="$PRE_PUSH_REMOTE_IDLE_WARNING_SECONDS"
+  if [[ ! "$threshold" =~ ^[0-9]+$ ]]; then
+    threshold=300
+  fi
+
+  local elapsed=$((SECONDS - HOOK_START_SECONDS))
+  if ((elapsed < threshold)); then
+    return
+  fi
+
+  echo >&2
+  echo >&2 "WARNING: pre-push checks took ${elapsed}s."
+  echo >&2 "Git contacts the remote before running this hook, so a long hook can leave"
+  echo >&2 "the remote SSH connection idle long enough to time out. If the push stops"
+  echo >&2 "after this point without normal object-transfer output, retry the same"
+  echo >&2 "command. The local caches should be warm, so the checks should finish faster"
+  echo >&2 "and the push will usually succeed on the second attempt."
+}
 
 # shellcheck disable=SC2016
 echo 'Running pre-push check; to skip this step use `push --no-verify` or add `NO_VERIFY=1` to `.env`'
@@ -89,5 +111,7 @@ do
     "$SCRIPT_DIR"/check_repositories.sh || exit 1
   fi
 done
+
+warn_if_remote_may_have_timed_out
 
 exit 0


### PR DESCRIPTION
Commit Message: [git pre-push] Add explanation for the mysterious nothing outcome
Additional Description: The git pre-push hooks sometimes just exit silently without actually doing the push, the cause of which has finally been tracked down to "it's not the hook, it's the git stuff *around* the hook that expires a connection and then fails without output". This makes it so if that's likely to have happened, the hook at least gives you a coherent explanation of what's up and what to do, so the next person to be baffled by this doesn't have to do all the diagnostics.

I tried to come up with a way to make the hook faster in the unwarmed state, and it seems to be a losing game - if we want to make sure the tools are all up to date then we *could* offload them into a tools repo and make them prebuild at startup like clang-format and clangd do (which has its own problem, in the container they should really have a wrapper that blocks until they're built, to stop vscode from flipping out about unready tools). But short of that, and that alone wouldn't help anyway since one tool is using do_ci, the useful thing is to make the hook at least explain itself.
Risk Level: None, only git pre-push hook that almost nobody uses.
Testing: Used the updated hook when pushing this PR.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
