### PR TITLE
test/wasm: Migrate wee8_compile to use proxy_wasm serialization API

### DIFF
--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -184,7 +184,6 @@ public:
     std::string_view precompiled = {};
     // clang-format on
 
-    // Load precompiled module on Linux-x86_64, since it's only support there.
     if (GetParam() /* allow_precompiled */) {
       // Section name is expected to be available in the tested runtimes.
       const auto section_name = wasm_vm_->getPrecompiledSectionName();
@@ -206,13 +205,7 @@ protected:
   WasmVmPtr wasm_vm_;
 };
 
-INSTANTIATE_TEST_SUITE_P(AllowPrecompiled, WasmVmTest,
-#if defined(__linux__) && defined(__x86_64__)
-                         testing::Values(false, true)
-#else
-                         testing::Values(false)
-#endif
-);
+INSTANTIATE_TEST_SUITE_P(AllowPrecompiled, WasmVmTest, testing::Values(false, true));
 
 TEST_P(WasmVmTest, V8BadCode) {
   wasm_vm_ = createWasmVm("envoy.wasm.runtime.v8");

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -171,11 +171,9 @@ public:
   }
   void TearDown() override { delete g_host_functions; }
 
-  bool init(std::string code = {}) {
+  void init(std::string code = {}) {
     wasm_vm_ = createWasmVm("envoy.wasm.runtime.v8");
-    if (wasm_vm_.get() == nullptr) {
-      return false;
-    }
+    ASSERT_NE(wasm_vm_.get(), nullptr);
 
     if (code.empty()) {
       code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
@@ -187,29 +185,19 @@ public:
     // clang-format on
 
     // Load precompiled module on Linux-x86_64, since it's only support there.
-#if defined(__linux__) && defined(__x86_64__)
     if (GetParam() /* allow_precompiled */) {
       // Section name is expected to be available in the tested runtimes.
       const auto section_name = wasm_vm_->getPrecompiledSectionName();
-      if (section_name.empty()) {
-        return false;
-      }
-      if (!proxy_wasm::BytecodeUtil::getCustomSection(code, section_name, precompiled)) {
-        return false;
-      }
+      ASSERT_FALSE(section_name.empty());
+      ASSERT_TRUE(proxy_wasm::BytecodeUtil::getCustomSection(code, section_name, precompiled));
       // Precompiled module is expected to be available in the test file.
-      if (precompiled.empty()) {
-        return false;
-      }
+      ASSERT_FALSE(precompiled.empty());
     }
-#endif
 
     std::string stripped;
-    if (!proxy_wasm::BytecodeUtil::getStrippedSource(code, stripped)) {
-      return false;
-    }
+    ASSERT_TRUE(proxy_wasm::BytecodeUtil::getStrippedSource(code, stripped));
 
-    return wasm_vm_->load(stripped, precompiled, {});
+    ASSERT_TRUE(wasm_vm_->load(stripped, precompiled, {}));
   }
 
 protected:
@@ -226,17 +214,21 @@ INSTANTIATE_TEST_SUITE_P(AllowPrecompiled, WasmVmTest,
 #endif
 );
 
-TEST_P(WasmVmTest, V8BadCode) { ASSERT_FALSE(init("bad code")); }
+TEST_P(WasmVmTest, V8BadCode) {
+  wasm_vm_ = createWasmVm("envoy.wasm.runtime.v8");
+  ASSERT_NE(wasm_vm_.get(), nullptr);
+  EXPECT_FALSE(wasm_vm_->load("bad code", "", {}));
+}
 
 TEST_P(WasmVmTest, V8Load) {
-  ASSERT_TRUE(init());
+  ASSERT_NO_FATAL_FAILURE(init());
   EXPECT_TRUE(wasm_vm_->getEngineName() == "v8");
   EXPECT_TRUE(wasm_vm_->cloneable() == Cloneable::CompiledBytecode);
   EXPECT_TRUE(wasm_vm_->clone() != nullptr);
 }
 
 TEST_P(WasmVmTest, V8BadHostFunctions) {
-  ASSERT_TRUE(init());
+  ASSERT_NO_FATAL_FAILURE(init());
 
   wasm_vm_->registerCallback("env", "random", &random, CONVERT_FUNCTION_WORD_TO_UINT32(random));
   EXPECT_FALSE(wasm_vm_->link("test"));
@@ -252,7 +244,7 @@ TEST_P(WasmVmTest, V8BadHostFunctions) {
 }
 
 TEST_P(WasmVmTest, V8BadModuleFunctions) {
-  ASSERT_TRUE(init());
+  ASSERT_NO_FATAL_FAILURE(init());
 
   wasm_vm_->registerCallback("env", "pong", &pong, CONVERT_FUNCTION_WORD_TO_UINT32(pong));
   wasm_vm_->registerCallback("env", "random", &random, CONVERT_FUNCTION_WORD_TO_UINT32(random));
@@ -275,7 +267,7 @@ TEST_P(WasmVmTest, V8BadModuleFunctions) {
 }
 
 TEST_P(WasmVmTest, V8FunctionCalls) {
-  ASSERT_TRUE(init());
+  ASSERT_NO_FATAL_FAILURE(init());
 
   wasm_vm_->registerCallback("env", "pong", &pong, CONVERT_FUNCTION_WORD_TO_UINT32(pong));
   wasm_vm_->registerCallback("env", "random", &random, CONVERT_FUNCTION_WORD_TO_UINT32(random));
@@ -308,7 +300,7 @@ TEST_P(WasmVmTest, V8FunctionCalls) {
 }
 
 TEST_P(WasmVmTest, V8Memory) {
-  ASSERT_TRUE(init());
+  ASSERT_NO_FATAL_FAILURE(init());
 
   wasm_vm_->registerCallback("env", "pong", &pong, CONVERT_FUNCTION_WORD_TO_UINT32(pong));
   wasm_vm_->registerCallback("env", "random", &random, CONVERT_FUNCTION_WORD_TO_UINT32(random));

--- a/test/tools/wee8_compile/BUILD
+++ b/test/tools/wee8_compile/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
         "-Wno-unused-parameter",
     ],
     deps = [
-        "@v8//:wee8",
+        "@proxy_wasm_cpp_host//:base_lib",
+        "@proxy_wasm_cpp_host//:v8_lib",
     ],
 )

--- a/test/tools/wee8_compile/wee8_compile.cc
+++ b/test/tools/wee8_compile/wee8_compile.cc
@@ -30,7 +30,7 @@ std::string readWasmModule(const char* path) {
   return content;
 }
 
-bool writeWasmModule(absl::string_view module, absl::string_view path) {
+bool writeWasmModule(absl::string_view module, const char* path) {
   auto file = std::fstream(path, std::ios::out | std::ios::binary);
   file.write(module.data(), module.size());
   file.close();

--- a/test/tools/wee8_compile/wee8_compile.cc
+++ b/test/tools/wee8_compile/wee8_compile.cc
@@ -7,192 +7,32 @@
 #include <thread>
 #include <vector>
 
-#include "src/flags/flags.h"
-#include "src/wasm/c-api.h"
-#include "v8-version.h"
-#include "wasm-api/wasm.hh"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "include/proxy-wasm/bytecode_util.h"
+#include "include/proxy-wasm/pairs_util.h"
+#include "include/proxy-wasm/sdk.h"
+#include "include/proxy-wasm/v8.h"
+#include "include/proxy-wasm/wasm_vm.h"
 
-uint32_t parseVarint(const byte_t*& pos, const byte_t* end) {
-  uint32_t n = 0;
-  uint32_t shift = 0;
-  byte_t b;
-
-  do {
-    if (pos + 1 > end) {
-      return static_cast<uint32_t>(-1);
-    }
-    b = *pos++;
-    n += (b & 0x7f) << shift;
-    shift += 7;
-  } while ((b & 0x80) != 0);
-
-  return n;
-}
-
-wasm::vec<byte_t> getVarint(uint32_t value) {
-  byte_t bytes[5];
-  int pos = 0;
-
-  while (pos < 5) {
-    if ((value & ~0x7F) == 0) {
-      bytes[pos++] = static_cast<uint8_t>(value);
-      break;
-    }
-
-    bytes[pos++] = static_cast<uint8_t>(value & 0x7F) | 0x80;
-    value >>= 7;
-  }
-
-  auto vec = wasm::vec<byte_t>::make_uninitialized(pos);
-  ::memcpy(vec.get(), bytes, pos);
-
-  return vec;
-}
-
-wasm::vec<byte_t> readWasmModule(const char* path, const std::string& name) {
+std::string readWasmModule(const char* path) {
   // Open binary file.
   auto file = std::ifstream(path, std::ios::binary);
-  file.seekg(0, std::ios_base::end);
-  const auto size = file.tellg();
-  file.seekg(0);
-  auto content = wasm::vec<byte_t>::make_uninitialized(size);
-  file.read(content.get(), size);
+  auto content =
+      std::string(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
   file.close();
 
   if (file.fail()) {
     std::cerr << "ERROR: Failed to read the input file from: " << path << std::endl;
-    return wasm::vec<byte_t>::invalid();
-  }
-
-  // Wasm header is 8 bytes (magic number + version).
-  const uint8_t magic_number[4] = {0x00, 0x61, 0x73, 0x6d};
-  if (size < 8 || ::memcmp(content.get(), magic_number, 4) != 0) {
-    std::cerr << "ERROR: Failed to parse corrupted Wasm module from: " << path << std::endl;
-    return wasm::vec<byte_t>::invalid();
-  }
-
-  // Parse custom sections to see if precompiled module already exists.
-  const byte_t* pos = content.get() + 8 /* Wasm header */;
-  const byte_t* end = content.get() + content.size();
-  while (pos < end) {
-    if (pos + 1 > end) {
-      std::cerr << "ERROR: Failed to parse corrupted Wasm module from: " << path << std::endl;
-      return wasm::vec<byte_t>::invalid();
-    }
-    const auto section_type = *pos++;
-    const auto section_len = parseVarint(pos, end);
-    if (section_len == static_cast<uint32_t>(-1) || pos + section_len > end) {
-      std::cerr << "ERROR: Failed to parse corrupted Wasm module from: " << path << std::endl;
-      return wasm::vec<byte_t>::invalid();
-    }
-    if (section_type == 0 /* custom section */) {
-      const auto section_data_start = pos;
-      const auto section_name_len = parseVarint(pos, end);
-      if (section_name_len == static_cast<uint32_t>(-1) || pos + section_name_len > end) {
-        std::cerr << "ERROR: Failed to parse corrupted Wasm module from: " << path << std::endl;
-        return wasm::vec<byte_t>::invalid();
-      }
-      if (section_name_len == name.size() && ::memcmp(pos, name.data(), section_name_len) == 0) {
-        std::cerr << "ERROR: Wasm module: " << path << " already contains precompiled module."
-                  << std::endl;
-        return wasm::vec<byte_t>::invalid();
-      }
-      pos = section_data_start + section_len;
-    } else {
-      pos += section_len;
-    }
+    return "";
   }
 
   return content;
 }
 
-wasm::vec<byte_t> stripWasmModule(const wasm::vec<byte_t>& module) {
-  std::vector<byte_t> stripped;
-
-  const byte_t* pos = module.get();
-  const byte_t* end = module.get() + module.size();
-
-  // Copy Wasm header.
-  stripped.insert(stripped.end(), pos, pos + 8);
-  pos += 8;
-
-  while (pos < end) {
-    const auto section_start = pos;
-    if (pos + 1 > end) {
-      std::cerr << "ERROR: Failed to parse corrupted Wasm module." << std::endl;
-      return wasm::vec<byte_t>::invalid();
-    }
-    const auto section_type = *pos++;
-    const auto section_len = parseVarint(pos, end);
-    if (section_len == static_cast<uint32_t>(-1) || pos + section_len > end) {
-      std::cerr << "ERROR: Failed to parse corrupted Wasm module." << std::endl;
-      return wasm::vec<byte_t>::invalid();
-    }
-    if (section_type == 0 /* custom section */) {
-      const auto section_data_start = pos;
-      const auto section_name_len = parseVarint(pos, end);
-      if (section_name_len == static_cast<uint32_t>(-1) || pos + section_name_len > end) {
-        std::cerr << "ERROR: Failed to parse corrupted Wasm module." << std::endl;
-        return wasm::vec<byte_t>::invalid();
-      }
-      auto section_name = std::string(pos, section_name_len);
-      if (section_name.find("precompiled_") == std::string::npos) {
-        stripped.insert(stripped.end(), section_start, section_data_start + section_len);
-      }
-      pos = section_data_start + section_len;
-    } else {
-      pos += section_len;
-      stripped.insert(stripped.end(), section_start, pos /* section end */);
-    }
-  }
-
-  return wasm::vec<byte_t>::make(stripped.size(), stripped.data());
-}
-
-wasm::vec<byte_t> serializeWasmModule(const char* path, const wasm::vec<byte_t>& content) {
-  ::v8::internal::v8_flags.liftoff = false;
-  ::v8::internal::v8_flags.wasm_max_mem_pages = 16384; /* 16,384 * 64 KiB pages == 1 GiB limit */
-  ::v8::internal::v8_flags.stack_trace_limit = 20;
-  const auto engine = wasm::Engine::make();
-  if (engine == nullptr) {
-    std::cerr << "ERROR: Failed to start V8." << std::endl;
-    return wasm::vec<byte_t>::invalid();
-  }
-
-  const auto store = wasm::Store::make(engine.get());
-  if (store == nullptr) {
-    std::cerr << "ERROR: Failed to create V8 isolate." << std::endl;
-    return wasm::vec<byte_t>::invalid();
-  }
-
-  const auto module = wasm::Module::make(store.get(), content);
-  if (module == nullptr) {
-    std::cerr << "ERROR: Failed to instantiate WebAssembly module from: " << path << std::endl;
-    return wasm::vec<byte_t>::invalid();
-  }
-
-  wasm::StoreImpl* store_impl = reinterpret_cast<wasm::StoreImpl*>(store.get());
-  auto isolate = store_impl->isolate();
-  while (isolate->HasPendingBackgroundTasks()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-
-  return module->serialize();
-}
-
-bool writeWasmModule(const char* path, const wasm::vec<byte_t>& module, size_t stripped_module_size,
-                     const std::string& section_name, const wasm::vec<byte_t>& serialized) {
+bool writeWasmModule(absl::string_view module, absl::string_view path) {
   auto file = std::fstream(path, std::ios::out | std::ios::binary);
-  file.write(module.get(), module.size());
-  const char section_type = '\0'; // custom section
-  file.write(&section_type, 1);
-  const auto section_name_len = getVarint(section_name.size());
-  const auto section_size =
-      getVarint(section_name_len.size() + section_name.size() + serialized.size());
-  file.write(section_size.get(), section_size.size());
-  file.write(section_name_len.get(), section_name_len.size());
-  file.write(section_name.data(), section_name.size());
-  file.write(serialized.get(), serialized.size());
+  file.write(module.data(), module.size());
   file.close();
 
   if (file.fail()) {
@@ -200,63 +40,41 @@ bool writeWasmModule(const char* path, const wasm::vec<byte_t>& module, size_t s
     return false;
   }
 
-  const auto total_size = module.size() + 1 + section_size.size() + section_name_len.size() +
-                          section_name.size() + serialized.size();
-  std::cout << "Written " << total_size << " bytes (bytecode: " << stripped_module_size << " bytes,"
-            << " precompiled: " << serialized.size() << " bytes)." << std::endl;
+  std::cout << "Written " << module.size() << " bytes." << std::endl;
   return true;
 }
 
-#if defined(__linux__) && defined(__x86_64__)
-#define WEE8_PLATFORM "linux_x86_64"
-#elif defined(__linux__) && defined(__aarch64__)
-#define WEE8_PLATFORM "linux_aarch64"
-#elif defined(__linux__) && (defined(__ppc64le__) || defined(__PPC64LE__))
-#define WEE8_PLATFORM "linux_ppc64le"
-#elif defined(__linux__) && defined(__s390x__)
-#define WEE8_PLATFORM "linux_s390x"
-#elif defined(__APPLE__) && defined(__x86_64__)
-#define WEE8_PLATFORM "macos_x86_64"
-#elif defined(__APPLE__) && defined(__arm64__)
-#define WEE8_PLATFORM "macos_arm64"
-#elif defined(_WIN64) && defined(_M_X64)
-#define WEE8_PLATFORM "windows_x64"
-#else
-#define WEE8_PLATFORM ""
-#endif
-
 int main(int argc, char* argv[]) {
-  if (sizeof(WEE8_PLATFORM) - 1 == 0) {
-    std::cerr << "Unsupported platform." << std::endl;
-    return EXIT_FAILURE;
-  }
-
   if (argc != 3) {
     std::cerr << "Usage: " << argv[0] << " <input> <output>" << std::endl;
     return EXIT_FAILURE;
   }
 
-  const std::string section_name = "precompiled_wee8_v" + std::to_string(V8_MAJOR_VERSION) + "." +
-                                   std::to_string(V8_MINOR_VERSION) + "." +
-                                   std::to_string(V8_BUILD_NUMBER) + "." +
-                                   std::to_string(V8_PATCH_LEVEL) + "_" + WEE8_PLATFORM;
-
-  const auto module = readWasmModule(argv[1], section_name);
-  if (!module) {
+  const std::string module = readWasmModule(argv[1]);
+  if (module.empty()) {
     return EXIT_FAILURE;
   }
 
-  const auto stripped_module = stripWasmModule(module);
-  if (!stripped_module) {
+  std::string stripped_module;
+  if (!proxy_wasm::BytecodeUtil::getStrippedSource(module, stripped_module)) {
     return EXIT_FAILURE;
   }
 
-  const auto serialized = serializeWasmModule(argv[1], stripped_module);
-  if (!serialized) {
+  std::unique_ptr<proxy_wasm::WasmVm> vm = proxy_wasm::createV8Vm();
+  if (vm == nullptr) {
     return EXIT_FAILURE;
   }
 
-  if (!writeWasmModule(argv[2], module, stripped_module.size(), section_name, serialized)) {
+  if (!vm->load(stripped_module, "", {})) {
+    return EXIT_FAILURE;
+  }
+
+  absl::optional<std::string> serialized_module = vm->serialize(stripped_module);
+  if (!serialized_module) {
+    return EXIT_FAILURE;
+  }
+
+  if (!writeWasmModule(*serialized_module, argv[2])) {
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: test/wasm: Migrate wee8_compile to use proxy_wasm serialization API
Additional Description:

Proxy-Wasm introduced an officially supported mechanism for AOT compilation of wasm modules. Migrate Envoy's AOT compile script to use the supported mechanism.

Risk Level: None / test-only
Testing: `bazel test //test/extensions/common/wasm/... //test/extensions/filters/http/wasm/... //test/extensions/filters/network/wasm/...`
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
