### PR TITLE
http2: make stream reset rate limits configurable in nghttp2

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -568,7 +568,7 @@ message KeepaliveSettings {
       [(validate.rules).duration = {gte {nanos: 1000000}}];
 }
 
-// [#next-free-field: 21]
+// [#next-free-field: 23]
 message Http2ProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.Http2ProtocolOptions";
@@ -807,6 +807,26 @@ message Http2ProtocolOptions {
   // From RFC 9110, https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5:
   // obs-text = %x80-FF
   google.protobuf.BoolValue disallow_obs_text = 20;
+
+  // Configures the initial token count for the RST_STREAM rate limiter used by the ``nghttp2``
+  // server-side connection. This uses a token-bucket algorithm where each received RST_STREAM
+  // frame consumes one token, and tokens are replenished at :ref:`stream_reset_rate
+  // <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_reset_rate>` per second.
+  // When no tokens remain, ``nghttp2`` sends GOAWAY with ``INTERNAL_ERROR`` to close the
+  // connection, protecting against CVE-2023-44487 (HTTP/2 Rapid Reset). Defaults to ``1000``.
+  //
+  // This option only applies when using ``nghttp2`` as a server. It has no effect on ``oghttp2``
+  // or on client-side connections.
+  google.protobuf.UInt64Value stream_reset_burst = 21;
+
+  // Configures the token replenishment rate (tokens per second) for the RST_STREAM rate limiter
+  // used by the ``nghttp2`` server-side connection. See :ref:`stream_reset_burst
+  // <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_reset_burst>` for details.
+  // Defaults to ``33``.
+  //
+  // This option only applies when using ``nghttp2`` as a server. It has no effect on ``oghttp2``
+  // or on client-side connections.
+  google.protobuf.UInt64Value stream_reset_rate = 22;
 }
 
 // [#not-implemented-hide:]

--- a/changelogs/current/new_features/http2__stream-reset-rate-limit-config.rst
+++ b/changelogs/current/new_features/http2__stream-reset-rate-limit-config.rst
@@ -1,0 +1,8 @@
+Added :ref:`stream_reset_burst <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_reset_burst>`
+and :ref:`stream_reset_rate <envoy_v3_api_field_config.core.v3.Http2ProtocolOptions.stream_reset_rate>`
+fields to ``Http2ProtocolOptions``. These configure the token-bucket RST_STREAM rate limiter
+built into ``nghttp2`` (CVE-2023-44487 / HTTP/2 Rapid Reset protection) for server-side connections.
+The defaults (burst=1000, rate=33/sec) match the existing ``nghttp2`` behavior; operators can raise
+these limits when legitimate workloads (e.g. gRPC streaming with many short-lived streams that
+receive RST_STREAM on RESOURCE_EXHAUSTED) exhaust the budget faster than it replenishes.
+These options only apply when using ``nghttp2`` as a server.

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -2225,6 +2225,17 @@ ConnectionImpl::Http2Options::Http2Options(
   // 512 is chosen to accommodate Envoy's 8Mb max limit of max_request_headers_kb
   // in both headers and trailers
   nghttp2_option_set_max_continuations(options_, 512);
+
+  // Configure the RST_STREAM rate limiter (CVE-2023-44487 / HTTP/2 Rapid Reset protection).
+  // nghttp2 defaults: burst=1000, rate=33/sec. Allow operators to tune these when legitimate
+  // workloads (e.g. gRPC with many short-lived streams that get RST_STREAM on RESOURCE_EXHAUSTED)
+  // exhaust the default token budget faster than it replenishes.
+  if (http2_options.has_stream_reset_burst() || http2_options.has_stream_reset_rate()) {
+    const uint64_t burst =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(http2_options, stream_reset_burst, 1000);
+    const uint64_t rate = PROTOBUF_GET_WRAPPED_OR_DEFAULT(http2_options, stream_reset_rate, 33);
+    nghttp2_option_set_stream_reset_rate_limit(options_, burst, rate);
+  }
 #endif
 }
 

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -2231,8 +2231,7 @@ ConnectionImpl::Http2Options::Http2Options(
   // workloads (e.g. gRPC with many short-lived streams that get RST_STREAM on RESOURCE_EXHAUSTED)
   // exhaust the default token budget faster than it replenishes.
   if (http2_options.has_stream_reset_burst() || http2_options.has_stream_reset_rate()) {
-    const uint64_t burst =
-        PROTOBUF_GET_WRAPPED_OR_DEFAULT(http2_options, stream_reset_burst, 1000);
+    const uint64_t burst = PROTOBUF_GET_WRAPPED_OR_DEFAULT(http2_options, stream_reset_burst, 1000);
     const uint64_t rate = PROTOBUF_GET_WRAPPED_OR_DEFAULT(http2_options, stream_reset_rate, 33);
     nghttp2_option_set_stream_reset_rate_limit(options_, burst, rate);
   }

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -5234,7 +5234,7 @@ TEST_P(Http2CodecImplTest, TooManyCookiesHistogram) {
 }
 
 // Verify that the nghttp2 RST_STREAM rate limiter is configurable via stream_reset_burst and
-// stream_reset_rate. When the burst budget is exhausted by incoming RST_STREAMs, the server
+// stream_reset_rate. When the burst budget is exhausted by incoming RST_STREAM frames, the server
 // should send GOAWAY and close the connection.
 TEST_P(Http2CodecImplTest, StreamResetRateLimitConfigurable) {
   if (http2_implementation_ == Http2Impl::Oghttp2) {
@@ -5243,7 +5243,7 @@ TEST_P(Http2CodecImplTest, StreamResetRateLimitConfigurable) {
     return;
   }
 
-  // Set a very small burst so it is exhausted after a few RST_STREAMs.
+  // Set a very small burst so it is exhausted after a few RST_STREAM frames.
   const uint32_t burst = 5;
   server_http2_options_.mutable_stream_reset_burst()->set_value(burst);
   server_http2_options_.mutable_stream_reset_rate()->set_value(0);

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -5233,6 +5233,50 @@ TEST_P(Http2CodecImplTest, TooManyCookiesHistogram) {
   EXPECT_THAT(cookie_counts, ElementsAre(Ge(10)));
 }
 
+// Verify that the nghttp2 RST_STREAM rate limiter is configurable via stream_reset_burst and
+// stream_reset_rate. When the burst budget is exhausted by incoming RST_STREAMs, the server
+// should send GOAWAY and close the connection.
+TEST_P(Http2CodecImplTest, StreamResetRateLimitConfigurable) {
+  if (http2_implementation_ == Http2Impl::Oghttp2) {
+    // stream_reset_burst/rate only apply to nghttp2.
+    initialize();
+    return;
+  }
+
+  // Set a very small burst so it is exhausted after a few RST_STREAMs.
+  const uint32_t burst = 5;
+  server_http2_options_.mutable_stream_reset_burst()->set_value(burst);
+  server_http2_options_.mutable_stream_reset_rate()->set_value(0);
+  initialize();
+
+  // Send `burst + 1` streams that the client immediately resets. Each reset sends a RST_STREAM
+  // to the server and drains one token from its rate-limiter bucket.
+  for (uint32_t i = 0; i < burst + 1; ++i) {
+    MockResponseDecoder response_decoder;
+    RequestEncoder* encoder = (i == 0) ? request_encoder_ : &client_->newStream(response_decoder);
+
+    TestRequestHeaderMapImpl request_headers;
+    HttpTestUtility::addDefaultHeaders(request_headers);
+    EXPECT_CALL(request_decoder_, decodeHeaders_(_, false)).RetiresOnSaturation();
+    EXPECT_TRUE(encoder->encodeHeaders(request_headers, false).ok());
+    driveToCompletion();
+
+    MockStreamCallbacks client_stream_callbacks;
+    encoder->getStream().addCallbacks(client_stream_callbacks);
+    EXPECT_CALL(server_stream_callbacks_, onResetStream(StreamResetReason::RemoteReset, _))
+        .RetiresOnSaturation();
+    EXPECT_CALL(client_stream_callbacks, onResetStream(StreamResetReason::LocalReset, _))
+        .RetiresOnSaturation();
+    encoder->getStream().resetStream(StreamResetReason::LocalReset);
+    // On the last reset the burst is exhausted: nghttp2 sends GOAWAY synchronously during
+    // driveToCompletion, so the expectation must be registered before the drive runs.
+    if (i == burst) {
+      EXPECT_CALL(client_callbacks_, onGoAway(Http::GoAwayErrorCode::Other));
+    }
+    driveToCompletion();
+  }
+}
+
 } // namespace Http2
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: make stream reset rate limits configurable in nghttp2
Additional Description:
Risk Level: Low
Testing: Added
Docs Changes: N/A
Release Notes: Added
Fixes https://github.com/envoyproxy/envoy/issues/30882
