### PR TITLE
Suppress CEL nullability completeness warning

### DIFF
--- a/bazel/foreign_cc/cel-cpp.patch
+++ b/bazel/foreign_cc/cel-cpp.patch
@@ -19,6 +19,34 @@ index 1f8801df..64ad71b5 100644
      ],
  )
    """,
+diff --git a/common/allocator.h b/common/allocator.h
+index 81d56b096c..bf022c4e11 100644
+--- a/common/allocator.h
++++ b/common/allocator.h
+@@ -31,4 +31,11 @@
+ #include "internal/new.h"
+ #include "google/protobuf/arena.h"
+-
++
++#if defined(__clang__)
++// CEL 0.14.0 has partially annotated pointer APIs. Suppress Clang's
++// completeness diagnostic until upstream adds annotations.
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wnullability-completeness"
++#endif
++
+ namespace cel {
+@@ -603,4 +610,8 @@ inline Allocator<T> ArenaAllocatorFor(
+-
++
+ }  // namespace cel
+-
++
++#if defined(__clang__)
++#pragma clang diagnostic pop
++#endif
++
+ #endif  // THIRD_PARTY_CEL_CPP_COMMON_ALLOCATOR_H_
 diff --git a/common/internal/byte_string.cc b/common/internal/byte_string.cc
 index b9f47922..9d096424 100644
 --- a/common/internal/byte_string.cc


### PR DESCRIPTION
CEL 0.14.0 has partially annotated pointer APIs in common/allocator.h. Clang 18 can emit -Wnullability-completeness for those declarations, which becomes fatal when built with -Werror in some local toolchain configurations.

Suppress the diagnostic in Envoy's CEL patch until upstream adds complete nullability annotations.

On Linux, the Envoy build (>=1.37) currently fails with:

```
external/com_google_cel_cpp/common/allocator.h:91:28: error: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Werror,-Wnullability-completeness]
   91 |   ABSL_MUST_USE_RESULT void* allocate_bytes(
      |                            ^
external/com_google_cel_cpp/common/allocator.h:91:28: note: insert '_Nullable' if the pointer may be null
   91 |   ABSL_MUST_USE_RESULT void* allocate_bytes(
      |                            ^
      |                              _Nullable
external/com_google_cel_cpp/common/allocator.h:91:28: note: insert '_Nonnull' if the pointer should never be null
   91 |   ABSL_MUST_USE_RESULT void* allocate_bytes(
      |
...
```
More details in slack [convo](https://envoyproxy.slack.com/archives/C78HA81DH/p1781548083093459).

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features: 
