### PR TITLE
reverse_tunnel: jittered reconnect backoff and Retry-After handling

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -6,7 +6,10 @@ import "envoy/config/accesslog/v3/accesslog.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/extension.proto";
 
+import "google/protobuf/duration.proto";
+
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3";
 option java_outer_classname = "DownstreamReverseConnectionSocketInterfaceProto";
@@ -20,6 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for the downstream reverse connection socket interface.
 // This interface initiates reverse connections to upstream Envoys and provides
 // them as socket connections for downstream requests.
+// [#next-free-field: 6]
 message DownstreamReverseConnectionSocketInterface {
   // HTTP handshake settings for initiator envoy initiated reverse tunnels.
   message HttpHandshakeConfig {
@@ -60,4 +64,10 @@ message DownstreamReverseConnectionSocketInterface {
   // Reverse tunnel metadata (``node_id``, ``cluster_id``, ``tenant_id``, upstream cluster, etc.)
   // is available via ``%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:*)%`` substitutions.
   repeated config.accesslog.v3.AccessLog access_log = 4;
+
+  // Upper bound on the per-host reconnect backoff. The initiator retries a failed handshake on a
+  // deterministic exponential schedule (1s, 2s, 4s, ...) with small upward jitter; this value caps
+  // that schedule.
+  google.protobuf.Duration max_reconnect_backoff = 5
+      [(validate.rules).duration = {gte {seconds: 1}}];
 }

--- a/source/extensions/bootstrap/reverse_tunnel/common/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/common/BUILD
@@ -16,6 +16,7 @@ envoy_cc_extension(
     visibility = ["//visibility:public"],
     deps = [
         "//envoy/buffer:buffer_interface",
+        "//envoy/common:random_generator_interface",
         "//envoy/network:connection_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:logger_lib",

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.cc
@@ -13,6 +13,15 @@ namespace Extensions {
 namespace Bootstrap {
 namespace ReverseConnection {
 
+uint64_t ReverseConnectionUtility::addJitter(uint64_t interval_ms, uint64_t jitter_percent,
+                                             Random::RandomGenerator& random) {
+  const uint64_t jitter_mod = jitter_percent * interval_ms / 100;
+  if (jitter_mod > 0) {
+    interval_ms += random.random() % jitter_mod;
+  }
+  return interval_ms;
+}
+
 bool ReverseConnectionUtility::isPingMessage(absl::string_view data) {
   if (data.size() != PING_MESSAGE.size()) {
     return false;

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/network/connection.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -54,6 +55,15 @@ public:
                                                  absl::string_view identifier);
 
   static void applySslQuietClose(Network::Connection& conn);
+
+  /**
+   * @param interval_ms the base interval in milliseconds.
+   * @param jitter_percent the maximum upward jitter as a percentage of the interval.
+   * @param random the random generator.
+   * @return the jittered interval in milliseconds.
+   */
+  static uint64_t addJitter(uint64_t interval_ms, uint64_t jitter_percent,
+                            Random::RandomGenerator& random);
 
 private:
   ReverseConnectionUtility() = delete;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -40,6 +40,8 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//envoy/access_log:access_log_interface",
+        "//envoy/api:api_interface",
+        "//envoy/common:random_generator_interface",
         "//envoy/http:header_map_interface",
         "//envoy/server:bootstrap_extension_config_interface",
         "//envoy/stats:stats_interface",
@@ -75,6 +77,7 @@ envoy_cc_library(
         ":reverse_tunnel_extension_lib",
         "//envoy/access_log:access_log_interface",
         "//envoy/api:io_error_interface",
+        "//envoy/common:random_generator_interface",
         "//envoy/grpc:async_client_interface",
         "//envoy/network:address_interface",
         "//envoy/network:io_handle_interface",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h"
 
+#include <algorithm>
+
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 
@@ -13,6 +15,8 @@
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
+
+#include "absl/strings/numbers.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -211,10 +215,41 @@ void RCConnectionWrapper::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bo
   if (status == expected) {
     ENVOY_LOG(debug, "Received HTTP {} response", status);
     onHandshakeSuccess();
-  } else {
-    ENVOY_LOG(error, "Received unexpected HTTP response: {} (expected {})", status, expected);
-    onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)));
+    return;
   }
+  ENVOY_LOG(error, "Received unexpected HTTP response: {} (expected {})", status, expected);
+  // A 429 may carry a Retry-After cool-off hint; forward it so the parent can honor it as the
+  // per-host backoff before the next attempt.
+  absl::optional<std::chrono::milliseconds> retry_after;
+  if (status == 429) {
+    retry_after = parseRetryAfter(*headers);
+  }
+  onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)), retry_after);
+}
+
+absl::optional<std::chrono::milliseconds>
+RCConnectionWrapper::parseRetryAfter(const Http::ResponseHeaderMap& headers) {
+  // ``Retry-After`` is not a registered inline header, so look it up by name. The key is a
+  // function-local static to avoid reconstructing the LowerCaseString on every handshake response.
+  static const Http::LowerCaseString retry_after_header{"retry-after"};
+  const auto result = headers.get(retry_after_header);
+  if (result.empty()) {
+    return absl::nullopt;
+  }
+  const absl::string_view value = result[0]->value().getStringView();
+  // RFC 7231 allows delta-seconds or an HTTP-date. Rate limiters emit delta-seconds; honor that
+  // form and ignore the date form (the caller falls back to its computed backoff). A zero (or
+  // unparseable) value is treated as absent so it cannot short-circuit the backoff.
+  uint64_t seconds = 0;
+  if (!absl::SimpleAtoi(value, &seconds) || seconds == 0) {
+    return absl::nullopt;
+  }
+  // Clamp purely to avoid overflow when widening seconds to milliseconds; this is NOT the backoff
+  // policy cap. The effective ceiling (the configured ``max_reconnect_backoff``) is applied by the
+  // caller in trackConnectionFailure(), so this bound is intentionally far above any sane value.
+  constexpr uint64_t kMaxRetryAfterSeconds = 3600; // 1 hour.
+  seconds = std::min(seconds, kMaxRetryAfterSeconds);
+  return std::chrono::seconds(static_cast<int64_t>(seconds));
 }
 
 void RCConnectionWrapper::dispatchHttp1(Buffer::Instance& buffer) {
@@ -243,7 +278,8 @@ void RCConnectionWrapper::onHandshakeSuccess() {
   parent_.onConnectionDone(message, this, false);
 }
 
-void RCConnectionWrapper::onHandshakeFailure(const HandshakeFailureReason& reason) {
+void RCConnectionWrapper::onHandshakeFailure(
+    const HandshakeFailureReason& reason, absl::optional<std::chrono::milliseconds> retry_after) {
   const std::string error_message = reason.getDetailedName();
   const std::string stats_failure_reason = reason.getNameForStats();
 
@@ -255,7 +291,7 @@ void RCConnectionWrapper::onHandshakeFailure(const HandshakeFailureReason& reaso
     extension->incrementHandshakeStats(cluster_name_, false, stats_failure_reason);
   }
 
-  parent_.onConnectionDone(error_message, this, false);
+  parent_.onConnectionDone(error_message, this, false, retry_after);
 }
 
 void RCConnectionWrapper::shutdown() {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -185,8 +186,21 @@ public:
   /**
    * Handle handshake failure.
    * @param reason the failure reason with type and context
+   * @param retry_after optional server cool-off hint parsed from a ``Retry-After`` header on a 429
+   *        response; forwarded to the parent to drive the per-host backoff.
    */
-  void onHandshakeFailure(const HandshakeFailureReason& reason);
+  void onHandshakeFailure(const HandshakeFailureReason& reason,
+                          absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
+
+  /**
+   * Parse an HTTP ``Retry-After`` header into a cool-off duration. Only the RFC 7231 delta-seconds
+   * form is supported (the form rate limiters emit); the HTTP-date form, a zero value, and
+   * malformed/absent values return ``nullopt`` so the caller falls back to its computed backoff.
+   * @param headers the response headers to inspect.
+   * @return the parsed cool-off duration, or ``nullopt`` if not present/parseable/zero.
+   */
+  static absl::optional<std::chrono::milliseconds>
+  parseRetryAfter(const Http::ResponseHeaderMap& headers);
 
   /**
    * Perform graceful shutdown of the connection.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -29,6 +30,22 @@ namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
 namespace ReverseConnection {
+
+namespace {
+// Base interval of the deterministic exponential reconnect backoff schedule (1s, 2s, 4s, ...). The
+// cap on the schedule is configurable via ``max_reconnect_backoff`` and read from the extension.
+constexpr uint64_t kReconnectBaseBackoffMs = 1000;
+// Largest exponent applied to the base interval. Capped purely to keep the bit-shift well within
+// uint64 for pathological failure counts; the schedule is bounded by the configured max long before
+// this (e.g. base 1s reaches a 30s cap by the 5th failure), so this never affects a real backoff.
+constexpr uint32_t kMaxBackoffExponent = 32;
+// Upward jitter applied to every reconnect-related timer (the per-host backoff, a server
+// ``Retry-After`` cool-off, and the maintenance re-check) so agents that fail together
+// de-synchronize their next attempt.
+constexpr uint64_t kReconnectJitterPercent = 15;
+// Steady-state maintenance re-check interval.
+constexpr uint64_t kMaintainIntervalMs = 10000;
+} // namespace
 
 // ReverseConnectionIOHandle implementation
 ReverseConnectionIOHandle::ReverseConnectionIOHandle(os_fd_t fd,
@@ -661,8 +678,9 @@ bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(const std::string&
   return true;
 }
 
-void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_address,
-                                                       const std::string& cluster_name) {
+void ReverseConnectionIOHandle::trackConnectionFailure(
+    const std::string& host_address, const std::string& cluster_name,
+    absl::optional<std::chrono::milliseconds> retry_after) {
   auto host_it = host_to_conn_info_map_.find(host_address);
   if (host_it == host_to_conn_info_map_.end()) {
     ENVOY_LOG(debug, "Host {} not found in host_to_conn_info_map_, skipping failure tracking",
@@ -672,12 +690,25 @@ void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_a
   auto& host_info = host_it->second;
   host_info.failure_count++;
   host_info.last_failure_time = getTimeSource().monotonicTime();
-  // Calculate exponential backoff: base_delay * 2^(failure_count - 1)
-  const uint32_t base_delay_ms = 1000; // 1 second base delay
-  const uint32_t max_delay_ms = 30000; // 30 seconds max delay
 
-  uint32_t backoff_delay_ms = base_delay_ms * (1 << (host_info.failure_count - 1));
-  backoff_delay_ms = std::min(backoff_delay_ms, max_delay_ms);
+  const uint64_t max_backoff_ms = extension_->maxReconnectBackoffMs();
+
+  uint64_t backoff_delay_ms;
+  if (retry_after.has_value()) {
+    // Honor the server's explicit cool-off hint
+    backoff_delay_ms =
+        std::min<uint64_t>(static_cast<uint64_t>(retry_after->count()), max_backoff_ms);
+  } else {
+    // Deterministic exponential backoff: base * 2^(failure_count - 1), capped at the configured
+    // max.
+    const uint32_t exponent = std::min(host_info.failure_count - 1, kMaxBackoffExponent);
+    backoff_delay_ms = std::min<uint64_t>(kReconnectBaseBackoffMs << exponent, max_backoff_ms);
+  }
+  // Apply small upward jitter to whichever delay was chosen so hosts that fail together
+  // de-synchronize their next attempt.
+  backoff_delay_ms = ReverseConnectionUtility::addJitter(backoff_delay_ms, kReconnectJitterPercent,
+                                                         extension_->randomGenerator());
+
   // Update the backoff until time. This is used in shouldAttemptConnectionToHost() to check if we
   // should attempt to connect to the host.
   host_info.backoff_until =
@@ -889,12 +920,12 @@ void ReverseConnectionIOHandle::maintainReverseConnections() {
   }
   ENVOY_LOG(debug, "Completed reverse TCP connection maintenance for all clusters.");
 
-  // Enable the retry timer to periodically check for missing connections (like maintainConnCount)
+  // Enable the retry timer to periodically check for missing connections (like maintainConnCount).
   if (rev_conn_retry_timer_) {
-    // TODO(basundhara-c): Make the retry timeout configurable.
-    const std::chrono::milliseconds retry_timeout(10000); // 10 seconds
-    rev_conn_retry_timer_->enableTimer(retry_timeout);
-    ENVOY_LOG(debug, "Enabled retry timer for next connection check in 10 seconds.");
+    const uint64_t retry_timeout_ms = ReverseConnectionUtility::addJitter(
+        kMaintainIntervalMs, kReconnectJitterPercent, extension_->randomGenerator());
+    rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(retry_timeout_ms));
+    ENVOY_LOG(debug, "Enabled retry timer for next connection check in {}ms.", retry_timeout_ms);
   }
 }
 
@@ -1052,8 +1083,9 @@ bool ReverseConnectionIOHandle::isTriggerPipeReady() const {
   return trigger_pipe_read_fd_ != -1 && trigger_pipe_write_fd_ != -1;
 }
 
-void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
-                                                 RCConnectionWrapper* wrapper, bool closed) {
+void ReverseConnectionIOHandle::onConnectionDone(
+    const std::string& error, RCConnectionWrapper* wrapper, bool closed,
+    absl::optional<std::chrono::milliseconds> retry_after) {
   ENVOY_LOG(info,
             "reverse_tunnel: Connection wrapper done - error: '{}', closed: {}, for node_id: {}",
             error, closed, config_.src_node_id);
@@ -1132,7 +1164,7 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
       connection->close(Network::ConnectionCloseType::NoFlush);
     }
 
-    trackConnectionFailure(host_address, cluster_name);
+    trackConnectionFailure(host_address, cluster_name, retry_after);
 
     emitAccessLog("handshake_failure", host_address, cluster_name, connection_key, error);
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <queue>
 #include <string>
@@ -27,6 +28,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -233,8 +235,11 @@ public:
    * @param error error message if the handshake failed, empty string if successful.
    * @param wrapper pointer to the connection wrapper that wraps over the established connection.
    * @param closed whether the connection was closed during handshake.
+   * @param retry_after optional server-provided cool-off hint (from a ``Retry-After`` header on a
+   * 429 handshake response) to use as the per-host backoff; ignored when unset.
    */
-  void onConnectionDone(const std::string& error, RCConnectionWrapper* wrapper, bool closed);
+  void onConnectionDone(const std::string& error, RCConnectionWrapper* wrapper, bool closed,
+                        absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
 
   // Backoff logic for connection failures.
   /**
@@ -250,8 +255,11 @@ public:
    * Track a connection failure for a specific host and cluster and trigger backoff logic.
    * @param host_address the address of the host that failed.
    * @param cluster_name the name of the cluster the host belongs to.
+   * @param retry_after optional server-provided cool-off hint.
    */
-  void trackConnectionFailure(const std::string& host_address, const std::string& cluster_name);
+  void
+  trackConnectionFailure(const std::string& host_address, const std::string& cluster_name,
+                         absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
 
   /**
    * Reset backoff state for a specific host. Called when a connection is established successfully.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -23,6 +23,11 @@ namespace ReverseConnection {
 // Static warning flag for reverse tunnel detailed stats activation.
 static bool reverse_tunnel_detailed_stats_warning_logged = false;
 
+namespace {
+// Default cap on the per-host reconnect backoff when ``max_reconnect_backoff`` is unset.
+constexpr uint64_t kDefaultMaxReconnectBackoffMs = 30000;
+} // namespace
+
 ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
     Server::Configuration::ServerFactoryContext& context,
     const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
@@ -31,6 +36,8 @@ ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
   stat_prefix_ = PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_initiator");
   // Configure detailed stats flag (defaults to false).
   enable_detailed_stats_ = config.enable_detailed_stats();
+  max_reconnect_backoff_ms_ =
+      PROTOBUF_GET_MS_OR_DEFAULT(config, max_reconnect_backoff, kDefaultMaxReconnectBackoffMs);
   if (config.has_http_handshake() && !config.http_handshake().request_path().empty()) {
     handshake_request_path_ = config.http_handshake().request_path();
   } else {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "envoy/access_log/access_log.h"
+#include "envoy/api/api.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.pb.h"
 #include "envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.pb.validate.h"
 #include "envoy/formatter/substitution_formatter.h"
@@ -99,6 +101,17 @@ public:
   Stats::Scope& getStatsScope() const { return context_.scope(); }
 
   /**
+   * @return the server's thread-safe random generator, used to apply jitter to the reconnect
+   * maintenance timer and the per-host reconnect backoff.
+   */
+  Random::RandomGenerator& randomGenerator() const { return context_.api().randomGenerator(); }
+
+  /**
+   * @return the configured upper bound on the per-host reconnect backoff, in milliseconds.
+   */
+  uint64_t maxReconnectBackoffMs() const { return max_reconnect_backoff_ms_; }
+
+  /**
    * @return reference to the configured HTTP handshake request path.
    */
   const std::string& handshakeRequestPath() const { return handshake_request_path_; }
@@ -174,6 +187,7 @@ private:
   ThreadLocal::TypedSlotPtr<DownstreamSocketThreadLocal> tls_slot_;
   std::string stat_prefix_; // Reverse connection stats prefix
   bool enable_detailed_stats_{false};
+  uint64_t max_reconnect_backoff_ms_{};
   std::string handshake_request_path_;
   std::vector<envoy::config::core::v3::HeaderValueOption> additional_headers_;
   bool use_http_upgrade_{false};

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -660,13 +660,10 @@ void UpstreamSocketManager::onPingTimeout(const int fd) {
 }
 
 uint64_t UpstreamSocketManager::pingIntervalWithJitterMs() {
-  uint64_t interval_ms = static_cast<uint64_t>(ping_interval_.count()) * 1000;
+  // 15% upward jitter, matching the HTTP/2 keepalive pattern.
   constexpr uint64_t jitter_percent = 15;
-  uint64_t jitter_mod = jitter_percent * interval_ms / 100;
-  if (jitter_mod > 0) {
-    interval_ms += random_generator_->random() % jitter_mod;
-  }
-  return interval_ms;
+  const uint64_t interval_ms = static_cast<uint64_t>(ping_interval_.count()) * 1000;
+  return ReverseConnectionUtility::addJitter(interval_ms, jitter_percent, *random_generator_);
 }
 
 void UpstreamSocketManager::rearmPingSendTimer(int fd) {

--- a/test/extensions/bootstrap/reverse_tunnel/common/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/common/BUILD
@@ -17,6 +17,7 @@ envoy_cc_test(
         "//source/common/network:connection_lib",
         "//source/extensions/bootstrap/reverse_tunnel/common:reverse_connection_utility_lib",
         "//test/common/tls:mock_ssl_handshaker_lib",
+        "//test/mocks:common_lib",
         "//test/mocks/network:network_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:test_runtime_lib",

--- a/test/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility_test.cc
@@ -3,6 +3,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 
 #include "test/common/tls/mock_ssl_handshaker.h"
+#include "test/mocks/common.h"
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/test_runtime.h"
@@ -294,6 +295,29 @@ TEST_F(ReverseConnectionUtilityTest, ApplySslQuietCloseOnValidSslHandshaker) {
   ReverseConnectionUtility::applySslQuietClose(connection);
 
   EXPECT_EQ(1, SSL_get_quiet_shutdown(ssl));
+}
+
+// addJitter adds an upward, bounded jitter using the supplied random generator.
+TEST_F(ReverseConnectionUtilityTest, AddJitterUpwardDeterministic) {
+  NiceMock<Random::MockRandomGenerator> random;
+  // 15% of 10000 = 1500 jitter window; 10000 + (700 % 1500) = 10700.
+  EXPECT_CALL(random, random()).WillRepeatedly(Return(700));
+  EXPECT_EQ(ReverseConnectionUtility::addJitter(10000, 15, random), 10700);
+}
+
+// A 0% jitter (or sub-1% interval) returns the interval unchanged.
+TEST_F(ReverseConnectionUtilityTest, AddJitterZeroPercentIsNoOp) {
+  NiceMock<Random::MockRandomGenerator> random;
+  EXPECT_EQ(ReverseConnectionUtility::addJitter(10000, 0, random), 10000);
+}
+
+// The jittered interval never drops below the base nor reaches base*(1 + jitter%).
+TEST_F(ReverseConnectionUtilityTest, AddJitterStaysWithinUpperBound) {
+  NiceMock<Random::MockRandomGenerator> random;
+  EXPECT_CALL(random, random()).WillRepeatedly(Return(123456789ULL));
+  const uint64_t result = ReverseConnectionUtility::addJitter(10000, 15, random);
+  EXPECT_GE(result, 10000);
+  EXPECT_LT(result, 11500);
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1264,6 +1264,55 @@ TEST_F(RCConnectionWrapperTest, DecodeHeadersUpgradeMode) {
   }
 }
 
+// parseRetryAfter honors the RFC 7231 delta-seconds form, clamps it (overflow guard) at one hour,
+// and returns nullopt for absent/zero/HTTP-date/malformed values so the caller falls back to its
+// computed backoff.
+TEST_F(RCConnectionWrapperTest, ParseRetryAfter) {
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->addCopy(Http::LowerCaseString("retry-after"), "7");
+    auto result = RCConnectionWrapper::parseRetryAfter(*headers);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->count(), 7000);
+  }
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    EXPECT_FALSE(RCConnectionWrapper::parseRetryAfter(*headers).has_value());
+  }
+  {
+    // A zero cool-off must be treated as absent so it cannot short-circuit the backoff.
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->addCopy(Http::LowerCaseString("retry-after"), "0");
+    EXPECT_FALSE(RCConnectionWrapper::parseRetryAfter(*headers).has_value());
+  }
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->addCopy(Http::LowerCaseString("retry-after"), "Wed, 21 Oct 2026 07:28:00 GMT");
+    EXPECT_FALSE(RCConnectionWrapper::parseRetryAfter(*headers).has_value());
+  }
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->addCopy(Http::LowerCaseString("retry-after"), "100000"); // > 1h.
+    auto result = RCConnectionWrapper::parseRetryAfter(*headers);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->count(), 3600 * 1000);
+  }
+}
+
+// A 429 carrying Retry-After is handled by decodeHeaders via the failure/cool-off path.
+TEST_F(RCConnectionWrapperTest, DecodeHeadersRateLimited) {
+  auto mock_connection = setupMockConnection();
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+
+  Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+  headers->setStatus(429);
+  headers->addCopy(Http::LowerCaseString("retry-after"), "5");
+
+  wrapper.decodeHeaders(std::move(headers), true);
+}
+
 // In upgrade mode, connect() emits `Connection: Upgrade` + `Upgrade: reverse-tunnel`
 // in the handshake request. Verifies by capturing the bytes written by the encoder.
 TEST_F(RCConnectionWrapperTest, ConnectEmitsUpgradeHeaders) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -53,6 +53,12 @@ protected:
     EXPECT_CALL(context_, scope()).WillRepeatedly(ReturnRef(*stats_scope_));
     EXPECT_CALL(context_, clusterManager()).WillRepeatedly(ReturnRef(cluster_manager_));
 
+    // Make the jittered reconnect backoff deterministic in tests. The backoff is the deterministic
+    // exponential schedule (1s, 2s, 4s, ...) plus addJitter()'s upward jitter of random() % (15% of
+    // the interval). With a fixed random of 3999 the jitter is reproducible, e.g. the first three
+    // failures yield 1099/2099/4399ms (1000+99, 2000+99, 4000+399).
+    ON_CALL(context_.api_.random_, random()).WillByDefault(Return(3999));
+
     // Create the socket interface.
     socket_interface_ = std::make_unique<ReverseTunnelInitiator>(context_);
 
@@ -218,6 +224,22 @@ protected:
 
   void trackConnectionFailure(const std::string& host_address, const std::string& cluster_name) {
     io_handle_->trackConnectionFailure(host_address, cluster_name);
+  }
+
+  void trackConnectionFailureWithRetryAfter(const std::string& host_address,
+                                            const std::string& cluster_name,
+                                            std::chrono::milliseconds retry_after) {
+    io_handle_->trackConnectionFailure(host_address, cluster_name, retry_after);
+  }
+
+  // Returns the backoff window (backoff_until - last_failure_time) in ms for a host. Both stamps
+  // come from the same trackConnectionFailure() call, so this is the exact delay, free of
+  // wall-clock drift.
+  int64_t getBackoffDelayMs(const std::string& host_address) const {
+    const auto& info = getHostConnectionInfo(host_address);
+    return std::chrono::duration_cast<std::chrono::milliseconds>(info.backoff_until -
+                                                                 info.last_failure_time)
+        .count();
   }
 
   void resetHostBackoff(const std::string& host_address) {
@@ -930,7 +952,9 @@ TEST_F(ReverseConnectionIOHandleTest, ResetHostBackoffReturnsIfHostNotFound) {
   EXPECT_EQ(stat_map["test_scope.reverse_connections.host.non-existent-host.recovered"], 0);
 }
 
-// Test trackConnectionFailure exponential backoff.
+// Test trackConnectionFailure deterministic exponential backoff with upward jitter. The schedule is
+// base * 2^(failure_count-1) (1s, 2s, 4s, ...) plus addJitter()'s random() % (15% of the interval).
+// With the fixture's fixed random of 3999 the jitter is exactly 1000+99/2000+99/4000+399ms.
 TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureExponentialBackoff) {
   // Set up thread local slot first so stats can be properly tracked.
   setupThreadLocalSlot();
@@ -964,45 +988,99 @@ TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureExponentialBackoff) 
   const auto& host_info_initial = getHostConnectionInfo("192.168.1.1");
   EXPECT_EQ(host_info_initial.failure_count, 0);
 
-  // First failure - should have 1 second backoff (1000ms)
+  // getBackoffDelayMs() measures backoff_until - last_failure_time, the exact delay free of
+  // wall-clock slop, so the deterministic+jitter values can be asserted precisely.
+  // Failure 1: 1000 (base) + 3999 % 150  = 1000 + 99  = 1099ms.
   trackConnectionFailure("192.168.1.1", "test-cluster");
-  const auto& host_info_1 = getHostConnectionInfo("192.168.1.1");
-  EXPECT_EQ(host_info_1.failure_count, 1);
-  // Verify backoff_until is set to a future time (approximately current_time + 1000ms)
-  auto backoff_duration_1 =
-      host_info_1.backoff_until - std::chrono::steady_clock::now(); // NO_CHECK_FORMAT(real_time)
-  // backoff_delay_ms = 1000 * 2^(1-1) = 1000 * 2^0 = 1000 * 1 = 1000ms
-  auto backoff_ms_1 =
-      std::chrono::duration_cast<std::chrono::milliseconds>(backoff_duration_1).count();
-  EXPECT_GE(backoff_ms_1, 900);  // Should be at least 900ms (allowing for small timing variations)
-  EXPECT_LE(backoff_ms_1, 1100); // Should be at most 1100ms
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 1);
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 1099);
 
-  // Second failure - should have 2 second backoff (2000ms)
+  // Failure 2: 2000 + 3999 % 300 = 2000 + 99 = 2099ms.
   trackConnectionFailure("192.168.1.1", "test-cluster");
-  const auto& host_info_2 = getHostConnectionInfo("192.168.1.1");
-  EXPECT_EQ(host_info_2.failure_count, 2);
-  // backoff_delay_ms = 1000 * 2^(2-1) = 1000 * 2^1 = 1000 * 2 = 2000ms
-  auto backoff_duration_2 =
-      host_info_2.backoff_until - std::chrono::steady_clock::now(); // NO_CHECK_FORMAT(real_time)
-  auto backoff_ms_2 =
-      std::chrono::duration_cast<std::chrono::milliseconds>(backoff_duration_2).count();
-  EXPECT_GE(backoff_ms_2, 1900); // Should be at least 1900ms
-  EXPECT_LE(backoff_ms_2, 2100); // Should be at most 2100ms
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 2);
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 2099);
 
-  // Third failure - should have 4 second backoff (4000ms)
+  // Failure 3: 4000 + 3999 % 600 = 4000 + 399 = 4399ms.
   trackConnectionFailure("192.168.1.1", "test-cluster");
-  const auto& host_info_3 = getHostConnectionInfo("192.168.1.1");
-  EXPECT_EQ(host_info_3.failure_count, 3);
-  // backoff_delay_ms = 1000 * 2^(3-1) = 1000 * 2^2 = 1000 * 4 = 4000ms
-  auto backoff_duration_3 =
-      host_info_3.backoff_until - std::chrono::steady_clock::now(); // NO_CHECK_FORMAT(real_time)
-  auto backoff_ms_3 =
-      std::chrono::duration_cast<std::chrono::milliseconds>(backoff_duration_3).count();
-  EXPECT_GE(backoff_ms_3, 3900); // Should be at least 3900ms
-  EXPECT_LE(backoff_ms_3, 4100); // Should be at most 4100ms
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 3);
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 4399);
 
   // Verify that shouldAttemptConnectionToHost returns false during backoff.
   EXPECT_FALSE(shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
+}
+
+// Test that a server Retry-After hint is honored as the per-host backoff: bounded by the configured
+// max (default 30s) and then jittered upward like every other reconnect delay.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureHonorsRetryAfter) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  // A 7s hint is below the cap, so it is used as-is then jittered: 7000 + 3999 % 1050 = 7000 + 849.
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  trackConnectionFailureWithRetryAfter("192.168.1.1", "test-cluster",
+                                       std::chrono::milliseconds(7000));
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 7849);
+  EXPECT_FALSE(shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
+
+  // A 20-minute hint is first clamped to the 30s max, then jittered: 30000 + 3999 % 4500 = 33999.
+  // (Jitter is intentionally applied after the cap and not re-capped, so a small overshoot is
+  // expected.)
+  addHostConnectionInfo("192.168.1.2", "test-cluster", 1);
+  trackConnectionFailureWithRetryAfter("192.168.1.2", "test-cluster",
+                                       std::chrono::milliseconds(1200000));
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.2"), 33999);
+}
+
+// Test that max_reconnect_backoff caps the exponential schedule. With a 5s cap, the schedule
+// saturates at 5000ms (then jittered) instead of continuing to 8s/16s/etc.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureRespectsConfiguredMaxBackoff) {
+  // Rebuild the extension with a 5s max_reconnect_backoff, then wire its thread-local slot (the IO
+  // handle reads the time source through the extension's slot, so it must be set on this instance).
+  config_.mutable_max_reconnect_backoff()->set_seconds(5);
+  extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
+  setupThreadLocalSlot();
+  EXPECT_EQ(extension_->maxReconnectBackoffMs(), 5000);
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config); // Uses the rebuilt extension_.
+  ASSERT_NE(io_handle_, nullptr);
+
+  // Drive 4 failures. The deterministic step on the 4th failure would be 1000 * 2^3 = 8000ms, but
+  // it is capped at the configured 5000ms and then jittered: 5000 + 3999 % 750 = 5000 + 249 =
+  // 5249ms.
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  for (int i = 0; i < 4; ++i) {
+    trackConnectionFailure("192.168.1.1", "test-cluster");
+  }
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 4);
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 5249);
+}
+
+// Test that resetHostBackoff clears failure_count so the next failure restarts at the base
+// interval.
+TEST_F(ReverseConnectionIOHandleTest, ResetHostBackoffRestartsScheduleAtBase) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  // Escalate (failure_count starts at 0), then reset.
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  trackConnectionFailure("192.168.1.1", "test-cluster"); // failure_count 0 -> 1
+  trackConnectionFailure("192.168.1.1", "test-cluster"); // failure_count 1 -> 2
+  trackConnectionFailure("192.168.1.1", "test-cluster"); // failure_count 2 -> 3
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 3);
+  resetHostBackoff("192.168.1.1");
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 0);
+
+  // The next failure starts from the base interval again (1000 + jitter), not an escalated value.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").failure_count, 1);
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 1099);
 }
 
 // Test host mapping and backoff integration.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -154,6 +154,23 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, HandshakeRequestPathOverride) {
   EXPECT_EQ(custom_extension->handshakeRequestPath(), "/custom/handshake");
 }
 
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaxReconnectBackoffDefaults) {
+  // Unset max_reconnect_backoff falls back to the historical 30s ceiling.
+  envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+      DownstreamReverseConnectionSocketInterface empty_config;
+  auto extension_with_default =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, empty_config);
+  EXPECT_EQ(extension_with_default->maxReconnectBackoffMs(), 30000);
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaxReconnectBackoffOverride) {
+  auto custom_config = config_;
+  custom_config.mutable_max_reconnect_backoff()->set_seconds(5);
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+  EXPECT_EQ(custom_extension->maxReconnectBackoffMs(), 5000);
+}
+
 TEST_F(ReverseTunnelInitiatorExtensionTest, AdditionalHeadersDefaults) {
   EXPECT_TRUE(extension_->handshakeAdditionalHeaders().empty());
 }


### PR DESCRIPTION
Commit Message: reverse_tunnel: jittered reconnect backoff and Retry-After handling

Additional Description:
The downstream reverse tunnel initiator
(`envoy.bootstrap.reverse_tunnel.downstream_socket_interface`) reconnected on a deterministic
1s..30s per-host exponential backoff and a fixed 10s maintenance tick, and treated an HTTP `429`
handshake rejection as a generic failure. On synchronized fleet events (tunnel-server
rollout/recovery, fleet restart) this makes initiators re-dial in lock-step, which can trip
server-side rate limits ("thundering herd").

This applies jitter to the reconnect schedule, reusing existing Envoy machinery and keeping the API
surface lean (no new config):
- The per-host connection backoff now uses the stock `JitteredExponentialBackOffStrategy` (1s base,
  30s cap).
- The connection-maintenance timer carries upward jitter via a shared
  `ReverseConnectionUtility::addJitter` helper in `common/`, which the upstream tunnel **ping** send
  timer now also uses — unifying the two jitter paths.
- An HTTP `Retry-After` header (delta-seconds) on a `429` handshake response is honored as the
  per-host backoff, bounded by the 30s max.

Addresses review feedback on the earlier revision (keep the API lean, reuse
`JitteredExponentialBackOffStrategy`, and unify the jitter with the ping path in `common/`).

Risk Level: Low (no new config; jitter bounds match the previous envelope; Retry-After only applies
when the server sends it)
Testing: unit tests — `bazel test //test/extensions/bootstrap/reverse_tunnel/...`
Docs Changes: n/a (no API change)
Release Notes: added (`changelogs/current/minor_behavior_changes/reverse_tunnel__jittered-reconnect-backoff.rst`)