### PR TITLE
format: moving absl::nullopt => std::nullopt

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h"
 
 #include <algorithm>
+#include <optional>
 
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
@@ -220,21 +221,21 @@ void RCConnectionWrapper::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bo
   ENVOY_LOG(error, "Received unexpected HTTP response: {} (expected {})", status, expected);
   // A 429 may carry a Retry-After cool-off hint; forward it so the parent can honor it as the
   // per-host backoff before the next attempt.
-  absl::optional<std::chrono::milliseconds> retry_after;
+  std::optional<std::chrono::milliseconds> retry_after;
   if (status == 429) {
     retry_after = parseRetryAfter(*headers);
   }
   onHandshakeFailure(HandshakeFailureReason::httpStatusError(absl::StrCat(status)), retry_after);
 }
 
-absl::optional<std::chrono::milliseconds>
+std::optional<std::chrono::milliseconds>
 RCConnectionWrapper::parseRetryAfter(const Http::ResponseHeaderMap& headers) {
   // ``Retry-After`` is not a registered inline header, so look it up by name. The key is a
   // function-local static to avoid reconstructing the LowerCaseString on every handshake response.
   static const Http::LowerCaseString retry_after_header{"retry-after"};
   const auto result = headers.get(retry_after_header);
   if (result.empty()) {
-    return absl::nullopt;
+    return std::nullopt;
   }
   const absl::string_view value = result[0]->value().getStringView();
   // RFC 7231 allows delta-seconds or an HTTP-date. Rate limiters emit delta-seconds; honor that
@@ -242,7 +243,7 @@ RCConnectionWrapper::parseRetryAfter(const Http::ResponseHeaderMap& headers) {
   // unparseable) value is treated as absent so it cannot short-circuit the backoff.
   uint64_t seconds = 0;
   if (!absl::SimpleAtoi(value, &seconds) || seconds == 0) {
-    return absl::nullopt;
+    return std::nullopt;
   }
   // Clamp purely to avoid overflow when widening seconds to milliseconds; this is NOT the backoff
   // policy cap. The effective ceiling (the configured ``max_reconnect_backoff``) is applied by the
@@ -278,8 +279,8 @@ void RCConnectionWrapper::onHandshakeSuccess() {
   parent_.onConnectionDone(message, this, false);
 }
 
-void RCConnectionWrapper::onHandshakeFailure(
-    const HandshakeFailureReason& reason, absl::optional<std::chrono::milliseconds> retry_after) {
+void RCConnectionWrapper::onHandshakeFailure(const HandshakeFailureReason& reason,
+                                             std::optional<std::chrono::milliseconds> retry_after) {
   const std::string error_message = reason.getDetailedName();
   const std::string stats_failure_reason = reason.getNameForStats();
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -190,7 +190,7 @@ public:
    *        response; forwarded to the parent to drive the per-host backoff.
    */
   void onHandshakeFailure(const HandshakeFailureReason& reason,
-                          absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
+                          std::optional<std::chrono::milliseconds> retry_after = std::nullopt);
 
   /**
    * Parse an HTTP ``Retry-After`` header into a cool-off duration. Only the RFC 7231 delta-seconds
@@ -199,7 +199,7 @@ public:
    * @param headers the response headers to inspect.
    * @return the parsed cool-off duration, or ``nullopt`` if not present/parseable/zero.
    */
-  static absl::optional<std::chrono::milliseconds>
+  static std::optional<std::chrono::milliseconds>
   parseRetryAfter(const Http::ResponseHeaderMap& headers);
 
   /**

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -4,6 +4,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 
 #include "envoy/event/timer.h"
 #include "envoy/network/address.h"
@@ -680,7 +681,7 @@ bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(const std::string&
 
 void ReverseConnectionIOHandle::trackConnectionFailure(
     const std::string& host_address, const std::string& cluster_name,
-    absl::optional<std::chrono::milliseconds> retry_after) {
+    std::optional<std::chrono::milliseconds> retry_after) {
   auto host_it = host_to_conn_info_map_.find(host_address);
   if (host_it == host_to_conn_info_map_.end()) {
     ENVOY_LOG(debug, "Host {} not found in host_to_conn_info_map_, skipping failure tracking",
@@ -1085,7 +1086,7 @@ bool ReverseConnectionIOHandle::isTriggerPipeReady() const {
 
 void ReverseConnectionIOHandle::onConnectionDone(
     const std::string& error, RCConnectionWrapper* wrapper, bool closed,
-    absl::optional<std::chrono::milliseconds> retry_after) {
+    std::optional<std::chrono::milliseconds> retry_after) {
   ENVOY_LOG(info,
             "reverse_tunnel: Connection wrapper done - error: '{}', closed: {}, for node_id: {}",
             error, closed, config_.src_node_id);

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <string>
 #include <vector>
@@ -28,7 +29,6 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/synchronization/mutex.h"
-#include "absl/types/optional.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -239,7 +239,7 @@ public:
    * 429 handshake response) to use as the per-host backoff; ignored when unset.
    */
   void onConnectionDone(const std::string& error, RCConnectionWrapper* wrapper, bool closed,
-                        absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
+                        std::optional<std::chrono::milliseconds> retry_after = std::nullopt);
 
   // Backoff logic for connection failures.
   /**
@@ -257,9 +257,8 @@ public:
    * @param cluster_name the name of the cluster the host belongs to.
    * @param retry_after optional server-provided cool-off hint.
    */
-  void
-  trackConnectionFailure(const std::string& host_address, const std::string& cluster_name,
-                         absl::optional<std::chrono::milliseconds> retry_after = absl::nullopt);
+  void trackConnectionFailure(const std::string& host_address, const std::string& cluster_name,
+                              std::optional<std::chrono::milliseconds> retry_after = std::nullopt);
 
   /**
    * Reset backoff state for a specific host. Called when a connection is established successfully.


### PR DESCRIPTION
## Description

This PR fixes the broken main by moving `absl::nullopt` => `std::nullopt`.

---

**Commit Message:** format: moving absl::nullopt => std::nullopt
**Risk Level:** Low
**Testing:** CI
**Docs Changes**: N/A
**Release Notes:** N/A