### PR TITLE
Update docs about release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,11 +152,15 @@ versioning guidelines:
   build. If your PR cannot have 100% coverage for some reason please clearly explain why when you
   open it.
 * Any PR that changes user-facing behavior **must** have associated documentation in [docs](docs) as
-  well as [release notes](changelogs/current.yaml). API changes should be documented
-  inline with protos as per the [API contribution guidelines](api/CONTRIBUTING.md). If a change applies
-  to multiple sections of the release notes, it should be noted in the first (most important) section
-  that applies. For instance, a bug fix that introduces incompatible behavior should be noted in
-  `Incompatible Behavior Changes` but not in `Bug Fixes`.
+  well as a release note fragment in [changelogs/current](changelogs/current). Add the fragment to
+  the most appropriate section directory, using the canonical sections and areas listed in
+  [changelogs/changelogs.yaml](changelogs/changelogs.yaml). Fragment filenames should use the form
+  `<area>__<short-description>.rst`, for example
+  `http__added-new-request-stat.rst`. API changes should be documented inline with protos as per
+  the [API contribution guidelines](api/CONTRIBUTING.md). If a change applies to multiple sections
+  of the release notes, it should be noted in the first (most important) section that applies. For
+  instance, a bug fix that introduces incompatible behavior should be noted in
+  `behavior_changes` but not in `bug_fixes`.
 * All code comments and documentation are expected to have proper English grammar and punctuation.
   If you are not a fluent English speaker (or a bad writer ;-)) please let us know and we will try
   to find some help but there are no guarantees.
@@ -193,8 +197,9 @@ versioning guidelines:
   changes for 7 days. Obviously PRs that are closed due to lack of activity can be reopened later.
   Closing stale PRs helps us to keep on top of all of the work currently in flight.
 * If a commit deprecates a feature, the commit message must mention what has been deprecated.
-  Additionally, the [version history](changelogs/current.yaml) must be updated with
-  relevant RST links for fields and messages as part of the commit.
+  Additionally, add a release note fragment under the `deprecated` section in
+  [changelogs/current](changelogs/current), with relevant RST links for fields and messages as part
+  of the commit.
 * Please consider joining the [envoy-dev](https://groups.google.com/forum/#!forum/envoy-dev)
   mailing list.
 * If your PR involves any changes to
@@ -266,12 +271,14 @@ Runtime code is held to the same standard as regular Envoy code, so both the old
 path and the new should have 100% coverage both with the feature defaulting true
 and false.
 
-Please note that if adding a runtime guarded feature, your [release notes](changelogs/current.yaml) should include both the functional change, and how to revert it, for example
+Please note that if adding a runtime guarded feature, your release note fragment in
+[changelogs/current](changelogs/current) should include both the functional change, and how to
+revert it, for example in `changelogs/current/behavior_changes/http__header-validation.rst`:
 
-```yaml
-- area: config
-  change: |
-      type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` to false.
+```rst
+HTTP request header validation is now performed before route selection. This behavioral change can
+be temporarily reverted by setting runtime guard
+``envoy.reloadable_features.http_validate_headers_before_route_selection`` to ``false``.
 ```
 
 # PR review policy for maintainers

--- a/PULL_REQUESTS.md
+++ b/PULL_REQUESTS.md
@@ -65,10 +65,11 @@ Request](https://www.envoyproxy.io/docs/envoy/latest/intro/life_of_a_request) do
 ### <a name="relnotes"></a>Release notes
 
 If this change is user impacting OR extension developer impacting (filter API, etc.) you **must**
-add a release note to the [version history](changelogs/current.yaml) for the
-current version. Please include any relevant links. Each release note should be prefixed with the
-relevant subsystem in **alphabetical order** (see existing examples as a guide) and include links
-to relevant parts of the documentation. Thank you! Please write in N/A if there are no release notes.
+add a release note fragment under [changelogs/current](changelogs/current) for the
+current version. Choose the appropriate section directory and name the file
+`<area>__<short-description>.rst`, using the canonical sections and areas listed in
+[changelogs/changelogs.yaml](changelogs/changelogs.yaml). Please include any relevant links to
+documentation. Thank you! Please write in N/A if there are no release notes.
 
 ### <a name="platform_specific_features"></a>Platform Specific Features
 
@@ -118,8 +119,7 @@ merged.
 ### <a name="deprecated"></a>Deprecated
 
 If this PR deprecates existing Envoy APIs or code, it should include an update to the deprecated
-section of the [version history](changelogs/current.yaml) and a one line note in the
-PR description.
+section under [changelogs/current](changelogs/current) and a one line note in the PR description.
 
 If you mark existing APIs or code as deprecated, when the next release is cut, the
 deprecation script will create and assign an issue to you for

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -132,7 +132,7 @@ deadline of 3 weeks.
 * Begin marshalling the ongoing PR flow in this repo. Ask maintainers to hold off merging any
   particularly risky PRs until after the release is tagged. This is because we aim for main to be
   at release candidate quality at all times.
-* Do a final check of the [release notes](changelogs/current.yaml):
+* Do a final check of the release note fragments in [changelogs/current](changelogs/current):
   * Make any needed corrections (grammar, punctuation, formatting, etc.).
   * Check to see if any security/stable version release notes are duplicated in
     the major version release notes. These should not be duplicated.


### PR DESCRIPTION
Commit Message: Update docs about release notes
Additional Description: Multiple docs still referenced the outdated `changelogs/current.yaml`. This updates them. I'm not certain about the accuracy of the `RELEASES.md` change, please double-check.
Related to: #45095 
Risk Level: Docs-only.
Testing: No.
Docs Changes: Yes.
Release Notes: That's what it's about.
Platform Specific Features: n/a
