### PR TITLE
dynamic_modules: share ownership of the listener filter

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__fixed-a-crash-in-the-listener-filter.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__fixed-a-crash-in-the-listener-filter.rst
@@ -1,0 +1,4 @@
+Fixed a crash in the listener dynamic module filter where a module that issued an HTTP callout
+aborted the worker. The callout path called ``shared_from_this`` on a filter that was not shared
+owned, which threw ``std::bad_weak_ptr``. The filter is now held by a ``shared_ptr`` so the async
+callout and scheduler paths work.

--- a/source/extensions/filters/listener/dynamic_modules/factory.cc
+++ b/source/extensions/filters/listener/dynamic_modules/factory.cc
@@ -75,10 +75,15 @@ DynamicModuleListenerFilterConfigFactory::createListenerFilterFactoryFromProto(
 
   return [filter_cfg = filter_config.value(),
           listener_filter_matcher](Network::ListenerFilterManager& filter_manager) -> void {
+    // The manager owns filters as a unique_ptr, but the async callout and scheduler paths call
+    // shared_from_this. Hold the filter in a shared_ptr and hand the manager a forwarding adapter.
     auto filter =
-        std::make_unique<Extensions::DynamicModules::ListenerFilters::DynamicModuleListenerFilter>(
+        std::make_shared<Extensions::DynamicModules::ListenerFilters::DynamicModuleListenerFilter>(
             filter_cfg);
-    filter_manager.addAcceptFilter(listener_filter_matcher, std::move(filter));
+    filter_manager.addAcceptFilter(
+        listener_filter_matcher,
+        std::make_unique<Extensions::DynamicModules::ListenerFilters::SharedListenerFilterAdapter>(
+            std::move(filter)));
   };
 }
 

--- a/source/extensions/filters/listener/dynamic_modules/filter.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter.h
@@ -113,7 +113,7 @@ private:
   // Worker dispatcher published at callback-init, cleared on destroy. Read via `dispatcher()`.
   std::atomic<Event::Dispatcher*> cached_dispatcher_{nullptr};
 
-  uint32_t worker_index_;
+  uint32_t worker_index_ = 0;
 
   /**
    * This implementation of the AsyncClient::Callbacks is used to handle the response from the HTTP
@@ -146,6 +146,29 @@ private:
 
   absl::flat_hash_map<uint64_t, std::unique_ptr<DynamicModuleListenerFilter::HttpCalloutCallback>>
       http_callouts_;
+};
+
+/**
+ * Adapts a shared_ptr-owned DynamicModuleListenerFilter to the unique_ptr that the listener
+ * filter manager requires. Shared ownership is needed because the async HTTP callout and
+ * scheduler paths call shared_from_this. Every ListenerFilter method forwards to the filter.
+ */
+class SharedListenerFilterAdapter : public Network::ListenerFilter {
+public:
+  explicit SharedListenerFilterAdapter(DynamicModuleListenerFilterSharedPtr filter)
+      : filter_(std::move(filter)) {}
+
+  Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override {
+    return filter_->onAccept(cb);
+  }
+  Network::FilterStatus onData(Network::ListenerFilterBuffer& buffer) override {
+    return filter_->onData(buffer);
+  }
+  void onClose() override { filter_->onClose(); }
+  size_t maxReadBytes() const override { return filter_->maxReadBytes(); }
+
+private:
+  const DynamicModuleListenerFilterSharedPtr filter_;
 };
 
 /**

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -2064,6 +2064,32 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
   envoy_dynamic_module_callback_listener_filter_scheduler_delete(scheduler);
 }
 
+// new_scheduler captures weak_from_this. On a make_unique-owned filter that is empty, so commit
+// never posts and onScheduled never runs. Shared ownership delivers the event. This guards the
+// scheduler half of the fix the same way the callout test guards the callout half.
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SchedulerRequiresSharedOwnership) {
+  auto unique_filter = std::make_unique<DynamicModuleListenerFilter>(filter_config_);
+  unique_filter->onAccept(callbacks_);
+  auto* unique_scheduler =
+      envoy_dynamic_module_callback_listener_filter_scheduler_new(unique_filter.get());
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).Times(0);
+  envoy_dynamic_module_callback_listener_filter_scheduler_commit(unique_scheduler, 1);
+  envoy_dynamic_module_callback_listener_filter_scheduler_delete(unique_scheduler);
+  testing::Mock::VerifyAndClearExpectations(&worker_thread_dispatcher_);
+
+  auto shared_filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  shared_filter->onAccept(callbacks_);
+  auto* shared_scheduler =
+      envoy_dynamic_module_callback_listener_filter_scheduler_new(shared_filter.get());
+  Event::PostCb captured_cb;
+  EXPECT_CALL(worker_thread_dispatcher_, post(_)).WillOnce(testing::Invoke([&](Event::PostCb cb) {
+    captured_cb = std::move(cb);
+  }));
+  envoy_dynamic_module_callback_listener_filter_scheduler_commit(shared_scheduler, 1);
+  captured_cb();
+  envoy_dynamic_module_callback_listener_filter_scheduler_delete(shared_scheduler);
+}
+
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest,
        ListenerFilterConfigSchedulerCommitAfterConfigDestroyedDoesNotCrash) {
   auto* scheduler = envoy_dynamic_module_callback_listener_filter_config_scheduler_new(
@@ -2482,6 +2508,40 @@ TEST_F(DynamicModuleListenerFilterHttpCalloutTest, SendHttpCalloutSuccess) {
 
   EXPECT_CALL(request, cancel());
   filter_.reset();
+}
+
+// sendHttpCallout calls shared_from_this. On a make_unique-owned filter that throws
+// std::bad_weak_ptr. Under shared ownership the call proceeds and returns CannotCreateRequest. The
+// integration test guards the production factory wiring.
+TEST_F(DynamicModuleListenerFilterHttpCalloutTest, HttpCalloutRequiresSharedOwnership) {
+  NiceMock<Upstream::MockThreadLocalCluster> cluster;
+  NiceMock<Http::MockAsyncClient> async_client;
+  ON_CALL(cluster_manager_, getThreadLocalCluster("test_cluster"))
+      .WillByDefault(testing::Return(&cluster));
+  ON_CALL(cluster, httpAsyncClient()).WillByDefault(testing::ReturnRef(async_client));
+  ON_CALL(async_client, send_(testing::_, testing::_, testing::_))
+      .WillByDefault(testing::Return(nullptr));
+
+  std::vector<envoy_dynamic_module_type_module_http_header> headers = {
+      {.key_ptr = ":method", .key_length = 7, .value_ptr = "GET", .value_length = 3},
+      {.key_ptr = ":path", .key_length = 5, .value_ptr = "/test", .value_length = 5},
+      {.key_ptr = "host", .key_length = 4, .value_ptr = "example.com", .value_length = 11},
+  };
+  uint64_t callout_id = 0;
+
+  auto unique_filter = std::make_unique<DynamicModuleListenerFilter>(filter_config_);
+  unique_filter->onAccept(callbacks_);
+  EXPECT_THROW(envoy_dynamic_module_callback_listener_filter_http_callout(
+                   unique_filter.get(), &callout_id, {"test_cluster", 12}, headers.data(),
+                   headers.size(), {nullptr, 0}, 5000),
+               std::bad_weak_ptr);
+
+  auto shared_filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  shared_filter->onAccept(callbacks_);
+  EXPECT_EQ(envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest,
+            envoy_dynamic_module_callback_listener_filter_http_callout(
+                shared_filter.get(), &callout_id, {"test_cluster", 12}, headers.data(),
+                headers.size(), {nullptr, 0}, 5000));
 }
 
 TEST_F(DynamicModuleListenerFilterHttpCalloutTest, SendHttpCalloutSuccessWithCallback) {

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -402,6 +402,31 @@ TEST_F(DynamicModuleListenerFilterTest, MetricsInvalidId) {
                 static_cast<void*>(filter.get()), 999, 1));
 }
 
+// The listener manager owns filters as a unique_ptr, so the adapter holds the filter in a
+// shared_ptr and forwards every ListenerFilter method to it. Shared ownership is what lets the
+// async callout and scheduler paths call shared_from_this. The integration test is the guard for
+// the production factory wiring.
+TEST_F(DynamicModuleListenerFilterTest, AdapterForwardsAndOwnsFilter) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  std::weak_ptr<DynamicModuleListenerFilter> weak = filter;
+  auto adapter = std::make_unique<SharedListenerFilterAdapter>(filter);
+
+  EXPECT_EQ(Network::FilterStatus::Continue, adapter->onAccept(callbacks_));
+  EXPECT_EQ(&callbacks_, filter->callbacks());
+
+  Buffer::OwnedImpl buffer("test data");
+  TestListenerFilterBuffer test_buffer(buffer);
+  EXPECT_EQ(Network::FilterStatus::Continue, adapter->onData(test_buffer));
+  EXPECT_EQ(filter->maxReadBytes(), adapter->maxReadBytes());
+  adapter->onClose();
+
+  // The adapter holds the only remaining strong reference and releases it on destruction.
+  filter.reset();
+  EXPECT_FALSE(weak.expired());
+  adapter.reset();
+  EXPECT_TRUE(weak.expired());
+}
+
 } // namespace ListenerFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/listener/integration_test.cc
+++ b/test/extensions/dynamic_modules/listener/integration_test.cc
@@ -77,4 +77,23 @@ TEST_P(DynamicModulesListenerSdkIntegrationTest, BufferRead) {
   tcp_client->close();
 }
 
+// Regression test for the listener filter shared-ownership fix. A make_unique-owned listener filter
+// aborted the worker when a module issued an HTTP callout, because sendHttpCallout calls
+// shared_from_this which throws std::bad_weak_ptr on a non-shared-owned object. The production
+// factory now shares ownership via an adapter. The autonomous upstream services the callout so the
+// filter resumes the accept. Rust-only because the bug is in the language-agnostic C++ factory and
+// one module exercises it.
+TEST_P(DynamicModulesListenerSdkIntegrationTest, HttpCalloutOnAcceptDoesNotCrash) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the http_callout_on_accept filter is only in the rust test module";
+  }
+  autonomous_upstream_ = true;
+  initializeFilter("http_callout_on_accept");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("ping"));
+  tcp_client->waitForData("ping");
+  tcp_client->close();
+}
+
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -17,6 +17,7 @@ fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListen
   match name {
     "write_to_socket" => Some(Box::new(WriteToSocketFilterConfig)),
     "buffer_read" => Some(Box::new(BufferReadFilterConfig)),
+    "http_callout_on_accept" => Some(Box::new(HttpCalloutOnAcceptFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -91,5 +92,59 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for BufferReadFilter {
 
   fn max_read_bytes(&mut self, _envoy_filter: &mut ELF) -> usize {
     4
+  }
+}
+
+// =============================================================================
+// HTTP Callout On Accept Test Filter
+// =============================================================================
+
+// Issues an HTTP callout on accept and resumes the chain when it completes. The callout calls
+// shared_from_this on the filter, which throws std::bad_weak_ptr and aborts the worker unless the
+// production factory shares ownership. The callout targets cluster_0, served by the test autonomous
+// upstream.
+struct HttpCalloutOnAcceptFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for HttpCalloutOnAcceptFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(HttpCalloutOnAcceptFilter)
+  }
+}
+
+struct HttpCalloutOnAcceptFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for HttpCalloutOnAcceptFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    let (result, _id) = envoy_filter.send_http_callout(
+      "cluster_0",
+      vec![
+        (":method", b"GET"),
+        (":path", b"/"),
+        ("host", b"example.com"),
+      ],
+      None,
+      5000,
+    );
+    // Always wait for the callout. The accept resumes only from on_http_callout_done, so the test
+    // echo proves the round trip ran. The autonomous upstream makes the callout succeed.
+    assert_eq!(
+      result,
+      abi::envoy_dynamic_module_type_http_callout_init_result::Success
+    );
+    abi::envoy_dynamic_module_type_on_listener_filter_status::StopIteration
+  }
+
+  fn on_http_callout_done(
+    &mut self,
+    envoy_filter: &mut ELF,
+    _callout_id: u64,
+    _result: abi::envoy_dynamic_module_type_http_callout_result,
+    _response_headers: Vec<(EnvoyBuffer, EnvoyBuffer)>,
+    _response_body: Vec<EnvoyBuffer>,
+  ) {
+    envoy_filter.continue_filter_chain(true);
   }
 }


### PR DESCRIPTION
## Description

The listener filter derives `enable_shared_from_this` and uses `shared_from_this` for the HTTP callout path and `weak_from_this` for the scheduler, but the factory created it with `make_unique`. `shared_from_this` then threw `std::bad_weak_ptr` and aborted the worker on the first callout, and the scheduler silently dropped its events.

We are making it such that the factory now holds the filter in a `shared_ptr` and hands the manager a `SharedListenerFilterAdapter` that forwards the `ListenerFilter` interface, so both async paths work.

---

**Commit Message:** dynamic_modules: share ownership of the listener filter
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** Added