### PR TITLE
ci: add distroless-fips image variant built with --config=aws-lc-fips

### DIFF
--- a/.github/workflows/_publish_build.yml
+++ b/.github/workflows/_publish_build.yml
@@ -60,6 +60,33 @@ jobs:
       upload-name: release.${{ inputs.arch }}
       upload-path: container/envoy/${{ inputs.arch }}/bin/
 
+  binary-fips:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    name: Binary (FIPS)
+    uses: ./.github/workflows/_run.yml
+    with:
+      arch: ${{ inputs.arch }}
+      bazel-cache: true
+      bazel-extra: >-
+        --config=rbe
+      target: release.server_only.fips
+      target-suffix: ${{ inputs.arch }}-fips
+      cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
+      cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
+      concurrency-suffix: -${{ inputs.arch }}-fips
+      rbe: true
+      request: ${{ inputs.request }}
+      runs-on: ${{ inputs.arch == 'arm64' && (vars.ENVOY_ARM_VM || 'ubuntu-24.04-arm') || null }}
+      timeout-minutes: 180
+      trusted: ${{ inputs.trusted }}
+      upload-name: release-fips.${{ inputs.arch }}
+      upload-path: container/envoy/${{ inputs.arch }}/bin/
+
   docker:
     secrets:
       dockerhub-token: ${{ secrets.dockerhub-token }}
@@ -89,6 +116,37 @@ jobs:
       trusted: ${{ inputs.trusted }}
       upload-name: oci.${{ inputs.arch }}
       upload-path: container/envoy/${{ inputs.arch }}/build_images
+      runs-on: ${{ inputs.arch == 'arm64' && (vars.ENVOY_ARM_VM || 'ubuntu-24.04-arm') || null }}
+
+  docker-fips:
+    secrets:
+      dockerhub-token: ${{ secrets.dockerhub-token }}
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    name: Docker OCI (FIPS)
+    needs:
+    - binary-fips
+    uses: ./.github/workflows/_run.yml
+    with:
+      arch: ${{ inputs.arch }}
+      target: docker
+      target-suffix: ${{ inputs.arch }}-fips
+      cache-build-image: ${{ fromJSON(inputs.request).request.build-image.default }}
+      cache-build-image-key-suffix: ${{ inputs.arch == 'arm64' && '-arm64' || '' }}
+      concurrency-suffix: -${{ inputs.arch }}-fips
+      downloads: |
+        release-fips.${{ inputs.arch }}: container/envoy/${{ inputs.arch }}/bin/
+      request: ${{ inputs.request }}
+      source: |
+        export NO_BUILD_SETUP=1
+        export ENVOY_DOCKER_IN_DOCKER=1
+        export ENVOY_DOCKER_SAVE_IMAGE=true
+        export ENVOY_OCI_DIR=build_images_fips
+      trusted: ${{ inputs.trusted }}
+      upload-name: oci-fips.${{ inputs.arch }}
+      upload-path: container/envoy/${{ inputs.arch }}/build_images_fips
       runs-on: ${{ inputs.arch == 'arm64' && (vars.ENVOY_ARM_VM || 'ubuntu-24.04-arm') || null }}
 
   distribution:

--- a/.github/workflows/_publish_release_container.yml
+++ b/.github/workflows/_publish_release_container.yml
@@ -119,6 +119,15 @@ jobs:
             additional-tags:
             - distroless-dev-${{ github.sha }}
           - name: ${{ inputs.dockerhub-repo }}
+            tag: distroless-fips-dev
+            registry: docker.io/envoyproxy
+            architectures:
+            - amd64
+            - arm64
+            artifact-pattern: envoy-distroless-fips.{arch}.tar
+            additional-tags:
+            - distroless-fips-dev-${{ github.sha }}
+          - name: ${{ inputs.dockerhub-repo }}
             tag: google-vrp-dev
             registry: docker.io/envoyproxy
             architectures:
@@ -208,6 +217,15 @@ jobs:
             artifact-pattern: envoy-distroless.{arch}.tar
             additional-tags:
             - distroless-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
+          - name: ${{ inputs.dockerhub-repo }}
+            tag: distroless-fips-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
+            registry: docker.io/envoyproxy
+            architectures:
+            - amd64
+            - arm64
+            artifact-pattern: envoy-distroless-fips.{arch}.tar
+            additional-tags:
+            - distroless-fips-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
           - name: ${{ inputs.dockerhub-repo }}
             tag: google-vrp-v${{ inputs.version-major }}.${{ inputs.version-minor }}.${{ inputs.version-patch }}
             registry: docker.io/envoyproxy

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -854,7 +854,7 @@ case $CI_TARGET in
                  "${PUBLISH_ARGS[@]}"
         ;;
 
-    release|release.server_only|release.test_only)
+    release|release.server_only|release.server_only.fips|release.test_only)
         if [[ "$CI_TARGET" == "release" || "$CI_TARGET" == "release.test_only" ]]; then
             # When testing memory consumption, we want to test against exact byte-counts
             # where possible. As these differ between platforms and compile options, we
@@ -873,6 +873,9 @@ case $CI_TARGET in
         BAZEL_RELEASE_OPTIONS=(
             --stripopt=--strip-all
             -c opt)
+        if [[ "$CI_TARGET" == "release.server_only.fips" ]]; then
+            BAZEL_RELEASE_OPTIONS+=(--config=aws-lc-fips)
+        fi
         if [[ "$CI_TARGET" == "release" || "$CI_TARGET" == "release.test_only" ]]; then
             # Run release tests
             echo "Testing with:"
@@ -909,9 +912,13 @@ case $CI_TARGET in
               --remote_download_outputs=toplevel \
               //distribution/binary:release
         # Copy release binaries to binary export directory
+        RELEASE_TARBALL_NAME="release.tar.zst"
+        if [[ "$CI_TARGET" == "release.server_only.fips" ]]; then
+            RELEASE_TARBALL_NAME="release.fips.tar.zst"
+        fi
         cp -a \
            "bazel-bin/distribution/binary/release.tar.zst" \
-           "${ENVOY_BINARY_DIR}/release.tar.zst"
+           "${ENVOY_BINARY_DIR}/${RELEASE_TARBALL_NAME}"
         # Grab the schema_validator_tool
         # TODO(phlax): bundle this with the release when #26390 is resolved
         bazel build "${BAZEL_BUILD_OPTIONS[@]}" "${BAZEL_RELEASE_OPTIONS[@]}" \

--- a/distribution/docker/Dockerfile-envoy
+++ b/distribution/docker/Dockerfile-envoy
@@ -10,7 +10,8 @@ ADD configs/envoyproxy_io_proxy.yaml /etc/envoy/envoy.yaml
 # See https://github.com/docker/buildx/issues/510 for why this _must_ be this way
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM="${TARGETPLATFORM:-linux/amd64}"
-ADD "${TARGETPLATFORM}/release.tar.zst" /usr/local/bin/
+ARG ENVOY_RELEASE_TARBALL=release.tar.zst
+ADD "${TARGETPLATFORM}/${ENVOY_RELEASE_TARBALL}" /usr/local/bin/
 
 
 # STAGE: envoy-base

--- a/distribution/docker/build.sh
+++ b/distribution/docker/build.sh
@@ -64,7 +64,7 @@ config_env() {
     docker buildx create --use --name envoy-builder --platform "${DOCKER_PLATFORM}" --driver-opt "image=moby/buildkit:${BUILDKIT_VERSION}"
 }
 
-BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-contrib-distroless" "-distroless" "-tools")
+BUILD_TYPES=("" "-debug" "-contrib" "-contrib-debug" "-contrib-distroless" "-distroless" "-distroless-fips" "-tools")
 
 if [[ "$DOCKER_PLATFORM" == "linux/amd64" ]]; then
     BUILD_TYPES+=("-google-vrp")
@@ -97,6 +97,7 @@ build_args() {
 
     target="${build_type/-debug/}"
     target="${target/-contrib/}"
+    target="${target/-fips/}"
     printf ' -f distribution/docker/Dockerfile-envoy --target %s' "envoy${target}"
 
     if [[ "${build_type}" == *-contrib* ]]; then
@@ -105,6 +106,10 @@ build_args() {
 
     if [[ "${build_type}" == *-debug ]]; then
         printf ' --build-arg ENVOY_BINARY_PREFIX=dbg/'
+    fi
+
+    if [[ "${build_type}" == *-fips* ]]; then
+        printf ' --build-arg ENVOY_RELEASE_TARBALL=release.fips.tar.zst'
     fi
 }
 


### PR DESCRIPTION
## Summary

Adds a `distroless-fips-v{X}.{Y}.{Z}` Docker image published alongside each standard release, built with `--config=aws-lc-fips`. A `distroless-fips-dev` image is also published on each push to `main`.

This addresses #45812.

## Changes

- **`ci/do_ci.sh`**: add `release.server_only.fips` target that appends `--config=aws-lc-fips` to `BAZEL_RELEASE_OPTIONS` and outputs the binary as `release.fips.tar.zst`
- **`distribution/docker/Dockerfile-envoy`**: add `ENVOY_RELEASE_TARBALL` build arg (default: `release.tar.zst`) to allow the FIPS build to supply an alternative tarball without duplicating the `envoy-distroless` stage
- **`distribution/docker/build.sh`**: add `-distroless-fips` to `BUILD_TYPES`; update `build_args` to strip `-fips` when deriving the Docker `--target` and pass `--build-arg ENVOY_RELEASE_TARBALL=release.fips.tar.zst` for FIPS builds
- **`.github/workflows/_publish_build.yml`**: add `binary-fips` and `docker-fips` jobs mirroring the existing `binary`/`docker` jobs, with `timeout-minutes: 180` to account for the longer AWS-LC FIPS compilation
- **`.github/workflows/_publish_release_container.yml`**: add `distroless-fips-dev` and `distroless-fips-v{X}.{Y}.{Z}` manifest entries

## Notes

- `--config=aws-lc-fips` is used (not `--config=boringssl-fips`) as it supports both `amd64` and `arm64`; the boringssl-fips config is limited to Linux x86_64
- No new Dockerfile stage is needed — the FIPS image reuses the existing `envoy-distroless` target with a FIPS-built binary injected via the `ENVOY_RELEASE_TARBALL` build arg
- The Envoy project makes no compliance certification claim by publishing this image; users validate against their own requirements