### PR TITLE
Use std::optional in contrib

### DIFF
--- a/contrib/checksum/filters/http/source/checksum_filter.cc
+++ b/contrib/checksum/filters/http/source/checksum_filter.cc
@@ -2,6 +2,8 @@
 
 #include <openssl/mem.h>
 
+#include <optional>
+
 #include "source/common/common/assert.h"
 #include "source/common/common/hex.h"
 
@@ -34,7 +36,7 @@ OptRef<const Sha256Checksum> ChecksumFilterConfig::expectedChecksum(absl::string
       return m.second;
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 ChecksumFilter::ChecksumFilter(ChecksumFilterConfigSharedPtr config) : config_(config) {}
@@ -44,7 +46,7 @@ Http::FilterHeadersStatus ChecksumFilter::decodeHeaders(Http::RequestHeaderMap& 
   expected_checksum_ = config_->expectedChecksum(headers.Path()->value().getStringView());
   if (!expected_checksum_.has_value() && config_->rejectUnmatched()) {
     decoder_callbacks_->sendLocalReply(Http::Code::Forbidden, "No checksum for path", nullptr,
-                                       absl::nullopt, "no_checksum_for_path");
+                                       std::nullopt, "no_checksum_for_path");
     return Http::FilterHeadersStatus::StopIteration;
   }
   return Http::FilterHeadersStatus::Continue;
@@ -55,7 +57,7 @@ Http::FilterHeadersStatus ChecksumFilter::encodeHeaders(Http::ResponseHeaderMap&
   if (end_stream && expected_checksum_.has_value()) {
     encoder_callbacks_->sendLocalReply(Http::Code::Forbidden,
                                        "Expected checksum has value but response has no body",
-                                       nullptr, absl::nullopt, "checksum_but_no_body");
+                                       nullptr, std::nullopt, "checksum_but_no_body");
     return Http::FilterHeadersStatus::StopIteration;
   }
   SHA256_Init(&sha_);
@@ -71,7 +73,7 @@ Http::FilterDataStatus ChecksumFilter::encodeData(Buffer::Instance& data, bool e
   }
   if (end_stream && !checksumMatched()) {
     encoder_callbacks_->sendLocalReply(Http::Code::Forbidden, "Mismatched checksum", nullptr,
-                                       absl::nullopt, "mismatched_checksum");
+                                       std::nullopt, "mismatched_checksum");
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
   return Http::FilterDataStatus::Continue;
@@ -82,7 +84,7 @@ Http::FilterTrailersStatus ChecksumFilter::encodeTrailers(Http::ResponseTrailerM
     return Http::FilterTrailersStatus::Continue;
   }
   encoder_callbacks_->sendLocalReply(Http::Code::Forbidden, "Mismatched checksum", nullptr,
-                                     absl::nullopt, "mismatched_checksum");
+                                     std::nullopt, "mismatched_checksum");
   return Http::FilterTrailersStatus::StopIteration;
 }
 

--- a/contrib/config/source/kv_store_xds_delegate.cc
+++ b/contrib/config/source/kv_store_xds_delegate.cc
@@ -1,5 +1,7 @@
 #include "contrib/config/source/kv_store_xds_delegate.h"
 
+#include <optional>
+
 #include "envoy/registry/registry.h"
 #include "envoy/service/discovery/v3/discovery.pb.h"
 
@@ -9,7 +11,6 @@
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
-#include "absl/types/optional.h"
 #include "contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.pb.h"
 #include "contrib/envoy/extensions/config/v3alpha/kv_store_xds_delegate_config.pb.validate.h"
 
@@ -103,7 +104,7 @@ void KeyValueStoreXdsDelegate::onConfigUpdated(
       r.set_name(decoded_resource.name());
       r.set_version(decoded_resource.version());
       r.mutable_resource()->PackFrom(decoded_resource.resource());
-      absl::optional<std::chrono::seconds> ttl = absl::nullopt;
+      std::optional<std::chrono::seconds> ttl = std::nullopt;
       if (decoded_resource.ttl().has_value()) {
         r.mutable_ttl()->CopyFrom(
             Protobuf::util::TimeUtil::MillisecondsToDuration(decoded_resource.ttl()->count()));
@@ -130,7 +131,7 @@ void KeyValueStoreXdsDelegate::onConfigUpdated(
 
 void KeyValueStoreXdsDelegate::onResourceLoadFailed(
     const XdsSourceId& source_id, const std::string& resource_name,
-    const absl::optional<EnvoyException>& exception) {
+    const std::optional<EnvoyException>& exception) {
   // The resource failed to load, so remove it from the store.
   xds_config_store_->remove(constructKey(source_id, resource_name));
   stats_.xds_load_failed_.inc();

--- a/contrib/config/source/kv_store_xds_delegate.h
+++ b/contrib/config/source/kv_store_xds_delegate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/common/key_value_store.h"
 #include "envoy/config/xds_resources_delegate.h"
 #include "envoy/stats/scope.h"
@@ -53,7 +55,7 @@ public:
 
   void onResourceLoadFailed(const Envoy::Config::XdsSourceId& source_id,
                             const std::string& resource_name,
-                            const absl::optional<EnvoyException>& exception) override;
+                            const std::optional<EnvoyException>& exception) override;
 
 private:
   // Gets all the resources present in the KeyValueStore for the given source_id. This is the

--- a/contrib/config/test/kv_store_xds_delegate_integration_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_integration_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "envoy/admin/v3/config_dump.pb.h"
 #include "envoy/api/os_sys_calls.h"
 #include "envoy/common/key_value_store.h"
@@ -420,10 +422,10 @@ TEST_P(KeyValueStoreXdsDelegateIntegrationTest, BasicSuccess) {
 // A KeyValueStore implementation that returns an invalid proto field value for a Cluster resource.
 class InvalidProtoKeyValueStore : public KeyValueStore {
 public:
-  absl::optional<absl::string_view> get(absl::string_view) override { return absl::nullopt; }
+  std::optional<absl::string_view> get(absl::string_view) override { return std::nullopt; }
   void remove(absl::string_view) override {}
   void addOrUpdate(absl::string_view, absl::string_view,
-                   absl::optional<std::chrono::seconds>) override {}
+                   std::optional<std::chrono::seconds>) override {}
   void flush() override {}
 
   // We only have a cds_config making wildcard requests, so we only need to implement the iterate

--- a/contrib/dlb/source/connection_balancer_impl.h
+++ b/contrib/dlb/source/connection_balancer_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "envoy/event/dispatcher.h"
@@ -33,7 +34,7 @@ public:
   void post(Network::ConnectionSocketPtr&& socket) override;
 
   void onAcceptWorker(Network::ConnectionSocketPtr&&, bool, bool,
-                      const absl::optional<std::string>&) override {}
+                      const std::optional<std::string>&) override {}
 
   // Create Dlb event and callback.
   void setDlbEvent();
@@ -55,8 +56,8 @@ private:
 
 // The dir should always be "/dev" in production.
 // For test it is a temporary directory.
-// Return Dlb device id, absl::nullopt means error.
-static absl::optional<uint> detectDlbDevice(const uint config_id, const std::string& dir) {
+// Return Dlb device id, std::nullopt means error.
+static std::optional<uint> detectDlbDevice(const uint config_id, const std::string& dir) {
   uint device_id = config_id;
   Api::OsSysCalls& os_sys_calls = Api::OsSysCallsSingleton::get();
   struct stat buffer;
@@ -74,10 +75,10 @@ static absl::optional<uint> detectDlbDevice(const uint config_id, const std::str
       }
     }
     if (i == 64) {
-      return absl::nullopt;
+      return std::nullopt;
     }
   }
-  return absl::optional<uint>{device_id};
+  return std::optional<uint>{device_id};
 }
 
 class DlbConnectionBalanceFactory : public Envoy::Network::ConnectionBalanceFactory,

--- a/contrib/dynamo/filters/http/source/dynamo_request_parser.cc
+++ b/contrib/dynamo/filters/http/source/dynamo_request_parser.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -127,17 +128,17 @@ RequestParser::TableDescriptor RequestParser::parseTable(const std::string& oper
   return table;
 }
 
-absl::optional<std::string>
+std::optional<std::string>
 RequestParser::getTableNameFromTransactItem(const Json::Object& transact_item) {
   for (const std::string& operation : TRANSACT_ITEM_OPERATIONS) {
     Json::ObjectSharedPtr item =
         THROW_OR_RETURN_VALUE(transact_item.getObject(operation, true), Json::ObjectSharedPtr);
     std::string table_name = THROW_OR_RETURN_VALUE(item->getString("TableName", ""), std::string);
     if (!table_name.empty()) {
-      return absl::make_optional(table_name);
+      return std::make_optional(table_name);
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 std::vector<std::string> RequestParser::parseBatchUnProcessedKeys(const Json::Object& json_data) {

--- a/contrib/dynamo/filters/http/source/dynamo_request_parser.h
+++ b/contrib/dynamo/filters/http/source/dynamo_request_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -61,8 +62,7 @@ public:
   /**
    * @return string name of table in transaction object, or empty string if none
    */
-  static absl::optional<std::string>
-  getTableNameFromTransactItem(const Json::Object& transact_item);
+  static std::optional<std::string> getTableNameFromTransactItem(const Json::Object& transact_item);
 
   /**
    * Parse error details which might be provided for a given response code.

--- a/contrib/generic_proxy/filters/network/test/codecs/kafka/config_test.cc
+++ b/contrib/generic_proxy/filters/network/test/codecs/kafka/config_test.cc
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "test/extensions/filters/network/generic_proxy/mocks/codec.h"
 #include "test/mocks/network/connection.h"
@@ -25,7 +26,7 @@ TEST(KafkaCodecTest, SimpleFrameTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     KafkaRequestFrame frame(request);
@@ -64,7 +65,7 @@ TEST(KafkaCodecTest, KafkaRequestCallbacksTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     request_callbacks.onMessage(request);
@@ -117,7 +118,7 @@ TEST(KafkaCodecTest, KafkaServerCodecTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     KafkaRequestFrame frame(request);
@@ -131,7 +132,7 @@ TEST(KafkaCodecTest, KafkaServerCodecTest) {
     // Test decode() method.
     ON_CALL(mock_connection, bufferLimit()).WillByDefault(testing::Return(1024 * 1024));
     EXPECT_CALL(callbacks, onDecodingSuccess(_, _))
-        .WillOnce(testing::Invoke([](RequestHeaderFramePtr request, absl::optional<StartTime>) {
+        .WillOnce(testing::Invoke([](RequestHeaderFramePtr request, std::optional<StartTime>) {
           EXPECT_EQ(dynamic_cast<KafkaRequestFrame*>(request.get())
                         ->request_->request_header_.correlation_id_,
                     3);
@@ -140,7 +141,7 @@ TEST(KafkaCodecTest, KafkaServerCodecTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     Buffer::OwnedImpl buffer;
@@ -158,7 +159,7 @@ TEST(KafkaCodecTest, KafkaServerCodecTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     Buffer::OwnedImpl buffer;
@@ -177,7 +178,7 @@ TEST(KafkaCodecTest, KafkaServerCodecTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
     KafkaRequestFrame request_frame(request);
 
@@ -238,7 +239,7 @@ TEST(KafkaCodecTest, KafkaClientCodecTest) {
     // Test decode() method.
     ON_CALL(mock_connection, bufferLimit()).WillByDefault(testing::Return(1024 * 1024));
     EXPECT_CALL(callbacks, onDecodingSuccess(_, _))
-        .WillOnce(testing::Invoke([](ResponseHeaderFramePtr response, absl::optional<StartTime>) {
+        .WillOnce(testing::Invoke([](ResponseHeaderFramePtr response, std::optional<StartTime>) {
           EXPECT_EQ(dynamic_cast<KafkaResponseFrame*>(response.get())
                         ->response_->metadata_.correlation_id_,
                     3);
@@ -303,7 +304,7 @@ TEST(KafkaCodecTest, KafkaClientCodecTest) {
     auto request =
         std::make_shared<NetworkFilters::Kafka::Request<NetworkFilters::Kafka::FetchRequest>>(
             NetworkFilters::Kafka::RequestHeader(NetworkFilters::Kafka::FETCH_REQUEST_API_KEY, 0, 3,
-                                                 absl::nullopt),
+                                                 std::nullopt),
             NetworkFilters::Kafka::FetchRequest({}, {}, {}, {}));
 
     KafkaRequestFrame request_frame(request);

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -1552,8 +1553,8 @@ CAPIStatus Filter::getStringPropertyCommon(absl::string_view path, uint64_t* val
   return status;
 }
 
-absl::optional<google::api::expr::runtime::CelValue> Filter::findValue(absl::string_view name,
-                                                                       Protobuf::Arena* arena) {
+std::optional<google::api::expr::runtime::CelValue> Filter::findValue(absl::string_view name,
+                                                                      Protobuf::Arena* arena) {
   // as we already support getting/setting FilterState, we don't need to implement
   // getProperty with non-attribute name & setProperty which actually work on FilterState
   return StreamActivation::FindValue(name, arena);
@@ -2090,12 +2091,12 @@ SecretReader::SecretReader(
   }
 }
 
-absl::optional<const std::string> SecretReader::secret(const std::string& name) const {
+std::optional<const std::string> SecretReader::secret(const std::string& name) const {
   auto secret = secrets_.find(name);
   if (secret != secrets_.end()) {
     return secret->second->secret();
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 } // namespace Golang

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <optional>
 
 #include "envoy/access_log/access_log.h"
 #include "envoy/http/filter.h"
@@ -15,7 +16,6 @@
 #include "source/extensions/filters/common/expr/evaluator.h"
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/http/golang/v3alpha/golang.pb.h"
 #include "contrib/golang/filters/http/source/processor_state.h"
 #include "contrib/golang/filters/http/source/stats.h"
@@ -64,7 +64,7 @@ class SecretReader {
 public:
   SecretReader(const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
                Server::Configuration::FactoryContext& context);
-  absl::optional<const std::string> secret(const std::string& name) const;
+  std::optional<const std::string> secret(const std::string& name) const;
 
 private:
   absl::flat_hash_map<std::string, std::unique_ptr<Secret::ThreadLocalGenericSecretProvider>>
@@ -389,8 +389,8 @@ private:
 
   CAPIStatus getStringPropertyCommon(absl::string_view path, uint64_t* value_data, int* value_len);
   CAPIStatus getStringPropertyInternal(absl::string_view path, std::string* result);
-  absl::optional<google::api::expr::runtime::CelValue> findValue(absl::string_view name,
-                                                                 Protobuf::Arena* arena);
+  std::optional<google::api::expr::runtime::CelValue> findValue(absl::string_view name,
+                                                                Protobuf::Arena* arena);
   CAPIStatus serializeStringValue(Filters::Common::Expr::CelValue value, std::string* result);
 
   const FilterConfigSharedPtr config_;

--- a/contrib/golang/filters/http/source/processor_state.cc
+++ b/contrib/golang/filters/http/source/processor_state.cc
@@ -1,5 +1,7 @@
 #include "contrib/golang/filters/http/source/processor_state.h"
 
+#include <optional>
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/protobuf/utility.h"
 
@@ -289,7 +291,7 @@ void DecodingProcessorState::addBufferData(Buffer::Instance& data) {
             ENVOY_LOG(debug, "golang filter decode data buffer is full, reply with 413");
             decoder_callbacks_->sendLocalReply(
                 Http::Code::PayloadTooLarge,
-                Http::CodeUtility::toString(Http::Code::PayloadTooLarge), nullptr, absl::nullopt,
+                Http::CodeUtility::toString(Http::Code::PayloadTooLarge), nullptr, std::nullopt,
                 StreamInfo::ResponseCodeDetails::get().RequestPayloadTooLarge);
             return;
           }
@@ -323,8 +325,8 @@ void EncodingProcessorState::addBufferData(Buffer::Instance& data) {
             // reset the stream.
             encoder_callbacks_->sendLocalReply(
                 Http::Code::InternalServerError,
-                Http::CodeUtility::toString(Http::Code::InternalServerError), nullptr,
-                absl::nullopt, StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
+                Http::CodeUtility::toString(Http::Code::InternalServerError), nullptr, std::nullopt,
+                StreamInfo::ResponseCodeDetails::get().ResponsePayloadTooLarge);
             return;
           }
           if (!watermark_requested_) {

--- a/contrib/golang/upstreams/http/tcp/source/config.cc
+++ b/contrib/golang/upstreams/http/tcp/source/config.cc
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <optional>
+
 #include "upstream_request.h"
 
 namespace Envoy {
@@ -12,7 +14,7 @@ namespace Golang {
 Router::GenericConnPoolPtr GolangGenericConnPoolFactory::createGenericConnPool(
     Upstream::HostConstSharedPtr, Upstream::ThreadLocalCluster& thread_local_cluster,
     Router::GenericConnPoolFactory::UpstreamProtocol, Upstream::ResourcePriority priority,
-    absl::optional<Envoy::Http::Protocol>, Upstream::LoadBalancerContext* ctx,
+    std::optional<Envoy::Http::Protocol>, Upstream::LoadBalancerContext* ctx,
     const Protobuf::Message& config) const {
   auto ret = std::make_unique<TcpConnPool>(thread_local_cluster, priority, ctx, config);
   return (ret->valid() ? std::move(ret) : nullptr);

--- a/contrib/golang/upstreams/http/tcp/source/config.h
+++ b/contrib/golang/upstreams/http/tcp/source/config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/registry/registry.h"
 #include "envoy/router/router.h"
 
@@ -22,9 +24,8 @@ public:
   Router::GenericConnPoolPtr createGenericConnPool(
       Upstream::HostConstSharedPtr host, Upstream::ThreadLocalCluster& thread_local_cluster,
       Router::GenericConnPoolFactory::UpstreamProtocol upstream_protocol,
-      Upstream::ResourcePriority priority,
-      absl::optional<Envoy::Http::Protocol> downstream_protocol, Upstream::LoadBalancerContext* ctx,
-      const Protobuf::Message& config) const override;
+      Upstream::ResourcePriority priority, std::optional<Envoy::Http::Protocol> downstream_protocol,
+      Upstream::LoadBalancerContext* ctx, const Protobuf::Message& config) const override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::upstreams::http::tcp::golang::v3alpha::Config>();

--- a/contrib/golang/upstreams/http/tcp/source/upstream_request.h
+++ b/contrib/golang/upstreams/http/tcp/source/upstream_request.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "envoy/config/core/v3/extension.pb.h"
@@ -105,7 +106,7 @@ public:
                    Upstream::HostDescriptionConstSharedPtr host) override;
 
 private:
-  absl::optional<Envoy::Upstream::TcpPoolData> conn_pool_data_;
+  std::optional<Envoy::Upstream::TcpPoolData> conn_pool_data_;
   Envoy::Tcp::ConnectionPool::Cancellable* upstream_handle_{};
   Router::GenericConnectionPoolCallbacks* callbacks_{};
   Envoy::Tcp::ConnectionPool::ConnectionDataPtr upstream_conn_data_;

--- a/contrib/istio/filters/common/source/hashable_string.cc
+++ b/contrib/istio/filters/common/source/hashable_string.cc
@@ -1,6 +1,7 @@
 #include "contrib/istio/filters/common/source/hashable_string.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "envoy/registry/registry.h"
@@ -14,7 +15,7 @@ namespace Common {
 
 HashableString::HashableString(absl::string_view value) : Router::StringAccessorImpl(value) {}
 
-absl::optional<uint64_t> HashableString::hash() const { return HashUtil::xxHash64(asString()); }
+std::optional<uint64_t> HashableString::hash() const { return HashUtil::xxHash64(asString()); }
 
 namespace {
 

--- a/contrib/istio/filters/common/source/hashable_string.h
+++ b/contrib/istio/filters/common/source/hashable_string.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/common/hashable.h"
 
 #include "source/common/router/string_accessor_impl.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Istio {
@@ -15,7 +15,7 @@ public:
   HashableString(absl::string_view value);
 
   // Hashable
-  absl::optional<uint64_t> hash() const override;
+  std::optional<uint64_t> hash() const override;
 };
 
 } // namespace Common

--- a/contrib/istio/filters/common/source/metadata_object.cc
+++ b/contrib/istio/filters/common/source/metadata_object.cc
@@ -1,5 +1,7 @@
 #include "contrib/istio/filters/common/source/metadata_object.h"
 
+#include <optional>
+
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/registry/registry.h"
 
@@ -56,7 +58,7 @@ static absl::flat_hash_map<absl::string_view, WorkloadType> ALL_WORKLOAD_TOKENS 
     {CronJobSuffix, WorkloadType::CronJob},
 };
 
-absl::optional<absl::string_view> toSuffix(WorkloadType workload_type) {
+std::optional<absl::string_view> toSuffix(WorkloadType workload_type) {
   switch (workload_type) {
   case WorkloadType::Deployment:
     return DeploymentSuffix;
@@ -214,16 +216,16 @@ WorkloadMetadataObject::serializeAsPairs() const {
   return parts;
 }
 
-absl::optional<std::string> WorkloadMetadataObject::serializeAsString() const {
+std::optional<std::string> WorkloadMetadataObject::serializeAsString() const {
   const auto parts = serializeAsPairs();
   return absl::StrJoin(parts, ",", absl::PairFormatter("="));
 }
 
-absl::optional<uint64_t> WorkloadMetadataObject::hash() const {
+std::optional<uint64_t> WorkloadMetadataObject::hash() const {
   return Envoy::HashUtil::xxHash64(*serializeAsString());
 }
 
-absl::optional<std::string> WorkloadMetadataObject::owner() const {
+std::optional<std::string> WorkloadMetadataObject::owner() const {
   const auto suffix = toSuffix(workload_type_);
   if (suffix) {
     return absl::StrCat(OwnerPrefix, namespace_name_, "/", *suffix, "s/", workload_name_);
@@ -315,7 +317,7 @@ convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
 std::unique_ptr<WorkloadMetadataObject>
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
-                                const absl::optional<envoy::config::core::v3::Locality> locality) {
+                                const std::optional<envoy::config::core::v3::Locality> locality) {
   absl::string_view instance, namespace_name, owner, workload, cluster, identity, canonical_name,
       canonical_revision, app_name, app_version, region, zone;
   std::vector<std::pair<std::string, std::string>> labels;
@@ -379,15 +381,15 @@ convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
   return obj;
 }
 
-absl::optional<WorkloadMetadataObject>
+std::optional<WorkloadMetadataObject>
 convertEndpointMetadata(const std::string& endpoint_encoding) {
   std::vector<absl::string_view> parts = absl::StrSplit(endpoint_encoding, ';');
   if (parts.size() < 5) {
     return {};
   }
-  return absl::make_optional<WorkloadMetadataObject>("", parts[4], parts[1], parts[0], parts[2],
-                                                     parts[3], "", "", WorkloadType::Unknown, "",
-                                                     "", "");
+  return std::make_optional<WorkloadMetadataObject>("", parts[4], parts[1], parts[0], parts[2],
+                                                    parts[3], "", "", WorkloadType::Unknown, "", "",
+                                                    "");
 }
 
 std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metadata) {
@@ -403,8 +405,7 @@ std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metada
   return out;
 }
 
-absl::optional<absl::string_view>
-WorkloadMetadataObject::field(absl::string_view field_name) const {
+std::optional<absl::string_view> WorkloadMetadataObject::field(absl::string_view field_name) const {
   const auto it = ALL_METADATA_FIELDS.find(field_name);
   if (it != ALL_METADATA_FIELDS.end()) {
     switch (it->second) {
@@ -435,7 +436,7 @@ WorkloadMetadataObject::field(absl::string_view field_name) const {
       return locality_zone_;
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 WorkloadMetadataObject::FieldType

--- a/contrib/istio/filters/common/source/metadata_object.h
+++ b/contrib/istio/filters/common/source/metadata_object.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/common/hashable.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/stream_info/filter_state.h"
 
 #include "source/common/protobuf/protobuf.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Istio {
@@ -118,16 +118,16 @@ public:
         workload_type_(workload_type), identity_(identity), locality_region_(region),
         locality_zone_(zone) {}
 
-  absl::optional<uint64_t> hash() const override;
+  std::optional<uint64_t> hash() const override;
   Envoy::ProtobufTypes::MessagePtr serializeAsProto() const override;
   std::vector<std::pair<absl::string_view, absl::string_view>> serializeAsPairs() const;
-  absl::optional<std::string> serializeAsString() const override;
-  absl::optional<std::string> owner() const;
+  std::optional<std::string> serializeAsString() const override;
+  std::optional<std::string> owner() const;
   std::string identity() const;
   bool hasFieldSupport() const override { return true; }
   using Envoy::StreamInfo::FilterState::Object::FieldType;
   FieldType getField(absl::string_view) const override;
-  absl::optional<absl::string_view> field(absl::string_view field_name) const;
+  std::optional<absl::string_view> field(absl::string_view field_name) const;
   void setLabels(std::vector<std::pair<std::string, std::string>> labels) { labels_ = labels; }
   std::vector<std::pair<std::string, std::string>> getLabels() const { return labels_; }
   std::string baggage() const;
@@ -167,14 +167,13 @@ convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
 std::unique_ptr<WorkloadMetadataObject>
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
-                                const absl::optional<envoy::config::core::v3::Locality> locality);
+                                const std::optional<envoy::config::core::v3::Locality> locality);
 
 // Convert endpoint metadata string to a metadata object.
 // Telemetry metadata is compressed into a semicolon separated string:
 // workload-name;namespace;canonical-service-name;canonical-service-revision;cluster-id.
 // Telemetry metadata is stored as a string under "istio", "workload" field path.
-absl::optional<WorkloadMetadataObject>
-convertEndpointMetadata(const std::string& endpoint_encoding);
+std::optional<WorkloadMetadataObject> convertEndpointMetadata(const std::string& endpoint_encoding);
 
 std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metadata);
 

--- a/contrib/istio/filters/common/source/workload_discovery.cc
+++ b/contrib/istio/filters/common/source/workload_discovery.cc
@@ -1,5 +1,7 @@
 #include "contrib/istio/filters/common/source/workload_discovery.h"
 
+#include <optional>
+
 #include "envoy/registry/registry.h"
 #include "envoy/server/bootstrap_extension_config.h"
 #include "envoy/server/factory_context.h"
@@ -81,7 +83,7 @@ public:
     subscription_.start();
   }
 
-  absl::optional<Istio::Common::WorkloadMetadataObject>
+  std::optional<Istio::Common::WorkloadMetadataObject>
   getMetadata(const Network::Address::InstanceConstSharedPtr& address) override {
     if (address && address->ip()) {
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
@@ -127,7 +129,7 @@ private:
     }
     size_t total() const { return address_to_workload_.size(); }
     // Returns by-value since the flat map does not provide pointer stability.
-    absl::optional<Istio::Common::WorkloadMetadataObject> get(const std::string& address) {
+    std::optional<Istio::Common::WorkloadMetadataObject> get(const std::string& address) {
       const auto it = address_to_workload_.find(address);
       if (it != address_to_workload_.end()) {
         return it->second;

--- a/contrib/istio/filters/common/source/workload_discovery.h
+++ b/contrib/istio/filters/common/source/workload_discovery.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/network/address.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/stats/stats_macros.h"
@@ -20,7 +22,7 @@ struct WorkloadDiscoveryStats {
 class WorkloadMetadataProvider {
 public:
   virtual ~WorkloadMetadataProvider() = default;
-  virtual absl::optional<Istio::Common::WorkloadMetadataObject>
+  virtual std::optional<Istio::Common::WorkloadMetadataObject>
   getMetadata(const Network::Address::InstanceConstSharedPtr& address) PURE;
 };
 

--- a/contrib/istio/filters/common/test/metadata_object_test.cc
+++ b/contrib/istio/filters/common/test/metadata_object_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "envoy/registry/registry.h"
 
 #include "contrib/istio/filters/common/source/metadata_object.h"
@@ -195,10 +197,10 @@ TEST(WorkloadMetadataObjectTest, ConvertFromEmpty) {
 }
 
 TEST(WorkloadMetadataObjectTest, ConvertFromEndpointMetadata) {
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata(""));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;b"));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;;;b"));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;b;c;d"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata(""));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;;;b"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b;c;d"));
   auto obj = convertEndpointMetadata("foo-pod;default;foo-service;v1;my-cluster");
   ASSERT_TRUE(obj.has_value());
   EXPECT_EQ(obj->serializeAsString(), "workload=foo-pod,cluster=my-cluster,"

--- a/contrib/istio/filters/http/alpn/test/alpn_test.cc
+++ b/contrib/istio/filters/http/alpn/test/alpn_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "source/common/network/application_protocol.h"
 
 #include "test/mocks/http/mocks.h"
@@ -72,7 +74,7 @@ TEST_F(AlpnFilterTest, OverrideAlpnUseDownstreamProtocol) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol> protocol) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol> protocol) -> std::vector<Http::Protocol> {
         return {protocol.value()};
       });
 
@@ -106,7 +108,7 @@ TEST_F(AlpnFilterTest, OverrideAlpn) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
         return {Http::Protocol::Http2};
       });
 
@@ -139,7 +141,7 @@ TEST_F(AlpnFilterTest, EmptyOverrideAlpn) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
         return {Http::Protocol::Http2};
       });
 

--- a/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
+++ b/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
@@ -15,6 +15,7 @@
 #include "contrib/istio/filters/http/istio_stats/source/istio_stats.h"
 
 #include <atomic>
+#include <optional>
 
 #include "envoy/registry/registry.h"
 #include "envoy/router/string_accessor.h"
@@ -56,7 +57,7 @@ namespace {
 
 constexpr absl::string_view NamespaceKey = "/ns/";
 
-absl::optional<absl::string_view> getNamespace(absl::string_view principal) {
+std::optional<absl::string_view> getNamespace(absl::string_view principal) {
   // The namespace is a substring in principal with format:
   // "<DOMAIN>/ns/<NAMESPACE>/sa/<SERVICE-ACCOUNT>". '/' is not allowed to
   // appear in actual content except as delimiter between tokens.
@@ -89,7 +90,7 @@ absl::string_view extractMapString(const Protobuf::Struct& metadata, const std::
   return extractString(it->second.struct_value(), key);
 }
 
-absl::optional<Istio::Common::WorkloadMetadataObject>
+std::optional<Istio::Common::WorkloadMetadataObject>
 extractEndpointMetadata(const StreamInfo::StreamInfo& info) {
   auto upstream_info = info.upstreamInfo();
   auto upstream_host = upstream_info ? upstream_info->upstreamHost() : nullptr;
@@ -126,7 +127,7 @@ bool peerInfoRead(Reporter reporter, const StreamInfo::FilterState& filter_state
          filter_state.hasDataWithName(Istio::Common::NoPeer);
 }
 
-absl::optional<Istio::Common::WorkloadMetadataObject>
+std::optional<Istio::Common::WorkloadMetadataObject>
 peerInfo(Reporter reporter, const StreamInfo::FilterState& filter_state) {
   const auto& cel_state_key =
       reporter == Reporter::ServerSidecar || reporter == Reporter::ServerGateway
@@ -393,7 +394,7 @@ struct MetricOverrides : public Logger::Loggable<Logger::Id::filter> {
   // Initial transformation: metrics dropped.
   absl::flat_hash_set<Stats::StatName> drop_;
   // Second transformation: tags changed.
-  using TagOverrides = absl::flat_hash_map<Stats::StatName, absl::optional<uint32_t>>;
+  using TagOverrides = absl::flat_hash_map<Stats::StatName, std::optional<uint32_t>>;
   absl::flat_hash_map<Stats::StatName, TagOverrides> tag_overrides_;
   // Third transformation: tags added.
   using TagAdditions = std::vector<std::pair<Stats::StatName, uint32_t>>;
@@ -429,7 +430,7 @@ struct MetricOverrides : public Logger::Loggable<Logger::Id::filter> {
     }
     return out;
   }
-  absl::optional<uint32_t> getOrCreateExpression(const std::string& expr, bool int_expr) {
+  std::optional<uint32_t> getOrCreateExpression(const std::string& expr, bool int_expr) {
     const auto& it = expression_ids_.find(expr);
     if (it != expression_ids_.end()) {
       return {it->second};
@@ -977,7 +978,7 @@ private:
   void populatePeerInfo(const StreamInfo::StreamInfo& info,
                         const StreamInfo::FilterState& filter_state) {
     // Compute peer info with client-side fallbacks.
-    absl::optional<Istio::Common::WorkloadMetadataObject> peer;
+    std::optional<Istio::Common::WorkloadMetadataObject> peer;
     auto object = peerInfo(config_->reporter(), filter_state);
     if (object) {
       peer.emplace(object.value());
@@ -1072,7 +1073,7 @@ private:
     case Reporter::ClientSidecar: {
       const Ssl::ConnectionInfoConstSharedPtr ssl_info =
           info.upstreamInfo() ? info.upstreamInfo()->upstreamSslConnection() : nullptr;
-      absl::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
+      std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
       if (ssl_info && !ssl_info->uriSanPeerCertificate().empty()) {
         peer_san = ssl_info->uriSanPeerCertificate()[0];
       }
@@ -1131,7 +1132,7 @@ private:
                                                      : context_.unknown_});
       switch (config_->reporter()) {
       case Reporter::ServerGateway: {
-        absl::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
+        std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
         auto endpoint_object = peerInfo(Reporter::ClientSidecar, filter_state);
         if (endpoint_object) {
           endpoint_peer.emplace(endpoint_object.value());
@@ -1260,7 +1261,7 @@ private:
   bool peer_read_{false};
   uint64_t bytes_sent_{0};
   uint64_t bytes_received_{0};
-  absl::optional<bool> mutual_tls_;
+  std::optional<bool> mutual_tls_;
   bool is_grpc_{false};
   uint64_t request_message_count_{0};
   uint64_t response_message_count_{0};

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -1,5 +1,7 @@
 #include "contrib/istio/filters/http/peer_metadata/source/peer_metadata.h"
 
+#include <optional>
+
 #include "envoy/registry/registry.h"
 #include "envoy/server/factory_context.h"
 
@@ -22,8 +24,8 @@ public:
       : downstream_(downstream),
         metadata_provider_(Extensions::Common::WorkloadDiscovery::getProvider(factory_context)),
         local_info_(factory_context.localInfo()) {}
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 
 private:
   const bool downstream_;
@@ -31,8 +33,8 @@ private:
   const LocalInfo::LocalInfo& local_info_;
 };
 
-absl::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
-                                                   Http::HeaderMap& headers, Context&) const {
+std::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
+                                                  Http::HeaderMap& headers, Context&) const {
   if (!metadata_provider_) {
     return {};
   }
@@ -108,8 +110,8 @@ MXMethod::MXMethod(bool downstream, const absl::flat_hash_set<std::string> addit
   tls_.set([](Event::Dispatcher&) { return std::make_shared<MXCache>(); });
 }
 
-absl::optional<PeerInfo> MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                  Http::HeaderMap& headers, Context& ctx) const {
+std::optional<PeerInfo> MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
+                                                 Http::HeaderMap& headers, Context& ctx) const {
   const auto peer_id_header = headers.get(Headers::get().ExchangeMetadataHeaderId);
   if (downstream_) {
     ctx.request_peer_id_received_ = !peer_id_header.empty();
@@ -133,7 +135,7 @@ void MXMethod::remove(Http::HeaderMap& headers) const {
   headers.remove(Headers::get().ExchangeMetadataHeader);
 }
 
-absl::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view value) const {
+std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view value) const {
   // This code is copied from:
   // https://github.com/istio/proxy/blob/release-1.18/extensions/metadata_exchange/plugin.cc#L116
   auto& cache = tls_->cache_;
@@ -183,14 +185,14 @@ public:
   UpstreamFilterStateMethod(
       const io::istio::http::peer_metadata::Config_UpstreamFilterState& config)
       : peer_metadata_key_(config.peer_metadata_key()) {}
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 
 private:
   std::string peer_metadata_key_;
 };
 
-absl::optional<PeerInfo>
+std::optional<PeerInfo>
 UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Http::HeaderMap&,
                                           Context&) const {
   const auto upstream = info.upstreamInfo();
@@ -243,9 +245,9 @@ void BaggagePropagationMethod::inject(const StreamInfo::StreamInfo&, Http::Heade
 
 BaggageDiscoveryMethod::BaggageDiscoveryMethod() = default;
 
-absl::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                                Http::HeaderMap& headers,
-                                                                Context&) const {
+std::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
+                                                               Http::HeaderMap& headers,
+                                                               Context&) const {
   const auto baggage_header = headers.get(Headers::get().Baggage);
   if (baggage_header.empty()) {
     return {};

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "source/common/singleton/const_singleton.h"
 #include "source/extensions/filters/common/expr/cel_state.h"
 #include "source/extensions/filters/http/common/factory_base.h"
@@ -38,8 +40,8 @@ struct Context {
 class DiscoveryMethod {
 public:
   virtual ~DiscoveryMethod() = default;
-  virtual absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                                  Context&) const PURE;
+  virtual std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                                 Context&) const PURE;
   virtual void remove(Http::HeaderMap&) const {}
 };
 
@@ -49,12 +51,12 @@ class MXMethod : public DiscoveryMethod {
 public:
   MXMethod(bool downstream, const absl::flat_hash_set<std::string> additional_labels,
            Server::Configuration::ServerFactoryContext& factory_context);
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
   void remove(Http::HeaderMap&) const override;
 
 private:
-  absl::optional<PeerInfo> lookup(absl::string_view id, absl::string_view value) const;
+  std::optional<PeerInfo> lookup(absl::string_view id, absl::string_view value) const;
   const bool downstream_;
   struct MXCache : public ThreadLocal::ThreadLocalObject {
     absl::flat_hash_map<std::string, PeerInfo> cache_;
@@ -104,8 +106,8 @@ private:
 class BaggageDiscoveryMethod : public DiscoveryMethod, public Logger::Loggable<Logger::Id::filter> {
 public:
   BaggageDiscoveryMethod();
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {

--- a/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
+++ b/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "source/common/network/address_impl.h"
 
 #include "test/common/stream_info/test_util.h"
@@ -33,7 +35,7 @@ class MockWorkloadMetadataProvider
       public Singleton::Instance {
 public:
   MockWorkloadMetadataProvider() = default;
-  MOCK_METHOD(absl::optional<WorkloadMetadataObject>, getMetadata,
+  MOCK_METHOD(std::optional<WorkloadMetadataObject>, getMetadata,
               (const Network::Address::InstanceConstSharedPtr& address));
 };
 
@@ -121,7 +123,7 @@ TEST_F(PeerMetadataTest, DownstreamXDS) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) {
           return {pod};
         }
@@ -143,7 +145,7 @@ TEST_F(PeerMetadataTest, UpstreamXDS) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) {
           return {pod};
         }
@@ -179,7 +181,7 @@ TEST_F(PeerMetadataTest, UpstreamXDSInternal) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.100")) {
           return {pod};
         }
@@ -248,7 +250,7 @@ TEST_F(PeerMetadataTest, DownstreamFallbackSecond) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) { // remote address
           return {pod};
         }
@@ -331,7 +333,7 @@ TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address
           return {pod};
         }
@@ -353,7 +355,7 @@ TEST_F(PeerMetadataTest, UpstreamFallbackFirstXDS) {
                                    "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
   EXPECT_CALL(*metadata_provider_, getMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> absl::optional<WorkloadMetadataObject> {
+                                 -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address
           return {pod};
         }

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -1,5 +1,7 @@
 #include "contrib/istio/filters/network/peer_metadata/source/peer_metadata.h"
 
+#include <optional>
+
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
@@ -19,12 +21,12 @@ std::string baggageValue(const LocalInfo::LocalInfo& local_info) {
   return obj->baggage();
 }
 
-absl::optional<absl::string_view> internalListenerName(const Network::Address::Instance& address) {
+std::optional<absl::string_view> internalListenerName(const Network::Address::Instance& address) {
   const auto internal = address.envoyInternalAddress();
   if (internal != nullptr) {
     return internal->addressId();
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 bool allowedInternalListener(const Network::Address::Instance& address) {
@@ -76,7 +78,7 @@ Network::FilterStatus Filter::onWrite(Buffer::Instance& buffer, bool) {
     // for peer metadata anymore, if the upstream sent it, we'd have it by
     // now. So we can check if the peer metadata is available or not, and if
     // no peer metadata available, we can give up waiting for it.
-    absl::optional<Protobuf::Any> peer_metadata = discoverPeerMetadata();
+    std::optional<Protobuf::Any> peer_metadata = discoverPeerMetadata();
     if (peer_metadata) {
       propagatePeerMetadata(*peer_metadata);
     } else {
@@ -115,7 +117,7 @@ bool Filter::disableDiscovery() const {
   return discoveryDisabled(metadata);
 }
 
-absl::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
+std::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
   ENVOY_LOG(trace, "Trying to discover peer metadata from filter state set by TCP Proxy");
   ASSERT(write_callbacks_);
 
@@ -126,7 +128,7 @@ absl::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
           TcpProxy::TunnelResponseHeaders::key());
   if (!state) {
     ENVOY_LOG(trace, "TCP Proxy didn't set expected filter state");
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   const Http::HeaderMap& headers = state->value();
@@ -135,7 +137,7 @@ absl::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
     ENVOY_LOG(
         trace,
         "TCP Proxy saved response headers to the filter state, but there is no baggage header");
-    return absl::nullopt;
+    return std::nullopt;
   }
 
   ENVOY_LOG(trace,

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "envoy/local_info/local_info.h"
@@ -72,7 +73,7 @@ public:
 private:
   void populateBaggage();
   bool disableDiscovery() const;
-  absl::optional<Protobuf::Any> discoverPeerMetadata();
+  std::optional<Protobuf::Any> discoverPeerMetadata();
   void propagatePeerMetadata(const Protobuf::Any& peer_metadata);
   void propagateNoPeerMetadata();
 

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -345,24 +346,24 @@ public:
     return upstream_host_->cluster_.metadata_;
   }
 
-  absl::optional<Istio::Common::WorkloadMetadataObject> peerInfoFromFilterState() const {
+  std::optional<Istio::Common::WorkloadMetadataObject> peerInfoFromFilterState() const {
     const auto& filter_state = stream_info_.filterState();
     const auto* cel_state =
         filter_state.getDataReadOnly<Extensions::Filters::Common::Expr::CelState>(
             Istio::Common::UpstreamPeer);
     if (!cel_state) {
-      return absl::nullopt;
+      return std::nullopt;
     }
 
     Protobuf::Struct obj;
     if (!obj.ParseFromString(absl::string_view(cel_state->value()))) {
-      return absl::nullopt;
+      return std::nullopt;
     }
 
     std::unique_ptr<Istio::Common::WorkloadMetadataObject> peer_info =
         Istio::Common::convertStructToWorkloadMetadata(obj);
     if (!peer_info) {
-      return absl::nullopt;
+      return std::nullopt;
     }
 
     return *peer_info;

--- a/contrib/kafka/filters/network/source/broker/filter_config.cc
+++ b/contrib/kafka/filters/network/source/broker/filter_config.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
 
+#include <optional>
+
 #include "source/common/common/assert.h"
 
 namespace Envoy {
@@ -49,7 +51,7 @@ bool BrokerFilterConfig::needsResponseRewrite() const {
   return force_response_rewrite_ || !broker_address_rewrite_rules_.empty();
 }
 
-absl::optional<HostAndPort>
+std::optional<HostAndPort>
 BrokerFilterConfig::findBrokerAddressOverride(const uint32_t broker_id) const {
   for (const auto& rule : broker_address_rewrite_rules_) {
     if (rule.matches(broker_id)) {
@@ -57,7 +59,7 @@ BrokerFilterConfig::findBrokerAddressOverride(const uint32_t broker_id) const {
       return {hp};
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 absl::flat_hash_set<int16_t> BrokerFilterConfig::apiKeysAllowed() const {

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <utility>
 
 #include "absl/container/flat_hash_set.h"
-#include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.h"
 #include "contrib/envoy/extensions/filters/network/kafka_broker/v3/kafka_broker.pb.validate.h"
 
@@ -57,7 +57,7 @@ public:
   /**
    * Returns override address for a broker.
    */
-  virtual absl::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const;
+  virtual std::optional<HostAndPort> findBrokerAddressOverride(const uint32_t broker_id) const;
 
   /**
    * Returns what API keys are allowed.

--- a/contrib/kafka/filters/network/source/broker/rewriter.h
+++ b/contrib/kafka/filters/network/source/broker/rewriter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include "envoy/buffer/buffer.h"
@@ -69,7 +70,7 @@ private:
   // Pointer-to-member used to handle varying field names across the structs.
   template <typename T> void maybeUpdateHostAndPort(T& arg, const int32_t T::*node_id_field) const {
     const int32_t node_id = arg.*node_id_field;
-    const absl::optional<HostAndPort> hostAndPort = config_->findBrokerAddressOverride(node_id);
+    const std::optional<HostAndPort> hostAndPort = config_->findBrokerAddressOverride(node_id);
     if (hostAndPort) {
       ENVOY_LOG(trace, "Changing broker [{}] from {}:{} to {}:{}", node_id, arg.host_, arg.port_,
                 hostAndPort->first, hostAndPort->second);

--- a/contrib/kafka/filters/network/source/kafka_request_parser.h
+++ b/contrib/kafka/filters/network/source/kafka_request_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "envoy/common/exception.h"
 
@@ -32,7 +33,7 @@ struct RequestContext {
   /**
    * Request header that gets filled in during the parse.
    */
-  RequestHeader request_header_{-1, -1, -1, absl::nullopt};
+  RequestHeader request_header_{-1, -1, -1, std::nullopt};
 
   /**
    * Bytes left to consume.

--- a/contrib/kafka/filters/network/source/kafka_types.h
+++ b/contrib/kafka/filters/network/source/kafka_types.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -15,7 +14,7 @@ namespace Kafka {
 /**
  * Nullable string used by Kafka.
  */
-using NullableString = absl::optional<std::string>;
+using NullableString = std::optional<std::string>;
 
 /**
  * Bytes array used by Kafka.
@@ -25,12 +24,12 @@ using Bytes = std::vector<unsigned char>;
 /**
  * Nullable bytes array used by Kafka.
  */
-using NullableBytes = absl::optional<Bytes>;
+using NullableBytes = std::optional<Bytes>;
 
 /**
  * Kafka array of elements of type T.
  */
-template <typename T> using NullableArray = absl::optional<std::vector<T>>;
+template <typename T> using NullableArray = std::optional<std::vector<T>>;
 
 /**
  * Analogous to:

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h"
 
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/serialization.h"
 
 namespace Envoy {
@@ -34,7 +36,7 @@ FetchRecordConverterImpl::convert(const InboundRecordsMap& arg) const {
     const int16_t error_code = 0;
     const int64_t high_watermark = 0;
     const auto frrpd = FetchResponseResponsePartitionData{partition, error_code, high_watermark,
-                                                          absl::make_optional(record_batch.second)};
+                                                          std::make_optional(record_batch.second)};
 
     frrpds.push_back(frrpd);
   }

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/metadata.cc
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/metadata.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/metadata.h"
 
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/external/responses.h"
 
 namespace Envoy {
@@ -42,7 +44,7 @@ AbstractResponseSharedPtr MetadataRequestHolder::computeAnswer() const {
       }
       const std::string& topic_name = *(topic.name_);
       std::vector<MetadataResponsePartition> topic_partitions;
-      const absl::optional<ClusterConfig> cluster_config =
+      const std::optional<ClusterConfig> cluster_config =
           configuration_.computeClusterConfigForTopic(topic_name);
       if (!cluster_config) {
         // Someone is requesting topics that are not known to our configuration.

--- a/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.cc
@@ -1,6 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/shared_consumer_manager_impl.h"
 
 #include <functional>
+#include <optional>
 
 #include "source/common/common/fmt.h"
 
@@ -84,7 +85,7 @@ void SharedConsumerManagerImpl::registerNewConsumer(const std::string& topic) {
   ENVOY_LOG(debug, "Creating consumer for topic [{}]", topic);
 
   // Compute which upstream cluster corresponds to the topic.
-  const absl::optional<ClusterConfig> cluster_config =
+  const std::optional<ClusterConfig> cluster_config =
       configuration_.computeClusterConfigForTopic(topic);
   if (!cluster_config) {
     throw EnvoyException(
@@ -315,7 +316,7 @@ int32_t countForTest(const std::string& topic, const int32_t partition, Partitio
   if (map.end() != it) {
     return it->second.size();
   } else {
-    return -1; // Tests are simpler to type if we do this instead of absl::optional.
+    return -1; // Tests are simpler to type if we do this instead of std::optional.
   }
 }
 

--- a/contrib/kafka/filters/network/source/mesh/upstream_config.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_config.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/upstream_config.h"
 
+#include <optional>
+
 #include "envoy/common/exception.h"
 
 #include "source/common/common/assert.h"
@@ -88,16 +90,16 @@ UpstreamKafkaConfigurationImpl::UpstreamKafkaConfigurationImpl(const KafkaMeshPr
   ASSERT(config.consumer_proxy_mode() == KafkaMesh::StatefulConsumerProxy);
 }
 
-absl::optional<ClusterConfig>
+std::optional<ClusterConfig>
 UpstreamKafkaConfigurationImpl::computeClusterConfigForTopic(const std::string& topic) const {
   // We find the first matching prefix (this is why ordering is important).
   for (const auto& it : topic_prefix_to_cluster_config_) {
     if (absl::StartsWith(topic, it.first)) {
       const ClusterConfig cluster_config = it.second;
-      return absl::make_optional(cluster_config);
+      return std::make_optional(cluster_config);
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 std::pair<std::string, int32_t> UpstreamKafkaConfigurationImpl::getAdvertisedAddress() const {

--- a/contrib/kafka/filters/network/source/mesh/upstream_config.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_config.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -9,7 +10,6 @@
 
 #include "source/common/common/logger.h"
 
-#include "absl/types/optional.h"
 #include "contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.pb.h"
 #include "contrib/envoy/extensions/filters/network/kafka_mesh/v3alpha/kafka_mesh.pb.validate.h"
 
@@ -63,7 +63,7 @@ public:
 
   // Provides cluster for given Kafka topic, according to the rules contained within this
   // configuration object.
-  virtual absl::optional<ClusterConfig>
+  virtual std::optional<ClusterConfig>
   computeClusterConfigForTopic(const std::string& topic) const PURE;
 };
 
@@ -78,7 +78,7 @@ public:
   UpstreamKafkaConfigurationImpl(const KafkaMeshProtoConfig& config);
 
   // UpstreamKafkaConfiguration
-  absl::optional<ClusterConfig>
+  std::optional<ClusterConfig>
   computeClusterConfigForTopic(const std::string& topic) const override;
 
   // UpstreamKafkaConfiguration

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer_impl.h"
 
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/kafka_types.h"
 #include "contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h"
 
@@ -107,7 +109,7 @@ static NullableBytes toBytes(const void* data, const size_t size) {
     Bytes bytes(as_char, as_char + size);
     return {bytes};
   } else {
-    return absl::nullopt;
+    return std::nullopt;
   }
 }
 

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_facade.h"
 
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/mesh/upstream_kafka_client_impl.h"
 
 namespace Envoy {
@@ -47,7 +49,7 @@ ThreadLocalKafkaFacade::~ThreadLocalKafkaFacade() {
 }
 
 KafkaProducer& ThreadLocalKafkaFacade::getProducerForTopic(const std::string& topic) {
-  const absl::optional<ClusterConfig> cluster_config =
+  const std::optional<ClusterConfig> cluster_config =
       configuration_.computeClusterConfigForTopic(topic);
   if (cluster_config) {
     const auto it = cluster_to_kafka_client_.find(cluster_config->name_);

--- a/contrib/kafka/filters/network/source/protocol/generator.py
+++ b/contrib/kafka/filters/network/source/protocol/generator.py
@@ -358,7 +358,7 @@ class FieldList:
                         init_list.append(init_list_item)
                     else:
                         # Field is optional<T>, and the parameter is T in this version.
-                        init_list_item = '%s_{absl::make_optional(%s)}' % (field.name, field.name)
+                        init_list_item = '%s_{std::make_optional(%s)}' % (field.name, field.name)
                         init_list.append(init_list_item)
                 else:
                     # Field is T, so parameter cannot be optional<T>.
@@ -408,13 +408,13 @@ class FieldSpec:
 
     def field_declaration(self):
         if self.is_nullable():
-            return 'absl::optional<%s> %s' % (self.type.name, self.name)
+            return 'std::optional<%s> %s' % (self.type.name, self.name)
         else:
             return '%s %s' % (self.type.name, self.name)
 
     def parameter_declaration(self, version):
         if self.is_nullable_in_version(version):
-            return 'absl::optional<%s> %s' % (self.type.name, self.name)
+            return 'std::optional<%s> %s' % (self.type.name, self.name)
         else:
             return '%s %s' % (self.type.name, self.name)
 
@@ -425,13 +425,13 @@ class FieldSpec:
             if type_default_value != 'null':
                 return '{%s}' % type_default_value
             else:
-                return 'absl::nullopt'
+                return 'std::nullopt'
         else:
             return str(self.type.default_value())
 
     def example_value_for_test(self, version):
         if self.is_nullable_in_version(version):
-            return 'absl::make_optional<%s>(%s)' % (
+            return 'std::make_optional<%s>(%s)' % (
                 self.type.name, self.type.example_value_for_test(version))
         else:
             return str(self.type.example_value_for_test(version))

--- a/contrib/kafka/filters/network/source/serialization.cc
+++ b/contrib/kafka/filters/network/source/serialization.cc
@@ -1,5 +1,7 @@
 #include "contrib/kafka/filters/network/source/serialization.h"
 
+#include <optional>
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -193,9 +195,9 @@ uint32_t NullableCompactStringDeserializer::feed(absl::string_view& data) {
 NullableString NullableCompactStringDeserializer::get() const {
   const uint32_t original_data_len = length_buf_.get();
   if (NULL_COMPACT_STRING_LENGTH == original_data_len) {
-    return absl::nullopt;
+    return std::nullopt;
   } else {
-    return absl::make_optional(std::string(data_buf_.begin(), data_buf_.end()));
+    return std::make_optional(std::string(data_buf_.begin(), data_buf_.end()));
   }
 }
 
@@ -214,9 +216,9 @@ uint32_t NullableCompactBytesDeserializer::feed(absl::string_view& data) {
 NullableBytes NullableCompactBytesDeserializer::get() const {
   const uint32_t original_data_len = length_buf_.get();
   if (NULL_COMPACT_BYTES_LENGTH == original_data_len) {
-    return absl::nullopt;
+    return std::nullopt;
   } else {
-    return absl::make_optional(data_buf_);
+    return std::make_optional(data_buf_);
   }
 }
 

--- a/contrib/kafka/filters/network/source/serialization.h
+++ b/contrib/kafka/filters/network/source/serialization.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -423,8 +424,8 @@ public:
   bool ready() const override { return ready_; }
 
   NullableString get() const override {
-    return required_ >= 0 ? absl::make_optional(std::string(data_buf_.begin(), data_buf_.end()))
-                          : absl::nullopt;
+    return required_ >= 0 ? std::make_optional(std::string(data_buf_.begin(), data_buf_.end()))
+                          : std::nullopt;
   }
 
 private:
@@ -540,7 +541,7 @@ public:
   bool ready() const override { return ready_; }
 
   NullableBytes get() const override {
-    return required_ >= 0 ? absl::make_optional(data_buf_) : absl::nullopt;
+    return required_ >= 0 ? std::make_optional(data_buf_) : std::nullopt;
   }
 
 private:
@@ -816,7 +817,7 @@ public:
       }
       return result;
     } else {
-      return absl::nullopt;
+      return std::nullopt;
     }
   }
 
@@ -904,7 +905,7 @@ public:
       }
       return result;
     } else {
-      return absl::nullopt;
+      return std::nullopt;
     }
   }
 
@@ -924,9 +925,9 @@ private:
  */
 template <typename DeserializerType>
 class NullableStructDeserializer
-    : public Deserializer<absl::optional<typename DeserializerType::result_type>> {
+    : public Deserializer<std::optional<typename DeserializerType::result_type>> {
 public:
-  using ResponseType = absl::optional<typename DeserializerType::result_type>;
+  using ResponseType = std::optional<typename DeserializerType::result_type>;
 
   uint32_t feed(absl::string_view& data) override {
 
@@ -945,7 +946,7 @@ public:
       marker_consumed_ = true;
 
       if (marker >= 0) {
-        data_buf_ = absl::make_optional(DeserializerType());
+        data_buf_ = std::make_optional(DeserializerType());
       } else {
         return bytes_read;
       }
@@ -973,15 +974,15 @@ public:
   ResponseType get() const override {
     if (data_buf_) {
       const typename ResponseType::value_type deserialized_form = data_buf_->get();
-      return absl::make_optional(deserialized_form);
+      return std::make_optional(deserialized_form);
     } else {
-      return absl::nullopt;
+      return std::nullopt;
     }
   }
 
 private:
   bool marker_consumed_{false};
-  absl::optional<DeserializerType> data_buf_; // Present if marker was consumed and was 0 or more.
+  std::optional<DeserializerType> data_buf_; // Present if marker was consumed and was 0 or more.
 };
 
 /**
@@ -1066,7 +1067,7 @@ public:
    * Compute size of given nullable object, if it were to be encoded.
    * @return serialized size of argument.
    */
-  template <typename T> uint32_t computeSize(const absl::optional<T>& arg) const;
+  template <typename T> uint32_t computeSize(const std::optional<T>& arg) const;
 
   /**
    * Compute size of given reference, if it were to be compactly encoded.
@@ -1108,7 +1109,7 @@ public:
    * Encode given nullable object in a buffer.
    * @return bytes written
    */
-  template <typename T> uint32_t encode(const absl::optional<T>& arg, Buffer::Instance& dst);
+  template <typename T> uint32_t encode(const std::optional<T>& arg, Buffer::Instance& dst);
 
   /**
    * Compactly encode given reference in a buffer.
@@ -1218,7 +1219,7 @@ inline uint32_t EncodingContext::computeSize(const NullableArray<T>& arg) const 
  * The size of nullable object is 1 (for market byte) and the size of real object (if any).
  */
 template <typename T>
-inline uint32_t EncodingContext::computeSize(const absl::optional<T>& arg) const {
+inline uint32_t EncodingContext::computeSize(const std::optional<T>& arg) const {
   return 1 + (arg ? computeSize(*arg) : 0);
 }
 
@@ -1523,7 +1524,7 @@ uint32_t EncodingContext::encode(const NullableArray<T>& arg, Buffer::Instance& 
  * have it to serialize itself.
  */
 template <typename T>
-uint32_t EncodingContext::encode(const absl::optional<T>& arg, Buffer::Instance& dst) {
+uint32_t EncodingContext::encode(const std::optional<T>& arg, Buffer::Instance& dst) {
   if (arg) {
     const int8_t marker = 1;
     encode(marker, dst);

--- a/contrib/kafka/filters/network/test/broker/mock_filter_config.h
+++ b/contrib/kafka/filters/network/test/broker/mock_filter_config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
 #include "gmock/gmock.h"
 
@@ -13,7 +15,7 @@ class MockBrokerFilterConfig : public BrokerFilterConfig {
 public:
   MOCK_METHOD((const std::string&), stat_prefix, (), (const));
   MOCK_METHOD(bool, needsResponseRewrite, (), (const));
-  MOCK_METHOD((absl::optional<HostAndPort>), findBrokerAddressOverride, (const uint32_t), (const));
+  MOCK_METHOD((std::optional<HostAndPort>), findBrokerAddressOverride, (const uint32_t), (const));
   MOCK_METHOD((absl::flat_hash_set<int16_t>), apiKeysAllowed, (), (const));
   MOCK_METHOD((absl::flat_hash_set<int16_t>), apiKeysDenied, (), (const));
   MockBrokerFilterConfig() : BrokerFilterConfig{"prefix", false, {}, {}, {}} {};

--- a/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/broker/rewriter_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "source/common/buffer/buffer_impl.h"
 
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"
@@ -81,11 +83,11 @@ TEST(ResponseRewriterImplUnitTest, ShouldRewriteMetadataResponse) {
   MetadataResponse mr = {brokers, {}};
 
   auto config = std::make_shared<MockBrokerFilterConfig>();
-  absl::optional<HostAndPort> r1 = {{"nh1", 4444}};
+  std::optional<HostAndPort> r1 = {{"nh1", 4444}};
   EXPECT_CALL(*config, findBrokerAddressOverride(b1.node_id_)).WillOnce(Return(r1));
-  absl::optional<HostAndPort> r2 = absl::nullopt;
+  std::optional<HostAndPort> r2 = std::nullopt;
   EXPECT_CALL(*config, findBrokerAddressOverride(b2.node_id_)).WillOnce(Return(r2));
-  absl::optional<HostAndPort> r3 = {{"nh3", 6666}};
+  std::optional<HostAndPort> r3 = {{"nh3", 6666}};
   EXPECT_CALL(*config, findBrokerAddressOverride(b3.node_id_)).WillOnce(Return(r3));
   ResponseRewriterImpl testee{config};
 
@@ -108,13 +110,13 @@ TEST(ResponseRewriterImplUnitTest, ShouldRewriteFindCoordinatorResponse) {
   fcr.coordinators_ = {c1, c2, c3};
 
   auto config = std::make_shared<MockBrokerFilterConfig>();
-  absl::optional<HostAndPort> fcrhp = {{"nh1", 4444}};
+  std::optional<HostAndPort> fcrhp = {{"nh1", 4444}};
   EXPECT_CALL(*config, findBrokerAddressOverride(fcr.node_id_)).WillOnce(Return(fcrhp));
-  absl::optional<HostAndPort> cr1 = {{"nh1", 4444}};
+  std::optional<HostAndPort> cr1 = {{"nh1", 4444}};
   EXPECT_CALL(*config, findBrokerAddressOverride(c1.node_id_)).WillOnce(Return(cr1));
-  absl::optional<HostAndPort> cr2 = absl::nullopt;
+  std::optional<HostAndPort> cr2 = std::nullopt;
   EXPECT_CALL(*config, findBrokerAddressOverride(c2.node_id_)).WillOnce(Return(cr2));
-  absl::optional<HostAndPort> cr3 = {{"nh3", 6666}};
+  std::optional<HostAndPort> cr3 = {{"nh3", 6666}};
   EXPECT_CALL(*config, findBrokerAddressOverride(c3.node_id_)).WillOnce(Return(cr3));
   ResponseRewriterImpl testee{config};
 
@@ -130,18 +132,18 @@ TEST(ResponseRewriterImplUnitTest, ShouldRewriteFindCoordinatorResponse) {
 
 TEST(ResponseRewriterImplUnitTest, ShouldRewriteDescribeClusterResponse) {
   // given
-  DescribeClusterBroker b1 = {13, "host1", 1111, absl::nullopt, {}};
-  DescribeClusterBroker b2 = {42, "host2", 2222, absl::nullopt, {}};
-  DescribeClusterBroker b3 = {77, "host3", 3333, absl::nullopt, {}};
+  DescribeClusterBroker b1 = {13, "host1", 1111, std::nullopt, {}};
+  DescribeClusterBroker b2 = {42, "host2", 2222, std::nullopt, {}};
+  DescribeClusterBroker b3 = {77, "host3", 3333, std::nullopt, {}};
   std::vector<DescribeClusterBroker> brokers = {b1, b2, b3};
-  DescribeClusterResponse dcr = {0, 0, absl::nullopt, "", 0, brokers, 0, {}};
+  DescribeClusterResponse dcr = {0, 0, std::nullopt, "", 0, brokers, 0, {}};
 
   auto config = std::make_shared<MockBrokerFilterConfig>();
-  absl::optional<HostAndPort> cr1 = {{"nh1", 4444}};
+  std::optional<HostAndPort> cr1 = {{"nh1", 4444}};
   EXPECT_CALL(*config, findBrokerAddressOverride(b1.broker_id_)).WillOnce(Return(cr1));
-  absl::optional<HostAndPort> cr2 = absl::nullopt;
+  std::optional<HostAndPort> cr2 = std::nullopt;
   EXPECT_CALL(*config, findBrokerAddressOverride(b2.broker_id_)).WillOnce(Return(cr2));
-  absl::optional<HostAndPort> cr3 = {{"nh3", 6666}};
+  std::optional<HostAndPort> cr3 = {{"nh3", 6666}};
   EXPECT_CALL(*config, findBrokerAddressOverride(b3.broker_id_)).WillOnce(Return(cr3));
   ResponseRewriterImpl testee{config};
 

--- a/contrib/kafka/filters/network/test/kafka_request_parser_test.cc
+++ b/contrib/kafka/filters/network/test/kafka_request_parser_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/kafka_request_parser.h"
 #include "contrib/kafka/filters/network/test/buffer_based_test.h"
 #include "contrib/kafka/filters/network/test/serialization_utilities.h"
@@ -109,7 +111,7 @@ TEST_F(KafkaRequestParserTest, RequestDataParserShouldHandleDeserializerExceptio
     int32_t get() const override { throw std::runtime_error("should not be invoked at all"); };
   };
 
-  RequestContextSharedPtr request_context{new RequestContext{1024, {0, 0, 0, absl::nullopt}}};
+  RequestContextSharedPtr request_context{new RequestContext{1024, {0, 0, 0, std::nullopt}}};
   RequestDataParser<int32_t, ThrowingDeserializer> testee{request_context};
 
   absl::string_view data = putGarbageIntoBuffer();
@@ -144,7 +146,7 @@ TEST_F(KafkaRequestParserTest,
   // given
   const int32_t request_size = 1024; // There are still 1024 bytes to read to complete the request.
   RequestContextSharedPtr request_context{
-      new RequestContext{request_size, {0, 0, 0, absl::nullopt}}};
+      new RequestContext{request_size, {0, 0, 0, std::nullopt}}};
 
   RequestDataParser<int32_t, SomeBytesDeserializer> testee{request_context};
 

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/api_versions_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/api_versions.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,7 +22,7 @@ TEST(ApiVersionsTest, shouldBeAlwaysReadyForAnswer) {
   // given
   MockAbstractRequestListener filter;
   EXPECT_CALL(filter, onRequestReadyForAnswer());
-  const RequestHeader header = {API_VERSIONS_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {API_VERSIONS_REQUEST_API_KEY, 0, 0, std::nullopt};
   ApiVersionsRequestHolder testee = {filter, header};
 
   // when, then - invoking should immediately notify the filter.

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/fetch_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "test/mocks/event/mocks.h"
 
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/fetch.h"
@@ -46,7 +48,7 @@ protected:
   FetchUnitTest() { ON_CALL(filter_, dispatcher).WillByDefault(ReturnRef(dispatcher_)); }
 
   std::shared_ptr<FetchRequestHolder> makeTestee() {
-    const RequestHeader header = {FETCH_REQUEST_API_KEY, 0, TEST_CORRELATION_ID, absl::nullopt};
+    const RequestHeader header = {FETCH_REQUEST_API_KEY, 0, TEST_CORRELATION_ID, std::nullopt};
     // Our request refers to aaa-0, aaa-1, bbb-10, bbb-20.
     const FetchTopic t1 = {"aaa", {{0, 0, 0}, {1, 0, 0}}};
     const FetchTopic t2 = {"bbb", {{10, 0, 0}, {20, 0, 0}}};
@@ -98,7 +100,7 @@ TEST_F(FetchUnitTest, ShouldCleanupAfterTimer) {
 
 // Helper method to generate records.
 InboundRecordSharedPtr makeRecord() {
-  return std::make_shared<InboundRecord>("aaa", 0, 0, absl::nullopt, absl::nullopt);
+  return std::make_shared<InboundRecord>("aaa", 0, 0, std::nullopt, std::nullopt);
 }
 
 TEST_F(FetchUnitTest, ShouldReceiveRecords) {

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/list_offsets_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/list_offsets.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,7 +22,7 @@ TEST(ListOffsetsTest, shouldBeAlwaysReadyForAnswer) {
   // given
   MockAbstractRequestListener filter;
   EXPECT_CALL(filter, onRequestReadyForAnswer());
-  const RequestHeader header = {LIST_OFFSETS_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {LIST_OFFSETS_REQUEST_API_KEY, 0, 0, std::nullopt};
   const ListOffsetsRequest data = {0, {}};
   const auto message = std::make_shared<Request<ListOffsetsRequest>>(header, data);
   ListOffsetsRequestHolder testee = {filter, message};

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/metadata_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/external/responses.h"
 #include "contrib/kafka/filters/network/source/mesh/command_handlers/metadata.h"
 #include "gmock/gmock.h"
@@ -21,7 +23,7 @@ public:
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
-  MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
+  MOCK_METHOD(std::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
               (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
@@ -36,16 +38,15 @@ TEST(MetadataTest, shouldBeAlwaysReadyForAnswer) {
   // First topic is going to have configuration present (42 partitions for each topic).
   const ClusterConfig topic1config = {"", 42, {}, {}};
   EXPECT_CALL(configuration, computeClusterConfigForTopic("topic1"))
-      .WillOnce(Return(absl::make_optional(topic1config)));
+      .WillOnce(Return(std::make_optional(topic1config)));
   // Second topic is not going to have configuration present.
-  EXPECT_CALL(configuration, computeClusterConfigForTopic("topic2"))
-      .WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(configuration, computeClusterConfigForTopic("topic2")).WillOnce(Return(std::nullopt));
   const RequestHeader header = {METADATA_REQUEST_API_KEY, METADATA_REQUEST_MAX_VERSION, 0,
-                                absl::nullopt};
+                                std::nullopt};
   const MetadataRequestTopic t1 = MetadataRequestTopic{"topic1"};
   const MetadataRequestTopic t2 = MetadataRequestTopic{"topic2"};
   // Third topic is not going to have an explicit name.
-  const MetadataRequestTopic t3 = MetadataRequestTopic{Uuid{13, 42}, absl::nullopt, TaggedFields{}};
+  const MetadataRequestTopic t3 = MetadataRequestTopic{Uuid{13, 42}, std::nullopt, TaggedFields{}};
   const MetadataRequest data = {{t1, t2, t3}};
   const auto message = std::make_shared<Request<MetadataRequest>>(header, data);
   MetadataRequestHolder testee = {filter, configuration, message};

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_record_extractor_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_record_extractor_unit_test.cc
@@ -1,3 +1,4 @@
+#include <optional>
 #include <set>
 
 #include "test/test_common/utility.h"
@@ -95,7 +96,7 @@ TEST(RecordExtractorImpl, shouldProcessRecordBytes) {
   const TopicProduceData tpd1 = {"topic1", {t1_ppd1, t1_ppd2, t1_ppd3}};
 
   // Weird input from client, protocol allows sending null value as bytes array.
-  const PartitionProduceData t2_ppd = {20, absl::nullopt};
+  const PartitionProduceData t2_ppd = {20, std::nullopt};
   const TopicProduceData tpd2 = {"topic2", {t2_ppd}};
 
   const std::vector<TopicProduceData> input = {tpd1, tpd2};

--- a/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/command_handlers/produce_unit_test.cc
@@ -1,3 +1,4 @@
+#include <optional>
 #include <set>
 
 #include "test/test_common/utility.h"
@@ -57,7 +58,7 @@ TEST_F(ProduceUnitTest, ShouldHandleProduceRequestWithNoRecords) {
   const std::vector<OutboundRecord> records = {};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 
-  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const RequestHeader header = {0, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
   ProduceRequestHolder testee = {filter_, upstream_kafka_facade_, extractor_, message};
@@ -86,7 +87,7 @@ TEST_F(ProduceUnitTest, ShouldSendRecordsInNormalFlow) {
   const std::vector<OutboundRecord> records = {r1, r2};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 
-  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const RequestHeader header = {0, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
   std::shared_ptr<ProduceRequestHolder> testee =
@@ -144,7 +145,7 @@ TEST_F(ProduceUnitTest, ShouldMergeOutboundRecordResponses) {
   const std::vector<OutboundRecord> records = {r1, r2};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 
-  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const RequestHeader header = {0, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
   std::shared_ptr<ProduceRequestHolder> testee =
@@ -198,7 +199,7 @@ TEST_F(ProduceUnitTest, ShouldHandleDeliveryErrors) {
   const std::vector<OutboundRecord> records = {r1, r2};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 
-  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const RequestHeader header = {0, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
   std::shared_ptr<ProduceRequestHolder> testee =
@@ -248,7 +249,7 @@ TEST_F(ProduceUnitTest, ShouldIgnoreMementoFromAnotherRequest) {
   const std::vector<OutboundRecord> records = {r1};
   EXPECT_CALL(extractor_, extractRecords(_)).WillOnce(Return(records));
 
-  const RequestHeader header = {0, 0, 0, absl::nullopt};
+  const RequestHeader header = {0, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
   std::shared_ptr<ProduceRequestHolder> testee =

--- a/contrib/kafka/filters/network/test/mesh/filter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/filter_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "test/mocks/network/mocks.h"
 
 #include "contrib/kafka/filters/network/source/mesh/filter.h"
@@ -179,7 +181,7 @@ class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
   MOCK_METHOD(void, onData, (Buffer::Instance&));
   MOCK_METHOD(void, reset, ());
-  MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic,
+  MOCK_METHOD(std::optional<ClusterConfig>, computeClusterConfigForTopic,
               (const std::string& topic), (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };

--- a/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/request_processor_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "test/mocks/event/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -50,7 +52,7 @@ public:
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
-  MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
+  MOCK_METHOD(std::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
               (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
@@ -67,7 +69,7 @@ protected:
 
 TEST_F(RequestProcessorTest, ShouldProcessProduceRequest) {
   // given
-  const RequestHeader header = {PRODUCE_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {PRODUCE_REQUEST_API_KEY, 0, 0, std::nullopt};
   const ProduceRequest data = {0, 0, {}};
   const auto message = std::make_shared<Request<ProduceRequest>>(header, data);
 
@@ -83,7 +85,7 @@ TEST_F(RequestProcessorTest, ShouldProcessProduceRequest) {
 
 TEST_F(RequestProcessorTest, ShouldProcessFetchRequest) {
   // given
-  const RequestHeader header = {FETCH_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {FETCH_REQUEST_API_KEY, 0, 0, std::nullopt};
   const FetchRequest data = {0, 0, 0, {}};
   const auto message = std::make_shared<Request<FetchRequest>>(header, data);
 
@@ -99,7 +101,7 @@ TEST_F(RequestProcessorTest, ShouldProcessFetchRequest) {
 
 TEST_F(RequestProcessorTest, ShouldProcessListOffsetsRequest) {
   // given
-  const RequestHeader header = {LIST_OFFSETS_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {LIST_OFFSETS_REQUEST_API_KEY, 0, 0, std::nullopt};
   const ListOffsetsRequest data = {0, {}};
   const auto message = std::make_shared<Request<ListOffsetsRequest>>(header, data);
 
@@ -115,8 +117,8 @@ TEST_F(RequestProcessorTest, ShouldProcessListOffsetsRequest) {
 
 TEST_F(RequestProcessorTest, ShouldProcessMetadataRequest) {
   // given
-  const RequestHeader header = {METADATA_REQUEST_API_KEY, 0, 0, absl::nullopt};
-  const MetadataRequest data = {absl::nullopt};
+  const RequestHeader header = {METADATA_REQUEST_API_KEY, 0, 0, std::nullopt};
+  const MetadataRequest data = {std::nullopt};
   const auto message = std::make_shared<Request<MetadataRequest>>(header, data);
 
   InFlightRequestSharedPtr capture = nullptr;
@@ -131,7 +133,7 @@ TEST_F(RequestProcessorTest, ShouldProcessMetadataRequest) {
 
 TEST_F(RequestProcessorTest, ShouldProcessApiVersionsRequest) {
   // given
-  const RequestHeader header = {API_VERSIONS_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {API_VERSIONS_REQUEST_API_KEY, 0, 0, std::nullopt};
   const ApiVersionsRequest data = {};
   const auto message = std::make_shared<Request<ApiVersionsRequest>>(header, data);
 
@@ -147,7 +149,7 @@ TEST_F(RequestProcessorTest, ShouldProcessApiVersionsRequest) {
 
 TEST_F(RequestProcessorTest, ShouldHandleUnsupportedRequest) {
   // given
-  const RequestHeader header = {END_TXN_REQUEST_API_KEY, 0, 0, absl::nullopt};
+  const RequestHeader header = {END_TXN_REQUEST_API_KEY, 0, 0, std::nullopt};
   const EndTxnRequest data = {"", 0, 0, false};
   const auto message = std::make_shared<Request<EndTxnRequest>>(header, data);
 
@@ -157,7 +159,7 @@ TEST_F(RequestProcessorTest, ShouldHandleUnsupportedRequest) {
 
 TEST_F(RequestProcessorTest, ShouldHandleUnparseableRequest) {
   // given
-  const RequestHeader header = {42, 42, 42, absl::nullopt};
+  const RequestHeader header = {42, 42, 42, std::nullopt};
   const auto arg = std::make_shared<RequestParseFailure>(header);
 
   // when, then - exception gets thrown.

--- a/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/shared_consumer_manager_impl_unit_test.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <optional>
 
 #include "envoy/common/exception.h"
 #include "envoy/thread/thread.h"
@@ -22,7 +23,7 @@ using testing::Return;
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
-  MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
+  MOCK_METHOD(std::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
               (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
@@ -80,7 +81,7 @@ TEST_F(SharedConsumerManagerTest, ShouldHandleMissingConfig) {
   // given
   const std::string topic = "topic";
 
-  EXPECT_CALL(configuration_, computeClusterConfigForTopic(topic)).WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(configuration_, computeClusterConfigForTopic(topic)).WillOnce(Return(std::nullopt));
 
   EXPECT_CALL(consumer_factory_, createConsumer(_, _, _, _, _)).Times(0);
 
@@ -144,7 +145,7 @@ protected:
   }
 
   InboundRecordSharedPtr makeRecord(const std::string& topic, const int32_t partition) {
-    return std::make_shared<InboundRecord>(topic, partition, 0, absl::nullopt, absl::nullopt);
+    return std::make_shared<InboundRecord>(topic, partition, 0, std::nullopt, std::nullopt);
   }
 };
 

--- a/contrib/kafka/filters/network/test/mesh/upstream_kafka_facade_unit_test.cc
+++ b/contrib/kafka/filters/network/test/mesh/upstream_kafka_facade_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "envoy/thread/thread.h"
 #include "envoy/thread_local/thread_local.h"
 
@@ -20,7 +22,7 @@ namespace {
 
 class MockUpstreamKafkaConfiguration : public UpstreamKafkaConfiguration {
 public:
-  MOCK_METHOD(absl::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
+  MOCK_METHOD(std::optional<ClusterConfig>, computeClusterConfigForTopic, (const std::string&),
               (const));
   MOCK_METHOD((std::pair<std::string, int32_t>), getAdvertisedAddress, (), (const));
 };
@@ -87,7 +89,7 @@ TEST(UpstreamKafkaFacadeTest, shouldThrowIfThereIsNoConfigurationForGivenTopic) 
   MockUpstreamKafkaConfiguration configuration;
   const ClusterConfig cluster_config = {
       "cluster", 1, {{"bootstrap.servers", "localhost:9092"}}, {}};
-  EXPECT_CALL(configuration, computeClusterConfigForTopic(topic)).WillOnce(Return(absl::nullopt));
+  EXPECT_CALL(configuration, computeClusterConfigForTopic(topic)).WillOnce(Return(std::nullopt));
   ThreadLocal::MockInstance slot_allocator;
   EXPECT_CALL(slot_allocator, allocateSlot())
       .WillOnce(Invoke(&slot_allocator, &ThreadLocal::MockInstance::allocateSlotMock));

--- a/contrib/kafka/filters/network/test/protocol/requests_test_cc.j2
+++ b/contrib/kafka/filters/network/test/protocol/requests_test_cc.j2
@@ -58,7 +58,7 @@ TEST_F(RequestTest, ShouldParse{{ message_type.name }}V{{ field_list.version }})
   // given
   {{ message_type.name }} data = { {{ field_list.example_value() }} };
   Request<{{ message_type.name }}> message = { {
-    {{ message_type.get_extra('api_key') }}, {{ field_list.version }}, 0, absl::nullopt }, data };
+    {{ message_type.get_extra('api_key') }}, {{ field_list.version }}, 0, std::nullopt }, data };
 
   // when
   auto received = serializeAndDeserialize(message);

--- a/contrib/kafka/filters/network/test/request_codec_unit_test.cc
+++ b/contrib/kafka/filters/network/test/request_codec_unit_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/kafka/filters/network/source/request_codec.h"
 #include "contrib/kafka/filters/network/test/buffer_based_test.h"
 #include "gmock/gmock.h"
@@ -136,7 +138,7 @@ TEST_F(RequestCodecUnitTest, ShouldPassParsedMessageToCallbackAndInitializeNextP
   putGarbageIntoBuffer();
 
   const AbstractRequestSharedPtr parsed_message =
-      std::make_shared<Request<int32_t>>(RequestHeader{0, 0, 0, absl::nullopt}, 0);
+      std::make_shared<Request<int32_t>>(RequestHeader{0, 0, 0, std::nullopt}, 0);
 
   MockParserSharedPtr parser1 = std::make_shared<MockParser>();
   EXPECT_CALL(*parser1, parse(_))
@@ -167,7 +169,7 @@ TEST_F(RequestCodecUnitTest, ShouldPassParseFailureDataToCallback) {
   putGarbageIntoBuffer();
 
   const RequestParseFailureSharedPtr failure_data =
-      std::make_shared<RequestParseFailure>(RequestHeader{0, 0, 0, absl::nullopt});
+      std::make_shared<RequestParseFailure>(RequestHeader{0, 0, 0, std::nullopt});
 
   MockParserSharedPtr parser = std::make_shared<MockParser>();
   auto consume_and_return = [&failure_data](absl::string_view& data) -> RequestParseResponse {

--- a/contrib/kafka/filters/network/test/serialization_test.cc
+++ b/contrib/kafka/filters/network/test/serialization_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "test/test_common/utility.h"
 
 #include "contrib/kafka/filters/network/source/tagged_fields.h"
@@ -306,7 +308,7 @@ TEST(NullableStringDeserializer, ShouldDeserializeEmptyString) {
 
 TEST(NullableStringDeserializer, ShouldDeserializeAbsentString) {
   // given
-  const NullableString value = absl::nullopt;
+  const NullableString value = std::nullopt;
   serializeThenDeserializeAndCheckEquality<NullableStringDeserializer>(value);
 }
 
@@ -341,7 +343,7 @@ TEST(NullableCompactStringDeserializer, ShouldDeserializeEmptyString) {
 
 TEST(NullableCompactStringDeserializer, ShouldDeserializeAbsentString) {
   // given
-  const NullableString value = absl::nullopt;
+  const NullableString value = std::nullopt;
   serializeCompactThenDeserializeAndCheckEquality<NullableCompactStringDeserializer>(value);
 }
 
@@ -413,7 +415,7 @@ TEST(NullableBytesDeserializer, ShouldDeserializeEmptyBytes) {
 }
 
 TEST(NullableBytesDeserializer, ShouldDeserializeNullBytes) {
-  const NullableBytes value = absl::nullopt;
+  const NullableBytes value = std::nullopt;
   serializeThenDeserializeAndCheckEquality<NullableBytesDeserializer>(value);
 }
 
@@ -445,7 +447,7 @@ TEST(NullableCompactBytesDeserializer, ShouldDeserializeEmptyBytes) {
 }
 
 TEST(NullableCompactBytesDeserializer, ShouldDeserializeNullBytes) {
-  const NullableBytes value = absl::nullopt;
+  const NullableBytes value = std::nullopt;
   serializeCompactThenDeserializeAndCheckEquality<NullableCompactBytesDeserializer>(value);
 }
 
@@ -502,7 +504,7 @@ TEST(NullableArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
 }
 
 TEST(NullableArrayDeserializer, ShouldConsumeNullArray) {
-  const NullableArray<std::string> value = absl::nullopt;
+  const NullableArray<std::string> value = std::nullopt;
   serializeThenDeserializeAndCheckEquality<NullableArrayDeserializer<StringDeserializer>>(value);
 }
 
@@ -530,7 +532,7 @@ TEST(NullableCompactArrayDeserializer, ShouldConsumeCorrectAmountOfData) {
 }
 
 TEST(NullableCompactArrayDeserializer, ShouldConsumeNullArray) {
-  const NullableArray<int32_t> value = absl::nullopt;
+  const NullableArray<int32_t> value = std::nullopt;
   serializeCompactThenDeserializeAndCheckEquality<
       NullableCompactArrayDeserializer<Int32Deserializer>>(value);
 }
@@ -556,7 +558,7 @@ TEST(NullableStructDeserializer, ShouldConsumeCorrectAmountOfData) {
 }
 
 TEST(NullableStructDeserializer, ShouldConsumeNullStruct) {
-  const ExampleNSD::ResponseType value = absl::nullopt;
+  const ExampleNSD::ResponseType value = std::nullopt;
   serializeThenDeserializeAndCheckEquality<ExampleNSD>(value);
 }
 

--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -1,6 +1,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
+
 #include "contrib/postgres_proxy/filters/network/source/postgres_decoder.h"
 #include "contrib/postgres_proxy/filters/network/test/postgres_test_utils.h"
 
@@ -712,7 +714,7 @@ public:
   MOCK_METHOD(uint64_t, copyOutToSlices,
               (uint64_t size, Buffer::RawSlice* slices, uint64_t num_slice), (const, override));
   MOCK_METHOD(void, drain, (uint64_t), (override));
-  MOCK_METHOD(Buffer::RawSliceVector, getRawSlices, (absl::optional<uint64_t>), (const, override));
+  MOCK_METHOD(Buffer::RawSliceVector, getRawSlices, (std::optional<uint64_t>), (const, override));
   MOCK_METHOD(Buffer::RawSlice, frontSlice, (), (const, override));
   MOCK_METHOD(Buffer::SliceDataPtr, extractMutableFrontSlice, (), (override));
   MOCK_METHOD(uint64_t, length, (), (const, override));

--- a/contrib/reverse_tunnel_reporter/test/clients/grpc_client_integration_test.cc
+++ b/contrib/reverse_tunnel_reporter/test/clients/grpc_client_integration_test.cc
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/extensions/upstreams/http/v3/http_protocol_options.pb.h"
@@ -47,7 +48,7 @@ using envoy::extensions::upstreams::http::v3::HttpProtocolOptions;
 class TestingService final : public ReverseTunnelReportingService::Service {
   absl::flat_hash_map<std::string, ReverseTunnelEvent::Connected> state_;
   std::atomic<std::size_t> num_events_;
-  absl::optional<std::chrono::milliseconds> newInterval;
+  std::optional<std::chrono::milliseconds> newInterval;
 
 public:
   grpc::Status StreamReverseTunnels(

--- a/contrib/rocketmq_proxy/filters/network/source/active_message.h
+++ b/contrib/rocketmq_proxy/filters/network/source/active_message.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
@@ -9,7 +11,6 @@
 #include "source/common/common/linked_object.h"
 #include "source/common/common/logger.h"
 
-#include "absl/types/optional.h"
 #include "contrib/rocketmq_proxy/filters/network/source/codec.h"
 #include "contrib/rocketmq_proxy/filters/network/source/protocol.h"
 #include "contrib/rocketmq_proxy/filters/network/source/router/router.h"
@@ -91,7 +92,7 @@ private:
   RemotingCommandPtr response_;
   MessageMetadataSharedPtr metadata_;
   Router::RouterPtr router_;
-  absl::optional<Router::RouteConstSharedPtr> cached_route_;
+  std::optional<Router::RouteConstSharedPtr> cached_route_;
 
   void updateActiveRequestStats(bool is_inc = true);
 };

--- a/contrib/rocketmq_proxy/filters/network/source/metadata.h
+++ b/contrib/rocketmq_proxy/filters/network/source/metadata.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "source/common/http/header_map_impl.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -30,7 +29,7 @@ public:
 
 private:
   bool is_oneway_{false};
-  absl::optional<std::string> topic_name_;
+  std::optional<std::string> topic_name_;
 
   Http::HeaderMapPtr headers_{Http::RequestHeaderMapImpl::create()};
 };

--- a/contrib/rocketmq_proxy/filters/network/test/router_test.cc
+++ b/contrib/rocketmq_proxy/filters/network/test/router_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "test/mocks/server/factory_context.h"
 
 #include "contrib/rocketmq_proxy/filters/network/source/config.h"
@@ -253,7 +255,7 @@ TEST_F(RocketmqRouterTest, NoHealthyHosts) {
       }));
   EXPECT_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _))
-      .WillOnce(Return(absl::nullopt));
+      .WillOnce(Return(std::nullopt));
   EXPECT_CALL(*active_message_, onReset());
 
   startRequest();

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -1,5 +1,7 @@
 #include "contrib/sip_proxy/filters/network/source/conn_manager.h"
 
+#include <optional>
+
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
 
@@ -30,7 +32,7 @@ TrafficRoutingAssistantHandler::TrafficRoutingAssistantHandler(
 
 void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(
     const std::string& type, const std::string& key, const std::string& val,
-    const absl::optional<TraContextMap> context) {
+    const std::optional<TraContextMap> context) {
 
   bool should_update_tra = true;
 
@@ -50,7 +52,7 @@ void TrafficRoutingAssistantHandler::updateTrafficRoutingAssistant(
 }
 
 QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
-    const std::string& type, const std::string& key, const absl::optional<TraContextMap> context,
+    const std::string& type, const std::string& key, const std::optional<TraContextMap> context,
     SipFilters::DecoderFilterCallbacks& activetrans, std::string& host) {
 
   host = {};
@@ -74,7 +76,7 @@ QueryStatus TrafficRoutingAssistantHandler::retrieveTrafficRoutingAssistant(
 }
 
 void TrafficRoutingAssistantHandler::deleteTrafficRoutingAssistant(
-    const std::string& type, const std::string& key, const absl::optional<TraContextMap> context) {
+    const std::string& type, const std::string& key, const std::optional<TraContextMap> context) {
   cache_manager_.erase(type, key);
   if (traClient()) {
     traClient()->deleteTrafficRoutingAssistant(type, key, context, Tracing::NullSpan::instance(),

--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/common/pure.h"
 #include "envoy/common/random_generator.h"
 #include "envoy/event/deferred_deletable.h"
@@ -69,12 +71,12 @@ public:
 
   virtual void updateTrafficRoutingAssistant(const std::string& type, const std::string& key,
                                              const std::string& val,
-                                             const absl::optional<TraContextMap> context);
+                                             const std::optional<TraContextMap> context);
   virtual QueryStatus retrieveTrafficRoutingAssistant(
-      const std::string& type, const std::string& key, const absl::optional<TraContextMap> context,
+      const std::string& type, const std::string& key, const std::optional<TraContextMap> context,
       SipFilters::DecoderFilterCallbacks& activetrans, std::string& host);
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                             const absl::optional<TraContextMap> context);
+                                             const std::optional<TraContextMap> context);
   virtual void subscribeTrafficRoutingAssistant(const std::string& type);
   void complete(const TrafficRoutingAssistant::ResponseType& type, const std::string& message_type,
                 const absl::any& resp) override;
@@ -337,7 +339,7 @@ private:
     MessageMetadataSharedPtr metadata_;
     std::list<ActiveTransDecoderFilterPtr> decoder_filters_;
     ResponseDecoderPtr response_decoder_;
-    absl::optional<Router::RouteConstSharedPtr> cached_route_;
+    std::optional<Router::RouteConstSharedPtr> cached_route_;
 
     std::function<FilterStatus(DecoderEventHandler*)> filter_action_;
 

--- a/contrib/sip_proxy/filters/network/source/decoder.h
+++ b/contrib/sip_proxy/filters/network/source/decoder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "source/common/buffer/buffer_impl.h"
 
 #include "contrib/sip_proxy/filters/network/source/filters/filter.h"
@@ -51,7 +53,7 @@ private:
         : next_state_(next_state), filter_status_(filter_status) {};
 
     State next_state_;
-    absl::optional<FilterStatus> filter_status_;
+    std::optional<FilterStatus> filter_status_;
   };
 
   DecoderStatus transportBegin();

--- a/contrib/sip_proxy/filters/network/source/metadata.h
+++ b/contrib/sip_proxy/filters/network/source/metadata.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "source/common/common/logger.h"
 
 #include "contrib/envoy/extensions/filters/network/sip_proxy/v3alpha/sip_proxy.pb.h"
@@ -107,10 +109,10 @@ public:
   MethodType methodType() { return method_type_; }
   void setMethodType(MethodType data) { method_type_ = data; }
 
-  absl::optional<absl::string_view> ep() { return ep_; }
+  std::optional<absl::string_view> ep() { return ep_; }
   void setEP(absl::string_view data) { ep_ = data; }
 
-  absl::optional<absl::string_view> opaque() { return opaque_; }
+  std::optional<absl::string_view> opaque() { return opaque_; }
   void setOpaque(absl::string_view data) { opaque_ = data; }
 
   std::vector<Operation>& operationList() { return operation_list_; }
@@ -118,11 +120,11 @@ public:
 
 #if 1
   // TODO Only used for NOKIA customized affinity. should be deleted later.
-  absl::optional<std::pair<std::string, std::string>> pCookieIpMap() { return p_cookie_ip_map_; }
+  std::optional<std::pair<std::string, std::string>> pCookieIpMap() { return p_cookie_ip_map_; }
   void setPCookieIpMap(std::pair<std::string, std::string>&& data) { p_cookie_ip_map_ = data; }
 #endif
 
-  absl::optional<absl::string_view> transactionId() { return transaction_id_; }
+  std::optional<absl::string_view> transactionId() { return transaction_id_; }
   /**
    * @param data full SIP header
    */
@@ -192,12 +194,12 @@ private:
   std::vector<std::vector<SipHeader>> headers_{HeaderType::HeaderMaxNum};
 
   std::vector<Operation> operation_list_;
-  absl::optional<absl::string_view> ep_;
-  absl::optional<absl::string_view> opaque_;
+  std::optional<absl::string_view> ep_;
+  std::optional<absl::string_view> opaque_;
 
-  absl::optional<std::pair<std::string, std::string>> p_cookie_ip_map_;
+  std::optional<std::pair<std::string, std::string>> p_cookie_ip_map_;
 
-  absl::optional<absl::string_view> transaction_id_;
+  std::optional<absl::string_view> transaction_id_;
 
   std::string destination_;
 

--- a/contrib/sip_proxy/filters/network/source/router/router_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/router/router_impl.cc
@@ -1,5 +1,7 @@
 #include "contrib/sip_proxy/filters/network/source/router/router_impl.h"
 
+#include <optional>
+
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/common/logger.h"
@@ -200,7 +202,7 @@ FilterStatus Router::handleAffinity() {
   if (metadata->pCookieIpMap().has_value()) {
     auto [key, val] = metadata->pCookieIpMap().value();
     ENVOY_LOG(trace, "update p-cookie-ip-map {}={}", key, val);
-    callbacks_->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, absl::nullopt);
+    callbacks_->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, std::nullopt);
   }
 
   const std::shared_ptr<const ProtocolOptionsConfig> options =
@@ -724,8 +726,7 @@ FilterStatus ResponseDecoder::transportBegin(MessageMetadataSharedPtr metadata) 
       if (metadata->pCookieIpMap().has_value()) {
         auto [key, val] = metadata->pCookieIpMap().value();
         ENVOY_LOG(trace, "update p-cookie-ip-map {}={}", key, val);
-        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val,
-                                                                  absl::nullopt);
+        active_trans->traHandler()->updateTrafficRoutingAssistant("lskpmc", key, val, std::nullopt);
       }
 
       active_trans->startUpstreamResponse();

--- a/contrib/sip_proxy/filters/network/source/tra/tra.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/common/pure.h"
 #include "envoy/singleton/manager.h"
 #include "envoy/stream_info/stream_info.h"
@@ -7,7 +9,6 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/any.h"
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -47,18 +48,18 @@ public:
   virtual void setRequestCallbacks(RequestCallbacks& callbacks) PURE;
   virtual void createTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+      const std::optional<TraContextMap> context, Tracing::Span& parent_span,
       const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void updateTrafficRoutingAssistant(
       const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-      const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+      const std::optional<TraContextMap> context, Tracing::Span& parent_span,
       const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                               const absl::optional<TraContextMap> context,
+                                               const std::optional<TraContextMap> context,
                                                Tracing::Span& parent_span,
                                                const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                             const absl::optional<TraContextMap> context,
+                                             const std::optional<TraContextMap> context,
                                              Tracing::Span& parent_span,
                                              const StreamInfo::StreamInfo& stream_info) PURE;
   virtual void subscribeTrafficRoutingAssistant(const std::string& type, Tracing::Span& parent_span,

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -1,5 +1,7 @@
 #include "contrib/sip_proxy/filters/network/source/tra/tra_impl.h"
 
+#include <optional>
+
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/stats/scope.h"
 
@@ -16,7 +18,7 @@ namespace TrafficRoutingAssistant {
 
 GrpcClientImpl::GrpcClientImpl(const Grpc::RawAsyncClientSharedPtr& async_client,
                                Event::Dispatcher& dispatcher,
-                               const absl::optional<std::chrono::milliseconds>& timeout)
+                               const std::optional<std::chrono::milliseconds>& timeout)
     : async_client_(async_client), dispatcher_(dispatcher), timeout_(timeout) {}
 
 GrpcClientImpl::~GrpcClientImpl() {
@@ -38,7 +40,7 @@ void GrpcClientImpl::setRequestCallbacks(RequestCallbacks& callbacks) {
 
 void GrpcClientImpl::createTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+    const std::optional<TraContextMap> context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
 
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
@@ -60,7 +62,7 @@ void GrpcClientImpl::createTrafficRoutingAssistant(
 
 void GrpcClientImpl::updateTrafficRoutingAssistant(
     const std::string& type, const absl::flat_hash_map<std::string, std::string>& data,
-    const absl::optional<TraContextMap> context, Tracing::Span& parent_span,
+    const std::optional<TraContextMap> context, Tracing::Span& parent_span,
     const StreamInfo::StreamInfo& stream_info) {
   envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceRequest request;
   request.set_type(type);
@@ -81,7 +83,7 @@ void GrpcClientImpl::updateTrafficRoutingAssistant(
 
 void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
                                                      const std::string& key,
-                                                     const absl::optional<TraContextMap> context,
+                                                     const std::optional<TraContextMap> context,
                                                      Tracing::Span& parent_span,
                                                      const StreamInfo::StreamInfo& stream_info) {
 
@@ -100,7 +102,7 @@ void GrpcClientImpl::retrieveTrafficRoutingAssistant(const std::string& type,
 }
 
 void GrpcClientImpl::deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                                   const absl::optional<TraContextMap> context,
+                                                   const std::optional<TraContextMap> context,
                                                    Tracing::Span& parent_span,
                                                    const StreamInfo::StreamInfo& stream_info) {
 

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/grpc/async_client.h"
 #include "envoy/grpc/async_client_manager.h"
@@ -37,27 +39,27 @@ class GrpcClientImpl : public Client,
                        public Logger::Loggable<Logger::Id::filter> {
 public:
   GrpcClientImpl(const Grpc::RawAsyncClientSharedPtr& async_client, Event::Dispatcher& dispatcher,
-                 const absl::optional<std::chrono::milliseconds>& timeout);
+                 const std::optional<std::chrono::milliseconds>& timeout);
   ~GrpcClientImpl() override;
 
   // Extensions::NetworkFilters::SipProxy::TrafficRoutingAssistant::Client
   void setRequestCallbacks(RequestCallbacks& callbacks) override;
   void createTrafficRoutingAssistant(const std::string& type,
                                      const absl::flat_hash_map<std::string, std::string>& data,
-                                     const absl::optional<TraContextMap> context,
+                                     const std::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void updateTrafficRoutingAssistant(const std::string& type,
                                      const absl::flat_hash_map<std::string, std::string>& data,
-                                     const absl::optional<TraContextMap> context,
+                                     const std::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void retrieveTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                       const absl::optional<TraContextMap> context,
+                                       const std::optional<TraContextMap> context,
                                        Tracing::Span& parent_span,
                                        const StreamInfo::StreamInfo& stream_info) override;
   void deleteTrafficRoutingAssistant(const std::string& type, const std::string& key,
-                                     const absl::optional<TraContextMap> context,
+                                     const std::optional<TraContextMap> context,
                                      Tracing::Span& parent_span,
                                      const StreamInfo::StreamInfo& stream_info) override;
   void subscribeTrafficRoutingAssistant(const std::string& type, Tracing::Span& parent_span,
@@ -183,7 +185,7 @@ private:
       envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>
       async_client_;
   Event::Dispatcher& dispatcher_;
-  absl::optional<std::chrono::milliseconds> timeout_;
+  std::optional<std::chrono::milliseconds> timeout_;
 
   std::list<std::unique_ptr<AsyncRequestCallbacks>> request_callbacks_;
   std::list<std::unique_ptr<AsyncStreamCallbacks>> stream_callbacks_;

--- a/contrib/sip_proxy/filters/network/test/cache_manager_test.cc
+++ b/contrib/sip_proxy/filters/network/test/cache_manager_test.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "contrib/sip_proxy/filters/network/source/utility.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -10,7 +12,7 @@ namespace SipProxy {
 TEST(CacheManagerTest, FindTypeNotExist) {
   auto cache_manager = CacheManager<std::string, std::string, std::string>();
   auto result = cache_manager.at("empty", "empty");
-  EXPECT_EQ(absl::nullopt, result);
+  EXPECT_EQ(std::nullopt, result);
   EXPECT_EQ(false, cache_manager.contains("empty", "empty"));
 }
 
@@ -19,7 +21,7 @@ TEST(CacheManagerTest, FindKeyNotExist) {
   cache_manager.initCache("lskpmc", 12);
   cache_manager.insertCache("lskpmc", "S3F2", "192.168.0.1");
   auto result = cache_manager.at("lskpmc", "fake");
-  EXPECT_EQ(absl::nullopt, result);
+  EXPECT_EQ(std::nullopt, result);
   EXPECT_EQ(true, cache_manager.contains("lskpmc", "S3F2"));
   EXPECT_EQ(false, cache_manager.contains("lskpmc", "fake"));
 }

--- a/contrib/sip_proxy/filters/network/test/mocks.cc
+++ b/contrib/sip_proxy/filters/network/test/mocks.cc
@@ -1,6 +1,7 @@
 #include "contrib/sip_proxy/filters/network/test/mocks.h"
 
 #include <memory>
+#include <optional>
 
 #include "source/common/protobuf/protobuf.h"
 
@@ -99,7 +100,7 @@ MockTrafficRoutingAssistantHandler::MockTrafficRoutingAssistantHandler(
     : TrafficRoutingAssistantHandler(parent, dispatcher, config, context, stream_info) {
   ON_CALL(*this, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillByDefault(
-          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
+          Invoke([&](const std::string&, const std::string&, const std::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Continue;

--- a/contrib/sip_proxy/filters/network/test/mocks.h
+++ b/contrib/sip_proxy/filters/network/test/mocks.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "envoy/router/router.h"
@@ -201,14 +202,14 @@ public:
       Server::Configuration::FactoryContext& context, StreamInfo::StreamInfoImpl& stream_info);
   MOCK_METHOD(void, updateTrafficRoutingAssistant,
               (const std::string&, const std::string&, const std::string&,
-               const absl::optional<TraContextMap>),
+               const std::optional<TraContextMap>),
               ());
   MOCK_METHOD(QueryStatus, retrieveTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const absl::optional<TraContextMap>,
+              (const std::string&, const std::string&, const std::optional<TraContextMap>,
                SipFilters::DecoderFilterCallbacks&, std::string&),
               ());
   MOCK_METHOD(void, deleteTrafficRoutingAssistant,
-              (const std::string&, const std::string&, const absl::optional<TraContextMap>), ());
+              (const std::string&, const std::string&, const std::optional<TraContextMap>), ());
   MOCK_METHOD(void, subscribeTrafficRoutingAssistant, (const std::string&), ());
   MOCK_METHOD(void, doSubscribe,
               (const envoy::extensions::filters::network::sip_proxy::v3alpha::CustomizedAffinity),

--- a/contrib/sip_proxy/filters/network/test/router_test.cc
+++ b/contrib/sip_proxy/filters/network/test/router_test.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <optional>
 #include <type_traits>
 
 #include "envoy/tcp/conn_pool.h"
@@ -239,7 +240,7 @@ public:
 
     EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
         .WillRepeatedly(
-            Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
+            Invoke([&](const std::string&, const std::string&, const std::optional<TraContextMap>,
                        SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
               host = "10.0.0.11";
               return QueryStatus::Pending;
@@ -408,7 +409,7 @@ TEST_F(SipRouterTest, NoTcpConnPool) {
   initializeMetadata(MsgType::Request);
   EXPECT_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _))
-      .WillOnce(Return(absl::nullopt));
+      .WillOnce(Return(std::nullopt));
   try {
     startRequest(FilterStatus::Continue);
   } catch (const AppException& ex) {
@@ -430,7 +431,7 @@ TEST_F(SipRouterTest, NoTcpConnPoolEmptyDest) {
 
   EXPECT_CALL(context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
               tcpConnPool(_, _))
-      .WillOnce(Return(absl::nullopt));
+      .WillOnce(Return(std::nullopt));
   try {
     startRequest(FilterStatus::Continue);
   } catch (const AppException& ex) {
@@ -451,7 +452,7 @@ TEST_F(SipRouterTest, QueryPending) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
+          Invoke([&](const std::string&, const std::string&, const std::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "10.0.0.11";
             return QueryStatus::Pending;
@@ -469,7 +470,7 @@ TEST_F(SipRouterTest, QueryStop) {
   metadata_->resetAffinityIteration();
   EXPECT_CALL(*tra_handler_, retrieveTrafficRoutingAssistant(_, _, _, _, _))
       .WillRepeatedly(
-          Invoke([&](const std::string&, const std::string&, const absl::optional<TraContextMap>,
+          Invoke([&](const std::string&, const std::string&, const std::optional<TraContextMap>,
                      SipFilters::DecoderFilterCallbacks&, std::string& host) -> QueryStatus {
             host = "";
             return QueryStatus::Stop;

--- a/contrib/sip_proxy/filters/network/test/tra_test.cc
+++ b/contrib/sip_proxy/filters/network/test/tra_test.cc
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <memory>
+#include <optional>
 
 #include "source/common/buffer/buffer_impl.h"
 
@@ -83,7 +84,7 @@ public:
 
 TEST_F(SipTraTest, TraUpdate) {
   auto tra_handler = initTraHandler();
-  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S2F1", "10.0.0.1", absl::nullopt);
+  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S2F1", "10.0.0.1", std::nullopt);
 }
 
 TEST_F(SipTraTest, TraUpdateWithSIPContext) {
@@ -96,12 +97,12 @@ TEST_F(SipTraTest, TraUpdateWithSIPContext) {
 
 TEST_F(SipTraTest, TraRetrieveContinue) {
   auto tra_handler = initTraHandler();
-  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1", absl::nullopt);
+  tra_handler->updateTrafficRoutingAssistant("lskpmc", "S1F1", "10.0.0.1", std::nullopt);
 
   NiceMock<SipFilters::MockDecoderFilterCallbacks> callbacks;
   std::string host = "";
   EXPECT_EQ(QueryStatus::Continue, tra_handler->retrieveTrafficRoutingAssistant(
-                                       "lskpmc", "S1F1", absl::nullopt, callbacks, host));
+                                       "lskpmc", "S1F1", std::nullopt, callbacks, host));
   EXPECT_EQ(host, "10.0.0.1");
 }
 
@@ -195,7 +196,7 @@ TEST_F(SipTraTest, TraDoSubscribe) {
 
 TEST_F(SipTraTest, TraDelete) {
   auto tra_handler = initTraHandler();
-  tra_handler->deleteTrafficRoutingAssistant("lskpmc", "S1F1", absl::nullopt);
+  tra_handler->deleteTrafficRoutingAssistant("lskpmc", "S1F1", std::nullopt);
 }
 
 TEST_F(SipTraTest, TraDeleteWithSIPContext) {
@@ -228,7 +229,7 @@ TEST_F(SipTraTest, GrpcClientOnSuccessRetrieveRsp) {
           envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>(
           service_response_config);
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onSuccess(std::move(response), span_);
@@ -252,7 +253,7 @@ TEST_F(SipTraTest, GrpcClientOnSuccessCreateRsp) {
           envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>(
           service_response_config);
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onSuccess(std::move(response), span_);
@@ -275,7 +276,7 @@ TEST_F(SipTraTest, GrpcClientOnSuccessUpdateRsp) {
       envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>(
       service_response_config);
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onSuccess(std::move(response), span_);
@@ -298,7 +299,7 @@ TEST_F(SipTraTest, GrpcClientOnSuccessDeleteRsp) {
       envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>(
       service_response_config);
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onSuccess(std::move(response), span_);
@@ -309,7 +310,7 @@ TEST_F(SipTraTest, GrpcClientOnReceiveMessage) {
       response = std::make_unique<
           envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>();
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onReceiveMessage(std::move(response));
@@ -318,7 +319,7 @@ TEST_F(SipTraTest, GrpcClientOnReceiveMessage) {
 TEST_F(SipTraTest, GrpcClientOnFailure) {
   Grpc::Status::GrpcStatus status = Grpc::Status::WellKnownGrpcStatus::Unknown;
 
-  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, absl::nullopt);
+  auto grpc_client = TrafficRoutingAssistant::GrpcClientImpl(nullptr, dispatcher_, std::nullopt);
   NiceMock<SipProxy::MockRequestCallbacks> request_callbacks;
   grpc_client.setRequestCallbacks(request_callbacks);
   grpc_client.onFailure(status, "", span_);
@@ -353,7 +354,7 @@ TEST_F(SipTraTest, Misc) {
 
   absl::flat_hash_map<std::string, std::string> data;
   data.emplace(std::make_pair("S1F1", "10.0.0.1"));
-  grpc_client.createTrafficRoutingAssistant("lskpmc", data, absl::nullopt, span_, stream_info_);
+  grpc_client.createTrafficRoutingAssistant("lskpmc", data, std::nullopt, span_, stream_info_);
 
   Http::TestRequestHeaderMapImpl request_headers;
   request_cb->onCreateInitialMetadata(request_headers);

--- a/contrib/stat_sinks/wasm_filter/source/enriched_metric.h
+++ b/contrib/stat_sinks/wasm_filter/source/enriched_metric.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -8,8 +9,6 @@
 #include "envoy/stats/stats.h"
 
 #include "source/common/stats/symbol_table.h"
-
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -82,7 +81,7 @@ private:
   const Stats::Counter& original_;
   const Stats::TagVector& extra_tags_;
   const std::string& name_override_;
-  absl::optional<Stats::StatNameManagedStorage> override_stat_name_;
+  std::optional<Stats::StatNameManagedStorage> override_stat_name_;
 };
 
 // Wraps an existing Gauge with tag/name overrides.
@@ -142,7 +141,7 @@ private:
   const Stats::Gauge& original_;
   const Stats::TagVector& extra_tags_;
   const std::string& name_override_;
-  absl::optional<Stats::StatNameManagedStorage> override_stat_name_;
+  std::optional<Stats::StatNameManagedStorage> override_stat_name_;
 };
 
 // Wraps an existing ParentHistogram with tag/name overrides.
@@ -214,7 +213,7 @@ private:
   const Stats::ParentHistogram& original_;
   const Stats::TagVector& extra_tags_;
   const std::string& name_override_;
-  absl::optional<Stats::StatNameManagedStorage> override_stat_name_;
+  std::optional<Stats::StatNameManagedStorage> override_stat_name_;
 };
 
 // A standalone synthetic counter with stored name, value, and tags.

--- a/contrib/vcl/source/vcl_io_handle.cc
+++ b/contrib/vcl/source/vcl_io_handle.cc
@@ -1,5 +1,7 @@
 #include "contrib/vcl/source/vcl_io_handle.h"
 
+#include <optional>
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/network/address_impl.h"
 
@@ -197,7 +199,7 @@ Api::IoCallUint64Result VclIoHandle::readv(uint64_t max_length, Buffer::RawSlice
 }
 
 #if VCL_RX_ZC
-Api::IoCallUint64Result VclIoHandle::read(Buffer::Instance& buffer, absl::optional<uint64_t>) {
+Api::IoCallUint64Result VclIoHandle::read(Buffer::Instance& buffer, std::optional<uint64_t>) {
   vppcom_data_segment_t ds[16];
   int32_t rv;
 
@@ -227,7 +229,7 @@ Api::IoCallUint64Result VclIoHandle::read(Buffer::Instance& buffer, absl::option
 }
 #else
 Api::IoCallUint64Result VclIoHandle::read(Buffer::Instance& buffer,
-                                          absl::optional<uint64_t> max_length_opt) {
+                                          std::optional<uint64_t> max_length_opt) {
   uint64_t max_length = max_length_opt.value_or(UINT64_MAX);
   if (max_length == 0) {
     return Api::ioCallUint64ResultNoError();
@@ -620,7 +622,7 @@ Api::SysCallIntResult VclIoHandle::setBlocking(bool) {
   return {rv < 0 ? -1 : 0, -rv};
 }
 
-absl::optional<int> VclIoHandle::domain() {
+std::optional<int> VclIoHandle::domain() {
   VCL_LOG("grabbing domain sh {:x}", sh_);
   return {AF_INET};
 };
@@ -769,9 +771,9 @@ IoHandlePtr VclIoHandle::duplicate() {
   return io_handle;
 }
 
-absl::optional<std::chrono::milliseconds> VclIoHandle::lastRoundTripTime() { return {}; }
+std::optional<std::chrono::milliseconds> VclIoHandle::lastRoundTripTime() { return {}; }
 
-absl::optional<uint64_t> VclIoHandle::congestionWindowInBytes() const { return {}; }
+std::optional<uint64_t> VclIoHandle::congestionWindowInBytes() const { return {}; }
 
 } // namespace Vcl
 } // namespace Network

--- a/contrib/vcl/source/vcl_io_handle.h
+++ b/contrib/vcl/source/vcl_io_handle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <list>
+#include <optional>
 
 #include "envoy/api/io_error.h"
 #include "envoy/common/exception.h"
@@ -35,7 +36,7 @@ public:
   Api::IoCallUint64Result readv(uint64_t max_length, Buffer::RawSlice* slices,
                                 uint64_t num_slice) override;
   Api::IoCallUint64Result read(Buffer::Instance& buffer,
-                               absl::optional<uint64_t> max_length) override;
+                               std::optional<uint64_t> max_length) override;
   Api::IoCallUint64Result writev(const Buffer::RawSlice* slices, uint64_t num_slice) override;
   Api::IoCallUint64Result write(Buffer::Instance& buffer) override;
   Api::IoCallUint64Result recv(void* buffer, size_t length, int flags) override;
@@ -48,8 +49,8 @@ public:
   Api::IoCallUint64Result recvmmsg(RawSliceArrays& slices, uint32_t self_port,
                                    const UdpSaveCmsgConfig& save_cmsg_config,
                                    RecvMsgOutput& output) override;
-  absl::optional<std::chrono::milliseconds> lastRoundTripTime() override;
-  absl::optional<uint64_t> congestionWindowInBytes() const override;
+  std::optional<std::chrono::milliseconds> lastRoundTripTime() override;
+  std::optional<uint64_t> congestionWindowInBytes() const override;
 
   bool supportsMmsg() const override;
   bool supportsUdpGro() const override { return false; }
@@ -65,7 +66,7 @@ public:
                               unsigned long in_buffer_len, void* out_buffer,
                               unsigned long out_buffer_len, unsigned long* bytes_returned) override;
   Api::SysCallIntResult setBlocking(bool blocking) override;
-  absl::optional<int> domain() override;
+  std::optional<int> domain() override;
   absl::StatusOr<Envoy::Network::Address::InstanceConstSharedPtr> localAddress() override;
   absl::StatusOr<Envoy::Network::Address::InstanceConstSharedPtr> peerAddress() override;
   Api::SysCallIntResult shutdown(int) override { return {0, 0}; }
@@ -77,7 +78,7 @@ public:
   void resetFileEvents() override;
   IoHandlePtr duplicate() override;
 
-  absl::optional<std::string> interfaceName() override { return absl::nullopt; }
+  std::optional<std::string> interfaceName() override { return std::nullopt; }
 
   void cb(uint32_t events) { THROW_IF_NOT_OK(cb_(events)); }
   void setCb(Event::FileReadyCb cb) { cb_ = cb; }

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -688,12 +688,28 @@ class FormatChecker:
             report_error("Don't use std::get_if; use absl::get_if instead")
         if self.token_in_line("std::holds_alternative", line):
             report_error("Don't use std::holds_alternative; use absl::holds_alternative instead")
-        if self.token_in_line("std::make_optional", line):
-            report_error("Don't use std::make_optional; use absl::make_optional instead")
+        if file_path.startswith("./contrib/") or file_path.startswith("contrib/"):
+            if self.token_in_line("absl::make_optional", line):
+                report_error(
+                    "Don't use absl::make_optional (deprecated), use std::make_optional instead"
+                )
+            if self.token_in_line("absl::nullopt", line):
+                report_error(
+                    "Don't use absl::nullopt (deprecated), use std::nullopt instead")
+            if self.token_in_line("absl::optional", line):
+                report_error(
+                    "Don't use absl::optional (deprecated), use std::optional instead")
+            if "absl/types/optional.h" in line:
+                report_error(
+                    "Don't include absl/types/optional.h (deprecated), use <optional> instead"
+                )
+        else:
+            if self.token_in_line("std::make_optional", line):
+                report_error("Don't use std::make_optional; use absl::make_optional instead")
+            if self.token_in_line("std::optional", line):
+                report_error("Don't use std::optional; use absl::optional instead")
         if self.token_in_line("std::monostate", line):
             report_error("Don't use std::monostate; use absl::monostate instead")
-        if self.token_in_line("std::optional", line):
-            report_error("Don't use std::optional; use absl::optional instead")
         if not self.allow_listed_for_std_string_view(
                 file_path) and not "NOLINT(std::string_view)" in line:
             if self.token_in_line("std::string_view", line) or self.token_in_line("toStdStringView",


### PR DESCRIPTION
Abseil is deprecating absl::optional, so begin the migration with contrib code.

Update the format check to enforce std::optional for contrib while preserving the existing absl::optional policy for the rest of the tree.

Ai/Codex assisted.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
