### PR TITLE
dynamic_modules: add network and listener metadata batch setters

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -4254,6 +4254,25 @@ bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, bool* result);
 
+/**
+ * envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch is called by the module
+ * to set multiple string-valued dynamic metadata entries under a single namespace in one call. It
+ * is equivalent to calling envoy_dynamic_module_callback_network_set_dynamic_metadata_string once
+ * per entry but resolves the namespace and merges into the metadata struct only once. Existing
+ * entries with the same key are overwritten. Within a single call, a later entry overwrites an
+ * earlier entry with the same key. An empty array is a no-op and does not create the namespace.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @param filter_namespace is the namespace owned by the module.
+ * @param entries is the pointer to an array of key-value pairs whose values are set as strings. It
+ * may be null only when entries_size is zero.
+ * @param entries_size is the number of entries in the array.
+ */
+void envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size);
+
 // ------------------------------ HTTP Callouts -------------------------------
 
 /**
@@ -5649,6 +5668,26 @@ void envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_number(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, double value);
+
+/**
+ * envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch is called by the
+ * module to set multiple string-valued dynamic metadata entries under a single namespace in one
+ * call. It is equivalent to calling
+ * envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string once per entry but
+ * resolves the namespace and merges into the metadata struct only once. Existing entries with the
+ * same key are overwritten. Within a single call, a later entry overwrites an earlier entry with
+ * the same key. An empty array is a no-op and does not create the namespace.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object.
+ * @param filter_namespace is the namespace of the metadata.
+ * @param entries is the pointer to an array of key-value pairs whose values are set as strings. It
+ * may be null only when entries_size is zero.
+ * @param entries_size is the number of entries in the array.
+ */
+void envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size);
 
 /**
  * envoy_dynamic_module_callback_listener_filter_max_read_bytes is called by the

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -1551,6 +1551,13 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_network_get_dynamic_met
   return false;
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    const envoy_dynamic_module_type_module_key_value_pair*, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch: "
+               "not implemented in this context");
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_http_callout_init_result
 envoy_dynamic_module_callback_network_filter_http_callout(
     envoy_dynamic_module_type_network_filter_envoy_ptr, uint64_t*,
@@ -3053,6 +3060,14 @@ envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_number(
     envoy_dynamic_module_type_module_buffer, double) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_number: not "
                "implemented in this context");
+}
+
+__attribute__((weak)) void
+envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    const envoy_dynamic_module_type_module_key_value_pair*, size_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch: "
+               "not implemented in this context");
 }
 
 __attribute__((weak)) envoy_dynamic_module_type_metrics_result

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -245,6 +245,18 @@ pub trait EnvoyListenerFilter {
   /// Set the string-typed dynamic metadata value with the given namespace and key value.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
+  ///
+  /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
+  /// namespace and merges into the metadata struct only once. Existing entries with the same key
+  /// are overwritten. Within `entries`, a later entry overwrites an earlier one with the same key.
+  /// An empty `entries` is a no-op and does not create the namespace.
+  fn set_dynamic_metadata_string_batch<'a>(
+    &mut self,
+    namespace: &'a str,
+    entries: &'a [(&'a str, &'a str)],
+  );
+
   /// Get the number-typed dynamic metadata value with the given namespace and key value.
   /// Returns None if the metadata is not found or is the wrong type.
   fn get_dynamic_metadata_number(&self, namespace: &str, key: &str) -> Option<f64>;
@@ -947,6 +959,30 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),
         str_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_string_batch(&mut self, namespace: &str, entries: &[(&str, &str)]) {
+    // `pairs` borrows the key/value bytes of `entries`, which outlive this call. Envoy copies the
+    // bytes into the metadata Struct synchronously, so the pointers never dangle. An empty
+    // `entries` yields an empty Vec paired with a zero length the callback treats as a no-op.
+    let mut pairs: Vec<abi::envoy_dynamic_module_type_module_key_value_pair> =
+      Vec::with_capacity(entries.len());
+    for (key, value) in entries {
+      pairs.push(abi::envoy_dynamic_module_type_module_key_value_pair {
+        key_ptr: key.as_ptr() as *const _,
+        key_length: key.len(),
+        value_ptr: value.as_ptr() as *const _,
+        value_length: value.len(),
+      });
+    }
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+        self.raw,
+        str_to_module_buffer(namespace),
+        pairs.as_ptr(),
+        pairs.len(),
       )
     }
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -315,6 +315,18 @@ pub trait EnvoyNetworkFilter {
   /// Set the string-typed dynamic metadata value with the given namespace and key value.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
+  ///
+  /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
+  /// namespace and merges into the metadata struct only once. Existing entries with the same key
+  /// are overwritten. Within `entries`, a later entry overwrites an earlier one with the same key.
+  /// An empty `entries` is a no-op and does not create the namespace.
+  fn set_dynamic_metadata_string_batch<'a>(
+    &mut self,
+    namespace: &'a str,
+    entries: &'a [(&'a str, &'a str)],
+  );
+
   /// Get the string-typed dynamic metadata value with the given namespace and key value.
   /// Returns None if the metadata is not found or is the wrong type.
   fn get_dynamic_metadata_string<'a>(
@@ -1227,6 +1239,30 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),
         str_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_string_batch(&mut self, namespace: &str, entries: &[(&str, &str)]) {
+    // `pairs` borrows the key/value bytes of `entries`, which outlive this call. Envoy copies the
+    // bytes into the metadata Struct synchronously, so the pointers never dangle. An empty
+    // `entries` yields an empty Vec paired with a zero length the callback treats as a no-op.
+    let mut pairs: Vec<abi::envoy_dynamic_module_type_module_key_value_pair> =
+      Vec::with_capacity(entries.len());
+    for (key, value) in entries {
+      pairs.push(abi::envoy_dynamic_module_type_module_key_value_pair {
+        key_ptr: key.as_ptr() as *const _,
+        key_length: key.len(),
+        value_ptr: value.as_ptr() as *const _,
+        value_length: value.len(),
+      });
+    }
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+        self.raw,
+        str_to_module_buffer(namespace),
+        pairs.as_ptr(),
+        pairs.len(),
       )
     }
   }

--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -744,29 +744,6 @@ bool envoy_dynamic_module_callback_listener_filter_get_socket_option_bytes(
   return true;
 }
 
-void envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata(
-    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
-    envoy_dynamic_module_type_module_buffer filter_namespace,
-    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
-  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
-  auto* callbacks = filter->callbacks();
-
-  if (callbacks == nullptr || filter_namespace.ptr == nullptr || key.ptr == nullptr ||
-      value.ptr == nullptr) {
-    return;
-  }
-
-  std::string ns(filter_namespace.ptr, filter_namespace.length);
-  std::string key_str(key.ptr, key.length);
-  std::string value_str(value.ptr, value.length);
-
-  Protobuf::Struct metadata;
-  auto& fields = *metadata.mutable_fields();
-  fields[key_str].set_string_value(value_str);
-
-  callbacks->setDynamicMetadata(ns, metadata);
-}
-
 bool envoy_dynamic_module_callback_listener_filter_set_filter_state(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
@@ -961,6 +938,31 @@ void envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_number(
   Protobuf::Struct metadata;
   auto& fields = *metadata.mutable_fields();
   fields[key_str].set_number_value(value);
+
+  callbacks->setDynamicMetadata(ns, metadata);
+}
+
+void envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+
+  if (callbacks == nullptr || filter_namespace.ptr == nullptr || entries_size == 0) {
+    // An empty batch is a no-op and must not create the namespace.
+    return;
+  }
+
+  std::string ns(filter_namespace.ptr, filter_namespace.length);
+  Protobuf::Struct metadata;
+  auto& fields = *metadata.mutable_fields();
+  for (size_t i = 0; i < entries_size; i++) {
+    const auto& entry = entries[i];
+    absl::string_view key_view(entry.key_ptr, entry.key_length);
+    absl::string_view value_view(entry.value_ptr, entry.value_length);
+    fields[key_view].set_string_value(value_view);
+  }
 
   callbacks->setDynamicMetadata(ns, metadata);
 }

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -52,6 +52,22 @@ void fillBufferChunks(const Buffer::Instance& buffer,
   }
 }
 
+// Returns the mutable dynamic metadata struct for the namespace, creating it if absent. The
+// connection stream info is always available while the filter is processing.
+Protobuf::Struct*
+getDynamicMetadataNamespace(envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+                            envoy_dynamic_module_type_module_buffer ns) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  auto& stream_info = filter->connection().streamInfo();
+  auto* metadata = stream_info.dynamicMetadata().mutable_filter_metadata();
+  absl::string_view namespace_view{ns.ptr, ns.length};
+  auto metadata_namespace = metadata->find(namespace_view);
+  if (metadata_namespace == metadata->end()) {
+    metadata_namespace = metadata->emplace(namespace_view, Protobuf::Struct{}).first;
+  }
+  return &metadata_namespace->second;
+}
+
 } // namespace
 
 extern "C" {
@@ -529,19 +545,12 @@ void envoy_dynamic_module_callback_network_set_dynamic_metadata_string(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
-  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  auto& stream_info = filter->connection().streamInfo();
-
-  std::string namespace_str(filter_namespace.ptr, filter_namespace.length);
+  auto* metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, filter_namespace);
   absl::string_view key_view(key.ptr, key.length);
   absl::string_view value_view(value.ptr, value.length);
-
-  // Get or create the metadata for this namespace.
-  Protobuf::Struct metadata(
-      (*stream_info.dynamicMetadata().mutable_filter_metadata())[namespace_str]);
-  auto& fields = *metadata.mutable_fields();
-  fields[std::string(key_view)].set_string_value(std::string(value_view));
-  stream_info.setDynamicMetadata(namespace_str, metadata);
+  Protobuf::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_string_value(value_view);
+  metadata_namespace->MergeFrom(metadata_value);
 }
 
 bool envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
@@ -581,18 +590,11 @@ void envoy_dynamic_module_callback_network_set_dynamic_metadata_number(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, double value) {
-  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  auto& stream_info = filter->connection().streamInfo();
-
-  std::string namespace_str(filter_namespace.ptr, filter_namespace.length);
+  auto* metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, filter_namespace);
   absl::string_view key_view(key.ptr, key.length);
-
-  // Get or create the metadata for this namespace.
-  Protobuf::Struct metadata(
-      (*stream_info.dynamicMetadata().mutable_filter_metadata())[namespace_str]);
-  auto& fields = *metadata.mutable_fields();
-  fields[std::string(key_view)].set_number_value(value);
-  stream_info.setDynamicMetadata(namespace_str, metadata);
+  Protobuf::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_number_value(value);
+  metadata_namespace->MergeFrom(metadata_value);
 }
 
 bool envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
@@ -629,18 +631,11 @@ void envoy_dynamic_module_callback_network_set_dynamic_metadata_bool(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer filter_namespace,
     envoy_dynamic_module_type_module_buffer key, bool value) {
-  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
-  auto& stream_info = filter->connection().streamInfo();
-
-  std::string namespace_str(filter_namespace.ptr, filter_namespace.length);
+  auto* metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, filter_namespace);
   absl::string_view key_view(key.ptr, key.length);
-
-  // Get or create the metadata for this namespace.
-  Protobuf::Struct metadata(
-      (*stream_info.dynamicMetadata().mutable_filter_metadata())[namespace_str]);
-  auto& fields = *metadata.mutable_fields();
-  fields[std::string(key_view)].set_bool_value(value);
-  stream_info.setDynamicMetadata(namespace_str, metadata);
+  Protobuf::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_bool_value(value);
+  metadata_namespace->MergeFrom(metadata_value);
 }
 
 bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
@@ -671,6 +666,26 @@ bool envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(
 
   *result = field_it->second.bool_value();
   return true;
+}
+
+void envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer filter_namespace,
+    const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size) {
+  if (entries_size == 0) {
+    // An empty batch is a no-op and must not create the namespace.
+    return;
+  }
+  auto* metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, filter_namespace);
+  Protobuf::Struct metadata_value;
+  auto* fields = metadata_value.mutable_fields();
+  for (size_t i = 0; i < entries_size; i++) {
+    const auto& entry = entries[i];
+    absl::string_view key_view(entry.key_ptr, entry.key_length);
+    absl::string_view value_view(entry.value_ptr, entry.value_length);
+    (*fields)[key_view].set_string_value(value_view);
+  }
+  metadata_namespace->MergeFrom(metadata_value);
 }
 
 envoy_dynamic_module_type_http_callout_init_result

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1218,6 +1218,10 @@ WEAK_STUB(NetworkSetDynamicMetadataBool,
 WEAK_STUB(NetworkGetDynamicMetadataBool,
           envoy_dynamic_module_callback_network_get_dynamic_metadata_bool(nullptr, {nullptr, 0},
                                                                           {nullptr, 0}, nullptr))
+WEAK_STUB(NetworkSetDynamicMetadataStringBatch,
+          envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(nullptr,
+                                                                                  {nullptr, 0},
+                                                                                  nullptr, 0))
 
 WEAK_STUB(ListenerFilterGetAddressType,
           envoy_dynamic_module_callback_listener_filter_get_address_type(nullptr))
@@ -1228,6 +1232,9 @@ WEAK_STUB(ListenerFilterGetDynamicMetadataNumber,
 WEAK_STUB(ListenerFilterSetDynamicMetadataNumber,
           envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_number(
               nullptr, {nullptr, 0}, {nullptr, 0}, 0))
+WEAK_STUB(ListenerFilterSetDynamicMetadataStringBatch,
+          envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+              nullptr, {nullptr, 0}, nullptr, 0))
 
 WEAK_STUB(HttpAddDynamicMetadataListNumber,
           envoy_dynamic_module_callback_http_add_dynamic_metadata_list_number(nullptr, {nullptr, 0},

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -1456,6 +1456,56 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetDynamicMetadataNullValue) 
                                                                             key_buf, value_buf);
 }
 
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetDynamicMetadataStringBatch) {
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(callbacks_, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(callbacks_, setDynamicMetadata(std::string("test_ns"), testing::_))
+      .WillRepeatedly(testing::SaveArg<1>(&(*metadata.mutable_filter_metadata())["test_ns"]));
+
+  char ns[] = "test_ns";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns, 7};
+
+  // A batch sets every entry, and within the batch a later duplicate key wins.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> entries = {
+      {"k1", 2, "v1", 2},
+      {"k2", 2, "v2", 2},
+      {"k1", 2, "v1b", 3},
+  };
+  envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+      filterPtr(), ns_buf, entries.data(), entries.size());
+
+  envoy_dynamic_module_type_envoy_buffer result;
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_dynamic_metadata_string(
+      filterPtr(), ns_buf, {"k1", 2}, &result));
+  EXPECT_EQ("v1b", std::string(result.ptr, result.length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_dynamic_metadata_string(
+      filterPtr(), ns_buf, {"k2", 2}, &result));
+  EXPECT_EQ("v2", std::string(result.ptr, result.length));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetDynamicMetadataStringBatchEmpty) {
+  // An empty batch is a no-op and must not set any metadata.
+  EXPECT_CALL(callbacks_, setDynamicMetadata(testing::_, testing::_)).Times(0);
+
+  char ns[] = "test_ns";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns, 7};
+  envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+      filterPtr(), ns_buf, nullptr, 0);
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetDynamicMetadataStringBatchNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  filter->onAccept(callbacks_);
+  filter->setCallbacksForTest(nullptr);
+
+  char ns[] = "test_ns";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns, 7};
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> entries = {{"k1", 2, "v1", 2}};
+  // Should not crash with null callbacks.
+  envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string_batch(
+      static_cast<void*>(filter.get()), ns_buf, entries.data(), entries.size());
+}
+
 // =============================================================================
 // Tests for set_filter_state.
 // =============================================================================

--- a/test/extensions/dynamic_modules/listener/integration_test.cc
+++ b/test/extensions/dynamic_modules/listener/integration_test.cc
@@ -96,4 +96,18 @@ TEST_P(DynamicModulesListenerSdkIntegrationTest, HttpCalloutOnAcceptDoesNotCrash
   tcp_client->close();
 }
 
+TEST_P(DynamicModulesListenerSdkIntegrationTest, DynamicMetadataBatch) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the dynamic_metadata filter is only in the rust test module";
+  }
+  initializeFilter("dynamic_metadata");
+
+  // The filter sets batch metadata and reads it back on accept, asserting in the module. A failure
+  // there stops the chain and the echo upstream never returns the payload.
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("ping"));
+  tcp_client->waitForData("ping");
+  tcp_client->close();
+}
+
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -1129,6 +1129,85 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetAndGetDynamicMetadataString
   EXPECT_EQ(value, std::string(result.ptr, result.length));
 }
 
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetDynamicMetadataMergesInPlace) {
+  const std::string ns = "test.ns";
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+
+  // Sequential single sets accumulate under one namespace rather than replacing it.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k1", 2}, {"v1", 2});
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_number(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k2", 2}, 7.0);
+
+  envoy_dynamic_module_type_envoy_buffer result;
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k1", 2}, &result));
+  EXPECT_EQ("v1", std::string(result.ptr, result.length));
+  double number = 0.0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_number(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k2", 2}, &number));
+  EXPECT_DOUBLE_EQ(7.0, number);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetDynamicMetadataStringBatch) {
+  const std::string ns = "test.ns";
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(connection_.stream_info_, dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+
+  envoy_dynamic_module_type_envoy_buffer result;
+
+  // An empty batch is a no-op and must not create the namespace.
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, nullptr, 0);
+  EXPECT_TRUE(metadata.filter_metadata().empty());
+
+  // A batch creates the namespace once and sets every entry.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> entries = {
+      {"k1", 2, "v1", 2},
+      {"k2", 2, "v2", 2},
+  };
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, entries.data(), entries.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k1", 2}, &result));
+  EXPECT_EQ("v1", std::string(result.ptr, result.length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k2", 2}, &result));
+  EXPECT_EQ("v2", std::string(result.ptr, result.length));
+
+  // A later batch overwrites an existing key and merges new keys while leaving untouched keys
+  // intact, proving the in place merge does not drop existing fields.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> merge = {
+      {"k1", 2, "new", 3},
+      {"k3", 2, "v3", 2},
+  };
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, merge.data(), merge.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k1", 2}, &result));
+  EXPECT_EQ("new", std::string(result.ptr, result.length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k2", 2}, &result));
+  EXPECT_EQ("v2", std::string(result.ptr, result.length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"k3", 2}, &result));
+  EXPECT_EQ("v3", std::string(result.ptr, result.length));
+
+  // Within a single batch, a later entry with a duplicate key wins.
+  std::vector<envoy_dynamic_module_type_module_key_value_pair> dup = {
+      {"dup", 3, "first", 5},
+      {"dup", 3, "last", 4},
+  };
+  envoy_dynamic_module_callback_network_set_dynamic_metadata_string_batch(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, dup.data(), dup.size());
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_get_dynamic_metadata_string(
+      filterPtr(), {const_cast<char*>(ns.data()), ns.size()}, {"dup", 3}, &result));
+  EXPECT_EQ("last", std::string(result.ptr, result.length));
+}
+
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, SetAndGetDynamicMetadataNumber) {
   const std::string ns = "test.ns";
   const std::string key = "number.key";

--- a/test/extensions/dynamic_modules/network/integration_test.cc
+++ b/test/extensions/dynamic_modules/network/integration_test.cc
@@ -264,4 +264,28 @@ TEST_P(DynamicModulesNetworkSdkIntegrationTest, BufferLimits) {
   tcp_client->close();
 }
 
+TEST_P(DynamicModulesNetworkSdkIntegrationTest, DynamicMetadataBatch) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the dynamic_metadata filter is only in the rust test module";
+  }
+  initializeSdkFilter("dynamic_metadata");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->connected());
+
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+
+  // The filter sets batch metadata and reads it back on new connection, asserting in the module. A
+  // failure there stops the chain and the upstream never sees data.
+  ASSERT_TRUE(tcp_client->write("hello", false));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+
+  ASSERT_TRUE(tcp_client->write("", true));
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_connection->close());
+  tcp_client->waitForHalfClose();
+  tcp_client->close();
+}
+
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -18,6 +18,7 @@ fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListen
     "write_to_socket" => Some(Box::new(WriteToSocketFilterConfig)),
     "buffer_read" => Some(Box::new(BufferReadFilterConfig)),
     "http_callout_on_accept" => Some(Box::new(HttpCalloutOnAcceptFilterConfig)),
+    "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -146,5 +147,56 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for HttpCalloutOnAcceptFilter
     _response_body: Vec<EnvoyBuffer>,
   ) {
     envoy_filter.continue_filter_chain(true);
+  }
+}
+
+// =============================================================================
+// Dynamic Metadata Test Filter
+// =============================================================================
+
+// Sets several string entries under one namespace via the batch setter on accept, then reads them
+// back to prove the batch and the getter round trip through the ABI. An empty batch must not create
+// a namespace.
+struct DynamicMetadataFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for DynamicMetadataFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(DynamicMetadataFilter)
+  }
+}
+
+struct DynamicMetadataFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for DynamicMetadataFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    envoy_filter.set_dynamic_metadata_string_batch(
+      "dynamic_modules.test",
+      &[
+        ("batch_key1", "batch_value1"),
+        ("batch_key2", "batch_value2"),
+      ],
+    );
+    envoy_filter.set_dynamic_metadata_string_batch("dynamic_modules.empty", &[]);
+
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "batch_key1")
+        .map(|value| value.as_slice().to_vec()),
+      Some(b"batch_value1".to_vec())
+    );
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "batch_key2")
+        .map(|value| value.as_slice().to_vec()),
+      Some(b"batch_value2".to_vec())
+    );
+    assert!(envoy_filter
+      .get_dynamic_metadata_string("dynamic_modules.empty", "batch_key1")
+      .is_none());
+
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
@@ -28,6 +28,7 @@ fn new_network_filter_config_fn<EC: EnvoyNetworkFilterConfig, ENF: EnvoyNetworkF
     },
     "half_close" => Some(Box::new(HalfCloseFilterConfig)),
     "buffer_limits" => Some(Box::new(BufferLimitsFilterConfig)),
+    "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -309,5 +310,56 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for BufferLimitsFilter {
 
   fn on_below_write_buffer_low_watermark(&mut self, _envoy_filter: &mut ENF) {
     BELOW_LOW_WATERMARK_CALLED.store(true, Ordering::SeqCst);
+  }
+}
+
+// =============================================================================
+// Dynamic Metadata Test Filter
+// =============================================================================
+
+// Sets several string entries under one namespace via the batch setter, then reads them back to
+// prove the batch and the getter round trip through the ABI. An empty batch must not create a
+// namespace.
+struct DynamicMetadataFilterConfig;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for DynamicMetadataFilterConfig {
+  fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+    Box::new(DynamicMetadataFilter)
+  }
+}
+
+struct DynamicMetadataFilter;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for DynamicMetadataFilter {
+  fn on_new_connection(
+    &mut self,
+    envoy_filter: &mut ENF,
+  ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+    envoy_filter.set_dynamic_metadata_string_batch(
+      "dynamic_modules.test",
+      &[
+        ("batch_key1", "batch_value1"),
+        ("batch_key2", "batch_value2"),
+      ],
+    );
+    envoy_filter.set_dynamic_metadata_string_batch("dynamic_modules.empty", &[]);
+
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "batch_key1")
+        .map(|value| value.as_slice().to_vec()),
+      Some(b"batch_value1".to_vec())
+    );
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "batch_key2")
+        .map(|value| value.as_slice().to_vec()),
+      Some(b"batch_value2".to_vec())
+    );
+    assert!(envoy_filter
+      .get_dynamic_metadata_string("dynamic_modules.empty", "batch_key1")
+      .is_none());
+
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
   }
 }


### PR DESCRIPTION
## Description

This PR adds a batch string dynamic-metadata setters to the network and listener filter ABIs, the counterparts to the existing HTTP batch callback. Each resolves the namespace and merges into the metadata struct once instead of
once per entry, and is exposed in the Rust SDK as `set_dynamic_metadata_string_batch`.

It also rewrite the network single-key setters (string/number/bool) to merge each value into the namespace in place. Previously each write copied the whole namespace Struct out of stream_info and merged it back, making K writes on a connection cost O(K^2). Behavior is unchanged because `StreamInfo::setDynamicMetadata` already does an in-place MergeFrom. Finally, remove a dead, undeclared duplicate listener string setter.

---

**Commit Message:** dynamic_modules: add network and listener metadata batch setters
**Risk Level:** Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes:** N/A