### PR TITLE
local_ratelimit: fix resetSeconds() calculation

### DIFF
--- a/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
+++ b/source/extensions/filters/common/local_ratelimit/local_ratelimit_impl.h
@@ -122,7 +122,8 @@ public:
     return static_cast<uint64_t>(token_bucket_.remainingTokens());
   }
   uint64_t resetSeconds() const override {
-    return static_cast<uint64_t>(std::ceil(token_bucket_.nextTokenAvailable().count() / 1000));
+    return static_cast<uint64_t>(
+        std::chrono::ceil<std::chrono::seconds>(token_bucket_.nextTokenAvailable()).count());
   }
 
 private:


### PR DESCRIPTION
Commit Message: local_ratelimit: fix resetSeconds() calculation
Additional Description: Use std::chrono::ceil to correctly round up nextTokenAvailable() to seconds, avoiding integer division truncation which caused incorrect x-ratelimit-reset header values when simulated time advanced by small increments. Part of trying to use simulated time in tests.