### PR TITLE
fix: prevent SSL assert when connection closed during filter init

### DIFF
--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1073,7 +1073,7 @@ void ServerConnectionImpl::raiseEvent(ConnectionEvent event) {
 }
 bool ServerConnectionImpl::initializeReadFilters() {
   bool initialized = ConnectionImpl::initializeReadFilters();
-  if (initialized) {
+  if (initialized && state() == State::Open) {
     // Server connection starts as connected, and we must explicitly signal to
     // the downstream transport socket that the underlying socket is connected.
     // We delay this step until after the filters are initialized and can

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1078,6 +1078,9 @@ bool ServerConnectionImpl::initializeReadFilters() {
     // the downstream transport socket that the underlying socket is connected.
     // We delay this step until after the filters are initialized and can
     // receive the connection events.
+    // A filter may close the connection during onNewConnection() (e.g. circuit
+    // breaker overflow), in which case the state is no longer Open and we must
+    // skip signaling onConnected to the transport socket.
     onConnected();
   }
   return initialized;

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -1755,6 +1755,29 @@ TEST_P(TcpProxySslIntegrationTest, SslConnectionDataEarlyReadNotCached) {
             "fingerprint=c07e14fc43b9c7b3d92f1004f91d3a9e071d9c93a58afc76b4c14303ae3a0f34");
 }
 
+// Test that Envoy does not crash when a downstream TLS connection is rejected
+// due to upstream circuit breaker max_connections overflow.
+TEST_P(TcpProxySslIntegrationTest, CircuitBreakerOverflowWithDownstreamTls) {
+  config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+    auto* threshold = cluster->mutable_circuit_breakers()->add_thresholds();
+    threshold->mutable_max_connections()->set_value(1);
+  });
+
+  initialize();
+
+  // Connection 1: should succeed.
+  auto client1 = std::make_unique<ClientSslConnection>(*this);
+  client1->waitForUpstreamConnection();
+
+  // Connection 2: should be rejected by circuit breaker and NOT crash Envoy.
+  auto client2 = std::make_unique<ClientSslConnection>(*this);
+  client2->waitForDisconnect();
+
+  // Clean up.
+  client1->close();
+}
+
 // Test that a half-close on the downstream side is proxied correctly.
 TEST_P(TcpProxySslIntegrationTest, DownstreamHalfClose) {
   setupConnections();


### PR DESCRIPTION
ServerConnectionImpl::initializeReadFilters() unconditionally called onConnected() after filter initialization. If a filter closed the connection during onNewConnection() (e.g. due to circuit breaker max_connections overflow), the SSL socket state would have already transitioned from PreHandshake to ShutdownSent, causing the assert in SslSocket::onConnected() to fire (on debug builds).

Add a state() == Open check before calling onConnected() to skip the call when the connection was already closed during filter init.
