### PR TITLE
Quiche roll 20260625203454

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -296,7 +296,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-06-18"
+  release_date: "2026-06-25"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -5143,6 +5143,7 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
+        ":quiche_common_platform_client_stats",
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
         "@abseil-cpp//absl/algorithm:container",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "846ced76db5e1b6297408cc11a8bfe1fc1c0e49f",
-        sha256 = "0e11aec4ebd778fcd3c2775e3693cccbd966af4928e9fa7573c2e2975ccd9c50",
+        version = "4729ceb221725bb52c6f4d48229d9c3ba059c36e",
+        sha256 = "4262624d5b23dd3dc5e75bcf6a4f70fe91f7e5a0cbcf994067d5e0897d8f5e0f",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),

--- a/test/mocks/http/webtransport.h
+++ b/test/mocks/http/webtransport.h
@@ -83,6 +83,8 @@ public:
   MOCK_METHOD(void, SetOnDraining, (quiche::SingleUseCallback<void()> callback), (override));
   MOCK_METHOD(std::optional<std::string>, GetNegotiatedSubprotocol, (), // NOLINT(std::optional)
               (const, override));
+  MOCK_METHOD(webtransport::Perspective, GetPerspective, (), (const, override));
+  MOCK_METHOD(webtransport::UnderlyingProtocol, GetUnderlyingProtocol, (), (const, override));
 };
 
 } // namespace Http


### PR DESCRIPTION
Update QUICHE from 846ced76d to 4729ceb22
https://github.com/google/quiche/compare/846ced76d..4729ceb22

```
$ git log 846ced76d..4729ceb22 --date=short --no-merges --format="%ad %al %s"

2026-06-25 vasilvv Refactor FrameAckTimestampRanges to make subsequent truncation work easier to implement.
2026-06-25 vasilvv Remove `process_timestamps_` and use `max_receive_timestamps_per_ack` as the control for whether QUIC ACK timestamps are processed.
2026-06-24 quiche-dev Add a method to retrieve the creation time of TLS session tickets used for resumption.
2026-06-24 vasilvv Remove code for serializing and processing Q046 timestamps.
2026-06-24 vasilvv Add methods to WebTransportSession to expose perspective and underlying protocol.
2026-06-24 asedeno Fix OSS QUICHE build.
2026-06-24 vasilvv Create a dedicated WebTransport-only client class, and switch MoqtClient to using it.
2026-06-23 vasilvv Fold all of the control message handlers from the control stream object to the session itself.
2026-06-23 martinduke Fix msan error in moqt_publish_stream_test.
2026-06-23 quiche-dev No public description
2026-06-23 haoyuewang Deprecate --gfe2_reloadable_flag_quic_clear_body_manager_along_with_sequencer.
2026-06-22 quiche-dev Add the new `size()` method to ConstHeaderApi and its implementations.
2026-06-22 martinduke Move PUBLISH to a Bidi stream
2026-06-22 vasilvv Split ACK timestamp parameters into local and remote ones.
2026-06-22 quiche-dev Replace counter with boolean histogram for trailing decimal points
2026-06-22 quiche-dev Add counter for occurrences of trailing decimal points
2026-06-22 quiche-dev //third_party/quic: allow BoringSSL to enable ML-KEM by default.
2026-06-22 quiche-dev //third_party/quic: allow BoringSSL to enable ML-KEM by default.
2026-06-19 quiche-dev No public description
2026-06-19 quiche-dev //third_party/quic: allow BoringSSL to enable ML-KEM by default.
2026-06-19 quiche-dev [SM] CL 1/n: Refactor BlindSignAuth to accept generic attestation data
2026-06-18 quiche-dev QBONE Bonnet: Convert `TunDevicePacketExchanger::ReadPacket` to use kernel `readv`
2026-06-18 dschinazi Track GOAWAY in MasqueConnectionPool responses
```

Signed-off-by: Dan Zhang <danzh@google.com>

Risk Level: low
Testing: existing tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
