### PR TITLE
stats: optimize decRefCount to help reduce hot-spot in stats sink

### DIFF
--- a/source/common/stats/allocator.cc
+++ b/source/common/stats/allocator.cc
@@ -92,19 +92,40 @@ public:
   // RefcountInterface
   void incRefCount() override { ++ref_count_; }
   bool decRefCount() override {
-    // We must, unfortunately, hold the allocator's lock when decrementing the
-    // refcount. Otherwise another thread may simultaneously try to allocate the
-    // same name'd stat after we decrement it, and we'll wind up with a
-    // dtor/update race. To avoid this we must hold the lock until the stat is
-    // removed from the map.
-    //
-    // It might be worth thinking about a race-free way to decrement ref-counts
-    // without a lock, for the case where ref_count > 2, and we don't need to
-    // destruct anything. But it seems preferable at to be conservative here,
-    // as stats will only go out of scope when a scope is destructed (during
-    // xDS) or during admin stats operations.
-    Thread::LockGuard lock(alloc_.mutex_);
     ASSERT(ref_count_ >= 1);
+    // Takes a snapshot of the current ref_count_
+    uint32_t ref_count_snapshot = ref_count_.load(std::memory_order_relaxed);
+
+    // Checks if ref_count_snapshot is 1. If it is 1, then a decrement would free memory, and we
+    // would need to acquire the allocator mutex.
+    //
+    // If ref_count_snapshot is > 1, then we there are some important cases where thread
+    // interuptions can might change what happens:
+    //
+    // First case: ref_count_ is unchanged (ref_count_ == ref_count_snapshot)
+    // Zero or more threads touch ref_count_ before compare_exchange_weak is called.
+    // compare_exchange_weak returns true, and decRefCount returns false.
+    //
+    // Second case: ref_count_ is changed (ref_count_ != ref_count_snapshot && ref_count_ > 1)
+    // One or more threads touch ref_count_ before compare_exchange_weak is called.
+    // compare_exchange_weak returns false, ref_count_snapshot is set to be ref_count_. Loop
+    // restarts.
+    //
+    // Third case: ref_count_ is changed (ref_count_ != ref_count_snapshot && ref_count <= 1)
+    // One or more threads touch ref_count_ before compare_exchange_weak is called.
+    // compare_exchange_weak returns false. ref_count_snapshot is set to be ref_count_. Loop
+    // restarts, but exits out of the while loop because conditional is false (a decrement would
+    // free memory; check start of comment).
+    while (ref_count_snapshot > 1) {
+      if (ref_count_.compare_exchange_weak(ref_count_snapshot, ref_count_snapshot - 1,
+                                           std::memory_order_acq_rel)) {
+        return false;
+      }
+    }
+    // If ref_count_ is 0, then our allocator is inconsistent with the number of references that
+    // exist (there has to be at least 1 reference at this point because how else are we able to
+    // access ref_count_).
+    Thread::LockGuard lock(alloc_.mutex_);
     if (--ref_count_ == 0) {
       alloc_.sync().syncPoint(Allocator::DecrementToZeroSyncPoint);
       removeFromSetLockHeld();

--- a/source/common/stats/allocator.cc
+++ b/source/common/stats/allocator.cc
@@ -99,8 +99,8 @@ public:
     // Checks if ref_count_snapshot is 1. If it is 1, then a decrement would free memory, and we
     // would need to acquire the allocator mutex.
     //
-    // If ref_count_snapshot is > 1, then we there are some important cases where thread
-    // interuptions can might change what happens:
+    // If ref_count_snapshot is > 1, then there are some important cases where thread
+    // interruptions might change what happens:
     //
     // First case: ref_count_ is unchanged (ref_count_ == ref_count_snapshot)
     // Zero or more threads touch ref_count_ before compare_exchange_weak is called.
@@ -122,9 +122,8 @@ public:
         return false;
       }
     }
-    // If ref_count_ is 0, then our allocator is inconsistent with the number of references that
-    // exist (there has to be at least 1 reference at this point because how else are we able to
-    // access ref_count_).
+    // Another thread may call incRefCount at this point. The lock path still does the right thing
+    // because the stat is not freed if ref_count_ is not 0.
     Thread::LockGuard lock(alloc_.mutex_);
     if (--ref_count_ == 0) {
       alloc_.sync().syncPoint(Allocator::DecrementToZeroSyncPoint);

--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -416,6 +416,24 @@ envoy_benchmark_test(
     benchmark_binary = "thread_local_store_speed_test",
 )
 
+envoy_cc_benchmark_binary(
+    name = "dec_ref_count_speed_test",
+    srcs = ["dec_ref_count_speed_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:assert_lib",
+        "//source/common/stats:allocator_lib",
+        "//source/common/stats:symbol_table_lib",
+        "@abseil-cpp//absl/strings",
+        "@benchmark",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "dec_ref_count_speed_test_benchmark_test",
+    benchmark_binary = "dec_ref_count_speed_test",
+)
+
 envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],

--- a/test/common/stats/dec_ref_count_speed_test.cc
+++ b/test/common/stats/dec_ref_count_speed_test.cc
@@ -1,0 +1,127 @@
+// Note: this should be run with --compilation_mode=opt, and would benefit from a
+// quiescent system with disabled cstate power management.
+//
+// Exercises both paths of StatsSharedImpl::decRefCount():
+//   * Fast path  (ref_count_ > 1): single-thread, multi-thread same stat,
+//                                  multi-thread distinct stats.
+//   * Slow path  (ref_count_ == 1): single-thread.
+//
+// Fast-path benchmarks pre-seed ref_count_ so every dec in the timed loop
+// stays on the CAS path. Slow-path benchmark pre-allocates one counter per
+// iteration with ref_count_=1, so each timed dec frees its counter.
+
+#include <limits>
+#include <optional>
+#include <vector>
+
+#include "source/common/common/assert.h"
+#include "source/common/stats/allocator.h"
+#include "source/common/stats/symbol_table.h"
+
+#include "absl/strings/str_cat.h"
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Stats {
+namespace {
+
+class DecRefCountFixture {
+public:
+  explicit DecRefCountFixture(size_t num_counters) : alloc_(symbol_table_), pool_(symbol_table_) {
+    counters_.reserve(num_counters);
+    for (size_t i = 0; i < num_counters; ++i) {
+      counters_.push_back(
+          alloc_.makeCounter(pool_.add(absl::StrCat("benchmark.counter.", i)), StatName(), {}));
+    }
+  }
+
+  Counter& counter(size_t i) { return *counters_[i]; }
+  CounterSharedPtr& counterPtr(size_t i) { return counters_[i]; }
+  size_t size() const { return counters_.size(); }
+
+private:
+  SymbolTable symbol_table_;
+  Allocator alloc_;
+  StatNamePool pool_;
+  std::vector<CounterSharedPtr> counters_;
+};
+
+// Single thread, single stat, ref_count_ > 1
+void bmDecRefCountFastPathSingleThread(benchmark::State& state) {
+  DecRefCountFixture fixture(1);
+  Counter& counter = fixture.counter(0);
+  RELEASE_ASSERT(state.max_iterations < std::numeric_limits<uint32_t>::max() - 1,
+                 "ref_count_ will overflow");
+  for (uint32_t i = 0; i < state.max_iterations; i++) {
+    counter.incRefCount();
+  }
+  for (auto _ : state) { // NOLINT
+    const bool freed = counter.decRefCount();
+    benchmark::DoNotOptimize(freed);
+  }
+}
+BENCHMARK(bmDecRefCountFastPathSingleThread);
+
+std::optional<DecRefCountFixture> multi_thread_fixture;
+void multiThreadInitSameStat(const benchmark::State&) {
+  multi_thread_fixture.emplace(1);
+}
+void multiThreadInitDistinctStat(const benchmark::State& state) {
+  multi_thread_fixture.emplace(state.threads());
+}
+void multiThreadDestroy(const benchmark::State&) {
+  multi_thread_fixture.reset();
+}
+
+// Multiple threads, same stat, ref_count_ > 1
+void bmDecRefCountFastPathMultiThreadSameStat(benchmark::State& state) {
+  Counter& counter = multi_thread_fixture->counter(0);
+  RELEASE_ASSERT(static_cast<uint64_t>(state.max_iterations) * state.threads() <
+                     std::numeric_limits<uint32_t>::max() - 1,
+                 "ref_count_ will overflow across all threads");
+  for (uint32_t i = 0; i < state.max_iterations; i++) {
+    counter.incRefCount();
+  }
+  for (auto _ : state) { // NOLINT
+    const bool freed = counter.decRefCount();
+    benchmark::DoNotOptimize(freed);
+  }
+}
+BENCHMARK(bmDecRefCountFastPathMultiThreadSameStat)
+    ->ThreadRange(1, 16)
+    ->UseRealTime()
+    ->Setup(multiThreadInitSameStat)
+    ->Teardown(multiThreadDestroy);
+
+// Multiple threads, different stats, ref_count_ > 1
+void bmDecRefCountFastPathMultiThreadDistinctStat(benchmark::State& state) {
+  Counter& counter = multi_thread_fixture->counter(state.thread_index());
+  RELEASE_ASSERT(state.max_iterations < std::numeric_limits<uint32_t>::max() - 1,
+                 "ref_count_ will overflow on a per-thread counter");
+  for (uint32_t i = 0; i < state.max_iterations; i++) {
+    counter.incRefCount();
+  }
+  for (auto _ : state) { // NOLINT
+    const bool freed = counter.decRefCount();
+    benchmark::DoNotOptimize(freed);
+  }
+}
+BENCHMARK(bmDecRefCountFastPathMultiThreadDistinctStat)
+    ->ThreadRange(1, 16)
+    ->UseRealTime()
+    ->Setup(multiThreadInitDistinctStat)
+    ->Teardown(multiThreadDestroy);
+
+// Single thread, multiple stats, ref_count_ == 1
+void bmDecRefCountSlowPathSingleThread(benchmark::State& state) {
+  DecRefCountFixture fixture(state.max_iterations);
+  size_t idx = 0;
+  for (auto _ : state) { // NOLINT
+    fixture.counterPtr(idx++).reset();
+  }
+}
+BENCHMARK(bmDecRefCountSlowPathSingleThread)->Iterations(1 << 18);
+
+} // namespace
+} // namespace Stats
+} // namespace Envoy

--- a/test/common/stats/dec_ref_count_speed_test.cc
+++ b/test/common/stats/dec_ref_count_speed_test.cc
@@ -11,7 +11,6 @@
 // iteration with ref_count_=1, so each timed dec frees its counter.
 
 #include <limits>
-#include <optional>
 #include <vector>
 
 #include "source/common/common/assert.h"
@@ -19,6 +18,7 @@
 #include "source/common/stats/symbol_table.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/types/optional.h"
 #include "benchmark/benchmark.h"
 
 namespace Envoy {
@@ -62,16 +62,12 @@ void bmDecRefCountFastPathSingleThread(benchmark::State& state) {
 }
 BENCHMARK(bmDecRefCountFastPathSingleThread);
 
-std::optional<DecRefCountFixture> multi_thread_fixture;
-void multiThreadInitSameStat(const benchmark::State&) {
-  multi_thread_fixture.emplace(1);
-}
+absl::optional<DecRefCountFixture> multi_thread_fixture;
+void multiThreadInitSameStat(const benchmark::State&) { multi_thread_fixture.emplace(1); }
 void multiThreadInitDistinctStat(const benchmark::State& state) {
   multi_thread_fixture.emplace(state.threads());
 }
-void multiThreadDestroy(const benchmark::State&) {
-  multi_thread_fixture.reset();
-}
+void multiThreadDestroy(const benchmark::State&) { multi_thread_fixture.reset(); }
 
 // Multiple threads, same stat, ref_count_ > 1
 void bmDecRefCountFastPathMultiThreadSameStat(benchmark::State& state) {


### PR DESCRIPTION
Commit Message: adds a lock free fast path to decRefCount

Additional Description: The original decRefCount holds the global allocator lock for every decrement. We needed to hold the lock to prevent a same named stat from being created at the same time as a decrement to 0. For a ref_count_ > 1, we can exercise a lock free fast path using a CAS (compare and swap) atomic operation. There are two advantages the CAS decRefCount has over the original implementation:
- Multiple threads can decrement and allocate new stats at the same time. Holding the global allocator lock would prevent this (plus the fact that a contended lock would need syscalls).
- Less atomic operations (1 CAS for the optimized decRefCount), (1 CAS for locking, 2 atomic operations for unlocking and decrementing ref_count_ for the original decRefCount).

There is a small theoretical cost for the optimized decRefCount. When ref_count_ == 1, the CAS decRefCount needs an extra atomic relaxed load (~1 ns difference during benchmarking).

Benchmarks summary:

- 2.1x speedup for single threaded decrements to a single ref_count_.
- 20-245x speedup for multithreaded decrements to multiple ref_counts_.
- 1.7–4.6x speedup for multithreaded decrements to a single ref_count_.
- 1 ns regression (304 -> 305 ns) for a single threaded decrement for ref_count == 1 (because of extra atomic relaxed load).
<details>
<summary>Full Benchmark</summary>
<pre>
### Original:
------------------------------------------------------------------------------------------------------------
Benchmark                                                                  Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------
bmDecRefCountFastPathSingleThread                                       5.30 ns         5.30 ns    129486456
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:1            5.26 ns         5.25 ns    132120435
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:2             124 ns          123 ns      5683960
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:4             231 ns          212 ns      3057072
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:8             631 ns          394 ns       800000
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:16           1164 ns          438 ns       649312
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:1        5.13 ns         5.13 ns    136056691
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:2        52.3 ns         52.3 ns     11502592
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:4         184 ns          175 ns      4299432
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:8         462 ns          281 ns      1381520
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:16       1125 ns          425 ns       707456
bmDecRefCountSlowPathSingleThread/iterations:262144                      304 ns          304 ns       262144
</pre>
<pre>
### Optimized:
------------------------------------------------------------------------------------------------------------
Benchmark                                                                  Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------
bmDecRefCountFastPathSingleThread                                       2.51 ns         2.51 ns    270946766
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:1            2.60 ns         2.60 ns    277691125
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:2            32.1 ns         32.1 ns     21338224
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:4            63.2 ns         63.2 ns     11335356
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:8             136 ns          136 ns      4619312
bmDecRefCountFastPathMultiThreadSameStat/real_time/threads:16            665 ns          537 ns      1321792
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:1        2.60 ns         2.60 ns    274380078
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:2        2.61 ns         2.61 ns    270253628
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:4        2.65 ns         2.65 ns    263411788
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:8        3.10 ns         3.10 ns    220235360
bmDecRefCountFastPathMultiThreadDistinctStat/real_time/threads:16       4.59 ns         3.71 ns    160133760
bmDecRefCountSlowPathSingleThread/iterations:262144                      305 ns          305 ns       262144
</pre>
</details>
Risk Level: medium - high. Affects the allocation and freeing of all stats (changes when the global allocator mutex is acquired).

Testing: Passes all existing allocator tests (allocator_test.cc and thread_local_store_test.cc).

Docs Changes: N/A

Release Notes: N/A

Platform Specific Features: Should affect ARM more than x86 architectures (atomics/locking syscalls cost more with ARM).
