### PR TITLE
dynamic modules: support reentrancy in CatchUnwind

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__fixed-ub-if-catch-unwind-filter-reenters.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__fixed-ub-if-catch-unwind-filter-reenters.rst
@@ -1,0 +1,4 @@
+Fixed undefined behavior in dynamic modules wrapped with CatchUnwind if the filter
+was reentered during a callback (e.g., on_stream_complete being invoked inline when
+responding with end-of-stream from on_scheduled). The filter is now borrowed instead
+of taken when checking for poison.

--- a/source/extensions/dynamic_modules/sdk/rust/src/catch_unwind.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/catch_unwind.rs
@@ -1,15 +1,19 @@
 /// Opt-in panic guard that wraps a filter and catches panics at the trait boundary.
 ///
 /// When a wrapped filter method panics, `CatchUnwind`:
-/// 1. Drops the inner filter (preventing access to potentially inconsistent state).
+/// 1. Marks the wrapper poisoned so no later callback re-enters the (possibly inconsistent) filter.
 /// 2. Logs the panic payload.
 /// 3. Fails closed — sends a 500 response and/or returns `StopIteration` for HTTP filters, closes
 ///    the connection for network filters, etc.
 ///
-/// Subsequent callbacks on a poisoned wrapper behave differently depending on type:
-/// - Status-returning callbacks panic immediately. This indicates the fail-closed mechanism did not
-///   terminate the stream as expected.
+/// Subsequent callbacks on a poisoned wrapper are not forwarded to the filter:
+/// - Status-returning callbacks fail closed (apply the same fail-closed action as a panic).
 /// - Late async, event, and cleanup callbacks are silently skipped.
+///
+/// The filter is borrowed in place for each callback rather than moved out, so synchronous
+/// re-entrancy (Envoy calling back into the same wrapper while a callback is still on the stack,
+/// e.g. `on_stream_complete` fired inline while completing a response from `on_scheduled`) sees a
+/// live filter instead of being misread as poisoned.
 ///
 /// # Usage
 ///
@@ -29,7 +33,8 @@
 /// }
 /// ```
 pub struct CatchUnwind<F> {
-  filter: Option<F>,
+  filter: F,
+  poisoned: bool,
 }
 
 enum CatchError {
@@ -40,40 +45,47 @@ enum CatchError {
 impl<F> CatchUnwind<F> {
   pub fn new(filter: F) -> Self {
     Self {
-      filter: Some(filter),
+      filter,
+      poisoned: false,
     }
   }
 
   /// Run `f` on the inner filter, catching any panic.
   ///
-  /// If the filter was already poisoned by a prior panic, panics immediately — a
-  /// status-returning callback on a poisoned filter means the fail-closed mechanism
-  /// didn't terminate the stream as expected.
+  /// If the filter was already poisoned by a prior panic, fails closed immediately (returns
+  /// `Err(())`) rather than calling into the inconsistent filter.
+  ///
+  /// The filter is borrowed in place rather than moved out for the duration of the call. This keeps
+  /// the inner filter reachable if Envoy synchronously re-enters this same wrapper while `f` is
+  /// still on the stack (e.g. completing a response with end-of-stream from a scheduled callback
+  /// drives `on_stream_complete` inline). A move-out approach would make that legitimate re-entrancy
+  /// look like a poisoned filter.
+  ///
+  /// SAFETY: re-entrancy means two `&mut self.filter` can be live across stack frames (the outer
+  /// call plus the re-entrant one, each deriving `&mut CatchUnwind` from the same raw FFI pointer).
+  /// This mirrors the aliasing that already exists for the wrapper itself at every FFI entry point;
+  /// borrowing the filter in place does not widen it.
   fn catch<R>(&mut self, name: &str, f: impl FnOnce(&mut F) -> R) -> Result<R, ()> {
-    let mut filter = self
-      .filter
-      .take()
-      .expect("status-returning callback invoked on a poisoned filter");
-    // AssertUnwindSafe is sound here: if a panic occurs, `filter` is not put back into
-    // `self.filter` — it is dropped at the end of this scope, so no code ever observes
-    // the potentially inconsistent state.
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut filter))) {
-      Ok(val) => {
-        self.filter = Some(filter);
-        Ok(val)
-      },
+    if self.poisoned {
+      return Err(());
+    }
+    // AssertUnwindSafe is sound here: if `f` panics, `poisoned` is set so no later callback ever
+    // observes the potentially inconsistent filter. The filter is dropped only when the wrapper is.
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut self.filter))) {
+      Ok(val) => Ok(val),
       Err(panic) => {
         crate::envoy_log_error!(
           "{}: caught panic: {}",
           name,
           crate::panic_payload_to_string(panic)
         );
+        self.poisoned = true;
         Err(())
       },
     }
   }
 
-  /// Like [`catch`](Self::catch), but skips if the filter is already poisoned.
+  /// Like [`catch`](Self::catch), but reports skip vs panic separately.
   ///
   /// This is intended for async, event, and cleanup callbacks that Envoy may still
   /// invoke after a prior fail-closed.
@@ -85,21 +97,19 @@ impl<F> CatchUnwind<F> {
   /// - `Err(CatchError::Poisoned)` if the wrapper was already poisoned and the callback was
   ///   skipped.
   fn catch_or_skip<R>(&mut self, name: &str, f: impl FnOnce(&mut F) -> R) -> Result<R, CatchError> {
-    let Some(mut filter) = self.filter.take() else {
+    if self.poisoned {
       return Err(CatchError::Poisoned);
-    };
-    // See `catch` for AssertUnwindSafe justification.
-    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut filter))) {
-      Ok(val) => {
-        self.filter = Some(filter);
-        Ok(val)
-      },
+    }
+    // See `catch` for the AssertUnwindSafe and borrow-in-place justifications.
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(&mut self.filter))) {
+      Ok(val) => Ok(val),
       Err(panic) => {
         crate::envoy_log_error!(
           "{}: caught panic: {}",
           name,
           crate::panic_payload_to_string(panic)
         );
+        self.poisoned = true;
         Err(CatchError::Panicked)
       },
     }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4170,6 +4170,57 @@ fn test_catch_unwind_http_scheduled_after_poison_is_skipped() {
   );
 }
 
+// Regression test for CatchUnwind re-entrancy. Envoy can synchronously re-enter the same wrapper
+// while an outer callback is still on the stack (e.g. a callback that completes a response with
+// end-of-stream). Here on_scheduled re-derives `&mut CatchUnwind` from the raw wrapper pointer (as
+// every FFI entry point does) and calls a status-returning callback. The take()-based poisoning
+// misread this as a poisoned filter and panicked/failed closed; borrowing in place lets the
+// re-entrant callback run.
+#[test]
+fn test_catch_unwind_http_reentrant_status_callback_is_not_poisoned() {
+  thread_local! {
+    static WRAPPER_PTR: std::cell::Cell<*mut std::ffi::c_void> =
+      const { std::cell::Cell::new(std::ptr::null_mut()) };
+    static RESPONSE_HEADERS_RAN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+  }
+  struct ReentrantFilter;
+  impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ReentrantFilter {
+    fn on_scheduled(&mut self, envoy_filter: &mut EHF, _event_id: u64) {
+      let ptr = WRAPPER_PTR.with(|p| p.get()) as *mut CatchUnwind<ReentrantFilter>;
+      // SAFETY: mirrors the FFI entry points re-deriving &mut from the raw filter ptr while an
+      // outer callback (this on_scheduled) is still on the stack.
+      let wrapper = unsafe { &mut *ptr };
+      HttpFilter::on_response_headers(wrapper, envoy_filter, false);
+    }
+    fn on_response_headers(
+      &mut self,
+      _envoy_filter: &mut EHF,
+      _end_of_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+      RESPONSE_HEADERS_RAN.with(|c| c.set(true));
+      abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+    }
+  }
+
+  RESET_STREAM_CALLED.store(false, std::sync::atomic::Ordering::SeqCst);
+  RESPONSE_HEADERS_RAN.with(|c| c.set(false));
+
+  let mut envoy_filter = http::EnvoyHttpFilterImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+  let mut wrapper = CatchUnwind::new(ReentrantFilter);
+  WRAPPER_PTR.with(|p| {
+    p.set(&mut wrapper as *mut CatchUnwind<ReentrantFilter> as *mut std::ffi::c_void)
+  });
+
+  HttpFilter::on_scheduled(&mut wrapper, &mut envoy_filter, 1);
+
+  // The re-entrant status-returning callback ran instead of being misread as poisoned.
+  assert!(RESPONSE_HEADERS_RAN.with(std::cell::Cell::get));
+  // No false fail-closed: the legitimate re-entrancy did not trip the panic guard.
+  assert!(!RESET_STREAM_CALLED.load(std::sync::atomic::Ordering::SeqCst));
+}
+
 // =============================================================================
 // Cluster Extension FFI stubs for testing.
 // =============================================================================

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4209,9 +4209,8 @@ fn test_catch_unwind_http_reentrant_status_callback_is_not_poisoned() {
     raw_ptr: std::ptr::null_mut(),
   };
   let mut wrapper = CatchUnwind::new(ReentrantFilter);
-  WRAPPER_PTR.with(|p| {
-    p.set(&mut wrapper as *mut CatchUnwind<ReentrantFilter> as *mut std::ffi::c_void)
-  });
+  WRAPPER_PTR
+    .with(|p| p.set(&mut wrapper as *mut CatchUnwind<ReentrantFilter> as *mut std::ffi::c_void));
 
   HttpFilter::on_scheduled(&mut wrapper, &mut envoy_filter, 1);
 

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -486,6 +486,36 @@ TEST_P(DynamicModulesIntegrationTest, StreamingResponseDoesNotReenterEncodeHooks
   EXPECT_TRUE(response->headers().get(Http::LowerCaseString("x-reentered")).empty());
 }
 
+// Regression test for CatchUnwind re-entrancy. The filter is wrapped in the SDK's CatchUnwind panic
+// guard and completes its response with end-of-stream from on_scheduled. Completing with eos drives
+// FilterManager::onStreamComplete inline, synchronously re-entering the same wrapped filter's
+// on_stream_complete while the on_scheduled catch frame is still on the stack. on_stream_complete
+// bumps a counter; before the fix the re-entrant call is misread as a poisoned filter and skipped,
+// so the counter never moves. Rust-only because the reentrant_stream_complete filter lives in the
+// rust test module.
+TEST_P(DynamicModulesIntegrationTest, ReentrantStreamCompleteRunsUnderCatchUnwind) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the reentrant_stream_complete filter is only in the rust test module";
+  }
+  initializeFilter("reentrant_stream_complete");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_, true);
+  auto response = std::move(encoder_decoder.second);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ(
+      "yes",
+      response->headers().get(Http::LowerCaseString("x-done"))[0]->value().getStringView());
+
+  // on_stream_complete must run even though the response was completed (eos) from on_scheduled,
+  // which re-enters the CatchUnwind-wrapped filter synchronously.
+  test_server_->waitForCounter("dynamicmodulescustom.reentrant_stream_complete_total",
+                               testing::Eq(1));
+}
+
 TEST_P(DynamicModulesIntegrationTest, HttpCalloutsNonExistentCluster) {
   initializeFilter("http_callouts", "missing");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -486,7 +486,7 @@ TEST_P(DynamicModulesIntegrationTest, StreamingResponseDoesNotReenterEncodeHooks
   EXPECT_TRUE(response->headers().get(Http::LowerCaseString("x-reentered")).empty());
 }
 
-// Regression test for CatchUnwind re-entrancy. The filter is wrapped in the SDK's CatchUnwind panic
+// Regression test for CatchUnwind reentrancy. The filter is wrapped in the SDK's CatchUnwind panic
 // guard and completes its response with end-of-stream from on_scheduled. Completing with eos drives
 // FilterManager::onStreamComplete inline, synchronously re-entering the same wrapped filter's
 // on_stream_complete while the on_scheduled catch frame is still on the stack. on_stream_complete

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -486,7 +486,7 @@ TEST_P(DynamicModulesIntegrationTest, StreamingResponseDoesNotReenterEncodeHooks
   EXPECT_TRUE(response->headers().get(Http::LowerCaseString("x-reentered")).empty());
 }
 
-// Regression test for CatchUnwind reentrancy. The filter is wrapped in the SDK's CatchUnwind panic
+// Regression test for CatchUnwind re-entry. The filter is wrapped in the SDK's CatchUnwind panic
 // guard and completes its response with end-of-stream from on_scheduled. Completing with eos drives
 // FilterManager::onStreamComplete inline, synchronously re-entering the same wrapped filter's
 // on_stream_complete while the on_scheduled catch frame is still on the stack. on_stream_complete

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -506,9 +506,8 @@ TEST_P(DynamicModulesIntegrationTest, ReentrantStreamCompleteRunsUnderCatchUnwin
 
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-  EXPECT_EQ(
-      "yes",
-      response->headers().get(Http::LowerCaseString("x-done"))[0]->value().getStringView());
+  EXPECT_EQ("yes",
+            response->headers().get(Http::LowerCaseString("x-done"))[0]->value().getStringView());
 
   // on_stream_complete must run even though the response was completed (eos) from on_scheduled,
   // which re-enters the CatchUnwind-wrapped filter synchronously.

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -87,6 +87,11 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     },
     "streaming_terminal_filter" => Some(Box::new(StreamingTerminalFilterConfig {})),
     "streaming_response_reentry" => Some(Box::new(StreamingResponseReentryFilterConfig {})),
+    "reentrant_stream_complete" => Some(Box::new(ReentrantStreamCompleteFilterConfig {
+      stream_complete_total: envoy_filter_config
+        .define_counter("reentrant_stream_complete_total")
+        .unwrap(),
+    })),
     "buffer_limit_filter" => Some(Box::new(BufferLimitFilterConfig {})),
     "http_stream_basic" => Some(Box::new(HttpStreamBasicConfig {
       cluster_name: String::from_utf8(config.to_owned()).unwrap(),
@@ -1525,6 +1530,61 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StreamingResponseReentryHttpFilte
   ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
     envoy_filter.set_response_header("x-reentered", b"yes");
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  }
+}
+
+// =============================================================================
+// Reentrant on_stream_complete Test Filter
+// =============================================================================
+
+// Completes its response with end-of-stream from on_scheduled. Completing with eos drives
+// FilterManager::onStreamComplete inline (before the scheduled callback returns), which synchronously
+// re-enters the same CatchUnwind-wrapped filter's on_stream_complete. If the filter isn't kept
+// alive across the re-entry, on_stream_complete is skipped and the counter isn't incremented.
+struct ReentrantStreamCompleteFilterConfig {
+  stream_complete_total: EnvoyCounterId,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for ReentrantStreamCompleteFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    // The bug under test only manifests through the CatchUnwind panic guard, so the filter must be
+    // wrapped here rather than returned bare.
+    Box::new(CatchUnwind::new(ReentrantStreamCompleteFilter {
+      stream_complete_total: self.stream_complete_total,
+    }))
+  }
+}
+
+struct ReentrantStreamCompleteFilter {
+  stream_complete_total: EnvoyCounterId,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ReentrantStreamCompleteFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    // Defer the response so it is completed from inside a callback rather than inline here.
+    let scheduler = envoy_filter.new_scheduler();
+    _ = std::thread::spawn(move || {
+      scheduler.commit(1);
+    });
+    envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  }
+
+  fn on_scheduled(&mut self, envoy_filter: &mut EHF, _event_id: u64) {
+    // Completing the response with eos re-enters on_stream_complete before this returns. Use the
+    // streaming response ABI (headers then eos data) rather than a local reply so the only re-entry
+    // is into on_stream_complete (the encode hooks are gated by sent_local_reply_).
+    envoy_filter.send_response_headers(&[(":status", b"200"), ("x-done", b"yes")], false);
+    envoy_filter.send_response_data(b"body", true);
+  }
+
+  fn on_stream_complete(&mut self, envoy_filter: &mut EHF) {
+    envoy_filter
+      .increment_counter(self.stream_complete_total, 1)
+      .unwrap();
   }
 }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

I used AI to write this and read each line of code / tweaked comments

Commit Message: dynamic modules: support reentrancy in CatchUnwind
Additional Description:

While #45707 removed a lot of re-entering, it still happens when completing a response with eos since the filter is torn down inline. It seems better for CatchUnwind to independently work if there ever is reentrancy. I have found two reentrancy issues (just added test looking like one since they're the same error)

- send_response_data(eos) - on_stream_complete skipped
- send_response - aborted by heap corruption

Risk Level: Low
Testing: Added
Docs Changes: n/a
Release Notes: Added


/cc @mathetake @agrawroh 