### PR TITLE
Fix more  warnings

### DIFF
--- a/contrib/config/source/kv_store_xds_delegate.cc
+++ b/contrib/config/source/kv_store_xds_delegate.cc
@@ -86,7 +86,7 @@ KeyValueStoreXdsDelegate::getAllResources(const XdsSourceId& source_id) const {
           // The source id is a prefix of the key, so it should be included in the list of returned
           // resources.
           envoy::service::discovery::v3::Resource r;
-          r.ParseFromString(value);
+          std::ignore = r.ParseFromString(value);
           resources.push_back(std::move(r));
         }
         return KeyValueStore::Iterate::Continue;
@@ -103,7 +103,7 @@ void KeyValueStoreXdsDelegate::onConfigUpdated(
       // TODO(abeyad): Support dynamic parameter constraints.
       r.set_name(decoded_resource.name());
       r.set_version(decoded_resource.version());
-      r.mutable_resource()->PackFrom(decoded_resource.resource());
+      std::ignore = r.mutable_resource()->PackFrom(decoded_resource.resource());
       std::optional<std::chrono::seconds> ttl = std::nullopt;
       if (decoded_resource.ttl().has_value()) {
         r.mutable_ttl()->CopyFrom(

--- a/contrib/config/test/kv_store_xds_delegate_integration_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_integration_test.cc
@@ -97,7 +97,7 @@ public:
           tls_context.mutable_common_tls_context()->add_tls_certificate_sds_secret_configs();
       setUpSdsConfig(secret_config, CLIENT_CERT_NAME);
       transport_socket->set_name("envoy.transport_sockets.tls");
-      transport_socket->mutable_typed_config()->PackFrom(tls_context);
+      std::ignore = transport_socket->mutable_typed_config()->PackFrom(tls_context);
     });
 
     // Add static runtime values.
@@ -455,10 +455,10 @@ public:
     envoy::service::discovery::v3::Resource r;
     r.set_name(cluster_name);
     r.set_version("1");
-    r.mutable_resource()->PackFrom(cluster_resource);
+    std::ignore = r.mutable_resource()->PackFrom(cluster_resource);
 
     std::string value;
-    r.SerializeToString(&value);
+    std::ignore = r.SerializeToString(&value);
 
     cb(key, value);
   }

--- a/contrib/config/test/kv_store_xds_delegate_test.cc
+++ b/contrib/config/test/kv_store_xds_delegate_test.cc
@@ -295,14 +295,14 @@ TEST_F(KeyValueStoreXdsDelegateTest, ResourcesWithTTL) {
   Protobuf::RepeatedPtrField<envoy::service::discovery::v3::Resource> resources;
   auto* resource = resources.Add();
   resource->set_name("some_resource_1");
-  resource->mutable_resource()->PackFrom(runtime_resource_1);
+  std::ignore = resource->mutable_resource()->PackFrom(runtime_resource_1);
   resource = resources.Add();
   resource->set_name("some_resource_2");
-  resource->mutable_resource()->PackFrom(runtime_resource_2);
+  std::ignore = resource->mutable_resource()->PackFrom(runtime_resource_2);
   resource->mutable_ttl()->set_seconds(30);
   resource = resources.Add();
   resource->set_name("some_resource_3");
-  resource->mutable_resource()->PackFrom(runtime_resource_3);
+  std::ignore = resource->mutable_resource()->PackFrom(runtime_resource_3);
   resource->mutable_ttl()->set_seconds(60);
 
   auto decoded_resources = TestUtility::decodeResources<envoy::service::runtime::v3::Runtime>(

--- a/contrib/cryptomb/private_key_providers/source/config.cc
+++ b/contrib/cryptomb/private_key_providers/source/config.cc
@@ -40,6 +40,7 @@ CryptoMbPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
               *message, private_key_provider_context.messageValidationVisitor());
   Ssl::PrivateKeyMethodProviderSharedPtr provider = nullptr;
 #ifdef IPP_CRYPTO_DISABLED
+  static_cast<void>(conf);
   throw EnvoyException("X86_64 architecture is required for cryptomb provider.");
 #else
   IppCryptoSharedPtr ipp = std::make_shared<IppCryptoImpl>();

--- a/contrib/dlb/test/config_test.cc
+++ b/contrib/dlb/test/config_test.cc
@@ -20,7 +20,7 @@ protected:
   static void makeDlbConnectionBalanceConfig(
       envoy::config::core::v3::TypedExtensionConfig& typed_config,
       envoy::extensions::network::connection_balance::dlb::v3alpha::Dlb& dlb) {
-    typed_config.mutable_typed_config()->PackFrom(dlb);
+    std::ignore = typed_config.mutable_typed_config()->PackFrom(dlb);
     typed_config.set_name("envoy.network.connection_balance.dlb");
   }
 

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1402,7 +1402,7 @@ void Filter::populateSliceWithMetadata(const std::string& filter_name, uint64_t*
   const auto& metadata = streamInfo().dynamicMetadata().filter_metadata();
   const auto filter_it = metadata.find(filter_name);
   if (filter_it != metadata.end()) {
-    filter_it->second.SerializeToString(&req_->strValue);
+    std::ignore = filter_it->second.SerializeToString(&req_->strValue);
     *buf_data = reinterpret_cast<uint64_t>(req_->strValue.data());
     *buf_len = req_->strValue.length();
   }
@@ -1440,7 +1440,7 @@ void Filter::setDynamicMetadataInternal(std::string filter_name, std::string key
                                         const absl::string_view& buf) {
   Protobuf::Struct value;
   Protobuf::Value v;
-  v.ParseFromArray(buf.data(), buf.length());
+  std::ignore = v.ParseFromArray(buf.data(), buf.length());
 
   (*value.mutable_fields())[key] = v;
 

--- a/contrib/golang/upstreams/http/tcp/test/golang_bridge_integration_test.cc
+++ b/contrib/golang/upstreams/http/tcp/test/golang_bridge_integration_test.cc
@@ -45,7 +45,8 @@ public:
           proto_config.set_library_path(genSoPath());
           proto_config.set_plugin_name(bridge_name);
 
-          cluster->mutable_upstream_config()->mutable_typed_config()->PackFrom(proto_config);
+          std::ignore =
+              cluster->mutable_upstream_config()->mutable_typed_config()->PackFrom(proto_config);
         });
 
     initialize();

--- a/contrib/hyperscan/matching/input_matchers/source/config.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/config.cc
@@ -22,6 +22,7 @@ Config::createInputMatcherFactoryCb(const Protobuf::Message& config,
       config, factory_context.messageValidationVisitor());
 
 #ifdef HYPERSCAN_DISABLED
+  static_cast<void>(hyperscan_config);
   throw EnvoyException("X86_64 architecture is required for Hyperscan.");
 #else
   // Hyperscan's API requires vectors of expressions, flags and IDs for matching database

--- a/contrib/hyperscan/matching/input_matchers/test/config_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/config_test.cc
@@ -18,7 +18,7 @@ protected:
     config.set_name("hyperscan");
     envoy::extensions::matching::input_matchers::hyperscan::v3alpha::Hyperscan hyperscan;
     TestUtility::loadFromYaml(yaml, hyperscan);
-    config.mutable_typed_config()->PackFrom(hyperscan);
+    std::ignore = config.mutable_typed_config()->PackFrom(hyperscan);
 
     Config factory;
     auto message = Envoy::Config::Utility::translateAnyToFactoryConfig(

--- a/contrib/hyperscan/regex_engines/source/config.cc
+++ b/contrib/hyperscan/regex_engines/source/config.cc
@@ -12,7 +12,7 @@ namespace Hyperscan {
 Envoy::Regex::EnginePtr
 Config::createEngine(const Protobuf::Message& config,
                      Server::Configuration::ServerFactoryContext& server_factory_context) {
-  const auto hyperscan = MessageUtil::downcastAndValidate<
+  MessageUtil::downcastAndValidate<
       const envoy::extensions::regex_engines::hyperscan::v3alpha::Hyperscan&>(
       config, server_factory_context.messageValidationVisitor());
 #ifdef HYPERSCAN_DISABLED

--- a/contrib/istio/filters/common/test/istio_hbone_two_proxy_integration_test.cc
+++ b/contrib/istio/filters/common/test/istio_hbone_two_proxy_integration_test.cc
@@ -240,7 +240,7 @@ typed_config:
       envoy::extensions::bootstrap::internal_listener::v3::InternalListener il;
       auto* be = bootstrap.add_bootstrap_extensions();
       be->set_name("envoy.bootstrap.internal_listener");
-      be->mutable_typed_config()->PackFrom(il);
+      std::ignore = be->mutable_typed_config()->PackFrom(il);
 
       // outbound listener → [istio.stats(network, source), tcp_proxy → "encap"].
       auto* outbound = sr->mutable_listeners(0);
@@ -260,7 +260,7 @@ typed_config:
       out_tcp.set_cluster("encap");
       auto* of = ofc->add_filters();
       of->set_name("envoy.filters.network.tcp_proxy");
-      of->mutable_typed_config()->PackFrom(out_tcp);
+      std::ignore = of->mutable_typed_config()->PackFrom(out_tcp);
 
       // "connect_originate" internal listener: downstream peer_metadata computes the
       // local (client) baggage into filter state, which the tunneling tcp_proxy adds
@@ -384,7 +384,7 @@ typed_config:
           envoy::extensions::bootstrap::internal_listener::v3::InternalListener il;
           auto* be = bootstrap.add_bootstrap_extensions();
           be->set_name("envoy.bootstrap.internal_listener");
-          be->mutable_typed_config()->PackFrom(il);
+          std::ignore = be->mutable_typed_config()->PackFrom(il);
 
           // "connect_originate" internal listener: a tunneling tcp_proxy that wraps the
           // HCM's upstream HTTP bytes in an HTTP/2 CONNECT to the SERVER.
@@ -518,7 +518,7 @@ typed_config:
       envoy::extensions::bootstrap::internal_listener::v3::InternalListener il;
       auto* be = bootstrap.add_bootstrap_extensions();
       be->set_name("envoy.bootstrap.internal_listener");
-      be->mutable_typed_config()->PackFrom(il);
+      std::ignore = be->mutable_typed_config()->PackFrom(il);
 
       auto* listener = sr->mutable_listeners(0);
       listener->set_name("inbound");

--- a/contrib/istio/filters/common/test/istio_tcp_two_proxy_integration_test.cc
+++ b/contrib/istio/filters/common/test/istio_tcp_two_proxy_integration_test.cc
@@ -81,7 +81,7 @@ typed_config:
 
     envoy::config::listener::v3::Filter filter;
     filter.set_name(name);
-    filter.mutable_typed_config()->PackFrom(config);
+    std::ignore = filter.mutable_typed_config()->PackFrom(config);
     return MessageUtil::getJsonStringFromMessageOrError(filter);
   }
 

--- a/contrib/istio/filters/common/test/istio_two_proxy_integration_base.h
+++ b/contrib/istio/filters/common/test/istio_two_proxy_integration_base.h
@@ -163,7 +163,7 @@ typed_config:
 
     envoy::extensions::filters::network::http_connection_manager::v3::HttpFilter filter;
     filter.set_name("envoy.filters.http.peer_metadata");
-    filter.mutable_typed_config()->PackFrom(config);
+    std::ignore = filter.mutable_typed_config()->PackFrom(config);
     return MessageUtil::getJsonStringFromMessageOrError(filter);
   }
 

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -164,7 +164,7 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
 
   Envoy::Protobuf::Struct data = ::Istio::Common::convertWorkloadMetadataToStruct(*metadata);
   Envoy::Protobuf::Any wrapped;
-  wrapped.PackFrom(data);
+  std::ignore = wrapped.PackFrom(data);
   return wrapped;
 }
 

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -317,7 +317,7 @@ std::string encodeMetadataOnly(absl::string_view baggage, absl::string_view iden
       Istio::Common::convertBaggageToWorkloadMetadata(baggage, identity);
   Protobuf::Struct data = ::Istio::Common::convertWorkloadMetadataToStruct(*metadata);
   Protobuf::Any wrapped;
-  wrapped.PackFrom(data);
+  std::ignore = wrapped.PackFrom(data);
   return wrapped.SerializeAsString();
 }
 

--- a/contrib/kae/private_key_providers/source/config.cc
+++ b/contrib/kae/private_key_providers/source/config.cc
@@ -37,6 +37,7 @@ KaePrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
           *message, private_key_provider_context.messageValidationVisitor());
 
 #ifdef KAE_DISABLED
+  static_cast<void>(conf);
   throw EnvoyException("Arm64 architecture is required for KAE.");
 #else
   LibUadkCryptoSharedPtr libuadk = std::make_shared<LibUadkCryptoImpl>();

--- a/contrib/postgres_inspector/filters/listener/source/postgres_inspector.cc
+++ b/contrib/postgres_inspector/filters/listener/source/postgres_inspector.cc
@@ -253,7 +253,7 @@ void Filter::extractMetadata(const StartupMessage& message) {
     }
 
     Protobuf::Any any;
-    any.PackFrom(typed);
+    std::ignore = any.PackFrom(typed);
     cb_->setDynamicTypedMetadata("envoy.postgres_inspector", any);
     ENVOY_LOG(debug, "postgres inspector: extracted metadata - user: {}, database: {}, app: {}",
               user_, database_, application_name_);

--- a/contrib/postgres_inspector/filters/listener/test/postgres_inspector_integration_test.cc
+++ b/contrib/postgres_inspector/filters/listener/test/postgres_inspector_integration_test.cc
@@ -66,7 +66,7 @@ typed_config:
       envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy pg_config;
       pg_config.set_stat_prefix("tcp_postgres");
       pg_config.set_cluster("cluster_postgres");
-      pg_filter->mutable_typed_config()->PackFrom(pg_config);
+      std::ignore = pg_filter->mutable_typed_config()->PackFrom(pg_config);
 
       // Default filter chain for non-PostgreSQL traffic.
       auto* default_chain = listener->add_filter_chains();
@@ -76,7 +76,7 @@ typed_config:
       envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy default_config;
       default_config.set_stat_prefix("tcp_default");
       default_config.set_cluster("cluster_default");
-      default_filter->mutable_typed_config()->PackFrom(default_config);
+      std::ignore = default_filter->mutable_typed_config()->PackFrom(default_config);
     });
 
     setUpstreamCount(2);

--- a/contrib/postgres_inspector/filters/listener/test/postgres_inspector_sni_integration_test.cc
+++ b/contrib/postgres_inspector/filters/listener/test/postgres_inspector_sni_integration_test.cc
@@ -73,7 +73,7 @@ typed_config:
       envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy pg_config;
       pg_config.set_stat_prefix("postgres_with_ssl");
       pg_config.set_terminate_ssl(false);
-      pg_filter->mutable_typed_config()->PackFrom(pg_config);
+      std::ignore = pg_filter->mutable_typed_config()->PackFrom(pg_config);
 
       // Add TCP proxy for routing to backend.
       auto* tcp_filter = pg_chain->add_filters();
@@ -81,7 +81,7 @@ typed_config:
       envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy tcp_config;
       tcp_config.set_stat_prefix("tcp_postgres");
       tcp_config.set_cluster("cluster_db1");
-      tcp_filter->mutable_typed_config()->PackFrom(tcp_config);
+      std::ignore = tcp_filter->mutable_typed_config()->PackFrom(tcp_config);
 
       // Default chain for non-PostgreSQL traffic.
       auto* default_chain = listener->add_filter_chains();
@@ -91,7 +91,7 @@ typed_config:
       envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy default_config;
       default_config.set_stat_prefix("tcp_default");
       default_config.set_cluster("cluster_db2");
-      default_filter->mutable_typed_config()->PackFrom(default_config);
+      std::ignore = default_filter->mutable_typed_config()->PackFrom(default_config);
     });
 
     setUpstreamCount(2);

--- a/contrib/qat/compression/qatzip/compressor/source/config.cc
+++ b/contrib/qat/compression/qatzip/compressor/source/config.cc
@@ -122,6 +122,7 @@ QatzipCompressorLibraryFactory::createCompressorFactoryFromProto(
           const envoy::extensions::compression::qatzip::compressor::v3alpha::Qatzip&>(
           proto_config, context.messageValidationVisitor());
 #ifdef QAT_DISABLED
+  static_cast<void>(config);
   throw EnvoyException("X86_64 architecture is required for QAT.");
 #else
   return createCompressorFactoryFromProtoTyped(config, context);

--- a/contrib/qat/private_key_providers/source/config.cc
+++ b/contrib/qat/private_key_providers/source/config.cc
@@ -37,6 +37,7 @@ QatPrivateKeyMethodFactory::createPrivateKeyMethodProviderInstance(
           *message, private_key_provider_context.messageValidationVisitor());
 
 #ifdef QAT_DISABLED
+  static_cast<void>(conf);
   throw EnvoyException("X86_64 architecture is required for QAT.");
 #else
   LibQatCryptoSharedPtr libqat = std::make_shared<LibQatCryptoImpl>();

--- a/contrib/reverse_tunnel_reporter/test/clients/grpc_client_integration_test.cc
+++ b/contrib/reverse_tunnel_reporter/test/clients/grpc_client_integration_test.cc
@@ -173,7 +173,7 @@ protected:
         Protobuf::util::TimeUtil::MillisecondsToDuration(sendInterval);
     grpc_cfg.set_max_retries(maxRetries);
     grpc_cfg.set_max_buffer_count(1'000'000);
-    client->mutable_typed_config()->PackFrom(grpc_cfg);
+    std::ignore = client->mutable_typed_config()->PackFrom(grpc_cfg);
 
     return cfg;
   }

--- a/contrib/reverse_tunnel_reporter/test/clients/integration_test_utils.h
+++ b/contrib/reverse_tunnel_reporter/test/clients/integration_test_utils.h
@@ -53,7 +53,7 @@ inline TypedExtensionConfig getDownstreamExtension() {
 
   TypedExtensionConfig ext;
   ext.set_name(downstreamExtension);
-  ext.mutable_typed_config()->PackFrom(cfg);
+  std::ignore = ext.mutable_typed_config()->PackFrom(cfg);
 
   return ext;
 }
@@ -68,11 +68,11 @@ inline TypedExtensionConfig getUpstreamExtension(const EventReporterConfig& conf
       "envoy.extensions.reverse_tunnel.reverse_tunnel_reporting_service.reporters.event_reporter";
   auto* reporter = cfg.mutable_reporter_config();
   reporter->set_name(reporterName);
-  reporter->mutable_typed_config()->PackFrom(config);
+  std::ignore = reporter->mutable_typed_config()->PackFrom(config);
 
   TypedExtensionConfig ext;
   ext.set_name(upstreamExtension);
-  ext.mutable_typed_config()->PackFrom(cfg);
+  std::ignore = ext.mutable_typed_config()->PackFrom(cfg);
 
   return ext;
 }
@@ -134,7 +134,7 @@ inline Listener getUpstreamListener(absl::string_view anyhost) {
   ReverseTunnel rtFilter;
   rtFilter.mutable_ping_interval()->set_seconds(300); // No ping timeouts.
 
-  filter->mutable_typed_config()->PackFrom(rtFilter);
+  std::ignore = filter->mutable_typed_config()->PackFrom(rtFilter);
 
   return listener;
 }
@@ -172,9 +172,9 @@ inline Listener getDownstreamListener(const std::string& name, int num_listeners
   auto* http_filter = hcm.add_http_filters();
   http_filter->set_name("envoy.filters.http.router");
   envoy::extensions::filters::http::router::v3::Router router_cfg;
-  http_filter->mutable_typed_config()->PackFrom(router_cfg);
+  std::ignore = http_filter->mutable_typed_config()->PackFrom(router_cfg);
 
-  filter->mutable_typed_config()->PackFrom(hcm);
+  std::ignore = filter->mutable_typed_config()->PackFrom(hcm);
 
   return listener;
 }
@@ -218,9 +218,9 @@ Cluster getHttp2Cluster(Cluster& cluster) {
   ConfigHelper::HttpProtocolOptions http2_options;
   http2_options.mutable_explicit_http_config()->mutable_http2_protocol_options();
 
-  (*cluster.mutable_typed_extension_protocol_options())
-      ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
-          .PackFrom(http2_options);
+  std::ignore = (*cluster.mutable_typed_extension_protocol_options())
+                    ["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+                        .PackFrom(http2_options);
 
   return cluster;
 }

--- a/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
+++ b/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
@@ -595,7 +595,7 @@ TEST_F(EventReporterFactoryTest, CreateReporterWithRegisteredClient) {
 
   auto* client_entry = reporter_config.add_clients();
   client_entry->set_name("mock_client_factory");
-  client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
+  std::ignore = client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
 
   auto reporter = factory_.createReporter(context_, std::move(config));
   EXPECT_NE(nullptr, reporter);
@@ -610,7 +610,7 @@ TEST_F(EventReporterFactoryTest, CreateClientWithUnknownFactoryThrows) {
 
   auto* client_entry = reporter_config.add_clients();
   client_entry->set_name("nonexistent_client_factory");
-  client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
+  std::ignore = client_entry->mutable_typed_config()->PackFrom(Protobuf::Struct());
 
   EXPECT_THROW_WITH_REGEX(factory_.createReporter(context_, std::move(config)), EnvoyException,
                           "Unknown Reporter Client Factory: 'nonexistent_client_factory'");

--- a/contrib/sip_proxy/filters/network/source/config.cc
+++ b/contrib/sip_proxy/filters/network/source/config.cc
@@ -94,7 +94,7 @@ ConfigImpl::ConfigImpl(
     envoy::extensions::filters::network::sip_proxy::v3alpha::SipFilter router;
     envoy::extensions::filters::network::sip_proxy::router::v3alpha::Router default_router;
     router.set_name(SipFilters::SipFilterNames::get().ROUTER);
-    router.mutable_typed_config()->PackFrom(default_router);
+    std::ignore = router.mutable_typed_config()->PackFrom(default_router);
     processFilter(router);
   } else {
     for (const auto& filter : config.sip_filters()) {

--- a/mobile/library/jni/jni_utility.cc
+++ b/mobile/library/jni/jni_utility.cc
@@ -450,7 +450,7 @@ LocalRefUniquePtr<jbyteArray> protoToJavaByteArray(JniHelper& jni_helper,
   size_t size = source.ByteSizeLong();
   LocalRefUniquePtr<jbyteArray> byte_array = jni_helper.newByteArray(size);
   auto bytes = jni_helper.getByteArrayElements(byte_array.get(), nullptr);
-  source.SerializeToArray(bytes.get(), size);
+  std::ignore = source.SerializeToArray(bytes.get(), size);
   return byte_array;
 }
 

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -345,7 +345,7 @@ public:
 #if defined(ENVOY_ENABLE_FULL_PROTOS)
       duration_message.CheckTypeAndMergeFrom(message);
 #else
-      duration_message.MergeFromCord(message.SerializeAsCord());
+      std::ignore = duration_message.MergeFromCord(message.SerializeAsCord());
 #endif
       // Validate the value of the duration.
       RETURN_IF_NOT_OK(validateDurationNoThrow(duration_message));

--- a/test/extensions/filters/http/on_demand/odcds_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/odcds_integration_test.cc
@@ -411,7 +411,7 @@ TEST_P(OdCdsIntegrationTest, OnDemandClusterDiscoveryFetchesClusterInfo) {
     test_filter->set_name("odcds-test-filter");
 
     test::common::config::DummyConfig test_filter_config;
-    test_filter->mutable_typed_config()->PackFrom(test_filter_config);
+    std::ignore = test_filter->mutable_typed_config()->PackFrom(test_filter_config);
   });
 
   initialize();


### PR DESCRIPTION
Fix unused variable warnings and suppress protobuf nodiscard in contrib, mobile, and core.

Follow-up to PR #45705.

Protobuf v34+ adds [[nodiscard]] to APIs like PackFrom, SerializeToArray, and MergeFromCord. This adds std::ignore = where return values are intentionally discarded.

Also fixes unused variables behind architecture-disabled #ifdef guards (QAT_DISABLED, KAE_DISABLED, IPP_CRYPTO_DISABLED, HYPERSCAN_DISABLED) by adding static_cast<void>() suppressions.
