### PR TITLE
cluster_manager: Add overloaded drainOrCloseConnPools API with pool predicate

### DIFF
--- a/envoy/common/conn_pool.h
+++ b/envoy/common/conn_pool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/upstream/upstream.h"
@@ -54,6 +56,9 @@ enum class DrainBehavior {
   DrainExistingNonMigratableConnections,
 };
 
+class Instance;
+using DrainConnectionsPoolPredicate = std::function<bool(Instance&)>;
+
 /**
  * An instance of a generic connection pool.
  */
@@ -86,6 +91,12 @@ public:
    * @return Upstream::HostDescriptionConstSharedPtr the host for which connections are pooled.
    */
   virtual Upstream::HostDescriptionConstSharedPtr host() const PURE;
+
+  /**
+   * @return const Network::ConnectionSocket::OptionsSharedPtr& the socket
+   * options used to configure connections in this pool.
+   */
+  virtual const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() PURE;
 
   /**
    * Creates an upstream connection, if existing connections do not meet both current and

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -506,6 +506,7 @@ public:
    * to all worker threads and run concurrently.
    */
   using DrainConnectionsHostPredicate = std::function<bool(const Host&)>;
+  using DrainConnectionsPoolPredicate = std::function<bool(ConnectionPool::Instance&)>;
 
   /**
    * Drain all connection pool connections owned by this cluster.
@@ -523,6 +524,14 @@ public:
    */
   virtual void drainConnections(DrainConnectionsHostPredicate predicate,
                                 ConnectionPool::DrainBehavior drain_behavior) PURE;
+
+  /**
+   * Drain all connection pool connections matching the pool predicate owned by
+   * all clusters.
+   * @param predicate supplies the drain connections pool predicate.
+   */
+  virtual void drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate,
+                                     ConnectionPool::DrainBehavior drain_behavior) PURE;
 
   /**
    * Check if the cluster is active and statically configured, and if not, return an error

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -74,6 +74,9 @@ public:
     drainConnectionsImpl(drain_behavior);
   }
   Upstream::HostDescriptionConstSharedPtr host() const override { return host_; }
+  const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() override {
+    return Envoy::ConnectionPool::ConnPoolImplBase::socketOptions();
+  }
   ConnectionPool::Cancellable* newStream(Http::ResponseDecoder& response_decoder,
                                          Http::ConnectionPool::Callbacks& callbacks,
                                          const Instance::StreamOptions& options) override;

--- a/source/common/http/conn_pool_grid.h
+++ b/source/common/http/conn_pool_grid.h
@@ -206,6 +206,7 @@ public:
   bool isIdle() const override;
   void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior) override;
   Upstream::HostDescriptionConstSharedPtr host() const override;
+  const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() override { return options_; }
   bool maybePreconnect(float preconnect_ratio) override;
   absl::string_view protocolDescription() const override { return "connection grid"; }
 

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -174,6 +174,9 @@ public:
   Upstream::HostDescriptionConstSharedPtr host() const override {
     return Envoy::ConnectionPool::ConnPoolImplBase::host();
   }
+  const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() override {
+    return Envoy::ConnectionPool::ConnPoolImplBase::socketOptions();
+  }
   Envoy::ConnectionPool::ActiveClientPtr instantiateActiveClient() override;
   void onPoolReady(Envoy::ConnectionPool::ActiveClient& client,
                    Envoy::ConnectionPool::AttachContext& context) override;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1105,6 +1105,16 @@ void ClusterManagerImpl::drainConnections(DrainConnectionsHostPredicate predicat
       });
 }
 
+void ClusterManagerImpl::drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate,
+                                               ConnectionPool::DrainBehavior drain_behavior) {
+  ENVOY_LOG_EVENT(debug, "drain_connections_by_pool_predicate",
+                  "drainOrCloseConnPools called with pool predicate");
+  tls_.runOnAllThreads(
+      [predicate, drain_behavior](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+        cluster_manager->drainOrCloseConnPools(predicate, drain_behavior);
+      });
+}
+
 absl::Status ClusterManagerImpl::checkActiveStaticCluster(const std::string& cluster) {
   const auto& it = active_clusters_.find(cluster);
   if (it == active_clusters_.end()) {
@@ -1906,6 +1916,54 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::ClusterEntry(
   // benefit given the healthy panic, locality, and priority calculations that take place.
   ASSERT(lb_factory_ != nullptr);
   lb_ = lb_factory_->create({priority_set_, parent_.local_priority_set_});
+}
+
+void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainOrCloseConnPools(
+    DrainConnectionsPoolPredicate predicate, ConnectionPool::DrainBehavior behavior) {
+  std::vector<HostConstSharedPtr> hosts;
+  hosts.reserve(host_http_conn_pool_map_.size());
+  for (const auto& [host, container] : host_http_conn_pool_map_) {
+    hosts.push_back(host);
+  }
+
+  for (const auto& host : hosts) {
+    const auto container = getHttpConnPoolsContainer(host);
+    if (container != nullptr) {
+      container->do_not_delete_ = true;
+      container->pools_->drainConnectionsIf(predicate, behavior);
+      container->do_not_delete_ = false;
+
+      if (container->pools_->empty()) {
+        host_http_conn_pool_map_.erase(host);
+      }
+    }
+  }
+
+  // Drain any matching TCP connection pool for the host.
+  std::vector<HostConstSharedPtr> tcp_hosts;
+  tcp_hosts.reserve(host_tcp_conn_pool_map_.size());
+  for (const auto& [host, container] : host_tcp_conn_pool_map_) {
+    tcp_hosts.push_back(host);
+  }
+
+  for (const auto& host : tcp_hosts) {
+    const auto container = host_tcp_conn_pool_map_.find(host);
+    if (container != host_tcp_conn_pool_map_.end()) {
+      // Draining pools or closing connections can cause pool deletion if it becomes
+      // idle. Copy `pools_` so that we aren't iterating through a container that
+      // gets mutated by callbacks deleting from it.
+      std::vector<Tcp::ConnectionPool::Instance*> pools;
+      for (const auto& pair : container->second.pools_) {
+        pools.push_back(pair.second.get());
+      }
+
+      for (auto* pool : pools) {
+        if (predicate(*pool)) {
+          pool->drainConnections(behavior);
+        }
+      }
+    }
+  }
 }
 
 void ClusterManagerImpl::ThreadLocalClusterManagerImpl::drainOrCloseConnPools(

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -385,6 +385,9 @@ public:
   void drainConnections(DrainConnectionsHostPredicate predicate,
                         ConnectionPool::DrainBehavior drain_behavior) override;
 
+  void drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate,
+                             ConnectionPool::DrainBehavior drain_behavior) override;
+
   absl::Status checkActiveStaticCluster(const std::string& cluster) override;
 
   // Upstream::MissingClusterNotifier
@@ -703,6 +706,9 @@ private:
     // be immediate.
     void drainOrCloseConnPools(const HostSharedPtr& host,
                                absl::optional<ConnectionPool::DrainBehavior> drain_behavior);
+
+    void drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate,
+                               ConnectionPool::DrainBehavior behavior);
 
     void httpConnPoolIsIdle(HostConstSharedPtr host, ResourcePriority priority,
                             const std::vector<uint8_t>& hash_key);

--- a/source/common/upstream/conn_pool_map.h
+++ b/source/common/upstream/conn_pool_map.h
@@ -69,6 +69,13 @@ public:
    */
   void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior);
 
+  /**
+   * See `Envoy::ConnectionPool::Instance::drainConnections()`.
+   * Drains only the pools that match the predicate.
+   */
+  void drainConnectionsIf(Envoy::ConnectionPool::DrainConnectionsPoolPredicate predicate,
+                          Envoy::ConnectionPool::DrainBehavior drain_behavior);
+
 private:
   /**
    * Frees the first idle pool in `active_pools_`.

--- a/source/common/upstream/conn_pool_map_impl.h
+++ b/source/common/upstream/conn_pool_map_impl.h
@@ -120,6 +120,25 @@ void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
+void ConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnectionsIf(
+    Envoy::ConnectionPool::DrainConnectionsPoolPredicate predicate,
+    Envoy::ConnectionPool::DrainBehavior drain_behavior) {
+  // Copy the `active_pools_` so that it is safe for the call to result
+  // in deletion, and avoid iteration through a mutating container.
+  std::vector<POOL_TYPE*> pools;
+  pools.reserve(active_pools_.size());
+  for (auto& pool_pair : active_pools_) {
+    pools.push_back(pool_pair.second.get());
+  }
+
+  for (auto* pool : pools) {
+    if (predicate(*pool)) {
+      pool->drainConnections(drain_behavior);
+    }
+  }
+}
+
+template <typename KEY_TYPE, typename POOL_TYPE>
 bool ConnPoolMap<KEY_TYPE, POOL_TYPE>::freeOnePool() {
   // Try to find a pool that isn't doing anything.
   auto pool_iter = active_pools_.begin();

--- a/source/common/upstream/priority_conn_pool_map.h
+++ b/source/common/upstream/priority_conn_pool_map.h
@@ -61,6 +61,13 @@ public:
    */
   void drainConnections(Envoy::ConnectionPool::DrainBehavior drain_behavior);
 
+  /**
+   * See `Envoy::ConnectionPool::Instance::drainConnections()`.
+   * Drains only the pools that match the predicate.
+   */
+  void drainConnectionsIf(Envoy::ConnectionPool::DrainConnectionsPoolPredicate predicate,
+                          Envoy::ConnectionPool::DrainBehavior drain_behavior);
+
 private:
   size_t getPriorityIndex(ResourcePriority priority) const;
 

--- a/source/common/upstream/priority_conn_pool_map_impl.h
+++ b/source/common/upstream/priority_conn_pool_map_impl.h
@@ -73,6 +73,15 @@ void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnections(
 }
 
 template <typename KEY_TYPE, typename POOL_TYPE>
+void PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::drainConnectionsIf(
+    ConnectionPool::DrainConnectionsPoolPredicate predicate,
+    ConnectionPool::DrainBehavior drain_behavior) {
+  for (auto& pool_map : conn_pool_maps_) {
+    pool_map->drainConnectionsIf(predicate, drain_behavior);
+  }
+}
+
+template <typename KEY_TYPE, typename POOL_TYPE>
 size_t PriorityConnPoolMap<KEY_TYPE, POOL_TYPE>::getPriorityIndex(ResourcePriority priority) const {
   size_t index = static_cast<size_t>(priority);
   ASSERT(index < conn_pool_maps_.size());

--- a/test/common/tcp/conn_pool_test.cc
+++ b/test/common/tcp/conn_pool_test.cc
@@ -116,6 +116,9 @@ public:
     return conn_pool_->newConnection(callbacks);
   }
   Upstream::HostDescriptionConstSharedPtr host() const override { return conn_pool_->host(); }
+  const Network::ConnectionSocket::OptionsSharedPtr& socketOptions() override {
+    return conn_pool_->socketOptions();
+  }
 
   MOCK_METHOD(void, onConnReleasedForTest, ());
   MOCK_METHOD(void, onConnDestroyedForTest, ());

--- a/test/common/upstream/cluster_manager_impl_test.cc
+++ b/test/common/upstream/cluster_manager_impl_test.cc
@@ -19,6 +19,7 @@
 #include "test/mocks/config/mocks.h"
 #include "test/mocks/http/conn_pool.h"
 #include "test/mocks/matcher/mocks.h"
+#include "test/mocks/network/mocks.h"
 #include "test/mocks/server/instance.h"
 #include "test/mocks/upstream/cluster_priority_set.h"
 #include "test/mocks/upstream/load_balancer_context.h"
@@ -1842,6 +1843,66 @@ TEST_F(ClusterManagerImplTest, HttpPoolDataForwardsCallsToConnectionPool) {
 
   EXPECT_CALL(*pool_mock, drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete));
   opt_cp.value().drainConnections(ConnectionPool::DrainBehavior::DrainAndDelete);
+}
+
+TEST_F(ClusterManagerImplTest, DrainConnectionsByPredicate) {
+  createWithBasicStaticCluster();
+  NiceMock<MockLoadBalancerContext> context;
+
+  auto* http_pool_mock = new Http::ConnectionPool::MockInstance();
+  EXPECT_CALL(factory_, allocateConnPool_(_, _, _, _, _, _, _)).WillOnce(Return(http_pool_mock));
+  EXPECT_CALL(*http_pool_mock, addIdleCallback(_));
+
+  auto opt_http_cp =
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->httpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, Http::Protocol::Http11, &context);
+  ASSERT_TRUE(opt_http_cp.has_value());
+
+  auto* tcp_pool_mock = new Tcp::ConnectionPool::MockInstance();
+  EXPECT_CALL(factory_, allocateTcpConnPool_(_)).WillOnce(Return(tcp_pool_mock));
+  EXPECT_CALL(*tcp_pool_mock, addIdleCallback(_));
+
+  auto opt_tcp_cp =
+      cluster_manager_->getThreadLocalCluster("cluster_1")
+          ->tcpConnPool(
+              cluster_manager_->getThreadLocalCluster("cluster_1")->chooseHost(nullptr).host,
+              ResourcePriority::Default, &context);
+  auto mock_option = std::make_shared<Network::MockSocketOption>();
+  auto given_option = std::make_shared<Network::MockSocketOption>();
+  auto pool_options = std::make_shared<Network::ConnectionSocket::Options>();
+  pool_options->push_back(mock_option);
+
+  http_pool_mock->socket_options_ = pool_options;
+  tcp_pool_mock->socket_options_ = pool_options;
+  EXPECT_CALL(*http_pool_mock, socketOptions())
+      .WillRepeatedly(ReturnRef(http_pool_mock->socket_options_));
+  EXPECT_CALL(*tcp_pool_mock, socketOptions())
+      .WillRepeatedly(ReturnRef(tcp_pool_mock->socket_options_));
+
+  // First verify predicate matching given_option (not in pool) does not drain
+  cluster_manager_->drainOrCloseConnPools(
+      [given_option](ConnectionPool::Instance& pool) {
+        return pool.socketOptions() != nullptr &&
+               std::find(pool.socketOptions()->begin(), pool.socketOptions()->end(),
+                         given_option) != pool.socketOptions()->end();
+      },
+      ConnectionPool::DrainBehavior::DrainExistingConnections);
+
+  // Next verify predicate matching mock_option (in pool) drains both pools
+  EXPECT_CALL(*http_pool_mock,
+              drainConnections(ConnectionPool::DrainBehavior::DrainExistingConnections));
+  EXPECT_CALL(*tcp_pool_mock,
+              drainConnections(ConnectionPool::DrainBehavior::DrainExistingConnections));
+
+  cluster_manager_->drainOrCloseConnPools(
+      [mock_option](ConnectionPool::Instance& pool) {
+        return pool.socketOptions() != nullptr &&
+               std::find(pool.socketOptions()->begin(), pool.socketOptions()->end(), mock_option) !=
+                   pool.socketOptions()->end();
+      },
+      ConnectionPool::DrainBehavior::DrainExistingConnections);
 }
 
 class TestUpstreamNetworkFilter : public Network::WriteFilter {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -567,6 +567,7 @@ envoy_cc_test(
         "//source/common/protobuf",
         "//source/extensions/http/original_ip_detection/xff:config",
         "//test/config:v2_link_hacks",
+        "//test/mocks/network:network_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/api/v2:pkg_cc_proto",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/http_conn_pool_integration_test.cc
+++ b/test/integration/http_conn_pool_integration_test.cc
@@ -223,5 +223,54 @@ TEST_P(HttpConnPoolIntegrationTest, PoolDrainAfterDrainApiAllClusters) {
   test_server_->waitForGauge("cluster.cluster_1.circuit_breakers.default.cx_pool_open", Eq(0));
 }
 
+// Verify the drainConnections() with a pool predicate is able to filter pool drains.
+TEST_P(HttpConnPoolIntegrationTest, DrainConnectionsWithPoolPredicate) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeData(512, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+
+  auto pool_matches_cluster = [](ConnectionPool::Instance& pool,
+                                 const std::string& expected_cluster) {
+    return pool.host()->cluster().name() == expected_cluster;
+  };
+
+  // Perform a drain request matching cluster_1 (returns false for cluster_0's pool, no drain).
+  test_server_->server().dispatcher().post([this, pool_matches_cluster] {
+    test_server_->server().clusterManager().drainOrCloseConnPools(
+        [pool_matches_cluster](ConnectionPool::Instance& pool) {
+          return pool_matches_cluster(pool, "cluster_1");
+        },
+        ConnectionPool::DrainBehavior::DrainExistingConnections);
+  });
+
+  // The existing upstream connection should continue to work.
+  response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  upstream_request_->encodeData(512, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+
+  // Now do a drain matching cluster_0 (returns true for cluster_0's pool).
+  test_server_->waitForGauge("cluster.cluster_0.circuit_breakers.default.cx_pool_open", Eq(1));
+  test_server_->server().dispatcher().post([this, pool_matches_cluster] {
+    test_server_->server().clusterManager().drainOrCloseConnPools(
+        [pool_matches_cluster](ConnectionPool::Instance& pool) {
+          return pool_matches_cluster(pool, "cluster_0");
+        },
+        ConnectionPool::DrainBehavior::DrainExistingConnections);
+  });
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  test_server_->waitForGauge("cluster.cluster_0.circuit_breakers.default.cx_pool_open", Eq(0));
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/mocks/http/conn_pool.cc
+++ b/test/mocks/http/conn_pool.cc
@@ -2,6 +2,7 @@
 
 using testing::_;
 using testing::Return;
+using testing::ReturnRef;
 using testing::SaveArg;
 
 namespace Envoy {
@@ -12,6 +13,7 @@ MockInstance::MockInstance()
     : host_{std::make_shared<testing::NiceMock<Upstream::MockHostDescription>>()} {
   ON_CALL(*this, host()).WillByDefault(Return(host_));
   ON_CALL(*this, addIdleCallback(_)).WillByDefault(SaveArg<0>(&idle_cb_));
+  ON_CALL(*this, socketOptions()).WillByDefault(ReturnRef(socket_options_));
 }
 MockInstance::~MockInstance() = default;
 

--- a/test/mocks/http/conn_pool.h
+++ b/test/mocks/http/conn_pool.h
@@ -39,9 +39,11 @@ public:
   MOCK_METHOD(bool, maybePreconnect, (float));
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
   MOCK_METHOD(absl::string_view, protocolDescription, (), (const));
+  MOCK_METHOD(const Network::ConnectionSocket::OptionsSharedPtr&, socketOptions, (), (override));
 
   std::shared_ptr<testing::NiceMock<Upstream::MockHostDescription>> host_;
   IdleCb idle_cb_;
+  Network::ConnectionSocket::OptionsSharedPtr socket_options_;
 };
 
 } // namespace ConnectionPool

--- a/test/mocks/tcp/mocks.cc
+++ b/test/mocks/tcp/mocks.cc
@@ -30,6 +30,7 @@ MockInstance::MockInstance() {
   }));
   ON_CALL(*this, host()).WillByDefault(Return(host_));
   ON_CALL(*this, addIdleCallback(_)).WillByDefault(SaveArg<0>(&idle_cb_));
+  ON_CALL(*this, socketOptions()).WillByDefault(ReturnRef(socket_options_));
 }
 MockInstance::~MockInstance() = default;
 

--- a/test/mocks/tcp/mocks.h
+++ b/test/mocks/tcp/mocks.h
@@ -66,6 +66,7 @@ public:
   MOCK_METHOD(Cancellable*, newConnection, (Tcp::ConnectionPool::Callbacks & callbacks));
   MOCK_METHOD(bool, maybePreconnect, (float), ());
   MOCK_METHOD(Upstream::HostDescriptionConstSharedPtr, host, (), (const));
+  MOCK_METHOD(const Network::ConnectionSocket::OptionsSharedPtr&, socketOptions, (), (override));
 
   Envoy::ConnectionPool::MockCancellable* newConnectionImpl(Callbacks& cb);
   void poolFailure(PoolFailureReason reason, bool host_null = false);
@@ -82,6 +83,7 @@ public:
       new NiceMock<Upstream::MockHostDescription>()};
   std::unique_ptr<NiceMock<MockConnectionData>> connection_data_{
       new NiceMock<MockConnectionData>()};
+  Network::ConnectionSocket::OptionsSharedPtr socket_options_;
 };
 
 } // namespace ConnectionPool

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -90,6 +90,9 @@ public:
   MOCK_METHOD(void, drainConnections,
               (DrainConnectionsHostPredicate predicate,
                ConnectionPool::DrainBehavior drain_behavior));
+  MOCK_METHOD(void, drainOrCloseConnPools,
+              (DrainConnectionsPoolPredicate predicate,
+               ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(absl::Status, checkActiveStaticCluster, (const std::string& cluster));
   MOCK_METHOD(absl::StatusOr<OdCdsApiHandlePtr>, allocateOdCdsApi,
               (OdCdsCreationFunction creation_function,


### PR DESCRIPTION
Introduce an overloaded `ClusterManager::drainOrCloseConnPools` API that accepts a `ConnectionPool::PoolPredicate` and a `DrainBehavior`. 

To support custom filtering logic inside these predicates, we also added `socketOptions()` to `ConnectionPool::Instance`. Together, these changes enable callers—specifically Envoy Mobile—to selectively drain connection pools matching a given socket option without disrupting unrelated pools across host clusters.

### Key Changes
* **`ConnectionPool::Instance`**: Added virtual `socketOptions()` interface. This exposes the underlying socket configuration so predicates can inspect and match specific socket options during draining.
* **`ClusterManager`**: Added overloaded `drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate, DrainBehavior drain_behavior)` interface and implementation, enabling Envoy Mobile to selectively trigger pool drains based on socket options.
* **`ConnPoolMap` & `PriorityConnPoolMap`**: Added `drainConnectionsIf(...)` helper implementations. These safely copy active pool instances before filtering to prevent container mutation errors when callbacks trigger pool deletions during iteration.


Risk Level: low, guarded by new API
Testing:
* **Unit Tests**: Added `ClusterManagerImplTest.DrainConnectionsByPredicate` verifying predicate matching against `socketOptions()` across both HTTP and TCP pools.
* **Integration Tests**: Added `HttpConnPoolIntegrationTest.DrainConnectionsWithPoolPredicate` verifying selective connection pool draining and circuit breaker gauge tracking across HTTP/1.1, HTTP/2, and HTTP/3.

Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

