### PR TITLE
filter_chain: refactor the default behavior to merge multiple chains

### DIFF
--- a/api/envoy/extensions/filters/http/filter_chain/v3/filter_chain.proto
+++ b/api/envoy/extensions/filters/http/filter_chain/v3/filter_chain.proto
@@ -23,11 +23,23 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Filter-level configuration for the filter chain filter. This filter acts as a wrapper
 // that applies a configurable chain of HTTP filters to incoming requests.
+//
+// When a request arrives the filter collects all active filter chains in order from least
+// to most specific: ``default_filter_chain`` first, then any per-route chains ordered from
+// the outermost scope (e.g. route configuration level) to the innermost scope (route level).
+// Each filter in a less-specific chain is applied **unless** a more-specific chain contains
+// a filter with the same ``name``.
+//
+// The final set of filters is applied in order from least to most specific, so that the
+// least-specific filter runs first and the most-specific filter runs last. This allows
+// more specific filters to override the behavior of less specific ones.
+//
+// If no chains are found at all the filter passes through without modifying the request.
 message FilterChainConfig {
-  // Default filter chain applied when no route level filter chain is specified.
+  // Default filter chain to apply when processing every request.
   //
-  // This field is optional. If not specified and no route-level configuration matches,
-  // the filter will pass through without applying any additional filters.
+  // This field is optional. When omitted the filter still participates in per-route
+  // override resolution.
   FilterChain default_filter_chain = 1;
 }
 
@@ -38,9 +50,11 @@ message FilterChainConfig {
 //   Only the initial route match is considered for filter chain selection. Subsequent
 //   internal route refreshes do not affect the filter chain applied to the request.
 //
-// This could be used to implement route specific filter chains.
+// When multiple per-route configs exist along the route hierarchy (e.g. one at virtual-host
+// level and one at route level) the same merge rules apply iteratively from least specific
+// to most specific, so the most specific definition of any named filter always wins.
 message FilterChainConfigPerRoute {
-  // Filter chain to be applied on current route.
+  // Filter chain to apply on this route. Must contain at least one filter.
   //
   // .. note::
   //   Not all HTTP filters are compatible to be used within this route level filter chain
@@ -67,5 +81,5 @@ message FilterChain {
   //
   // [#extension-category: envoy.filters.http]
   repeated config.core.v3.TypedExtensionConfig filters = 1
-      [(validate.rules).repeated = {min_items: 1}];
+  [(validate.rules).repeated = {min_items: 1}];
 }

--- a/api/envoy/extensions/filters/http/filter_chain/v3/filter_chain.proto
+++ b/api/envoy/extensions/filters/http/filter_chain/v3/filter_chain.proto
@@ -81,5 +81,5 @@ message FilterChain {
   //
   // [#extension-category: envoy.filters.http]
   repeated config.core.v3.TypedExtensionConfig filters = 1
-  [(validate.rules).repeated = {min_items: 1}];
+      [(validate.rules).repeated = {min_items: 1}];
 }

--- a/docs/root/configuration/http/http_filters/filter_chain_filter.rst
+++ b/docs/root/configuration/http/http_filters/filter_chain_filter.rst
@@ -6,18 +6,27 @@ Filter Chain
 * This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfig``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.filter_chain.v3.FilterChainConfig>`
 
-The filter chain filter acts as a wrapper that applies a configurable chain of HTTP filters
-to incoming requests. This allows you to define reusable filter chains that can be applied
-selectively based on route configuration.
+The filter chain filter acts as a wrapper that applies a configurable set of HTTP filters to
+incoming requests. It supports a ``default_filter_chain`` at the filter level and optional
+per-route overrides, all merged together using name-based override semantics.
 
-The filter supports:
+Overview
+--------
 
-* A default filter chain that is applied when no route-specific configuration is present.
-* Named filter chains that can be referenced by route-level configuration.
-* Inline filter chains defined directly in per-route configuration.
+When a request arrives the filter collects all active filter chains in order from least to
+most specific:
 
-The filter processes the request through the configured filter chain in order during the
-decode phase, and in reverse order during the encode phase.
+1. ``default_filter_chain`` (from the filter-level ``FilterChainConfig``)
+2. Per-route chains from outermost to innermost scope (e.g. virtual-host level, then route level)
+
+Each filter in a less-specific chain is applied **unless** a more-specific chain contains a
+filter with the same ``name``. In that case the less-specific entry is silently skipped.
+
+This lets per-route configuration selectively extend or replace the default chain without
+redefining it entirely.
+
+If no chains are resolved for a request the filter passes through without any modification and
+the ``pass_through`` counter is incremented.
 
 Configuration
 -------------
@@ -26,25 +35,38 @@ Filter-level Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The filter-level configuration (:ref:`FilterChainConfig <envoy_v3_api_msg_extensions.filters.http.filter_chain.v3.FilterChainConfig>`)
-defines:
+accepts one optional field:
 
-* ``default_filter_chain``: The default filter chain to apply when no route-specific configuration matches.
+* ``default_filter_chain``: The default chain applied to every request. Can be overridden per
+  route using ``FilterChainConfigPerRoute``.
 
 Per-Route Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The per-route configuration (:ref:`FilterChainConfigPerRoute <envoy_v3_api_msg_extensions.filters.http.filter_chain.v3.FilterChainConfigPerRoute>`)
-allows different filter chains to be applied on different routes:
+accepts one required field:
 
-* ``filter_chain``: An inline filter chain definition that takes precedence if specified.
+* ``filter_chain``: An inline filter chain. Filters in this chain override same-named filters
+  from less-specific chains (e.g. the default chain).
 
-Example Configuration
----------------------
+Statistics
+----------
 
-Basic Configuration
+The filter emits the following counters under the ``<stat_prefix>filter_chain.`` namespace:
+
+.. csv-table::
+   :header: Name, Type, Description
+   :widths: auto
+
+   pass_through, Counter, Number of requests for which no filter chain was resolved (the filter passed through without modification)
+
+Example Configurations
+----------------------
+
+Basic Default Chain
 ~~~~~~~~~~~~~~~~~~~
 
-This example configures a default filter chain with a buffer filter:
+Applies a header-mutation filter to every request by default:
 
 .. code-block:: yaml
 
@@ -56,22 +78,47 @@ This example configures a default filter chain with a buffer filter:
         filters:
         - name: envoy.filters.http.buffer
           typed_config:
-            "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-            max_request_bytes: 65536
+            "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+            mutations:
+              request_mutations:
+              - append:
+                  header:
+                    key: x-default-tag
+                    value: "true"
+                  append_action: APPEND_IF_EXISTS_OR_ADD
   - name: envoy.filters.http.router
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-Inline Per-Route Filter Chain
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Per-Route Filter Chain
+~~~~~~~~~~~~~~~~~~~~~~
 
-You can also define a filter chain inline in the per-route configuration:
+The default chain adds ``x-default-tag`` to every request. The ``/upload/`` route adds its
+own ``x-upload-tag`` header. Both filters run because their names are distinct — the
+per-route chain extends the default rather than replacing it:
 
 .. code-block:: yaml
 
+  http_filters:
+  - name: envoy.filters.http.filter_chain
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfig
+      default_filter_chain:
+        filters:
+        - name: envoy.filters.http.header_mutation
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+            mutations:
+              request_mutations:
+              - append:
+                  header:
+                    key: x-default-tag
+                    value: "true"
+                  append_action: APPEND_IF_EXISTS_OR_ADD
+
   routes:
   - match:
-      prefix: "/upload/"
+      prefix: /upload/
     route:
       cluster: upload_cluster
     typed_per_filter_config:
@@ -79,16 +126,81 @@ You can also define a filter chain inline in the per-route configuration:
         "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfigPerRoute
         filter_chain:
           filters:
-          - name: envoy.filters.http.buffer
+          - name: add-upload-tag                   # distinct name — does NOT override the default
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
-              max_request_bytes: 104857600
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+              mutations:
+                request_mutations:
+                - append:
+                    header:
+                      key: x-upload-tag
+                      value: "true"
+                    append_action: APPEND_IF_EXISTS_OR_ADD
+
+Overriding a Default Filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default chain and the per-route chain both configure a filter named
+``envoy.filters.http.header_mutation``. Because the names match, the per-route definition
+wins — only the per-route version of that filter runs on the ``/api/`` route. The default
+version is skipped entirely:
+
+.. code-block:: yaml
+
+  http_filters:
+  - name: envoy.filters.http.filter_chain
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfig
+      default_filter_chain:
+        filters:
+        - name: envoy.filters.http.header_mutation
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+            mutations:
+              request_mutations:
+              - append:
+                  header:
+                    key: x-tag
+                    value: default
+                  append_action: APPEND_IF_EXISTS_OR_ADD
+
+  routes:
+  - match:
+      prefix: /api/
+    route:
+      cluster: api_cluster
+    typed_per_filter_config:
+      envoy.filters.http.filter_chain:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfigPerRoute
+        filter_chain:
+          filters:
+          - name: envoy.filters.http.header_mutation  # same name — overrides the default
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+              mutations:
+                request_mutations:
+                - append:
+                    header:
+                      key: x-tag
+                      value: api-specific
+                    append_action: APPEND_IF_EXISTS_OR_ADD
 
 Behavior Notes
 --------------
 
-* When no filter chain is configured (either at filter level or route level), the filter
-  passes through all requests without modification.
-* The filter chain is resolved once per request during the initialization of the filter chain.
-* Filters in the chain are executed in order during decoding (request processing) and
-  in reverse order during encoding (response processing).
+* **No chains resolved**: If no filter chain exists at either the filter level or the route
+  level the filter passes through without modification and increments ``pass_through``.
+* **Merge order**: The default chain always runs first (least specific). Per-route chains run
+  after in scope order from outermost (virtual-host) to innermost (route). Within each chain
+  filters are applied in the order they are listed.
+* **Override by name**: A filter in a less-specific chain is skipped if any more-specific chain
+  defines a filter with the same ``name`` field. The ``name`` field is the sole key for
+  override resolution — the typed config type does not matter.
+* **Route match timing**: Only the initial route match determines which per-route chains are
+  collected. Subsequent internal route refreshes do not change the active chains.
+* **Override change order**: If a filter X is overridden by name in a more-specific chain,
+  the less-specific X is skipped entirely and the most-specific one will run. But note
+  that the order of the filters in the final chain is always from least to most specific, so the
+  less-specific filters run first and the X from the more-specific chain runs
+  after previous filters. This changes the order of execution for X. If the order matters,
+  consider to override the whole chain.

--- a/source/extensions/filters/http/filter_chain/config.cc
+++ b/source/extensions/filters/http/filter_chain/config.cc
@@ -11,24 +11,63 @@ namespace FilterChain {
 
 namespace {
 
-OptRef<const FilterChain> routeLevelFilterChain(FilterChainConfig& filter_chain_config,
-                                                Http::FilterChainFactoryCallbacks& callbacks) {
+using FilterChains = absl::InlinedVector<const FilterChain*, 5>;
+// HCM -> RouteConfiguration -> VirtualHost -> Route -> WeightedCluster
+FilterChains getAllFilterChains(OptRef<const FilterChain> default_chain,
+                                Http::FilterChainFactoryCallbacks& callbacks) {
+  FilterChains filter_chains;
+  if (default_chain.has_value()) {
+    filter_chains.push_back(default_chain.ptr());
+  }
+
   const OptRef<const Router::Route> route = callbacks.route();
   if (!route.has_value()) {
-    filter_chain_config.stats().no_route_.inc();
-    return {};
+    return filter_chains;
   }
-  const auto* per_route_config = dynamic_cast<const FilterChainPerRouteConfig*>(
-      route->mostSpecificPerFilterConfig(callbacks.filterConfigName()));
-  if (per_route_config == nullptr) {
-    filter_chain_config.stats().no_route_filter_config_.inc();
-    return {};
+
+  for (auto config : route->perFilterConfigs(callbacks.filterConfigName())) {
+    auto* route_chain = dynamic_cast<const FilterChainPerRouteConfig*>(config);
+    if (route_chain == nullptr) {
+      continue;
+    }
+    if (auto chain = route_chain->filterChain(); chain.has_value()) {
+      filter_chains.push_back(chain.ptr());
+    }
   }
-  if (auto chain = per_route_config->filterChain(); chain.has_value()) {
-    filter_chain_config.stats().use_route_filter_chain_.inc();
-    return chain;
+  return filter_chains;
+}
+
+bool hasFilter(absl::string_view filter_name, absl::Span<const FilterChain*> filter_chains) {
+  for (const auto* filter_chain : filter_chains) {
+    ASSERT(filter_chain != nullptr);
+    if (filter_chain->hasFilter(filter_name)) {
+      return true;
+    }
   }
-  return {};
+  return false;
+}
+
+void createFilterChain(Http::FilterChainFactoryCallbacks& callbacks,
+                       const FilterChain* filter_chain,
+                       absl::Span<const FilterChain*> more_specific_filter_chains) {
+  ASSERT(filter_chain != nullptr);
+
+  for (const auto& config_provider : filter_chain->filterFactories()) {
+    absl::string_view filter_config_name = config_provider->name();
+
+    // If there is a more specific filter chain that has the same name filter, skip this one.
+    if (hasFilter(filter_config_name, more_specific_filter_chains)) {
+      continue;
+    }
+
+    auto config = config_provider->config();
+    // In the filter_chain filter, we only has static filter config providers, so the config should
+    // always be available.
+    if (config.has_value()) {
+      callbacks.setFilterConfigName(filter_config_name);
+      config.value()(callbacks);
+    }
+  }
 }
 
 } // namespace
@@ -39,20 +78,17 @@ Http::FilterFactoryCb FilterChainFilterFactory::createFilterFactoryFromProtoType
   auto filter_config = std::make_shared<FilterChainConfig>(proto_config, context, stats_prefix);
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    OptRef<const FilterChain> chain = routeLevelFilterChain(*filter_config, callbacks);
-
-    // If no route level filter chain, use the default one.
-    if (!chain.has_value()) {
-      if (chain = filter_config->filterChain(); !chain.has_value()) {
-        ENVOY_LOG(debug, "filter chain filter: no filter chain found, passing through");
-        filter_config->stats().pass_through_.inc();
-        return;
-      }
-      filter_config->stats().use_default_filter_chain_.inc();
+    FilterChains filter_chains = getAllFilterChains(filter_config->filterChain(), callbacks);
+    if (filter_chains.empty()) {
+      filter_config->stats().pass_through_.inc();
+      return;
     }
+    absl::Span<const FilterChain*> chains_span = absl::MakeSpan(filter_chains);
 
-    ASSERT(chain.has_value());
-    Http::FilterChainUtility::createFilterChainForFactories(callbacks, chain->filterFactories());
+    for (size_t i = 0; i < chains_span.size(); ++i) {
+      ASSERT(chains_span[i] != nullptr);
+      createFilterChain(callbacks, chains_span[i], chains_span.subspan(i + 1));
+    }
   };
 }
 

--- a/source/extensions/filters/http/filter_chain/filter.cc
+++ b/source/extensions/filters/http/filter_chain/filter.cc
@@ -16,10 +16,10 @@ namespace {
 constexpr absl::string_view FilterChainName = "envoy.filters.http.filter_chain";
 
 // Helper to process filter config and create filter factories
-Http::FilterChainUtility::FilterFactoriesList createFilterFactoriesFromConfig(
+FilterFactoriesVector createFilterFactoriesFromConfig(
     const envoy::extensions::filters::http::filter_chain::v3::FilterChain& proto_config,
     Server::Configuration::ServerFactoryContext& context, const std::string& stats_prefix) {
-  Http::FilterChainUtility::FilterFactoriesList filter_factories;
+  FilterFactoriesVector filter_factories;
   filter_factories.reserve(proto_config.filters_size());
 
   for (const auto& filter_config : proto_config.filters()) {
@@ -38,16 +38,16 @@ Http::FilterChainUtility::FilterFactoriesList createFilterFactoriesFromConfig(
     auto filter_config_provider =
         Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(context)
             ->createStaticFilterConfigProvider(callback_or_error, filter_config.name());
-    filter_factories.push_back({std::move(filter_config_provider), false});
+    filter_factories.push_back({std::move(filter_config_provider)});
   }
   return filter_factories;
 }
 
 // Helper to process filter config and create filter factories
-Http::FilterChainUtility::FilterFactoriesList createFilterFactoriesFromConfig(
+FilterFactoriesVector createFilterFactoriesFromConfig(
     const envoy::extensions::filters::http::filter_chain::v3::FilterChain& proto_config,
     Server::Configuration::FactoryContext& context, const std::string& stats_prefix) {
-  Http::FilterChainUtility::FilterFactoriesList filter_factories;
+  FilterFactoriesVector filter_factories;
   filter_factories.reserve(proto_config.filters_size());
 
   for (const auto& filter_config : proto_config.filters()) {
@@ -68,7 +68,7 @@ Http::FilterChainUtility::FilterFactoriesList createFilterFactoriesFromConfig(
             context.serverFactoryContext())
             ->createStaticFilterConfigProvider(std::move(callback_or_error.value()),
                                                filter_config.name());
-    filter_factories.push_back({std::move(filter_config_provider), false});
+    filter_factories.push_back({std::move(filter_config_provider)});
   }
   return filter_factories;
 }
@@ -78,12 +78,20 @@ Http::FilterChainUtility::FilterFactoriesList createFilterFactoriesFromConfig(
 FilterChain::FilterChain(
     const envoy::extensions::filters::http::filter_chain::v3::FilterChain& proto_config,
     Server::Configuration::ServerFactoryContext& context, const std::string& stats_prefix)
-    : filter_factories_(createFilterFactoriesFromConfig(proto_config, context, stats_prefix)) {}
+    : filter_factories_(createFilterFactoriesFromConfig(proto_config, context, stats_prefix)) {
+  for (const auto& factory : filter_factories_) {
+    filters_.insert(factory->name());
+  }
+}
 
 FilterChain::FilterChain(
     const envoy::extensions::filters::http::filter_chain::v3::FilterChain& proto_config,
     Server::Configuration::FactoryContext& context, const std::string& stats_prefix)
-    : filter_factories_(createFilterFactoriesFromConfig(proto_config, context, stats_prefix)) {}
+    : filter_factories_(createFilterFactoriesFromConfig(proto_config, context, stats_prefix)) {
+  for (const auto& factory : filter_factories_) {
+    filters_.insert(factory->name());
+  }
+}
 
 FilterChainPerRouteConfig::FilterChainPerRouteConfig(
     const envoy::extensions::filters::http::filter_chain::v3::FilterChainConfigPerRoute&

--- a/source/extensions/filters/http/filter_chain/filter.h
+++ b/source/extensions/filters/http/filter_chain/filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "envoy/extensions/filters/http/filter_chain/v3/filter_chain.pb.h"
@@ -21,16 +22,14 @@ using FilterChainConfigProto =
 using FilterChainConfigProtoPerRoute =
     envoy::extensions::filters::http::filter_chain::v3::FilterChainConfigPerRoute;
 
-#define COMMON_FILTER_CHAIN_STATS(COUNTER)                                                         \
-  COUNTER(no_route)                                                                                \
-  COUNTER(no_route_filter_config)                                                                  \
-  COUNTER(use_route_filter_chain)                                                                  \
-  COUNTER(use_default_filter_chain)                                                                \
-  COUNTER(pass_through)
+#define COMMON_FILTER_CHAIN_STATS(COUNTER) COUNTER(pass_through)
 
 struct FilterChainStats {
   COMMON_FILTER_CHAIN_STATS(GENERATE_COUNTER_STRUCT)
 };
+
+using FilterFactory = Filter::FilterConfigProviderPtr<Filter::HttpFilterFactoryCb>;
+using FilterFactoriesVector = std::vector<FilterFactory>;
 
 /**
  * Configuration for a single filter chain.
@@ -43,12 +42,12 @@ public:
   FilterChain(const envoy::extensions::filters::http::filter_chain::v3::FilterChain& proto_config,
               Server::Configuration::FactoryContext& context, const std::string& stats_prefix);
 
-  const Http::FilterChainUtility::FilterFactoriesList& filterFactories() const {
-    return filter_factories_;
-  }
+  absl::Span<const FilterFactory> filterFactories() const { return filter_factories_; }
+  bool hasFilter(absl::string_view filter_name) const { return filters_.contains(filter_name); }
 
 private:
-  Http::FilterChainUtility::FilterFactoriesList filter_factories_;
+  FilterFactoriesVector filter_factories_;
+  absl::flat_hash_set<std::string> filters_;
 };
 
 using FilterChainConstSharedPtr = std::shared_ptr<const FilterChain>;

--- a/test/extensions/filters/http/filter_chain/filter_chain_integration_test.cc
+++ b/test/extensions/filters/http/filter_chain/filter_chain_integration_test.cc
@@ -124,5 +124,116 @@ typed_config:
       response->headers().get(Http::LowerCaseString("x-new-header"))[0]->value().getStringView());
 }
 
+// Adds a per-route filter chain config with a single header_mutation filter that appends
+// `header_value` to `header_key`. `filter_name` controls the configured filter name, which is the
+// key used for cross-chain override.
+void addPerRouteHeaderMutation(ConfigHelper& config_helper, const std::string& filter_name,
+                               const std::string& header_key, const std::string& header_value) {
+  config_helper.addConfigModifier([filter_name, header_key, header_value](
+                                      envoy::extensions::filters::network::http_connection_manager::
+                                          v3::HttpConnectionManager& hcm) {
+    auto* virtual_host = hcm.mutable_route_config()->mutable_virtual_hosts(0);
+    auto* route = virtual_host->mutable_routes(0);
+    auto* typed_per_filter_config = route->mutable_typed_per_filter_config();
+
+    envoy::extensions::filters::http::filter_chain::v3::FilterChainConfigPerRoute per_route;
+    auto* filter_chain = per_route.mutable_filter_chain();
+    auto* filter = filter_chain->add_filters();
+    filter->set_name(filter_name);
+    envoy::extensions::filters::http::header_mutation::v3::HeaderMutation header_mutation_config;
+    auto* mutation = header_mutation_config.mutable_mutations()->add_response_mutations();
+    mutation->mutable_append()->set_append_action(
+        envoy::config::core::v3::HeaderValueOption::APPEND_IF_EXISTS_OR_ADD);
+    mutation->mutable_append()->mutable_header()->set_key(header_key);
+    mutation->mutable_append()->mutable_header()->set_value(header_value);
+    std::ignore = filter->mutable_typed_config()->PackFrom(header_mutation_config);
+
+    std::ignore = (*typed_per_filter_config)["envoy.filters.http.filter_chain"].PackFrom(per_route);
+  });
+}
+
+// The default filter chain and a per-route filter chain with distinct filter names are merged, so
+// both filters run.
+TEST_P(FilterChainIntegrationTest, DefaultAndPerRouteMerged) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.filter_chain
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfig
+  default_filter_chain:
+    filters:
+    - name: header_mutation_default
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+        mutations:
+          response_mutations:
+          - append:
+              header:
+                key: "x-default-header"
+                value: "from-default"
+              append_action: APPEND_IF_EXISTS_OR_ADD
+)EOF";
+
+  config_helper_.prependFilter(filter_config, true);
+  addPerRouteHeaderMutation(config_helper_, "header_mutation_route", "x-route-header",
+                            "from-route");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_EQ("from-default", response->headers()
+                                .get(Http::LowerCaseString("x-default-header"))[0]
+                                ->value()
+                                .getStringView());
+  EXPECT_EQ(
+      "from-route",
+      response->headers().get(Http::LowerCaseString("x-route-header"))[0]->value().getStringView());
+}
+
+// When the default chain and the per-route chain configure a filter with the same name, the more
+// specific per-route chain overrides the default: only the per-route filter runs.
+TEST_P(FilterChainIntegrationTest, PerRouteOverridesDefault) {
+  const std::string filter_config = R"EOF(
+name: envoy.filters.http.filter_chain
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.filter_chain.v3.FilterChainConfig
+  default_filter_chain:
+    filters:
+    - name: envoy.filters.http.header_mutation
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+        mutations:
+          response_mutations:
+          - append:
+              header:
+                key: "x-shared-header"
+                value: "from-default"
+              append_action: APPEND_IF_EXISTS_OR_ADD
+)EOF";
+
+  config_helper_.prependFilter(filter_config, true);
+  addPerRouteHeaderMutation(config_helper_, "envoy.filters.http.header_mutation", "x-shared-header",
+                            "from-route");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  // The default chain's same-named filter is overridden, so only "from-route" is appended.
+  const auto values = response->headers().get(Http::LowerCaseString("x-shared-header"));
+  ASSERT_EQ(1, values.size());
+  EXPECT_EQ("from-route", values[0]->value().getStringView());
+}
+
 } // namespace
 } // namespace Envoy

--- a/test/extensions/filters/http/filter_chain/filter_test.cc
+++ b/test/extensions/filters/http/filter_chain/filter_test.cc
@@ -21,9 +21,17 @@ namespace FilterChain {
 namespace {
 
 using testing::_;
+using testing::ElementsAre;
+using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 
+constexpr absl::string_view FilterConfigName = "envoy.filters.http.filter_chain";
+
+// A mock filter factory that handles any filter configured with a `google.protobuf.Struct`
+// typed config. Filters are resolved by their typed config type URL, so a single registered
+// factory can back filters configured with arbitrary `name` fields. Each created filter adds a
+// stream decoder filter and bumps `filter_added_`.
 class MockFilterConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
   MockFilterConfigFactory() = default;
@@ -62,27 +70,43 @@ public:
     registry_ = std::make_unique<
         Registry::InjectFactory<Server::Configuration::NamedHttpFilterConfigFactory>>(
         *mock_factory_);
+
+    // Record the order in which filters are applied to the chain. The production code calls
+    // setFilterConfigName() with the configured filter name right before adding each filter.
+    ON_CALL(callbacks_, setFilterConfigName(_))
+        .WillByDefault(Invoke(
+            [this](absl::string_view name) { applied_filters_.push_back(std::string(name)); }));
+    ON_CALL(callbacks_, filterConfigName()).WillByDefault(Return(FilterConfigName));
   }
 
-  void initialize(const std::string& yaml_config, const std::string& per_route_yaml = "") {
+  void initialize(const std::string& yaml_config) {
     FilterChainConfigProto proto_config;
     if (!yaml_config.empty()) {
       TestUtility::loadFromYaml(yaml_config, proto_config);
     }
     auto callback_or_error = factory_.createFilterFactoryFromProto(proto_config, "test.", context_);
     EXPECT_TRUE(callback_or_error.status().ok());
-
     cb_ = callback_or_error.value();
+  }
 
-    if (!per_route_yaml.empty()) {
-      FilterChainConfigProtoPerRoute proto_per_route;
-      TestUtility::loadFromYaml(per_route_yaml, proto_per_route);
+  // Create a per-route filter chain config and keep it alive for the duration of the test. Returns
+  // a raw pointer suitable for placing into a `perFilterConfigs()` result.
+  const Router::RouteSpecificFilterConfig* makePerRoute(const std::string& yaml) {
+    FilterChainConfigProtoPerRoute proto_per_route;
+    TestUtility::loadFromYaml(yaml, proto_per_route);
+    auto config_or_error = factory_.createRouteSpecificFilterConfig(
+        proto_per_route, context_.serverFactoryContext(), context_.messageValidationVisitor());
+    EXPECT_TRUE(config_or_error.status().ok());
+    per_route_configs_.push_back(config_or_error.value());
+    return per_route_configs_.back().get();
+  }
 
-      auto specific_config_or_error = factory_.createRouteSpecificFilterConfig(
-          proto_per_route, context_.serverFactoryContext(), context_.messageValidationVisitor());
-      EXPECT_TRUE(specific_config_or_error.status().ok());
-      specific_config_ = specific_config_or_error.value();
-    }
+  // Wire up the callbacks so that the route returns the given per-route configs from
+  // perFilterConfigs(). The configs must be ordered from least to most specific.
+  void setRouteConfigs(const Router::RouteSpecificFilterConfigs& configs) {
+    EXPECT_CALL(callbacks_, route())
+        .WillOnce(Return(makeOptRefFromPtr<const Router::Route>(&route_)));
+    EXPECT_CALL(route_, perFilterConfigs(FilterConfigName)).WillOnce(Return(configs));
   }
 
   FilterChainFilterFactory factory_;
@@ -93,58 +117,186 @@ public:
   Http::FilterFactoryCb cb_;
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks_;
   NiceMock<Router::MockRoute> route_;
-  Router::RouteSpecificFilterConfigConstSharedPtr specific_config_;
+  std::vector<Router::RouteSpecificFilterConfigConstSharedPtr> per_route_configs_;
+  std::vector<std::string> applied_filters_;
 };
 
+// No config and no route: the filter passes through.
 TEST_F(FilterChainFactoryTest, EmptyConfig) {
   initialize("");
 
   EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(0);
   cb_(callbacks_);
   EXPECT_EQ(mock_factory_->filter_added_, 0);
-  EXPECT_EQ(context_.store_.counter("test.filter_chain.no_route").value(), 1);
   EXPECT_EQ(context_.store_.counter("test.filter_chain.pass_through").value(), 1);
 }
 
+// A route exists but provides no filter chain config and there is no default chain: pass through.
+TEST_F(FilterChainFactoryTest, RouteWithoutFilterChainConfig) {
+  initialize("");
+
+  EXPECT_CALL(callbacks_, route())
+      .WillOnce(Return(makeOptRefFromPtr<const Router::Route>(&route_)));
+  EXPECT_CALL(route_, perFilterConfigs(FilterConfigName))
+      .WillOnce(Return(Router::RouteSpecificFilterConfigs{}));
+  EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(0);
+  cb_(callbacks_);
+  EXPECT_EQ(mock_factory_->filter_added_, 0);
+  EXPECT_EQ(context_.store_.counter("test.filter_chain.pass_through").value(), 1);
+}
+
+// Only the default filter chain is configured and there is no route.
 TEST_F(FilterChainFactoryTest, DefaultFilterChain) {
-  const std::string yaml_config = R"EOF(
+  initialize(R"EOF(
     default_filter_chain:
       filters:
-      - name: mock_filter
+      - name: filter_a
         typed_config:
           "@type": type.googleapis.com/google.protobuf.Struct
-    )EOF";
-  initialize(yaml_config);
+  )EOF");
 
   EXPECT_CALL(callbacks_, addStreamDecoderFilter(_));
   cb_(callbacks_);
   EXPECT_EQ(mock_factory_->filter_added_, 1);
-  EXPECT_EQ(context_.store_.counter("test.filter_chain.no_route").value(), 1);
-  EXPECT_EQ(context_.store_.counter("test.filter_chain.use_default_filter_chain").value(), 1);
+  EXPECT_THAT(applied_filters_, ElementsAre("filter_a"));
+  EXPECT_EQ(context_.store_.counter("test.filter_chain.pass_through").value(), 0);
 }
 
-TEST_F(FilterChainFactoryTest, InlinedPerRouteConfig) {
-  const std::string per_route_yaml = R"EOF(
+// A single per-route filter chain is applied.
+TEST_F(FilterChainFactoryTest, PerRouteFilterChain) {
+  initialize("");
+
+  setRouteConfigs({makePerRoute(R"EOF(
     filter_chain:
       filters:
-      - name: mock_filter
+      - name: filter_a
         typed_config:
           "@type": type.googleapis.com/google.protobuf.Struct
-      - name: another_filter
+      - name: filter_b
         typed_config:
           "@type": type.googleapis.com/google.protobuf.Struct
-  )EOF";
-  initialize("", per_route_yaml);
+  )EOF")});
 
-  EXPECT_CALL(callbacks_, route())
-      .WillOnce(Return(makeOptRefFromPtr<const Router::Route>(&route_)));
-  EXPECT_CALL(callbacks_, filterConfigName()).WillOnce(Return("envoy.filters.http.filter_chain"));
-  EXPECT_CALL(route_, mostSpecificPerFilterConfig("envoy.filters.http.filter_chain"))
-      .WillOnce(Return(specific_config_.get()));
   EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(2);
   cb_(callbacks_);
   EXPECT_EQ(mock_factory_->filter_added_, 2);
-  EXPECT_EQ(context_.store_.counter("test.filter_chain.use_route_filter_chain").value(), 1);
+  EXPECT_THAT(applied_filters_, ElementsAre("filter_a", "filter_b"));
+}
+
+// The default chain and a per-route chain with disjoint filters are both applied. The default
+// (least specific) chain runs first in decode order.
+TEST_F(FilterChainFactoryTest, DefaultAndPerRouteMerged) {
+  initialize(R"EOF(
+    default_filter_chain:
+      filters:
+      - name: filter_a
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF");
+
+  setRouteConfigs({makePerRoute(R"EOF(
+    filter_chain:
+      filters:
+      - name: filter_b
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF")});
+
+  EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(2);
+  cb_(callbacks_);
+  EXPECT_EQ(mock_factory_->filter_added_, 2);
+  EXPECT_THAT(applied_filters_, ElementsAre("filter_a", "filter_b"));
+}
+
+// A more specific (per-route) chain overrides a same-named filter from a less specific (default)
+// chain: the default's "shared" filter is skipped, and only the per-route one is applied.
+TEST_F(FilterChainFactoryTest, PerRouteOverridesDefault) {
+  initialize(R"EOF(
+    default_filter_chain:
+      filters:
+      - name: shared
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+      - name: filter_a
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF");
+
+  setRouteConfigs({makePerRoute(R"EOF(
+    filter_chain:
+      filters:
+      - name: shared
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+      - name: filter_b
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF")});
+
+  EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(3);
+  cb_(callbacks_);
+  // The default's "shared" is overridden, so it is not applied. The default's unique "filter_a"
+  // still runs first, then the per-route chain.
+  EXPECT_EQ(mock_factory_->filter_added_, 3);
+  EXPECT_THAT(applied_filters_, ElementsAre("filter_a", "shared", "filter_b"));
+}
+
+// Multiple per-route configs along the hierarchy (e.g. virtual host then route) are merged, with
+// the most specific definition of a shared filter winning.
+TEST_F(FilterChainFactoryTest, HierarchyOverride) {
+  initialize("");
+
+  // perFilterConfigs returns configs from least to most specific.
+  setRouteConfigs({
+      makePerRoute(R"EOF(
+        filter_chain:
+          filters:
+          - name: common
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.Struct
+          - name: vhost_only
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.Struct
+      )EOF"),
+      makePerRoute(R"EOF(
+        filter_chain:
+          filters:
+          - name: common
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.Struct
+          - name: route_only
+            typed_config:
+              "@type": type.googleapis.com/google.protobuf.Struct
+      )EOF"),
+  });
+
+  EXPECT_CALL(callbacks_, addStreamDecoderFilter(_)).Times(3);
+  cb_(callbacks_);
+  EXPECT_EQ(mock_factory_->filter_added_, 3);
+  // "common" from the less specific config is overridden by the more specific one.
+  EXPECT_THAT(applied_filters_, ElementsAre("vhost_only", "common", "route_only"));
+}
+
+// Non filter-chain per-route configs in the list are ignored.
+TEST_F(FilterChainFactoryTest, IgnoresUnrelatedPerRouteConfig) {
+  initialize("");
+
+  // A bare RouteSpecificFilterConfig that is not a FilterChainPerRouteConfig.
+  class OtherConfig : public Router::RouteSpecificFilterConfig {};
+  OtherConfig other;
+
+  setRouteConfigs({&other, makePerRoute(R"EOF(
+    filter_chain:
+      filters:
+      - name: filter_a
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF")});
+
+  EXPECT_CALL(callbacks_, addStreamDecoderFilter(_));
+  cb_(callbacks_);
+  EXPECT_EQ(mock_factory_->filter_added_, 1);
+  EXPECT_THAT(applied_filters_, ElementsAre("filter_a"));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: filter_chain: refactor the default behavior to merge multiple chains
Additional Description:

After discussion with EG's maintainer (@zirain ) and also @agrawroh , we both agree that to merge multiple layers filter chain, it makes more sense rather than two shadow whole level filter chain. 

Because the filter_chain filter hasn’t been released and it was merged just ~2 weeks ago. So, this PR refactors the default behavior directly.

With new behavior, if there is filter chain at default_filter_chain with filters A and B, a chain at vhost with filter C, and a chain at route with filter D, the final executed chain and order is A B C  D.

If there is filter chain at default_filter_chain with filters A and B, a chain at vhost with filter C, and a chain at route with filter A D, the final executed chain and order is B C A D. For completely same name filter (not same type, but same config name), the more specific one will shadow the less specific one.

Risk Level: low.
Testing: unit + integration.
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
