### PR TITLE
xds mux: harden queueing

### DIFF
--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
@@ -597,6 +597,9 @@ void GrpcMuxImpl::onEstablishmentFailure(bool) {
 }
 
 void GrpcMuxImpl::queueDiscoveryRequest(absl::string_view queue_item) {
+  if (shutdown_) {
+    return;
+  }
   if (!grpc_stream_->grpcStreamAvailable()) {
     ENVOY_LOG(debug, "No stream available to queueDiscoveryRequest for {}", queue_item);
     return; // Drop this request; the reconnect will enqueue a new one.


### PR DESCRIPTION
Change-Id: I83367169d4e37e14370d1dd764e1baef052e27c9

Commit Message: Harden shutdown sequence to early exit and not queue xDS requests.
Additional Description:
Risk Level: low
Testing: detected in my local integration test run
Docs Changes:
Release Notes: none