### PR TITLE
contrib/istio: sync code with istio/proxy to simplify diff

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/peer_metadata/v3/peer_metadata.proto
+++ b/api/contrib/envoy/extensions/filters/network/peer_metadata/v3/peer_metadata.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
-package envoy.extensions.filters.network.peer_metadata.v3;
+package envoy.extensions.network_filters.peer_metadata;
 
 import "udpa/annotations/status.proto";
 
-option java_package = "io.envoyproxy.envoy.extensions.filters.network.peer_metadata.v3";
+option java_package = "io.envoyproxy.envoy.extensions.network_filters.peer_metadata";
 option java_outer_classname = "PeerMetadataProto";
 option java_multiple_files = true;
-option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/filters/network/peer_metadata/v3;peer_metadatav3";
+option go_package = "github.com/envoyproxy/go-control-plane/contrib/envoy/extensions/network_filters/peer_metadata";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // [#protodoc-title: Peer metadata network filter]
@@ -22,9 +22,25 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // response) and injects it as a data preamble to be consumed by the upstream
 // filter.
 message Config {
-  // Filter state key under which the baggage value encoding the proxy workload
-  // is stored. The upstream filter that populates the baggage header in the
-  // HBONE request should use the same key.
+  // What filter state to use to save the baggage value that encodes the proxy
+  // workload.
+  //
+  // The upstream filter that will populate the baggage header in the HBONE
+  // request should be configured to use the same key.
+  //
+  // Why share baggage value via filter state instead of to configure upstream
+  // filter to use the baggage key value directly?
+  //
+  // ztunnel and waypoint have to be aware of the baggage header format,
+  // because they should be able to parse baggage headers to extract the
+  // metadata and report the metrics. However, pilot does not need to be aware
+  // of the baggage encoding yet.
+  //
+  // If instead of using custom filter to generate baggage header value we just
+  // let pilot generate it, it would spread the logic for generating baggage to
+  // the pilot as well. While not a big deal, if there is no clear reason to do
+  // it, let's not duplicate the implementation of baggage logic in pilot and
+  // just re-use the logic we already have in Envoy.
   string baggage_key = 1;
 }
 

--- a/contrib/extensions_metadata.yaml
+++ b/contrib/extensions_metadata.yaml
@@ -184,7 +184,7 @@ envoy.filters.network.peer_metadata:
   security_posture: requires_trusted_downstream_and_upstream
   status: alpha
   type_urls:
-  - envoy.extensions.filters.network.peer_metadata.v3.Config
+  - envoy.extensions.network_filters.peer_metadata.Config
 envoy.filters.network.metadata_exchange:
   categories:
   - envoy.filters.network

--- a/contrib/istio/filters/common/source/hashable_string.cc
+++ b/contrib/istio/filters/common/source/hashable_string.cc
@@ -9,31 +9,33 @@
 
 #include "source/common/common/hash.h"
 
-namespace Envoy {
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 
-HashableString::HashableString(absl::string_view value) : Router::StringAccessorImpl(value) {}
+HashableString::HashableString(absl::string_view value)
+    : Envoy::Router::StringAccessorImpl(value) {}
 
-std::optional<uint64_t> HashableString::hash() const { return HashUtil::xxHash64(asString()); }
+std::optional<uint64_t> HashableString::hash() const {
+  return Envoy::HashUtil::xxHash64(asString());
+}
 
 namespace {
 
-class HashableStringObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+class HashableStringObjectFactory : public Envoy::StreamInfo::FilterState::ObjectFactory {
 public:
   // ObjectFactory
   std::string name() const override { return "istio.hashable_string"; }
 
-  std::unique_ptr<StreamInfo::FilterState::Object>
+  std::unique_ptr<Envoy::StreamInfo::FilterState::Object>
   createFromBytes(absl::string_view data) const override {
     return std::make_unique<HashableString>(data);
   }
 };
 
-REGISTER_FACTORY(HashableStringObjectFactory, StreamInfo::FilterState::ObjectFactory);
+REGISTER_FACTORY(HashableStringObjectFactory, Envoy::StreamInfo::FilterState::ObjectFactory);
 
 } // namespace
 
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/source/hashable_string.h
+++ b/contrib/istio/filters/common/source/hashable_string.h
@@ -6,11 +6,11 @@
 
 #include "source/common/router/string_accessor_impl.h"
 
-namespace Envoy {
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 
-class HashableString : public Router::StringAccessorImpl, public Hashable {
+class HashableString : public Envoy::Router::StringAccessorImpl, public Envoy::Hashable {
 public:
   HashableString(absl::string_view value);
 
@@ -20,4 +20,3 @@ public:
 
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/source/metadata_object.cc
+++ b/contrib/istio/filters/common/source/metadata_object.cc
@@ -11,7 +11,7 @@
 
 #include "absl/strings/str_join.h"
 
-namespace Envoy {
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 
@@ -83,33 +83,35 @@ std::string WorkloadMetadataObject::baggage() const {
     parts.push_back("k8s." + std::string(workload_type) + ".name=" + std::string(workload_name_));
   }
 
-  const auto appName = field(AppNameToken).value_or("");
-  const auto serviceName = field(ServiceNameToken).value_or(appName);
+  const auto appName = field(Istio::Common::AppNameToken).value_or("");
+  const auto serviceName = field(Istio::Common::ServiceNameToken).value_or(appName);
 
   if (!serviceName.empty()) {
-    parts.push_back(absl::StrCat(ServiceNameBaggageToken, "=", serviceName));
+    parts.push_back(absl::StrCat(Istio::Common::ServiceNameBaggageToken, "=", serviceName));
   }
 
   if (!appName.empty() && appName != serviceName) {
-    parts.push_back(absl::StrCat(AppNameBaggageToken, "=", appName));
+    parts.push_back(absl::StrCat(Istio::Common::AppNameBaggageToken, "=", appName));
   }
 
-  const auto appVersion = field(AppVersionToken).value_or("");
-  const auto serviceVersion = field(ServiceVersionToken).value_or(appVersion);
+  const auto appVersion = field(Istio::Common::AppVersionToken).value_or("");
+  const auto serviceVersion = field(Istio::Common::ServiceVersionToken).value_or(appVersion);
 
   if (!serviceVersion.empty()) {
-    parts.push_back(absl::StrCat(ServiceVersionBaggageToken, "=", serviceVersion));
+    parts.push_back(absl::StrCat(Istio::Common::ServiceVersionBaggageToken, "=", serviceVersion));
   }
 
   if (!appVersion.empty() && appVersion != serviceVersion) {
-    parts.push_back(absl::StrCat(AppVersionBaggageToken, "=", appVersion));
+    parts.push_back(absl::StrCat(Istio::Common::AppVersionBaggageToken, "=", appVersion));
   }
 
   // Map the workload metadata fields to baggage tokens
   const std::vector<std::pair<absl::string_view, absl::string_view>> field_to_baggage = {
-      {NamespaceNameToken, NamespaceNameBaggageToken}, {ClusterNameToken, ClusterNameBaggageToken},
-      {InstanceNameToken, InstanceNameBaggageToken},   {RegionToken, LocalityRegionBaggageToken},
-      {ZoneToken, LocalityZoneBaggageToken},
+      {Istio::Common::NamespaceNameToken, Istio::Common::NamespaceNameBaggageToken},
+      {Istio::Common::ClusterNameToken, Istio::Common::ClusterNameBaggageToken},
+      {Istio::Common::InstanceNameToken, Istio::Common::InstanceNameBaggageToken},
+      {Istio::Common::RegionToken, Istio::Common::LocalityRegionBaggageToken},
+      {Istio::Common::ZoneToken, Istio::Common::LocalityZoneBaggageToken},
   };
 
   for (const auto& [field_name, baggage_key] : field_to_baggage) {
@@ -533,4 +535,3 @@ convertBaggageToWorkloadMetadata(absl::string_view data, absl::string_view ident
 
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/source/metadata_object.h
+++ b/contrib/istio/filters/common/source/metadata_object.h
@@ -8,7 +8,7 @@
 
 #include "source/common/protobuf/protobuf.h"
 
-namespace Envoy {
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 
@@ -110,8 +110,8 @@ public:
                                   absl::string_view canonical_name,
                                   absl::string_view canonical_revision, absl::string_view app_name,
                                   absl::string_view app_version, WorkloadType workload_type,
-                                  absl::string_view identity, absl::string_view region = "",
-                                  absl::string_view zone = "")
+                                  absl::string_view identity, absl::string_view region,
+                                  absl::string_view zone)
       : instance_name_(instance_name), cluster_name_(cluster_name), namespace_name_(namespace_name),
         workload_name_(workload_name), canonical_name_(canonical_name),
         canonical_revision_(canonical_revision), app_name_(app_name), app_version_(app_version),
@@ -184,4 +184,3 @@ convertBaggageToWorkloadMetadata(absl::string_view baggage, absl::string_view id
 
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/source/workload_discovery.cc
+++ b/contrib/istio/filters/common/source/workload_discovery.cc
@@ -84,7 +84,7 @@ public:
   }
 
   std::optional<Istio::Common::WorkloadMetadataObject>
-  getMetadata(const Network::Address::InstanceConstSharedPtr& address) override {
+  GetMetadata(const Network::Address::InstanceConstSharedPtr& address) override {
     if (address && address->ip()) {
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
         uint32_t value = ipv4->address();
@@ -274,7 +274,7 @@ public:
 REGISTER_FACTORY(WorkloadDiscoveryFactory, Server::Configuration::BootstrapExtensionFactory);
 
 WorkloadMetadataProviderSharedPtr
-getProvider(Server::Configuration::ServerFactoryContext& context) {
+GetProvider(Server::Configuration::ServerFactoryContext& context) {
   return context.singletonManager().getTyped<WorkloadMetadataProvider>(
       SINGLETON_MANAGER_REGISTERED_NAME(workload_metadata_provider));
 }

--- a/contrib/istio/filters/common/source/workload_discovery.h
+++ b/contrib/istio/filters/common/source/workload_discovery.h
@@ -23,12 +23,14 @@ class WorkloadMetadataProvider {
 public:
   virtual ~WorkloadMetadataProvider() = default;
   virtual std::optional<Istio::Common::WorkloadMetadataObject>
-  getMetadata(const Network::Address::InstanceConstSharedPtr& address) PURE;
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  GetMetadata(const Network::Address::InstanceConstSharedPtr& address) PURE;
 };
 
 using WorkloadMetadataProviderSharedPtr = std::shared_ptr<WorkloadMetadataProvider>;
 
-WorkloadMetadataProviderSharedPtr getProvider(Server::Configuration::ServerFactoryContext& context);
+// NOLINTNEXTLINE(readability-identifier-naming)
+WorkloadMetadataProviderSharedPtr GetProvider(Server::Configuration::ServerFactoryContext& context);
 
 } // namespace WorkloadDiscovery
 } // namespace Common

--- a/contrib/istio/filters/common/test/hashable_string_test.cc
+++ b/contrib/istio/filters/common/test/hashable_string_test.cc
@@ -13,6 +13,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 namespace {

--- a/contrib/istio/filters/common/test/hashable_string_test.cc
+++ b/contrib/istio/filters/common/test/hashable_string_test.cc
@@ -1,3 +1,4 @@
+// NOLINT(namespace-envoy)
 #include <memory>
 #include <vector>
 
@@ -13,7 +14,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 namespace {

--- a/contrib/istio/filters/common/test/hashable_string_test.cc
+++ b/contrib/istio/filters/common/test/hashable_string_test.cc
@@ -13,7 +13,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 namespace Istio {
 namespace Common {
 namespace {
@@ -21,29 +20,29 @@ namespace {
 TEST(HashableStringTest, TestHashableStringIsHashable) {
   using FilterStateValue =
       envoy::extensions::filters::common::set_filter_state::v3::FilterStateValue;
-  using Config = Extensions::Filters::Common::SetFilterState::Config;
+  using Config = Envoy::Extensions::Filters::Common::SetFilterState::Config;
 
-  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
-  Http::TestRequestHeaderMapImpl header_map;
-  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  NiceMock<Envoy::Server::Configuration::MockGenericFactoryContext> context;
+  Envoy::Http::TestRequestHeaderMapImpl header_map;
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
 
   FilterStateValue proto;
-  TestUtility::loadFromYaml(R"YAML(
+  Envoy::TestUtility::loadFromYaml(R"YAML(
     object_key: key
     factory_key: istio.hashable_string
     format_string:
       text_format_source:
         inline_string: "value"
   )YAML",
-                            proto);
+                                   proto);
   std::vector<FilterStateValue> protos{{proto}};
 
   auto config = std::make_shared<Config>(
-      Protobuf::RepeatedPtrField<FilterStateValue>(protos.begin(), protos.end()),
-      StreamInfo::FilterState::LifeSpan::FilterChain, context);
+      Envoy::Protobuf::RepeatedPtrField<FilterStateValue>(protos.begin(), protos.end()),
+      Envoy::StreamInfo::FilterState::LifeSpan::FilterChain, context);
   config->updateFilterState({&header_map}, stream_info);
 
-  const auto* s = stream_info.filterState()->getDataReadOnly<Hashable>("key");
+  const auto* s = stream_info.filterState()->getDataReadOnly<Envoy::Hashable>("key");
   ASSERT_NE(s, nullptr);
 
   const HashableString* h = dynamic_cast<const HashableString*>(s);
@@ -55,4 +54,3 @@ TEST(HashableStringTest, TestHashableStringIsHashable) {
 } // namespace
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/test/metadata_object_test.cc
+++ b/contrib/istio/filters/common/test/metadata_object_test.cc
@@ -1,3 +1,4 @@
+// NOLINT(namespace-envoy)
 #include <optional>
 
 #include "envoy/registry/registry.h"
@@ -6,7 +7,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 

--- a/contrib/istio/filters/common/test/metadata_object_test.cc
+++ b/contrib/istio/filters/common/test/metadata_object_test.cc
@@ -6,7 +6,6 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace Envoy {
 namespace Istio {
 namespace Common {
 
@@ -14,18 +13,21 @@ using Envoy::Protobuf::util::MessageDifferencer;
 
 TEST(WorkloadMetadataObjectTest, AsString) {
   constexpr absl::string_view identity = "spiffe://cluster.local/ns/default/sa/default";
-  WorkloadMetadataObject deploy("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                "v1alpha3", "", "", WorkloadType::Deployment, identity, "", "");
+  ::Istio::Common::WorkloadMetadataObject deploy(
+      "pod-foo-1234", "my-cluster", "default", "foo", "foo-service", "v1alpha3", "", "",
+      ::Istio::Common::WorkloadType::Deployment, identity, "", "");
 
-  WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                             "v1alpha3", "", "", WorkloadType::Pod, identity, "", "");
+  ::Istio::Common::WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo",
+                                              "foo-service", "v1alpha3", "", "",
+                                              ::Istio::Common::WorkloadType::Pod, identity, "", "");
 
-  WorkloadMetadataObject cronjob("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                 "v1alpha3", "foo-app", "v1", WorkloadType::CronJob, identity, "",
-                                 "");
+  ::Istio::Common::WorkloadMetadataObject cronjob(
+      "pod-foo-1234", "my-cluster", "default", "foo", "foo-service", "v1alpha3", "foo-app", "v1",
+      ::Istio::Common::WorkloadType::CronJob, identity, "", "");
 
-  WorkloadMetadataObject job("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                             "v1alpha3", "", "", WorkloadType::Job, identity, "", "");
+  ::Istio::Common::WorkloadMetadataObject job("pod-foo-1234", "my-cluster", "default", "foo",
+                                              "foo-service", "v1alpha3", "", "",
+                                              ::Istio::Common::WorkloadType::Job, identity, "", "");
 
   EXPECT_EQ(deploy.serializeAsString(),
             absl::StrCat("type=deployment,workload=foo,name=pod-foo-1234,cluster=my-cluster,",
@@ -46,9 +48,9 @@ TEST(WorkloadMetadataObjectTest, AsString) {
 }
 
 void checkStructConversion(const Envoy::StreamInfo::FilterState::Object& data) {
-  const auto& obj = dynamic_cast<const WorkloadMetadataObject&>(data);
-  auto pb = convertWorkloadMetadataToStruct(obj);
-  auto obj2 = convertStructToWorkloadMetadata(pb);
+  const auto& obj = dynamic_cast<const ::Istio::Common::WorkloadMetadataObject&>(data);
+  auto pb = ::Istio::Common::convertWorkloadMetadataToStruct(obj);
+  auto obj2 = ::Istio::Common::convertStructToWorkloadMetadata(pb);
   EXPECT_EQ(obj2->serializeAsString(), obj.serializeAsString());
   MessageDifferencer::Equals(*(obj2->serializeAsProto()), *(obj.serializeAsProto()));
   EXPECT_EQ(obj2->hash(), obj.hash());
@@ -56,30 +58,31 @@ void checkStructConversion(const Envoy::StreamInfo::FilterState::Object& data) {
 
 TEST(WorkloadMetadataObjectTest, ConversionWithLabels) {
   constexpr absl::string_view identity = "spiffe://cluster.local/ns/default/sa/default";
-  WorkloadMetadataObject deploy("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                "v1alpha3", "", "", WorkloadType::Deployment, identity, "", "");
+  ::Istio::Common::WorkloadMetadataObject deploy(
+      "pod-foo-1234", "my-cluster", "default", "foo", "foo-service", "v1alpha3", "", "",
+      ::Istio::Common::WorkloadType::Deployment, identity, "", "");
   deploy.setLabels({{"label1", "value1"}, {"label2", "value2"}});
-  auto pb = convertWorkloadMetadataToStruct(deploy);
-  auto obj1 = convertStructToWorkloadMetadata(pb, {"label1", "label2"});
+  auto pb = ::Istio::Common::convertWorkloadMetadataToStruct(deploy);
+  auto obj1 = ::Istio::Common::convertStructToWorkloadMetadata(pb, {"label1", "label2"});
   EXPECT_EQ(obj1->getLabels().size(), 2);
-  auto obj2 = convertStructToWorkloadMetadata(pb, {"label1"});
+  auto obj2 = ::Istio::Common::convertStructToWorkloadMetadata(pb, {"label1"});
   EXPECT_EQ(obj2->getLabels().size(), 1);
   absl::flat_hash_set<std::string> empty;
-  auto obj3 = convertStructToWorkloadMetadata(pb, empty);
+  auto obj3 = ::Istio::Common::convertStructToWorkloadMetadata(pb, empty);
   EXPECT_EQ(obj3->getLabels().size(), 0);
 }
 
 TEST(WorkloadMetadataObjectTest, Conversion) {
   {
     constexpr absl::string_view identity = "spiffe://cluster.local/ns/default/sa/default";
-    const auto r = convertBaggageToWorkloadMetadata(
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
         "k8s.deployment.name=foo,k8s.cluster.name=my-cluster,"
         "k8s.namespace.name=default,service.name=foo-service,service.version=v1alpha3,app.name=foo-"
         "app,app.version=latest",
         identity);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1alpha3");
-    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), DeploymentSuffix);
+    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), ::Istio::Common::DeploymentSuffix);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("workload")), "foo");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("name")), "");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "default");
@@ -91,12 +94,12 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata(
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
         "k8s.pod.name=foo-pod-435,k8s.cluster.name=my-cluster,k8s.namespace.name="
         "test,k8s.instance.name=foo-instance-435,service.name=foo-service,service.version=v1beta2");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1beta2");
-    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), PodSuffix);
+    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), ::Istio::Common::PodSuffix);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("workload")), "foo-pod-435");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("name")), "foo-instance-435");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "test");
@@ -107,12 +110,12 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata(
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
         "k8s.job.name=foo-job-435,k8s.cluster.name=my-cluster,k8s.namespace.name="
         "test,k8s.instance.name=foo-instance-435,service.name=foo-service,service.version=v1beta4");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1beta4");
-    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), JobSuffix);
+    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), ::Istio::Common::JobSuffix);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("workload")), "foo-job-435");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("name")), "foo-instance-435");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "test");
@@ -123,12 +126,12 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata(
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
         "k8s.cronjob.name=foo-cronjob,k8s.cluster.name=my-cluster,"
         "k8s.namespace.name=test,service.name=foo-service,service.version=v1beta4");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1beta4");
-    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), CronJobSuffix);
+    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), ::Istio::Common::CronJobSuffix);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("workload")), "foo-cronjob");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("name")), "");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "test");
@@ -139,12 +142,12 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r =
-        convertBaggageToWorkloadMetadata("k8s.deployment.name=foo,k8s.namespace.name=default,"
-                                         "service.name=foo-service,service.version=v1alpha3");
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
+        "k8s.deployment.name=foo,k8s.namespace.name=default,"
+        "service.name=foo-service,service.version=v1alpha3");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1alpha3");
-    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), DeploymentSuffix);
+    EXPECT_EQ(absl::get<absl::string_view>(r->getField("type")), ::Istio::Common::DeploymentSuffix);
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("workload")), "foo");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "default");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("cluster")), "");
@@ -154,8 +157,8 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r =
-        convertBaggageToWorkloadMetadata("service.name=foo-service,service.version=v1alpha3");
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
+        "service.name=foo-service,service.version=v1alpha3");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1alpha3");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("app")), "foo-service");
@@ -164,7 +167,8 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata("app.name=foo-app,app.version=latest");
+    const auto r =
+        ::Istio::Common::convertBaggageToWorkloadMetadata("app.name=foo-app,app.version=latest");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-app");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "latest");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("app")), "foo-app");
@@ -173,7 +177,7 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata(
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata(
         "service.name=foo-service,service.version=v1alpha3,app.name=foo-app,app.version=latest");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("service")), "foo-service");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("revision")), "v1alpha3");
@@ -183,25 +187,25 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
   }
 
   {
-    const auto r = convertBaggageToWorkloadMetadata("k8s.namespace.name=default");
+    const auto r = ::Istio::Common::convertBaggageToWorkloadMetadata("k8s.namespace.name=default");
     EXPECT_EQ(absl::get<absl::string_view>(r->getField("namespace")), "default");
     checkStructConversion(*r);
   }
 }
 
 TEST(WorkloadMetadataObjectTest, ConvertFromEmpty) {
-  Protobuf::Struct node;
-  auto obj = convertStructToWorkloadMetadata(node);
+  Envoy::Protobuf::Struct node;
+  auto obj = ::Istio::Common::convertStructToWorkloadMetadata(node);
   EXPECT_EQ(obj->serializeAsString(), "");
   checkStructConversion(*obj);
 }
 
 TEST(WorkloadMetadataObjectTest, ConvertFromEndpointMetadata) {
-  EXPECT_EQ(std::nullopt, convertEndpointMetadata(""));
-  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b"));
-  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;;;b"));
-  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b;c;d"));
-  auto obj = convertEndpointMetadata("foo-pod;default;foo-service;v1;my-cluster");
+  EXPECT_EQ(std::nullopt, ::Istio::Common::convertEndpointMetadata(""));
+  EXPECT_EQ(std::nullopt, ::Istio::Common::convertEndpointMetadata("a;b"));
+  EXPECT_EQ(std::nullopt, ::Istio::Common::convertEndpointMetadata("a;;;b"));
+  EXPECT_EQ(std::nullopt, ::Istio::Common::convertEndpointMetadata("a;b;c;d"));
+  auto obj = ::Istio::Common::convertEndpointMetadata("foo-pod;default;foo-service;v1;my-cluster");
   ASSERT_TRUE(obj.has_value());
   EXPECT_EQ(obj->serializeAsString(), "workload=foo-pod,cluster=my-cluster,"
                                       "namespace=default,service=foo-service,revision=v1");
@@ -209,4 +213,3 @@ TEST(WorkloadMetadataObjectTest, ConvertFromEndpointMetadata) {
 
 } // namespace Common
 } // namespace Istio
-} // namespace Envoy

--- a/contrib/istio/filters/common/test/metadata_object_test.cc
+++ b/contrib/istio/filters/common/test/metadata_object_test.cc
@@ -6,6 +6,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+// NOLINT(namespace-envoy)
 namespace Istio {
 namespace Common {
 

--- a/contrib/istio/filters/http/alpn/source/alpn_filter.cc
+++ b/contrib/istio/filters/http/alpn/source/alpn_filter.cc
@@ -41,7 +41,7 @@ Http::Protocol AlpnFilterConfig::getHttpProtocol(
 }
 
 Http::FilterHeadersStatus AlpnFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
-  const auto route = decoder_callbacks_->route();
+  Router::RouteConstSharedPtr route = decoder_callbacks_->routeSharedPtr();
   const Router::RouteEntry* route_entry;
   if (!route || !(route_entry = route->routeEntry())) {
     ENVOY_LOG(debug, "cannot find route entry");

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -22,7 +22,7 @@ class XDSMethod : public DiscoveryMethod {
 public:
   XDSMethod(bool downstream, Server::Configuration::ServerFactoryContext& factory_context)
       : downstream_(downstream),
-        metadata_provider_(Extensions::Common::WorkloadDiscovery::getProvider(factory_context)),
+        metadata_provider_(Extensions::Common::WorkloadDiscovery::GetProvider(factory_context)),
         local_info_(factory_context.localInfo()) {}
   std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
                                          Context&) const override;
@@ -100,7 +100,7 @@ std::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& 
     return {};
   }
   ENVOY_LOG_MISC(debug, "Peer address: {}", peer_address->asString());
-  return metadata_provider_->getMetadata(peer_address);
+  return metadata_provider_->GetMetadata(peer_address);
 }
 
 MXMethod::MXMethod(bool downstream, const absl::flat_hash_set<std::string> additional_labels,
@@ -146,7 +146,7 @@ std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view
     }
   }
   const auto bytes = Base64::decodeWithoutPadding(value);
-  Protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   if (!metadata.ParseFromString(bytes)) {
     return {};
   }
@@ -159,25 +159,6 @@ std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view
     cache.emplace(id, *out);
   }
   return *out;
-}
-
-MXPropagationMethod::MXPropagationMethod(
-    bool downstream, Server::Configuration::ServerFactoryContext& factory_context,
-    const absl::flat_hash_set<std::string>& additional_labels,
-    const io::istio::http::peer_metadata::Config_IstioHeaders& istio_headers)
-    : downstream_(downstream), id_(factory_context.localInfo().node().id()),
-      value_(computeValue(additional_labels, factory_context)),
-      skip_external_clusters_(istio_headers.skip_external_clusters()) {}
-
-std::string MXPropagationMethod::computeValue(
-    const absl::flat_hash_set<std::string>& additional_labels,
-    Server::Configuration::ServerFactoryContext& factory_context) const {
-  const auto obj = Istio::Common::convertStructToWorkloadMetadata(
-      factory_context.localInfo().node().metadata(), additional_labels,
-      factory_context.localInfo().node().locality());
-  const Protobuf::Struct metadata = Istio::Common::convertWorkloadMetadataToStruct(*obj);
-  const std::string metadata_bytes = Istio::Common::serializeToStringDeterministic(metadata);
-  return Base64::encode(metadata_bytes.data(), metadata_bytes.size());
 }
 
 class UpstreamFilterStateMethod : public DiscoveryMethod {
@@ -212,17 +193,49 @@ UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Ht
     return {};
   }
 
-  Protobuf::Struct obj;
+  Envoy::Protobuf::Struct obj;
   if (!obj.ParseFromString(absl::string_view(cel_state->value()))) {
     return {};
   }
 
-  std::unique_ptr<PeerInfo> peer_info = Istio::Common::convertStructToWorkloadMetadata(obj);
+  std::unique_ptr<PeerInfo> peer_info = ::Istio::Common::convertStructToWorkloadMetadata(obj);
   if (!peer_info) {
     return {};
   }
 
   return *peer_info;
+}
+
+MXPropagationMethod::MXPropagationMethod(
+    bool downstream, Server::Configuration::ServerFactoryContext& factory_context,
+    const absl::flat_hash_set<std::string>& additional_labels,
+    const io::istio::http::peer_metadata::Config_IstioHeaders& istio_headers)
+    : downstream_(downstream), id_(factory_context.localInfo().node().id()),
+      value_(computeValue(additional_labels, factory_context)),
+      skip_external_clusters_(istio_headers.skip_external_clusters()) {}
+
+std::string MXPropagationMethod::computeValue(
+    const absl::flat_hash_set<std::string>& additional_labels,
+    Server::Configuration::ServerFactoryContext& factory_context) const {
+  const auto obj = Istio::Common::convertStructToWorkloadMetadata(
+      factory_context.localInfo().node().metadata(), additional_labels,
+      factory_context.localInfo().node().locality());
+  const Envoy::Protobuf::Struct metadata = Istio::Common::convertWorkloadMetadataToStruct(*obj);
+  const std::string metadata_bytes = Istio::Common::serializeToStringDeterministic(metadata);
+  return Base64::encode(metadata_bytes.data(), metadata_bytes.size());
+}
+
+void MXPropagationMethod::inject(const StreamInfo::StreamInfo& info, Http::HeaderMap& headers,
+                                 Context& ctx) const {
+  if (skipMXHeaders(skip_external_clusters_, info)) {
+    return;
+  }
+  if (!downstream_ || ctx.request_peer_id_received_) {
+    headers.setReference(Headers::get().ExchangeMetadataHeaderId, id_);
+  }
+  if (!downstream_ || ctx.request_peer_received_) {
+    headers.setReference(Headers::get().ExchangeMetadataHeader, value_);
+  }
 }
 
 BaggagePropagationMethod::BaggagePropagationMethod(
@@ -258,19 +271,6 @@ std::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo:
     return *workload;
   }
   return {};
-}
-
-void MXPropagationMethod::inject(const StreamInfo::StreamInfo& info, Http::HeaderMap& headers,
-                                 Context& ctx) const {
-  if (skipMXHeaders(skip_external_clusters_, info)) {
-    return;
-  }
-  if (!downstream_ || ctx.request_peer_id_received_) {
-    headers.setReference(Headers::get().ExchangeMetadataHeaderId, id_);
-  }
-  if (!downstream_ || ctx.request_peer_received_) {
-    headers.setReference(Headers::get().ExchangeMetadataHeader, value_);
-  }
 }
 
 FilterConfig::FilterConfig(const io::istio::http::peer_metadata::Config& config,

--- a/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
+++ b/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
@@ -11,7 +11,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using Envoy::Istio::Common::WorkloadMetadataObject;
+using Istio::Common::WorkloadMetadataObject;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
@@ -35,7 +35,7 @@ class MockWorkloadMetadataProvider
       public Singleton::Instance {
 public:
   MockWorkloadMetadataProvider() = default;
-  MOCK_METHOD(std::optional<WorkloadMetadataObject>, getMetadata,
+  MOCK_METHOD(std::optional<WorkloadMetadataObject>, GetMetadata,
               (const Network::Address::InstanceConstSharedPtr& address));
 };
 
@@ -107,7 +107,7 @@ TEST_F(PeerMetadataTest, None) {
 }
 
 TEST_F(PeerMetadataTest, DownstreamXDSNone) {
-  EXPECT_CALL(*metadata_provider_, getMetadata(_)).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_)).WillRepeatedly(Return(std::nullopt));
   initialize(R"EOF(
     downstream_discovery:
       - workload_discovery: {}
@@ -120,8 +120,9 @@ TEST_F(PeerMetadataTest, DownstreamXDSNone) {
 
 TEST_F(PeerMetadataTest, DownstreamXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) {
@@ -142,8 +143,9 @@ TEST_F(PeerMetadataTest, DownstreamXDS) {
 
 TEST_F(PeerMetadataTest, UpstreamXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) {
@@ -178,8 +180,9 @@ TEST_F(PeerMetadataTest, UpstreamXDSInternal) {
                             *host_metadata);
 
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.100")) {
@@ -233,7 +236,7 @@ constexpr absl::string_view SampleIstioHeader =
 TEST_F(PeerMetadataTest, DownstreamFallbackFirst) {
   request_headers_.setReference(Headers::get().ExchangeMetadataHeaderId, "test-pod");
   request_headers_.setReference(Headers::get().ExchangeMetadataHeader, SampleIstioHeader);
-  EXPECT_CALL(*metadata_provider_, getMetadata(_)).Times(0);
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_)).Times(0);
   initialize(R"EOF(
     downstream_discovery:
       - istio_headers: {}
@@ -247,8 +250,9 @@ TEST_F(PeerMetadataTest, DownstreamFallbackFirst) {
 
 TEST_F(PeerMetadataTest, DownstreamFallbackSecond) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) { // remote address
@@ -314,7 +318,7 @@ TEST_F(PeerMetadataTest, UpstreamMX) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamFallbackFirst) {
-  EXPECT_CALL(*metadata_provider_, getMetadata(_)).Times(0);
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_)).Times(0);
   response_headers_.setReference(Headers::get().ExchangeMetadataHeaderId, "test-pod");
   response_headers_.setReference(Headers::get().ExchangeMetadataHeader, SampleIstioHeader);
   initialize(R"EOF(
@@ -330,8 +334,9 @@ TEST_F(PeerMetadataTest, UpstreamFallbackFirst) {
 
 TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address
@@ -352,8 +357,9 @@ TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
 
 TEST_F(PeerMetadataTest, UpstreamFallbackFirstXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "");
-  EXPECT_CALL(*metadata_provider_, getMetadata(_))
+                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
+                                   "");
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address

--- a/contrib/istio/filters/network/metadata_exchange/source/config.cc
+++ b/contrib/istio/filters/network/metadata_exchange/source/config.cc
@@ -6,8 +6,7 @@
 #include "contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 namespace {
@@ -88,6 +87,5 @@ static Registry::RegisterFactory<MetadataExchangeUpstreamConfigFactory,
     registered_upstream_;
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/source/config.h
+++ b/contrib/istio/filters/network/metadata_exchange/source/config.h
@@ -6,8 +6,7 @@
 #include "contrib/envoy/extensions/filters/network/metadata_exchange/v3/metadata_exchange.pb.validate.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 /**
@@ -53,6 +52,5 @@ private:
 };
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.cc
+++ b/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.cc
@@ -18,8 +18,7 @@
 #include "contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 using ::Envoy::Extensions::Filters::Common::Expr::CelState;
@@ -63,7 +62,7 @@ MetadataExchangeConfig::MetadataExchangeConfig(
       filter_direction_(filter_direction), stats_(generateStats(stat_prefix, scope)),
       additional_labels_(additional_labels) {
   if (enable_discovery) {
-    metadata_provider_ = Extensions::Common::WorkloadDiscovery::getProvider(factory_context);
+    metadata_provider_ = Extensions::Common::WorkloadDiscovery::GetProvider(factory_context);
   }
 }
 
@@ -184,6 +183,7 @@ void MetadataExchangeFilter::writeNodeMetadata() {
   Protobuf::Struct data;
   const auto obj = Istio::Common::convertStructToWorkloadMetadata(
       local_info_.node().metadata(), config_->additional_labels_, local_info_.node().locality());
+
   *(*data.mutable_fields())[ExchangeMetadataHeader].mutable_struct_value() =
       Istio::Common::convertWorkloadMetadataToStruct(*obj);
   std::string metadata_id = getMetadataId();
@@ -324,7 +324,7 @@ void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
     auto downstream_peer_address = [&]() -> Network::Address::InstanceConstSharedPtr {
       if (upstream_peer) {
         // Query upstream peer data and save it in metadata for stats
-        const auto metadata_object = config_->metadata_provider_->getMetadata(upstream_peer);
+        const auto metadata_object = config_->metadata_provider_->GetMetadata(upstream_peer);
         if (metadata_object) {
           ENVOY_LOG(debug, "Metadata found for upstream peer address {}",
                     upstream_peer->asString());
@@ -347,7 +347,7 @@ void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
         config_->filter_direction_ == FilterDirection::Downstream ? downstream_peer_address()
                                                                   : upstream_peer_address();
     ENVOY_LOG(debug, "Look up metadata based on peer address {}", peer_address->asString());
-    const auto metadata_object = config_->metadata_provider_->getMetadata(peer_address);
+    const auto metadata_object = config_->metadata_provider_->GetMetadata(peer_address);
     if (metadata_object) {
       ENVOY_LOG(trace, "Metadata found for peer address {}", peer_address->asString());
       updatePeer(metadata_object.value());
@@ -363,6 +363,5 @@ void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
 }
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.h
+++ b/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.h
@@ -18,8 +18,7 @@
 #include "contrib/istio/filters/common/source/workload_discovery.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 using ::Envoy::Extensions::Filters::Common::Expr::CelStatePrototype;
@@ -98,7 +97,7 @@ class MetadataExchangeFilter : public Network::Filter,
 public:
   MetadataExchangeFilter(MetadataExchangeConfigSharedPtr config,
                          const LocalInfo::LocalInfo& local_info)
-      : config_(config), local_info_(local_info) {}
+      : config_(config), local_info_(local_info), conn_state_(ConnProtocolNotRead) {}
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
@@ -155,10 +154,9 @@ private:
     NeedMoreDataProxyHeader,   // Need more data to be read
     Done,                      // Alpn Protocol Found and all the read is done
     Invalid,                   // Invalid state, all operations fail
-  } conn_state_{};
+  } conn_state_;
 };
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.cc
+++ b/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.cc
@@ -1,13 +1,11 @@
 #include "contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 const uint32_t MetadataExchangeInitialHeader::magic_number;
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.h
+++ b/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange_initial_header.h
@@ -5,8 +5,7 @@
 #include "envoy/common/platform.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 
 // Used with MetadataExchangeHeaderProto to be extensible.
@@ -19,6 +18,5 @@ PACKED_STRUCT(struct MetadataExchangeInitialHeader {
 });
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/metadata_exchange/test/metadata_exchange_test.cc
+++ b/contrib/istio/filters/network/metadata_exchange/test/metadata_exchange_test.cc
@@ -17,8 +17,7 @@ using testing::Return;
 using testing::ReturnRef;
 
 namespace Envoy {
-namespace Extensions {
-namespace NetworkFilters {
+namespace Tcp {
 namespace MetadataExchange {
 namespace {
 
@@ -140,6 +139,5 @@ TEST_F(MetadataExchangeFilterTest, MetadataExchangeNotFound) {
 }
 
 } // namespace MetadataExchange
-} // namespace NetworkFilters
-} // namespace Extensions
+} // namespace Tcp
 } // namespace Envoy

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -17,7 +17,7 @@ using CelState = ::Envoy::Extensions::Filters::Common::Expr::CelState;
 using CelStateType = ::Envoy::Extensions::Filters::Common::Expr::CelStateType;
 
 std::string baggageValue(const LocalInfo::LocalInfo& local_info) {
-  const auto obj = Istio::Common::convertStructToWorkloadMetadata(local_info.node().metadata());
+  const auto obj = ::Istio::Common::convertStructToWorkloadMetadata(local_info.node().metadata());
   return obj->baggage();
 }
 
@@ -78,7 +78,7 @@ Network::FilterStatus Filter::onWrite(Buffer::Instance& buffer, bool) {
     // for peer metadata anymore, if the upstream sent it, we'd have it by
     // now. So we can check if the peer metadata is available or not, and if
     // no peer metadata available, we can give up waiting for it.
-    std::optional<Protobuf::Any> peer_metadata = discoverPeerMetadata();
+    std::optional<Envoy::Protobuf::Any> peer_metadata = discoverPeerMetadata();
     if (peer_metadata) {
       propagatePeerMetadata(*peer_metadata);
     } else {
@@ -117,7 +117,12 @@ bool Filter::disableDiscovery() const {
   return discoveryDisabled(metadata);
 }
 
-std::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
+// discoveryPeerMetadata is called to check if the baggage HTTP2 CONNECT
+// response headers have been populated already in the filter state.
+//
+// NOTE: It's safe to call this function during any step of processing - it
+// will not do anything if the filter is not in the right state.
+std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
   ENVOY_LOG(trace, "Trying to discover peer metadata from filter state set by TCP Proxy");
   ASSERT(write_callbacks_);
 
@@ -153,21 +158,24 @@ std::optional<Protobuf::Any> Filter::discoverPeerMetadata() {
     }
   }
 
-  std::unique_ptr<Istio::Common::WorkloadMetadataObject> metadata =
-      Istio::Common::convertBaggageToWorkloadMetadata(baggage[0]->value().getStringView(),
-                                                      identity);
+  std::unique_ptr<::Istio::Common::WorkloadMetadataObject> metadata =
+      ::Istio::Common::convertBaggageToWorkloadMetadata(baggage[0]->value().getStringView(),
+                                                        identity);
 
-  Protobuf::Struct data = Istio::Common::convertWorkloadMetadataToStruct(*metadata);
-  Protobuf::Any wrapped;
+  Envoy::Protobuf::Struct data = ::Istio::Common::convertWorkloadMetadataToStruct(*metadata);
+  Envoy::Protobuf::Any wrapped;
   wrapped.PackFrom(data);
   return wrapped;
 }
 
-void Filter::propagatePeerMetadata(const Protobuf::Any& peer_metadata) {
+void Filter::propagatePeerMetadata(const Envoy::Protobuf::Any& peer_metadata) {
   ENVOY_LOG(trace, "Sending peer metadata downstream with the data stream");
   ASSERT(write_callbacks_);
 
   if (state_ != PeerMetadataState::WaitingForData) {
+    // It's only safe and correct to send the peer metadata downstream with
+    // the data if we haven't done that already, otherwise the downstream
+    // could be very confused by the data they received.
     ENVOY_LOG(trace, "Filter has already sent the peer metadata downstream");
     return;
   }
@@ -205,6 +213,9 @@ Network::FilterStatus UpstreamFilter::onData(Buffer::Instance& buffer, bool end_
     if (consumePeerMetadata(buffer, end_stream)) {
       state_ = PeerMetadataState::PassThrough;
     } else {
+      // If we got here it means that we are waiting for more data to arrive.
+      // NOTE: if error happened, we will not get here, consumePeerMetadata
+      // will just return true and we will enter PassThrough state.
       return Network::FilterStatus::StopIteration;
     }
     break;
@@ -221,6 +232,21 @@ void UpstreamFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks&
   callbacks_ = &callbacks;
 }
 
+// We want to enable baggage based peer metadata discovery if all of the following is true
+// - the upstream host is an internal listener, and specifically connect_originate or
+//   inner_connect_originate internal listener - those are the only listeners that
+//   support baggage-based peer metadata discovery
+// - communication with upstream happens in plain text, e.g., there is no TLS upstream
+//   transport socket or PROXY transport socket there - we need it in the current
+//   implemetation of the baggage-based peer metadata discovery because we inject peer
+//   metadata into the data stream and transport sockets that modify the data stream
+//   interfere with that (NOTE: in the future release we are planning to lift this
+//   limitation by communicating over shared memory instead).
+//
+// We can easily check if the upstream host is an internal listener, so checking the first
+// condition is easy. We can't easily check the second condition in the filter itself, so
+// instead we rely on istiod providing that information in form of the host metadata on the
+// endpoint or cluster level.
 bool UpstreamFilter::disableDiscovery() const {
   ASSERT(callbacks_);
 
@@ -253,7 +279,7 @@ bool UpstreamFilter::disableDiscovery() const {
 
 bool UpstreamFilter::consumePeerMetadata(Buffer::Instance& buffer, bool end_stream) {
   ENVOY_LOG(trace, "Trying to consume peer metadata from the data stream");
-  using namespace Istio::Common;
+  using namespace ::Istio::Common;
 
   ASSERT(callbacks_);
 
@@ -306,14 +332,14 @@ bool UpstreamFilter::consumePeerMetadata(Buffer::Instance& buffer, bool end_stre
   absl::string_view data{static_cast<const char*>(buffer.linearize(peer_metadata_size)),
                          peer_metadata_size};
   data = data.substr(sizeof(PeerMetadataHeader));
-  Protobuf::Any any;
+  Envoy::Protobuf::Any any;
   if (!any.ParseFromArray(data.data(), data.size())) {
     ENVOY_LOG(trace, "Failed to parse peer metadata proto from the data stream");
     populateNoPeerMetadata();
     return true;
   }
 
-  Protobuf::Struct peer_metadata;
+  Envoy::Protobuf::Struct peer_metadata;
   if (!any.UnpackTo(&peer_metadata)) {
     ENVOY_LOG(trace, "Failed to unpack peer metadata struct");
     populateNoPeerMetadata();
@@ -334,15 +360,15 @@ const CelStatePrototype& UpstreamFilter::peerInfoPrototype() {
   return *prototype;
 }
 
-void UpstreamFilter::populatePeerMetadata(const Istio::Common::WorkloadMetadataObject& peer) {
+void UpstreamFilter::populatePeerMetadata(const ::Istio::Common::WorkloadMetadataObject& peer) {
   ENVOY_LOG(trace, "Populating peer metadata in the upstream filter state");
   ASSERT(callbacks_);
 
-  auto proto = Istio::Common::convertWorkloadMetadataToStruct(peer);
+  auto proto = ::Istio::Common::convertWorkloadMetadataToStruct(peer);
   auto cel = std::make_shared<CelState>(peerInfoPrototype());
   cel->setValue(absl::string_view(proto.SerializeAsString()));
   callbacks_->connection().streamInfo().filterState()->setData(
-      Istio::Common::UpstreamPeer, std::move(cel), StreamInfo::FilterState::LifeSpan::Connection);
+      ::Istio::Common::UpstreamPeer, std::move(cel), StreamInfo::FilterState::LifeSpan::Connection);
 }
 
 void UpstreamFilter::populateNoPeerMetadata() {
@@ -350,7 +376,7 @@ void UpstreamFilter::populateNoPeerMetadata() {
   ASSERT(callbacks_);
 
   callbacks_->connection().streamInfo().filterState()->setData(
-      Istio::Common::NoPeer, std::make_shared<StreamInfo::BoolAccessorImpl>(true),
+      ::Istio::Common::NoPeer, std::make_shared<StreamInfo::BoolAccessorImpl>(true),
       StreamInfo::FilterState::LifeSpan::Connection);
 }
 

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
@@ -16,13 +16,81 @@
 #include "contrib/envoy/extensions/filters/network/peer_metadata/v3/peer_metadata.pb.validate.h"
 #include "contrib/istio/filters/common/source/metadata_object.h"
 
+/**
+ * PeerMetadata network and upstream network filters are used in one of ambient
+ * peer metadata discovery mechanims. The peer metadata discovery mechanism
+ * these filters are part of relies on peer reporting their own metadata in
+ * HBONE CONNECT request and response headers.
+ *
+ * The purpose of these filters is to extract this metadata from the request/
+ * response headers and propagate it to the Istio filters reporting telemetry
+ * where this metadata will be used as labels.
+ *
+ * The filters in this folder are specifically concerned with extracting and
+ * propagating upstream peer metadata. The working setup includes a combination
+ * of several filters that together get the job done.
+ *
+ * A bit of background, here is a very simplified description of how Istio
+ * waypoint processes a request:
+ *
+ * 1. connect_terminate listener recieves an incoming HBONE connection;
+ *    * it uwraps HBONE tunnel and extracts the data passed inside it;
+ *    * it passes the data inside the HBONE tunnel to a main_internal listener
+ *      that performs the next stage of processing;
+ * 2. main_internal listener is responsible for parsing the data as L7 data
+ *    (HTTP/gRPC), applying configured L7 policies, picking the endpoint to
+ *    route the request to and reports L7 stats
+ *    * At this level we are processing the incoming request at L7 level and
+ *      have access to things like status of the request and can report
+ *      meaningful metrics;
+ *    * To report in metrics where the request came from and where it went
+ *      after we need to know the details of downstream and upstream peers -
+ *      that's what we call peer metadata;
+ *    * Once we've done with L7 processing of the request, we pass the request
+ *      to the connect_originate (or inner_connect_originate in case of double
+ *      HBONE) listener that will handle the next stage of processing;
+ * 3. connect_originate - is responsible for wrapping processed L7 traffic into
+ *    an HBONE tunnel and sending it out
+ *    * This stage of processing treats data as a stream of bytes without any
+ *      knowledge of L7 protocol details;
+ *    * It takes the upstream peer address as input an establishes an HBONE
+ *      tunnel to the destination and sends the data via that tunnel.
+ *
+ * With that picture in mind, what we want to do is in connect_originate (or
+ * inner_connect_originate in case of double-HBONE) when we establish HBONE
+ * tunnel, we want to extract peer metadata from the CONNECT response and
+ * propagate it to the main_internal.
+ *
+ * To establish HBONE tunnel we rely on Envoy TCP Proxy filter, so we don't
+ * handle HTTP2 CONNECT responses or requests directly, instead we rely on the
+ * TCP Proxy filter to extract required information from the response and save
+ * it in the filter state. We then use the custom network filter to take filter
+ * state proved by TCP Proxy filter, encode it, and send it to main_internal
+ * *as data* before any actual response data. This is what the network filter
+ * defined here is responsible for.
+ *
+ * In main_internal we use a custom upstream network filter to extract and
+ * remove the metadata from the data stream and populate filter state that
+ * could be used by Istio telemetry filters. That's what the upstream network
+ * filter defined here is responsible for.
+ *
+ * Why do we do it this way? Generally in Envoy we use filter state and dynamic
+ * metadata to communicate additional information between filters. While it's
+ * possible to propagate filter state from downstream to upstream, i.e., we
+ * could set filter state in connect_terminate and propagate it to
+ * main_internal and then to connect_originate, it's not possible to propagate
+ * filter state from upstream to downstream, i.e., we cannot make filter state
+ * set in connect_originate available to main_internal directly. That's why we
+ * push that metadata with the data instead.
+ */
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace PeerMetadata {
 
-using Config = ::envoy::extensions::filters::network::peer_metadata::v3::Config;
-using UpstreamConfig = ::envoy::extensions::filters::network::peer_metadata::v3::UpstreamConfig;
+using Config = ::envoy::extensions::network_filters::peer_metadata::Config;
+using UpstreamConfig = ::envoy::extensions::network_filters::peer_metadata::UpstreamConfig;
 using CelStatePrototype = ::Envoy::Extensions::Filters::Common::Expr::CelStatePrototype;
 
 struct HeaderValues {
@@ -73,8 +141,8 @@ public:
 private:
   void populateBaggage();
   bool disableDiscovery() const;
-  std::optional<Protobuf::Any> discoverPeerMetadata();
-  void propagatePeerMetadata(const Protobuf::Any& peer_metadata);
+  std::optional<Envoy::Protobuf::Any> discoverPeerMetadata();
+  void propagatePeerMetadata(const Envoy::Protobuf::Any& peer_metadata);
   void propagateNoPeerMetadata();
 
   PeerMetadataState state_ = PeerMetadataState::WaitingForData;
@@ -90,6 +158,15 @@ private:
  * HBONE) to communicate with the upstream peers and it will parse and remove
  * the data injected by the filter above. The parsed peer metadata details will
  * be saved in the filter state.
+ *
+ * NOTE: This filter has built-in safety checks that would prevent it from
+ * trying to interpret the actual connection data as peer metadata injected
+ * by the filter above. However, those checks are rather shallow and rely on a
+ * bunch of implicit assumptions (i.e., the magic number does not match
+ * accidentally, the upstream host actually sends back some data that we can
+ * check, etc). What I'm trying to say is that in correct setup we don't need
+ * to rely on those checks for correctness and if it's not the case, then we
+ * definitely have a bug.
  */
 class UpstreamFilter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
@@ -106,7 +183,7 @@ private:
 
   static const CelStatePrototype& peerInfoPrototype();
 
-  void populatePeerMetadata(const Istio::Common::WorkloadMetadataObject& peer);
+  void populatePeerMetadata(const ::Istio::Common::WorkloadMetadataObject& peer);
   void populateNoPeerMetadata();
 
   PeerMetadataState state_ = PeerMetadataState::WaitingForData;
@@ -115,6 +192,10 @@ private:
 
 /**
  * PeerMetadata network filter factory.
+ *
+ * This filter is responsible for collecting peer metadata from filter state
+ * and other sources, encoding it and passing it downstream before the actual
+ * data.
  */
 class ConfigFactory : public Common::ExceptionFreeFactoryBase<Config> {
 public:
@@ -128,6 +209,11 @@ private:
 
 /**
  * PeerMetadata upstream network filter factory.
+ *
+ * This filter is responsible for detecting the peer metadata passed in the
+ * data stream, parsing it, populating filter state based on that and finally
+ * removing it from the data stream, so that downstream filters can process
+ * the data as usual.
  */
 class UpstreamConfigFactory
     : public Server::Configuration::NamedUpstreamNetworkFilterConfigFactory {

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -315,7 +315,7 @@ std::string encodePeerMetadataHeaderOnly(const PeerMetadataHeader& header) {
 std::string encodeMetadataOnly(absl::string_view baggage, absl::string_view identity) {
   std::unique_ptr<Istio::Common::WorkloadMetadataObject> metadata =
       Istio::Common::convertBaggageToWorkloadMetadata(baggage, identity);
-  Protobuf::Struct data = convertWorkloadMetadataToStruct(*metadata);
+  Protobuf::Struct data = ::Istio::Common::convertWorkloadMetadataToStruct(*metadata);
   Protobuf::Any wrapped;
   wrapped.PackFrom(data);
   return wrapped.SerializeAsString();

--- a/tools/type_whisperer/proto_build_targets_gen.py
+++ b/tools/type_whisperer/proto_build_targets_gen.py
@@ -45,6 +45,7 @@ NONSTANDARD_V3_PKGS = [
     'envoy.tcp.metadataexchange.config',  # Istio TCP metadata exchange.
     'istio.envoy.config.filter.http.alpn.v2alpha1',  # Istio ALPN.
     'istio.workload',  # Istio workload discovery.
+    'envoy.extensions.network_filters.peer_metadata',
 ]
 
 API_BUILD_FILE_TEMPLATE = string.Template(


### PR DESCRIPTION

Commit Message: contrib/istio: sync code with istio/proxy to simplify diff
Additional Description:

1. Fixed inconsistent package name of network peer metadata extension.
2. Sync all code to simplify the code diff. After this change, it would be much easier to compare the actual difference between the upstream istio/proxy and the migrated code in the Envoy.

See also https://github.com/istio/proxy/pull/6748

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
