### PR TITLE
dynamic_modules: add http span override_sampled callback

### DIFF
--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -114,6 +114,14 @@ public:
   virtual void setSampled(bool sampled) PURE;
 
   /**
+   * Override the sampling decision so the connection manager does not re-derive it after a route
+   * cache refresh. Implementations that use the Envoy local tracing decision should stop using it
+   * so the refresh leaves this decision intact. The default implementation delegates to setSampled.
+   * @param sampled whether the span and any subsequent child spans should be sampled
+   */
+  virtual void overrideSampled(bool sampled) { setSampled(sampled); }
+
+  /**
    * @return whether this span will be exported to the tracing backend. The HTTP connection
    * manager may skip finalize-time tag work for spans that return false, since those tags
    * would be discarded by the driver anyway.

--- a/envoy/tracing/trace_driver.h
+++ b/envoy/tracing/trace_driver.h
@@ -114,14 +114,6 @@ public:
   virtual void setSampled(bool sampled) PURE;
 
   /**
-   * Override the sampling decision so the connection manager does not re-derive it after a route
-   * cache refresh. Implementations that use the Envoy local tracing decision should stop using it
-   * so the refresh leaves this decision intact. The default implementation delegates to setSampled.
-   * @param sampled whether the span and any subsequent child spans should be sampled
-   */
-  virtual void overrideSampled(bool sampled) { setSampled(sampled); }
-
-  /**
    * @return whether this span will be exported to the tracing backend. The HTTP connection
    * manager may skip finalize-time tag work for spans that return false, since those tags
    * would be discarded by the driver anyway.
@@ -147,6 +139,14 @@ public:
    * by the HTTP connection manager based on the new Envoy tracing decision.
    */
   virtual bool useLocalDecision() const PURE;
+
+  /**
+   * Stop using the Envoy local tracing decision for this span. After this is called the connection
+   * manager will not re-derive the sampling decision on a later route refresh, so a decision set
+   * via setSampled is kept. The default implementation is a no-op and is overridden by tracers that
+   * support this.
+   */
+  virtual void disableLocalDecision() {}
 
   /**
    * Retrieve a key's value from the span's baggage.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -3054,17 +3054,17 @@ void envoy_dynamic_module_callback_http_span_set_sampled(
     envoy_dynamic_module_type_span_envoy_ptr span, bool sampled);
 
 /**
- * envoy_dynamic_module_callback_http_span_override_sampled sets the sampling decision for the span
- * and asks the tracer to keep it across a later route refresh. With the OpenTelemetry tracer the
- * connection manager does not re-derive the decision after a route cache change, so a decision made
- * from a filter is not lost. Tracers that do not support this fall back to the
- * envoy_dynamic_module_callback_http_span_set_sampled behavior.
+ * envoy_dynamic_module_callback_http_span_disable_local_decision stops the span from using the
+ * Envoy local tracing decision. Combined with
+ * envoy_dynamic_module_callback_http_span_set_sampled, this keeps a filter's sampling decision when
+ * Envoy refreshes tracing after a route cache change. With the OpenTelemetry tracer the connection
+ * manager does not re-derive the decision after a route cache change. Other tracers may not support
+ * this.
  *
  * @param span is the pointer to the span (either active span or child span).
- * @param sampled is true if the span should be sampled, false otherwise.
  */
-void envoy_dynamic_module_callback_http_span_override_sampled(
-    envoy_dynamic_module_type_span_envoy_ptr span, bool sampled);
+void envoy_dynamic_module_callback_http_span_disable_local_decision(
+    envoy_dynamic_module_type_span_envoy_ptr span);
 
 /**
  * envoy_dynamic_module_callback_http_span_get_baggage retrieves a baggage value from the span.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -3054,6 +3054,19 @@ void envoy_dynamic_module_callback_http_span_set_sampled(
     envoy_dynamic_module_type_span_envoy_ptr span, bool sampled);
 
 /**
+ * envoy_dynamic_module_callback_http_span_override_sampled sets the sampling decision for the span
+ * and asks the tracer to keep it across a later route refresh. With the OpenTelemetry tracer the
+ * connection manager does not re-derive the decision after a route cache change, so a decision made
+ * from a filter is not lost. Tracers that do not support this fall back to the
+ * envoy_dynamic_module_callback_http_span_set_sampled behavior.
+ *
+ * @param span is the pointer to the span (either active span or child span).
+ * @param sampled is true if the span should be sampled, false otherwise.
+ */
+void envoy_dynamic_module_callback_http_span_override_sampled(
+    envoy_dynamic_module_type_span_envoy_ptr span, bool sampled);
+
+/**
  * envoy_dynamic_module_callback_http_span_get_baggage retrieves a baggage value from the span.
  * Baggage data may have been set by this span or any parent spans.
  *

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4444,11 +4444,10 @@ envoy_dynamic_module_callback_http_span_set_sampled(envoy_dynamic_module_type_sp
       "envoy_dynamic_module_callback_http_span_set_sampled: not implemented in this context");
 }
 
-__attribute__((weak)) void
-envoy_dynamic_module_callback_http_span_override_sampled(envoy_dynamic_module_type_span_envoy_ptr,
-                                                         bool) {
-  IS_ENVOY_BUG(
-      "envoy_dynamic_module_callback_http_span_override_sampled: not implemented in this context");
+__attribute__((weak)) void envoy_dynamic_module_callback_http_span_disable_local_decision(
+    envoy_dynamic_module_type_span_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_span_disable_local_decision: not implemented "
+               "in this context");
 }
 
 __attribute__((weak)) bool

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4444,6 +4444,13 @@ envoy_dynamic_module_callback_http_span_set_sampled(envoy_dynamic_module_type_sp
       "envoy_dynamic_module_callback_http_span_set_sampled: not implemented in this context");
 }
 
+__attribute__((weak)) void
+envoy_dynamic_module_callback_http_span_override_sampled(envoy_dynamic_module_type_span_envoy_ptr,
+                                                         bool) {
+  IS_ENVOY_BUG(
+      "envoy_dynamic_module_callback_http_span_override_sampled: not implemented in this context");
+}
+
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_http_span_get_baggage(envoy_dynamic_module_type_span_envoy_ptr,
                                                     envoy_dynamic_module_type_module_buffer,

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1998,6 +1998,13 @@ pub trait EnvoySpan {
   /// reported to the tracing system.
   fn set_sampled(&self, sampled: bool);
 
+  /// Set the sampling decision for this span and keep it across a later route refresh.
+  ///
+  /// With the OpenTelemetry tracer the connection manager does not re-derive the decision after a
+  /// route cache change, so a decision made from a filter is not lost. Tracers that do not support
+  /// this fall back to the [`EnvoySpan::set_sampled`] behavior.
+  fn override_sampled(&self, sampled: bool);
+
   /// Get a baggage value from this span.
   ///
   /// Baggage data may have been set by this span or any parent spans.
@@ -2073,6 +2080,12 @@ impl EnvoySpan for EnvoySpanImpl {
   fn set_sampled(&self, sampled: bool) {
     unsafe {
       abi::envoy_dynamic_module_callback_http_span_set_sampled(self.raw_ptr, sampled);
+    }
+  }
+
+  fn override_sampled(&self, sampled: bool) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_span_override_sampled(self.raw_ptr, sampled);
     }
   }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1998,12 +1998,13 @@ pub trait EnvoySpan {
   /// reported to the tracing system.
   fn set_sampled(&self, sampled: bool);
 
-  /// Set the sampling decision for this span and keep it across a later route refresh.
+  /// Stop using the Envoy local tracing decision for this span.
   ///
-  /// With the OpenTelemetry tracer the connection manager does not re-derive the decision after a
-  /// route cache change, so a decision made from a filter is not lost. Tracers that do not support
-  /// this fall back to the [`EnvoySpan::set_sampled`] behavior.
-  fn override_sampled(&self, sampled: bool);
+  /// Combined with [`EnvoySpan::set_sampled`], this keeps a filter's sampling decision when Envoy
+  /// refreshes tracing after a route cache change. With the OpenTelemetry tracer the connection
+  /// manager does not re-derive the decision after a route cache change. Other tracers may not
+  /// support this.
+  fn disable_local_decision(&self);
 
   /// Get a baggage value from this span.
   ///
@@ -2083,9 +2084,9 @@ impl EnvoySpan for EnvoySpanImpl {
     }
   }
 
-  fn override_sampled(&self, sampled: bool) {
+  fn disable_local_decision(&self) {
     unsafe {
-      abi::envoy_dynamic_module_callback_http_span_override_sampled(self.raw_ptr, sampled);
+      abi::envoy_dynamic_module_callback_http_span_disable_local_decision(self.raw_ptr);
     }
   }
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -2395,6 +2395,15 @@ void envoy_dynamic_module_callback_http_span_set_sampled(
   span->setSampled(sampled);
 }
 
+void envoy_dynamic_module_callback_http_span_override_sampled(
+    envoy_dynamic_module_type_span_envoy_ptr span_ptr, bool sampled) {
+  if (span_ptr == nullptr) {
+    return;
+  }
+  auto* span = static_cast<Tracing::Span*>(span_ptr);
+  span->overrideSampled(sampled);
+}
+
 // Thread-local storage for temporary strings returned by tracing functions.
 // These strings are valid until the next call to a tracing function on the same thread.
 static thread_local std::string tls_trace_string_storage;

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -2395,13 +2395,13 @@ void envoy_dynamic_module_callback_http_span_set_sampled(
   span->setSampled(sampled);
 }
 
-void envoy_dynamic_module_callback_http_span_override_sampled(
-    envoy_dynamic_module_type_span_envoy_ptr span_ptr, bool sampled) {
+void envoy_dynamic_module_callback_http_span_disable_local_decision(
+    envoy_dynamic_module_type_span_envoy_ptr span_ptr) {
   if (span_ptr == nullptr) {
     return;
   }
   auto* span = static_cast<Tracing::Span*>(span_ptr);
-  span->overrideSampled(sampled);
+  span->disableLocalDecision();
 }
 
 // Thread-local storage for temporary strings returned by tracing functions.

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -104,6 +104,14 @@ public:
   void setSampled(bool sampled) override { sampled_ = sampled; };
 
   /**
+   * Stop using the local decision so the connection manager does not re-derive it on refresh.
+   */
+  void overrideSampled(bool sampled) override {
+    setSampled(sampled);
+    use_local_decision_ = false;
+  }
+
+  /**
    * @return whether the local tracing decision is used by the span.
    */
   bool useLocalDecision() const override { return use_local_decision_; }
@@ -182,7 +190,7 @@ private:
   Tracer& parent_tracer_;
   Envoy::TimeSource& time_source_;
   bool sampled_;
-  const bool use_local_decision_{false};
+  bool use_local_decision_{false};
 };
 
 using TracerPtr = std::unique_ptr<Tracer>;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -104,17 +104,11 @@ public:
   void setSampled(bool sampled) override { sampled_ = sampled; };
 
   /**
-   * Stop using the local decision so the connection manager does not re-derive it on refresh.
-   */
-  void overrideSampled(bool sampled) override {
-    setSampled(sampled);
-    use_local_decision_ = false;
-  }
-
-  /**
    * @return whether the local tracing decision is used by the span.
    */
   bool useLocalDecision() const override { return use_local_decision_; }
+
+  void disableLocalDecision() override { use_local_decision_ = false; }
 
   /**
    * @return whether the span will be exported to the OTLP backend.

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -362,6 +362,7 @@ TEST(NullTracerTest, BasicFunctionality) {
   span_ptr->injectContext(trace_context, upstream_context);
   span_ptr->log(SystemTime(), "fake_event");
   span_ptr->useLocalDecision();
+  span_ptr->overrideSampled(true);
 
   // NullSpan is never exported
   EXPECT_FALSE(span_ptr->exportedSpan());

--- a/test/common/tracing/tracer_impl_test.cc
+++ b/test/common/tracing/tracer_impl_test.cc
@@ -362,7 +362,7 @@ TEST(NullTracerTest, BasicFunctionality) {
   span_ptr->injectContext(trace_context, upstream_context);
   span_ptr->log(SystemTime(), "fake_event");
   span_ptr->useLocalDecision();
-  span_ptr->overrideSampled(true);
+  span_ptr->disableLocalDecision();
 
   // NullSpan is never exported
   EXPECT_FALSE(span_ptr->exportedSpan());

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1584,6 +1584,8 @@ WEAK_STUB(HttpSpanSetOperation,
           envoy_dynamic_module_callback_http_span_set_operation(nullptr, {nullptr, 0}))
 WEAK_STUB(HttpSpanLog, envoy_dynamic_module_callback_http_span_log(nullptr, nullptr, {nullptr, 0}))
 WEAK_STUB(HttpSpanSetSampled, envoy_dynamic_module_callback_http_span_set_sampled(nullptr, false))
+WEAK_STUB(HttpSpanOverrideSampled,
+          envoy_dynamic_module_callback_http_span_override_sampled(nullptr, false))
 WEAK_STUB(HttpSpanGetBaggage,
           envoy_dynamic_module_callback_http_span_get_baggage(nullptr, {nullptr, 0}, nullptr))
 WEAK_STUB(HttpSpanSetBaggage,

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1584,8 +1584,8 @@ WEAK_STUB(HttpSpanSetOperation,
           envoy_dynamic_module_callback_http_span_set_operation(nullptr, {nullptr, 0}))
 WEAK_STUB(HttpSpanLog, envoy_dynamic_module_callback_http_span_log(nullptr, nullptr, {nullptr, 0}))
 WEAK_STUB(HttpSpanSetSampled, envoy_dynamic_module_callback_http_span_set_sampled(nullptr, false))
-WEAK_STUB(HttpSpanOverrideSampled,
-          envoy_dynamic_module_callback_http_span_override_sampled(nullptr, false))
+WEAK_STUB(HttpSpanDisableLocalDecision,
+          envoy_dynamic_module_callback_http_span_disable_local_decision(nullptr))
 WEAK_STUB(HttpSpanGetBaggage,
           envoy_dynamic_module_callback_http_span_get_baggage(nullptr, {nullptr, 0}, nullptr))
 WEAK_STUB(HttpSpanSetBaggage,

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2993,6 +2993,18 @@ TEST_F(DynamicModuleHttpFilterTest, SpanSetSampled) {
   envoy_dynamic_module_callback_http_span_set_sampled(span, true);
 }
 
+TEST_F(DynamicModuleHttpFilterTest, SpanOverrideSampled) {
+  NiceMock<Tracing::MockSpan> mock_span;
+  EXPECT_CALL(decoder_callbacks_, activeSpan()).WillOnce(testing::ReturnRef(mock_span));
+
+  EXPECT_CALL(mock_span, overrideSampled(true));
+
+  auto* span = envoy_dynamic_module_callback_http_get_active_span(filter_.get());
+  ASSERT_NE(span, nullptr);
+
+  envoy_dynamic_module_callback_http_span_override_sampled(span, true);
+}
+
 TEST_F(DynamicModuleHttpFilterTest, SpanGetBaggage) {
   NiceMock<Tracing::MockSpan> mock_span;
   EXPECT_CALL(decoder_callbacks_, activeSpan()).WillOnce(testing::ReturnRef(mock_span));
@@ -3135,6 +3147,7 @@ TEST_F(DynamicModuleHttpFilterTest, TracingCallbacksWithNullSpan) {
   envoy_dynamic_module_callback_http_span_set_operation(nullptr, {key.data(), key.size()});
   envoy_dynamic_module_callback_http_span_log(nullptr, nullptr, {key.data(), key.size()});
   envoy_dynamic_module_callback_http_span_set_sampled(nullptr, true);
+  envoy_dynamic_module_callback_http_span_override_sampled(nullptr, true);
   envoy_dynamic_module_callback_http_span_set_baggage(nullptr, {key.data(), key.size()},
                                                       {value.data(), value.size()});
   EXPECT_FALSE(envoy_dynamic_module_callback_http_span_get_baggage(

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2993,16 +2993,16 @@ TEST_F(DynamicModuleHttpFilterTest, SpanSetSampled) {
   envoy_dynamic_module_callback_http_span_set_sampled(span, true);
 }
 
-TEST_F(DynamicModuleHttpFilterTest, SpanOverrideSampled) {
+TEST_F(DynamicModuleHttpFilterTest, SpanDisableLocalDecision) {
   NiceMock<Tracing::MockSpan> mock_span;
   EXPECT_CALL(decoder_callbacks_, activeSpan()).WillOnce(testing::ReturnRef(mock_span));
 
-  EXPECT_CALL(mock_span, overrideSampled(true));
+  EXPECT_CALL(mock_span, disableLocalDecision());
 
   auto* span = envoy_dynamic_module_callback_http_get_active_span(filter_.get());
   ASSERT_NE(span, nullptr);
 
-  envoy_dynamic_module_callback_http_span_override_sampled(span, true);
+  envoy_dynamic_module_callback_http_span_disable_local_decision(span);
 }
 
 TEST_F(DynamicModuleHttpFilterTest, SpanGetBaggage) {
@@ -3147,7 +3147,7 @@ TEST_F(DynamicModuleHttpFilterTest, TracingCallbacksWithNullSpan) {
   envoy_dynamic_module_callback_http_span_set_operation(nullptr, {key.data(), key.size()});
   envoy_dynamic_module_callback_http_span_log(nullptr, nullptr, {key.data(), key.size()});
   envoy_dynamic_module_callback_http_span_set_sampled(nullptr, true);
-  envoy_dynamic_module_callback_http_span_override_sampled(nullptr, true);
+  envoy_dynamic_module_callback_http_span_disable_local_decision(nullptr);
   envoy_dynamic_module_callback_http_span_set_baggage(nullptr, {key.data(), key.size()},
                                                       {value.data(), value.size()});
   EXPECT_FALSE(envoy_dynamic_module_callback_http_span_get_baggage(

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -685,10 +685,10 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
   EXPECT_CALL(span, setOperation("operation"));
   EXPECT_CALL(span, log(testing::_, "event"));
   EXPECT_CALL(span, setSampled(true));
-  // The override_sampled SDK wrapper is Rust-only, so scope this expectation to the rust
+  // The disable_local_decision SDK wrapper is Rust-only, so scope this expectation to the rust
   // parameterization like the other language guards in the dynamic_modules integration tests.
   if (GetParam() == "rust") {
-    EXPECT_CALL(span, overrideSampled(true));
+    EXPECT_CALL(span, disableLocalDecision());
   }
   EXPECT_CALL(span, getBaggage("key")).WillOnce(testing::Return(""));
   EXPECT_CALL(span, setBaggage("key", "value"));

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -685,6 +685,11 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
   EXPECT_CALL(span, setOperation("operation"));
   EXPECT_CALL(span, log(testing::_, "event"));
   EXPECT_CALL(span, setSampled(true));
+  // The override_sampled SDK wrapper is Rust-only, so scope this expectation to the rust
+  // parameterization like the other language guards in the dynamic_modules integration tests.
+  if (GetParam() == "rust") {
+    EXPECT_CALL(span, overrideSampled(true));
+  }
   EXPECT_CALL(span, getBaggage("key")).WillOnce(testing::Return(""));
   EXPECT_CALL(span, setBaggage("key", "value"));
   EXPECT_CALL(span, getTraceId()).WillOnce(testing::Return("trace-id"));

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -632,6 +632,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SpanCallbacksFilter {
       span.set_operation("operation");
       span.log("event");
       span.set_sampled(true);
+      span.override_sampled(true);
       let _ = span.get_baggage("key");
       span.set_baggage("key", "value");
       let _ = span.get_trace_id();

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -632,7 +632,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SpanCallbacksFilter {
       span.set_operation("operation");
       span.log("event");
       span.set_sampled(true);
-      span.override_sampled(true);
+      span.disable_local_decision();
       let _ = span.get_baggage("key");
       span.set_baggage("key", "value");
       let _ = span.get_trace_id();

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -1111,8 +1111,8 @@ TEST_F(OpenTelemetryDriverTest, UseLocalDecisionFalse) {
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
-// Overriding the sampling decision to false stops using the local decision and drops the span.
-TEST_F(OpenTelemetryDriverTest, OverrideSampledFalse) {
+// Disabling the local decision keeps a setSampled(false) decision and drops the span.
+TEST_F(OpenTelemetryDriverTest, DisableLocalDecisionWithSampledFalse) {
   setupValidDriver();
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
@@ -1123,8 +1123,9 @@ TEST_F(OpenTelemetryDriverTest, OverrideSampledFalse) {
   EXPECT_TRUE(span->useLocalDecision());
   EXPECT_TRUE(dynamic_cast<Span*>(span.get())->sampled());
 
-  span->overrideSampled(false);
-  // The override stops using the local decision so a route refresh will not re-derive it.
+  span->setSampled(false);
+  span->disableLocalDecision();
+  // Disabling the local decision stops the connection manager from re-deriving the decision.
   EXPECT_FALSE(span->useLocalDecision());
   EXPECT_FALSE(dynamic_cast<Span*>(span.get())->sampled());
 
@@ -1134,8 +1135,8 @@ TEST_F(OpenTelemetryDriverTest, OverrideSampledFalse) {
   EXPECT_EQ(0U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
-// Overriding the sampling decision to true stops using the local decision and keeps the span.
-TEST_F(OpenTelemetryDriverTest, OverrideSampledTrue) {
+// Disabling the local decision keeps a setSampled(true) decision and keeps the span.
+TEST_F(OpenTelemetryDriverTest, DisableLocalDecisionWithSampledTrue) {
   setupValidDriver();
   Tracing::TestTraceContextImpl request_headers{
       {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
@@ -1147,7 +1148,8 @@ TEST_F(OpenTelemetryDriverTest, OverrideSampledTrue) {
   EXPECT_TRUE(span->useLocalDecision());
   EXPECT_FALSE(dynamic_cast<Span*>(span.get())->sampled());
 
-  span->overrideSampled(true);
+  span->setSampled(true);
+  span->disableLocalDecision();
   EXPECT_FALSE(span->useLocalDecision());
   EXPECT_TRUE(dynamic_cast<Span*>(span.get())->sampled());
 

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -1111,6 +1111,54 @@ TEST_F(OpenTelemetryDriverTest, UseLocalDecisionFalse) {
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
+// Overriding the sampling decision to false stops using the local decision and drops the span.
+TEST_F(OpenTelemetryDriverTest, OverrideSampledFalse) {
+  setupValidDriver();
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             operation_name_, {Tracing::Reason::Sampling, true});
+  // The span starts on the local decision and is sampled because there is no traceparent header.
+  EXPECT_TRUE(span->useLocalDecision());
+  EXPECT_TRUE(dynamic_cast<Span*>(span.get())->sampled());
+
+  span->overrideSampled(false);
+  // The override stops using the local decision so a route refresh will not re-derive it.
+  EXPECT_FALSE(span->useLocalDecision());
+  EXPECT_FALSE(dynamic_cast<Span*>(span.get())->sampled());
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U)).Times(0);
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _)).Times(0);
+  span->finishSpan();
+  EXPECT_EQ(0U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
+// Overriding the sampling decision to true stops using the local decision and keeps the span.
+TEST_F(OpenTelemetryDriverTest, OverrideSampledTrue) {
+  setupValidDriver();
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+
+  Tracing::SpanPtr span =
+      driver_->startSpan(mock_tracing_config_, request_headers, stream_info_, operation_name_,
+                         {Tracing::Reason::NotTraceable, false});
+  // The span starts on the local decision and is unsampled because there is no traceparent header.
+  EXPECT_TRUE(span->useLocalDecision());
+  EXPECT_FALSE(dynamic_cast<Span*>(span.get())->sampled());
+
+  span->overrideSampled(true);
+  EXPECT_FALSE(span->useLocalDecision());
+  EXPECT_TRUE(dynamic_cast<Span*>(span.get())->sampled());
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
+      .Times(1)
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(*mock_client_, sendRaw(_, _, _, _, _, _));
+  span->finishSpan();
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
 // Verifies tracer is "disabled" when no exporter is configured
 TEST_F(OpenTelemetryDriverTest, NoExportWithoutGrpcService) {
   const std::string yaml_string = "{}";

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -42,6 +42,7 @@ public:
   MOCK_METHOD(void, injectContext,
               (Tracing::TraceContext & request_headers, const Tracing::UpstreamContext& upstream));
   MOCK_METHOD(void, setSampled, (bool sampled));
+  MOCK_METHOD(void, overrideSampled, (bool sampled));
   MOCK_METHOD(bool, exportedSpan, (), (const, override));
   MOCK_METHOD(bool, useLocalDecision, (), (const));
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));

--- a/test/mocks/tracing/mocks.h
+++ b/test/mocks/tracing/mocks.h
@@ -42,7 +42,7 @@ public:
   MOCK_METHOD(void, injectContext,
               (Tracing::TraceContext & request_headers, const Tracing::UpstreamContext& upstream));
   MOCK_METHOD(void, setSampled, (bool sampled));
-  MOCK_METHOD(void, overrideSampled, (bool sampled));
+  MOCK_METHOD(void, disableLocalDecision, ());
   MOCK_METHOD(bool, exportedSpan, (), (const, override));
   MOCK_METHOD(bool, useLocalDecision, (), (const));
   MOCK_METHOD(void, setBaggage, (absl::string_view key, absl::string_view value));


### PR DESCRIPTION
## Description

This PR adds a new `envoy_dynamic_module_callback_http_span_override_sampled` ABI callback and a `Tracing::Span::overrideSampled()` method so that a dynamic module HTTP filter can set a span's sampling decision and keep it across a route cache refresh.

The `OpenTelemetry` span clears its local decision so the connection manager does not re-derive the decision in `refreshTracing`. Tracers that do not implement `overrideSampled` fall back to `setSampled`. 

---

**Commit Message**: dynamic_modules: add http span override_sampled callback
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes**: Added
**Release Notes**: N/A
