### PR TITLE
reverse_tunnel: honor Retry-After on 429 reverse-connection handshakes

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -40,6 +40,7 @@ message DownstreamReverseConnectionSocketInterface {
   // limits ("thundering herd"). When this message is unset, the initiator uses the historical
   // defaults (10s maintain interval, 1s base backoff, 30s max backoff, no jitter), preserving
   // prior behavior exactly.
+  // [#next-free-field: 6]
   message ReconnectBackoffConfig {
     // Steady-state interval at which the initiator re-checks each cluster and re-creates any
     // missing reverse connections. Defaults to 10s. When jitter is set, the effective tick is
@@ -65,6 +66,14 @@ message DownstreamReverseConnectionSocketInterface {
     // full jitter at 1.0). For the maintain interval the tick is spread upward as described on
     // ``maintain_interval``.
     google.protobuf.DoubleValue jitter = 4 [(validate.rules).double = {lte: 1.0 gte: 0.0}];
+
+    // Whether to honor an HTTP ``Retry-After`` header on a ``429`` reverse-connection handshake
+    // response. When enabled (the default) and the server returns a ``Retry-After`` delta-seconds
+    // hint, that value (bounded by ``max_backoff_interval`` and spread upward by ``jitter``) is used
+    // as the per-host backoff before the next attempt, instead of the computed exponential backoff.
+    // When the header is absent, malformed, or this is disabled, the computed jittered backoff
+    // applies. Defaults to ``true``.
+    google.protobuf.BoolValue respect_retry_after = 5;
   }
 
   // Stat prefix to be used for downstream reverse connection socket interface stats.

--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -4,7 +4,11 @@ package envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3
 
 import "envoy/config/core/v3/base.proto";
 
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3";
 option java_outer_classname = "DownstreamReverseConnectionSocketInterfaceProto";
@@ -29,6 +33,40 @@ message DownstreamReverseConnectionSocketInterface {
     repeated config.core.v3.HeaderValueOption additional_headers = 2;
   }
 
+  // Tunables controlling how the initiator re-establishes reverse connections after failures
+  // and how frequently it re-checks for missing connections. The intent is to let operators
+  // de-synchronize a fleet of initiators (for example after a tunnel-server rollout or a fleet
+  // restart) so that over-limit handshakes do not retry in lock-step and trip server-side rate
+  // limits ("thundering herd"). When this message is unset, the initiator uses the historical
+  // defaults (10s maintain interval, 1s base backoff, 30s max backoff, no jitter), preserving
+  // prior behavior exactly.
+  message ReconnectBackoffConfig {
+    // Steady-state interval at which the initiator re-checks each cluster and re-creates any
+    // missing reverse connections. Defaults to 10s. When jitter is set, the effective tick is
+    // spread upward into ``[maintain_interval, maintain_interval * (1 + jitter)]`` so that
+    // connections are never refilled faster than this value.
+    google.protobuf.Duration maintain_interval = 1 [(validate.rules).duration = {gt {}}];
+
+    // Base delay for the per-host exponential backoff applied after a failed reverse-connection
+    // attempt. The nth consecutive failure waits ``base_backoff_interval * 2^(n-1)`` (before
+    // jitter), capped at ``max_backoff_interval``. Keeping the first failure cheap preserves fast
+    // refill of a single dropped connection. Defaults to 1s.
+    google.protobuf.Duration base_backoff_interval = 2 [(validate.rules).duration = {gt {}}];
+
+    // Upper bound on the per-host backoff delay. Should be greater than or equal to
+    // ``base_backoff_interval``; if a smaller value is configured it is raised to
+    // ``base_backoff_interval`` at runtime. Defaults to 30s.
+    google.protobuf.Duration max_backoff_interval = 3 [(validate.rules).duration = {gt {}}];
+
+    // Jitter factor in the range ``[0.0, 1.0]`` applied to both the per-host backoff and the
+    // maintain interval. ``0.0`` (the default) reproduces the deterministic, jitter-free behavior.
+    // For the per-host backoff the delay becomes
+    // ``computed * (1 - jitter) + uniform_random(0, jitter * computed)`` (equal jitter at 0.5,
+    // full jitter at 1.0). For the maintain interval the tick is spread upward as described on
+    // ``maintain_interval``.
+    google.protobuf.DoubleValue jitter = 4 [(validate.rules).double = {lte: 1.0 gte: 0.0}];
+  }
+
   // Stat prefix to be used for downstream reverse connection socket interface stats.
   string stat_prefix = 1;
 
@@ -40,4 +78,8 @@ message DownstreamReverseConnectionSocketInterface {
   // Optional HTTP handshake configuration. When unset, the initiator envoy uses the defaults
   // provided by ``HttpHandshakeConfig``.
   HttpHandshakeConfig http_handshake = 3;
+
+  // Optional reconnect backoff/jitter configuration. When unset, the historical defaults apply
+  // (see ``ReconnectBackoffConfig``).
+  ReconnectBackoffConfig reconnect_backoff = 4;
 }

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -64,5 +64,14 @@ new_features:
     RSA public key exchange on behalf of the client. Added a new
     :ref:`downstream_ssl <envoy_v3_api_field_extensions.filters.network.mysql_proxy.v3.MySQLProxy.downstream_ssl>`
     config option with ``DISABLE``, ``REQUIRE``, and ``ALLOW`` modes.
+- area: reverse_tunnel
+  change: |
+    Added configurable reconnect cadence and jitter to the downstream reverse tunnel socket interface
+    (``envoy.bootstrap.reverse_tunnel.downstream_socket_interface``) via the new ``reconnect_backoff``
+    field. Operators can now tune the connection maintenance interval, the per-host exponential
+    backoff base and cap, and a jitter factor that is applied to both the per-host backoff (spread
+    downward) and the maintenance tick (spread upward) to de-synchronize a fleet of initiators after
+    synchronized events. Defaults reproduce the previous hardcoded behavior (10s maintenance interval,
+    1s base backoff, 30s cap, no jitter), so existing deployments are unaffected until configured.
 
 deprecated:

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -73,5 +73,13 @@ new_features:
     downward) and the maintenance tick (spread upward) to de-synchronize a fleet of initiators after
     synchronized events. Defaults reproduce the previous hardcoded behavior (10s maintenance interval,
     1s base backoff, 30s cap, no jitter), so existing deployments are unaffected until configured.
+- area: reverse_tunnel
+  change: |
+    The downstream reverse tunnel socket interface now honors an HTTP ``Retry-After`` header on a
+    ``429`` reverse-connection handshake response. When present (delta-seconds form), the hint is used
+    as the per-host backoff before the next attempt, bounded by ``max_backoff_interval`` and spread
+    upward by the configured jitter. This is controlled by the new ``respect_retry_after`` field on
+    ``reconnect_backoff`` and defaults to enabled; since rate limiters only emit the header when
+    actively limiting, behavior is unchanged until a server starts sending it.
 
 deprecated:

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -39,6 +39,8 @@ envoy_cc_library(
     hdrs = ["reverse_tunnel_initiator_extension.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//envoy/api:api_interface",
+        "//envoy/common:random_generator_interface",
         "//envoy/server:bootstrap_extension_config_interface",
         "//envoy/stats:stats_interface",
         "//envoy/thread_local:thread_local_interface",
@@ -67,6 +69,7 @@ envoy_cc_library(
         ":reverse_connection_address_lib",
         ":reverse_tunnel_extension_lib",
         "//envoy/api:io_error_interface",
+        "//envoy/common:random_generator_interface",
         "//envoy/grpc:async_client_interface",
         "//envoy/network:address_interface",
         "//envoy/network:io_handle_interface",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h"
 
+#include <algorithm>
+
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
 
@@ -12,6 +14,8 @@
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
+
+#include "absl/strings/numbers.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -181,10 +185,35 @@ void RCConnectionWrapper::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bo
   if (status == 200) {
     ENVOY_LOG(debug, "Received HTTP 200 OK response");
     onHandshakeSuccess();
-  } else {
-    ENVOY_LOG(error, "Received non-200 HTTP response: {}", status);
-    onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)));
+    return;
   }
+  ENVOY_LOG(error, "Received non-200 HTTP response: {}", status);
+  // A 429 may carry a Retry-After cool-off hint; forward it so the parent can honor it as the
+  // per-host backoff before the next attempt.
+  absl::optional<std::chrono::milliseconds> retry_after;
+  if (status == 429) {
+    retry_after = parseRetryAfter(*headers);
+  }
+  onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)), retry_after);
+}
+
+absl::optional<std::chrono::milliseconds>
+RCConnectionWrapper::parseRetryAfter(const Http::ResponseHeaderMap& headers) {
+  const auto result = headers.get(Http::LowerCaseString("retry-after"));
+  if (result.empty()) {
+    return absl::nullopt;
+  }
+  const absl::string_view value = result[0]->value().getStringView();
+  // RFC 7231 allows either delta-seconds or an HTTP-date. Rate limiters emit delta-seconds; honor
+  // that form and ignore the date form (the caller falls back to its computed backoff).
+  uint64_t seconds = 0;
+  if (!absl::SimpleAtoi(value, &seconds)) {
+    return absl::nullopt;
+  }
+  // Cap before converting to milliseconds to avoid overflow; downstream policy bounds it further.
+  constexpr uint64_t kMaxRetryAfterSeconds = 3600; // 1 hour.
+  seconds = std::min(seconds, kMaxRetryAfterSeconds);
+  return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(seconds));
 }
 
 void RCConnectionWrapper::dispatchHttp1(Buffer::Instance& buffer) {
@@ -213,7 +242,8 @@ void RCConnectionWrapper::onHandshakeSuccess() {
   parent_.onConnectionDone(message, this, false);
 }
 
-void RCConnectionWrapper::onHandshakeFailure(const HandshakeFailureReason& reason) {
+void RCConnectionWrapper::onHandshakeFailure(
+    const HandshakeFailureReason& reason, absl::optional<std::chrono::milliseconds> retry_after) {
   const std::string error_message = reason.getDetailedName();
   const std::string stats_failure_reason = reason.getNameForStats();
 
@@ -225,7 +255,7 @@ void RCConnectionWrapper::onHandshakeFailure(const HandshakeFailureReason& reaso
     extension->incrementHandshakeStats(cluster_name_, false, stats_failure_reason);
   }
 
-  parent_.onConnectionDone(error_message, this, false);
+  parent_.onConnectionDone(error_message, this, false, retry_after);
 }
 
 void RCConnectionWrapper::shutdown() {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -185,8 +186,22 @@ public:
   /**
    * Handle handshake failure.
    * @param reason the failure reason with type and context
+   * @param retry_after optional server-provided cool-off hint parsed from a ``Retry-After`` header
+   * on a 429 response; forwarded to the parent so it can drive the per-host backoff.
    */
-  void onHandshakeFailure(const HandshakeFailureReason& reason);
+  void onHandshakeFailure(const HandshakeFailureReason& reason,
+                          absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
+
+  /**
+   * Parse an HTTP ``Retry-After`` header into a cool-off duration. Only the RFC 7231 delta-seconds
+   * form is supported (the form rate limiters emit); the HTTP-date form and malformed/absent values
+   * return ``nullopt``, in which case the caller falls back to its computed backoff. The result is
+   * capped at one hour to bound the value before any further policy is applied.
+   * @param headers the response headers to inspect.
+   * @return the parsed cool-off duration, or ``nullopt`` if not present/parseable.
+   */
+  static absl::optional<std::chrono::milliseconds>
+  parseRetryAfter(const Http::ResponseHeaderMap& headers);
 
   /**
    * Perform graceful shutdown of the connection.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -1,9 +1,11 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
 
+#include "envoy/common/random_generator.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/timer.h"
 #include "envoy/network/address.h"
@@ -670,6 +672,22 @@ bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(const std::string&
   return true;
 }
 
+uint64_t ReverseConnectionIOHandle::applyJitter(uint64_t base_ms, JitterDirection direction) const {
+  const double jitter = config_.jitter;
+  // Fast path: no jitter configured (the default) or nothing to spread. This avoids touching the
+  // random generator entirely and keeps the schedule deterministic for the common case.
+  if (jitter <= 0.0 || base_ms == 0 || extension_ == nullptr) {
+    return base_ms;
+  }
+  const uint64_t window = static_cast<uint64_t>(static_cast<double>(base_ms) * jitter);
+  if (window == 0) {
+    return base_ms;
+  }
+  const uint64_t rand_part = extension_->randomGenerator().random() % (window + 1);
+  // Down: spread into [base*(1-jitter), base]; Up: spread into [base, base*(1+jitter)].
+  return direction == JitterDirection::Down ? (base_ms - window) + rand_part : base_ms + rand_part;
+}
+
 void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_address,
                                                        const std::string& cluster_name) {
   auto host_it = host_to_conn_info_map_.find(host_address);
@@ -681,12 +699,24 @@ void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_a
   auto& host_info = host_it->second;
   host_info.failure_count++;
   host_info.last_failure_time = getTimeSource().monotonicTime();
-  // Calculate exponential backoff: base_delay * 2^(failure_count - 1)
-  const uint32_t base_delay_ms = 1000; // 1 second base delay
-  const uint32_t max_delay_ms = 30000; // 30 seconds max delay
 
-  uint32_t backoff_delay_ms = base_delay_ms * (1 << (host_info.failure_count - 1));
-  backoff_delay_ms = std::min(backoff_delay_ms, max_delay_ms);
+  // Exponential backoff with a hard cap: the nth consecutive failure waits
+  // base_backoff_ms * 2^(n-1), capped at max_backoff_ms. The shift is evaluated in 64-bit and
+  // bounded (failure_count grows without limit on sustained failures) to avoid undefined-behavior
+  // overflow; once the shift would exceed the cap the delay simply pins to max_backoff_ms.
+  const uint64_t base_delay_ms = config_.base_backoff_ms;
+  const uint64_t max_delay_ms = config_.max_backoff_ms;
+  const uint32_t shift = host_info.failure_count - 1;
+  uint64_t computed_backoff_ms = max_delay_ms;
+  if (shift < 31) {
+    computed_backoff_ms = std::min(base_delay_ms << shift, max_delay_ms);
+  }
+
+  // Apply the configured jitter (downward spread) so synchronized fleet-wide failures do not retry
+  // in lock-step. With the default jitter of 0 this is a no-op and the schedule stays
+  // deterministic.
+  const uint64_t backoff_delay_ms = applyJitter(computed_backoff_ms, JitterDirection::Down);
+
   // Update the backoff until time. This is used in shouldAttemptConnectionToHost() to check if we
   // should attempt to connect to the host.
   host_info.backoff_until =
@@ -896,12 +926,16 @@ void ReverseConnectionIOHandle::maintainReverseConnections() {
   }
   ENVOY_LOG(debug, "Completed reverse TCP connection maintenance for all clusters.");
 
-  // Enable the retry timer to periodically check for missing connections (like maintainConnCount)
+  // Enable the retry timer to periodically check for missing connections (like maintainConnCount).
   if (rev_conn_retry_timer_) {
-    // TODO(basundhara-c): Make the retry timeout configurable.
-    const std::chrono::milliseconds retry_timeout(10000); // 10 seconds
+    // Re-arm the steady-state maintenance tick. The interval is configurable (defaults to 10s);
+    // when jitter is enabled the tick is spread upward so agents that booted together
+    // de-synchronize, without ever refilling connections faster than the configured interval.
+    const std::chrono::milliseconds retry_timeout(
+        applyJitter(config_.maintain_interval_ms, JitterDirection::Up));
     rev_conn_retry_timer_->enableTimer(retry_timeout);
-    ENVOY_LOG(debug, "Enabled retry timer for next connection check in 10 seconds.");
+    ENVOY_LOG(debug, "Enabled retry timer for next connection check in {}ms.",
+              retry_timeout.count());
   }
 }
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -688,8 +688,9 @@ uint64_t ReverseConnectionIOHandle::applyJitter(uint64_t base_ms, JitterDirectio
   return direction == JitterDirection::Down ? (base_ms - window) + rand_part : base_ms + rand_part;
 }
 
-void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_address,
-                                                       const std::string& cluster_name) {
+void ReverseConnectionIOHandle::trackConnectionFailure(
+    const std::string& host_address, const std::string& cluster_name,
+    absl::optional<std::chrono::milliseconds> retry_after) {
   auto host_it = host_to_conn_info_map_.find(host_address);
   if (host_it == host_to_conn_info_map_.end()) {
     ENVOY_LOG(debug, "Host {} not found in host_to_conn_info_map_, skipping failure tracking",
@@ -700,22 +701,35 @@ void ReverseConnectionIOHandle::trackConnectionFailure(const std::string& host_a
   host_info.failure_count++;
   host_info.last_failure_time = getTimeSource().monotonicTime();
 
-  // Exponential backoff with a hard cap: the nth consecutive failure waits
-  // base_backoff_ms * 2^(n-1), capped at max_backoff_ms. The shift is evaluated in 64-bit and
-  // bounded (failure_count grows without limit on sustained failures) to avoid undefined-behavior
-  // overflow; once the shift would exceed the cap the delay simply pins to max_backoff_ms.
-  const uint64_t base_delay_ms = config_.base_backoff_ms;
-  const uint64_t max_delay_ms = config_.max_backoff_ms;
-  const uint32_t shift = host_info.failure_count - 1;
-  uint64_t computed_backoff_ms = max_delay_ms;
-  if (shift < 31) {
-    computed_backoff_ms = std::min(base_delay_ms << shift, max_delay_ms);
-  }
+  uint64_t backoff_delay_ms;
+  if (retry_after.has_value() && config_.respect_retry_after) {
+    // Honor the server's explicit cool-off hint. Bound it by the configured max so a large or
+    // malformed value cannot park the agent indefinitely, and spread it upward by jitter so a fleet
+    // that all received the same Retry-After does not retry in lock-step (upward keeps us at or
+    // after the requested time).
+    const uint64_t hint_ms =
+        std::min<uint64_t>(static_cast<uint64_t>(retry_after->count()), config_.max_backoff_ms);
+    backoff_delay_ms = applyJitter(hint_ms, JitterDirection::Up);
+    ENVOY_LOG(debug, "Host {} honoring Retry-After hint {}ms (bounded/jittered to {}ms)",
+              host_address, retry_after->count(), backoff_delay_ms);
+  } else {
+    // Exponential backoff with a hard cap: the nth consecutive failure waits
+    // base_backoff_ms * 2^(n-1), capped at max_backoff_ms. The shift is evaluated in 64-bit and
+    // bounded (failure_count grows without limit on sustained failures) to avoid undefined-behavior
+    // overflow; once the shift would exceed the cap the delay simply pins to max_backoff_ms.
+    const uint64_t base_delay_ms = config_.base_backoff_ms;
+    const uint64_t max_delay_ms = config_.max_backoff_ms;
+    const uint32_t shift = host_info.failure_count - 1;
+    uint64_t computed_backoff_ms = max_delay_ms;
+    if (shift < 31) {
+      computed_backoff_ms = std::min(base_delay_ms << shift, max_delay_ms);
+    }
 
-  // Apply the configured jitter (downward spread) so synchronized fleet-wide failures do not retry
-  // in lock-step. With the default jitter of 0 this is a no-op and the schedule stays
-  // deterministic.
-  const uint64_t backoff_delay_ms = applyJitter(computed_backoff_ms, JitterDirection::Down);
+    // Apply the configured jitter (downward spread) so synchronized fleet-wide failures do not
+    // retry in lock-step. With the default jitter of 0 this is a no-op and the schedule stays
+    // deterministic.
+    backoff_delay_ms = applyJitter(computed_backoff_ms, JitterDirection::Down);
+  }
 
   // Update the backoff until time. This is used in shouldAttemptConnectionToHost() to check if we
   // should attempt to connect to the host.
@@ -1093,8 +1107,9 @@ bool ReverseConnectionIOHandle::isTriggerPipeReady() const {
   return trigger_pipe_read_fd_ != -1 && trigger_pipe_write_fd_ != -1;
 }
 
-void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
-                                                 RCConnectionWrapper* wrapper, bool closed) {
+void ReverseConnectionIOHandle::onConnectionDone(
+    const std::string& error, RCConnectionWrapper* wrapper, bool closed,
+    absl::optional<std::chrono::milliseconds> retry_after) {
   ENVOY_LOG(debug, "reverse_tunnel: Connection wrapper done - error: '{}', closed: {}", error,
             closed);
 
@@ -1172,7 +1187,7 @@ void ReverseConnectionIOHandle::onConnectionDone(const std::string& error,
       connection->close(Network::ConnectionCloseType::NoFlush);
     }
 
-    trackConnectionFailure(host_address, cluster_name);
+    trackConnectionFailure(host_address, cluster_name, retry_after);
 
   } else {
     // Handle connection success.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -43,6 +43,13 @@ static constexpr absl::string_view kDoubleCrlf = "\r\n\r\n";
 
 // Connection timing constants.
 static constexpr uint32_t kDefaultMaxReconnectAttempts = 10;
+
+// Default reconnect backoff/jitter parameters. These reproduce the historical hardcoded values so
+// that an unset bootstrap ``reconnect_backoff`` config preserves prior behavior exactly.
+static constexpr uint32_t kDefaultMaintainIntervalMs = 10000; // 10s steady-state re-check cadence.
+static constexpr uint32_t kDefaultBaseBackoffMs = 1000;       // 1s base per-host backoff delay.
+static constexpr uint32_t kDefaultMaxBackoffMs = 30000;       // 30s cap on per-host backoff delay.
+static constexpr double kDefaultReconnectJitter = 0.0; // No jitter (deterministic) by default.
 } // namespace
 
 /**
@@ -96,6 +103,13 @@ struct ReverseConnectionSocketConfig {
       remote_clusters;         // List of remote cluster configurations.
   bool enable_circuit_breaker; // Whether to place a cluster in backoff when reverse connection
                                // attempts fail.
+  // Reconnect backoff/jitter tunables, populated from the bootstrap extension's
+  // ``reconnect_backoff`` proto (see ReconnectBackoffConfig). Defaults reproduce the historical
+  // hardcoded behavior so an unset config changes nothing.
+  uint32_t maintain_interval_ms{kDefaultMaintainIntervalMs}; // Steady-state re-check cadence.
+  uint32_t base_backoff_ms{kDefaultBaseBackoffMs};           // Base per-host exponential backoff.
+  uint32_t max_backoff_ms{kDefaultMaxBackoffMs};             // Cap on per-host backoff delay.
+  double jitter{kDefaultReconnectJitter}; // Jitter factor in [0,1]; 0 = deterministic.
   ReverseConnectionSocketConfig() : enable_circuit_breaker(true) {}
 };
 
@@ -113,6 +127,7 @@ class ReverseConnectionIOHandle : public Network::IoSocketHandleImpl,
   friend class ReverseConnectionIOHandleTest;
   friend class RCConnectionWrapperTest;
   friend class DownstreamReverseConnectionIOHandleTest;
+  friend class ReverseTunnelInitiatorTest;
 
 public:
   /**
@@ -332,6 +347,27 @@ private:
    * @return true if dispatcher is available and safe to use
    */
   bool isThreadLocalDispatcherAvailable() const;
+
+  // Direction in which the configured jitter factor spreads a base delay.
+  enum class JitterDirection {
+    // Result in [base*(1-jitter), base]; used for per-host backoff so a retry never waits longer
+    // than the computed backoff (full jitter at 1.0, equal jitter at 0.5).
+    Down,
+    // Result in [base, base*(1+jitter)]; used for the maintain tick so connections are never
+    // refilled faster than the configured interval while still de-syncing co-started agents.
+    Up,
+  };
+
+  /**
+   * Apply the configured jitter factor to a deterministic base delay using Envoy's thread-safe
+   * Random::RandomGenerator (never rand()). With jitter 0 (the default) this returns ``base_ms``
+   * unchanged, preserving historical deterministic behavior. The random generator is only consulted
+   * when jitter is active. See JitterDirection for the spread semantics.
+   * @param base_ms the deterministic base delay in milliseconds.
+   * @param direction whether to spread downward (backoff) or upward (maintain tick).
+   * @return the jittered delay in milliseconds.
+   */
+  uint64_t applyJitter(uint64_t base_ms, JitterDirection direction) const;
 
   /**
    * Create the trigger mechanism used to wake up accept() when connections are established.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <queue>
 #include <string>
@@ -26,6 +27,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -50,6 +52,9 @@ static constexpr uint32_t kDefaultMaintainIntervalMs = 10000; // 10s steady-stat
 static constexpr uint32_t kDefaultBaseBackoffMs = 1000;       // 1s base per-host backoff delay.
 static constexpr uint32_t kDefaultMaxBackoffMs = 30000;       // 30s cap on per-host backoff delay.
 static constexpr double kDefaultReconnectJitter = 0.0; // No jitter (deterministic) by default.
+// Honor an HTTP Retry-After hint on a 429 handshake by default; the agent should respect an
+// explicit server cool-off when one is provided.
+static constexpr bool kDefaultRespectRetryAfter = true;
 } // namespace
 
 /**
@@ -110,6 +115,8 @@ struct ReverseConnectionSocketConfig {
   uint32_t base_backoff_ms{kDefaultBaseBackoffMs};           // Base per-host exponential backoff.
   uint32_t max_backoff_ms{kDefaultMaxBackoffMs};             // Cap on per-host backoff delay.
   double jitter{kDefaultReconnectJitter}; // Jitter factor in [0,1]; 0 = deterministic.
+  // Whether to honor an HTTP Retry-After hint on a 429 handshake response as the per-host backoff.
+  bool respect_retry_after{kDefaultRespectRetryAfter};
   ReverseConnectionSocketConfig() : enable_circuit_breaker(true) {}
 };
 
@@ -244,8 +251,11 @@ public:
    * @param error error message if the handshake failed, empty string if successful.
    * @param wrapper pointer to the connection wrapper that wraps over the established connection.
    * @param closed whether the connection was closed during handshake.
+   * @param retry_after optional server-provided cool-off hint (from an HTTP ``Retry-After`` header
+   * on a 429 handshake) to use as the per-host backoff; ignored when unset.
    */
-  void onConnectionDone(const std::string& error, RCConnectionWrapper* wrapper, bool closed);
+  void onConnectionDone(const std::string& error, RCConnectionWrapper* wrapper, bool closed,
+                        absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
 
   // Backoff logic for connection failures.
   /**
@@ -261,8 +271,14 @@ public:
    * Track a connection failure for a specific host and cluster and trigger backoff logic.
    * @param host_address the address of the host that failed.
    * @param cluster_name the name of the cluster the host belongs to.
+   * @param retry_after optional server-provided cool-off hint (from an HTTP ``Retry-After`` header
+   * on a 429 handshake). When present and ``respect_retry_after`` is enabled, it is used (bounded
+   *        by the max backoff and spread upward by jitter) as the next backoff instead of the
+   *        computed exponential value.
    */
-  void trackConnectionFailure(const std::string& host_address, const std::string& cluster_name);
+  void
+  trackConnectionFailure(const std::string& host_address, const std::string& cluster_name,
+                         absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
 
   /**
    * Reset backoff state for a specific host. Called when a connection is established successfully.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -128,6 +129,26 @@ ReverseTunnelInitiator::socket(Envoy::Network::Socket::Type socket_type,
     if (extension_ != nullptr) {
       socket_config.request_path = extension_->handshakeRequestPath();
       socket_config.additional_headers = extension_->handshakeAdditionalHeaders();
+      // Override the reconnect backoff/jitter tunables only when the bootstrap config set the
+      // ``reconnect_backoff`` block; otherwise the ReverseConnectionSocketConfig defaults
+      // (historical behavior) apply. Each duration sub-field independently falls back to the
+      // existing default when unset.
+      if (extension_->hasReconnectBackoffConfig()) {
+        const auto& reconnect_backoff = extension_->reconnectBackoffConfig();
+        socket_config.maintain_interval_ms = PROTOBUF_GET_MS_OR_DEFAULT(
+            reconnect_backoff, maintain_interval, socket_config.maintain_interval_ms);
+        socket_config.base_backoff_ms = PROTOBUF_GET_MS_OR_DEFAULT(
+            reconnect_backoff, base_backoff_interval, socket_config.base_backoff_ms);
+        socket_config.max_backoff_ms = PROTOBUF_GET_MS_OR_DEFAULT(
+            reconnect_backoff, max_backoff_interval, socket_config.max_backoff_ms);
+        if (reconnect_backoff.has_jitter()) {
+          socket_config.jitter = reconnect_backoff.jitter().value();
+        }
+        // The cap must never sit below the base, even if misconfigured; raise it if needed so the
+        // exponential backoff math stays well-formed.
+        socket_config.max_backoff_ms =
+            std::max(socket_config.max_backoff_ms, socket_config.base_backoff_ms);
+      }
     }
 
     // Pass config directly to helper method.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.cc
@@ -144,6 +144,9 @@ ReverseTunnelInitiator::socket(Envoy::Network::Socket::Type socket_type,
         if (reconnect_backoff.has_jitter()) {
           socket_config.jitter = reconnect_backoff.jitter().value();
         }
+        if (reconnect_backoff.has_respect_retry_after()) {
+          socket_config.respect_retry_after = reconnect_backoff.respect_retry_after().value();
+        }
         // The cap must never sit below the base, even if misconfigured; raise it if needed so the
         // exponential backoff math stays well-formed.
         socket_config.max_backoff_ms =

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <string>
 
+#include "envoy/api/api.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.pb.h"
 #include "envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.pb.validate.h"
 #include "envoy/server/bootstrap_extension_config.h"
@@ -116,6 +118,29 @@ public:
   handshakeAdditionalHeaders() const {
     return additional_headers_;
   }
+
+  /**
+   * @return whether the bootstrap config explicitly set the ``reconnect_backoff`` block. When
+   * false, the initiator applies the historical defaults baked into ReverseConnectionSocketConfig.
+   */
+  bool hasReconnectBackoffConfig() const { return config_.has_reconnect_backoff(); }
+
+  /**
+   * @return the explicit reconnect backoff/jitter configuration. Only meaningful when
+   * ``hasReconnectBackoffConfig()`` is true.
+   */
+  const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+      DownstreamReverseConnectionSocketInterface::ReconnectBackoffConfig&
+      reconnectBackoffConfig() const {
+    return config_.reconnect_backoff();
+  }
+
+  /**
+   * @return the server's thread-safe random generator, used to jitter the reconnect backoff and
+   * the maintain tick. Sourced from the server factory context so it is consistent across the
+   * server and injectable in tests.
+   */
+  Random::RandomGenerator& randomGenerator() const { return context_.api().randomGenerator(); }
 
   /**
    * Increment handshake stats for reverse tunnel connections (per-worker only).

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1063,6 +1063,58 @@ TEST_F(RCConnectionWrapperTest, DecodeHeadersNonOk) {
   wrapper.decodeHeaders(std::move(headers), true);
 }
 
+// Test decodeHeaders handles a 429 (with Retry-After) without crashing on the rate-limited path.
+TEST_F(RCConnectionWrapperTest, DecodeHeadersRateLimited) {
+  auto mock_connection = setupMockConnection();
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+
+  Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+  headers->setStatus(429);
+  headers->addCopy(Http::LowerCaseString("retry-after"), "5");
+
+  wrapper.decodeHeaders(std::move(headers), true);
+}
+
+// Test parseRetryAfter honors the RFC 7231 delta-seconds form.
+TEST_F(RCConnectionWrapperTest, ParseRetryAfterDeltaSeconds) {
+  Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+  headers->setStatus(429);
+  headers->addCopy(Http::LowerCaseString("retry-after"), "7");
+
+  auto result = RCConnectionWrapper::parseRetryAfter(*headers);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->count(), 7000);
+}
+
+// Test parseRetryAfter returns nullopt for absent, non-numeric (HTTP-date), and empty values.
+TEST_F(RCConnectionWrapperTest, ParseRetryAfterAbsentOrUnparseable) {
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->setStatus(429);
+    EXPECT_FALSE(RCConnectionWrapper::parseRetryAfter(*headers).has_value());
+  }
+  {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    headers->setStatus(429);
+    headers->addCopy(Http::LowerCaseString("retry-after"), "Wed, 21 Oct 2025 07:28:00 GMT");
+    EXPECT_FALSE(RCConnectionWrapper::parseRetryAfter(*headers).has_value());
+  }
+}
+
+// Test parseRetryAfter caps very large hints at one hour to avoid overflow before downstream
+// bounding.
+TEST_F(RCConnectionWrapperTest, ParseRetryAfterCappedAtOneHour) {
+  Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+  headers->setStatus(429);
+  headers->addCopy(Http::LowerCaseString("retry-after"), "100000"); // ~27.7h, above the 1h cap.
+
+  auto result = RCConnectionWrapper::parseRetryAfter(*headers);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->count(), 3600 * 1000);
+}
+
 // Test dispatchHttp1 error path by initializing codec via connect() and
 // then feeding invalid bytes to the parser.
 TEST_F(RCConnectionWrapperTest, DispatchHttp1ErrorPath) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -242,6 +242,16 @@ protected:
     return it->second;
   }
 
+  // Returns the exact backoff window (backoff_until - last_failure_time) in ms for a host. Because
+  // both timestamps come from the same trackConnectionFailure() call, this equals the computed
+  // (and possibly jittered) delay independent of wall-clock drift, enabling exact assertions.
+  int64_t getBackoffDelayMs(const std::string& host_address) const {
+    const auto& info = getHostConnectionInfo(host_address);
+    return std::chrono::duration_cast<std::chrono::milliseconds>(info.backoff_until -
+                                                                 info.last_failure_time)
+        .count();
+  }
+
   const std::vector<std::unique_ptr<RCConnectionWrapper>>& getConnectionWrappers() const {
     return io_handle_->connection_wrappers_;
   }
@@ -991,6 +1001,148 @@ TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureExponentialBackoff) 
 
   // Verify that shouldAttemptConnectionToHost returns false during backoff.
   EXPECT_FALSE(shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
+}
+
+// Test that the per-host backoff honors configured base/max intervals (jitter off =>
+// deterministic).
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureRespectsConfiguredIntervals) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 2000; // Non-default base delay.
+  config.max_backoff_ms = 5000;  // Non-default cap.
+  config.jitter = 0.0;           // Deterministic schedule.
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // Failure 1: 2000 * 2^0 = 2000ms.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 2000);
+  // Failure 2: 2000 * 2^1 = 4000ms.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 4000);
+  // Failure 3: 2000 * 2^2 = 8000ms, capped at the configured max of 5000ms.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 5000);
+}
+
+// Test full jitter (1.0): the backoff is spread into [0, computed]. An injected RNG value of 0 pins
+// the result to the lower bound, proving the random generator (not rand()) drives the spread.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureFullJitterLowerBound) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 30000;
+  config.jitter = 1.0; // Full jitter.
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // RNG = 0 => full-jitter lower bound => 0ms regardless of the computed backoff.
+  EXPECT_CALL(context_.api_.random_, random()).WillRepeatedly(testing::Return(0));
+
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 0);
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 0);
+}
+
+// Test full jitter stays within [0, computed] for an arbitrary RNG value across several failures.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureFullJitterWithinBounds) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 30000;
+  config.jitter = 1.0;
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  EXPECT_CALL(context_.api_.random_, random()).WillRepeatedly(testing::Return(123456789ULL));
+
+  for (uint32_t failure = 1; failure <= 6; ++failure) {
+    trackConnectionFailure("192.168.1.1", "test-cluster");
+    const uint32_t shift = failure - 1;
+    const int64_t computed =
+        std::min<int64_t>(static_cast<int64_t>(1000) << shift, 30000); // base*2^(n-1), capped.
+    const int64_t delay = getBackoffDelayMs("192.168.1.1");
+    EXPECT_GE(delay, 0);
+    EXPECT_LE(delay, computed) << "failure #" << failure;
+  }
+}
+
+// Test equal jitter (0.5): the backoff is spread into [computed/2, computed]. RNG = 0 pins it to
+// the lower bound computed/2.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureEqualJitterLowerBound) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 30000;
+  config.jitter = 0.5; // Equal jitter.
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  EXPECT_CALL(context_.api_.random_, random()).WillRepeatedly(testing::Return(0));
+
+  // Failure 1: computed 1000 => lower bound 500.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 500);
+  // Failure 2: computed 2000 => lower bound 1000.
+  trackConnectionFailure("192.168.1.1", "test-cluster");
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 1000);
+}
+
+// Test that the maintain timer is armed with the configured interval (jitter off => exact).
+TEST_F(ReverseConnectionIOHandleTest, MaintainTimerUsesConfiguredInterval) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.maintain_interval_ms = 12345; // Non-default interval.
+  config.jitter = 0.0;
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(12345), _))
+      .Times(testing::AtLeast(1));
+
+  Event::FileReadyCb cb = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, cb, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+}
+
+// Test that maintain-tick jitter spreads the interval upward into [interval, interval*(1+jitter)].
+TEST_F(ReverseConnectionIOHandleTest, MaintainTimerJitterSpreadsUpward) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.maintain_interval_ms = 10000;
+  config.jitter = 0.5; // Jitter window = 5000ms => tick in [10000, 15000].
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  // RNG = 3000 => tick = 10000 + (3000 % 5001) = 13000ms.
+  EXPECT_CALL(context_.api_.random_, random()).WillRepeatedly(testing::Return(3000));
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  std::chrono::milliseconds captured_interval{0};
+  EXPECT_CALL(*mock_timer, enableTimer(_, _))
+      .WillRepeatedly(testing::SaveArg<0>(&captured_interval));
+
+  Event::FileReadyCb cb = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, cb, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  EXPECT_EQ(captured_interval.count(), 13000);
 }
 
 // Test host mapping and backoff integration.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -215,6 +215,12 @@ protected:
     io_handle_->trackConnectionFailure(host_address, cluster_name);
   }
 
+  void trackConnectionFailureWithRetryAfter(const std::string& host_address,
+                                            const std::string& cluster_name,
+                                            std::chrono::milliseconds retry_after) {
+    io_handle_->trackConnectionFailure(host_address, cluster_name, retry_after);
+  }
+
   void resetHostBackoff(const std::string& host_address) {
     io_handle_->resetHostBackoff(host_address);
   }
@@ -1143,6 +1149,67 @@ TEST_F(ReverseConnectionIOHandleTest, MaintainTimerJitterSpreadsUpward) {
                                   Event::FileReadyType::Read);
 
   EXPECT_EQ(captured_interval.count(), 13000);
+}
+
+// Test that a Retry-After hint is honored as the per-host backoff (jitter off => exact).
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureHonorsRetryAfter) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 30000;
+  config.jitter = 0.0;
+  config.respect_retry_after = true;
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // Server asked for 7s; with the hint honored the backoff is exactly 7000ms, not the computed
+  // 1000.
+  trackConnectionFailureWithRetryAfter("192.168.1.1", "test-cluster",
+                                       std::chrono::milliseconds(7000));
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 7000);
+}
+
+// Test that a Retry-After hint is bounded by max_backoff so a large hint cannot park the agent.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureRetryAfterCappedAtMax) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 5000; // Cap.
+  config.jitter = 0.0;
+  config.respect_retry_after = true;
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // Server asked for 20s but our cap is 5s.
+  trackConnectionFailureWithRetryAfter("192.168.1.1", "test-cluster",
+                                       std::chrono::milliseconds(20000));
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 5000);
+}
+
+// Test that the Retry-After hint is ignored when respect_retry_after is disabled.
+TEST_F(ReverseConnectionIOHandleTest, TrackConnectionFailureIgnoresRetryAfterWhenDisabled) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  config.base_backoff_ms = 1000;
+  config.max_backoff_ms = 30000;
+  config.jitter = 0.0;
+  config.respect_retry_after = false; // Disabled => fall back to computed exponential backoff.
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // Despite the 7s hint, the first failure uses the computed 1000ms.
+  trackConnectionFailureWithRetryAfter("192.168.1.1", "test-cluster",
+                                       std::chrono::milliseconds(7000));
+  EXPECT_EQ(getBackoffDelayMs("192.168.1.1"), 1000);
 }
 
 // Test host mapping and backoff integration.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -184,6 +184,7 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, ReconnectBackoffConfigParsed) {
   backoff->mutable_base_backoff_interval()->set_seconds(2);
   backoff->mutable_max_backoff_interval()->set_seconds(45);
   backoff->mutable_jitter()->set_value(0.5);
+  backoff->mutable_respect_retry_after()->set_value(false);
 
   auto custom_extension =
       std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
@@ -195,6 +196,8 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, ReconnectBackoffConfigParsed) {
   EXPECT_EQ(parsed.max_backoff_interval().seconds(), 45);
   ASSERT_TRUE(parsed.has_jitter());
   EXPECT_DOUBLE_EQ(parsed.jitter().value(), 0.5);
+  ASSERT_TRUE(parsed.has_respect_retry_after());
+  EXPECT_FALSE(parsed.respect_retry_after().value());
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, RandomGeneratorReturnsContextGenerator) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -171,6 +171,39 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, AdditionalHeadersOverride) {
             envoy::config::core::v3::HeaderValueOption::APPEND_IF_EXISTS_OR_ADD);
 }
 
+TEST_F(ReverseTunnelInitiatorExtensionTest, ReconnectBackoffConfigDefaults) {
+  // The fixture's config_ does not set reconnect_backoff, so the accessor reports it absent and the
+  // initiator falls back to the historical defaults baked into ReverseConnectionSocketConfig.
+  EXPECT_FALSE(extension_->hasReconnectBackoffConfig());
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, ReconnectBackoffConfigParsed) {
+  auto custom_config = config_;
+  auto* backoff = custom_config.mutable_reconnect_backoff();
+  backoff->mutable_maintain_interval()->set_seconds(20);
+  backoff->mutable_base_backoff_interval()->set_seconds(2);
+  backoff->mutable_max_backoff_interval()->set_seconds(45);
+  backoff->mutable_jitter()->set_value(0.5);
+
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+
+  ASSERT_TRUE(custom_extension->hasReconnectBackoffConfig());
+  const auto& parsed = custom_extension->reconnectBackoffConfig();
+  EXPECT_EQ(parsed.maintain_interval().seconds(), 20);
+  EXPECT_EQ(parsed.base_backoff_interval().seconds(), 2);
+  EXPECT_EQ(parsed.max_backoff_interval().seconds(), 45);
+  ASSERT_TRUE(parsed.has_jitter());
+  EXPECT_DOUBLE_EQ(parsed.jitter().value(), 0.5);
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, RandomGeneratorReturnsContextGenerator) {
+  // Jitter randomness must come from the server factory context's generator so it is consistent
+  // server-wide and injectable in tests.
+  EXPECT_EQ(&extension_->randomGenerator(),
+            static_cast<Random::RandomGenerator*>(&context_.api_.random_));
+}
+
 TEST_F(ReverseTunnelInitiatorExtensionTest, OnServerInitialized) {
   // This should be a no-op.
   extension_->onServerInitialized(server_);

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
@@ -82,6 +82,13 @@ protected:
     return Network::Utility::parseInternetAddressNoThrow(ip, port);
   }
 
+  // Exposes the (private) merged socket config of an IO handle to TEST_F bodies. The fixture is a
+  // friend of ReverseConnectionIOHandle; the generated per-test classes that derive from it are
+  // not, so private access must go through a fixture member like this one.
+  const ReverseConnectionSocketConfig& getSocketConfig(ReverseConnectionIOHandle& handle) const {
+    return handle.config_;
+  }
+
   void TearDown() override {
     tls_slot_.reset();
     thread_local_registry_.reset();
@@ -260,6 +267,66 @@ TEST_F(ReverseTunnelInitiatorTest, SocketUsesCustomHandshakeRequestPathFromExten
   auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
   ASSERT_NE(reverse_handle, nullptr);
   EXPECT_EQ(reverse_handle->requestPath(), "/custom/handshake");
+}
+
+TEST_F(ReverseTunnelInitiatorTest, SocketAppliesReconnectBackoffConfigFromExtension) {
+  // Configure non-default backoff/jitter, including a max below the base to exercise the runtime
+  // clamp (PGV only validates each duration is > 0, not the cross-field max >= base invariant).
+  auto* backoff = config_.mutable_reconnect_backoff();
+  backoff->mutable_maintain_interval()->set_seconds(5);
+  backoff->mutable_base_backoff_interval()->set_seconds(3);
+  backoff->mutable_max_backoff_interval()->set_seconds(2);
+  backoff->mutable_jitter()->set_value(0.25);
+  extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
+  setupThreadLocalSlot();
+
+  ReverseConnectionAddress::ReverseConnectionConfig config;
+  config.src_cluster_id = "test-cluster";
+  config.src_node_id = "test-node";
+  config.src_tenant_id = "test-tenant";
+  config.remote_cluster = "remote-cluster";
+  config.connection_count = 1;
+  auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
+
+  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
+                                          Network::SocketCreationOptions{});
+  ASSERT_NE(socket, nullptr);
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  ASSERT_NE(reverse_handle, nullptr);
+
+  const auto& cfg = getSocketConfig(*reverse_handle);
+  EXPECT_EQ(cfg.maintain_interval_ms, 5000u);
+  EXPECT_EQ(cfg.base_backoff_ms, 3000u);
+  // The configured max (2s) sat below the base (3s); the plumbing raises it to the base.
+  EXPECT_EQ(cfg.max_backoff_ms, 3000u);
+  EXPECT_DOUBLE_EQ(cfg.jitter, 0.25);
+}
+
+TEST_F(ReverseTunnelInitiatorTest, SocketUsesDefaultBackoffWhenUnset) {
+  // With no reconnect_backoff block, the io handle must keep the historical defaults so an upgrade
+  // changes nothing until the config opts in.
+  extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
+  setupThreadLocalSlot();
+
+  ReverseConnectionAddress::ReverseConnectionConfig config;
+  config.src_cluster_id = "test-cluster";
+  config.src_node_id = "test-node";
+  config.src_tenant_id = "test-tenant";
+  config.remote_cluster = "remote-cluster";
+  config.connection_count = 1;
+  auto reverse_address = std::make_shared<ReverseConnectionAddress>(config);
+
+  auto socket = socket_interface_->socket(Network::Socket::Type::Stream, reverse_address,
+                                          Network::SocketCreationOptions{});
+  ASSERT_NE(socket, nullptr);
+  auto* reverse_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  ASSERT_NE(reverse_handle, nullptr);
+
+  const auto& cfg = getSocketConfig(*reverse_handle);
+  EXPECT_EQ(cfg.maintain_interval_ms, 10000u);
+  EXPECT_EQ(cfg.base_backoff_ms, 1000u);
+  EXPECT_EQ(cfg.max_backoff_ms, 30000u);
+  EXPECT_DOUBLE_EQ(cfg.jitter, 0.0);
 }
 
 TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketStreamIPv4) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
@@ -277,6 +277,7 @@ TEST_F(ReverseTunnelInitiatorTest, SocketAppliesReconnectBackoffConfigFromExtens
   backoff->mutable_base_backoff_interval()->set_seconds(3);
   backoff->mutable_max_backoff_interval()->set_seconds(2);
   backoff->mutable_jitter()->set_value(0.25);
+  backoff->mutable_respect_retry_after()->set_value(false);
   extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
   setupThreadLocalSlot();
 
@@ -300,6 +301,7 @@ TEST_F(ReverseTunnelInitiatorTest, SocketAppliesReconnectBackoffConfigFromExtens
   // The configured max (2s) sat below the base (3s); the plumbing raises it to the base.
   EXPECT_EQ(cfg.max_backoff_ms, 3000u);
   EXPECT_DOUBLE_EQ(cfg.jitter, 0.25);
+  EXPECT_FALSE(cfg.respect_retry_after);
 }
 
 TEST_F(ReverseTunnelInitiatorTest, SocketUsesDefaultBackoffWhenUnset) {
@@ -327,6 +329,7 @@ TEST_F(ReverseTunnelInitiatorTest, SocketUsesDefaultBackoffWhenUnset) {
   EXPECT_EQ(cfg.base_backoff_ms, 1000u);
   EXPECT_EQ(cfg.max_backoff_ms, 30000u);
   EXPECT_DOUBLE_EQ(cfg.jitter, 0.0);
+  EXPECT_TRUE(cfg.respect_retry_after); // Honored by default.
 }
 
 TEST_F(ReverseTunnelInitiatorTest, CreateReverseConnectionSocketStreamIPv4) {


### PR DESCRIPTION
Commit Message: reverse_tunnel: honor Retry-After on 429 reverse-connection handshakes

Additional Description:
**Stacked on #45683** — review the top commit for the incremental change; the diff includes #45683
until that merges.

When a reverse-connection handshake is rejected with HTTP `429` by the tunnel server (for example via
`local_rate_limit` enforcement), the initiator treated it as a generic failure and applied its
computed exponential backoff, ignoring any server-provided cool-off hint.

This parses the `Retry-After` header (RFC 7231 delta-seconds form) on a 429 handshake response and
uses it as the per-host backoff before the next attempt, bounded by `max_backoff_interval` and spread
upward by the configured jitter (so a fleet that all received the same hint does not retry in
lock-step). Gated by the new `respect_retry_after` field (defaults to enabled); the HTTP-date form and
malformed/absent values fall back to the computed jittered backoff.

Risk Level: Low (only activates on a 429 carrying Retry-After; togglable, defaults to enabled)
Testing: unit tests — `bazel test //test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/...`
Docs Changes: API documentation via proto comments
Release Notes: added (`changelogs/current.yaml`)