### PR TITLE
dynamic_modules: add per-worker timer support to the cluster ABI

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -2,6 +2,7 @@
 
 // This file provides host-side implementations for the cluster dynamic module ABI callbacks.
 
+#include <chrono>
 #include <cstring>
 
 #include "source/common/common/assert.h"
@@ -980,6 +981,84 @@ void envoy_dynamic_module_callback_cluster_get_name(
   const auto& name = getCluster(cluster_envoy_ptr)->clusterName();
   result->ptr = name.data();
   result->length = name.size();
+}
+
+// =============================================================================
+// Cluster Worker Timer Callbacks
+// =============================================================================
+
+envoy_dynamic_module_type_cluster_worker_timer_module_ptr
+envoy_dynamic_module_callback_cluster_worker_timer_new(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr) {
+  using Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterWorkerTimer;
+  using Envoy::Extensions::Clusters::DynamicModules::DynamicModuleLoadBalancer;
+  auto* lb = getLb(lb_envoy_ptr);
+  if (lb == nullptr) {
+    return nullptr;
+  }
+  Envoy::Event::Dispatcher* dispatcher = lb->workerDispatcher();
+  if (dispatcher == nullptr) {
+    // No choose_host has captured a worker dispatcher on this worker yet.
+    return nullptr;
+  }
+  // Allocate the timer wrapper first so we can capture a stable heap pointer in the callback.
+  auto* timer_wrapper = new DynamicModuleClusterWorkerTimer();
+  // Timer create, fire, and delete all run on this worker thread. The empty lambda validates that
+  // the load balancer is still registered (defends against a module that leaks the timer past
+  // on_cluster_lb_destroy) while holding the registry lock only for that check; the module hook
+  // runs outside the lock. A load balancer observed live here cannot be freed during the call,
+  // since its destruction would run on this same worker thread.
+  timer_wrapper->setTimer(dispatcher->createTimer([lb, timer_wrapper]() {
+    if (!DynamicModuleLoadBalancer::withActiveInstance(lb,
+                                                       [](const DynamicModuleLoadBalancer&) {})) {
+      return;
+    }
+    const auto& config = lb->config();
+    if (config->on_cluster_worker_timer_fired_ != nullptr) {
+      config->on_cluster_worker_timer_fired_(lb, lb->inModuleLb(),
+                                             static_cast<void*>(timer_wrapper));
+    }
+  }));
+  return static_cast<void*>(timer_wrapper);
+}
+
+void envoy_dynamic_module_callback_cluster_worker_timer_enable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr,
+    uint64_t delay_milliseconds) {
+  auto* timer =
+      static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterWorkerTimer*>(
+          timer_ptr);
+  timer->timer().enableTimer(std::chrono::milliseconds(delay_milliseconds));
+}
+
+void envoy_dynamic_module_callback_cluster_worker_timer_disable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr) {
+  auto* timer =
+      static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterWorkerTimer*>(
+          timer_ptr);
+  timer->timer().disableTimer();
+}
+
+bool envoy_dynamic_module_callback_cluster_worker_timer_enabled(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr) {
+  auto* timer =
+      static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterWorkerTimer*>(
+          timer_ptr);
+  return timer->timer().enabled();
+}
+
+void envoy_dynamic_module_callback_cluster_worker_timer_delete(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr) {
+  // The underlying `Event::Timer` is removed from the worker dispatcher's timer list in its
+  // destructor, which is only safe on that worker thread. Guard explicitly since the
+  // ASSERT-based thread check is compiled out under NDEBUG.
+  if (Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_delete must be called "
+                 "on a worker thread");
+    return;
+  }
+  delete static_cast<Envoy::Extensions::Clusters::DynamicModules::DynamicModuleClusterWorkerTimer*>(
+      timer_ptr);
 }
 
 // =============================================================================

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -135,6 +135,12 @@ absl::StatusOr<std::shared_ptr<DynamicModuleClusterConfig>> DynamicModuleCluster
   config->on_cluster_lb_on_host_membership_update_ =
       on_lb_membership_update.ok() ? on_lb_membership_update.value() : nullptr;
 
+  auto on_worker_timer_fired =
+      config->dynamic_module_->getFunctionPointer<OnClusterWorkerTimerFiredType>(
+          "envoy_dynamic_module_on_cluster_worker_timer_fired");
+  config->on_cluster_worker_timer_fired_ =
+      on_worker_timer_fired.ok() ? on_worker_timer_fired.value() : nullptr;
+
   // Call on_cluster_config_new to get the in-module configuration.
   envoy_dynamic_module_type_envoy_buffer name_buffer = {config->cluster_name_.data(),
                                                         config->cluster_name_.size()};
@@ -787,6 +793,11 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   // a happens-before relationship via the thread::spawn synchronization in the module.
   const auto* connection = context != nullptr ? context->downstreamConnection() : nullptr;
   active_async_dispatcher_ = connection != nullptr ? &connection->dispatcher() : nullptr;
+  // Capture the worker dispatcher for worker timer creation. Sticky: keep any previously captured
+  // dispatcher when this call has no connection, since the worker dispatcher is stable.
+  if (active_async_dispatcher_ != nullptr) {
+    worker_dispatcher_ = active_async_dispatcher_;
+  }
   active_async_cancelled_ = std::make_shared<std::atomic<bool>>(false);
 
   envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -8,6 +8,7 @@
 #include "envoy/common/callback.h"
 #include "envoy/common/optref.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/event/timer.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.validate.h"
 #include "envoy/http/async_client.h"
@@ -60,6 +61,7 @@ using OnClusterShutdownType = decltype(&envoy_dynamic_module_on_cluster_shutdown
 using OnClusterHttpCalloutDoneType = decltype(&envoy_dynamic_module_on_cluster_http_callout_done);
 using OnClusterLbOnHostMembershipUpdateType =
     decltype(&envoy_dynamic_module_on_cluster_lb_on_host_membership_update);
+using OnClusterWorkerTimerFiredType = decltype(&envoy_dynamic_module_on_cluster_worker_timer_fired);
 
 /**
  * Configuration for a dynamic module cluster. This holds the loaded dynamic module, resolved
@@ -100,6 +102,7 @@ public:
   OnClusterShutdownType on_cluster_shutdown_ = nullptr;
   OnClusterHttpCalloutDoneType on_cluster_http_callout_done_ = nullptr;
   OnClusterLbOnHostMembershipUpdateType on_cluster_lb_on_host_membership_update_ = nullptr;
+  OnClusterWorkerTimerFiredType on_cluster_worker_timer_fired_ = nullptr;
 
   // The in-module configuration pointer.
   envoy_dynamic_module_type_cluster_config_module_ptr in_module_config_ = nullptr;
@@ -522,6 +525,24 @@ private:
 };
 
 /**
+ * Wraps an Envoy timer owned by a DynamicModuleLoadBalancer (per-worker). It is created via
+ * envoy_dynamic_module_callback_cluster_worker_timer_new and deleted via
+ * envoy_dynamic_module_callback_cluster_worker_timer_delete.
+ *
+ * The timer, its fired callback, and its deletion are all confined to the worker thread that
+ * created it, so no cross-thread synchronization is needed.
+ */
+class DynamicModuleClusterWorkerTimer {
+public:
+  // Separated from construction so the timer callback can capture a stable pointer to this object.
+  void setTimer(Event::TimerPtr timer) { timer_ = std::move(timer); }
+  Event::Timer& timer() { return *timer_; }
+
+private:
+  Event::TimerPtr timer_;
+};
+
+/**
  * Async host selection handle that bridges the dynamic module's async host selection to Envoy's
  * LoadBalancerContext::onAsyncHostSelection. This is created when the module returns an async
  * pending result from choose_host, and destroyed after the module delivers the result or the
@@ -595,6 +616,19 @@ public:
    */
   Event::Dispatcher* activeAsyncDispatcher() const { return active_async_dispatcher_; }
 
+  /**
+   * Returns the worker thread's dispatcher captured during chooseHost, or nullptr if no chooseHost
+   * has run on this worker yet. Used by the worker timer ABI callbacks to create timers on the
+   * correct worker dispatcher. The captured dispatcher is stable for the worker's lifetime.
+   */
+  Event::Dispatcher* workerDispatcher() const { return worker_dispatcher_; }
+
+  // The cluster config holding the resolved module function pointers.
+  const DynamicModuleClusterConfigSharedPtr& config() const { return handle_->cluster()->config(); }
+
+  // The in-module load balancer pointer passed to module hooks.
+  envoy_dynamic_module_type_cluster_lb_module_ptr inModuleLb() const { return in_module_lb_; }
+
   // Per-host custom data storage.
   bool setHostData(uint32_t priority, size_t index, uintptr_t data);
   bool getHostData(uint32_t priority, size_t index, uintptr_t* data) const;
@@ -628,6 +662,10 @@ private:
 
   // Worker thread dispatcher captured during chooseHost for async completion posting.
   Event::Dispatcher* active_async_dispatcher_{nullptr};
+
+  // Worker thread dispatcher captured during chooseHost, used to create worker timers. Sticky:
+  // once captured it is never cleared, since the worker dispatcher is stable for the worker's life.
+  Event::Dispatcher* worker_dispatcher_{nullptr};
 
   // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
   absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -9234,6 +9234,21 @@ typedef void* envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr;
  */
 typedef void* envoy_dynamic_module_type_cluster_worker_slot_data_module_ptr;
 
+/**
+ * envoy_dynamic_module_type_cluster_worker_timer_module_ptr is a raw pointer to the
+ * DynamicModuleClusterWorkerTimer class in Envoy. The timer runs on the worker thread that created
+ * it (the dispatcher captured during envoy_dynamic_module_on_cluster_lb_choose_host), so the timer,
+ * its callback, and its deletion are all confined to a single worker thread.
+ *
+ * OWNERSHIP: The allocation is done by Envoy but the module is responsible for managing the
+ * lifetime of the pointer. Notably, it must be explicitly destroyed by the module when the timer is
+ * no longer needed. The creation of this pointer is done by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new and the destruction is done by
+ * envoy_dynamic_module_callback_cluster_worker_timer_delete. Since its lifecycle is owned/managed
+ * by the module, this has _module_ptr suffix.
+ */
+typedef void* envoy_dynamic_module_type_cluster_worker_timer_module_ptr;
+
 // =============================================================================
 // Cluster Event Hooks
 // =============================================================================
@@ -9479,6 +9494,27 @@ void envoy_dynamic_module_on_cluster_http_callout_done(
     envoy_dynamic_module_type_http_callout_result result,
     envoy_dynamic_module_type_envoy_http_header* headers, size_t headers_size,
     envoy_dynamic_module_type_envoy_buffer* body_chunks, size_t body_chunks_size);
+
+/**
+ * envoy_dynamic_module_on_cluster_worker_timer_fired is called when a timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new fires. It runs on the worker thread that
+ * created the timer, so it can safely touch that worker's per-load-balancer state without
+ * synchronization.
+ *
+ * This is optional. Only modules that create worker timers need to implement it.
+ *
+ * The timer is one-shot per Envoy semantics; the module re-arms it by calling
+ * envoy_dynamic_module_callback_cluster_worker_timer_enable again for periodic behavior.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy-side load balancer, usable with the cluster LB
+ * callbacks (e.g. host queries) for the duration of this call.
+ * @param lb_module_ptr is the pointer to the in-module load balancer that owns the timer.
+ * @param timer_ptr is the pointer to the timer that fired.
+ */
+void envoy_dynamic_module_on_cluster_worker_timer_fired(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr,
+    envoy_dynamic_module_type_cluster_lb_module_ptr lb_module_ptr,
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr);
 
 // =============================================================================
 // Cluster Dynamic Module Callbacks
@@ -10054,6 +10090,87 @@ envoy_dynamic_module_callback_cluster_worker_slot_get(
 void envoy_dynamic_module_callback_cluster_get_name(
     envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result);
+
+// -------------------- Cluster Dynamic Module Callbacks - Worker Timer --------------------
+
+/**
+ * envoy_dynamic_module_callback_cluster_worker_timer_new creates a new timer on the calling
+ * worker thread's dispatcher. The timer is not enabled upon creation; the module must call
+ * envoy_dynamic_module_callback_cluster_worker_timer_enable to arm it.
+ *
+ * This must be called on a worker thread from within an
+ * envoy_dynamic_module_on_cluster_lb_choose_host call, so that the worker dispatcher has been
+ * captured for this load balancer. When the timer fires,
+ * envoy_dynamic_module_on_cluster_worker_timer_fired is called on the same worker thread.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy-side load balancer. The module receives this as
+ * the second parameter to envoy_dynamic_module_on_cluster_lb_new.
+ * @return the pointer to the created timer, or NULL if no worker dispatcher has been captured yet
+ * (no choose_host has run on this worker).
+ *
+ * NOTE: it is the caller's responsibility to delete the timer using
+ * envoy_dynamic_module_callback_cluster_worker_timer_delete when it is no longer needed, on the
+ * same worker thread.
+ */
+envoy_dynamic_module_type_cluster_worker_timer_module_ptr
+envoy_dynamic_module_callback_cluster_worker_timer_new(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_worker_timer_enable enables the timer with a given delay.
+ * If the timer is already enabled, it is reset to the new delay.
+ *
+ * This must be called on the worker thread that created the timer.
+ *
+ * @param timer_ptr is the pointer to the timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new.
+ * @param delay_milliseconds is the delay in milliseconds before the timer fires.
+ */
+void envoy_dynamic_module_callback_cluster_worker_timer_enable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr,
+    uint64_t delay_milliseconds);
+
+/**
+ * envoy_dynamic_module_callback_cluster_worker_timer_disable disables the timer without destroying
+ * it. The timer can be re-enabled later using
+ * envoy_dynamic_module_callback_cluster_worker_timer_enable.
+ *
+ * This must be called on the worker thread that created the timer.
+ *
+ * @param timer_ptr is the pointer to the timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new.
+ */
+void envoy_dynamic_module_callback_cluster_worker_timer_disable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_worker_timer_enabled checks whether the timer is currently
+ * armed.
+ *
+ * This must be called on the worker thread that created the timer.
+ *
+ * @param timer_ptr is the pointer to the timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new.
+ * @return true if the timer is currently enabled, false otherwise.
+ */
+bool envoy_dynamic_module_callback_cluster_worker_timer_enabled(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr);
+
+/**
+ * envoy_dynamic_module_callback_cluster_worker_timer_delete deletes a timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new. The timer is automatically disabled
+ * before deletion.
+ *
+ * This must be called on the worker thread that created the timer. The underlying Envoy timer
+ * `deregisters` from that worker dispatcher's timer list in its destructor, so invoking this
+ * callback from any other thread is undefined behavior. Same-thread ordering with
+ * envoy_dynamic_module_on_cluster_worker_timer_fired guarantees the timer cannot fire after delete.
+ *
+ * @param timer_ptr is the pointer to the timer created by
+ * envoy_dynamic_module_callback_cluster_worker_timer_new.
+ */
+void envoy_dynamic_module_callback_cluster_worker_timer_delete(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr timer_ptr);
 
 // =============================================================================
 // Cluster Dynamic Module Callbacks - Metrics

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -831,6 +831,41 @@ envoy_dynamic_module_callback_cluster_get_name(envoy_dynamic_module_type_cluster
   IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_get_name: not implemented in this context");
 }
 
+// ---- Cluster worker timer callbacks ----
+
+__attribute__((weak)) envoy_dynamic_module_type_cluster_worker_timer_module_ptr
+envoy_dynamic_module_callback_cluster_worker_timer_new(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_new: "
+               "not implemented in this context");
+  return nullptr;
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_worker_timer_enable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr, uint64_t) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_enable: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_worker_timer_disable(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_disable: "
+               "not implemented in this context");
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_worker_timer_enabled(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_enabled: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_worker_timer_delete(
+    envoy_dynamic_module_type_cluster_worker_timer_module_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_worker_timer_delete: "
+               "not implemented in this context");
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_metrics_result
 envoy_dynamic_module_callback_cluster_config_define_counter(
     envoy_dynamic_module_type_cluster_config_envoy_ptr, envoy_dynamic_module_type_module_buffer,

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -179,8 +179,9 @@ pub trait ClusterLb: Send {
   /// Select a host for a request.
   ///
   /// The `context` provides access to per-request information such as downstream headers,
-  /// hash keys, override host, and retry state. It may be `None` if no context is available
-  /// (e.g., health check requests).
+  /// hash keys, override host, and retry state, and (via
+  /// [`ClusterLbContext::worker_timer_new`]) lets the module arm a per-worker timer from the
+  /// request path. It may be `None` if no context is available (e.g., health check requests).
   ///
   /// The `async_completion` callback must be used when returning
   /// [`HostSelectionResult::AsyncPending`]. The module stores it and later calls
@@ -207,6 +208,19 @@ pub trait ClusterLb: Send {
     _envoy_lb: &dyn EnvoyClusterLoadBalancer,
     _num_hosts_added: usize,
     _num_hosts_removed: usize,
+  ) {
+  }
+
+  /// Called on the worker thread when a timer created via
+  /// [`EnvoyClusterLoadBalancer::worker_timer_new`] fires.
+  ///
+  /// The `timer` is a non-owning reference to the timer that fired. The module re-arms it by
+  /// calling [`EnvoyClusterWorkerTimer::enable`] for periodic behavior, or
+  /// [`EnvoyClusterWorkerTimer::disable`] to stop it. The default implementation is a no-op.
+  fn on_worker_timer_fired(
+    &mut self,
+    _envoy_lb: &dyn EnvoyClusterLoadBalancer,
+    _timer: &dyn EnvoyClusterWorkerTimer,
   ) {
   }
 }
@@ -293,6 +307,17 @@ pub trait ClusterLbContext {
     host: abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
     stat: abi::envoy_dynamic_module_type_host_stat,
   ) -> u64;
+
+  /// Creates a per-worker timer on this request's worker dispatcher.
+  ///
+  /// The worker dispatcher is captured on this load balancer for the duration of host selection,
+  /// so this is callable during [`ClusterLb::choose_host`]. The timer is not armed on creation;
+  /// call [`EnvoyClusterWorkerTimer::enable`] to arm it. When it fires,
+  /// [`ClusterLb::on_worker_timer_fired`] is invoked on this same worker thread.
+  ///
+  /// Returns `None` if no worker dispatcher is available. The returned handle owns the underlying
+  /// Envoy timer and destroys it when dropped, which must happen on this worker thread.
+  fn worker_timer_new(&self) -> Option<Box<dyn EnvoyClusterWorkerTimer>>;
 }
 
 /// Envoy-side cluster operations available to the module.
@@ -695,6 +720,32 @@ pub trait EnvoyClusterLoadBalancer: Send {
     index: usize,
     is_added: bool,
   ) -> Option<PackedAddress>;
+}
+
+/// A per-worker timer handle, created via [`EnvoyClusterLoadBalancer::worker_timer_new`].
+///
+/// The timer runs on the worker thread that created it and fires by calling
+/// [`ClusterLb::on_worker_timer_fired`]. All methods, including dropping the owning handle, must be
+/// called on that worker thread, since the underlying Envoy timer is removed from the worker
+/// dispatcher's timer list when destroyed.
+///
+/// The owning handle returned by `worker_timer_new` automatically destroys the underlying Envoy
+/// timer when dropped. The non-owning reference passed to [`ClusterLb::on_worker_timer_fired`] does
+/// not. Each timer has a unique [`id`](EnvoyClusterWorkerTimer::id) stable for its lifetime.
+#[automock]
+pub trait EnvoyClusterWorkerTimer: Send {
+  /// Returns a unique opaque identifier for this timer, stable for its lifetime. Lets a module with
+  /// multiple timers identify which one fired in [`ClusterLb::on_worker_timer_fired`].
+  fn id(&self) -> usize;
+
+  /// Enable the timer with the given delay. If already enabled, it is reset to the new delay.
+  fn enable(&self, delay: std::time::Duration);
+
+  /// Disable the timer without destroying it. It can be re-enabled later.
+  fn disable(&self);
+
+  /// Check whether the timer is currently armed.
+  fn enabled(&self) -> bool;
 }
 
 /// Envoy-side scheduler that dispatches events to the main thread.
@@ -1565,6 +1616,100 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
   }
 }
 
+/// Owning implementation of [`EnvoyClusterWorkerTimer`]. Calls `worker_timer_delete` on drop.
+struct EnvoyClusterWorkerTimerImpl {
+  raw_ptr: abi::envoy_dynamic_module_type_cluster_worker_timer_module_ptr,
+}
+
+// SAFETY: The raw pointer is only used on the worker thread that created the timer, matching
+// Envoy's threading model for worker timers.
+unsafe impl Send for EnvoyClusterWorkerTimerImpl {}
+
+impl Drop for EnvoyClusterWorkerTimerImpl {
+  fn drop(&mut self) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_worker_timer_delete(self.raw_ptr);
+    }
+  }
+}
+
+impl EnvoyClusterWorkerTimer for EnvoyClusterWorkerTimerImpl {
+  fn id(&self) -> usize {
+    self.raw_ptr as usize
+  }
+
+  fn enable(&self, delay: std::time::Duration) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_worker_timer_enable(
+        self.raw_ptr,
+        delay.as_millis() as u64,
+      );
+    }
+  }
+
+  fn disable(&self) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_worker_timer_disable(self.raw_ptr);
+    }
+  }
+
+  fn enabled(&self) -> bool {
+    unsafe { abi::envoy_dynamic_module_callback_cluster_worker_timer_enabled(self.raw_ptr) }
+  }
+}
+
+/// Non-owning reference to a worker timer, used in the [`ClusterLb::on_worker_timer_fired`]
+/// callback. Does NOT call `worker_timer_delete` on drop.
+struct EnvoyClusterWorkerTimerRef {
+  raw_ptr: abi::envoy_dynamic_module_type_cluster_worker_timer_module_ptr,
+}
+
+// SAFETY: The raw pointer is only used on the worker thread that owns the timer.
+unsafe impl Send for EnvoyClusterWorkerTimerRef {}
+
+impl EnvoyClusterWorkerTimer for EnvoyClusterWorkerTimerRef {
+  fn id(&self) -> usize {
+    self.raw_ptr as usize
+  }
+
+  fn enable(&self, delay: std::time::Duration) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_worker_timer_enable(
+        self.raw_ptr,
+        delay.as_millis() as u64,
+      );
+    }
+  }
+
+  fn disable(&self) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_worker_timer_disable(self.raw_ptr);
+    }
+  }
+
+  fn enabled(&self) -> bool {
+    unsafe { abi::envoy_dynamic_module_callback_cluster_worker_timer_enabled(self.raw_ptr) }
+  }
+}
+
+impl EnvoyClusterWorkerTimer for Box<dyn EnvoyClusterWorkerTimer> {
+  fn id(&self) -> usize {
+    (**self).id()
+  }
+
+  fn enable(&self, delay: std::time::Duration) {
+    (**self).enable(delay);
+  }
+
+  fn disable(&self) {
+    (**self).disable();
+  }
+
+  fn enabled(&self) -> bool {
+    (**self).enabled()
+  }
+}
+
 /// Implementation of [`EnvoyClusterMetrics`] that calls into the Envoy ABI.
 pub struct EnvoyClusterMetricsImpl {
   raw: abi::envoy_dynamic_module_type_cluster_config_envoy_ptr,
@@ -2112,6 +2257,15 @@ impl ClusterLbContext for ClusterLbContextRef<'_> {
       )
     }
   }
+
+  fn worker_timer_new(&self) -> Option<Box<dyn EnvoyClusterWorkerTimer>> {
+    let raw_ptr =
+      unsafe { abi::envoy_dynamic_module_callback_cluster_worker_timer_new(self.raw_lb) };
+    if raw_ptr.is_null() {
+      return None;
+    }
+    Some(Box::new(EnvoyClusterWorkerTimerImpl { raw_ptr }))
+  }
 }
 
 // Cluster Event Hook Implementations
@@ -2380,6 +2534,28 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_on_host_membership_u
       "envoy_dynamic_module_on_cluster_lb_on_host_membership_update",
       panic,
     );
+  });
+}
+
+/// # Safety
+///
+/// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
+/// by the Envoy dynamic module ABI.
+#[no_mangle]
+pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_worker_timer_fired(
+  lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  lb_module_ptr: abi::envoy_dynamic_module_type_cluster_lb_module_ptr,
+  timer_ptr: abi::envoy_dynamic_module_type_cluster_worker_timer_module_ptr,
+) {
+  let _ = catch_unwind(AssertUnwindSafe(|| {
+    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
+    // Non-owning reference so the module can re-arm the timer it already owns.
+    let timer_ref = EnvoyClusterWorkerTimerRef { raw_ptr: timer_ptr };
+    wrapper.lb.on_worker_timer_fired(&envoy_lb, &timer_ref);
+  }))
+  .map_err(|panic| {
+    crate::log_ffi_panic("envoy_dynamic_module_on_cluster_worker_timer_fired", panic);
   });
 }
 

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -1247,6 +1247,30 @@ TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
   result = absl::InternalError("cleanup");
 }
 
+// Worker timer creation returns null before any chooseHost has captured a worker dispatcher.
+TEST_F(DynamicModuleClusterTest, WorkerTimerNewReturnsNullWithoutDispatcher) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  NiceMock<Upstream::MockPrioritySet> worker_ps;
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
+  auto lb = std::make_unique<DynamicModuleLoadBalancer>(handle, worker_ps);
+
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_worker_timer_new(lb.get()));
+}
+
+// Deleting a worker timer off a worker thread (here, the test thread) trips an Envoy bug and skips
+// the deletion, since the underlying timer may only be destroyed on its worker dispatcher thread.
+TEST_F(DynamicModuleClusterTest, WorkerTimerDeleteOffWorkerThreadIsEnvoyBug) {
+  auto* timer = new DynamicModuleClusterWorkerTimer();
+  EXPECT_ENVOY_BUG(envoy_dynamic_module_callback_cluster_worker_timer_delete(timer),
+                   "must be called on a worker thread");
+  // The callback skipped deletion on the test thread, so free it directly.
+  delete timer;
+}
+
 // Test that onScheduled handles the case when cluster is already destroyed.
 TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
   Event::PostCb captured_cb;

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -217,6 +217,29 @@ TEST_P(DynamicModuleClusterIntegrationTest, LifecycleCallbacks) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Drives the per-worker timer ABI end to end. The first request arms a 50ms repeating worker timer
+// from choose_host (which exercises enable/enabled/disable and increments timer_armed_total). The
+// timer then fires repeatedly on the worker dispatcher and re-arms itself, so timer_fired_total
+// keeps climbing without further requests — proving the timer is created on the worker dispatcher,
+// fires on the worker thread, and re-arms.
+TEST_P(DynamicModuleClusterIntegrationTest, WorkerTimerArmsFiresAndReArms) {
+  initializeWithDecCluster("worker_timer");
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  // The first request runs choose_host, which captures the worker dispatcher and arms the timer.
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  // The timer is armed exactly once, with enabled()/disable() observed as expected.
+  test_server_->waitForCounter("dynamicmodulescustom.timer_armed_total", testing::Eq(1));
+
+  // The timer fires on the worker dispatcher and re-arms, so the counter keeps climbing.
+  test_server_->waitForCounter("dynamicmodulescustom.timer_fired_total", testing::Ge(3));
+}
+
 // =============================================================================
 // Filter-state read ABI: an upstream HTTP filter writes filter state on the
 // request path; the dynamic-module cluster reads it back during host selection.

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -482,6 +482,15 @@ WEAK_STUB(ClusterConfigDefineHistogram,
 WEAK_STUB(ClusterConfigRecordHistogramValue,
           envoy_dynamic_module_callback_cluster_config_record_histogram_value(nullptr, 0, nullptr,
                                                                               0, 0))
+WEAK_STUB(ClusterWorkerTimerNew, envoy_dynamic_module_callback_cluster_worker_timer_new(nullptr))
+WEAK_STUB(ClusterWorkerTimerEnable,
+          envoy_dynamic_module_callback_cluster_worker_timer_enable(nullptr, 0))
+WEAK_STUB(ClusterWorkerTimerDisable,
+          envoy_dynamic_module_callback_cluster_worker_timer_disable(nullptr))
+WEAK_STUB(ClusterWorkerTimerEnabled,
+          envoy_dynamic_module_callback_cluster_worker_timer_enabled(nullptr))
+WEAK_STUB(ClusterWorkerTimerDelete,
+          envoy_dynamic_module_callback_cluster_worker_timer_delete(nullptr))
 
 WEAK_STUB(LbGetClusterName, envoy_dynamic_module_callback_lb_get_cluster_name(nullptr, nullptr))
 WEAK_STUB(LbGetHostsCount, envoy_dynamic_module_callback_lb_get_hosts_count(nullptr, 0))

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -69,6 +69,20 @@ fn new_cluster_config(
         metrics: envoy_cluster_metrics,
       }))
     },
+    "worker_timer" => {
+      let armed_id = envoy_cluster_metrics
+        .define_counter("timer_armed_total")
+        .ok();
+      let fired_id = envoy_cluster_metrics
+        .define_counter("timer_fired_total")
+        .ok();
+      Some(Box::new(WorkerTimerClusterConfig {
+        upstream_address: config_str.to_string(),
+        armed_id,
+        fired_id,
+        metrics: envoy_cluster_metrics,
+      }))
+    },
     _ => None,
   }
 }
@@ -724,5 +738,118 @@ impl ClusterLb for MemberUpdatePackedAddressLb {
         }
       }
     }
+  }
+}
+
+// =============================================================================
+// Per-worker timer.
+// =============================================================================
+//
+// On the first choose_host (after the worker dispatcher has been captured) the load balancer
+// arms a 50ms repeating worker timer. Arming exercises enable/enabled/disable in one round-trip
+// and increments timer_armed_total only when the enabled/disabled observations agree. Each fire
+// runs on_worker_timer_fired on the worker thread, increments timer_fired_total, and re-arms the
+// timer, so it keeps firing without further requests. The timer is deleted when the load balancer
+// is destroyed on the worker thread at shutdown.
+
+const WORKER_TIMER_INTERVAL_MS: u64 = 50;
+
+struct WorkerTimerClusterConfig {
+  upstream_address: String,
+  armed_id: Option<EnvoyCounterId>,
+  fired_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterConfig for WorkerTimerClusterConfig {
+  fn new_cluster(&self, _envoy_cluster: &dyn EnvoyCluster) -> Box<dyn Cluster> {
+    Box::new(WorkerTimerCluster {
+      upstream_address: self.upstream_address.clone(),
+      hosts: Arc::new(Mutex::new(HostList(Vec::new()))),
+      armed_id: self.armed_id,
+      fired_id: self.fired_id,
+      metrics: self.metrics.clone(),
+    })
+  }
+}
+
+struct WorkerTimerCluster {
+  upstream_address: String,
+  hosts: SharedHostList,
+  armed_id: Option<EnvoyCounterId>,
+  fired_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl Cluster for WorkerTimerCluster {
+  fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
+    let addresses = vec![self.upstream_address.clone()];
+    let weights = vec![1u32];
+    if let Some(host_ptrs) = envoy_cluster.add_hosts(&addresses, &weights) {
+      self.hosts.lock().unwrap().0 = host_ptrs;
+    }
+    envoy_cluster.pre_init_complete();
+  }
+
+  fn new_load_balancer(&self, _envoy_lb: &dyn EnvoyClusterLoadBalancer) -> Box<dyn ClusterLb> {
+    Box::new(WorkerTimerLb {
+      hosts: self.hosts.clone(),
+      timer: None,
+      armed_id: self.armed_id,
+      fired_id: self.fired_id,
+      metrics: self.metrics.clone(),
+    })
+  }
+}
+
+struct WorkerTimerLb {
+  hosts: SharedHostList,
+  timer: Option<Box<dyn EnvoyClusterWorkerTimer>>,
+  armed_id: Option<EnvoyCounterId>,
+  fired_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterLb for WorkerTimerLb {
+  fn choose_host(
+    &mut self,
+    context: Option<&dyn ClusterLbContext>,
+    _async_completion: Box<dyn EnvoyAsyncHostSelectionComplete>,
+  ) -> HostSelectionResult {
+    if self.timer.is_none() {
+      if let Some(timer) = context.and_then(|ctx| ctx.worker_timer_new()) {
+        let interval = std::time::Duration::from_millis(WORKER_TIMER_INTERVAL_MS);
+        timer.enable(interval);
+        let enabled_after_enable = timer.enabled();
+        timer.disable();
+        let disabled_after_disable = !timer.enabled();
+        // Re-arm so the timer actually starts firing.
+        timer.enable(interval);
+        if enabled_after_enable && disabled_after_disable {
+          if let Some(armed_id) = self.armed_id {
+            let _ = self.metrics.increment_counter(armed_id, 1);
+          }
+        }
+        self.timer = Some(timer);
+      }
+    }
+
+    let hosts = self.hosts.lock().unwrap();
+    if hosts.0.is_empty() {
+      return HostSelectionResult::NoHost;
+    }
+    HostSelectionResult::Selected(hosts.0[0])
+  }
+
+  fn on_worker_timer_fired(
+    &mut self,
+    _envoy_lb: &dyn EnvoyClusterLoadBalancer,
+    timer: &dyn EnvoyClusterWorkerTimer,
+  ) {
+    if let Some(fired_id) = self.fired_id {
+      let _ = self.metrics.increment_counter(fired_id, 1);
+    }
+    // Re-arm for periodic firing.
+    timer.enable(std::time::Duration::from_millis(WORKER_TIMER_INTERVAL_MS));
   }
 }


### PR DESCRIPTION
**Commit Message:** dynamic_modules: add per-worker timer support to the cluster ABI
**Additional Description:**

Exposes the worker dispatcher's existing createTimer/enableTimer primitive to dynamic-module clusters 
so a module can run periodic per-worker work, e.g. expiring parked resolutions in a custom cluster so
a parked request can't sit indefinitely.

The per-worker load balancer has no dispatcher at construction, so the worker dispatcher is captured 
the first time chooseHost runs on that worker and the module arms the timer lazily from the request 
path. Timer create, fire, and delete are all confined to that one worker thread.

Risk Level: Low
Testing: Unit + Integration tests added
Docs Changes: N.A
Release Notes: N.A
Platform Specific Features: N.A

