### PR TITLE
mcp_transcoder: add default_server_info to ServerToolConfig config.

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -323,5 +323,5 @@ message HttpRule {
 
 // Per-route override configuration for the MCP JSON REST Bridge filter.
 message McpJsonRestBridgePerRoute {
-  ServerToolConfig tool_config = 1;
+  repeated ServerToolConfig tool_config = 1;
 }

--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -208,6 +208,10 @@ message ServerToolConfig {
     // ToolsListSpecificConfig.
     ToolsListLocal tool_list_local = 4;
   }
+
+  // [#not-implemented-hide:]
+  // Default server info for tools without specific ones.
+  McpServerInfo default_server_info = 5;
 }
 
 // [#not-implemented-hide:]

--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -183,6 +183,7 @@ message ToolsListLocal {
 }
 
 // Configuration for the MCP tool capability of the server.
+// [#next-free-field: 6]
 message ServerToolConfig {
   // List of MCP tools configurations.
   repeated ToolConfig tools = 1;

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -210,8 +210,10 @@ McpJsonRestBridgePerRouteConfig::McpJsonRestBridgePerRouteConfig(
     const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute&
         proto_config)
     : proto_config_(proto_config) {
-  for (const auto& tool : proto_config.tool_config().tools()) {
-    tool_entries_[tool.name()] = {tool.http_rule(), tool.text_content_streaming_enabled()};
+  for (const auto& tool_config : proto_config.tool_config()) {
+    for (const auto& tool : tool_config.tools()) {
+      tool_entries_[tool.name()] = {tool.http_rule(), tool.text_content_streaming_enabled()};
+    }
   }
   ENVOY_LOG(debug, "Received MCP JSON REST Bridge per-route config: {}",
             proto_config_.DebugString());
@@ -238,10 +240,12 @@ bool McpJsonRestBridgePerRouteConfig::textContentStreamingEnabled(
 
 absl::StatusOr<envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule>
 McpJsonRestBridgePerRouteConfig::getToolsListHttpRule() const {
-  if (!proto_config_.tool_config().has_tool_list_http_rule()) {
-    return absl::NotFoundError("tools_list_http_rule is not configured.");
+  for (const auto& tool_config : proto_config_.tool_config()) {
+    if (tool_config.has_tool_list_http_rule()) {
+      return tool_config.tool_list_http_rule();
+    }
   }
-  return proto_config_.tool_config().tool_list_http_rule();
+  return absl::NotFoundError("tools_list_http_rule is not configured.");
 }
 
 Http::FilterHeadersStatus

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -1846,7 +1846,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsCallPerRouteConfig) {
 
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
       override_config;
-  auto* override_tool = override_config.mutable_tool_config()->add_tools();
+  auto* override_tool = override_config.add_tool_config()->add_tools();
   override_tool->set_name("my_tool");
   override_tool->mutable_http_rule()->set_get("/override/path");
 
@@ -1921,7 +1921,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListPerRouteConfigOverridesStaticConfig
 
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
       override_config;
-  override_config.mutable_tool_config()->mutable_tool_list_http_rule()->set_get("/override/path");
+  override_config.add_tool_config()->mutable_tool_list_http_rule()->set_get("/override/path");
 
   McpJsonRestBridgePerRouteConfig override(override_config);
 

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -723,7 +723,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, PerRouteConfigOverridesHttpRule) {
                                           v3::HttpConnectionManager& hcm) {
     auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
     envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute per_route;
-    auto* tool = per_route.mutable_tool_config()->add_tools();
+    auto* tool = per_route.add_tool_config()->add_tools();
     tool->set_name("create_api_key");
     tool->mutable_http_rule()->set_post("/v1/{parent=projects/*}/keys_override");
     tool->mutable_http_rule()->set_body("key");


### PR DESCRIPTION
Commit Message: mcp_transcoder: add default_server_info to ServerToolConfig config.
Additional Description: Implementations will be added later.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

