### PR TITLE
build/wasm: Use default rust version for rust toolchain

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -70,7 +70,7 @@ def envoy_dependency_imports(
     )
     rules_rust_dependencies()
     rust_register_toolchains(
-        versions = ["1.88.0"],
+        versions = [rust_common.default_version],
         extra_target_triples = [
             "wasm32-unknown-unknown",
             "wasm32-wasip1",


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

This aligns with the version used by s390x rust toolchain in the immediately preceeding lines. In the current version of rules_rust, this corresponds to 1.93.1.

Commit Message: build/wasm: Use default rust version for rust toolchain
Additional Description:
Risk Level: Build toolchain only change.
Testing: `bazel test //test/extensions/common/wasm/... //test/extensions/filters/http/wasm/... //test/extensions/filters/network/wasm/... --define wasm=wasmtime --//bazel:jemalloc`
Docs Changes: None.
Release Notes: None.
Platform Specific Features: None.