### PR TITLE
aws: fix data race in credentials file provider with watched_directory

### DIFF
--- a/changelogs/current/bug_fixes/aws__fixed-data-race-in-credentials-file-provider.rst
+++ b/changelogs/current/bug_fixes/aws__fixed-data-race-in-credentials-file-provider.rst
@@ -1,0 +1,5 @@
+Fixed a data race in the AWS credentials file provider (``CredentialsFileCredentialsProvider``)
+that could corrupt the heap and crash Envoy when ``watched_directory`` was configured. With a
+watched directory the cached credentials were refreshed on every ``getCredentials()`` call, and
+concurrent worker threads wrote the cached ``Credentials`` and ``last_updated_`` members without
+synchronization. The cached state is now guarded by a mutex.

--- a/source/extensions/common/aws/cached_credentials_provider_base.h
+++ b/source/extensions/common/aws/cached_credentials_provider_base.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "envoy/common/time.h"
 
+#include "source/common/common/thread.h"
 #include "source/extensions/common/aws/credentials_provider.h"
 
 namespace Envoy {
@@ -12,23 +13,28 @@ class CachedCredentialsProviderBase : public CredentialsProvider,
                                       public Logger::Loggable<Logger::Id::aws> {
 public:
   Credentials getCredentials() override {
+    // The cached credentials are read by worker threads and refreshed in place by both
+    // refresh() and needsRefresh(). Guard the whole read-refresh-read sequence so concurrent
+    // getCredentials() calls cannot race on cached_credentials_ or last_updated_.
+    Thread::LockGuard guard(mu_);
     refreshIfNeeded();
     return cached_credentials_;
   }
   bool credentialsPending() override { return false; };
 
 protected:
-  SystemTime last_updated_;
-  Credentials cached_credentials_;
+  Thread::MutexBasicLockable mu_;
+  SystemTime last_updated_ ABSL_GUARDED_BY(mu_);
+  Credentials cached_credentials_ ABSL_GUARDED_BY(mu_);
 
-  void refreshIfNeeded() {
+  void refreshIfNeeded() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
     if (needsRefresh()) {
       refresh();
     }
   }
 
-  virtual bool needsRefresh() PURE;
-  virtual void refresh() PURE;
+  virtual bool needsRefresh() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) PURE;
+  virtual void refresh() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) PURE;
 };
 
 } // namespace Aws

--- a/source/extensions/common/aws/credential_providers/credentials_file_credentials_provider.h
+++ b/source/extensions/common/aws/credential_providers/credentials_file_credentials_provider.h
@@ -30,9 +30,10 @@ private:
       credential_file_data_source_provider_;
   bool has_watched_directory_ = false;
 
-  bool needsRefresh() override;
-  void refresh() override;
-  void extractCredentials(absl::string_view credentials_string, absl::string_view profile);
+  bool needsRefresh() override ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void refresh() override ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  void extractCredentials(absl::string_view credentials_string, absl::string_view profile)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 };
 
 } // namespace Aws

--- a/test/extensions/common/aws/credential_providers/credentials_file_credentials_provider_test.cc
+++ b/test/extensions/common/aws/credential_providers/credentials_file_credentials_provider_test.cc
@@ -1,3 +1,6 @@
+#include <thread>
+#include <vector>
+
 #include "source/extensions/common/aws/credential_providers/credentials_file_credentials_provider.h"
 
 #include "test/mocks/server/server_factory_context.h"
@@ -106,6 +109,50 @@ TEST_F(CredentialsFileCredentialsProviderTest, CustomProfileFromConfigWithWatche
   EXPECT_EQ("default_access_key", credentials.accessKeyId().value());
   EXPECT_EQ("default_secret", credentials.secretAccessKey().value());
   EXPECT_EQ("default_token", credentials.sessionToken().value());
+}
+
+// With a watched directory configured, needsRefresh() always returns true, so every
+// getCredentials() call re-parses the file and rewrites cached_credentials_/last_updated_.
+// Hammer getCredentials() from many threads concurrently; without a mutex protecting those
+// members this races and corrupts the heap (see issue #45667). This test is primarily a
+// TSAN regression guard.
+TEST_F(CredentialsFileCredentialsProviderTest, ConcurrentGetCredentialsWithWatched) {
+  auto file_path =
+      TestEnvironment::writeStringToFileForTest(CREDENTIALS_FILE, CREDENTIALS_FILE_CONTENTS);
+
+  envoy::extensions::common::aws::v3::CredentialsFileCredentialProvider config = {};
+  config.mutable_credentials_data_source()->set_filename(file_path);
+  config.mutable_credentials_data_source()->mutable_watched_directory()->set_path(
+      TestEnvironment::temporaryPath("test"));
+  EXPECT_CALL(context_, api()).WillRepeatedly(ReturnRef(*api_));
+  EXPECT_CALL(context_, mainThreadDispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
+  EXPECT_CALL(dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
+  EXPECT_CALL(dispatcher_, createFilesystemWatcher_()).WillRepeatedly(InvokeWithoutArgs([&] {
+    Filesystem::MockWatcher* mock_watcher = new NiceMock<Filesystem::MockWatcher>();
+    EXPECT_CALL(*mock_watcher, addWatch(_, Filesystem::Watcher::Events::MovedTo, _))
+        .WillRepeatedly(Return(absl::OkStatus()));
+    return mock_watcher;
+  }));
+
+  auto provider = CredentialsFileCredentialsProvider(context_, config);
+
+  constexpr int num_threads = 8;
+  constexpr int iterations = 100;
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+  for (int i = 0; i < num_threads; i++) {
+    threads.emplace_back([&provider]() {
+      for (int j = 0; j < iterations; j++) {
+        const auto credentials = provider.getCredentials();
+        EXPECT_EQ("default_access_key", credentials.accessKeyId().value());
+        EXPECT_EQ("default_secret", credentials.secretAccessKey().value());
+        EXPECT_EQ("default_token", credentials.sessionToken().value());
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
 }
 
 TEST_F(CredentialsFileCredentialsProviderTest, CustomFilePathFromConfig) {


### PR DESCRIPTION
## Commit Message

aws: fix data race in credentials file provider with watched_directory

## Additional Description

Fixes #45667.

`CredentialsFileCredentialsProvider` configured with a `watched_directory` sets `has_watched_directory_`, which makes `needsRefresh()` unconditionally return `true`. As a result, **every** `getCredentials()` call — invoked per-request by the `aws_request_signing` filter across all worker threads — re-parses the credentials file and rewrites `cached_credentials_` (a `Credentials` holding `std::string` members) and `last_updated_`.

These members live in `CachedCredentialsProviderBase` and had **no synchronization** of any kind. Under concurrent load, worker threads race writing/reading the cached `Credentials` strings, corrupting the heap and crashing Envoy with a SIGSEGV inside `malloc` (the crash surfaces in `SignerBaseImpl::sign`, a victim of the corruption rather than its cause). Reported on v1.36.0 and v1.38.2.

### Fix

Guard `cached_credentials_` and `last_updated_` with a `Thread::MutexBasicLockable` in `CachedCredentialsProviderBase`. `getCredentials()` now holds the lock across the full read-refresh-read sequence, so the refresh and the subsequent copy-out are atomic with respect to other threads. The `needsRefresh()`/`refresh()`/`refreshIfNeeded()` hierarchy is annotated with `ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_)` so clang's thread-safety analysis (`-Wthread-safety`, enabled in the build) statically verifies all guarded accesses are correctly locked. This matches the existing locking convention in the same directory (`metadata_credentials_provider_base.h`, `credentials_provider.h`).

## Risk Level

Low — adds a mutex around already-short cached-credential accesses; no behavior change beyond serialization.

## Testing

Added `ConcurrentGetCredentialsWithWatched`: 8 threads × 100 iterations hammering `getCredentials()` on a watched-directory provider. This is primarily a TSAN regression guard (the TSAN CI job flags the race deterministically against the unfixed code).

I also verified the test catches the bug empirically by reverting the source fix and running the test binary in a loop (with a widened race window) on a plain build — the unfixed code aborts intermittently with `std::bad_optional_access` from torn reads of `cached_credentials_`, while the fixed code passes every run. All 14 pre-existing tests in `credentials_file_credentials_provider_test` continue to pass.

## Docs Changes

None.

## Release Notes

Added a bug-fix changelog entry under `changelogs/current/bug_fixes/`.