### PR TITLE
[proto] Replace builtin casts with proto-specific casts for protobuf types.

### DIFF
--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -77,7 +77,7 @@ public:
 
 private:
   void onSuccessRaw(Buffer::InstancePtr&& response, Tracing::Span& span) override {
-    auto message = ResponsePtr<Response>(dynamic_cast<Response*>(
+    auto message = ResponsePtr<Response>(Envoy::Protobuf::DynamicCastMessage<Response>(
         Internal::parseMessageUntyped(std::make_unique<Response>(), std::move(response))
             .release()));
     if (!message) {
@@ -98,7 +98,7 @@ public:
 
 private:
   bool onReceiveMessageRaw(Buffer::InstancePtr&& response) override {
-    auto message = ResponsePtr<Response>(dynamic_cast<Response*>(
+    auto message = ResponsePtr<Response>(Envoy::Protobuf::DynamicCastMessage<Response>(
         Internal::parseMessageUntyped(std::make_unique<Response>(), std::move(response))
             .release()));
     if (!message) {

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -53,7 +53,7 @@ public:
                                              FilterChainActionFactoryContext&,
                                              ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<FilterChainNameAction>(
-        dynamic_cast<const Protobuf::StringValue&>(config).value());
+        Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(config).value());
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<Protobuf::StringValue>();

--- a/source/common/listener_manager/lds_api.cc
+++ b/source/common/listener_manager/lds_api.cc
@@ -90,7 +90,7 @@ LdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_
 
     TRY_ASSERT_MAIN_THREAD {
       const envoy::config::listener::v3::Listener& listener =
-          dynamic_cast<const envoy::config::listener::v3::Listener&>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::listener::v3::Listener>(resource.get().resource());
       listener_name = listener.name();
       if (!listener_names.insert(listener.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully

--- a/source/common/listener_manager/lds_api.cc
+++ b/source/common/listener_manager/lds_api.cc
@@ -90,7 +90,8 @@ LdsApiImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& added_
 
     TRY_ASSERT_MAIN_THREAD {
       const envoy::config::listener::v3::Listener& listener =
-          Envoy::Protobuf::DynamicCastMessage<envoy::config::listener::v3::Listener>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::listener::v3::Listener>(
+              resource.get().resource());
       listener_name = listener.name();
       if (!listener_names.insert(listener.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully

--- a/source/common/matcher/actions/string_returning_action.cc
+++ b/source/common/matcher/actions/string_returning_action.cc
@@ -67,7 +67,7 @@ public:
                                              StringReturningActionFactoryContext&,
                                              ProtobufMessage::ValidationVisitor&) override {
     // validate function doesn't exist for StringValue, so just cast.
-    const auto& config = dynamic_cast<const Protobuf::StringValue&>(proto_config);
+    const auto& config = Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(proto_config);
     return std::make_shared<StringReturningDirectActionImpl>(config);
   }
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/common/rds/common/config_traits_impl.h
+++ b/source/common/rds/common/config_traits_impl.h
@@ -22,7 +22,7 @@ public:
   ConfigConstSharedPtr createConfig(const Protobuf::Message& rc,
                                     Server::Configuration::ServerFactoryContext& context,
                                     bool validate_clusters_default) const override {
-    ASSERT(dynamic_cast<const RouteConfiguration*>(&rc));
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<RouteConfiguration>(&rc));
     return std::make_shared<const ConfigImpl>(static_cast<const RouteConfiguration&>(rc), context,
                                               validate_clusters_default);
   }

--- a/source/common/router/route_config_update_receiver_impl.cc
+++ b/source/common/router/route_config_update_receiver_impl.cc
@@ -43,7 +43,7 @@ Rds::ConfigConstSharedPtr
 ConfigTraitsImpl::createConfig(const Protobuf::Message& rc,
                                Server::Configuration::ServerFactoryContext& factory_context,
                                bool validate_clusters_default) const {
-  ASSERT(dynamic_cast<const envoy::config::route::v3::RouteConfiguration*>(&rc));
+  ASSERT(Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::RouteConfiguration>(&rc));
   return THROW_OR_RETURN_VALUE(
       ConfigImpl::create(static_cast<const envoy::config::route::v3::RouteConfiguration&>(rc),
                          factory_context, validator_, validate_clusters_default),

--- a/source/common/router/route_config_update_receiver_impl.h
+++ b/source/common/router/route_config_update_receiver_impl.h
@@ -66,7 +66,7 @@ public:
     return resource_ids_in_last_update_;
   }
   const envoy::config::route::v3::RouteConfiguration& protobufConfigurationCast() const override {
-    ASSERT(dynamic_cast<const envoy::config::route::v3::RouteConfiguration*>(
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::RouteConfiguration>(
         &RouteConfigUpdateReceiverImpl::protobufConfiguration()));
     return static_cast<const envoy::config::route::v3::RouteConfiguration&>(
         RouteConfigUpdateReceiverImpl::protobufConfiguration());

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -276,7 +276,7 @@ absl::StatusOr<bool> ScopedRdsConfigSubscription::addOrUpdateScopes(
   for (const auto& resource : resources) {
     // Explicit copy so that we can std::move later.
     envoy::config::route::v3::ScopedRouteConfiguration scoped_route_config =
-        dynamic_cast<const envoy::config::route::v3::ScopedRouteConfiguration&>(
+        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::ScopedRouteConfiguration>(
             resource.get().resource());
     const std::string scope_name = scoped_route_config.name();
     if (const auto& scope_info_iter = scoped_route_map_.find(scope_name);
@@ -510,7 +510,7 @@ ScopedRdsConfigSubscription::detectUpdateConflictAndCleanupRemoved(
   }
   for (const auto& resource : resources) {
     const auto& scoped_route =
-        dynamic_cast<const envoy::config::route::v3::ScopedRouteConfiguration&>(
+        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::ScopedRouteConfiguration>(
             resource.get().resource());
     updated_or_removed_scopes.insert(scoped_route.name());
   }
@@ -526,7 +526,7 @@ ScopedRdsConfigSubscription::detectUpdateConflictAndCleanupRemoved(
   for (const auto& resource : resources) {
     // Throws (thus rejects all) on any error.
     const auto& scoped_route =
-        dynamic_cast<const envoy::config::route::v3::ScopedRouteConfiguration&>(
+        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::ScopedRouteConfiguration>(
             resource.get().resource());
     const std::string& scope_name = scoped_route.name();
     auto scope_config_inserted = scoped_routes.try_emplace(scope_name, std::move(scoped_route));
@@ -657,8 +657,7 @@ ConfigProviderPtr ScopedRoutesConfigProviderManager::createXdsConfigProvider(
            &typed_optarg](const uint64_t manager_identifier,
                           ConfigProviderManagerImplBase& config_provider_manager)
               -> Envoy::Config::ConfigSubscriptionCommonBaseSharedPtr {
-            const auto& scoped_rds_config_source = dynamic_cast<
-                const envoy::extensions::filters::network::http_connection_manager::v3::ScopedRds&>(
+            const auto& scoped_rds_config_source = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::http_connection_manager::v3::ScopedRds>(
                 config_source_proto);
             return std::make_shared<ScopedRdsConfigSubscription>(
                 scoped_rds_config_source, manager_identifier, typed_optarg.scoped_routes_name_,

--- a/source/common/router/scoped_rds.cc
+++ b/source/common/router/scoped_rds.cc
@@ -657,7 +657,8 @@ ConfigProviderPtr ScopedRoutesConfigProviderManager::createXdsConfigProvider(
            &typed_optarg](const uint64_t manager_identifier,
                           ConfigProviderManagerImplBase& config_provider_manager)
               -> Envoy::Config::ConfigSubscriptionCommonBaseSharedPtr {
-            const auto& scoped_rds_config_source = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::http_connection_manager::v3::ScopedRds>(
+            const auto& scoped_rds_config_source = Envoy::Protobuf::DynamicCastMessage<
+                envoy::extensions::filters::network::http_connection_manager::v3::ScopedRds>(
                 config_source_proto);
             return std::make_shared<ScopedRdsConfigSubscription>(
                 scoped_rds_config_source, manager_identifier, typed_optarg.scoped_routes_name_,

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -119,7 +119,7 @@ absl::Status VhdsSubscription::onConfigUpdate(
       continue;
     }
     added_vhosts.emplace_back(
-        dynamic_cast<const envoy::config::route::v3::VirtualHost&>(resource.get().resource()));
+        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::VirtualHost>(resource.get().resource()));
   }
   if (config_update_info_->onVhdsUpdate(added_vhosts, std::move(added_resource_ids),
                                         removed_resources, version_info)) {

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -119,7 +119,8 @@ absl::Status VhdsSubscription::onConfigUpdate(
       continue;
     }
     added_vhosts.emplace_back(
-        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::VirtualHost>(resource.get().resource()));
+        Envoy::Protobuf::DynamicCastMessage<envoy::config::route::v3::VirtualHost>(
+            resource.get().resource()));
   }
   if (config_update_info_->onVhdsUpdate(added_vhosts, std::move(added_resource_ids),
                                         removed_resources, version_info)) {

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -41,7 +41,8 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     absl::string_view cluster_name = EMPTY_STRING;
     TRY_ASSERT_MAIN_THREAD {
       const envoy::config::cluster::v3::Cluster& cluster =
-          Envoy::Protobuf::DynamicCastMessage<envoy::config::cluster::v3::Cluster>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::cluster::v3::Cluster>(
+              resource.get().resource());
       cluster_name = cluster.name();
       if (!cluster_names.insert(cluster.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully applied.

--- a/source/common/upstream/cds_api_helper.cc
+++ b/source/common/upstream/cds_api_helper.cc
@@ -41,7 +41,7 @@ CdsApiHelper::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& adde
     absl::string_view cluster_name = EMPTY_STRING;
     TRY_ASSERT_MAIN_THREAD {
       const envoy::config::cluster::v3::Cluster& cluster =
-          dynamic_cast<const envoy::config::cluster::v3::Cluster&>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::cluster::v3::Cluster>(resource.get().resource());
       cluster_name = cluster.name();
       if (!cluster_names.insert(cluster.name()).second) {
         // NOTE: at this point, the first of these duplicates has already been successfully applied.

--- a/source/extensions/access_loggers/filters/process_ratelimit/config.cc
+++ b/source/extensions/access_loggers/filters/process_ratelimit/config.cc
@@ -17,9 +17,9 @@ AccessLog::FilterPtr ProcessRateLimitFilterFactory::createFilter(
     Server::Configuration::GenericFactoryContext& context) {
   auto factory_config =
       Config::Utility::translateToFactoryConfig(config, context.messageValidationVisitor(), *this);
-  const auto& process_ratelimit_config =
-      dynamic_cast<const envoy::extensions::access_loggers::filters::process_ratelimit::v3::
-                       ProcessRateLimitFilter&>(*factory_config);
+  const auto& process_ratelimit_config = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::access_loggers::filters::process_ratelimit::v3::ProcessRateLimitFilter>(
+      *factory_config);
   auto filter = std::make_unique<ProcessRateLimitFilter>(context, process_ratelimit_config);
   return filter;
 }

--- a/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
+++ b/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
@@ -131,7 +131,8 @@ RateLimiterProviderSingleton::TokenBucketSubscription::~TokenBucketSubscription(
 
 void RateLimiterProviderSingleton::TokenBucketSubscription::handleAddedResource(
     const Config::DecodedResourceRef& resource) {
-  const auto& config = Envoy::Protobuf::DynamicCastMessage<envoy::type::v3::TokenBucket>(resource.get().resource());
+  const auto& config =
+      Envoy::Protobuf::DynamicCastMessage<envoy::type::v3::TokenBucket>(resource.get().resource());
   size_t new_hash = MessageUtil::hash(config);
   // If the config is the same, no op.
   if (new_hash == token_bucket_config_hash_) {

--- a/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
+++ b/source/extensions/access_loggers/filters/process_ratelimit/provider_singleton.cc
@@ -131,7 +131,7 @@ RateLimiterProviderSingleton::TokenBucketSubscription::~TokenBucketSubscription(
 
 void RateLimiterProviderSingleton::TokenBucketSubscription::handleAddedResource(
     const Config::DecodedResourceRef& resource) {
-  const auto& config = dynamic_cast<const envoy::type::v3::TokenBucket&>(resource.get().resource());
+  const auto& config = Envoy::Protobuf::DynamicCastMessage<envoy::type::v3::TokenBucket>(resource.get().resource());
   size_t new_hash = MessageUtil::hash(config);
   // If the config is the same, no op.
   if (new_hash == token_bucket_config_hash_) {

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -210,7 +210,7 @@ EdsClusterImpl::onConfigUpdate(const std::vector<Config::DecodedResourceRef>& re
   }
 
   envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment =
-      dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+      Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
           resources[0].get().resource());
   if (cluster_load_assignment.cluster_name() != edsServiceName()) {
     const auto msg = fmt::format("Unexpected EDS cluster (expecting {}): {}", edsServiceName(),
@@ -466,7 +466,7 @@ void EdsClusterImpl::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReas
           "Did not receive EDS response on time, using cached ClusterLoadAssignment for cluster {}",
           edsServiceName());
       envoy::config::endpoint::v3::ClusterLoadAssignment cached_load_assignment =
-          dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(*cached_resource);
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(*cached_resource);
       info_->configUpdateStats().assignment_use_cached_.inc();
       using_cached_resource_ = true;
       update(std::move(cached_load_assignment));

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -466,7 +466,8 @@ void EdsClusterImpl::onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReas
           "Did not receive EDS response on time, using cached ClusterLoadAssignment for cluster {}",
           edsServiceName());
       envoy::config::endpoint::v3::ClusterLoadAssignment cached_load_assignment =
-          Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(*cached_resource);
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+              *cached_resource);
       info_->configUpdateStats().assignment_use_cached_.inc();
       using_cached_resource_ = true;
       update(std::move(cached_load_assignment));

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
@@ -541,7 +541,7 @@ void GrpcMuxImpl::processDiscoveryResources(const std::vector<DecodedResourcePtr
           (type_url == Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>())) {
         for (const auto& resource : found_resources) {
           const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resource.get().resource());
           eds_resources_cache_->setResource(resource.get().name(), cluster_load_assignment);
         }

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
@@ -541,8 +541,8 @@ void GrpcMuxImpl::processDiscoveryResources(const std::vector<DecodedResourcePtr
           (type_url == Config::getTypeUrl<envoy::config::endpoint::v3::ClusterLoadAssignment>())) {
         for (const auto& resource : found_resources) {
           const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resource.get().resource());
+              Envoy::Protobuf::DynamicCastMessage<
+                  envoy::config::endpoint::v3::ClusterLoadAssignment>(resource.get().resource());
           eds_resources_cache_->setResource(resource.get().name(), cluster_load_assignment);
         }
         // No need to remove resources from the cache, as currently only non-collection

--- a/source/extensions/config_subscription/grpc/watch_map.cc
+++ b/source/extensions/config_subscription/grpc/watch_map.cc
@@ -188,7 +188,7 @@ void WatchMap::onConfigUpdate(const std::vector<DecodedResourcePtr>& resources,
       if (interesting_resources[resource_idx]) {
         const auto& resource = resources[resource_idx];
         const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
-            dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+            Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                 resource.get()->resource());
         eds_resources_cache_->setResource(resource.get()->name(), cluster_load_assignment);
       }
@@ -294,7 +294,7 @@ void WatchMap::onConfigUpdate(
     // Add/update the watched resources to/in the cache.
     for (const auto& resource : decoded_resources) {
       const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment =
-          dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+          Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
               resource->resource());
       eds_resources_cache_->setResource(resource->name(), cluster_load_assignment);
     }

--- a/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
+++ b/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
@@ -70,9 +70,9 @@ Matcher::ActionConstSharedPtr
 ForwardClientCertActionFactory::createAction(const Protobuf::Message& config,
                                              ForwardClientCertActionFactoryContext&,
                                              ProtobufMessage::ValidationVisitor&) {
-  const auto& typed_config =
-      dynamic_cast<const envoy::extensions::filters::network::http_connection_manager::v3::
-                       HttpConnectionManager::ForwardClientCertConfig&>(config);
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+          ForwardClientCertConfig>(config);
 
   return std::make_shared<ForwardClientCertAction>(
       convertForwardClientCertDetailsType(typed_config.forward_client_cert_details()),

--- a/source/extensions/http/header_validators/envoy_default/config.cc
+++ b/source/extensions/http/header_validators/envoy_default/config.cc
@@ -15,7 +15,7 @@ namespace EnvoyDefault {
 ::Envoy::Http::HeaderValidatorFactoryPtr HeaderValidatorFactoryConfig::createFromProto(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& server_context) {
   auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(message), server_context.messageValidationVisitor(),
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
       *this);
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::

--- a/source/extensions/http/header_validators/envoy_default/config.cc
+++ b/source/extensions/http/header_validators/envoy_default/config.cc
@@ -15,8 +15,8 @@ namespace EnvoyDefault {
 ::Envoy::Http::HeaderValidatorFactoryPtr HeaderValidatorFactoryConfig::createFromProto(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& server_context) {
   auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
-      *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+      server_context.messageValidationVisitor(), *this);
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::
                                            envoy_default::v3::HeaderValidatorConfig&>(

--- a/source/extensions/http/original_ip_detection/xff/config.cc
+++ b/source/extensions/http/original_ip_detection/xff/config.cc
@@ -17,7 +17,7 @@ absl::StatusOr<Envoy::Http::OriginalIPDetectionSharedPtr>
 XffIPDetectionFactory::createExtension(const Protobuf::Message& message,
                                        Server::Configuration::FactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::http::original_ip_detection::xff::v3::XffConfig&>(
       *mptr, context.messageValidationVisitor());

--- a/source/extensions/http/original_ip_detection/xff/config.cc
+++ b/source/extensions/http/original_ip_detection/xff/config.cc
@@ -17,7 +17,8 @@ absl::StatusOr<Envoy::Http::OriginalIPDetectionSharedPtr>
 XffIPDetectionFactory::createExtension(const Protobuf::Message& message,
                                        Server::Configuration::FactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+      context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::http::original_ip_detection::xff::v3::XffConfig&>(
       *mptr, context.messageValidationVisitor());

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
@@ -36,7 +36,7 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    const auto& lb_config = dynamic_cast<const ClientSideWeightedRoundRobinLbProto&>(config);
+    const auto& lb_config = Envoy::Protobuf::DynamicCastMessage<ClientSideWeightedRoundRobinLbProto>(config);
     return Upstream::LoadBalancerConfigPtr{new Upstream::ClientSideWeightedRoundRobinLbConfig(
         lb_config, context.mainThreadDispatcher(), context.threadLocal())};
   }

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/config.h
@@ -36,7 +36,8 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    const auto& lb_config = Envoy::Protobuf::DynamicCastMessage<ClientSideWeightedRoundRobinLbProto>(config);
+    const auto& lb_config =
+        Envoy::Protobuf::DynamicCastMessage<ClientSideWeightedRoundRobinLbProto>(config);
     return Upstream::LoadBalancerConfigPtr{new Upstream::ClientSideWeightedRoundRobinLbConfig(
         lb_config, context.mainThreadDispatcher(), context.threadLocal())};
   }

--- a/source/extensions/load_balancing_policies/least_request/config.h
+++ b/source/extensions/load_balancing_policies/least_request/config.h
@@ -47,8 +47,8 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext&,
              const Protobuf::Message& config) override {
-    ASSERT(dynamic_cast<const LeastRequestLbProto*>(&config) != nullptr);
-    const LeastRequestLbProto& typed_config = dynamic_cast<const LeastRequestLbProto&>(config);
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<LeastRequestLbProto>(&config) != nullptr);
+    const LeastRequestLbProto& typed_config = Envoy::Protobuf::DynamicCastMessage<LeastRequestLbProto>(config);
     return Upstream::LoadBalancerConfigPtr{new TypedLeastRequestLbConfig(typed_config)};
   }
 

--- a/source/extensions/load_balancing_policies/least_request/config.h
+++ b/source/extensions/load_balancing_policies/least_request/config.h
@@ -48,7 +48,8 @@ public:
   loadConfig(Server::Configuration::ServerFactoryContext&,
              const Protobuf::Message& config) override {
     ASSERT(Envoy::Protobuf::DynamicCastMessage<LeastRequestLbProto>(&config) != nullptr);
-    const LeastRequestLbProto& typed_config = Envoy::Protobuf::DynamicCastMessage<LeastRequestLbProto>(config);
+    const LeastRequestLbProto& typed_config =
+        Envoy::Protobuf::DynamicCastMessage<LeastRequestLbProto>(config);
     return Upstream::LoadBalancerConfigPtr{new TypedLeastRequestLbConfig(typed_config)};
   }
 

--- a/source/extensions/load_balancing_policies/maglev/config.h
+++ b/source/extensions/load_balancing_policies/maglev/config.h
@@ -31,8 +31,8 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    ASSERT(dynamic_cast<const MaglevLbProto*>(&config) != nullptr);
-    const MaglevLbProto& typed_proto = dynamic_cast<const MaglevLbProto&>(config);
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<MaglevLbProto>(&config) != nullptr);
+    const MaglevLbProto& typed_proto = Envoy::Protobuf::DynamicCastMessage<MaglevLbProto>(config);
     absl::Status creation_status = absl::OkStatus();
     auto typed_config = std::make_unique<Upstream::TypedMaglevLbConfig>(
         typed_proto, context.regexEngine(), creation_status);

--- a/source/extensions/load_balancing_policies/random/config.h
+++ b/source/extensions/load_balancing_policies/random/config.h
@@ -42,8 +42,8 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext&,
              const Protobuf::Message& config) override {
-    ASSERT(dynamic_cast<const RandomLbProto*>(&config) != nullptr);
-    const RandomLbProto& typed_config = dynamic_cast<const RandomLbProto&>(config);
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<RandomLbProto>(&config) != nullptr);
+    const RandomLbProto& typed_config = Envoy::Protobuf::DynamicCastMessage<RandomLbProto>(config);
     return Upstream::LoadBalancerConfigPtr{new TypedRandomLbConfig(typed_config)};
   }
 

--- a/source/extensions/load_balancing_policies/ring_hash/config.h
+++ b/source/extensions/load_balancing_policies/ring_hash/config.h
@@ -32,7 +32,8 @@ public:
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
     ASSERT(Envoy::Protobuf::DynamicCastMessage<RingHashLbProto>(&config) != nullptr);
-    const RingHashLbProto& typed_proto = Envoy::Protobuf::DynamicCastMessage<RingHashLbProto>(config);
+    const RingHashLbProto& typed_proto =
+        Envoy::Protobuf::DynamicCastMessage<RingHashLbProto>(config);
     absl::Status creation_status = absl::OkStatus();
     auto typed_config = std::make_unique<Upstream::TypedRingHashLbConfig>(
         typed_proto, context.regexEngine(), creation_status);

--- a/source/extensions/load_balancing_policies/ring_hash/config.h
+++ b/source/extensions/load_balancing_policies/ring_hash/config.h
@@ -31,8 +31,8 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    ASSERT(dynamic_cast<const RingHashLbProto*>(&config) != nullptr);
-    const RingHashLbProto& typed_proto = dynamic_cast<const RingHashLbProto&>(config);
+    ASSERT(Envoy::Protobuf::DynamicCastMessage<RingHashLbProto>(&config) != nullptr);
+    const RingHashLbProto& typed_proto = Envoy::Protobuf::DynamicCastMessage<RingHashLbProto>(config);
     absl::Status creation_status = absl::OkStatus();
     auto typed_config = std::make_unique<Upstream::TypedRingHashLbConfig>(
         typed_proto, context.regexEngine(), creation_status);

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -54,7 +54,7 @@ SubsetLbFactory::create(OptRef<const Upstream::LoadBalancerConfig> lb_config,
                         TimeSource& time_source) {
 
   const auto* typed_config =
-      Envoy::Protobuf::DynamicCastMessage<Upstream::SubsetLoadBalancerConfig>(lb_config.ptr());
+      dynamic_cast<const Upstream::SubsetLoadBalancerConfig*>(lb_config.ptr());
   // The load balancing policy configuration will be loaded and validated in the main thread when we
   // load the cluster configuration. So we can assume the configuration is valid here.
   ASSERT(typed_config != nullptr,

--- a/source/extensions/load_balancing_policies/subset/config.cc
+++ b/source/extensions/load_balancing_policies/subset/config.cc
@@ -54,7 +54,7 @@ SubsetLbFactory::create(OptRef<const Upstream::LoadBalancerConfig> lb_config,
                         TimeSource& time_source) {
 
   const auto* typed_config =
-      dynamic_cast<const Upstream::SubsetLoadBalancerConfig*>(lb_config.ptr());
+      Envoy::Protobuf::DynamicCastMessage<Upstream::SubsetLoadBalancerConfig>(lb_config.ptr());
   // The load balancing policy configuration will be loaded and validated in the main thread when we
   // load the cluster configuration. So we can assume the configuration is valid here.
   ASSERT(typed_config != nullptr,
@@ -73,8 +73,8 @@ SubsetLbFactory::create(OptRef<const Upstream::LoadBalancerConfig> lb_config,
 absl::StatusOr<Upstream::LoadBalancerConfigPtr>
 SubsetLbFactory::loadConfig(Server::Configuration::ServerFactoryContext& factory_context,
                             const Protobuf::Message& config) {
-  ASSERT(dynamic_cast<const SubsetLbProto*>(&config) != nullptr);
-  const SubsetLbProto& typed_config = dynamic_cast<const SubsetLbProto&>(config);
+  ASSERT(Envoy::Protobuf::DynamicCastMessage<SubsetLbProto>(&config) != nullptr);
+  const SubsetLbProto& typed_config = Envoy::Protobuf::DynamicCastMessage<SubsetLbProto>(config);
 
   // Load the subset load balancer configuration. This will contains child load balancer
   // config and child load balancer factory.

--- a/source/extensions/load_balancing_policies/wrr_locality/config.h
+++ b/source/extensions/load_balancing_policies/wrr_locality/config.h
@@ -36,7 +36,7 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    const auto& lb_config = dynamic_cast<const WrrLocalityLbProto&>(config);
+    const auto& lb_config = Envoy::Protobuf::DynamicCastMessage<WrrLocalityLbProto>(config);
     Upstream::TypedLoadBalancerFactory* endpoint_picking_policy_factory = nullptr;
     // Iterate through the list of endpoint picking policies to find the first one that we know
     // about.
@@ -48,8 +48,7 @@ public:
 
       if (endpoint_picking_policy_factory != nullptr) {
         // Ensure that the endpoint picking policy is a ClientSideWeightedRoundRobin.
-        auto* client_side_weighted_round_robin_factory = dynamic_cast<
-            ::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory*>(
+        auto* client_side_weighted_round_robin_factory = Envoy::Protobuf::DynamicCastMessage<::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory>(
             endpoint_picking_policy_factory);
         if (client_side_weighted_round_robin_factory == nullptr) {
           return absl::InvalidArgumentError(

--- a/source/extensions/load_balancing_policies/wrr_locality/config.h
+++ b/source/extensions/load_balancing_policies/wrr_locality/config.h
@@ -36,7 +36,7 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    const auto& lb_config = Envoy::Protobuf::DynamicCastMessage<WrrLocalityLbProto>(config);
+    const auto& lb_config = dynamic_cast<const WrrLocalityLbProto&>(config);
     Upstream::TypedLoadBalancerFactory* endpoint_picking_policy_factory = nullptr;
     // Iterate through the list of endpoint picking policies to find the first one that we know
     // about.
@@ -48,7 +48,8 @@ public:
 
       if (endpoint_picking_policy_factory != nullptr) {
         // Ensure that the endpoint picking policy is a ClientSideWeightedRoundRobin.
-        auto* client_side_weighted_round_robin_factory = Envoy::Protobuf::DynamicCastMessage<::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory>(
+        auto* client_side_weighted_round_robin_factory = Envoy::Protobuf::DynamicCastMessage<
+            ::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory>(
             endpoint_picking_policy_factory);
         if (client_side_weighted_round_robin_factory == nullptr) {
           return absl::InvalidArgumentError(

--- a/source/extensions/load_balancing_policies/wrr_locality/config.h
+++ b/source/extensions/load_balancing_policies/wrr_locality/config.h
@@ -36,7 +36,7 @@ public:
   absl::StatusOr<Upstream::LoadBalancerConfigPtr>
   loadConfig(Server::Configuration::ServerFactoryContext& context,
              const Protobuf::Message& config) override {
-    const auto& lb_config = dynamic_cast<const WrrLocalityLbProto&>(config);
+    const auto& lb_config = Envoy::Protobuf::DynamicCastMessage<WrrLocalityLbProto>(config);
     Upstream::TypedLoadBalancerFactory* endpoint_picking_policy_factory = nullptr;
     // Iterate through the list of endpoint picking policies to find the first one that we know
     // about.
@@ -48,8 +48,8 @@ public:
 
       if (endpoint_picking_policy_factory != nullptr) {
         // Ensure that the endpoint picking policy is a ClientSideWeightedRoundRobin.
-        auto* client_side_weighted_round_robin_factory = Envoy::Protobuf::DynamicCastMessage<
-            ::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory>(
+        auto* client_side_weighted_round_robin_factory = dynamic_cast<
+            ::Envoy::Extensions::LoadBalancingPolicies::ClientSideWeightedRoundRobin::Factory*>(
             endpoint_picking_policy_factory);
         if (client_side_weighted_round_robin_factory == nullptr) {
           return absl::InvalidArgumentError(

--- a/source/extensions/matching/input_matchers/cel_matcher/config.h
+++ b/source/extensions/matching/input_matchers/cel_matcher/config.h
@@ -22,7 +22,7 @@ public:
   createInputMatcherFactoryCb(const Protobuf::Message& config,
                               Server::Configuration::ServerFactoryContext& context) override {
     const auto& cel_matcher_config =
-        dynamic_cast<const ::xds::type::matcher::v3::CelMatcher&>(config);
+        Envoy::Protobuf::DynamicCastMessage<::xds::type::matcher::v3::CelMatcher>(config);
     CelMatcherSharedPtr cel_matcher =
         std::make_shared<::xds::type::matcher::v3::CelMatcher>(cel_matcher_config);
 

--- a/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/config.cc
@@ -16,7 +16,7 @@ ResourceDetectorPtr DynatraceResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/dynatrace/config.cc
@@ -16,7 +16,8 @@ ResourceDetectorPtr DynatraceResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+      context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
@@ -15,7 +15,8 @@ ResourceDetectorPtr EnvironmentResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+      context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/environment/config.cc
@@ -15,7 +15,7 @@ ResourceDetectorPtr EnvironmentResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/resource_detectors/static/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/static/config.cc
@@ -15,7 +15,8 @@ ResourceDetectorPtr StaticConfigResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+      context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/resource_detectors/static/config.cc
+++ b/source/extensions/tracers/opentelemetry/resource_detectors/static/config.cc
@@ -15,7 +15,7 @@ ResourceDetectorPtr StaticConfigResourceDetectorFactory::createResourceDetector(
     const Protobuf::Message& message, Server::Configuration::ServerFactoryContext& context) {
 
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(message), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), context.messageValidationVisitor(), *this);
 
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::resource_detectors::v3::

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
@@ -16,7 +16,7 @@ SamplerSharedPtr
 ParentBasedSamplerFactory::createSampler(const Protobuf::Message& config,
                                          Server::Configuration::TracerFactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(config), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config), context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig&>(
       *mptr, context.messageValidationVisitor());

--- a/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/parent_based/config.cc
@@ -16,7 +16,8 @@ SamplerSharedPtr
 ParentBasedSamplerFactory::createSampler(const Protobuf::Message& config,
                                          Server::Configuration::TracerFactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config),
+      context.messageValidationVisitor(), *this);
   const auto& proto_config = MessageUtil::downcastAndValidate<
       const envoy::extensions::tracers::opentelemetry::samplers::v3::ParentBasedSamplerConfig&>(
       *mptr, context.messageValidationVisitor());

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
@@ -15,7 +15,8 @@ namespace OpenTelemetry {
 SamplerSharedPtr TraceIdRatioBasedSamplerFactory::createSampler(
     const Protobuf::Message& config, Server::Configuration::TracerFactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config),
+      context.messageValidationVisitor(), *this);
 
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::tracers::opentelemetry::samplers::

--- a/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
+++ b/source/extensions/tracers/opentelemetry/samplers/trace_id_ratio_based/config.cc
@@ -15,7 +15,7 @@ namespace OpenTelemetry {
 SamplerSharedPtr TraceIdRatioBasedSamplerFactory::createSampler(
     const Protobuf::Message& config, Server::Configuration::TracerFactoryContext& context) {
   auto mptr = Envoy::Config::Utility::translateAnyToFactoryConfig(
-      dynamic_cast<const Protobuf::Any&>(config), context.messageValidationVisitor(), *this);
+      Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(config), context.messageValidationVisitor(), *this);
 
   const auto& proto_config =
       MessageUtil::downcastAndValidate<const envoy::extensions::tracers::opentelemetry::samplers::

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1730,7 +1730,8 @@ public:
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 
-    Protobuf::Struct struct_config = *Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(factory_config.get());
+    Protobuf::Struct struct_config =
+        *Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(factory_config.get());
     return std::make_unique<SampleExtensionFilter>(
         static_cast<uint32_t>(struct_config.fields().at("rate").number_value()));
   }

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1730,7 +1730,7 @@ public:
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 
-    Protobuf::Struct struct_config = *dynamic_cast<const Protobuf::Struct*>(factory_config.get());
+    Protobuf::Struct struct_config = *Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(factory_config.get());
     return std::make_unique<SampleExtensionFilter>(
         static_cast<uint32_t>(struct_config.fields().at("rate").number_value()));
   }

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -80,7 +80,7 @@ public:
   absl::Status onConfigUpdate(const std::vector<DecodedResourceRef>& resources,
                               const std::string& version_info) override {
     const auto& config =
-        dynamic_cast<const test::common::config::DummyConfig&>(resources[0].get().resource());
+        Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(resources[0].get().resource());
     if (checkAndApplyConfigUpdate(config, "dummy_config", version_info)) {
       config_proto_ = config;
     }
@@ -199,7 +199,7 @@ public:
     // Currently, the dummy config provider only supports a single static config. We can extend this
     // to support multiple static configs if needed.
     ASSERT(configs.size() == 1);
-    auto config = dynamic_cast<const test::common::config::DummyConfig&>(*configs[0]);
+    auto config = Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(*configs[0]);
     return std::make_unique<StaticDummyConfigProvider>(config, factory_context, *this);
   }
 };
@@ -271,7 +271,7 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
   const auto dummy_config = parseDummyConfigFromYaml("a: a dummy config");
 
   DummyConfigSubscription& subscription =
-      dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription();
+      Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription();
   const auto decoded_resources = TestUtility::decodeResources({dummy_config}, "a");
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "1").ok());
 
@@ -282,8 +282,8 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
       ConfigProviderManager::NullOptionalArg());
 
   EXPECT_TRUE(provider2->configProtoInfoVector<test::common::config::DummyConfig>().has_value());
-  EXPECT_EQ(&dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription(),
-            &dynamic_cast<DummyDynamicConfigProvider&>(*provider2).subscription());
+  EXPECT_EQ(&Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription(),
+            &Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider2).subscription());
   EXPECT_EQ(provider1->config<const DummyConfig>().get(),
             provider2->config<const DummyConfig>().get());
 
@@ -293,12 +293,12 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
       config_source_proto, server_factory_context_, init_manager_, "dummy_prefix",
       ConfigProviderManager::NullOptionalArg());
 
-  EXPECT_NE(&dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription(),
-            &dynamic_cast<DummyDynamicConfigProvider&>(*provider3).subscription());
+  EXPECT_NE(&Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription(),
+            &Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider3).subscription());
   EXPECT_NE(provider1->config<const DummyConfig>().get(),
             provider3->config<const DummyConfig>().get());
 
-  ASSERT_TRUE(dynamic_cast<DummyDynamicConfigProvider&>(*provider3)
+  ASSERT_TRUE(Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider3)
                   .subscription()
                   .onConfigUpdate(decoded_resources.refvec_, "provider3")
                   .ok());
@@ -457,7 +457,7 @@ dynamic_dummy_configs:
 
   timeSystem().setSystemTime(std::chrono::milliseconds(1234567891567));
   DummyConfigSubscription& subscription =
-      dynamic_cast<DummyDynamicConfigProvider&>(*dynamic_provider).subscription();
+      Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*dynamic_provider).subscription();
   const auto decoded_resources = TestUtility::decodeResources({dummy_config}, "a");
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "v1").ok());
 
@@ -546,7 +546,7 @@ public:
     // implementations.
     for (const auto& resource : resources) {
       const auto& dummy_config =
-          dynamic_cast<const test::common::config::DummyConfig&>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(resource.get().resource());
       proto_map_[version_info] = dummy_config;
       // Propagate the new config proto to all worker threads.
       applyConfigUpdate([&dummy_config](ConfigProvider::ConfigConstSharedPtr prev_config)
@@ -708,7 +708,7 @@ TEST_F(DeltaConfigProviderImplTest, MultipleDeltaSubscriptions) {
       TestUtility::decodeResources({dummy_config_0, dummy_config_1}, "a");
 
   DeltaDummyConfigSubscription& subscription =
-      dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider1).subscription();
+      Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider1).subscription();
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "1").ok());
 
   ConfigProviderPtr provider2 = provider_manager_->createXdsConfigProvider(
@@ -717,8 +717,8 @@ TEST_F(DeltaConfigProviderImplTest, MultipleDeltaSubscriptions) {
 
   // Providers, config implementations (i.e., the DummyConfig) and config protos are
   // expected to be shared for a given subscription.
-  EXPECT_EQ(&dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider1).subscription(),
-            &dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider2).subscription());
+  EXPECT_EQ(&Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider1).subscription(),
+            &Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider2).subscription());
   ASSERT_TRUE(provider2->configProtoInfoVector<test::common::config::DummyConfig>().has_value());
   EXPECT_EQ(
       provider1->configProtoInfoVector<test::common::config::DummyConfig>().value().config_protos_,
@@ -746,7 +746,7 @@ TEST_F(DeltaConfigProviderImplTest, DeltaSubscriptionFailure) {
       config_source_proto, server_factory_context_, init_manager_, "dummy_prefix",
       ConfigProviderManager::NullOptionalArg());
   DeltaDummyConfigSubscription& subscription =
-      dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider).subscription();
+      Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider).subscription();
   const auto time = std::chrono::milliseconds(1234567891234);
   timeSystem().setSystemTime(time);
   const EnvoyException ex(fmt::format("config failure"));

--- a/test/common/config/config_provider_impl_test.cc
+++ b/test/common/config/config_provider_impl_test.cc
@@ -79,8 +79,8 @@ public:
   // Envoy::Config::SubscriptionCallbacks
   absl::Status onConfigUpdate(const std::vector<DecodedResourceRef>& resources,
                               const std::string& version_info) override {
-    const auto& config =
-        Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(resources[0].get().resource());
+    const auto& config = Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(
+        resources[0].get().resource());
     if (checkAndApplyConfigUpdate(config, "dummy_config", version_info)) {
       config_proto_ = config;
     }
@@ -199,7 +199,8 @@ public:
     // Currently, the dummy config provider only supports a single static config. We can extend this
     // to support multiple static configs if needed.
     ASSERT(configs.size() == 1);
-    auto config = Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(*configs[0]);
+    auto config =
+        Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(*configs[0]);
     return std::make_unique<StaticDummyConfigProvider>(config, factory_context, *this);
   }
 };
@@ -271,7 +272,7 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
   const auto dummy_config = parseDummyConfigFromYaml("a: a dummy config");
 
   DummyConfigSubscription& subscription =
-      Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription();
+      dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription();
   const auto decoded_resources = TestUtility::decodeResources({dummy_config}, "a");
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "1").ok());
 
@@ -282,8 +283,8 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
       ConfigProviderManager::NullOptionalArg());
 
   EXPECT_TRUE(provider2->configProtoInfoVector<test::common::config::DummyConfig>().has_value());
-  EXPECT_EQ(&Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription(),
-            &Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider2).subscription());
+  EXPECT_EQ(&dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription(),
+            &dynamic_cast<DummyDynamicConfigProvider&>(*provider2).subscription());
   EXPECT_EQ(provider1->config<const DummyConfig>().get(),
             provider2->config<const DummyConfig>().get());
 
@@ -293,12 +294,12 @@ TEST_F(ConfigProviderImplTest, SharedOwnership) {
       config_source_proto, server_factory_context_, init_manager_, "dummy_prefix",
       ConfigProviderManager::NullOptionalArg());
 
-  EXPECT_NE(&Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider1).subscription(),
-            &Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider3).subscription());
+  EXPECT_NE(&dynamic_cast<DummyDynamicConfigProvider&>(*provider1).subscription(),
+            &dynamic_cast<DummyDynamicConfigProvider&>(*provider3).subscription());
   EXPECT_NE(provider1->config<const DummyConfig>().get(),
             provider3->config<const DummyConfig>().get());
 
-  ASSERT_TRUE(Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*provider3)
+  ASSERT_TRUE(dynamic_cast<DummyDynamicConfigProvider&>(*provider3)
                   .subscription()
                   .onConfigUpdate(decoded_resources.refvec_, "provider3")
                   .ok());
@@ -457,7 +458,7 @@ dynamic_dummy_configs:
 
   timeSystem().setSystemTime(std::chrono::milliseconds(1234567891567));
   DummyConfigSubscription& subscription =
-      Envoy::Protobuf::DynamicCastMessage<DummyDynamicConfigProvider>(*dynamic_provider).subscription();
+      dynamic_cast<DummyDynamicConfigProvider&>(*dynamic_provider).subscription();
   const auto decoded_resources = TestUtility::decodeResources({dummy_config}, "a");
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "v1").ok());
 
@@ -546,7 +547,8 @@ public:
     // implementations.
     for (const auto& resource : resources) {
       const auto& dummy_config =
-          Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(resource.get().resource());
+          Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(
+              resource.get().resource());
       proto_map_[version_info] = dummy_config;
       // Propagate the new config proto to all worker threads.
       applyConfigUpdate([&dummy_config](ConfigProvider::ConfigConstSharedPtr prev_config)
@@ -708,7 +710,7 @@ TEST_F(DeltaConfigProviderImplTest, MultipleDeltaSubscriptions) {
       TestUtility::decodeResources({dummy_config_0, dummy_config_1}, "a");
 
   DeltaDummyConfigSubscription& subscription =
-      Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider1).subscription();
+      dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider1).subscription();
   ASSERT_TRUE(subscription.onConfigUpdate(decoded_resources.refvec_, "1").ok());
 
   ConfigProviderPtr provider2 = provider_manager_->createXdsConfigProvider(
@@ -717,8 +719,8 @@ TEST_F(DeltaConfigProviderImplTest, MultipleDeltaSubscriptions) {
 
   // Providers, config implementations (i.e., the DummyConfig) and config protos are
   // expected to be shared for a given subscription.
-  EXPECT_EQ(&Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider1).subscription(),
-            &Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider2).subscription());
+  EXPECT_EQ(&dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider1).subscription(),
+            &dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider2).subscription());
   ASSERT_TRUE(provider2->configProtoInfoVector<test::common::config::DummyConfig>().has_value());
   EXPECT_EQ(
       provider1->configProtoInfoVector<test::common::config::DummyConfig>().value().config_protos_,
@@ -746,7 +748,7 @@ TEST_F(DeltaConfigProviderImplTest, DeltaSubscriptionFailure) {
       config_source_proto, server_factory_context_, init_manager_, "dummy_prefix",
       ConfigProviderManager::NullOptionalArg());
   DeltaDummyConfigSubscription& subscription =
-      Envoy::Protobuf::DynamicCastMessage<DeltaDummyDynamicConfigProvider>(*provider).subscription();
+      dynamic_cast<DeltaDummyDynamicConfigProvider&>(*provider).subscription();
   const auto time = std::chrono::milliseconds(1234567891234);
   timeSystem().setSystemTime(time);
   const EnvoyException ex(fmt::format("config failure"));

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -344,7 +344,7 @@ protected:
     auto message_ptr =
         server_.admin_.config_tracker_.config_tracker_callbacks_["listeners"](name_matcher);
     const auto& listeners_config_dump =
-        dynamic_cast<const envoy::admin::v3::ListenersConfigDump&>(*message_ptr);
+        Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*message_ptr);
     envoy::admin::v3::ListenersConfigDump expected_listeners_config_dump;
     TestUtility::loadFromYaml(expected_dump_yaml, expected_listeners_config_dump);
     EXPECT_EQ(expected_listeners_config_dump.DebugString(), listeners_config_dump.DebugString());

--- a/test/common/matcher/test_utility.h
+++ b/test/common/matcher/test_utility.h
@@ -172,7 +172,7 @@ class StringActionFactory : public ActionFactory<absl::string_view> {
 public:
   ActionConstSharedPtr createAction(const Protobuf::Message& config, absl::string_view&,
                                     ProtobufMessage::ValidationVisitor&) override {
-    const auto& string = dynamic_cast<const Protobuf::StringValue&>(config);
+    const auto& string = Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(config);
     return std::make_shared<StringAction>(string.value());
   }
 
@@ -236,7 +236,7 @@ public:
   InputMatcherFactoryCb
   createInputMatcherFactoryCb(const Protobuf::Message& config,
                               Server::Configuration::ServerFactoryContext&) override {
-    const auto& string = dynamic_cast<const Protobuf::StringValue&>(config);
+    const auto& string = Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(config);
     return [string]() { return std::make_unique<CustomStringMatcher>(string.value()); };
   }
 

--- a/test/common/router/config_impl_integration_test.cc
+++ b/test/common/router/config_impl_integration_test.cc
@@ -28,7 +28,7 @@ public:
     RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
                               const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                               uint64_t) const override {
-      ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
+      ASSERT(Envoy::Protobuf::DynamicCastMessage<RouteEntryImplBase>(parent.get()) != nullptr);
       return std::make_shared<Router::DynamicRouteEntry>(parent, std::string(cluster_name_));
     }
 
@@ -39,7 +39,7 @@ public:
   ClusterSpecifierPluginSharedPtr
   createClusterSpecifierPlugin(const Protobuf::Message& config,
                                Server::Configuration::ServerFactoryContext&) override {
-    const auto& typed_config = dynamic_cast<const Protobuf::Struct&>(config);
+    const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
     return std::make_shared<FakeClusterSpecifierPlugin>(
         typed_config.fields().at("name").string_value());
   }

--- a/test/common/router/config_impl_integration_test.cc
+++ b/test/common/router/config_impl_integration_test.cc
@@ -28,7 +28,7 @@ public:
     RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
                               const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&,
                               uint64_t) const override {
-      ASSERT(Envoy::Protobuf::DynamicCastMessage<RouteEntryImplBase>(parent.get()) != nullptr);
+      ASSERT(dynamic_cast<const RouteEntryImplBase*>(parent.get()) != nullptr);
       return std::make_shared<Router::DynamicRouteEntry>(parent, std::string(cluster_name_));
     }
 

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4124,7 +4124,8 @@ virtual_hosts:
            mock_cluster_specifier_plugin_3](
               const Protobuf::Message& config,
               Server::Configuration::CommonFactoryContext&) -> ClusterSpecifierPluginSharedPtr {
-            const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
+            const auto& typed_config =
+                Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
             if (auto iter = typed_config.fields().find("a"); iter == typed_config.fields().end()) {
               return nullptr;
             } else if (iter->second.string_value() == "test1") {
@@ -4202,7 +4203,8 @@ virtual_hosts:
            mock_cluster_specifier_plugin_3](
               const Protobuf::Message& config,
               Server::Configuration::CommonFactoryContext&) -> ClusterSpecifierPluginSharedPtr {
-            const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
+            const auto& typed_config =
+                Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
             if (auto iter = typed_config.fields().find("a"); iter == typed_config.fields().end()) {
               return nullptr;
             } else if (iter->second.string_value() == "test1") {
@@ -11864,11 +11866,11 @@ public:
     const auto route = config.route(genHeaders("www.foo.com", "/", "GET"), 0);
     absl::InlinedVector<uint32_t, 3> traveled_cfg;
 
-    check(Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(
+    check(dynamic_cast<const DerivedFilterConfig*>(
               route->mostSpecificPerFilterConfig(route_config_name)),
           expected_most_specific_config, "most specific config");
     for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
-      auto* typed_cfg = Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(cfg);
+      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
       traveled_cfg.push_back(typed_cfg->config_.seconds());
     }
 
@@ -11890,7 +11892,7 @@ public:
 
     EXPECT_EQ(nullptr, route->mostSpecificPerFilterConfig(route_config_name));
     for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
-      auto* typed_cfg = Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(cfg);
+      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
       traveled_cfg.push_back(typed_cfg->config_.seconds());
     }
     EXPECT_EQ(0, traveled_cfg.size());
@@ -12728,7 +12730,7 @@ virtual_hosts:
         return RouteMatchStatus::Continue;
       },
       genHeaders("bat.com", "/", "GET"));
-  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<SslRedirectRoute>(accepted_route.get()));
+  EXPECT_NE(nullptr, dynamic_cast<const SslRedirectRoute*>(accepted_route.get()));
 
   {
     EXPECT_EQ(nullptr, accepted_route->routeEntry());
@@ -12772,7 +12774,7 @@ virtual_hosts:
         return RouteMatchStatus::Continue;
       },
       genHeaders("bat.com", "/", "GET"));
-  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<SslRedirectRoute>(accepted_route.get()));
+  EXPECT_NE(nullptr, dynamic_cast<const SslRedirectRoute*>(accepted_route.get()));
 }
 
 class CommonConfigImplTest : public testing::Test, public ConfigImplTestBase {};
@@ -12798,7 +12800,7 @@ virtual_hosts:
   TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
                         creation_status_);
 
-  const auto& shared_config = Envoy::Protobuf::DynamicCastMessage<CommonConfigImpl>(
+  const auto& shared_config = dynamic_cast<const CommonConfigImpl&>(
       config.route(genHeaders("bat.com", "/", "GET"), 0)->virtualHost().routeConfig());
 
   EXPECT_EQ(config.mostSpecificHeaderMutationsWins(),

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4124,7 +4124,7 @@ virtual_hosts:
            mock_cluster_specifier_plugin_3](
               const Protobuf::Message& config,
               Server::Configuration::CommonFactoryContext&) -> ClusterSpecifierPluginSharedPtr {
-            const auto& typed_config = dynamic_cast<const Protobuf::Struct&>(config);
+            const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
             if (auto iter = typed_config.fields().find("a"); iter == typed_config.fields().end()) {
               return nullptr;
             } else if (iter->second.string_value() == "test1") {
@@ -4202,7 +4202,7 @@ virtual_hosts:
            mock_cluster_specifier_plugin_3](
               const Protobuf::Message& config,
               Server::Configuration::CommonFactoryContext&) -> ClusterSpecifierPluginSharedPtr {
-            const auto& typed_config = dynamic_cast<const Protobuf::Struct&>(config);
+            const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(config);
             if (auto iter = typed_config.fields().find("a"); iter == typed_config.fields().end()) {
               return nullptr;
             } else if (iter->second.string_value() == "test1") {
@@ -11864,11 +11864,11 @@ public:
     const auto route = config.route(genHeaders("www.foo.com", "/", "GET"), 0);
     absl::InlinedVector<uint32_t, 3> traveled_cfg;
 
-    check(dynamic_cast<const DerivedFilterConfig*>(
+    check(Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(
               route->mostSpecificPerFilterConfig(route_config_name)),
           expected_most_specific_config, "most specific config");
     for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
-      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
+      auto* typed_cfg = Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(cfg);
       traveled_cfg.push_back(typed_cfg->config_.seconds());
     }
 
@@ -11890,7 +11890,7 @@ public:
 
     EXPECT_EQ(nullptr, route->mostSpecificPerFilterConfig(route_config_name));
     for (const auto* cfg : route->perFilterConfigs(route_config_name)) {
-      auto* typed_cfg = dynamic_cast<const DerivedFilterConfig*>(cfg);
+      auto* typed_cfg = Envoy::Protobuf::DynamicCastMessage<DerivedFilterConfig>(cfg);
       traveled_cfg.push_back(typed_cfg->config_.seconds());
     }
     EXPECT_EQ(0, traveled_cfg.size());
@@ -12728,7 +12728,7 @@ virtual_hosts:
         return RouteMatchStatus::Continue;
       },
       genHeaders("bat.com", "/", "GET"));
-  EXPECT_NE(nullptr, dynamic_cast<const SslRedirectRoute*>(accepted_route.get()));
+  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<SslRedirectRoute>(accepted_route.get()));
 
   {
     EXPECT_EQ(nullptr, accepted_route->routeEntry());
@@ -12772,7 +12772,7 @@ virtual_hosts:
         return RouteMatchStatus::Continue;
       },
       genHeaders("bat.com", "/", "GET"));
-  EXPECT_NE(nullptr, dynamic_cast<const SslRedirectRoute*>(accepted_route.get()));
+  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<SslRedirectRoute>(accepted_route.get()));
 }
 
 class CommonConfigImplTest : public testing::Test, public ConfigImplTestBase {};
@@ -12798,7 +12798,7 @@ virtual_hosts:
   TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
                         creation_status_);
 
-  const auto& shared_config = dynamic_cast<const CommonConfigImpl&>(
+  const auto& shared_config = Envoy::Protobuf::DynamicCastMessage<CommonConfigImpl>(
       config.route(genHeaders("bat.com", "/", "GET"), 0)->virtualHost().routeConfig());
 
   EXPECT_EQ(config.mostSpecificHeaderMutationsWins(),

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -48,7 +48,7 @@ protected:
       const Matchers::StringMatcher& name_matcher = Matchers::UniversalStringMatcher()) {
     auto message_ptr = config_tracker_.config_tracker_callbacks_["secrets"](name_matcher);
     const auto& secrets_config_dump =
-        dynamic_cast<const envoy::admin::v3::SecretsConfigDump&>(*message_ptr);
+        Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::SecretsConfigDump>(*message_ptr);
     envoy::admin::v3::SecretsConfigDump expected_secrets_config_dump;
     TestUtility::loadFromYaml(expected_dump_yaml, expected_secrets_config_dump);
     EXPECT_THAT(secrets_config_dump,

--- a/test/common/stream_info/uint32_accessor_impl_test.cc
+++ b/test/common/stream_info/uint32_accessor_impl_test.cc
@@ -25,7 +25,7 @@ TEST(UInt32AccessorImplTest, TestProto) {
   auto message = accessor.serializeAsProto();
   EXPECT_NE(nullptr, message);
 
-  auto* uint32_struct = dynamic_cast<Protobuf::UInt32Value*>(message.get());
+  auto* uint32_struct = Envoy::Protobuf::DynamicCastMessage<Protobuf::UInt32Value>(message.get());
   EXPECT_NE(nullptr, uint32_struct);
   EXPECT_EQ(init_value, uint32_struct->value());
 }

--- a/test/common/stream_info/uint64_accessor_impl_test.cc
+++ b/test/common/stream_info/uint64_accessor_impl_test.cc
@@ -26,7 +26,7 @@ TEST(UInt64AccessorImplTest, TestProto) {
   auto message = accessor.serializeAsProto();
   EXPECT_NE(nullptr, message);
 
-  auto* uint64_struct = dynamic_cast<Protobuf::UInt64Value*>(message.get());
+  auto* uint64_struct = Envoy::Protobuf::DynamicCastMessage<Protobuf::UInt64Value>(message.get());
   EXPECT_NE(nullptr, uint64_struct);
   EXPECT_EQ(init_value, uint64_struct->value());
 }

--- a/test/common/tls/cert_selector/async_cert_selector.h
+++ b/test/common/tls/cert_selector/async_cert_selector.h
@@ -67,7 +67,7 @@ public:
       return absl::InvalidArgumentError("does not support for quic");
     }
 
-    auto& string_value = dynamic_cast<const Protobuf::StringValue&>(config);
+    auto& string_value = Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(config);
     std::string mode = string_value.value();
     if (mode.empty()) {
       return absl::InvalidArgumentError("invalid cert selection mode");

--- a/test/common/upstream/cluster_manager_impl_test_common.cc
+++ b/test/common/upstream/cluster_manager_impl_test_common.cc
@@ -166,7 +166,7 @@ void ClusterManagerImplTest::checkConfigDump(const std::string& expected_dump_ya
       factory_.server_context_.admin_.config_tracker_.config_tracker_callbacks_["clusters"](
           name_matcher);
   const auto& clusters_config_dump =
-      dynamic_cast<const envoy::admin::v3::ClustersConfigDump&>(*message_ptr);
+      Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ClustersConfigDump>(*message_ptr);
 
   envoy::admin::v3::ClustersConfigDump expected_clusters_config_dump;
   TestUtility::loadFromYaml(expected_dump_yaml, expected_clusters_config_dump);

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -75,7 +75,7 @@ public:
   absl::StatusOr<Network::UpstreamTransportSocketFactoryPtr>
   createTransportSocketFactory(const Protobuf::Message& proto,
                                Server::Configuration::TransportSocketFactoryContext&) override {
-    const auto& node = dynamic_cast<const envoy::config::core::v3::Node&>(proto);
+    const auto& node = Envoy::Protobuf::DynamicCastMessage<envoy::config::core::v3::Node>(proto);
     std::string id = "default-foo";
     if (!node.id().empty()) {
       id = node.id();
@@ -113,7 +113,7 @@ public:
                 const envoy::config::core::v3::Metadata* locality_metadata,
                 const std::string& expected) {
     auto& factory = matcher_->resolve(endpoint_metadata, locality_metadata).factory_;
-    const auto& config_factory = dynamic_cast<const FakeTransportSocketFactory&>(factory);
+    const auto& config_factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory);
     EXPECT_EQ(expected, config_factory.id());
   }
 
@@ -308,7 +308,7 @@ filter_metadata:
 )EOF",
                             endpoint_metadata);
   auto& factory_tls = matcher_->resolve(&endpoint_metadata, nullptr).factory_;
-  const auto& foo_tls = dynamic_cast<const FakeTransportSocketFactory&>(factory_tls);
+  const auto& foo_tls = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory_tls);
   EXPECT_EQ("tls_id", foo_tls.id());
 
   // Endpoint metadata selects raw.
@@ -319,7 +319,7 @@ filter_metadata:
 )EOF",
                             endpoint_metadata2);
   auto& factory_raw = matcher_->resolve(&endpoint_metadata2, nullptr).factory_;
-  const auto& foo_raw = dynamic_cast<const FakeTransportSocketFactory&>(factory_raw);
+  const auto& foo_raw = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory_raw);
   EXPECT_EQ("raw_id", foo_raw.id());
 }
 
@@ -517,7 +517,7 @@ transport_socket:
   matcher_ = std::move(*result_or);
 
   auto& factory = matcher_->resolve(nullptr, nullptr).factory_;
-  const auto& f = dynamic_cast<const FakeTransportSocketFactory&>(factory);
+  const auto& f = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory);
   EXPECT_EQ("default", f.id());
 }
 
@@ -659,7 +659,7 @@ on_no_match:
 
     // Resolve transport socket - should select namespace_a_socket.
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
+    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id());
     EXPECT_EQ("namespace_a_socket", result.name_);
   }
@@ -680,7 +680,7 @@ on_no_match:
         absl::nullopt, std::move(shared_objects));
 
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
+    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
     EXPECT_EQ("namespace_b_id", factory.id());
     EXPECT_EQ("namespace_b_socket", result.name_);
   }
@@ -688,7 +688,7 @@ on_no_match:
   // Test 3: No TransportSocketOptions. It should fall back to on_no_match.
   {
     auto result = matcher_->resolve(nullptr, nullptr, nullptr);
-    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
+    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id()); // on_no_match defaults to namespace_a_socket
     EXPECT_EQ("namespace_a_socket", result.name_);
   }
@@ -703,7 +703,7 @@ on_no_match:
         absl::nullopt, std::move(shared_objects));
 
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
+    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id()); // on_no_match defaults to namespace_a_socket
     EXPECT_EQ("namespace_a_socket", result.name_);
   }

--- a/test/common/upstream/transport_socket_matcher_test.cc
+++ b/test/common/upstream/transport_socket_matcher_test.cc
@@ -113,7 +113,7 @@ public:
                 const envoy::config::core::v3::Metadata* locality_metadata,
                 const std::string& expected) {
     auto& factory = matcher_->resolve(endpoint_metadata, locality_metadata).factory_;
-    const auto& config_factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory);
+    const auto& config_factory = dynamic_cast<const FakeTransportSocketFactory&>(factory);
     EXPECT_EQ(expected, config_factory.id());
   }
 
@@ -308,7 +308,7 @@ filter_metadata:
 )EOF",
                             endpoint_metadata);
   auto& factory_tls = matcher_->resolve(&endpoint_metadata, nullptr).factory_;
-  const auto& foo_tls = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory_tls);
+  const auto& foo_tls = dynamic_cast<const FakeTransportSocketFactory&>(factory_tls);
   EXPECT_EQ("tls_id", foo_tls.id());
 
   // Endpoint metadata selects raw.
@@ -319,7 +319,7 @@ filter_metadata:
 )EOF",
                             endpoint_metadata2);
   auto& factory_raw = matcher_->resolve(&endpoint_metadata2, nullptr).factory_;
-  const auto& foo_raw = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory_raw);
+  const auto& foo_raw = dynamic_cast<const FakeTransportSocketFactory&>(factory_raw);
   EXPECT_EQ("raw_id", foo_raw.id());
 }
 
@@ -517,7 +517,7 @@ transport_socket:
   matcher_ = std::move(*result_or);
 
   auto& factory = matcher_->resolve(nullptr, nullptr).factory_;
-  const auto& f = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(factory);
+  const auto& f = dynamic_cast<const FakeTransportSocketFactory&>(factory);
   EXPECT_EQ("default", f.id());
 }
 
@@ -659,7 +659,7 @@ on_no_match:
 
     // Resolve transport socket - should select namespace_a_socket.
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
+    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id());
     EXPECT_EQ("namespace_a_socket", result.name_);
   }
@@ -680,7 +680,7 @@ on_no_match:
         absl::nullopt, std::move(shared_objects));
 
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
+    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
     EXPECT_EQ("namespace_b_id", factory.id());
     EXPECT_EQ("namespace_b_socket", result.name_);
   }
@@ -688,7 +688,7 @@ on_no_match:
   // Test 3: No TransportSocketOptions. It should fall back to on_no_match.
   {
     auto result = matcher_->resolve(nullptr, nullptr, nullptr);
-    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
+    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id()); // on_no_match defaults to namespace_a_socket
     EXPECT_EQ("namespace_a_socket", result.name_);
   }
@@ -703,7 +703,7 @@ on_no_match:
         absl::nullopt, std::move(shared_objects));
 
     auto result = matcher_->resolve(nullptr, nullptr, transport_socket_options);
-    const auto& factory = Envoy::Protobuf::DynamicCastMessage<FakeTransportSocketFactory>(result.factory_);
+    const auto& factory = dynamic_cast<const FakeTransportSocketFactory&>(result.factory_);
     EXPECT_EQ("namespace_a_id", factory.id()); // on_no_match defaults to namespace_a_socket
     EXPECT_EQ("namespace_a_socket", result.name_);
   }

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2838,7 +2838,7 @@ TEST_F(StaticClusterImplTest, RoundRobinWithSlowStart) {
 
   EXPECT_EQ("envoy.load_balancing_policies.round_robin",
             cluster->info()->loadBalancerFactory().name());
-  auto slow_start_config = Envoy::Protobuf::DynamicCastMessage<Upstream::TypedRoundRobinLbConfig>(
+  auto slow_start_config = dynamic_cast<const Upstream::TypedRoundRobinLbConfig*>(
                                cluster->info()->loadBalancerConfig().ptr())
                                ->lb_config_.slow_start_config();
   EXPECT_EQ(std::chrono::milliseconds(60000),
@@ -2881,7 +2881,8 @@ TEST_F(StaticClusterImplTest, LeastRequestWithSlowStart) {
   EXPECT_EQ("envoy.load_balancing_policies.least_request",
             cluster->info()->loadBalancerFactory().name());
   auto slow_start_config =
-      Envoy::Protobuf::DynamicCastMessage<Extensions::LoadBalancingPolicies::LeastRequest::TypedLeastRequestLbConfig>(
+      dynamic_cast<
+          const Extensions::LoadBalancingPolicies::LeastRequest::TypedLeastRequestLbConfig*>(
           cluster->info()->loadBalancerConfig().ptr())
           ->lb_config_.slow_start_config();
   EXPECT_EQ(std::chrono::milliseconds(60000),

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -2838,7 +2838,7 @@ TEST_F(StaticClusterImplTest, RoundRobinWithSlowStart) {
 
   EXPECT_EQ("envoy.load_balancing_policies.round_robin",
             cluster->info()->loadBalancerFactory().name());
-  auto slow_start_config = dynamic_cast<const Upstream::TypedRoundRobinLbConfig*>(
+  auto slow_start_config = Envoy::Protobuf::DynamicCastMessage<Upstream::TypedRoundRobinLbConfig>(
                                cluster->info()->loadBalancerConfig().ptr())
                                ->lb_config_.slow_start_config();
   EXPECT_EQ(std::chrono::milliseconds(60000),
@@ -2881,8 +2881,7 @@ TEST_F(StaticClusterImplTest, LeastRequestWithSlowStart) {
   EXPECT_EQ("envoy.load_balancing_policies.least_request",
             cluster->info()->loadBalancerFactory().name());
   auto slow_start_config =
-      dynamic_cast<
-          const Extensions::LoadBalancingPolicies::LeastRequest::TypedLeastRequestLbConfig*>(
+      Envoy::Protobuf::DynamicCastMessage<Extensions::LoadBalancingPolicies::LeastRequest::TypedLeastRequestLbConfig>(
           cluster->info()->loadBalancerConfig().ptr())
           ->lb_config_.slow_start_config();
   EXPECT_EQ(std::chrono::milliseconds(60000),
@@ -5528,7 +5527,7 @@ TEST_F(ClusterInfoImplTest, ExtensionProtocolOptionsForFilterWithOptions) {
   TestFilterConfigFactoryBase factoryBase(
       []() -> ProtobufTypes::MessagePtr { return std::make_unique<Protobuf::Struct>(); },
       [&](const Protobuf::Message& msg) -> Upstream::ProtocolOptionsConfigConstSharedPtr {
-        const auto& msg_struct = dynamic_cast<const Protobuf::Struct&>(msg);
+        const auto& msg_struct = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(msg);
         EXPECT_TRUE(msg_struct.fields().find("option") != msg_struct.fields().end());
 
         return protocol_options;

--- a/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
@@ -664,7 +664,7 @@ TEST_P(GrpcMuxImplTest, WildcardWatch) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -704,7 +704,7 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -731,11 +731,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_y));
           const auto& expected_assignment_1 =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_z));
           return absl::OkStatus();
@@ -745,11 +745,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_x));
           const auto& expected_assignment_1 =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_y));
           return absl::OkStatus();
@@ -1437,7 +1437,7 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -1478,7 +1478,7 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();

--- a/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/grpc_mux_impl_test.cc
@@ -663,9 +663,8 @@ TEST_P(GrpcMuxImplTest, WildcardWatch) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -703,9 +702,8 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -730,13 +728,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment_y, &load_assignment_z](
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_y));
-          const auto& expected_assignment_1 =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[1].get().resource());
+          const auto& expected_assignment_1 = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_z));
           return absl::OkStatus();
         }));
@@ -744,13 +740,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment_x, &load_assignment_y](
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_x));
-          const auto& expected_assignment_1 =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[1].get().resource());
+          const auto& expected_assignment_1 = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_y));
           return absl::OkStatus();
         }));
@@ -1436,9 +1430,8 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -1477,9 +1470,8 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));

--- a/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
@@ -556,7 +556,7 @@ TEST_P(GrpcMuxImplTest, WildcardWatch) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -596,7 +596,7 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -625,11 +625,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_y));
           const auto& expected_assignment_1 =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_z));
           return absl::OkStatus();
@@ -639,11 +639,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_x));
           const auto& expected_assignment_1 =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_y));
           return absl::OkStatus();
@@ -1010,7 +1010,7 @@ TEST_P(GrpcMuxImplTest, ValidResourceDecoderAfterRemoval) {
                                               const std::string&) {
             EXPECT_EQ(1, resources.size());
             const auto& expected_assignment =
-                dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+                Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                     resources[0].get().resource());
             EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
             return absl::OkStatus();
@@ -1045,7 +1045,7 @@ TEST_P(GrpcMuxImplTest, ValidResourceDecoderAfterRemoval) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -1351,7 +1351,7 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
@@ -1392,7 +1392,7 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
           const auto& expected_assignment =
-              dynamic_cast<const envoy::config::endpoint::v3::ClusterLoadAssignment&>(
+              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
                   resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();

--- a/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
+++ b/test/extensions/config_subscription/grpc/xds_grpc_mux_impl_test.cc
@@ -555,9 +555,8 @@ TEST_P(GrpcMuxImplTest, WildcardWatch) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -595,9 +594,8 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -624,13 +622,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment_y, &load_assignment_z](
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_y));
-          const auto& expected_assignment_1 =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[1].get().resource());
+          const auto& expected_assignment_1 = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_z));
           return absl::OkStatus();
         }));
@@ -638,13 +634,11 @@ TEST_P(GrpcMuxImplTest, WatchDemux) {
         .WillOnce(Invoke([&load_assignment_x, &load_assignment_y](
                              const std::vector<DecodedResourceRef>& resources, const std::string&) {
           EXPECT_EQ(2, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment_x));
-          const auto& expected_assignment_1 =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[1].get().resource());
+          const auto& expected_assignment_1 = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[1].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment_1, load_assignment_y));
           return absl::OkStatus();
         }));
@@ -1009,9 +1003,8 @@ TEST_P(GrpcMuxImplTest, ValidResourceDecoderAfterRemoval) {
           .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                               const std::string&) {
             EXPECT_EQ(1, resources.size());
-            const auto& expected_assignment =
-                Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                    resources[0].get().resource());
+            const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+                envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
             EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
             return absl::OkStatus();
           }));
@@ -1044,9 +1037,8 @@ TEST_P(GrpcMuxImplTest, ValidResourceDecoderAfterRemoval) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -1350,9 +1342,8 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));
@@ -1391,9 +1382,8 @@ TEST_P(GrpcMuxImplTest, MuxDynamicReplacementFetchingResources) {
         .WillOnce(Invoke([&load_assignment](const std::vector<DecodedResourceRef>& resources,
                                             const std::string&) {
           EXPECT_EQ(1, resources.size());
-          const auto& expected_assignment =
-              Envoy::Protobuf::DynamicCastMessage<envoy::config::endpoint::v3::ClusterLoadAssignment>(
-                  resources[0].get().resource());
+          const auto& expected_assignment = Envoy::Protobuf::DynamicCastMessage<
+              envoy::config::endpoint::v3::ClusterLoadAssignment>(resources[0].get().resource());
           EXPECT_TRUE(TestUtility::protoEqual(expected_assignment, load_assignment));
           return absl::OkStatus();
         }));

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -62,7 +62,7 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   BufferFilterFactory factory;
   auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(empty_proto.get());
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(empty_proto.get());
 
   config.mutable_max_request_bytes()->set_value(1028);
 
@@ -77,7 +77,7 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
   BufferFilterFactory factory;
   auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *dynamic_cast<envoy::extensions::filters::http::buffer::v3::Buffer*>(empty_proto.get());
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(empty_proto.get());
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context).value(),
@@ -87,7 +87,7 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
 TEST(BufferFilterFactoryTest, BufferFilterEmptyRouteProto) {
   BufferFilterFactory factory;
   EXPECT_NO_THROW({
-    EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::buffer::v3::BufferPerRoute*>(
+    EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(
                            factory.createEmptyRouteConfigProto().get()));
   });
 }
@@ -99,7 +99,7 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   EXPECT_TRUE(proto_config.get());
 
-  auto& cfg = dynamic_cast<envoy::extensions::filters::http::buffer::v3::BufferPerRoute&>(
+  auto& cfg = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(
       *proto_config.get());
   cfg.set_disabled(true);
 
@@ -110,7 +110,7 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
           .value();
   EXPECT_TRUE(route_config.get());
 
-  const auto* inflated = dynamic_cast<const BufferFilterSettings*>(route_config.get());
+  const auto* inflated = Envoy::Protobuf::DynamicCastMessage<BufferFilterSettings>(route_config.get());
   EXPECT_TRUE(inflated);
 }
 

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -62,7 +62,8 @@ TEST(BufferFilterFactoryTest, BufferFilterEmptyProto) {
   BufferFilterFactory factory;
   auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(empty_proto.get());
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(
+          empty_proto.get());
 
   config.mutable_max_request_bytes()->set_value(1028);
 
@@ -77,7 +78,8 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
   BufferFilterFactory factory;
   auto empty_proto = factory.createEmptyConfigProto();
   envoy::extensions::filters::http::buffer::v3::Buffer config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(empty_proto.get());
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::Buffer>(
+          empty_proto.get());
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProto(config, "stats", context).value(),
@@ -87,7 +89,8 @@ TEST(BufferFilterFactoryTest, BufferFilterNoMaxRequestBytes) {
 TEST(BufferFilterFactoryTest, BufferFilterEmptyRouteProto) {
   BufferFilterFactory factory;
   EXPECT_NO_THROW({
-    EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(
+    EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<
+                           envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(
                            factory.createEmptyRouteConfigProto().get()));
   });
 }
@@ -99,8 +102,8 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
   ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
   EXPECT_TRUE(proto_config.get());
 
-  auto& cfg = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(
-      *proto_config.get());
+  auto& cfg = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::buffer::v3::BufferPerRoute>(*proto_config.get());
   cfg.set_disabled(true);
 
   Router::RouteSpecificFilterConfigConstSharedPtr route_config =
@@ -110,7 +113,7 @@ TEST(BufferFilterFactoryTest, BufferFilterRouteSpecificConfig) {
           .value();
   EXPECT_TRUE(route_config.get());
 
-  const auto* inflated = Envoy::Protobuf::DynamicCastMessage<BufferFilterSettings>(route_config.get());
+  const auto* inflated = dynamic_cast<const BufferFilterSettings*>(route_config.get());
   EXPECT_TRUE(inflated);
 }
 

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -240,7 +240,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfiguration) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_TRUE(typed_config.grpcService().has_value());
 
@@ -277,7 +277,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteHttpServiceConfiguration) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_TRUE(typed_config.httpService().has_value());
   EXPECT_FALSE(typed_config.grpcService().has_value());
@@ -323,14 +323,14 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteServiceTypeSwitching) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration with HTTP service
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations - should use HTTP service from more specific config
@@ -384,14 +384,14 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteServiceTypeSwitchingHttpToGrpc) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration with gRPC service
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations - should use gRPC service from more specific config
@@ -436,7 +436,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteHttpServiceWithTimeout) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_TRUE(typed_config.httpService().has_value());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 
@@ -468,7 +468,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceWithTimeout) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_TRUE(typed_config.grpcService().has_value());
   EXPECT_FALSE(typed_config.httpService().has_value());
 
@@ -503,13 +503,13 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteEmptyContextExtensionsMerging) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   FilterConfigPerRoute merged_config(less_specific_config, more_specific_config);
@@ -553,14 +553,14 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationMerging) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations
@@ -597,7 +597,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationWithoutGrpcServic
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 
@@ -620,7 +620,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationDisabled) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
   EXPECT_TRUE(typed_config.disabled());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 }
@@ -679,7 +679,7 @@ private:
             ->getOrCreateRawAsyncClientWithHashKey(config_with_hash_key, context_.scope(), false)
             .value();
     Grpc::MockAsyncClient* mock_async_client =
-        dynamic_cast<Grpc::MockAsyncClient*>(async_client.get());
+        Envoy::Protobuf::DynamicCastMessage<Grpc::MockAsyncClient>(async_client.get());
     EXPECT_NE(mock_async_client, nullptr);
     // All the request in this thread should be sent through the same async client because the async
     // client is cached.

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -240,7 +240,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfiguration) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_TRUE(typed_config.grpcService().has_value());
 
@@ -277,7 +277,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteHttpServiceConfiguration) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_TRUE(typed_config.httpService().has_value());
   EXPECT_FALSE(typed_config.grpcService().has_value());
@@ -323,14 +323,16 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteServiceTypeSwitching) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration with HTTP service
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations - should use HTTP service from more specific config
@@ -384,14 +386,16 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteServiceTypeSwitchingHttpToGrpc) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration with gRPC service
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations - should use gRPC service from more specific config
@@ -436,7 +440,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteHttpServiceWithTimeout) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_TRUE(typed_config.httpService().has_value());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 
@@ -468,7 +472,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceWithTimeout) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_TRUE(typed_config.grpcService().has_value());
   EXPECT_FALSE(typed_config.httpService().has_value());
 
@@ -503,13 +507,15 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteEmptyContextExtensionsMerging) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   FilterConfigPerRoute merged_config(less_specific_config, more_specific_config);
@@ -553,14 +559,16 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationMerging) {
   ProtobufTypes::MessagePtr less_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(less_specific_config_yaml, *less_specific_proto);
   FilterConfigPerRoute less_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           less_specific_proto.get()));
 
   // Create more specific configuration
   ProtobufTypes::MessagePtr more_specific_proto = factory.createEmptyRouteConfigProto();
   TestUtility::loadFromYaml(more_specific_config_yaml, *more_specific_proto);
   FilterConfigPerRoute more_specific_config(
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute>(
           more_specific_proto.get()));
 
   // Merge configurations
@@ -597,7 +605,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationWithoutGrpcServic
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_FALSE(typed_config.disabled());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 
@@ -620,7 +628,7 @@ TEST_F(ExtAuthzFilterHttpTest, PerRouteGrpcServiceConfigurationDisabled) {
                                                               context.messageValidationVisitor());
   EXPECT_TRUE(route_config.ok());
 
-  const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<FilterConfigPerRoute>(*route_config.value());
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
   EXPECT_TRUE(typed_config.disabled());
   EXPECT_FALSE(typed_config.grpcService().has_value());
 }
@@ -679,7 +687,7 @@ private:
             ->getOrCreateRawAsyncClientWithHashKey(config_with_hash_key, context_.scope(), false)
             .value();
     Grpc::MockAsyncClient* mock_async_client =
-        Envoy::Protobuf::DynamicCastMessage<Grpc::MockAsyncClient>(async_client.get());
+        dynamic_cast<Grpc::MockAsyncClient*>(async_client.get());
     EXPECT_NE(mock_async_client, nullptr);
     // All the request in this thread should be sent through the same async client because the async
     // client is cached.

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1680,7 +1680,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedWithMock) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a low max_headers_count to trigger the limit.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/3);
@@ -1737,7 +1737,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInSet) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a limit of 1 to trigger the break in headers_to_set.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/1);
@@ -1822,7 +1822,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInAppend) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with max_headers_count=2 to trigger limit in append loop.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
@@ -6401,7 +6401,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimit) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {
@@ -6447,7 +6447,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimitDisabled) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1680,7 +1680,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedWithMock) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a low max_headers_count to trigger the limit.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/3);
@@ -1737,7 +1737,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInSet) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a limit of 1 to trigger the break in headers_to_set.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/1);
@@ -1822,7 +1822,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInAppend) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with max_headers_count=2 to trigger limit in append loop.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
@@ -6401,7 +6401,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimit) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {
@@ -6447,7 +6447,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimitDisabled) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {
@@ -6655,9 +6655,8 @@ TEST_F(HttpFilterTest, ShadowModeDeniedSetsFilterStateAndContinues) {
   // Exercise serializeAsProto (populates all non-empty branches) and serializeAsString.
   auto serialized = shadow->serializeAsProto();
   ASSERT_NE(serialized, nullptr);
-  const auto& proto =
-      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(
-          *serialized);
+  const auto& proto = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(*serialized);
   EXPECT_EQ(proto.check_result(),
             envoy::extensions::filters::http::ext_authz::v3::ShadowDecision::DENIED);
   EXPECT_EQ(proto.status_code(), 401);
@@ -6818,9 +6817,8 @@ TEST_F(HttpFilterTest, ShadowModeOkSetsFilterState) {
   // Exercise serializeAsProto on the OK branch.
   auto serialized = shadow->serializeAsProto();
   ASSERT_NE(serialized, nullptr);
-  const auto& proto =
-      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(
-          *serialized);
+  const auto& proto = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(*serialized);
   EXPECT_EQ(proto.check_result(),
             envoy::extensions::filters::http::ext_authz::v3::ShadowDecision::OK);
   EXPECT_EQ(proto.status_code(), 200);

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -6656,7 +6656,7 @@ TEST_F(HttpFilterTest, ShadowModeDeniedSetsFilterStateAndContinues) {
   auto serialized = shadow->serializeAsProto();
   ASSERT_NE(serialized, nullptr);
   const auto& proto =
-      dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ShadowDecision&>(
+      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(
           *serialized);
   EXPECT_EQ(proto.check_result(),
             envoy::extensions::filters::http::ext_authz::v3::ShadowDecision::DENIED);
@@ -6819,7 +6819,7 @@ TEST_F(HttpFilterTest, ShadowModeOkSetsFilterState) {
   auto serialized = shadow->serializeAsProto();
   ASSERT_NE(serialized, nullptr);
   const auto& proto =
-      dynamic_cast<const envoy::extensions::filters::http::ext_authz::v3::ShadowDecision&>(
+      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ext_authz::v3::ShadowDecision>(
           *serialized);
   EXPECT_EQ(proto.check_result(),
             envoy::extensions::filters::http::ext_authz::v3::ShadowDecision::OK);

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1680,7 +1680,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedWithMock) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a low max_headers_count to trigger the limit.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/3);
@@ -1737,7 +1737,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInSet) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with a limit of 1 to trigger the break in headers_to_set.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/1);
@@ -1822,7 +1822,7 @@ TEST_F(HttpFilterTest, ErrorResponseHeaderLimitsEnforcedInAppend) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             // Create a ResponseHeaderMap with max_headers_count=2 to trigger limit in append loop.
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
@@ -6401,7 +6401,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimit) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {
@@ -6447,7 +6447,7 @@ TEST_F(HttpFilterTest, DeniedResponseLocalReplyExceedsLimitDisabled) {
   EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
       .WillOnce(
           Invoke([&](Http::Code, absl::string_view,
-                     std::function<void(Http::ResponseHeaderMap& headers)> modify_headers,
+                     std::function<void(Http::ResponseHeaderMap & headers)> modify_headers,
                      const absl::optional<Grpc::Status::GrpcStatus>, absl::string_view) -> void {
             Http::TestResponseHeaderMapImpl response_headers({}, 99999, /*max_headers_count=*/2);
             if (modify_headers) {

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -171,7 +171,7 @@ TEST_F(GrpcStatsFilterConfigTest, StatsConnectUnaryBodies) {
   const auto* data =
       stream_info_.filterState()->getDataReadOnly<GrpcStatsObject>("envoy.filters.http.grpc_stats");
   auto filter_object =
-      *dynamic_cast<envoy::extensions::filters::http::grpc_stats::v3::FilterObject*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
           data->serializeAsProto().get());
   EXPECT_EQ(1U, data->request_message_count);
   EXPECT_EQ(1U, data->response_message_count);
@@ -571,7 +571,7 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
   EXPECT_EQ(3U, data->response_message_count);
 
   auto filter_object =
-      *dynamic_cast<envoy::extensions::filters::http::grpc_stats::v3::FilterObject*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
           data->serializeAsProto().get());
   EXPECT_EQ(2U, filter_object.request_message_count());
   EXPECT_EQ(3U, filter_object.response_message_count());

--- a/test/extensions/filters/http/grpc_stats/config_test.cc
+++ b/test/extensions/filters/http/grpc_stats/config_test.cc
@@ -170,9 +170,9 @@ TEST_F(GrpcStatsFilterConfigTest, StatsConnectUnaryBodies) {
 
   const auto* data =
       stream_info_.filterState()->getDataReadOnly<GrpcStatsObject>("envoy.filters.http.grpc_stats");
-  auto filter_object =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
-          data->serializeAsProto().get());
+  auto filter_object = *Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
+      data->serializeAsProto().get());
   EXPECT_EQ(1U, data->request_message_count);
   EXPECT_EQ(1U, data->response_message_count);
   EXPECT_EQ(1U, filter_object.request_message_count());
@@ -570,9 +570,9 @@ TEST_F(GrpcStatsFilterConfigTest, MessageCounts) {
   EXPECT_EQ(2U, data->request_message_count);
   EXPECT_EQ(3U, data->response_message_count);
 
-  auto filter_object =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
-          data->serializeAsProto().get());
+  auto filter_object = *Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::grpc_stats::v3::FilterObject>(
+      data->serializeAsProto().get());
   EXPECT_EQ(2U, filter_object.request_message_count());
   EXPECT_EQ(3U, filter_object.response_message_count());
   EXPECT_EQ("2,3", data->serializeAsString().value());

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -135,7 +135,8 @@ TEST(HealthCheckFilterConfig, HealthCheckFilterWithEmptyProto) {
   HealthCheckFilterConfig healthCheckFilterConfig;
   NiceMock<Server::Configuration::MockFactoryContext> context;
   envoy::extensions::filters::http::health_check::v3::HealthCheck config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::health_check::v3::HealthCheck>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::health_check::v3::HealthCheck>(
           healthCheckFilterConfig.createEmptyConfigProto().get());
 
   config.mutable_pass_through_mode()->set_value(false);
@@ -154,8 +155,8 @@ void testHealthCheckHeaderMatch(
   HealthCheckFilterConfig healthCheckFilterConfig;
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ProtobufTypes::MessagePtr config_msg = healthCheckFilterConfig.createEmptyConfigProto();
-  auto config = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::health_check::v3::HealthCheck>(
-      config_msg.get());
+  auto config = Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::filters::http::health_check::v3::HealthCheck>(config_msg.get());
   ASSERT_NE(config, nullptr);
 
   *config = input_config;

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -135,7 +135,7 @@ TEST(HealthCheckFilterConfig, HealthCheckFilterWithEmptyProto) {
   HealthCheckFilterConfig healthCheckFilterConfig;
   NiceMock<Server::Configuration::MockFactoryContext> context;
   envoy::extensions::filters::http::health_check::v3::HealthCheck config =
-      *dynamic_cast<envoy::extensions::filters::http::health_check::v3::HealthCheck*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::health_check::v3::HealthCheck>(
           healthCheckFilterConfig.createEmptyConfigProto().get());
 
   config.mutable_pass_through_mode()->set_value(false);
@@ -154,7 +154,7 @@ void testHealthCheckHeaderMatch(
   HealthCheckFilterConfig healthCheckFilterConfig;
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ProtobufTypes::MessagePtr config_msg = healthCheckFilterConfig.createEmptyConfigProto();
-  auto config = dynamic_cast<envoy::extensions::filters::http::health_check::v3::HealthCheck*>(
+  auto config = Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::health_check::v3::HealthCheck>(
       config_msg.get());
   ASSERT_NE(config, nullptr);
 

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -113,7 +113,7 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
   RateLimitFilterConfig factory;
 
   envoy::extensions::filters::http::ratelimit::v3::RateLimit empty_proto_config =
-      *dynamic_cast<envoy::extensions::filters::http::ratelimit::v3::RateLimit*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ratelimit::v3::RateLimit>(
           factory.createEmptyConfigProto().get());
 
   EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context).value(),

--- a/test/extensions/filters/http/ratelimit/config_test.cc
+++ b/test/extensions/filters/http/ratelimit/config_test.cc
@@ -113,7 +113,8 @@ TEST(RateLimitFilterConfigTest, RateLimitFilterEmptyProto) {
   RateLimitFilterConfig factory;
 
   envoy::extensions::filters::http::ratelimit::v3::RateLimit empty_proto_config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::ratelimit::v3::RateLimit>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::http::ratelimit::v3::RateLimit>(
           factory.createEmptyConfigProto().get());
 
   EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, "stats", context).value(),

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -57,14 +57,17 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidMatcherProto) {
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBAC>(
-                         factory.createEmptyConfigProto().get()));
+  EXPECT_NE(nullptr,
+            Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBAC>(
+                factory.createEmptyConfigProto().get()));
 }
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyRouteProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBACPerRoute>(
-                         factory.createEmptyRouteConfigProto().get()));
+  EXPECT_NE(
+      nullptr,
+      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBACPerRoute>(
+          factory.createEmptyRouteConfigProto().get()));
 }
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, InvalidMatcherProto) {

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -57,13 +57,13 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidMatcherProto) {
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBAC*>(
+  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBAC>(
                          factory.createEmptyConfigProto().get()));
 }
 
 TEST(RoleBasedAccessControlFilterConfigFactoryTest, EmptyRouteProto) {
   RoleBasedAccessControlFilterConfigFactory factory;
-  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::http::rbac::v3::RBACPerRoute*>(
+  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::http::rbac::v3::RBACPerRoute>(
                          factory.createEmptyRouteConfigProto().get()));
 }
 

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -2361,7 +2361,7 @@ TEST_P(ProxyProtocolTest, V2ExtractTLVToFilterStateSerializeMethods) {
   // Test serializeAsProto
   auto proto = tlv_obj->serializeAsProto();
   ASSERT_NE(nullptr, proto);
-  const auto* struct_proto = dynamic_cast<const Protobuf::Struct*>(proto.get());
+  const auto* struct_proto = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(proto.get());
   ASSERT_NE(nullptr, struct_proto);
   EXPECT_EQ(1, struct_proto->fields().size());
   EXPECT_EQ(1, struct_proto->fields().count("PP2 type authority"));
@@ -3109,7 +3109,7 @@ TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   cb(manager);
 
   // Make sure we actually create the correct type!
-  EXPECT_NE(dynamic_cast<ProxyProtocol::Filter*>(added_filter.get()), nullptr);
+  EXPECT_NE(Envoy::Protobuf::DynamicCastMessage<ProxyProtocol::Filter>(added_filter.get()), nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
+++ b/test/extensions/filters/listener/proxy_protocol/proxy_protocol_test.cc
@@ -3109,7 +3109,7 @@ TEST(ProxyProtocolConfigFactoryTest, TestCreateFactory) {
   cb(manager);
 
   // Make sure we actually create the correct type!
-  EXPECT_NE(Envoy::Protobuf::DynamicCastMessage<ProxyProtocol::Filter>(added_filter.get()), nullptr);
+  EXPECT_NE(dynamic_cast<ProxyProtocol::Filter*>(added_filter.get()), nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/network/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/network/ext_proc/ext_proc_integration_test.cc
@@ -87,7 +87,7 @@ public:
   absl::StatusOr<Network::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                Server::Configuration::FactoryContext&) override {
-    const auto& struct_config = dynamic_cast<const Protobuf::Struct&>(proto_config);
+    const auto& struct_config = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(proto_config);
     return [struct_config](Network::FilterManager& filter_manager) -> void {
       filter_manager.addReadFilter(std::make_shared<MetadataSetterFilter>(struct_config));
     };

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -2763,7 +2763,7 @@ TEST_F(HttpConnectionManagerConfigTest, CustomRequestIDExtension) {
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
   auto request_id_extension =
-      Envoy::Protobuf::DynamicCastMessage<TestRequestIDExtension>(config.requestIDExtension().get());
+      dynamic_cast<TestRequestIDExtension*>(config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_EQ("example", request_id_extension->testField());
 }
@@ -2829,7 +2829,7 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultRequestIDExtension) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  auto request_id_extension = Envoy::Protobuf::DynamicCastMessage<Extensions::RequestId::UUIDRequestIDExtension>(
+  auto request_id_extension = dynamic_cast<Extensions::RequestId::UUIDRequestIDExtension*>(
       config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_TRUE(request_id_extension->packTraceReason());
@@ -2857,7 +2857,7 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultRequestIDExtensionWithParams) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  auto request_id_extension = Envoy::Protobuf::DynamicCastMessage<Extensions::RequestId::UUIDRequestIDExtension>(
+  auto request_id_extension = dynamic_cast<Extensions::RequestId::UUIDRequestIDExtension*>(
       config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_FALSE(request_id_extension->packTraceReason());
@@ -3678,8 +3678,8 @@ public:
   createFromProto(const Protobuf::Message& message,
                   Server::Configuration::ServerFactoryContext& server_context) override {
     auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
-        *this);
+        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+        server_context.messageValidationVisitor(), *this);
     const auto& proto_config =
         MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::
                                              envoy_default::v3::HeaderValidatorConfig&>(
@@ -4025,7 +4025,7 @@ TEST_F(HttpConnectionManagerMobileConfigTest, Mobile) {
   EXPECT_CALL(fm, addReadFilter(_))
       .WillOnce(Invoke([&](Network::ReadFilterSharedPtr manager) -> void {
         hcm_filter = manager;
-        hcm = Envoy::Protobuf::DynamicCastMessage<Http::ConnectionManagerImpl>(manager.get());
+        hcm = dynamic_cast<Http::ConnectionManagerImpl*>(manager.get());
       }));
   create_hcm_cb(fm);
   ASSERT(hcm != nullptr);

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -2763,7 +2763,7 @@ TEST_F(HttpConnectionManagerConfigTest, CustomRequestIDExtension) {
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
   auto request_id_extension =
-      dynamic_cast<TestRequestIDExtension*>(config.requestIDExtension().get());
+      Envoy::Protobuf::DynamicCastMessage<TestRequestIDExtension>(config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_EQ("example", request_id_extension->testField());
 }
@@ -2829,7 +2829,7 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultRequestIDExtension) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  auto request_id_extension = dynamic_cast<Extensions::RequestId::UUIDRequestIDExtension*>(
+  auto request_id_extension = Envoy::Protobuf::DynamicCastMessage<Extensions::RequestId::UUIDRequestIDExtension>(
       config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_TRUE(request_id_extension->packTraceReason());
@@ -2857,7 +2857,7 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultRequestIDExtensionWithParams) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  auto request_id_extension = dynamic_cast<Extensions::RequestId::UUIDRequestIDExtension*>(
+  auto request_id_extension = Envoy::Protobuf::DynamicCastMessage<Extensions::RequestId::UUIDRequestIDExtension>(
       config.requestIDExtension().get());
   ASSERT_NE(nullptr, request_id_extension);
   EXPECT_FALSE(request_id_extension->packTraceReason());
@@ -3678,7 +3678,7 @@ public:
   createFromProto(const Protobuf::Message& message,
                   Server::Configuration::ServerFactoryContext& server_context) override {
     auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-        dynamic_cast<const Protobuf::Any&>(message), server_context.messageValidationVisitor(),
+        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
         *this);
     const auto& proto_config =
         MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::
@@ -4025,7 +4025,7 @@ TEST_F(HttpConnectionManagerMobileConfigTest, Mobile) {
   EXPECT_CALL(fm, addReadFilter(_))
       .WillOnce(Invoke([&](Network::ReadFilterSharedPtr manager) -> void {
         hcm_filter = manager;
-        hcm = dynamic_cast<Http::ConnectionManagerImpl*>(manager.get());
+        hcm = Envoy::Protobuf::DynamicCastMessage<Http::ConnectionManagerImpl>(manager.get());
       }));
   create_hcm_cb(fm);
   ASSERT(hcm != nullptr);

--- a/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
+++ b/test/extensions/filters/network/match_delegate/match_delegate_integration_test.cc
@@ -152,7 +152,7 @@ public:
   absl::StatusOr<Network::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                Server::Configuration::FactoryContext&) override {
-    const auto& config = dynamic_cast<const StringValue&>(proto_config);
+    const auto& config = Envoy::Protobuf::DynamicCastMessage<StringValue>(proto_config);
     return [value = config.value()](auto& filter_manager) {
       auto filter = std::make_shared<SetFilterStateFilter>(value);
       filter_manager.addReadFilter(filter);

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -121,8 +121,10 @@ TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, ValidMatcherProto) 
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlNetworkFilterConfigFactory factory;
-  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::rbac::v3::RBAC>(
-                         factory.createEmptyConfigProto().get()));
+  EXPECT_NE(
+      nullptr,
+      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::rbac::v3::RBAC>(
+          factory.createEmptyConfigProto().get()));
 }
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, InvalidPermission) {

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -121,7 +121,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, ValidMatcherProto) 
 
 TEST_F(RoleBasedAccessControlNetworkFilterConfigFactoryTest, EmptyProto) {
   RoleBasedAccessControlNetworkFilterConfigFactory factory;
-  EXPECT_NE(nullptr, dynamic_cast<envoy::extensions::filters::network::rbac::v3::RBAC*>(
+  EXPECT_NE(nullptr, Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::rbac::v3::RBAC>(
                          factory.createEmptyConfigProto().get()));
 }
 

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -33,7 +33,7 @@ TEST(ConfigTest, InvalidHeadersToAdd) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -58,7 +58,7 @@ TEST(ConfigTest, ConfigTest) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -79,7 +79,7 @@ TEST(ConfigTest, ConfigWithDrainCloseCheck) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -95,7 +95,7 @@ TEST(ConfigTest, TunnelingConfigWithFormatters) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -118,7 +118,7 @@ TEST(ConfigTest, TunnelingConfigWithUnknownFormatter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *dynamic_cast<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy*>(
+      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -33,7 +33,8 @@ TEST(ConfigTest, InvalidHeadersToAdd) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -58,7 +59,8 @@ TEST(ConfigTest, ConfigTest) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -79,7 +81,8 @@ TEST(ConfigTest, ConfigWithDrainCloseCheck) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -95,7 +98,8 @@ TEST(ConfigTest, TunnelingConfigWithFormatters) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");
@@ -118,7 +122,8 @@ TEST(ConfigTest, TunnelingConfigWithUnknownFormatter) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   ConfigFactory factory;
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config =
-      *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
+      *Envoy::Protobuf::DynamicCastMessage<
+          envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy>(
           factory.createEmptyConfigProto().get());
   config.set_stat_prefix("prefix");
   config.set_cluster("cluster");

--- a/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
+++ b/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
@@ -36,8 +36,7 @@ TEST(HealthCheckEventFileSinkFactory, createEmptyHealthCheckEventSink) {
       "envoy.health_check.event_sink.file");
   EXPECT_NE(factory, nullptr);
   auto empty_proto = factory->createEmptyConfigProto();
-  auto config = *dynamic_cast<
-      envoy::extensions::health_check::event_sinks::file::v3::HealthCheckEventFileSink*>(
+  auto config = *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::health_check::event_sinks::file::v3::HealthCheckEventFileSink>(
       empty_proto.get());
   EXPECT_TRUE(config.event_log_path().empty());
 }

--- a/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
+++ b/test/extensions/health_check/event_sinks/file/file_sink_impl_test.cc
@@ -36,7 +36,8 @@ TEST(HealthCheckEventFileSinkFactory, createEmptyHealthCheckEventSink) {
       "envoy.health_check.event_sink.file");
   EXPECT_NE(factory, nullptr);
   auto empty_proto = factory->createEmptyConfigProto();
-  auto config = *Envoy::Protobuf::DynamicCastMessage<envoy::extensions::health_check::event_sinks::file::v3::HealthCheckEventFileSink>(
+  auto config = *Envoy::Protobuf::DynamicCastMessage<
+      envoy::extensions::health_check::event_sinks::file::v3::HealthCheckEventFileSink>(
       empty_proto.get());
   EXPECT_TRUE(config.event_log_path().empty());
 }

--- a/test/extensions/retry/host/previous_hosts/config_test.cc
+++ b/test/extensions/retry/host/previous_hosts/config_test.cc
@@ -56,7 +56,7 @@ TEST(PreviousHostsRetryPredicateConfigTest, EmptyConfig) {
 
   ProtobufTypes::MessagePtr config = factory->createEmptyConfigProto();
   EXPECT_TRUE(
-      dynamic_cast<envoy::extensions::retry::host::previous_hosts::v3::PreviousHostsPredicate*>(
+      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::retry::host::previous_hosts::v3::PreviousHostsPredicate>(
           config.get()));
 }
 

--- a/test/extensions/retry/host/previous_hosts/config_test.cc
+++ b/test/extensions/retry/host/previous_hosts/config_test.cc
@@ -55,9 +55,9 @@ TEST(PreviousHostsRetryPredicateConfigTest, EmptyConfig) {
   ASSERT_NE(nullptr, factory);
 
   ProtobufTypes::MessagePtr config = factory->createEmptyConfigProto();
-  EXPECT_TRUE(
-      Envoy::Protobuf::DynamicCastMessage<envoy::extensions::retry::host::previous_hosts::v3::PreviousHostsPredicate>(
-          config.get()));
+  EXPECT_TRUE(Envoy::Protobuf::DynamicCastMessage<
+              envoy::extensions::retry::host::previous_hosts::v3::PreviousHostsPredicate>(
+      config.get()));
 }
 
 } // namespace

--- a/test/extensions/upstreams/http/config_test.cc
+++ b/test/extensions/upstreams/http/config_test.cc
@@ -160,7 +160,7 @@ public:
   createFromProto(const Protobuf::Message& message,
                   Server::Configuration::ServerFactoryContext& server_context) override {
     auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-        dynamic_cast<const Protobuf::Any&>(message), server_context.messageValidationVisitor(),
+        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
         *this);
     const auto& proto_config =
         MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::

--- a/test/extensions/upstreams/http/config_test.cc
+++ b/test/extensions/upstreams/http/config_test.cc
@@ -160,8 +160,8 @@ public:
   createFromProto(const Protobuf::Message& message,
                   Server::Configuration::ServerFactoryContext& server_context) override {
     auto mptr = ::Envoy::Config::Utility::translateAnyToFactoryConfig(
-        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message), server_context.messageValidationVisitor(),
-        *this);
+        Envoy::Protobuf::DynamicCastMessage<Protobuf::Any>(message),
+        server_context.messageValidationVisitor(), *this);
     const auto& proto_config =
         MessageUtil::downcastAndValidate<const ::envoy::extensions::http::header_validators::
                                              envoy_default::v3::HeaderValidatorConfig&>(

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -325,19 +325,19 @@ void AdsIntegrationTestBase::testBasicFlow() {
 envoy::admin::v3::ClustersConfigDump AdsIntegrationTestBase::getClustersConfigDump() {
   auto message_ptr = test_server_->server().admin()->getConfigTracker().getCallbacksMap().at(
       "clusters")(Matchers::UniversalStringMatcher());
-  return dynamic_cast<const envoy::admin::v3::ClustersConfigDump&>(*message_ptr);
+  return Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ClustersConfigDump>(*message_ptr);
 }
 
 envoy::admin::v3::ListenersConfigDump AdsIntegrationTestBase::getListenersConfigDump() {
   auto message_ptr = test_server_->server().admin()->getConfigTracker().getCallbacksMap().at(
       "listeners")(Matchers::UniversalStringMatcher());
-  return dynamic_cast<const envoy::admin::v3::ListenersConfigDump&>(*message_ptr);
+  return Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*message_ptr);
 }
 
 envoy::admin::v3::RoutesConfigDump AdsIntegrationTestBase::getRoutesConfigDump() {
   auto message_ptr = test_server_->server().admin()->getConfigTracker().getCallbacksMap().at(
       "routes")(Matchers::UniversalStringMatcher());
-  return dynamic_cast<const envoy::admin::v3::RoutesConfigDump&>(*message_ptr);
+  return Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::RoutesConfigDump>(*message_ptr);
 }
 
 } // namespace Envoy

--- a/test/integration/async_round_robin_lb.h
+++ b/test/integration/async_round_robin_lb.h
@@ -36,7 +36,8 @@ public:
 
   absl::StatusOr<LoadBalancerConfigPtr> loadConfig(Server::Configuration::ServerFactoryContext&,
                                                    const Protobuf::Message& config) override {
-    const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<test::integration::lb::AsyncRoundRobin>(config);
+    const auto& typed_config =
+        Envoy::Protobuf::DynamicCastMessage<test::integration::lb::AsyncRoundRobin>(config);
     return Upstream::LoadBalancerConfigPtr{new TypedAsyncRoundRobinLbConfig(typed_config)};
   }
 };

--- a/test/integration/async_round_robin_lb.h
+++ b/test/integration/async_round_robin_lb.h
@@ -36,7 +36,7 @@ public:
 
   absl::StatusOr<LoadBalancerConfigPtr> loadConfig(Server::Configuration::ServerFactoryContext&,
                                                    const Protobuf::Message& config) override {
-    const auto& typed_config = dynamic_cast<const test::integration::lb::AsyncRoundRobin&>(config);
+    const auto& typed_config = Envoy::Protobuf::DynamicCastMessage<test::integration::lb::AsyncRoundRobin>(config);
     return Upstream::LoadBalancerConfigPtr{new TypedAsyncRoundRobinLbConfig(typed_config)};
   }
 };

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -427,7 +427,7 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
 std::string getListenerDetails(Envoy::Server::Instance& server) {
   const auto& cbs_maps = server.admin()->getConfigTracker().getCallbacksMap();
   ProtobufTypes::MessagePtr details = cbs_maps.at("listeners")(Matchers::UniversalStringMatcher());
-  auto listener_info = dynamic_cast<envoy::admin::v3::ListenersConfigDump&>(*details);
+  auto listener_info = Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*details);
 #ifdef ENVOY_ENABLE_YAML
   return MessageUtil::getYamlStringFromMessage(listener_info.dynamic_listeners(0).error_state());
 #else

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -427,7 +427,8 @@ void BaseIntegrationTest::registerTestServerPorts(const std::vector<std::string>
 std::string getListenerDetails(Envoy::Server::Instance& server) {
   const auto& cbs_maps = server.admin()->getConfigTracker().getCallbacksMap();
   ProtobufTypes::MessagePtr details = cbs_maps.at("listeners")(Matchers::UniversalStringMatcher());
-  auto listener_info = Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*details);
+  auto listener_info =
+      Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*details);
 #ifdef ENVOY_ENABLE_YAML
   return MessageUtil::getYamlStringFromMessage(listener_info.dynamic_listeners(0).error_state());
 #else

--- a/test/integration/cluster_filter_integration_test.cc
+++ b/test/integration/cluster_filter_integration_test.cc
@@ -80,7 +80,7 @@ public:
   Network::FilterFactoryCb
   createFilterFactoryFromProto(const Protobuf::Message& proto_config,
                                Server::Configuration::UpstreamFactoryContext&) override {
-    auto config = dynamic_cast<const Protobuf::StringValue&>(proto_config);
+    auto config = Envoy::Protobuf::DynamicCastMessage<Protobuf::StringValue>(proto_config);
     return [this, config](Network::FilterManager& filter_manager) -> void {
       filter_manager.addFilter(std::make_shared<PoliteFilter>(test_parent_, config));
     };

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -388,7 +388,7 @@ void XdsFuzzTest::verifyState() {
 envoy::admin::v3::ListenersConfigDump XdsFuzzTest::getListenersConfigDump() {
   auto message_ptr = test_server_->server().admin()->getConfigTracker().getCallbacksMap().at(
       "listeners")(Matchers::UniversalStringMatcher());
-  return dynamic_cast<const envoy::admin::v3::ListenersConfigDump&>(*message_ptr);
+  return Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::ListenersConfigDump>(*message_ptr);
 }
 
 std::vector<envoy::config::route::v3::RouteConfiguration> XdsFuzzTest::getRoutesConfigDump() {
@@ -400,7 +400,7 @@ std::vector<envoy::config::route::v3::RouteConfiguration> XdsFuzzTest::getRoutes
   }
 
   auto message_ptr = map.at("routes")(Matchers::UniversalStringMatcher());
-  auto dump = dynamic_cast<const envoy::admin::v3::RoutesConfigDump&>(*message_ptr);
+  auto dump = Envoy::Protobuf::DynamicCastMessage<envoy::admin::v3::RoutesConfigDump>(*message_ptr);
 
   // Since the route config dump gives the RouteConfigurations as an Any, go through and cast them
   // back to RouteConfigurations.

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1533,7 +1533,7 @@ TEST_P(ServerInstanceImplTest, WithProcessContext) {
   EXPECT_NO_THROW(initialize("test/server/test_data/server/empty_bootstrap.yaml"));
 
   auto context = server_->processContext();
-  auto& object_from_context = Envoy::Protobuf::DynamicCastMessage<TestObject>(context->get().get());
+  auto& object_from_context = dynamic_cast<TestObject&>(context->get().get());
   EXPECT_EQ(&object_from_context, &object);
   EXPECT_TRUE(object_from_context.boolean_flag_);
 
@@ -1553,7 +1553,8 @@ TEST_P(ServerInstanceImplTest, WithBootstrapExtensions) {
   EXPECT_CALL(mock_factory, createBootstrapExtension(_, _))
       .WillOnce(
           Invoke([](const Protobuf::Message& config, Configuration::ServerFactoryContext& ctx) {
-            const auto* proto = Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(&config);
+            const auto* proto =
+                Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(&config);
             EXPECT_NE(nullptr, proto);
             EXPECT_EQ(proto->a(), "foo");
             auto mock_extension = std::make_unique<MockBootstrapExtension>();

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1533,7 +1533,7 @@ TEST_P(ServerInstanceImplTest, WithProcessContext) {
   EXPECT_NO_THROW(initialize("test/server/test_data/server/empty_bootstrap.yaml"));
 
   auto context = server_->processContext();
-  auto& object_from_context = dynamic_cast<TestObject&>(context->get().get());
+  auto& object_from_context = Envoy::Protobuf::DynamicCastMessage<TestObject>(context->get().get());
   EXPECT_EQ(&object_from_context, &object);
   EXPECT_TRUE(object_from_context.boolean_flag_);
 
@@ -1553,7 +1553,7 @@ TEST_P(ServerInstanceImplTest, WithBootstrapExtensions) {
   EXPECT_CALL(mock_factory, createBootstrapExtension(_, _))
       .WillOnce(
           Invoke([](const Protobuf::Message& config, Configuration::ServerFactoryContext& ctx) {
-            const auto* proto = dynamic_cast<const test::common::config::DummyConfig*>(&config);
+            const auto* proto = Envoy::Protobuf::DynamicCastMessage<test::common::config::DummyConfig>(&config);
             EXPECT_NE(nullptr, proto);
             EXPECT_EQ(proto->a(), "foo");
             auto mock_extension = std::make_unique<MockBootstrapExtension>();


### PR DESCRIPTION
Commit Message: Replace builtin casts with proto-specific casts for protobuf types.
Additional Description: There is a protobuf experiment to "devirtualize" messages, allowing protobuf to manage the dynamic dispatch of messages. When enabled, it breaks builtin dynamic/down casts, so the protobuf-specific alternatives should be preferred.
Risk Level: Low
Testing: unit test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a