### PR TITLE
fix unused variables and suppress nodiscard warnings in mobile and new extensions

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -380,12 +380,12 @@ std::string EngineBuilder::nativeNameToConfig(absl::string_view name) {
   envoymobile::extensions::filters::http::platform_bridge::PlatformBridge proto_config;
   proto_config.set_platform_filter_name(name);
   std::string ret;
-  proto_config.SerializeToString(&ret);
+  std::ignore = proto_config.SerializeToString(&ret);
   Protobuf::Any any_config;
   any_config.set_type_url(
       "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge");
   any_config.set_value(ret);
-  any_config.SerializeToString(&ret);
+  std::ignore = any_config.SerializeToString(&ret);
   return ret;
 #endif
 }
@@ -541,7 +541,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     auto* early_data = route_to->mutable_early_data_policy();
     early_data->set_name("envoy.route.early_data_policy.default");
     ::envoy::extensions::early_data::v3::DefaultEarlyDataPolicy config;
-    early_data->mutable_typed_config()->PackFrom(config);
+    std::ignore = early_data->mutable_typed_config()->PackFrom(config);
   }
 
   for (auto filter = native_filter_chain_.rbegin(); filter != native_filter_chain_.rend();
@@ -550,8 +550,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     native_filter->set_name(filter->name_);
     if (!filter->textproto_typed_config_.empty()) {
 #ifdef ENVOY_ENABLE_FULL_PROTOS
-      Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
-                                            native_filter->mutable_typed_config());
+      std::ignore = Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
+                                                          native_filter->mutable_typed_config());
       RELEASE_ASSERT(!native_filter->typed_config().DebugString().empty(),
                      "Failed to parse: " + (*filter).textproto_typed_config_);
 #else
@@ -569,7 +569,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig cache_config;
     auto* cache_filter = hcm->add_http_filters();
     cache_filter->set_name("alternate_protocols_cache");
-    cache_filter->mutable_typed_config()->PackFrom(cache_config);
+    std::ignore = cache_filter->mutable_typed_config()->PackFrom(cache_config);
   }
 
   if (gzip_decompression_filter_) {
@@ -577,8 +577,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     gzip_config.mutable_window_bits()->set_value(15);
     envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
     decompressor_config.mutable_decompressor_library()->set_name("gzip");
-    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
-        gzip_config);
+    std::ignore =
+        decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+            gzip_config);
     auto* common_request =
         decompressor_config.mutable_request_direction_config()->mutable_common_config();
     common_request->mutable_enabled()->mutable_default_value();
@@ -588,14 +589,15 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         ->set_ignore_no_transform_header(true);
     auto* gzip_filter = hcm->add_http_filters();
     gzip_filter->set_name("envoy.filters.http.decompressor");
-    gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
+    std::ignore = gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
   if (brotli_decompression_filter_) {
     envoy::extensions::compression::brotli::decompressor::v3::Brotli brotli_config;
     envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
     decompressor_config.mutable_decompressor_library()->set_name("text_optimized");
-    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
-        brotli_config);
+    std::ignore =
+        decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+            brotli_config);
     auto* common_request =
         decompressor_config.mutable_request_direction_config()->mutable_common_config();
     common_request->mutable_enabled()->mutable_default_value();
@@ -605,13 +607,13 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         ->set_ignore_no_transform_header(true);
     auto* brotli_filter = hcm->add_http_filters();
     brotli_filter->set_name("envoy.filters.http.decompressor");
-    brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
+    std::ignore = brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
   if (socket_tagging_filter_) {
     envoymobile::extensions::filters::http::socket_tag::SocketTag tag_config;
     auto* tag_filter = hcm->add_http_filters();
     tag_filter->set_name("envoy.filters.http.socket_tag");
-    tag_filter->mutable_typed_config()->PackFrom(tag_config);
+    std::ignore = tag_filter->mutable_typed_config()->PackFrom(tag_config);
   }
 
   // Set up the always-present filters
@@ -621,12 +623,12 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   network_config.set_enable_interface_binding(enable_interface_binding_);
   auto* network_filter = hcm->add_http_filters();
   network_filter->set_name("envoy.filters.http.network_configuration");
-  network_filter->mutable_typed_config()->PackFrom(network_config);
+  std::ignore = network_filter->mutable_typed_config()->PackFrom(network_config);
 
   envoymobile::extensions::filters::http::local_error::LocalError local_config;
   auto* local_filter = hcm->add_http_filters();
   local_filter->set_name("envoy.filters.http.local_error");
-  local_filter->mutable_typed_config()->PackFrom(local_config);
+  std::ignore = local_filter->mutable_typed_config()->PackFrom(local_config);
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig dfp_config;
   auto* dns_cache_config = dfp_config.mutable_dns_cache_config();
@@ -648,10 +650,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     kv_config.set_max_entries(100);
     dns_cache_config->mutable_key_value_config()->mutable_config()->set_name(
         "envoy.key_value.platform");
-    dns_cache_config->mutable_key_value_config()
-        ->mutable_config()
-        ->mutable_typed_config()
-        ->PackFrom(kv_config);
+    std::ignore = dns_cache_config->mutable_key_value_config()
+                      ->mutable_config()
+                      ->mutable_typed_config()
+                      ->PackFrom(kv_config);
   }
 
   if (dns_resolver_config_.has_value()) {
@@ -661,8 +663,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     envoy::extensions::network::dns_resolver::apple::v3::AppleDnsResolverConfig resolver_config;
     dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
         "envoy.network.dns_resolver.apple");
-    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
-        resolver_config);
+    std::ignore =
+        dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+            resolver_config);
 #else
     envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig
         resolver_config;
@@ -672,8 +675,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     resolver_config.mutable_num_resolver_threads()->set_value(getaddrinfo_num_threads_);
     dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
         "envoy.network.dns_resolver.getaddrinfo");
-    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
-        resolver_config);
+    std::ignore =
+        dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+            resolver_config);
 #endif
   }
 
@@ -685,12 +689,12 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
 
   auto* dfp_filter = hcm->add_http_filters();
   dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
-  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
+  std::ignore = dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
 
   auto* router_filter = hcm->add_http_filters();
   envoy::extensions::filters::http::router::v3::Router router_config;
   router_filter->set_name("envoy.router");
-  router_filter->mutable_typed_config()->PackFrom(router_config);
+  std::ignore = router_filter->mutable_typed_config()->PackFrom(router_config);
 
   auto* static_resources = bootstrap->mutable_static_resources();
 
@@ -702,7 +706,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   base_address->mutable_socket_address()->set_address("0.0.0.0");
   base_address->mutable_socket_address()->set_port_value(10000);
   base_listener->mutable_per_connection_buffer_limit_bytes()->set_value(10485760);
-  base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
+  std::ignore =
+      base_listener->mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
 
   // Basic TLS config.
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_socket;
@@ -728,7 +733,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     }
     validation->mutable_custom_validator_config()->set_name(
         "envoy_mobile.cert_validator.platform_bridge_cert_validator");
-    validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);
+    std::ignore =
+        validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);
   } else {
     std::string certs;
 #ifdef ENVOY_MOBILE_XDS
@@ -756,11 +762,12 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
       ssl_proxy_socket;
   ssl_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
-  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+  std::ignore =
+      ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
 
   envoy::config::core::v3::TransportSocket base_tls_socket;
   base_tls_socket.set_name("envoy.transport_sockets.http_11_proxy");
-  base_tls_socket.mutable_typed_config()->PackFrom(ssl_proxy_socket);
+  std::ignore = base_tls_socket.mutable_typed_config()->PackFrom(ssl_proxy_socket);
 
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions h2_protocol_options;
   h2_protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
@@ -771,7 +778,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   envoy::config::cluster::v3::Cluster::CustomClusterType base_cluster_type;
   base_cluster_config.mutable_dns_cache_config()->CopyFrom(*dns_cache_config);
   base_cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
-  base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
+  std::ignore = base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
 
   auto* upstream_opts = base_cluster->mutable_upstream_connection_options();
   upstream_opts->set_set_local_interface_name_on_upstream_connections(true);
@@ -818,24 +825,26 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   auto* h1_options = alpn_options.mutable_auto_config()->mutable_http_protocol_options();
   auto* formatter = h1_options->mutable_header_key_format()->mutable_stateful_formatter();
   formatter->set_name("preserve_case");
-  formatter->mutable_typed_config()->PackFrom(preserve_case_config);
+  std::ignore = formatter->mutable_typed_config()->PackFrom(preserve_case_config);
 
   // Base cluster
   base_cluster->set_name("base");
   base_cluster->mutable_connect_timeout()->set_seconds(connect_timeout_seconds_);
   base_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
-  (*base_cluster->mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(alpn_options);
+  std::ignore = (*base_cluster->mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(alpn_options);
   base_cluster->mutable_cluster_type()->CopyFrom(base_cluster_type);
   base_cluster->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
-  base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(ssl_proxy_socket);
+  std::ignore =
+      base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(ssl_proxy_socket);
 
   // Base clear-text cluster set up
   envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer raw_buffer;
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
       cleartext_proxy_socket;
-  cleartext_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
+  std::ignore = cleartext_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(
+      raw_buffer);
   cleartext_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions h1_protocol_options;
   h1_protocol_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
@@ -850,17 +859,19 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   base_clear->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
   base_clear->mutable_cluster_type()->CopyFrom(base_cluster_type);
   base_clear->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
-  base_clear->mutable_transport_socket()->mutable_typed_config()->PackFrom(cleartext_proxy_socket);
+  std::ignore = base_clear->mutable_transport_socket()->mutable_typed_config()->PackFrom(
+      cleartext_proxy_socket);
   base_clear->mutable_upstream_connection_options()->CopyFrom(
       *base_cluster->mutable_upstream_connection_options());
   base_clear->mutable_circuit_breakers()->CopyFrom(*base_cluster->mutable_circuit_breakers());
-  (*base_clear->mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(h1_protocol_options);
+  std::ignore = (*base_clear->mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(h1_protocol_options);
 
   // Edit and re-pack
   tls_socket.mutable_common_tls_context()->add_alpn_protocols("h2");
-  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+  std::ignore =
+      ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
 
   // Edit base cluster to be an HTTP/3 cluster.
   if (enable_http3_) {
@@ -869,7 +880,8 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_socket);
     envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
         h3_proxy_socket;
-    h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+    std::ignore = h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(
+        h3_inner_socket);
     h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
 
     auto* quic_protocol_options = alpn_options.mutable_auto_config()
@@ -925,8 +937,9 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
     if (use_quic_platform_packet_writer_ || enable_quic_connection_migration_) {
       envoy_mobile::extensions::quic_packet_writer::platform::QuicPlatformPacketWriterConfig
           writer_config;
-      quic_protocol_options->mutable_client_packet_writer()->mutable_typed_config()->PackFrom(
-          writer_config);
+      std::ignore =
+          quic_protocol_options->mutable_client_packet_writer()->mutable_typed_config()->PackFrom(
+              writer_config);
       quic_protocol_options->mutable_client_packet_writer()->set_name(
           "envoy.quic.packet_writer.platform");
     }
@@ -946,10 +959,11 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
           ->add_canonical_suffixes(suffix);
     }
 
-    base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
-    (*base_cluster->mutable_typed_extension_protocol_options())
-        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-            .PackFrom(alpn_options);
+    std::ignore =
+        base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+    std::ignore = (*base_cluster->mutable_typed_extension_protocol_options())
+                      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                          .PackFrom(alpn_options);
 
     // Set the upstream connections UDP socket receive buffer size. The operating system defaults
     // are usually too small for QUIC.
@@ -1096,7 +1110,7 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
         envoy::config::bootstrap::v3::ApiListenerManager::STANDALONE_WORKER_THREAD);
   }
   auto* listener_manager = bootstrap->mutable_listener_manager();
-  listener_manager->mutable_typed_config()->PackFrom(api);
+  std::ignore = listener_manager->mutable_typed_config()->PackFrom(api);
   listener_manager->set_name("envoy.listener_manager_impl.api");
 
   return bootstrap;

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -317,9 +317,10 @@ protected:
     router_filter->set_name("envoy.router");
     ::envoy::extensions::filters::http::router::v3::Router router_config;
     static_cast<T*>(this)->configureCustomRouterFilter(router_config);
-    router_filter->mutable_typed_config()->PackFrom(router_config);
+    std::ignore = router_filter->mutable_typed_config()->PackFrom(router_config);
 
-    listener.mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
+    std::ignore =
+        listener.mutable_api_listener()->mutable_api_listener()->PackFrom(api_listener_config);
 
     return listener;
   }
@@ -405,7 +406,7 @@ private:
           envoy::config::bootstrap::v3::ApiListenerManager::STANDALONE_WORKER_THREAD);
     }
     auto* listener_manager = bootstrap.mutable_listener_manager();
-    listener_manager->mutable_typed_config()->PackFrom(api);
+    std::ignore = listener_manager->mutable_typed_config()->PackFrom(api);
     listener_manager->set_name("envoy.listener_manager_impl.api");
   }
 

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -336,12 +336,12 @@ std::string MobileEngineBuilder::nativeNameToConfig(absl::string_view name) {
   envoymobile::extensions::filters::http::platform_bridge::PlatformBridge proto_config;
   proto_config.set_platform_filter_name(name);
   std::string ret;
-  proto_config.SerializeToString(&ret);
+  std::ignore = proto_config.SerializeToString(&ret);
   Protobuf::Any any_config;
   any_config.set_type_url(
       "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge");
   any_config.set_value(ret);
-  any_config.SerializeToString(&ret);
+  std::ignore = any_config.SerializeToString(&ret);
   return ret;
 #endif
 }
@@ -474,7 +474,7 @@ absl::Status MobileEngineBuilder::configureRouteConfig(
     auto* early_data = route_to->mutable_early_data_policy();
     early_data->set_name("envoy.route.early_data_policy.default");
     ::envoy::extensions::early_data::v3::DefaultEarlyDataPolicy config;
-    early_data->mutable_typed_config()->PackFrom(config);
+    std::ignore = early_data->mutable_typed_config()->PackFrom(config);
   }
   return absl::OkStatus();
 }
@@ -488,8 +488,8 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
     native_filter->set_name(filter->name_);
     if (!filter->textproto_typed_config_.empty()) {
 #if ENVOY_ENABLE_FULL_PROTOS
-      Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
-                                            native_filter->mutable_typed_config());
+      std::ignore = Protobuf::TextFormat::ParseFromString((*filter).textproto_typed_config_,
+                                                          native_filter->mutable_typed_config());
       RELEASE_ASSERT(!native_filter->typed_config().DebugString().empty(),
                      "Failed to parse: " + (*filter).textproto_typed_config_);
 #else
@@ -506,7 +506,7 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
     envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig cache_config;
     auto* cache_filter = add_filter();
     cache_filter->set_name("alternate_protocols_cache");
-    cache_filter->mutable_typed_config()->PackFrom(cache_config);
+    std::ignore = cache_filter->mutable_typed_config()->PackFrom(cache_config);
   }
 
   if (gzip_decompression_filter_) {
@@ -514,8 +514,9 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
     gzip_config.mutable_window_bits()->set_value(15);
     envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
     decompressor_config.mutable_decompressor_library()->set_name("gzip");
-    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
-        gzip_config);
+    std::ignore =
+        decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+            gzip_config);
     auto* common_request =
         decompressor_config.mutable_request_direction_config()->mutable_common_config();
     common_request->mutable_enabled()->mutable_default_value();
@@ -525,14 +526,15 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
         ->set_ignore_no_transform_header(true);
     auto* gzip_filter = add_filter();
     gzip_filter->set_name("envoy.filters.http.decompressor");
-    gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
+    std::ignore = gzip_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
   if (brotli_decompression_filter_) {
     envoy::extensions::compression::brotli::decompressor::v3::Brotli brotli_config;
     envoy::extensions::filters::http::decompressor::v3::Decompressor decompressor_config;
     decompressor_config.mutable_decompressor_library()->set_name("text_optimized");
-    decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
-        brotli_config);
+    std::ignore =
+        decompressor_config.mutable_decompressor_library()->mutable_typed_config()->PackFrom(
+            brotli_config);
     auto* common_request =
         decompressor_config.mutable_request_direction_config()->mutable_common_config();
     common_request->mutable_enabled()->mutable_default_value();
@@ -542,13 +544,13 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
         ->set_ignore_no_transform_header(true);
     auto* brotli_filter = add_filter();
     brotli_filter->set_name("envoy.filters.http.decompressor");
-    brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
+    std::ignore = brotli_filter->mutable_typed_config()->PackFrom(decompressor_config);
   }
   if (socket_tagging_filter_) {
     envoymobile::extensions::filters::http::socket_tag::SocketTag tag_config;
     auto* tag_filter = add_filter();
     tag_filter->set_name("envoy.filters.http.socket_tag");
-    tag_filter->mutable_typed_config()->PackFrom(tag_config);
+    std::ignore = tag_filter->mutable_typed_config()->PackFrom(tag_config);
   }
 
   envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration
@@ -557,18 +559,18 @@ absl::Status MobileEngineBuilder::configureHttpFilters(
   network_config.set_enable_interface_binding(enable_interface_binding_);
   auto* network_filter = add_filter();
   network_filter->set_name("envoy.filters.http.network_configuration");
-  network_filter->mutable_typed_config()->PackFrom(network_config);
+  std::ignore = network_filter->mutable_typed_config()->PackFrom(network_config);
 
   envoymobile::extensions::filters::http::local_error::LocalError local_config;
   auto* local_filter = add_filter();
   local_filter->set_name("envoy.filters.http.local_error");
-  local_filter->mutable_typed_config()->PackFrom(local_config);
+  std::ignore = local_filter->mutable_typed_config()->PackFrom(local_config);
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig dfp_config;
   configureDnsCache(dfp_config.mutable_dns_cache_config());
   auto* dfp_filter = add_filter();
   dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
-  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
+  std::ignore = dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
   return absl::OkStatus();
 }
 
@@ -592,10 +594,10 @@ void MobileEngineBuilder::configureDnsCache(
     kv_config.set_max_entries(100);
     dns_cache_config->mutable_key_value_config()->mutable_config()->set_name(
         "envoy.key_value.platform");
-    dns_cache_config->mutable_key_value_config()
-        ->mutable_config()
-        ->mutable_typed_config()
-        ->PackFrom(kv_config);
+    std::ignore = dns_cache_config->mutable_key_value_config()
+                      ->mutable_config()
+                      ->mutable_typed_config()
+                      ->PackFrom(kv_config);
   }
 
   if (dns_resolver_config_.has_value()) {
@@ -605,8 +607,9 @@ void MobileEngineBuilder::configureDnsCache(
     envoy::extensions::network::dns_resolver::apple::v3::AppleDnsResolverConfig resolver_config;
     dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
         "envoy.network.dns_resolver.apple");
-    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
-        resolver_config);
+    std::ignore =
+        dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+            resolver_config);
 #else
     envoy::extensions::network::dns_resolver::getaddrinfo::v3::GetAddrInfoDnsResolverConfig
         resolver_config;
@@ -616,8 +619,9 @@ void MobileEngineBuilder::configureDnsCache(
     resolver_config.mutable_num_resolver_threads()->set_value(getaddrinfo_num_threads_);
     dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
         "envoy.network.dns_resolver.getaddrinfo");
-    dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
-        resolver_config);
+    std::ignore =
+        dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+            resolver_config);
 #endif
   }
 
@@ -653,7 +657,8 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
     }
     validation->mutable_custom_validator_config()->set_name(
         "envoy_mobile.cert_validator.platform_bridge_cert_validator");
-    validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);
+    std::ignore =
+        validation->mutable_custom_validator_config()->mutable_typed_config()->PackFrom(validator);
   } else {
     std::string certs;
 #ifdef ENVOY_MOBILE_XDS
@@ -677,7 +682,8 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
       ssl_proxy_socket;
   ssl_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
-  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+  std::ignore =
+      ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
 
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions h2_protocol_options;
   h2_protocol_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
@@ -687,7 +693,7 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
   envoy::config::cluster::v3::Cluster::CustomClusterType base_cluster_type;
   configureDnsCache(base_cluster_config.mutable_dns_cache_config());
   base_cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
-  base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
+  std::ignore = base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
 
   auto* upstream_opts = base_cluster->mutable_upstream_connection_options();
   upstream_opts->set_set_local_interface_name_on_upstream_connections(true);
@@ -734,24 +740,26 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
   auto* h1_options = alpn_options.mutable_auto_config()->mutable_http_protocol_options();
   auto* formatter = h1_options->mutable_header_key_format()->mutable_stateful_formatter();
   formatter->set_name("preserve_case");
-  formatter->mutable_typed_config()->PackFrom(preserve_case_config);
+  std::ignore = formatter->mutable_typed_config()->PackFrom(preserve_case_config);
 
   // Base cluster
   base_cluster->set_name("base");
   base_cluster->mutable_connect_timeout()->set_seconds(connect_timeout_seconds_);
   base_cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
-  (*base_cluster->mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(alpn_options);
+  std::ignore = (*base_cluster->mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(alpn_options);
   base_cluster->mutable_cluster_type()->CopyFrom(base_cluster_type);
   base_cluster->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
-  base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(ssl_proxy_socket);
+  std::ignore =
+      base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(ssl_proxy_socket);
 
   // Base clear-text cluster set up
   envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer raw_buffer;
   envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
       cleartext_proxy_socket;
-  cleartext_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
+  std::ignore = cleartext_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(
+      raw_buffer);
   cleartext_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions h1_protocol_options;
   h1_protocol_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
@@ -766,17 +774,19 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
   base_clear->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
   base_clear->mutable_cluster_type()->CopyFrom(base_cluster_type);
   base_clear->mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
-  base_clear->mutable_transport_socket()->mutable_typed_config()->PackFrom(cleartext_proxy_socket);
+  std::ignore = base_clear->mutable_transport_socket()->mutable_typed_config()->PackFrom(
+      cleartext_proxy_socket);
   base_clear->mutable_upstream_connection_options()->CopyFrom(
       *base_cluster->mutable_upstream_connection_options());
   base_clear->mutable_circuit_breakers()->CopyFrom(*base_cluster->mutable_circuit_breakers());
-  (*base_clear->mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(h1_protocol_options);
+  std::ignore = (*base_clear->mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(h1_protocol_options);
 
   // Edit and re-pack
   tls_socket.mutable_common_tls_context()->add_alpn_protocols("h2");
-  ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
+  std::ignore =
+      ssl_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_socket);
 
   // Edit base cluster to be an HTTP/3 cluster.
   if (enable_http3_) {
@@ -785,7 +795,8 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
     h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_socket);
     envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
         h3_proxy_socket;
-    h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+    std::ignore = h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(
+        h3_inner_socket);
     h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
 
     auto* quic_protocol_options = alpn_options.mutable_auto_config()
@@ -841,8 +852,9 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
     if (use_quic_platform_packet_writer_ || enable_quic_connection_migration_) {
       envoy_mobile::extensions::quic_packet_writer::platform::QuicPlatformPacketWriterConfig
           writer_config;
-      quic_protocol_options->mutable_client_packet_writer()->mutable_typed_config()->PackFrom(
-          writer_config);
+      std::ignore =
+          quic_protocol_options->mutable_client_packet_writer()->mutable_typed_config()->PackFrom(
+              writer_config);
       quic_protocol_options->mutable_client_packet_writer()->set_name(
           "envoy.quic.packet_writer.platform");
     }
@@ -862,10 +874,11 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
           ->add_canonical_suffixes(suffix);
     }
 
-    base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
-    (*base_cluster->mutable_typed_extension_protocol_options())
-        ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-            .PackFrom(alpn_options);
+    std::ignore =
+        base_cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+    std::ignore = (*base_cluster->mutable_typed_extension_protocol_options())
+                      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                          .PackFrom(alpn_options);
 
     // Set the upstream connections UDP socket receive buffer size. The operating system defaults
     // are usually too small for QUIC.

--- a/mobile/test/cc/integration/base/integration_test.cc
+++ b/mobile/test/cc/integration/base/integration_test.cc
@@ -43,7 +43,7 @@ protected:
       ::envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter
           assertion_filter;
       assertion_filter.set_name("envoy.filters.http.assertion");
-      assertion_filter.mutable_typed_config()->PackFrom(assertion_config.value());
+      std::ignore = assertion_filter.mutable_typed_config()->PackFrom(assertion_config.value());
       engine_builder.addHcmHttpFilter(std::move(assertion_filter));
     }
 

--- a/mobile/test/cc/integration/base/test_engine_and_server.cc
+++ b/mobile/test/cc/integration/base/test_engine_and_server.cc
@@ -74,7 +74,7 @@ TestEngineAndServer::TestEngineAndServer(
           ->set_enable_trailers(true);
     }
     cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
-    cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
+    std::ignore = cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
 
     if (type == TestServerType::HTTP3) {
       protocol_options.mutable_explicit_http_config()->mutable_http3_protocol_options();
@@ -82,23 +82,25 @@ TestEngineAndServer::TestEngineAndServer(
       h3_inner_socket.mutable_upstream_tls_context()->CopyFrom(tls_context);
       ::envoy::extensions::transport_sockets::http_11_proxy::v3::Http11ProxyUpstreamTransport
           h3_proxy_socket;
-      h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_inner_socket);
+      std::ignore = h3_proxy_socket.mutable_transport_socket()->mutable_typed_config()->PackFrom(
+          h3_inner_socket);
       h3_proxy_socket.mutable_transport_socket()->set_name("envoy.transport_sockets.quic");
       cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.http_11_proxy");
-      cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
+      std::ignore =
+          cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(h3_proxy_socket);
     }
   } else {
     cluster.mutable_transport_socket()->set_name("envoy.transport_sockets.raw_buffer");
     ::envoy::extensions::transport_sockets::raw_buffer::v3::RawBuffer raw_buffer;
-    cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
+    std::ignore = cluster.mutable_transport_socket()->mutable_typed_config()->PackFrom(raw_buffer);
     protocol_options.mutable_explicit_http_config()
         ->mutable_http_protocol_options()
         ->set_enable_trailers(true);
   }
 
-  (*cluster.mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(protocol_options);
+  std::ignore = (*cluster.mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(protocol_options);
 
   engine_builder.addCluster(std::move(cluster));
 

--- a/mobile/test/cc/integration/send_data_test.cc
+++ b/mobile/test/cc/integration/send_data_test.cc
@@ -19,7 +19,7 @@ TEST(SendDataTest, Success) {
   typed_config.set_type_url(
       "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion");
   std::string serialized_assertion;
-  assertion.SerializeToString(&serialized_assertion);
+  std::ignore = assertion.SerializeToString(&serialized_assertion);
   typed_config.set_value(serialized_assertion);
 
   absl::Notification engine_running;

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -27,7 +27,7 @@ TEST(SendHeadersTest, Success) {
   typed_config.set_type_url(
       "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion");
   std::string serialized_assertion;
-  assertion.SerializeToString(&serialized_assertion);
+  std::ignore = assertion.SerializeToString(&serialized_assertion);
   typed_config.set_value(serialized_assertion);
 
   absl::Notification engine_running;

--- a/mobile/test/cc/integration/send_trailers_test.cc
+++ b/mobile/test/cc/integration/send_trailers_test.cc
@@ -21,7 +21,7 @@ TEST(SendTrailersTest, Success) {
   typed_config.set_type_url(
       "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion");
   std::string serialized_assertion;
-  assertion.SerializeToString(&serialized_assertion);
+  std::ignore = assertion.SerializeToString(&serialized_assertion);
   typed_config.set_value(serialized_assertion);
 
   absl::Notification engine_running;

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -501,7 +501,7 @@ TEST(TestConfig, AddNativeFilters) {
   Protobuf::Any typed_config;
   typed_config.set_type_url("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer");
   std::string serialized_buffer;
-  buffer.SerializeToString(&serialized_buffer);
+  std::ignore = buffer.SerializeToString(&serialized_buffer);
   typed_config.set_value(serialized_buffer);
 
   engine_builder.addNativeFilter(filter_name1, typed_config);

--- a/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
+++ b/mobile/test/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator_test.cc
@@ -459,7 +459,7 @@ TEST_P(PlatformBridgeCertValidatorTest, ThreadPriority) {
   platform_bridge_config.mutable_thread_priority()->set_value(expected_thread_priority);
   envoy::config::core::v3::TypedExtensionConfig typed_config;
   typed_config.set_name("PlatformBridgeCertValidator");
-  typed_config.mutable_typed_config()->PackFrom(platform_bridge_config);
+  std::ignore = typed_config.mutable_typed_config()->PackFrom(platform_bridge_config);
   platform_bridge_config_ = std::move(typed_config);
 
   EXPECT_CALL(helper_handle_->mock_helper(), cleanupAfterCertificateValidation());

--- a/mobile/test/common/extensions/stat_sinks/metrics_service/mobile_grpc_streamer_integration_test.cc
+++ b/mobile/test/common/extensions/stat_sinks/metrics_service/mobile_grpc_streamer_integration_test.cc
@@ -42,7 +42,7 @@ public:
       envoymobile::extensions::stat_sinks::metrics_service::EnvoyMobileMetricsServiceConfig config;
       setGrpcService(*config.mutable_grpc_service(), "metrics_service",
                      fake_upstreams_.back()->localAddress());
-      metrics_sink->mutable_typed_config()->PackFrom(config);
+      std::ignore = metrics_sink->mutable_typed_config()->PackFrom(config);
       // Shrink reporting period down to 1s to make test not take forever.
       bootstrap.mutable_stats_flush_interval()->CopyFrom(
           Protobuf::util::TimeUtil::MillisecondsToDuration(100));

--- a/mobile/test/common/http/filters/assertion/assertion_filter_test.cc
+++ b/mobile/test/common/http/filters/assertion/assertion_filter_test.cc
@@ -21,7 +21,7 @@ class AssertionFilterTest : public testing::Test {
 public:
   void setUpFilter(std::string&& proto_str) {
     envoymobile::extensions::filters::http::assertion::Assertion config;
-    Protobuf::TextFormat::ParseFromString(proto_str, &config);
+    std::ignore = Protobuf::TextFormat::ParseFromString(proto_str, &config);
     config_ = std::make_shared<AssertionFilterConfig>(config, context_);
     filter_ = std::make_unique<AssertionFilter>(config_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
@@ -689,7 +689,7 @@ match_config {
 }
 )EOF";
 
-  Protobuf::TextFormat::ParseFromString(config_str, &proto_config);
+  std::ignore = Protobuf::TextFormat::ParseFromString(config_str, &proto_config);
 
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(proto_config, "test", context).value();

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -309,7 +309,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   dns_resolver_config.set_name("envoy.test.mock_dns_resolver");
   envoy::test::mock_dns_resolver::v3::MockDnsResolverConfig config;
   config.add_non_existent_domains("doesnotexist");
-  dns_resolver_config.mutable_typed_config()->PackFrom(config);
+  std::ignore = dns_resolver_config.mutable_typed_config()->PackFrom(config);
   builder_.setDnsResolver(dns_resolver_config);
 
   builder_.setDisableDnsRefreshOnFailure(true);
@@ -1055,7 +1055,7 @@ TEST_P(ClientIntegrationTest, InvalidDomain) {
   dns_resolver_config.set_name("envoy.test.mock_dns_resolver");
   envoy::test::mock_dns_resolver::v3::MockDnsResolverConfig config;
   config.add_non_existent_domains("www.doesnotexist.com");
-  dns_resolver_config.mutable_typed_config()->PackFrom(config);
+  std::ignore = dns_resolver_config.mutable_typed_config()->PackFrom(config);
   builder_.setDnsResolver(dns_resolver_config);
 
   initialize();
@@ -1111,7 +1111,7 @@ TEST_P(ClientIntegrationTest, InvalidDomainReresolveWithNoAddresses) {
   dns_resolver_config.set_name("envoy.test.mock_dns_resolver");
   envoy::test::mock_dns_resolver::v3::MockDnsResolverConfig config;
   config.add_non_existent_domains("www.doesnotexist.com");
-  dns_resolver_config.mutable_typed_config()->PackFrom(config);
+  std::ignore = dns_resolver_config.mutable_typed_config()->PackFrom(config);
   builder_.setDnsResolver(dns_resolver_config);
 
   initialize();

--- a/mobile/test/common/integration/sds_integration_test.cc
+++ b/mobile/test/common/integration/sds_integration_test.cc
@@ -47,7 +47,7 @@ protected:
     setUpSdsConfig(secret_config, SECRET_NAME);
     auto* transport_socket = cds_cluster.mutable_transport_socket();
     transport_socket->set_name("envoy.transport_sockets.tls");
-    transport_socket->mutable_typed_config()->PackFrom(tls_context);
+    std::ignore = transport_socket->mutable_typed_config()->PackFrom(tls_context);
     sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
         Config::getTypeUrl<envoy::config::cluster::v3::Cluster>(), {cds_cluster}, {cds_cluster}, {},
         "55");
@@ -58,7 +58,7 @@ protected:
     discovery_response.set_version_info("1");
     discovery_response.set_type_url(
         Config::getTypeUrl<envoy::extensions::transport_sockets::tls::v3::Secret>());
-    discovery_response.add_resources()->PackFrom(secret);
+    std::ignore = discovery_response.add_resources()->PackFrom(secret);
     xds_stream_->sendGrpcMessage(discovery_response);
   }
 

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -88,22 +88,23 @@ baseProxyConfig(Network::Address::IpVersion version, bool http, int port) {
       resolver_config;
   dns_cache_config->mutable_typed_dns_resolver_config()->set_name(
       "envoy.network.dns_resolver.getaddrinfo");
-  dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
-      resolver_config);
+  std::ignore =
+      dns_cache_config->mutable_typed_dns_resolver_config()->mutable_typed_config()->PackFrom(
+          resolver_config);
 
   auto* dfp_filter = hcm.add_http_filters();
   dfp_filter->set_name("envoy.filters.http.dynamic_forward_proxy");
-  dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
+  std::ignore = dfp_filter->mutable_typed_config()->PackFrom(dfp_config);
 
   auto* router_filter = hcm.add_http_filters();
   envoy::extensions::filters::http::router::v3::Router router_config;
   router_filter->set_name("envoy.router");
-  router_filter->mutable_typed_config()->PackFrom(router_config);
+  std::ignore = router_filter->mutable_typed_config()->PackFrom(router_config);
 
   envoy::config::listener::v3::FilterChain* filter_chain = listener->add_filter_chains();
   auto* filter = filter_chain->add_filters();
   filter->set_name("envoy.filters.network.http_connection_manager");
-  filter->mutable_typed_config()->PackFrom(hcm);
+  std::ignore = filter->mutable_typed_config()->PackFrom(hcm);
 
   // Base cluster config (DFP cluster config)
   auto* base_cluster = static_resources->add_clusters();
@@ -114,7 +115,7 @@ baseProxyConfig(Network::Address::IpVersion version, bool http, int port) {
   envoy::config::cluster::v3::Cluster::CustomClusterType base_cluster_type;
   base_cluster_config.mutable_dns_cache_config()->CopyFrom(*dns_cache_config);
   base_cluster_type.set_name("envoy.clusters.dynamic_forward_proxy");
-  base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
+  std::ignore = base_cluster_type.mutable_typed_config()->PackFrom(base_cluster_config);
   base_cluster->mutable_cluster_type()->CopyFrom(base_cluster_type);
 
   return bootstrap;

--- a/mobile/test/common/integration/xds_integration_test.cc
+++ b/mobile/test/common/integration/xds_integration_test.cc
@@ -88,9 +88,9 @@ XdsIntegrationTest::createSingleEndpointClusterConfig(const std::string& cluster
   // Set the protocol options.
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions options;
   options.mutable_explicit_http_config()->mutable_http2_protocol_options();
-  (*config.mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(options);
+  std::ignore = (*config.mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(options);
   return config;
 }
 

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -344,7 +344,7 @@ TEST_F(InternalEngineTest, BasicStream) {
   Protobuf::Any typed_config;
   typed_config.set_type_url("type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer");
   std::string serialized_buffer;
-  buffer.SerializeToString(&serialized_buffer);
+  std::ignore = buffer.SerializeToString(&serialized_buffer);
   typed_config.set_value(serialized_buffer);
 
   Platform::EngineBuilder builder;

--- a/source/extensions/filters/http/bandwidth_share/config.cc
+++ b/source/extensions/filters/http/bandwidth_share/config.cc
@@ -33,7 +33,7 @@ const xds::type::matcher::v3::Matcher& blankTenantSelector() {
     action->set_name("empty_tenant");
     Protobuf::StringValue str;
     str.set_value("");
-    action->mutable_typed_config()->PackFrom(str);
+    std::ignore = action->mutable_typed_config()->PackFrom(str);
     return matcher;
   }());
 }

--- a/test/config/utility.cc
+++ b/test/config/utility.cc
@@ -603,8 +603,8 @@ ConfigHelper::buildLbEndpoint(const std::string& address_str, uint32_t port) {
 envoy::config::listener::v3::Listener
 ConfigHelper::buildBaseListener(const std::string& name, const std::string& address,
                                 const std::string& filter_chains) {
-  API_NO_BOOST(envoy::config::listener::v3::Listener) listener;
 #ifdef ENVOY_ENABLE_YAML
+  API_NO_BOOST(envoy::config::listener::v3::Listener) listener;
   TestUtility::loadFromYaml(fmt::format(
                                 R"EOF(
       name: {}
@@ -654,8 +654,8 @@ envoy::config::listener::v3::Listener ConfigHelper::buildListener(const std::str
 envoy::config::route::v3::RouteConfiguration
 ConfigHelper::buildRouteConfig(const std::string& name, const std::string& cluster,
                                bool header_mutations) {
-  API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
 #ifdef ENVOY_ENABLE_YAML
+  API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
   TestUtility::loadFromYaml(fmt::format(R"EOF(
       name: "{}"
       virtual_hosts:
@@ -698,8 +698,8 @@ ConfigHelper::buildRouteConfig(const std::string& name, const std::string& clust
 
 envoy::config::route::v3::RouteConfiguration
 ConfigHelper::buildRouteConfigWithVhdsOverAds(const std::string& name) {
-  API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
 #ifdef ENVOY_ENABLE_YAML
+  API_NO_BOOST(envoy::config::route::v3::RouteConfiguration) route;
   TestUtility::loadFromYaml(fmt::format(R"EOF(
       name: "{}"
       vhds:
@@ -719,8 +719,8 @@ envoy::config::route::v3::VirtualHost ConfigHelper::buildVirtualHost(const std::
                                                                      const std::string& domain,
                                                                      const std::string& prefix,
                                                                      const std::string& cluster) {
-  API_NO_BOOST(envoy::config::route::v3::VirtualHost) vhost;
 #ifdef ENVOY_ENABLE_YAML
+  API_NO_BOOST(envoy::config::route::v3::VirtualHost) vhost;
   TestUtility::loadFromYaml(fmt::format(R"EOF(
         name: {}
         domains: [{}]

--- a/test/extensions/filters/http/bandwidth_share/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_share/config_test.cc
@@ -35,7 +35,7 @@ public:
           absl::StrCat("No factory for type ", config_.typed_config().type_url()));
     }
     ProtobufTypes::MessagePtr config = factory()->createEmptyConfigProto();
-    config_.typed_config().UnpackTo(config.get());
+    std::ignore = config_.typed_config().UnpackTo(config.get());
     return factory()->createFilterFactoryFromProto(*config, "statprefix", mock_factory_context_);
   }
 
@@ -45,7 +45,7 @@ public:
           absl::StrCat("No factory for type ", config_.typed_config().type_url()));
     }
     ProtobufTypes::MessagePtr config = factory()->createEmptyConfigProto();
-    config_.typed_config().UnpackTo(config.get());
+    std::ignore = config_.typed_config().UnpackTo(config.get());
     return factory()->createRouteSpecificFilterConfig(
         *config, mock_factory_context_.server_factory_context_, validation_visitor_);
   }

--- a/test/extensions/filters/http/bandwidth_share/filter_integration_test.cc
+++ b/test/extensions/filters/http/bandwidth_share/filter_integration_test.cc
@@ -71,7 +71,7 @@ public:
                                ->mutable_virtual_hosts(0)
                                ->mutable_routes(0)
                                ->mutable_typed_per_filter_config();
-      (*typed_config)["bwshare"].PackFrom(per_route_config);
+      std::ignore = (*typed_config)["bwshare"].PackFrom(per_route_config);
     });
     initializeFilter(filter_config);
   }

--- a/test/extensions/load_balancing_policies/load_aware_locality/config_test.cc
+++ b/test/extensions/load_balancing_policies/load_aware_locality/config_test.cc
@@ -20,7 +20,7 @@ TEST(LoadAwareLocalityConfigTest, CreateFactory) {
   envoy::config::core::v3::TypedExtensionConfig config;
   config.set_name("envoy.load_balancing_policies.load_aware_locality");
   LoadAwareLocalityProto config_msg;
-  config.mutable_typed_config()->PackFrom(config_msg);
+  std::ignore = config.mutable_typed_config()->PackFrom(config_msg);
 
   auto& factory = Config::Utility::getAndCheckFactory<Upstream::TypedLoadBalancerFactory>(config);
   EXPECT_EQ("envoy.load_balancing_policies.load_aware_locality", factory.name());


### PR DESCRIPTION
Move API_NO_BOOST variable declarations inside #ifdef ENVOY_ENABLE_YAML guards in test/config/utility.cc to fix unused variable errors in mobile builds where YAML is disabled. Add std::ignore = to discard [[nodiscard]] return values from protobuf APIs (PackFrom, UnpackTo, ParseFromString, SerializeToString) in mobile code and newly added extensions (bandwidth_share, load_aware_locality) that were not covered by #45705.
