### PR TITLE
dynamic_modules: add HTTP filter getter for downstream TLS SNI attribute

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-http-filter-connection-requested-server-name-attribute.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-filter-connection-requested-server-name-attribute.rst
@@ -1,0 +1,3 @@
+Added support for reading the ``connection.requested_server_name`` attribute (downstream TLS SNI)
+from a dynamic module HTTP filter via ``get_attribute_string``. Returns ``None`` when no SNI was
+offered.

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1645,6 +1645,18 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     }
     break;
   }
+  case envoy_dynamic_module_type_attribute_id_ConnectionRequestedServerName: {
+    const auto stream_info = filter->streamInfo();
+    if (stream_info) {
+      // Downstream TLS SNI; empty when no SNI was offered, read as not-found.
+      const absl::string_view sni = stream_info->downstreamAddressProvider().requestedServerName();
+      if (!sni.empty()) {
+        *result = {sni.data(), sni.size()};
+        ok = true;
+      }
+    }
+    break;
+  }
   case envoy_dynamic_module_type_attribute_id_RequestId: {
     const auto stream_info = filter->streamInfo();
     if (stream_info) {

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2170,6 +2170,16 @@ TEST(ABIImpl, GetAttributes) {
       &filter, envoy_dynamic_module_type_attribute_id_DestinationAddress, &result_buffer));
   EXPECT_EQ(std::string(result_buffer.ptr, result_buffer.length), "127.0.0.2:4321");
 
+  // envoy_dynamic_module_type_attribute_id_ConnectionRequestedServerName, empty SNI => not found.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
+      &filter, envoy_dynamic_module_type_attribute_id_ConnectionRequestedServerName,
+      &result_buffer));
+  info.downstream_connection_info_provider_->setRequestedServerName("example.com");
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
+      &filter, envoy_dynamic_module_type_attribute_id_ConnectionRequestedServerName,
+      &result_buffer));
+  EXPECT_EQ(std::string(result_buffer.ptr, result_buffer.length), "example.com");
+
   // envoy_dynamic_module_type_attribute_id_RequestId
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_string(
       &filter, envoy_dynamic_module_type_attribute_id_RequestId, &result_buffer));

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -279,6 +279,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HeaderCallbacks) {
       .WillRepeatedly(testing::ReturnPointee(info.downstream_connection_info_provider_));
   auto addr = Envoy::Network::Utility::parseInternetAddressNoThrow("1.1.1.1", 1234, false);
   info.downstream_connection_info_provider_->setRemoteAddress(addr);
+  info.downstream_connection_info_provider_->setRequestedServerName("example.com");
 
   std::initializer_list<std::pair<std::string, std::string>> headers = {
       {"single", "value"}, {"multi", "value1"}, {"multi", "value2"}, {"to-be-deleted", "value"}};

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -243,6 +243,14 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for HeaderCallbacksFilter {
       std::str::from_utf8(downstream_addr.unwrap().as_slice()).unwrap(),
       "1.1.1.1:1234"
     );
+    let sni = envoy_filter.get_attribute_string(
+      abi::envoy_dynamic_module_type_attribute_id::ConnectionRequestedServerName,
+    );
+    assert!(sni.is_some());
+    assert_eq!(
+      std::str::from_utf8(sni.unwrap().as_slice()).unwrap(),
+      "example.com"
+    );
     let worker_index = envoy_filter.get_worker_index();
     assert_eq!(worker_index, 0);
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -104,6 +104,12 @@ fn test_header_callbacks_filter_on_request_headers() {
     .once();
 
   envoy_filter
+    .expect_get_attribute_string()
+    .withf(|id| *id == abi::envoy_dynamic_module_type_attribute_id::ConnectionRequestedServerName)
+    .returning(|_| Some(EnvoyBuffer::new(b"example.com")))
+    .once();
+
+  envoy_filter
     .expect_get_worker_index()
     .return_const(0u32)
     .once();


### PR DESCRIPTION
Commit Message: add HTTP filter getter for downstream TLS SNI attribute
Additional Description: This change allows dynamic module HTTP filters to access the SNI, like stock Envoy HTTP filters can already do via [requestedServerName()](https://github.com/envoyproxy/envoy/blob/aafc6ec47701f1505b0332b08b8a32f01f904309/source/extensions/filters/http/lua/wrappers.cc#L257).

Risk Level: Low
Testing: Unit Tests (added)
Docs Changes: N.A
Release Notes: N.A
Platform Specific Features: N.A
