### PR TITLE
Fix IPv4/IPv6 address encoding for big-endian architectures s390x

### DIFF
--- a/contrib/istio/filters/common/source/workload_discovery.cc
+++ b/contrib/istio/filters/common/source/workload_discovery.cc
@@ -89,14 +89,13 @@ public:
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
         uint32_t value = ipv4->address();
         std::array<uint8_t, 4> output;
-        absl::little_endian::Store32(&output, value);
+        memcpy(output.data(), &value, 4);
         return tls_->get(std::string(output.begin(), output.end()));
       } else if (const auto ipv6 = address->ip()->ipv6(); ipv6) {
-        const uint64_t high = absl::Uint128High64(ipv6->address());
-        const uint64_t low = absl::Uint128Low64(ipv6->address());
+        const auto* sa = reinterpret_cast<const sockaddr_in6*>(address->sockAddr());
         std::array<uint8_t, 16> output;
-        absl::little_endian::Store64(&output, low);
-        absl::little_endian::Store64(&output[8], high);
+        static_assert(sizeof(sa->sin6_addr.s6_addr) == 16);
+        memcpy(output.data(), sa->sin6_addr.s6_addr, 16);
         return tls_->get(std::string(output.begin(), output.end()));
       }
     }

--- a/contrib/istio/filters/common/source/workload_discovery.cc
+++ b/contrib/istio/filters/common/source/workload_discovery.cc
@@ -89,13 +89,13 @@ public:
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
         uint32_t value = ipv4->address();
         std::array<uint8_t, 4> output;
-        memcpy(output.data(), &value, 4);
+        memcpy(output.data(), &value, 4); // NOLINT(safe-memcpy)
         return tls_->get(std::string(output.begin(), output.end()));
       } else if (const auto ipv6 = address->ip()->ipv6(); ipv6) {
         const auto* sa = reinterpret_cast<const sockaddr_in6*>(address->sockAddr());
         std::array<uint8_t, 16> output;
         static_assert(sizeof(sa->sin6_addr.s6_addr) == 16);
-        memcpy(output.data(), sa->sin6_addr.s6_addr, 16);
+        memcpy(output.data(), sa->sin6_addr.s6_addr, 16); // NOLINT(safe-memcpy)
         return tls_->get(std::string(output.begin(), output.end()));
       }
     }


### PR DESCRIPTION
Commit Message: Fix IPv4/IPv6 address encoding for big-endian architectures s390x
Additional Description:

this is come from [surenderky](https://github.com/istio/proxy/commits?author=surenderky).

Risk Level: n/a.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.