### PR TITLE
lua: fix testPrint closure in LuaWrappersTestBase setup

### DIFF
--- a/test/extensions/filters/common/lua/lua_wrappers.h
+++ b/test/extensions/filters/common/lua/lua_wrappers.h
@@ -31,7 +31,7 @@ public:
     state_ = std::make_unique<ThreadLocalState>(code, tls_);
     state_->registerType<T>();
     coroutine_ = state_->createCoroutine();
-    lua_pushcclosure(coroutine_->luaState(), luaTestPrint, 1);
+    lua_pushcclosure(coroutine_->luaState(), luaTestPrint, 0);
     lua_setglobal(coroutine_->luaState(), "testPrint");
     testing::Mock::AllowLeak(&printer_);
   }


### PR DESCRIPTION
Commit Message: lua: fix testPrint closure in LuaWrappersTestBase setup

Additional Description:
This fixes usage of lua_pushcclosure which defines the function `testPrint` used in the lua wrappers tests. There used to be 1 upvalue used in this closure, but it was removed in https://github.com/envoyproxy/envoy/pull/12664, and the third argument to lua_pushcclosure (number of upvalues) was not updated. 

If luajit is built with `LUA_USE_ASSERT` defined (it is not currently), running the tests previously would abort with the following error:

```
LuaJIT ASSERT external/luajit/src/lj_api.c:698: lua_pushcclosure: stack slot 1 out of range
```

As a follow up it may be a good idea to enable `LUA_USE_ASSERT` for dbg builds, otherwise many errors appear to be silently ignored and checks on inputs for api functions are skipped entirely. This error would almost certainly have been detected by asan, but asan instrumentation is disabled for luajit for unrelated reasons (see https://github.com/envoyproxy/envoy/issues/6084)

Risk Level: Low
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
