### PR TITLE
Disable //test/config_test:config_test under coverage

### DIFF
--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -45,6 +45,7 @@ envoy_cc_test_library(
 envoy_cc_test(
     name = "config_test",
     size = "large",
+    coverage = False,
     data = [
         "configs_test_setup.sh",
         ":configs",

--- a/test/extensions/filters/http/alternate_protocols_cache/BUILD
+++ b/test/extensions/filters/http/alternate_protocols_cache/BUILD
@@ -19,6 +19,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/alternate_protocols_cache:config",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:logging_lib",
         "@envoy_api//envoy/extensions/filters/http/alternate_protocols_cache/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
@@ -40,6 +40,17 @@ TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterWithS
   cb(filter_callback);
 }
 
+TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterLogging) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  AlternateProtocolsCacheFilterFactory factory;
+  envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig proto_config;
+  proto_config.mutable_alternate_protocols_cache_options()->set_name("foo");
+  EXPECT_LOG_CONTAINS("warn",
+                      "Using deprecated and ignored alternate_protocols_cache_options in "
+                      "alternate_protocols_cache config.",
+                      (void)factory.createFilterFactoryFromProto(proto_config, "stats", context));
+}
+
 } // namespace
 } // namespace AlternateProtocolsCache
 } // namespace HttpFilters

--- a/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
@@ -40,7 +40,9 @@ TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterWithS
   cb(filter_callback);
 }
 
-TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterLogging) {
+// This test is only for coverage of the deprecated feature check.
+TEST(AlternateProtocolsCacheFilterConfigTest,
+     DEPRECATED_FEATURE_TEST(AlternateProtocolsCacheFilterLogging)) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   AlternateProtocolsCacheFilterFactory factory;
   envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig proto_config;

--- a/test/extensions/filters/http/csrf/BUILD
+++ b/test/extensions/filters/http/csrf/BUILD
@@ -36,7 +36,9 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/csrf:config",
+        "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/extensions/filters/http/csrf/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/csrf/csrf_config_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_config_test.cc
@@ -2,13 +2,17 @@
 
 #include "source/extensions/filters/http/csrf/config.h"
 
+#include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using Envoy::StatusHelpers::IsOkAndHolds;
 using testing::NiceMock;
+using testing::NotNull;
 
 namespace Envoy {
 namespace Extensions {
@@ -35,6 +39,32 @@ TEST(CsrfFilterConfigTest, ServerContextOnlyFactory) {
 
   auto cb = factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
   EXPECT_NE(cb, nullptr);
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
+TEST(CsrfFilterConfigTest, RouteSpecificConfig) {
+  const std::string yaml_string = R"EOF(
+  filter_enabled:
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  shadow_enabled:
+    default_value:
+      numerator: 100
+      denominator: HUNDRED
+  )EOF";
+
+  envoy::extensions::filters::http::csrf::v3::CsrfPolicy proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  CsrfFilterFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+
+  auto result = factory.createRouteSpecificFilterConfig(proto_config, context, validation_visitor);
+  ASSERT_THAT(result, IsOkAndHolds(NotNull()));
 }
 
 } // namespace

--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -376,6 +376,59 @@ providers:
                              HasSubstr("Duration out-of-range"));
 }
 
+TEST(HttpJwtAuthnFilterConfigTest, RemoteJwksWithRetryPolicy) {
+  const char config[] = R"(
+providers:
+  provider1:
+    issuer: issuer1
+    remote_jwks:
+      http_uri:
+        uri: http://www.valid.com/resource
+        cluster: pubkey_cluster
+        timeout: 1s
+      retry_policy:
+        retry_back_off:
+          base_interval: 1s
+          max_interval: 10s
+        num_retries: 5
+)";
+
+  JwtAuthentication proto_config;
+  TestUtility::loadFromYaml(config, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  auto filter_conf = std::make_unique<FilterConfigImpl>(proto_config, "", context);
+  auto* jwks_data = filter_conf->getJwksCache().findByIssuer("issuer1");
+  EXPECT_NE(nullptr, jwks_data);
+  EXPECT_NE(nullptr, jwks_data->retryPolicy());
+  EXPECT_EQ(5, jwks_data->retryPolicy()->numRetries());
+}
+
+TEST(HttpJwtAuthnFilterConfigTest, RemoteJwksWithInvalidRetryPolicy) {
+  const char config[] = R"(
+providers:
+  provider1:
+    issuer: issuer1
+    remote_jwks:
+      http_uri:
+        uri: http://www.valid.com/resource
+        cluster: pubkey_cluster
+        timeout: 1s
+      retry_policy:
+        retry_back_off:
+          base_interval: 10s
+          max_interval: 1s
+)";
+
+  JwtAuthentication proto_config;
+  TestUtility::loadFromYaml(config, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_THAT_THROWS_MESSAGE(
+      FilterConfigImpl(proto_config, "", context), EnvoyException,
+      HasSubstr("max_interval must be greater than or equal to the base_interval"));
+}
+
 } // namespace
 } // namespace JwtAuthn
 } // namespace HttpFilters


### PR DESCRIPTION
This test links all extensions and verifies that example configs are valid. The binary is very large with coverage instrumentation and will soon fail to link due to 36Gb limit on the link artifacts in remote bazel.

The value of the test is very low as the config parsing coverage should be attained via unit or integration tests. Disabling this binary will save build resources without negative impact on useful coverage. 

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
