### PR TITLE
dynamic_modules: pin function-registering modules in registry tests

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -529,7 +529,9 @@ bool envoy_dynamic_module_callback_is_validation_mode();
  * cross-module interactions.
  *
  * Registration is typically done once during bootstrap (e.g., in on_server_initialized). The
- * function pointer must remain valid for the lifetime of the process.
+ * function pointer must remain valid for the lifetime of the process, so a module that registers
+ * functions must be loaded with do_not_close set to true to avoid being unloaded while the registry
+ * still hands out the pointer.
  *
  * Callers are responsible for agreeing on the function signature out-of-band, since the registry
  * stores opaque void* pointers — analogous to dlsym semantics.
@@ -576,7 +578,9 @@ bool envoy_dynamic_module_callback_get_function(envoy_dynamic_module_type_module
  * Callers are responsible for managing the lifetime of overwritten data pointers.
  *
  * Registration is typically done once during bootstrap (e.g., in on_server_initialized or
- * on_scheduled). The data pointer must remain valid for the lifetime of the process.
+ * on_scheduled). The data pointer must remain valid while reachable through the registry. A module
+ * that registers a pointer into its own memory must either be loaded with do_not_close set to true
+ * or overwrite the pointer on each reload before any consumer reads it.
  *
  * This is thread-safe and can be called from any thread.
  *

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -217,7 +217,8 @@ pub unsafe fn is_validation_mode() -> bool {
 /// # Safety
 ///
 /// The `function_ptr` must point to a valid function that remains valid for the lifetime of the
-/// process.
+/// process. A module that registers functions must be loaded with `do_not_close` set to `true` to
+/// avoid being unloaded while the registry still hands out the pointer.
 pub unsafe fn register_function(key: &str, function_ptr: *const std::ffi::c_void) -> bool {
   unsafe {
     abi::envoy_dynamic_module_callback_register_function(
@@ -265,9 +266,11 @@ pub fn get_function(key: &str) -> Option<*const std::ffi::c_void> {
 ///
 /// # Safety
 ///
-/// The `data_ptr` must point to valid data that remains valid for the lifetime of the process.
-/// Callers are responsible for agreeing on the data type out-of-band, since the registry stores
-/// opaque pointers.
+/// The `data_ptr` must point to data that remains valid while reachable through the registry. A
+/// module that registers a pointer into its own memory must either be loaded with `do_not_close`
+/// set to `true` or overwrite the pointer on each reload before any consumer reads it. Callers
+/// are responsible for agreeing on the data type out-of-band, since the registry stores opaque
+/// pointers.
 pub unsafe fn register_shared_data(key: &str, data_ptr: *const std::ffi::c_void) -> bool {
   unsafe {
     abi::envoy_dynamic_module_callback_register_shared_data(

--- a/test/extensions/dynamic_modules/bootstrap/integration_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/integration_test.cc
@@ -19,20 +19,25 @@ public:
   void initializeWithBootstrapExtension(const std::string& module_dir,
                                         const std::string& module_name = "test",
                                         const std::string& extension_name = "test",
-                                        const std::string& extension_config = "test_config") {
+                                        const std::string& extension_config = "test_config",
+                                        bool do_not_close = false) {
     TestEnvironment::setEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH", module_dir, 1);
-    const std::string yaml = fmt::format(R"EOF(
+    // Only emit do_not_close when requested so the generated config is unchanged for modules that
+    // do not need to be pinned in memory.
+    const std::string do_not_close_config = do_not_close ? "\n          do_not_close: true" : "";
+    const std::string yaml =
+        fmt::format(R"EOF(
       name: envoy.bootstrap.dynamic_modules
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.bootstrap.dynamic_modules.v3.DynamicModuleBootstrapExtension
         dynamic_module_config:
-          name: {}
+          name: {}{}
         extension_name: {}
         extension_config:
           "@type": type.googleapis.com/google.protobuf.StringValue
           value: {}
     )EOF",
-                                         module_name, extension_name, extension_config);
+                    module_name, do_not_close_config, extension_name, extension_config);
 
     config_helper_.addBootstrapExtension(yaml);
     HttpIntegrationTest::initialize();
@@ -87,14 +92,20 @@ TEST_P(DynamicModulesBootstrapIntegrationTest, StatsAccessRust) {
 // This test verifies that the Rust bootstrap extension can register and resolve functions
 // via the process-wide function registry.
 TEST_P(DynamicModulesBootstrapIntegrationTest, FunctionRegistryRust) {
-  EXPECT_LOG_CONTAINS(
-      "info", "Bootstrap function registry test completed successfully!",
-      initializeWithBootstrapExtension(testDataDir("rust"), "bootstrap_function_registry_test"));
+  // The module registers process-wide function pointers, so it must be pinned with do_not_close.
+  // Otherwise the module would be unloaded between the IPv4 and IPv6 runs, and the registry would
+  // hand back a dangling pointer on the second run, crashing when it is called.
+  EXPECT_LOG_CONTAINS("info", "Bootstrap function registry test completed successfully!",
+                      initializeWithBootstrapExtension(testDataDir("rust"),
+                                                       "bootstrap_function_registry_test", "test",
+                                                       "test_config", /*do_not_close=*/true));
 }
 
 // This test verifies that the Rust bootstrap extension can register, retrieve, and overwrite
 // shared data via the process-wide shared data registry.
 TEST_P(DynamicModulesBootstrapIntegrationTest, SharedDataRegistryRust) {
+  // The shared data registry overwrites existing entries, so each parameterized run re-registers a
+  // fresh pointer before reading it; the module therefore needs no do_not_close.
   EXPECT_LOG_CONTAINS(
       "info", "Bootstrap shared data registry test completed successfully!",
       initializeWithBootstrapExtension(testDataDir("rust"), "bootstrap_shared_data_test"));
@@ -189,13 +200,17 @@ TEST_P(DynamicModulesBootstrapIntegrationTest, FunctionRegistryCrossFilterRust) 
   TestEnvironment::setEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH", module_dir, 1);
 
   // Add the bootstrap extension that initializes the routing table and registers the lookup
-  // function.
+  // function. As in FunctionRegistryRust, the module must be pinned with do_not_close so the
+  // registered function pointer stays valid across the IPv4 and IPv6 runs. Because do_not_close
+  // only takes effect on the first load of the shared module, both the bootstrap and the HTTP
+  // filter below set it to keep the module resident regardless of which loads first.
   const std::string bootstrap_yaml = R"EOF(
       name: envoy.bootstrap.dynamic_modules
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.bootstrap.dynamic_modules.v3.DynamicModuleBootstrapExtension
         dynamic_module_config:
           name: bootstrap_http_combined_test
+          do_not_close: true
         extension_name: combined_test
         extension_config:
           "@type": type.googleapis.com/google.protobuf.StringValue
@@ -210,6 +225,7 @@ typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_modules.v3.DynamicModuleFilter
   dynamic_module_config:
     name: bootstrap_http_combined_test
+    do_not_close: true
   filter_name: combined_filter
   filter_config:
     "@type": type.googleapis.com/google.protobuf.StringValue


### PR DESCRIPTION
## Description

Today, the process-wide function registry stores raw pointers and never overwrites an existing entry, so when a registering module is unloaded, `dlclose` removes the `.so` and the stored pointer dangles. The parameterized `FunctionRegistryRust` test runs IPv4 then IPv6 in one process. On the second run `register_function` refuses to overwrite the stale entry and `get_function` returns the dangling pointer, so calling it jumps into unmapped
memory and ASAN reports a SEGV ("wild jump") during server initialization.

In this PR, we are fixing it by pinning the registering modules with `do_not_close: true` (RTLD_NODELETE) so they stay resident and the registry pointers remain valid across runs, in `FunctionRegistryRust` and both load paths of `FunctionRegistryCrossFilterRust`.

---

**Commit Message:** dynamic_modules: pin function-registering modules in registry tests
**Risk Level:** Low
**Testing:** N/A
**Docs Changes**: N/A
**Release Notes**: N/A