### PR TITLE
dynamic_modules: stop the streaming-response ABI from re-entering the module

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__fixed-http-streaming-response-reentry.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__fixed-http-streaming-response-reentry.rst
@@ -1,0 +1,4 @@
+Fixed a bug in the HTTP dynamic module filter where the streaming-response callbacks
+``send_response_headers``, ``send_response_data`` and ``send_response_trailers`` re-entered the
+module's own encode hooks for the response it was producing. The encode hooks are now suppressed
+for these responses, matching the behavior of ``send_response``.

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -964,7 +964,7 @@ void envoy_dynamic_module_callback_http_send_response_headers(
     headers->addCopy(Http::LowerCaseString(key), value);
   }
 
-  filter->decoder_callbacks_->encodeHeaders(std::move(headers), end_stream, "");
+  filter->sendResponseHeaders(std::move(headers), end_stream);
 }
 
 void envoy_dynamic_module_callback_http_send_response_data(
@@ -976,7 +976,7 @@ void envoy_dynamic_module_callback_http_send_response_data(
   }
 
   Buffer::OwnedImpl buffer(absl::string_view{data.ptr, data.length});
-  filter->decoder_callbacks_->encodeData(buffer, end_stream);
+  filter->sendResponseData(buffer, end_stream);
 }
 
 void envoy_dynamic_module_callback_http_send_response_trailers(
@@ -996,7 +996,7 @@ void envoy_dynamic_module_callback_http_send_response_trailers(
     trailers->addCopy(Http::LowerCaseString(key), value);
   }
 
-  filter->decoder_callbacks_->encodeTrailers(std::move(trailers));
+  filter->sendResponseTrailers(std::move(trailers));
 }
 
 size_t envoy_dynamic_module_callback_http_get_body_size(

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -167,6 +167,21 @@ void DynamicModuleHttpFilter::sendLocalReply(
   decoder_callbacks_->sendLocalReply(code, body, modify_headers, grpc_status, details);
 }
 
+void DynamicModuleHttpFilter::sendResponseHeaders(ResponseHeaderMapPtr&& headers, bool end_stream) {
+  sent_local_reply_ = true;
+  decoder_callbacks_->encodeHeaders(std::move(headers), end_stream, "");
+}
+
+void DynamicModuleHttpFilter::sendResponseData(Buffer::Instance& data, bool end_stream) {
+  sent_local_reply_ = true;
+  decoder_callbacks_->encodeData(data, end_stream);
+}
+
+void DynamicModuleHttpFilter::sendResponseTrailers(ResponseTrailerMapPtr&& trailers) {
+  sent_local_reply_ = true;
+  decoder_callbacks_->encodeTrailers(std::move(trailers));
+}
+
 void DynamicModuleHttpFilter::encodeComplete() {};
 
 envoy_dynamic_module_type_http_callout_init_result

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -81,6 +81,13 @@ public:
                       const absl::optional<Grpc::Status::GrpcStatus> grpc_status,
                       absl::string_view details);
 
+  // Drive the response encoder directly for the streaming-response ABI. These set
+  // sent_local_reply_ so the module's own encode hooks are not re-entered for the response it is
+  // producing, matching sendLocalReply.
+  void sendResponseHeaders(ResponseHeaderMapPtr&& headers, bool end_stream);
+  void sendResponseData(Buffer::Instance& data, bool end_stream);
+  void sendResponseTrailers(ResponseTrailerMapPtr&& trailers);
+
   // The callbacks for the filter. Worker-thread only; foreign threads must use `dispatcher()`.
   // They are only valid until onDestroy() is called.
   StreamDecoderFilterCallbacks* decoder_callbacks_ = nullptr;
@@ -274,8 +281,9 @@ private:
   // This helps to avoid reentering the module when sending a local reply. For example, if
   // sendLocalReply() is called, encodeHeaders and encodeData will be called again inline on top of
   // the stack calling it, which can be problematic. For example, with Rust, that might cause
-  // multiple mutable borrows of the same object. In practice, a module shouldn't need encodeHeaders
-  // and encodeData to be called for local reply contents, so we just skip them with this flag.
+  // multiple mutable borrows of the same object. In practice, a module shouldn't need its encode
+  // hooks called for local reply contents, so we just skip them with this flag. The
+  // streaming-response ABI (sendResponseHeaders and friends) sets it for the same reason.
   bool sent_local_reply_ = false;
 
   const DynamicModuleHttpFilterConfigSharedPtr config_ = nullptr;

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -538,6 +538,39 @@ TEST_F(DynamicModuleHttpFilterTest, SendResponseWithCustomResponseCodeDetails) {
                                                    {test_details.data(), test_details.size()});
 }
 
+// The streaming-response ABI forwards to the encoder and sets sent_local_reply_. Each test pins the
+// forwarded encoder call, then drives the matching encode hook and asserts it returns Continue
+// without touching the null fixture config, which both proves the suppression and would crash
+// before the fix.
+TEST_F(DynamicModuleHttpFilterTest, SendResponseHeadersSuppressesEncodeHook) {
+  EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, false));
+  std::vector<envoy_dynamic_module_type_module_http_header> headers = {
+      {.key_ptr = ":status", .key_length = 7, .value_ptr = "200", .value_length = 3}};
+  envoy_dynamic_module_callback_http_send_response_headers(filter_.get(), headers.data(),
+                                                           headers.size(), false);
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter_->encodeHeaders(response_headers_, false));
+}
+
+TEST_F(DynamicModuleHttpFilterTest, SendResponseDataSuppressesEncodeHook) {
+  EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
+  absl::string_view data = "chunk";
+  envoy_dynamic_module_callback_http_send_response_data(filter_.get(), {data.data(), data.size()},
+                                                        true);
+  Buffer::OwnedImpl buffer("more");
+  EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+}
+
+TEST_F(DynamicModuleHttpFilterTest, SendResponseTrailersSuppressesEncodeHook) {
+  EXPECT_CALL(decoder_callbacks_, encodeTrailers_(_));
+  std::vector<envoy_dynamic_module_type_module_http_header> trailers = {
+      {.key_ptr = "x-trailer", .key_length = 9, .value_ptr = "v", .value_length = 1}};
+  envoy_dynamic_module_callback_http_send_response_trailers(filter_.get(), trailers.data(),
+                                                            trailers.size());
+  EXPECT_EQ(Envoy::Http::FilterTrailersStatus::Continue,
+            filter_->encodeTrailers(response_trailers_));
+}
+
 TEST_F(DynamicModuleHttpFilterTest, AddCustomFlag) {
   // Test with empty response.
   EXPECT_CALL(decoder_callbacks_.stream_info_, addCustomFlag(testing::Eq("XXX")));

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -464,6 +464,28 @@ TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnResponseHeaders) {
       response->headers().get(Http::LowerCaseString("some_header"))[0]->value().getStringView());
 }
 
+// Regression test for the streaming-response re-entry fix. The filter produces its response with
+// send_response_headers and stamps a marker from on_response_headers. Before the fix the streaming
+// response re-entered that hook and leaked the marker onto the module's own response. Rust-only
+// because the streaming_response_reentry filter lives in the rust test module.
+TEST_P(DynamicModulesIntegrationTest, StreamingResponseDoesNotReenterEncodeHooks) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the streaming_response_reentry filter is only in the rust test module";
+  }
+  initializeFilter("streaming_response_reentry");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_, true);
+  auto response = std::move(encoder_decoder.second);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_FALSE(response->headers().get(Http::LowerCaseString("x-produced")).empty());
+  // The module's response hook must not run for the response it produced.
+  EXPECT_TRUE(response->headers().get(Http::LowerCaseString("x-reentered")).empty());
+}
+
 TEST_P(DynamicModulesIntegrationTest, HttpCalloutsNonExistentCluster) {
   initializeFilter("http_callouts", "missing");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -86,6 +86,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       }))
     },
     "streaming_terminal_filter" => Some(Box::new(StreamingTerminalFilterConfig {})),
+    "streaming_response_reentry" => Some(Box::new(StreamingResponseReentryFilterConfig {})),
     "buffer_limit_filter" => Some(Box::new(BufferLimitFilterConfig {})),
     "http_stream_basic" => Some(Box::new(HttpStreamBasicConfig {
       cluster_name: String::from_utf8(config.to_owned()).unwrap(),
@@ -1486,6 +1487,44 @@ impl StreamingTerminalHttpFilter {
     let chunk = vec![b'a'; chunk_size];
     envoy_filter.send_response_data(&chunk, false);
     self.large_response_bytes_sent += chunk_size;
+  }
+}
+
+// =============================================================================
+// Streaming Response Reentry Test Filter
+// =============================================================================
+
+// Produces a response inline with the streaming-response ABI, then stamps a marker header from
+// on_response_headers. Without the fix the streaming response re-enters this hook, so the marker
+// leaks onto the module's own response. With the fix the hook is suppressed and the marker is
+// absent.
+struct StreamingResponseReentryFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for StreamingResponseReentryFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(StreamingResponseReentryHttpFilter {})
+  }
+}
+
+struct StreamingResponseReentryHttpFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamingResponseReentryHttpFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    envoy_filter.send_response_headers(&[(":status", b"200"), ("x-produced", b"yes")], true);
+    envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  }
+
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    envoy_filter.set_response_header("x-reentered", b"yes");
+    envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }
 


### PR DESCRIPTION
## Description

The HTTP filter streaming-response callbacks `send_response_headers`, `send_response_data` and `send_response_trailers` drove the encoder directly without setting `sent_local_reply_`, so the filter's own encode hooks re-entered the module on the response it was producing. `send_response` avoids this by going through `sendLocalReply` which sets the flag.

The three callbacks now go through filter methods that set `sent_local_reply_` first, matching send_response, so the encode hooks are suppressed.

---

**Commit Message:** dynamic_modules: stop the streaming-response ABI from re-entering the module
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** Added