### PR TITLE
dynamic_modules: add set_dynamic_metadata_bytes and scheduler commit docs

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -2467,6 +2467,10 @@ envoy_dynamic_module_callback_http_filter_scheduler_new(
  *
  * This can be called multiple times to schedule multiple events to the same filter.
  *
+ * This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+ * module must join or quiesce any thread that may call this before worker shutdown so a scheduled
+ * event cannot race the worker dispatcher teardown.
+ *
  * @param scheduler_module_ptr is the pointer to the HTTP filter scheduler created by
  * envoy_dynamic_module_callback_http_filter_scheduler_new.
  * @param event_id is the ID of the event. This can be used to differentiate between multiple
@@ -4726,6 +4730,10 @@ envoy_dynamic_module_callback_network_filter_scheduler_new(
  *
  * This can be called multiple times to schedule multiple events to the same filter.
  *
+ * This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+ * module must join or quiesce any thread that may call this before worker shutdown so a scheduled
+ * event cannot race the worker dispatcher teardown.
+ *
  * @param scheduler_module_ptr is the pointer to the network filter scheduler created by
  * envoy_dynamic_module_callback_network_filter_scheduler_new.
  * @param event_id is the ID of the event. This can be used to differentiate between multiple
@@ -5961,6 +5969,10 @@ envoy_dynamic_module_callback_listener_filter_scheduler_new(
  * event hook on the worker thread.
  *
  * This can be called multiple times to schedule multiple events to the same filter.
+ *
+ * This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+ * module must join or quiesce any thread that may call this before worker shutdown so a scheduled
+ * event cannot race the worker dispatcher teardown.
  *
  * @param scheduler_module_ptr is the pointer to the listener filter scheduler created by
  * envoy_dynamic_module_callback_listener_filter_scheduler_new.

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1161,6 +1161,12 @@ pub trait EnvoyHttpFilter {
   /// Returns true if the operation is successful.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set the dynamic metadata value with the given namespace and key to raw bytes.
+  ///
+  /// The bytes are stored as the metadata value as is, so non-UTF-8 values are preserved. Read
+  /// them back with [`Self::get_metadata_string`].
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]);
+
   /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
   ///
   /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
@@ -2627,6 +2633,17 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_string(
+        self.raw_ptr,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        bytes_to_module_buffer(value),
+      )
+    }
+  }
+
   fn set_dynamic_metadata_string_batch(&mut self, namespace: &str, entries: &[(&str, &str)]) {
     // `pairs` borrows the key/value bytes of `entries`, which outlive this call. Envoy copies the
     // bytes into the metadata Struct synchronously, so the pointers never dangle. An empty
@@ -4033,6 +4050,10 @@ pub trait EnvoyHttpFilterScheduler: Send + Sync {
   /// Once this is called, [`HttpFilter::on_scheduled`] will be called with
   /// the same `event_id` on the worker thread where the filter is running IF
   /// by the time the event is committed, the filter is still alive.
+  ///
+  /// This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+  /// module must join or quiesce any thread that may call this before worker shutdown so a
+  /// scheduled event cannot race the worker dispatcher teardown.
   fn commit(&self, event_id: u64);
 }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -245,6 +245,12 @@ pub trait EnvoyListenerFilter {
   /// Set the string-typed dynamic metadata value with the given namespace and key value.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set the dynamic metadata value with the given namespace and key to raw bytes.
+  ///
+  /// The bytes are stored as the metadata value as is, so non-UTF-8 values are preserved. Read
+  /// them back with [`Self::get_dynamic_metadata_string`].
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]);
+
   /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
   ///
   /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
@@ -471,6 +477,10 @@ pub trait EnvoyListenerFilterScheduler: Send + Sync {
   /// Once this is called, [`ListenerFilter::on_scheduled`] will be called with
   /// the same `event_id` on the worker thread where the filter is running IF
   /// by the time the event is committed, the filter is still alive.
+  ///
+  /// This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+  /// module must join or quiesce any thread that may call this before worker shutdown so a
+  /// scheduled event cannot race the worker dispatcher teardown.
   fn commit(&self, event_id: u64);
 }
 
@@ -959,6 +969,17 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),
         str_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_dynamic_metadata_string(
+        self.raw,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        crate::bytes_to_module_buffer(value),
       )
     }
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -315,6 +315,12 @@ pub trait EnvoyNetworkFilter {
   /// Set the string-typed dynamic metadata value with the given namespace and key value.
   fn set_dynamic_metadata_string(&mut self, namespace: &str, key: &str, value: &str);
 
+  /// Set the dynamic metadata value with the given namespace and key to raw bytes.
+  ///
+  /// The bytes are stored as the metadata value as is, so non-UTF-8 values are preserved. Read
+  /// them back with [`Self::get_dynamic_metadata_string`].
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]);
+
   /// Set multiple string-typed dynamic metadata entries under `namespace` in a single call.
   ///
   /// Equivalent to calling [`Self::set_dynamic_metadata_string`] once per entry but resolves the
@@ -584,6 +590,10 @@ pub trait EnvoyNetworkFilterScheduler: Send + Sync {
   /// Once this is called, [`NetworkFilter::on_scheduled`] will be called with
   /// the same `event_id` on the worker thread where the filter is running IF
   /// by the time the event is committed, the filter is still alive.
+  ///
+  /// This is safe to call from any thread and is a no-op once the filter has been destroyed. The
+  /// module must join or quiesce any thread that may call this before worker shutdown so a
+  /// scheduled event cannot race the worker dispatcher teardown.
   fn commit(&self, event_id: u64);
 }
 
@@ -1239,6 +1249,17 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
         str_to_module_buffer(namespace),
         str_to_module_buffer(key),
         str_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_bytes(&mut self, namespace: &str, key: &str, value: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_set_dynamic_metadata_string(
+        self.raw,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        bytes_to_module_buffer(value),
       )
     }
   }

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -388,6 +388,12 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
     // The empty batch must not have created a namespace.
     EXPECT_EQ(metadata.filter_metadata().find("ns_req_header_batch_empty"),
               metadata.filter_metadata().end());
+    // The non-UTF-8 byte value round-trips through the string value unchanged.
+    auto ns_req_header_bytes = metadata.filter_metadata().find("ns_req_header_bytes");
+    ASSERT_NE(ns_req_header_bytes, metadata.filter_metadata().end());
+    auto bytes_key = ns_req_header_bytes->second.fields().find("key");
+    ASSERT_NE(bytes_key, ns_req_header_bytes->second.fields().end());
+    EXPECT_EQ(bytes_key->second.string_value(), std::string("\xff\x00\xfe", 3));
   }
   auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
   ASSERT_NE(ns_req_body, metadata.filter_metadata().end());

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -728,6 +728,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
       .set_dynamic_metadata_string_batch("ns_req_header_batch", &[("k1", "v1"), ("k2", "v2")]);
     envoy_filter.set_dynamic_metadata_string_batch("ns_req_header_batch_empty", &[]);
 
+    // Set a non-UTF-8 byte value, asserted end-to-end by the C++ integration test in filter_test.cc.
+    envoy_filter.set_dynamic_metadata_bytes("ns_req_header_bytes", "key", &[0xff, 0x00, 0xfe]);
+
     // Try getting metadata from rotuer cluster and host.
     let metadata = envoy_filter.get_metadata_string(
       abi::envoy_dynamic_module_type_metadata_source::Route,

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -320,6 +320,13 @@ fn test_dynamic_metadata_callbacks_on_response_body() {
     .withf(|ns, entries| ns == "ns_req_header_batch_empty" && entries.is_empty())
     .return_const(())
     .once();
+  envoy_filter
+    .expect_set_dynamic_metadata_bytes()
+    .withf(|ns, key, value| {
+      ns == "ns_req_header_bytes" && key == "key" && value == &[0xff, 0x00, 0xfe]
+    })
+    .return_const(())
+    .once();
   // Route/Cluster/Host metadata.
   envoy_filter
     .expect_get_metadata_string()

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -197,6 +197,19 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for DynamicMetadataFilter {
       .get_dynamic_metadata_string("dynamic_modules.empty", "batch_key1")
       .is_none());
 
+    // Set a non-UTF-8 byte value and read it back to prove set_dynamic_metadata_bytes preserves it.
+    envoy_filter.set_dynamic_metadata_bytes(
+      "dynamic_modules.test",
+      "bytes_key",
+      &[0xff, 0x00, 0xfe],
+    );
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "bytes_key")
+        .map(|value| value.as_slice().to_vec()),
+      Some(vec![0xff, 0x00, 0xfe])
+    );
+
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
@@ -360,6 +360,19 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for DynamicMetadataFilter {
       .get_dynamic_metadata_string("dynamic_modules.empty", "batch_key1")
       .is_none());
 
+    // Set a non-UTF-8 byte value and read it back to prove set_dynamic_metadata_bytes preserves it.
+    envoy_filter.set_dynamic_metadata_bytes(
+      "dynamic_modules.test",
+      "bytes_key",
+      &[0xff, 0x00, 0xfe],
+    );
+    assert_eq!(
+      envoy_filter
+        .get_dynamic_metadata_string("dynamic_modules.test", "bytes_key")
+        .map(|value| value.as_slice().to_vec()),
+      Some(vec![0xff, 0x00, 0xfe])
+    );
+
     abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
   }
 }


### PR DESCRIPTION
## Description

This PR adds a Rust SDK `set_dynamic_metadata_bytes` setter on the HTTP, network, and listener filters. It reuses the existing set_dynamic_metadata_string callback, which already accepts a raw byte buffer, so a non-UTF-8 value is stored in the metadata string value as is and read back unchanged. No new ABI is added.

It also documents the worker-exit contract on the worker-bound filter scheduler commit callbacks. `commit()` is a no-op once the filter is destroyed, and the module must join or quiesce any thread that may call it before worker shutdown so a scheduled event cannot race the worker dispatcher teardown.

---

**Commit Message**: dynamic_modules: add set_dynamic_metadata_bytes and scheduler commit docs
**Risk Level**: Low
**Testing:** Added
**Docs Changes:** Added
**Release Notes**: N/A