### PR TITLE
gcp_authn: fix bound token requests

### DIFF
--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -24,7 +24,7 @@ constexpr absl::string_view TokenUrlPath = "token";
 constexpr absl::string_view AudienceQueryKey = "audience";
 constexpr char MetadataFlavorKey[] = "Metadata-Flavor";
 constexpr char MetadataFlavor[] = "Google";
-constexpr char ClientCertificateSha256Key[] = "client_certificate_sha256";
+constexpr char BindCertificateFingerprintKey[] = "bindCertificateFingerprint";
 
 Http::RequestMessagePtr buildRequest(absl::string_view url) {
   absl::string_view host;
@@ -100,7 +100,9 @@ void GcpAuthnClientImpl::fetchBoundJwt(
     const std::string& fingerprint, GcpAuthnClient::Callbacks& callbacks) {
   Http::Utility::QueryParamsMulti query_params;
   query_params.add(AudienceQueryKey, audience.bound_jwt().url());
-  query_params.add(ClientCertificateSha256Key, fingerprint);
+  const std::string double_encoded_fingerprint = Http::Utility::PercentEncoding::urlEncode(
+      Http::Utility::PercentEncoding::urlEncode(fingerprint));
+  query_params.add(BindCertificateFingerprintKey, double_encoded_fingerprint);
   const std::string final_url =
       absl::StrCat(DefaultServiceAccountPrefix, IdentityUrlPath, query_params.toString());
   makeTokenRequest(TokenType::BoundJwt, audience, final_url, fingerprint, callbacks);
@@ -110,7 +112,9 @@ void GcpAuthnClientImpl::fetchBoundAccessToken(
     const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience,
     const std::string& fingerprint, GcpAuthnClient::Callbacks& callbacks) {
   Http::Utility::QueryParamsMulti query_params;
-  query_params.add(ClientCertificateSha256Key, fingerprint);
+  const std::string double_encoded_fingerprint = Http::Utility::PercentEncoding::urlEncode(
+      Http::Utility::PercentEncoding::urlEncode(fingerprint));
+  query_params.add(BindCertificateFingerprintKey, double_encoded_fingerprint);
   const std::string final_url =
       absl::StrCat(DefaultServiceAccountPrefix, TokenUrlPath, query_params.toString());
   makeTokenRequest(TokenType::BoundAccessToken, audience, final_url, fingerprint, callbacks);

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -100,9 +100,10 @@ void GcpAuthnClientImpl::fetchBoundJwt(
     const std::string& fingerprint, GcpAuthnClient::Callbacks& callbacks) {
   Http::Utility::QueryParamsMulti query_params;
   query_params.add(AudienceQueryKey, audience.bound_jwt().url());
-  const std::string double_encoded_fingerprint = Http::Utility::PercentEncoding::urlEncode(
-      Http::Utility::PercentEncoding::urlEncode(fingerprint));
-  query_params.add(BindCertificateFingerprintKey, double_encoded_fingerprint);
+  // N.B.: double-URL-encoding is REQUIRED by the GCP metadata server.
+  query_params.add(BindCertificateFingerprintKey,
+                   Http::Utility::PercentEncoding::urlEncode(
+                       Http::Utility::PercentEncoding::urlEncode(fingerprint)));
   const std::string final_url =
       absl::StrCat(DefaultServiceAccountPrefix, IdentityUrlPath, query_params.toString());
   makeTokenRequest(TokenType::BoundJwt, audience, final_url, fingerprint, callbacks);
@@ -112,9 +113,10 @@ void GcpAuthnClientImpl::fetchBoundAccessToken(
     const envoy::extensions::filters::http::gcp_authn::v3::Audience& audience,
     const std::string& fingerprint, GcpAuthnClient::Callbacks& callbacks) {
   Http::Utility::QueryParamsMulti query_params;
-  const std::string double_encoded_fingerprint = Http::Utility::PercentEncoding::urlEncode(
-      Http::Utility::PercentEncoding::urlEncode(fingerprint));
-  query_params.add(BindCertificateFingerprintKey, double_encoded_fingerprint);
+  // N.B.: double-URL-encoding is REQUIRED by the GCP metadata server.
+  query_params.add(BindCertificateFingerprintKey,
+                   Http::Utility::PercentEncoding::urlEncode(
+                       Http::Utility::PercentEncoding::urlEncode(fingerprint)));
   const std::string final_url =
       absl::StrCat(DefaultServiceAccountPrefix, TokenUrlPath, query_params.toString());
   makeTokenRequest(TokenType::BoundAccessToken, audience, final_url, fingerprint, callbacks);

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
@@ -450,12 +450,12 @@ TEST_F(GcpAuthnClientImplTest, SuccessBoundJwt) {
 
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
   audience.mutable_bound_jwt()->set_url("http://test_audience");
-  const std::string fingerprint = "test_fingerprint_value";
+  const std::string fingerprint = "abc+def/ghi=";
   client_->fetchBoundJwt(audience, fingerprint, request_callbacks_);
   EXPECT_EQ(message_->headers().Method()->value().getStringView(), "GET");
   EXPECT_EQ(message_->headers().Path()->value().getStringView(),
             "/computeMetadata/v1/instance/service-accounts/default/identity?audience=http://"
-            "test_audience&client_certificate_sha256=test_fingerprint_value");
+            "test_audience&bindCertificateFingerprint=abc%252Bdef%252Fghi%253D");
 
   EXPECT_EQ(options_.retry_policy->num_retries().value(), 5);
 
@@ -477,12 +477,12 @@ TEST_F(GcpAuthnClientImplTest, SuccessBoundAccessToken) {
 
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
   audience.mutable_bound_access_token();
-  const std::string fingerprint = "test_fingerprint_value";
+  const std::string fingerprint = "abc+def/ghi=";
   client_->fetchBoundAccessToken(audience, fingerprint, request_callbacks_);
   EXPECT_EQ(message_->headers().Method()->value().getStringView(), "GET");
   EXPECT_EQ(message_->headers().Path()->value().getStringView(),
             "/computeMetadata/v1/instance/service-accounts/default/"
-            "token?client_certificate_sha256=test_fingerprint_value");
+            "token?bindCertificateFingerprint=abc%252Bdef%252Fghi%253D");
 
   EXPECT_EQ(options_.retry_policy->num_retries().value(), 5);
 

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_integration_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.pb.h"
 #include "envoy/extensions/filters/http/gcp_authn/v3/gcp_authn.pb.validate.h"
 
+#include "source/common/http/utility.h"
 #include "source/extensions/filters/http/gcp_authn/gcp_authn_filter.h"
 
 #include "test/integration/http_integration.h"
@@ -169,7 +170,9 @@ public:
 
     std::string expected_path = absl::StrCat(
         "/computeMetadata/v1/instance/service-accounts/default/identity?audience=http://test.com",
-        "&client_certificate_sha256=", expected_fingerprint);
+        "&bindCertificateFingerprint=",
+        Http::Utility::PercentEncoding::urlEncode(
+            Http::Utility::PercentEncoding::urlEncode(expected_fingerprint)));
 
     // Need to wait for headers complete before reading headers value.
     result = request_->waitForHeadersComplete();
@@ -197,8 +200,9 @@ public:
 
     std::string expected_path =
         absl::StrCat("/computeMetadata/v1/instance/service-accounts/default/token"
-                     "?client_certificate_sha256=",
-                     expected_fingerprint);
+                     "?bindCertificateFingerprint=",
+                     Http::Utility::PercentEncoding::urlEncode(
+                         Http::Utility::PercentEncoding::urlEncode(expected_fingerprint)));
 
     // Need to wait for headers complete before reading headers value.
     result = request_->waitForHeadersComplete();
@@ -502,7 +506,9 @@ TEST_P(GcpAuthnFilterIntegrationTest, BoundJwtCacheHit) {
 
   std::string expected_path = absl::StrCat(
       "/computeMetadata/v1/instance/service-accounts/default/identity?audience=http://test.com",
-      "&client_certificate_sha256=", expected_fingerprint);
+      "&bindCertificateFingerprint=",
+      Http::Utility::PercentEncoding::urlEncode(
+          Http::Utility::PercentEncoding::urlEncode(expected_fingerprint)));
 
   result = request_->waitForHeadersComplete();
   RELEASE_ASSERT(result, result.message());

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
@@ -319,7 +319,7 @@ TEST_F(GcpAuthnFilterTest, ResumeFilterChainIterationWithBoundAccessToken) {
   ON_CALL(*cluster_info_, metadata()).WillByDefault(testing::ReturnRef(metadata_));
 
   const std::string dummy_pem = "dummy cert PEM";
-  const std::string expected_fingerprint = "mock_fingerprint_base64";
+  const std::string expected_fingerprint = "mock+fingerprint/base64=";
 
   auto socket_factory = std::make_unique<NiceMock<Network::MockTransportSocketFactory>>();
   auto client_context_config = std::make_unique<NiceMock<Ssl::MockClientContextConfig>>();
@@ -349,7 +349,7 @@ TEST_F(GcpAuthnFilterTest, ResumeFilterChainIterationWithBoundAccessToken) {
   EXPECT_EQ(message_->headers().Method()->value().getStringView(), "GET");
   EXPECT_EQ(message_->headers().Path()->value().getStringView(),
             "/computeMetadata/v1/instance/service-accounts/default/"
-            "token?client_certificate_sha256=mock_fingerprint_base64");
+            "token?bindCertificateFingerprint=mock%252Bfingerprint%252Fbase64%253D");
 
   Envoy::Http::ResponseHeaderMapPtr resp_headers(new Envoy::Http::TestResponseHeaderMapImpl({
       {":status", "200"},


### PR DESCRIPTION
Commit Message: gcp_authn: fix bound token requests
Additional Description:

The gcp_authn filter was passing along the fingerprint incorrectly in bound token requests:

- The fingerprint query parameter key should be `bindCertificateFingerprint`.
- The fingerprint query parameter value should be base-64 encoded, then double url encoded.

This is exactly how the official Google python auth library structures its requests for bound tokens.

Risk Level: low
Testing: tests updated
Docs Changes: none
Release Notes: none