### PR TITLE
tls: fix connection close detection while handshake is waiting

### DIFF
--- a/changelogs/current/bug_fixes/tls__handshake_cancel_during_async_operation.rst
+++ b/changelogs/current/bug_fixes/tls__handshake_cancel_during_async_operation.rst
@@ -1,0 +1,4 @@
+Fixed a bug where Envoy would not detect a downstream connection close
+when the TLS handshake was blocked on an asynchronous operation. Only
+configurations using certain TLS private key providers, certificate selectors,
+or certificate validators were affected.

--- a/envoy/ssl/ssl_socket_state.h
+++ b/envoy/ssl/ssl_socket_state.h
@@ -3,7 +3,21 @@
 namespace Envoy {
 namespace Ssl {
 
-enum class SocketState { PreHandshake, HandshakeInProgress, HandshakeComplete, ShutdownSent };
+enum class SocketState {
+  // The handshake is in progress and waiting on data on the connection, either to be sent or
+  // received.
+  HandshakeWaitingForConnectionData,
+
+  // The handshake is in progress and waiting on Envoy to complete an operation before it can
+  // continue.
+  HandshakeBlockedOnAsyncOperation,
+
+  // The handshake is complete.
+  HandshakeComplete,
+
+  // A shutdown signal has been sent on the connection.
+  ShutdownSent
+};
 
 } // namespace Ssl
 } // namespace Envoy

--- a/source/common/tls/ssl_handshaker.cc
+++ b/source/common/tls/ssl_handshaker.cc
@@ -157,12 +157,13 @@ Network::PostIoAction SslHandshakerImpl::doHandshake() {
     switch (err) {
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
+      state_ = Ssl::SocketState::HandshakeWaitingForConnectionData;
       return PostIoAction::KeepOpen;
     case SSL_ERROR_PENDING_CERTIFICATE:
     case SSL_ERROR_WANT_PRIVATE_KEY_OPERATION:
     case SSL_ERROR_WANT_CERTIFICATE_VERIFY:
     case SSL_ERROR_WANT_X509_LOOKUP:
-      state_ = Ssl::SocketState::HandshakeInProgress;
+      state_ = Ssl::SocketState::HandshakeBlockedOnAsyncOperation;
       return PostIoAction::KeepOpen;
     default:
       handshake_callbacks_->onFailure();

--- a/source/common/tls/ssl_handshaker.h
+++ b/source/common/tls/ssl_handshaker.h
@@ -162,7 +162,7 @@ public:
 private:
   Ssl::HandshakeCallbacks* handshake_callbacks_;
 
-  Ssl::SocketState state_{Ssl::SocketState::PreHandshake};
+  Ssl::SocketState state_{Ssl::SocketState::HandshakeWaitingForConnectionData};
   mutable SslExtendedSocketInfoImpl extended_socket_info_;
   std::vector<bssl::UniquePtr<X509>> validated_chain_;
 };

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -211,9 +211,11 @@ PostIoAction SslSocket::doHandshake() {
   auto ret = info_->doHandshake();
   if (ret == PostIoAction::KeepOpen) {
     if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation && !read_disabled_) {
-      // Connection close events can only be detected if the connection has reading disabled,
-      // because the handshaker won't actually read any data (such as EOF) when the handshake is
-      // blocked on an async operation.
+      // Connection close events can only be detected if the connection has reading disabled.
+      // If reading is disabled, the connection registers for close events directly.
+      // If reading is enabled, the connection registers for read events, but `doRead()` doesn't
+      // process any data (including an EOF) when the handshake is in this state, so the connection
+      // close isn't detected.
       read_disabled_ = true;
       callbacks_->connection().readDisable(true);
     } else if (info_->state() != Ssl::SocketState::HandshakeBlockedOnAsyncOperation &&

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -177,7 +177,7 @@ void SslSocket::onPrivateKeyMethodComplete() { resumeHandshake(); }
 
 void SslSocket::resumeHandshake() {
   ASSERT(callbacks_ != nullptr && callbacks_->connection().dispatcher().isThreadSafe());
-  ASSERT(info_->state() == Ssl::SocketState::HandshakeInProgress);
+  ASSERT(info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation);
 
   // Resume handshake.
   PostIoAction action = doHandshake();
@@ -207,7 +207,23 @@ void SslSocket::onSuccess(SSL* ssl) {
 
 void SslSocket::onFailure() { drainErrorQueue(); }
 
-PostIoAction SslSocket::doHandshake() { return info_->doHandshake(); }
+PostIoAction SslSocket::doHandshake() {
+  auto ret = info_->doHandshake();
+  if (ret == PostIoAction::KeepOpen) {
+    if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation && !read_disabled_) {
+      // Connection close events can only be detected if the connection has reading disabled,
+      // because the handshaker won't actually read any data (such as EOF) when the handshake is
+      // blocked on an async operation.
+      read_disabled_ = true;
+      callbacks_->connection().readDisable(true);
+    } else if (info_->state() != Ssl::SocketState::HandshakeBlockedOnAsyncOperation &&
+               read_disabled_) {
+      read_disabled_ = false;
+      callbacks_->connection().readDisable(false);
+    }
+  }
+  return ret;
+}
 
 void SslSocket::drainErrorQueue() {
   bool saw_error = false;
@@ -360,12 +376,14 @@ Network::IoResult SslSocket::doWrite(Buffer::Instance& write_buffer, bool end_st
   return {PostIoAction::KeepOpen, total_bytes_written, false};
 }
 
-void SslSocket::onConnected() { ASSERT(info_->state() == Ssl::SocketState::PreHandshake); }
+void SslSocket::onConnected() {
+  ASSERT(info_->state() == Ssl::SocketState::HandshakeWaitingForConnectionData);
+}
 
 Ssl::ConnectionInfoConstSharedPtr SslSocket::ssl() const { return info_; }
 
 void SslSocket::shutdownSsl() {
-  ASSERT(info_->state() != Ssl::SocketState::PreHandshake);
+  ASSERT(info_->state() != Ssl::SocketState::HandshakeWaitingForConnectionData);
   if (info_->state() != Ssl::SocketState::ShutdownSent &&
       callbacks_->connection().state() != Network::Connection::State::Closed) {
     int rc = SSL_shutdown(rawSsl());
@@ -414,7 +432,7 @@ void SslSocket::closeSocket(Network::ConnectionEvent, bool abort_reset) {
   // Attempt to send a shutdown before closing the socket. It's possible this won't go out if
   // there is no room on the socket. We can extend the state machine to handle this at some point
   // if needed.
-  if (info_->state() == Ssl::SocketState::HandshakeInProgress ||
+  if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation ||
       info_->state() == Ssl::SocketState::HandshakeComplete) {
     shutdownSsl();
   } else {
@@ -430,14 +448,14 @@ absl::string_view SslSocket::failureReason() const { return failure_reason_; }
 
 void SslSocket::onAsynchronousCertValidationComplete() {
   ENVOY_CONN_LOG(debug, "Async cert validation completed", callbacks_->connection());
-  if (info_->state() == Ssl::SocketState::HandshakeInProgress) {
+  if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation) {
     resumeHandshake();
   }
 }
 
 void SslSocket::onAsynchronousCertificateSelectionComplete() {
   ENVOY_CONN_LOG(debug, "Async cert selection completed", callbacks_->connection());
-  if (info_->state() != Ssl::SocketState::HandshakeInProgress) {
+  if (info_->state() != Ssl::SocketState::HandshakeBlockedOnAsyncOperation) {
     IS_ENVOY_BUG(fmt::format("unexpected handshake state: {}", static_cast<int>(info_->state())));
     return;
   }

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -202,6 +202,15 @@ void SslSocket::onSuccess(SSL* ssl) {
     callbacks_->connection().streamInfo().downstreamTiming().onDownstreamHandshakeComplete(
         callbacks_->connection().dispatcher().timeSource());
   }
+
+  // There is at least one assertion that reads are enabled when the connected event is raised, so
+  // ensure we are in the correct state. The same operation would happen in
+  // `SslSocket::doHandshake()`, but it wouldn't happen until after the event was raised.
+  if (read_disabled_) {
+    read_disabled_ = false;
+    callbacks_->connection().readDisable(false);
+  }
+
   callbacks_->raiseEvent(Network::ConnectionEvent::Connected);
 }
 

--- a/source/common/tls/ssl_socket.h
+++ b/source/common/tls/ssl_socket.h
@@ -107,6 +107,7 @@ private:
   uint64_t bytes_to_retry_{};
   std::string failure_reason_;
   absl::optional<Api::IoError::IoErrorCode> detected_io_error_;
+  bool read_disabled_{false};
 
   SslHandshakerImplSharedPtr info_;
 };

--- a/test/common/tls/cert_selector/async_cert_selector.cc
+++ b/test/common/tls/cert_selector/async_cert_selector.cc
@@ -40,6 +40,18 @@ AsyncTlsCertificateSelector::selectTlsContext(const SSL_CLIENT_HELLO&,
     return {Ssl::SelectionResult::SelectionStatus::Pending, nullptr, false};
   }
 
+  if (mode_ == "cancel") {
+    // Expects the calling code to cancel the lookup before the 10 second timer fires.
+    ENVOY_LOG_MISC(info, "debug: select cert cancel");
+    stats_.cert_selection_cancel_.inc();
+    cb_ = std::move(cb);
+    selection_timer_ = cb_->dispatcher().createTimer(
+        [] { IS_ENVOY_BUG("timer fired when it was expected to be canceled"); });
+    selection_timer_->enableTimer(std::chrono::seconds(10));
+    return {Ssl::SelectionResult::SelectionStatus::Pending, nullptr, false,
+            std::make_shared<CancellableSelectionHandle>(stats_.cert_selection_cancelled_)};
+  }
+
   stats_.cert_selection_failed_.inc();
   return {Ssl::SelectionResult::SelectionStatus::Failed, nullptr, false};
 };

--- a/test/common/tls/cert_selector/async_cert_selector.cc
+++ b/test/common/tls/cert_selector/async_cert_selector.cc
@@ -44,12 +44,12 @@ AsyncTlsCertificateSelector::selectTlsContext(const SSL_CLIENT_HELLO&,
     // Expects the calling code to cancel the lookup before the 10 second timer fires.
     ENVOY_LOG_MISC(info, "debug: select cert cancel");
     stats_.cert_selection_cancel_.inc();
-    cb_ = std::move(cb);
-    selection_timer_ = cb_->dispatcher().createTimer(
+    auto timer = cb->dispatcher().createTimer(
         [] { IS_ENVOY_BUG("timer fired when it was expected to be canceled"); });
-    selection_timer_->enableTimer(std::chrono::seconds(10));
+    timer->enableTimer(std::chrono::seconds(10));
     return {Ssl::SelectionResult::SelectionStatus::Pending, nullptr, false,
-            std::make_shared<CancellableSelectionHandle>(stats_.cert_selection_cancelled_)};
+            std::make_shared<CancellableSelectionHandle>(stats_.cert_selection_cancelled_,
+                                                         std::move(cb), std::move(timer))};
   }
 
   stats_.cert_selection_failed_.inc();

--- a/test/common/tls/cert_selector/async_cert_selector.h
+++ b/test/common/tls/cert_selector/async_cert_selector.h
@@ -18,12 +18,15 @@ namespace Tls {
 // cancellation.
 class CancellableSelectionHandle : public Ssl::SelectionHandle {
 public:
-  explicit CancellableSelectionHandle(Stats::Counter& cancelled_counter)
-      : cancelled_counter_(cancelled_counter) {}
+  CancellableSelectionHandle(Stats::Counter& cancelled_counter,
+                             Ssl::CertificateSelectionCallbackPtr cb, Event::TimerPtr timer)
+      : cancelled_counter_(cancelled_counter), cb_(std::move(cb)), timer_(std::move(timer)) {}
   ~CancellableSelectionHandle() override { cancelled_counter_.inc(); }
 
 private:
   Stats::Counter& cancelled_counter_;
+  Ssl::CertificateSelectionCallbackPtr cb_;
+  Event::TimerPtr timer_;
 };
 
 class AsyncTlsCertificateSelector : public Ssl::TlsCertificateSelector,

--- a/test/common/tls/cert_selector/async_cert_selector.h
+++ b/test/common/tls/cert_selector/async_cert_selector.h
@@ -14,6 +14,18 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
+// SelectionHandle subclass used by the "cancel" mode to observe handshake
+// cancellation.
+class CancellableSelectionHandle : public Ssl::SelectionHandle {
+public:
+  explicit CancellableSelectionHandle(Stats::Counter& cancelled_counter)
+      : cancelled_counter_(cancelled_counter) {}
+  ~CancellableSelectionHandle() override { cancelled_counter_.inc(); }
+
+private:
+  Stats::Counter& cancelled_counter_;
+};
+
 class AsyncTlsCertificateSelector : public Ssl::TlsCertificateSelector,
                                     protected Logger::Loggable<Logger::Id::connection> {
 public:

--- a/test/common/tls/cert_selector/stats.h
+++ b/test/common/tls/cert_selector/stats.h
@@ -14,6 +14,8 @@ namespace Tls {
   COUNTER(cert_selection_async_finished)                                                           \
   COUNTER(cert_selection_sleep)                                                                    \
   COUNTER(cert_selection_sleep_finished)                                                           \
+  COUNTER(cert_selection_cancel)                                                                   \
+  COUNTER(cert_selection_cancelled)                                                                \
   COUNTER(cert_selection_failed)
 
 /**

--- a/test/common/tls/integration/ssl_integration_test.cc
+++ b/test/common/tls/integration/ssl_integration_test.cc
@@ -467,7 +467,7 @@ typed_config:
   const auto* socket = dynamic_cast<const Extensions::TransportSockets::Tls::SslHandshakerImpl*>(
       connection->ssl().get());
   ASSERT(socket);
-  while (socket->state() == Ssl::SocketState::PreHandshake) {
+  while (socket->state() == Ssl::SocketState::HandshakeWaitingForConnectionData) {
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
   ASSERT_EQ(connection->state(), Network::Connection::State::Open);
@@ -521,7 +521,7 @@ typed_config:
   const auto* socket = dynamic_cast<const Extensions::TransportSockets::Tls::SslHandshakerImpl*>(
       connection->ssl().get());
   ASSERT(socket);
-  while (socket->state() == Ssl::SocketState::PreHandshake) {
+  while (socket->state() == Ssl::SocketState::HandshakeWaitingForConnectionData) {
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
   ASSERT_EQ(connection->state(), Network::Connection::State::Open);
@@ -562,7 +562,7 @@ typed_config:
   const auto* socket = dynamic_cast<const Extensions::TransportSockets::Tls::SslHandshakerImpl*>(
       connection->ssl().get());
   ASSERT(socket);
-  while (socket->state() == Ssl::SocketState::PreHandshake) {
+  while (socket->state() == Ssl::SocketState::HandshakeWaitingForConnectionData) {
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
   Envoy::Ssl::ClientContextSharedPtr client_ssl_ctx =
@@ -612,7 +612,7 @@ typed_config:
   const auto* socket = dynamic_cast<const Extensions::TransportSockets::Tls::SslHandshakerImpl*>(
       connection->ssl().get());
   ASSERT(socket);
-  while (socket->state() == Ssl::SocketState::PreHandshake) {
+  while (socket->state() == Ssl::SocketState::HandshakeWaitingForConnectionData) {
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
   Envoy::Ssl::ClientContextSharedPtr client_ssl_ctx =
@@ -1477,6 +1477,38 @@ typed_config:
                                TestUtility::DefaultTimeout, dispatcher_.get());
 
   connection.reset();
+}
+
+// Verifies that when the downstream connection is closed while the handshake
+// is paused on async cert selection, the `SelectionHandle` returned by the
+// selector is destroyed.
+BORINGSSL_TEST_P(SslIntegrationTest, AsyncCertSelectionCancellationObservedOnDownstreamClose) {
+  tls_cert_selector_yaml_ = R"EOF(
+name: test-tls-context-provider
+typed_config:
+  "@type": type.googleapis.com/google.protobuf.StringValue
+  value: cancel
+  )EOF";
+  initialize();
+
+  Network::ClientConnectionPtr connection = makeSslClientConnection({});
+  ConnectionStatusCallbacks callbacks;
+  connection->addConnectionCallbacks(callbacks);
+  connection->connect();
+  const auto* socket = dynamic_cast<const Extensions::TransportSockets::Tls::SslHandshakerImpl*>(
+      connection->ssl().get());
+  ASSERT(socket);
+
+  test_server_->waitForCounter("aysnc_cert_selection.cert_selection_cancel", Eq(1),
+                               TestUtility::DefaultTimeout, dispatcher_.get());
+  EXPECT_EQ(test_server_->counter("aysnc_cert_selection.cert_selection_cancelled")->value(), 0);
+
+  ASSERT_EQ(connection->state(), Network::Connection::State::Open);
+  connection->close(Network::ConnectionCloseType::NoFlush);
+  connection.reset();
+
+  test_server_->waitForCounter("aysnc_cert_selection.cert_selection_cancelled", Eq(1),
+                               std::chrono::seconds(2), dispatcher_.get());
 }
 
 } // namespace Ssl


### PR DESCRIPTION
When a TLS handshake is waiting on an async operation (such as certificate selection through some extensions, async certificate validation, or async private key provider operations), it was failing to detect if the downstream connection was closed, so that the async operation could be canceled and the TLS connection resources could be released.

Added connection.readDisable() while in this state, which changes which socket events ConnectionImpl is registered to receive so that connection close is handled immediately. Without this change, SslSocket::doRead() was discarding the read event which would signal an EOF.

Risk Level: Medium
Testing: Added new tests; new integration test fails without this fix
Docs Changes: none
Release Notes: added