### PR TITLE
Update QUICHE from 0abb446b2 to 846ced76d

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-06-11"
+  release_date: "2026-06-18"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "0abb446b2b1d020f2feeada562b920fdf658a9be",
-        sha256 = "15cd2b0d49425958f895e258a0a3332ac71c78c4b518944b110b8708e8b8130e",
+        version = "846ced76db5e1b6297408cc11a8bfe1fc1c0e49f",
+        sha256 = "0e11aec4ebd778fcd3c2775e3693cccbd966af4928e9fa7573c2e2975ccd9c50",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/0abb446b2..846ced76d

```
$ git log 0abb446b2..846ced76d --date=short --no-merges --format="%ad %al %s"

2026-06-18 quiche-dev Import latest Structured Header tests.
2026-06-18 quiche-dev QBONE packet processor: pull the src address from `ProcessIpv6HeaderAndFilter`.
2026-06-18 quiche-dev Reject any incoming HEADERS and DATA frames on a stream that is already in a half-closed (remote) state
2026-06-18 dschinazi Allow using client certificates with MasqueSimpleGet
2026-06-18 quiche-dev //third_party/quic: allow BoringSSL to enable ML-KEM by default.
2026-06-18 quiche-dev //third_party/quic: turn off PQC in end_to_end_test.
2026-06-17 quiche-dev //third_party/quic: allow BoringSSL to enable ML-KEM by default.
2026-06-17 vasilvv Allow timestamps for reordered packets in IETF QUIC.
2026-06-17 danzh No public description
2026-06-17 vasilvv Add a callback to notify QuicSession whenever a new RTT sample is available.
2026-06-17 quiche-dev Add generator script for Structured Header tests.
2026-06-17 vasilvv Enforce the limits on the maximum number of ACK timestamps received.
2026-06-16 vasilvv Renumber IETF_ACK_RECEIVE_TIMESTAMPS and implement IETF_ACK_RECEIVE_TIMESTAMPS_ECN.
2026-06-16 vasilvv Fix a bug where HTTP/3 client stack will treat any extended CONNECT request as WebTransport.
2026-06-12 dschinazi OHTTP test client: run requests sequentially
2026-06-12 dschinazi OHTTP test client: return responses for further analysis
2026-06-12 vasilvv Implement actual zero-copy in EncapsulatedWebTransport.
2026-06-11 danzh No public description
```

