### PR TITLE
mcp: fix mcp_json_rest_bridge_filter build issue

### DIFF
--- a/source/extensions/filters/http/mcp_json_rest_bridge/BUILD
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     deps = [
         ":http_request_builder_lib",
         ":trace_context_lib",
+        "//envoy/common:optref_lib",
         "//envoy/http:filter_interface",
         "//envoy/server:filter_config_interface",
         "//source/common/buffer:buffer_lib",

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -494,7 +494,9 @@ void McpJsonRestBridgeFilter::buildStreamingPrefixAndSuffix(bool is_error) {
 // Send a local reply for a tools/list call. Construct the response body directly instead of
 // building a JSON object, to minimize copying.
 void McpJsonRestBridgeFilter::serveToolsListLocal(
-    const nlohmann::json& json_rpc, const McpJsonRestBridgePerRouteConfig* per_route_config) {
+    const nlohmann::json& json_rpc,
+    const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
+        tool_config) {
   std::string request_id_json = "null";
   if (json_rpc.contains("id")) {
     request_id_json = json_rpc["id"].dump();
@@ -502,8 +504,7 @@ void McpJsonRestBridgeFilter::serveToolsListLocal(
     ASSERT(false, "serveToolsListLocal requires an RPC ID");
   }
 
-  const auto& tools =
-      per_route_config ? per_route_config->toolConfig().tools() : config_->toolConfig().tools();
+  const auto& tools = tool_config.tools();
 
   size_t reserve_size = sizeof("{\"jsonrpc\":\"2.0\",\"id\":") - 1 + request_id_json.size() +
                         sizeof(",\"result\":{\"tools\":[") - 1 + sizeof("]}}") - 1;
@@ -595,9 +596,10 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
   }
 
   if (method == McpConstants::Methods::TOOLS_LIST) {
-    bool has_tool_list_local = per_route_config
-                                   ? per_route_config->toolConfig().has_tool_list_local()
-                                   : config_->toolConfig().has_tool_list_local();
+    OptRef<const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig>
+        tool_list_local_config =
+            (per_route_config == nullptr) ? config_->toolListLocalConfig()
+                                          : per_route_config->toolListLocalConfig();
     absl::StatusOr<envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule> http_rule =
         (per_route_config == nullptr) ? config_->getToolsListHttpRule()
                                       : per_route_config->getToolsListHttpRule();
@@ -619,9 +621,9 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
         decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
       }
       return;
-    } else if (has_tool_list_local) {
+    } else if (tool_list_local_config.has_value()) {
       mcp_operation_ = McpOperation::ToolsListLocal;
-      serveToolsListLocal(json_rpc, per_route_config);
+      serveToolsListLocal(json_rpc, *tool_list_local_config);
       return;
     }
 

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/optref.h"
 #include "envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.pb.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
@@ -50,9 +51,14 @@ public:
     return proto_config_.request_storage_mode();
   }
 
-  const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
-  toolConfig() const {
-    return proto_config_.tool_config();
+  // Returns the tool config to serve a local tools/list response, or nullopt when local serving is
+  // not configured.
+  OptRef<const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig>
+  toolListLocalConfig() const {
+    if (proto_config_.tool_config().has_tool_list_local()) {
+      return proto_config_.tool_config();
+    }
+    return absl::nullopt;
   }
 
   bool textContentStreamingEnabled(absl::string_view tool_name) const;
@@ -87,9 +93,16 @@ public:
   absl::StatusOr<envoy::extensions::filters::http::mcp_json_rest_bridge::v3::HttpRule>
   getToolsListHttpRule() const;
 
-  const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
-  toolConfig() const {
-    return proto_config_.tool_config();
+  // Returns the first tool config with local tools/list serving configured, or nullopt when none
+  // is configured.
+  OptRef<const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig>
+  toolListLocalConfig() const {
+    for (const auto& tool_config : proto_config_.tool_config()) {
+      if (tool_config.has_tool_list_local()) {
+        return tool_config;
+      }
+    }
+    return absl::nullopt;
   }
 
   bool textContentStreamingEnabled(absl::string_view tool_name) const;
@@ -130,8 +143,10 @@ private:
                        const McpJsonRestBridgePerRouteConfig* per_route_config);
 
   // Serves a local tools/list response using tools' ToolsListSpecificConfig.
-  void serveToolsListLocal(const nlohmann::json& json_rpc,
-                           const McpJsonRestBridgePerRouteConfig* per_route_config);
+  void serveToolsListLocal(
+      const nlohmann::json& json_rpc,
+      const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig&
+          tool_config);
 
   // Modifies the response from upstream into JSON-RPC response.
   void encodeJsonRpcData(Http::ResponseHeaderMapOptRef response_headers);

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -1848,20 +1848,22 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListPerRouteConfig) {
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
       override_config;
 
-  auto* tool1 = override_config.mutable_tool_config()->add_tools();
+  auto* override_tool_config = override_config.add_tool_config();
+
+  auto* tool1 = override_tool_config->add_tools();
   tool1->set_name("simple_tool");
   tool1->mutable_tool_list_config()->set_title("My Tool");
   tool1->mutable_tool_list_config()->set_description("Does something.");
   tool1->mutable_tool_list_config()->set_input_schema("");
 
-  auto* tool2 = override_config.mutable_tool_config()->add_tools();
+  auto* tool2 = override_tool_config->add_tools();
   tool2->set_name("complex_tool");
   tool2->mutable_tool_list_config()->set_title("Complex \"Tool\"");
   tool2->mutable_tool_list_config()->set_description("Has\\nspecial \"chars\" & \\t stuff.");
   tool2->mutable_tool_list_config()->set_input_schema(
       R"({"type": "object", "properties": {"a": {"type": "string"}}})");
 
-  override_config.mutable_tool_config()->mutable_tool_list_local();
+  override_tool_config->mutable_tool_list_local();
 
   McpJsonRestBridgePerRouteConfig override(override_config);
 
@@ -2081,8 +2083,9 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListLocalPerRouteConfig) {
 
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute
       override_config;
-  override_config.mutable_tool_config()->mutable_tool_list_local();
-  auto* tool = override_config.mutable_tool_config()->add_tools();
+  auto* override_tool_config = override_config.add_tool_config();
+  override_tool_config->mutable_tool_list_local();
+  auto* tool = override_tool_config->add_tools();
   tool->set_name("my_local_tool");
   tool->mutable_tool_list_config()->set_title("My Local Tool");
   tool->mutable_tool_list_config()->set_description("Does a local thing.");

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -643,8 +643,9 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsListLocalResponse) {
                                           v3::HttpConnectionManager& hcm) {
     auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
     envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute per_route;
-    per_route.mutable_tool_config()->mutable_tool_list_local();
-    auto* tool = per_route.mutable_tool_config()->add_tools();
+    auto* tool_config = per_route.add_tool_config();
+    tool_config->mutable_tool_list_local();
+    auto* tool = tool_config->add_tools();
     tool->set_name("my_local_tool");
     tool->mutable_tool_list_config()->set_title("My Local Tool");
     tool->mutable_tool_list_config()->set_description("Does a local thing.");


### PR DESCRIPTION
## Description

Master is broken right now due to PR #45690 changing `McpJsonRestBridgePerRoute.tool_config` from singular to repeated `ServerToolConfig`. It updated the per-route constructor and `getToolsListHttpRule()` to iterate.
```
./source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h:92:12: error: no viable conversion from returned value of type 'const ::google::protobuf::RepeatedPtrField< ::envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig>' to function return type 'const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::ServerToolConfig'
   92 |     return proto_config_.tool_config();
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR is trying to fix the issue.

---

**Commit Message:** mcp: fix mcp_json_rest_bridge_filter build
**Risk Level:** Low
**Testing:** CI
**Docs Changes:** N/A
**Release Notes:** N/A