### PR TITLE
mobile: Remove unused Blaze option

### DIFF
--- a/mobile/bazel/framework_imports_extractor.bzl
+++ b/mobile/bazel/framework_imports_extractor.bzl
@@ -53,6 +53,5 @@ framework_imports_extractor = rule(
         platform_type = attr.string(default = "ios"),
         minimum_os_version = attr.string(default = MINIMUM_IOS_VERSION),
     ),
-    # fragments = ["apple"],
     implementation = _framework_imports_extractor,
 )


### PR DESCRIPTION
Remove the commented out `fragments = ["apple"],` line from the `framework_imports_extractor` rule. This is a cleanup of unused configuration and references to inactive configuration fragments.