### PR TITLE
docs: fix capitalization of proper nouns and acronyms

### DIFF
--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -232,7 +232,7 @@ Current supported substitution commands include:
 
 ``%UPSTREAM_WIRE_BYTES_SENT%``
   HTTP
-    Total number of bytes sent to the upstream by the http stream.
+    Total number of bytes sent to the upstream by the HTTP stream.
 
   TCP
     Total number of bytes sent to the upstream by the tcp proxy.
@@ -242,7 +242,7 @@ Current supported substitution commands include:
 
 ``%UPSTREAM_WIRE_BYTES_RECEIVED%``
   HTTP
-    Total number of bytes received from the upstream by the http stream.
+    Total number of bytes received from the upstream by the HTTP stream.
 
   TCP
     Total number of bytes received from the upstream by the tcp proxy.
@@ -252,7 +252,7 @@ Current supported substitution commands include:
 
 ``%UPSTREAM_HEADER_BYTES_SENT%``
   HTTP
-    Number of header bytes sent to the upstream by the http stream.
+    Number of header bytes sent to the upstream by the HTTP stream.
 
   TCP
     Total number of HTTP header bytes sent to the upstream stream, for TCP tunneling flows. Not supported for non-tunneling.
@@ -262,14 +262,14 @@ Current supported substitution commands include:
 
 ``%UPSTREAM_DECOMPRESSED_HEADER_BYTES_SENT%``
   HTTP
-    Number of decompressed header bytes sent to the upstream by the http stream.
+    Number of decompressed header bytes sent to the upstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
 
 ``%UPSTREAM_HEADER_BYTES_RECEIVED%``
   HTTP
-    Number of header bytes received from the upstream by the http stream.
+    Number of header bytes received from the upstream by the HTTP stream.
 
   TCP
     Total number of HTTP header bytes received from the upstream stream, for TCP tunneling flows. Not supported for non-tunneling.
@@ -279,7 +279,7 @@ Current supported substitution commands include:
 
 ``%UPSTREAM_DECOMPRESSED_HEADER_BYTES_RECEIVED%``
   HTTP
-    Number of decompressed header bytes received from the upstream by the http stream.
+    Number of decompressed header bytes received from the upstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
@@ -287,7 +287,7 @@ Current supported substitution commands include:
 
 ``%DOWNSTREAM_WIRE_BYTES_SENT%``
   HTTP
-    Total number of bytes sent to the downstream by the http stream.
+    Total number of bytes sent to the downstream by the HTTP stream.
 
   TCP
     Total number of bytes sent to the downstream by the tcp proxy.
@@ -297,7 +297,7 @@ Current supported substitution commands include:
 
 ``%DOWNSTREAM_WIRE_BYTES_RECEIVED%``
   HTTP
-    Total number of bytes received from the downstream by the http stream. Envoy over counts sizes of received HTTP/1.1 pipelined requests by adding up bytes of requests in the pipeline to the one currently being processed.
+    Total number of bytes received from the downstream by the HTTP stream. Envoy over counts sizes of received HTTP/1.1 pipelined requests by adding up bytes of requests in the pipeline to the one currently being processed.
 
   TCP
     Total number of bytes received from the downstream by the tcp proxy.
@@ -307,21 +307,21 @@ Current supported substitution commands include:
 
 ``%DOWNSTREAM_HEADER_BYTES_SENT%``
   HTTP
-    Number of header bytes sent to the downstream by the http stream.
+    Number of header bytes sent to the downstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
 
 ``%DOWNSTREAM_DECOMPRESSED_HEADER_BYTES_SENT%``
   HTTP
-    Number of decompressed header bytes sent to the downstream by the http stream.
+    Number of decompressed header bytes sent to the downstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
 
 ``%DOWNSTREAM_HEADER_BYTES_RECEIVED%``
   HTTP
-    Number of header bytes received from the downstream by the http stream.
+    Number of header bytes received from the downstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
@@ -330,7 +330,7 @@ Current supported substitution commands include:
 
 ``%DOWNSTREAM_DECOMPRESSED_HEADER_BYTES_RECEIVED%``
   HTTP
-    Number of decompressed header bytes received from the downstream by the http stream.
+    Number of decompressed header bytes received from the downstream by the HTTP stream.
 
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.

--- a/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
+++ b/docs/root/configuration/http/http_filters/aws_lambda_filter.rst
@@ -101,7 +101,7 @@ Below are some examples that show how the filter can be used in different deploy
 Example configuration
 ---------------------
 
-In this configuration, the filter applies to all routes in the filter chain of the http connection manager:
+In this configuration, the filter applies to all routes in the filter chain of the HTTP connection manager:
 
 .. literalinclude:: _include/aws-lambda-filter.yaml
     :language: yaml

--- a/docs/root/configuration/http/http_filters/tap_filter.rst
+++ b/docs/root/configuration/http/http_filters/tap_filter.rst
@@ -169,9 +169,9 @@ conditions are met, the request will be tapped and streamed out to the admin end
 
 .. attention::
 
-  Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, http body is scanned byte by byte to find a match.
+  Searching for patterns in HTTP body is potentially cpu intensive. For each specified pattern, HTTP body is scanned byte by byte to find a match.
   If multiple patterns are specified, the process is repeated for each pattern. If location of a pattern is known, ``bytes_limit`` should be specified
-  to scan only part of the http body.
+  to scan only part of the HTTP body.
 
 Output format
 -------------

--- a/docs/root/configuration/observability/statistics.rst
+++ b/docs/root/configuration/observability/statistics.rst
@@ -30,8 +30,8 @@ Server related statistics are rooted at *server.* with following statistics:
   hot_restart_generation, Gauge, Current hot restart generation -- like hot_restart_epoch but computed automatically by incrementing from parent.
   initialization_time_ms, Histogram, Total time taken for Envoy initialization in milliseconds. This is the time from server start-up until the worker threads are ready to accept new connections
   debug_assertion_failures, Counter, Number of debug assertion failures detected in a release build if compiled with ``--define log_debug_assert_in_release=enabled`` or zero otherwise
-  envoy_bug_failures, Counter, Number of envoy bug failures detected in a release build. File or report the issue if this increments as this may be serious.
-  envoy_notifications, Counter, Number of envoy notifications detected. File or report the issue if this increments as this may be serious. Please include logs from the ``notification`` component at the debug level. See :ref:`command line option --component-log-level <operations_cli>` for details.
+  envoy_bug_failures, Counter, Number of Envoy bug failures detected in a release build. File or report the issue if this increments as this may be serious.
+  envoy_notifications, Counter, Number of Envoy notifications detected. File or report the issue if this increments as this may be serious. Please include logs from the ``notification`` component at the debug level. See :ref:`command line option --component-log-level <operations_cli>` for details.
   static_unknown_fields, Counter, Number of messages in static configuration with unknown fields
   dynamic_unknown_fields, Counter, Number of messages in dynamic configuration with unknown fields
   wip_protos, Counter, Number of messages and fields marked as work-in-progress being used
@@ -50,4 +50,4 @@ Server Compilation Settings related statistics are rooted at *server.compilation
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  fips_mode, Gauge, Integer representing whether the envoy build is FIPS compliant or not
+  fips_mode, Gauge, Integer representing whether the Envoy build is FIPS compliant or not

--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -233,7 +233,7 @@ The following core load shed points are supported:
 
   * - envoy.load_shed_points.http_connection_manager_decode_headers
     - Envoy will reject new HTTP streams by sending a local reply. This occurs
-      right after the http codec has finished parsing headers but before the
+      right after the HTTP codec has finished parsing headers but before the
       :ref:`HTTP Filter Chain is instantiated <life_of_a_request>`.
 
   * - envoy.load_shed_points.http1_server_abort_dispatch

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -165,7 +165,7 @@ input
   ssl
     *(optional, boolean)* A flag that determines whether to set x-forwarded-proto to https or http.
     By setting x-forwarded-proto to a given protocol, the tool is able to simulate the behavior of
-    a client issuing a request via http or https. By default ssl is false which corresponds to
+    a client issuing a request via HTTP or HTTPS. By default ssl is false which corresponds to
     x-forwarded-proto set to http.
 
   runtime


### PR DESCRIPTION
jCommit Message: docs: fix capitalization of proper nouns and acronyms
Additional Description:
Fix incorrect lowercase usage of proper nouns and acronyms in documentation
as described in #20238.

Changes:
- `http` → `HTTP` in prose text (not URLs, code blocks, or file paths)
- `envoy` → `Envoy` when referring to the project name in descriptions

Files changed:
- docs/root/configuration/advanced/substitution_formatter.rst
- docs/root/configuration/http/http_filters/tap_filter.rst
- docs/root/configuration/http/http_filters/aws_lambda_filter.rst
- docs/root/configuration/operations/overload_manager/overload_manager.rst
- docs/root/configuration/operations/tools/router_check.rst
- docs/root/configuration/observability/statistics.rst

Risk Level: Low
Testing: N/A (docs-only change)
Docs Changes: Yes, see above.
Release Notes: N/A

Partial fix for: #20238