### PR TITLE
reverse_tunnel: drain-aware HCM re-dials on peer GOAWAY

### DIFF
--- a/api/envoy/extensions/filters/network/reverse_tunnel/v3/drain_aware_hcm.proto
+++ b/api/envoy/extensions/filters/network/reverse_tunnel/v3/drain_aware_hcm.proto
@@ -26,4 +26,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message DrainAwareHttpConnectionManager {
   // The underlying HCM configuration to apply.
   http_connection_manager.v3.HttpConnectionManager hcm_config = 1;
+
+  // When true, a peer-initiated GOAWAY on a reverse tunnel makes the initiator drop the draining
+  // tunnel and dial a replacement, so capacity is restored before the old tunnel closes while its
+  // in-flight streams finish. Default false, so the behavior is opt-in and unconfigured listeners
+  // are unaffected.
+  bool enable_drain_with_goaway = 2;
 }

--- a/changelogs/current/new_features/reverse_tunnel__drain-aware-hcm-redial.rst
+++ b/changelogs/current/new_features/reverse_tunnel__drain-aware-hcm-redial.rst
@@ -1,0 +1,4 @@
+Added an opt-in ``enable_drain_with_goaway`` field to the reverse-tunnel drain-aware HTTP connection
+manager. When enabled, a peer-initiated GOAWAY on a reverse tunnel makes the initiator drop the
+draining tunnel and dial a replacement, restoring capacity before the old tunnel closes while its
+in-flight streams finish. Default off, so existing listeners are unaffected.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -20,6 +20,10 @@ DownstreamReverseConnectionIOHandle::DownstreamReverseConnectionIOHandle(
             "DownstreamReverseConnectionIOHandle: taking ownership of socket with FD: {} for "
             "connection key: {}",
             fd_, connection_key_);
+  // Register with the parent so it can null this back-pointer if it is torn down first.
+  if (parent_ != nullptr) {
+    parent_->registerChildIoHandle(*this);
+  }
 }
 
 // DownstreamReverseConnectionIOHandle destructor implementation
@@ -28,6 +32,9 @@ DownstreamReverseConnectionIOHandle::~DownstreamReverseConnectionIOHandle() {
       debug,
       "DownstreamReverseConnectionIOHandle: destroying handle for FD: {} with connection key: {}",
       fd_, connection_key_);
+  if (parent_ != nullptr) {
+    parent_->unregisterChildIoHandle(*this);
+  }
   SET_SOCKET_INVALID(fd_);
 }
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -47,6 +47,19 @@ public:
    */
   const Network::ConnectionSocket& getSocket() const { return *owned_socket_; }
 
+  /**
+   * Key the parent IOHandle uses to track this tunnel (the local address of the outbound TCP
+   * socket at handoff time). The drain-aware HCM passes this back to parent() when the tunnel
+   * begins draining so the parent can drop it from tracking and dial a replacement.
+   */
+  const std::string& connectionKey() const { return connection_key_; }
+
+  /**
+   * Parent ReverseConnectionIOHandle that owns this tunnel. Defensive nullptr return if the
+   * parent has already been torn down.
+   */
+  ReverseConnectionIOHandle* parent() const { return parent_; }
+
 private:
   // The socket that this IOHandle owns and manages lifetime for.
   Network::ConnectionSocketPtr owned_socket_;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -55,10 +55,17 @@ public:
   const std::string& connectionKey() const { return connection_key_; }
 
   /**
-   * Parent ReverseConnectionIOHandle that owns this tunnel. Defensive nullptr return if the
-   * parent has already been torn down.
+   * Parent ReverseConnectionIOHandle that owns this tunnel, or nullptr if the parent has already
+   * been torn down (it clears this back-pointer via detachParent() on teardown). Always re-check
+   * for nullptr at the point of use rather than caching the result.
    */
   ReverseConnectionIOHandle* parent() const { return parent_; }
+
+  /**
+   * Called by the parent ReverseConnectionIOHandle when it is destroyed, so a surviving tunnel's
+   * parent() returns nullptr instead of a dangling pointer.
+   */
+  void detachParent() { parent_ = nullptr; }
 
 private:
   // The socket that this IOHandle owns and manages lifetime for.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -82,6 +82,13 @@ void ReverseConnectionIOHandle::emitAccessLog(const std::string& event,
 void ReverseConnectionIOHandle::cleanup() {
   ENVOY_LOG_MISC(debug, "Starting cleanup of reverse connection resources.");
 
+  // Detach any still-live child tunnel IoHandles so their parent() returns nullptr instead of a
+  // dangling pointer after this object is destroyed.
+  for (auto* child : child_io_handles_) {
+    child->detachParent();
+  }
+  child_io_handles_.clear();
+
   // Reset file events before closing trigger pipe to avoid busy loop from EOF on read FD.
   ENVOY_LOG_MISC(trace,
                  "reverse_tunnel: resetting file events before closing trigger pipe; "

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -815,14 +815,11 @@ void ReverseConnectionIOHandle::removeConnectionState(const std::string& host_ad
             connection_key, host_address, cluster_name);
 }
 
-void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key) {
-  ENVOY_LOG(debug, "reverse_tunnel: Downstream connection closed: {}", connection_key);
-
-  // Find the host for this connection key.
+std::pair<std::string, std::string>
+ReverseConnectionIOHandle::dropTunnelFromTracking(const std::string& connection_key) {
+  // Find which host owns this connection key.
   std::string host_address;
   std::string cluster_name;
-
-  // Search through host_to_conn_info_map_ to find which host this connection belongs to.
   for (const auto& [host, host_info] : host_to_conn_info_map_) {
     if (host_info.connection_keys.find(connection_key) != host_info.connection_keys.end()) {
       host_address = host;
@@ -830,25 +827,33 @@ void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& 
       break;
     }
   }
-
   if (host_address.empty()) {
-    ENVOY_LOG(warn, "Could not find host for connection key: {}", connection_key);
-    return;
+    return {};
   }
 
-  ENVOY_LOG(debug, "Found connection {} belongs to host {} in cluster {}", connection_key,
-            host_address, cluster_name);
-
-  // Remove the connection key from the host's connection set.
   auto host_it = host_to_conn_info_map_.find(host_address);
   if (host_it != host_to_conn_info_map_.end()) {
     host_it->second.connection_keys.erase(connection_key);
-    ENVOY_LOG(debug, "Removed connection key {} from host {} (remaining: {})", connection_key,
-              host_address, host_it->second.connection_keys.size());
+    ENVOY_LOG(debug, "reverse_tunnel: removed connection key {} from host {} (remaining: {})",
+              connection_key, host_address, host_it->second.connection_keys.size());
   }
-
-  // Remove connection state tracking.
   removeConnectionState(host_address, cluster_name, connection_key);
+  return {host_address, cluster_name};
+}
+
+void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key) {
+  ENVOY_LOG(debug, "reverse_tunnel: Downstream connection closed: {}", connection_key);
+
+  auto [host_address, cluster_name] = dropTunnelFromTracking(connection_key);
+  if (host_address.empty()) {
+    // Key already removed (typically via markTunnelDrainingAndDialReplacement when the tunnel
+    // began draining earlier). Benign no-op; logged at debug to avoid noisy warnings.
+    ENVOY_LOG(debug,
+              "reverse_tunnel: connection key {} already removed from tracking; closure cleanup "
+              "is a no-op",
+              connection_key);
+    return;
+  }
 
   emitAccessLog("connection_closed", host_address, cluster_name, connection_key, "");
 
@@ -858,6 +863,29 @@ void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& 
             "reverse_tunnel: Connection closure recorded for host {} in cluster {}. "
             "Next maintenance cycle will re-initiate if needed.",
             host_address, cluster_name);
+}
+
+void ReverseConnectionIOHandle::markTunnelDrainingAndDialReplacement(
+    const std::string& connection_key) {
+  ENVOY_LOG(info,
+            "reverse_tunnel: tunnel {} draining; dropping from tracking and dialing replacement",
+            connection_key);
+
+  // Drop the key so the maintenance loop sees a deficit and dials a replacement. The underlying
+  // TCP socket is left alone: in-flight HTTP/2 streams keep running on it and it closes naturally
+  // on the next FIN; onDownstreamConnectionClosed() then no-ops.
+  const std::string host_address = dropTunnelFromTracking(connection_key).first;
+  if (host_address.empty()) {
+    // Already removed (e.g. a prior drain notice, or the host was pruned). Benign no-op.
+    ENVOY_LOG(debug, "reverse_tunnel: connection key {} not in tracking map; nothing to drain",
+              connection_key);
+    return;
+  }
+
+  // Dial the replacement on the next dispatcher pass instead of waiting for the periodic tick.
+  if (rev_conn_retry_timer_ != nullptr) {
+    rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(0));
+  }
 }
 
 void ReverseConnectionIOHandle::updateStateGauge(const std::string& host_address,

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -303,6 +303,26 @@ public:
   void onDownstreamConnectionClosed(const std::string& connection_key);
 
   /**
+   * Drop a tunnel from tracking because it has begun draining (the downstream HCM sent a
+   * shutdownNotice/GOAWAY due to max_connection_duration or graceful shutdown, or the peer sent a
+   * GOAWAY) and kick maintenance to dial a replacement immediately. The underlying TCP socket is
+   * left alone so in-flight HTTP/2 streams can finish; onDownstreamConnectionClosed() no-ops when
+   * the socket eventually closes.
+   *
+   * @param connection_key the local-address string of the outbound tunnel socket.
+   */
+  void markTunnelDrainingAndDialReplacement(const std::string& connection_key);
+
+  /**
+   * Remove a connection key from per-host tracking (the key set and its state gauge). Shared by the
+   * normal close path and the draining path.
+   * @param connection_key the unique key identifying the connection.
+   * @return {host_address, cluster_name} of the owning host, or empty strings if the key was not
+   *         tracked (already removed or the host was pruned).
+   */
+  std::pair<std::string, std::string> dropTunnelFromTracking(const std::string& connection_key);
+
+  /**
    * Get reference to the cluster manager.
    * @return reference to the cluster manager
    */

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -323,6 +323,18 @@ public:
   std::pair<std::string, std::string> dropTunnelFromTracking(const std::string& connection_key);
 
   /**
+   * Child DownstreamReverseConnectionIOHandles register/unregister here at construction/destruction
+   * so that, if this parent is destroyed while a tunnel connection is still draining, it can null
+   * each child's back-pointer (see cleanup()) and the child's parent() safely returns nullptr.
+   */
+  void registerChildIoHandle(DownstreamReverseConnectionIOHandle& child) {
+    child_io_handles_.insert(&child);
+  }
+  void unregisterChildIoHandle(DownstreamReverseConnectionIOHandle& child) {
+    child_io_handles_.erase(&child);
+  }
+
+  /**
    * Get reference to the cluster manager.
    * @return reference to the cluster manager
    */
@@ -477,6 +489,8 @@ private:
   absl::flat_hash_map<std::string, HostConnectionInfo> host_to_conn_info_map_;
   // Map from cluster name to set of resolved hosts
   absl::flat_hash_map<std::string, absl::flat_hash_set<std::string>> cluster_to_resolved_hosts_map_;
+  // Live child tunnel IoHandles; their back-pointers to this object are nulled on teardown.
+  absl::flat_hash_set<DownstreamReverseConnectionIOHandle*> child_io_handles_;
 
   // Core components
   const ReverseConnectionSocketConfig config_; // Configuration for reverse connections

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
@@ -22,6 +22,8 @@ envoy_cc_extension(
         "//envoy/network:drain_decision_interface",
         "//envoy/server:factory_context_interface",
         "//source/common/http:conn_manager_lib",
+        "//source/common/runtime:runtime_features_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "//source/extensions/filters/network/http_connection_manager:config",

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
@@ -25,18 +25,14 @@ Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createBaseCodec
 Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createCodec(
     Network::Connection& connection, const Buffer::Instance& data,
     Http::ServerConnectionCallbacks& callbacks, Server::OverloadManager& overload_manager) {
-  // Build the "dial a replacement tunnel" action, shared by two triggers:
-  //   - on_local_drain: this connection begins draining locally (max_connection_duration /
-  //     graceful shutdown / listener drain), surfaced via shutdownNotice()/the drain timer.
-  //   - on_peer_goaway: the peer (the upstream's client codec) sends a GOAWAY,
-  //     surfaced via the interposed ServerConnectionCallbacks below.
-  // In both cases we ask the initiator IOHandle to dial a replacement tunnel immediately so the
-  // upstream has a fresh tunnel for new requests while in-flight streams finish on the old one.
-  // Opt-in via enable_drain_with_goaway; off by default.
+  // Build the "dial a replacement tunnel" action shared by two triggers: on_local_drain (this
+  // connection drains locally via max_connection_duration/graceful shutdown/listener drain) and
+  // on_peer_goaway (the peer's client codec sends a GOAWAY). Either way we ask the initiator
+  // IOHandle to dial a replacement immediately so new requests get a fresh tunnel while in-flight
+  // streams finish on the old one. Opt-in via enable_drain_with_goaway.
   //
-  // Recover the ReverseConnectionIOHandle by typed cast on the accepted socket's IoHandle. We
-  // can't key off connection.localAddress() because the listener exposes its bound rc:// address
-  // rather than the underlying socket's local port.
+  // Recover the IOHandle by typed cast on the accepted socket: connection.localAddress() can't be
+  // used because the listener exposes its bound rc:// address, not the socket's local port.
   std::function<void()> on_local_drain = nullptr;
   std::function<void()> on_peer_goaway = nullptr;
   if (enable_drain_with_goaway_) {

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
@@ -44,14 +44,18 @@ Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createCodec(
           &connection.getSocket()->ioHandle());
     }
     if (tunnel_iohandle != nullptr && tunnel_iohandle->parent() != nullptr) {
-      auto* owner = tunnel_iohandle->parent();
       std::string connection_key = tunnel_iohandle->connectionKey();
       ENVOY_LOG_MISC(debug, "drain_aware_hcm: wired dial-replacement-on-drain for tunnel key='{}'",
                      connection_key);
-      // markTunnelDrainingAndDialReplacement is idempotent for a given key, so both triggers can
-      // safely share the same closure.
-      auto redial = [owner, connection_key]() {
-        owner->markTunnelDrainingAndDialReplacement(connection_key);
+      // Capture the tunnel IoHandle (owned by this connection, so alive whenever the closure can
+      // fire) and resolve parent() at invocation rather than caching the raw parent pointer: the
+      // parent ReverseConnectionIOHandle may be torn down first, in which case it has nulled this
+      // back-pointer. markTunnelDrainingAndDialReplacement is idempotent, so both triggers share
+      // it.
+      auto redial = [tunnel_iohandle, connection_key]() {
+        if (auto* owner = tunnel_iohandle->parent(); owner != nullptr) {
+          owner->markTunnelDrainingAndDialReplacement(connection_key);
+        }
       };
       on_local_drain = redial;
       on_peer_goaway = redial;

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.cc
@@ -1,8 +1,13 @@
 #include "source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.h"
 
+#include <functional>
+#include <string>
+
 #include "envoy/common/exception.h"
 
 #include "source/common/common/logger.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h"
 
 namespace Envoy {
@@ -20,7 +25,55 @@ Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createBaseCodec
 Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createCodec(
     Network::Connection& connection, const Buffer::Instance& data,
     Http::ServerConnectionCallbacks& callbacks, Server::OverloadManager& overload_manager) {
-  auto codec = createBaseCodec(connection, data, callbacks, overload_manager);
+  // Build the "dial a replacement tunnel" action, shared by two triggers:
+  //   - on_local_drain: this connection begins draining locally (max_connection_duration /
+  //     graceful shutdown / listener drain), surfaced via shutdownNotice()/the drain timer.
+  //   - on_peer_goaway: the peer (the upstream's client codec) sends a GOAWAY,
+  //     surfaced via the interposed ServerConnectionCallbacks below.
+  // In both cases we ask the initiator IOHandle to dial a replacement tunnel immediately so the
+  // upstream has a fresh tunnel for new requests while in-flight streams finish on the old one.
+  // Opt-in via enable_drain_with_goaway; off by default.
+  //
+  // Recover the ReverseConnectionIOHandle by typed cast on the accepted socket's IoHandle. We
+  // can't key off connection.localAddress() because the listener exposes its bound rc:// address
+  // rather than the underlying socket's local port.
+  std::function<void()> on_local_drain = nullptr;
+  std::function<void()> on_peer_goaway = nullptr;
+  if (enable_drain_with_goaway_) {
+    Envoy::Extensions::Bootstrap::ReverseConnection::DownstreamReverseConnectionIOHandle*
+        tunnel_iohandle = nullptr;
+    if (connection.getSocket() != nullptr) {
+      tunnel_iohandle = dynamic_cast<
+          Envoy::Extensions::Bootstrap::ReverseConnection::DownstreamReverseConnectionIOHandle*>(
+          &connection.getSocket()->ioHandle());
+    }
+    if (tunnel_iohandle != nullptr && tunnel_iohandle->parent() != nullptr) {
+      auto* owner = tunnel_iohandle->parent();
+      std::string connection_key = tunnel_iohandle->connectionKey();
+      ENVOY_LOG_MISC(debug, "drain_aware_hcm: wired dial-replacement-on-drain for tunnel key='{}'",
+                     connection_key);
+      // markTunnelDrainingAndDialReplacement is idempotent for a given key, so both triggers can
+      // safely share the same closure.
+      auto redial = [owner, connection_key]() {
+        owner->markTunnelDrainingAndDialReplacement(connection_key);
+      };
+      on_local_drain = redial;
+      on_peer_goaway = redial;
+    }
+  }
+
+  // If a peer GOAWAY should trigger a re-dial, interpose a callbacks wrapper between the codec and
+  // the HCM so we observe the received GOAWAY (the default server path ignores it). Otherwise use
+  // the HCM callbacks directly.
+  std::unique_ptr<DrainAwareServerConnectionCallbacks> callbacks_wrapper;
+  Http::ServerConnectionCallbacks* effective_callbacks = &callbacks;
+  if (on_peer_goaway != nullptr) {
+    callbacks_wrapper =
+        std::make_unique<DrainAwareServerConnectionCallbacks>(callbacks, std::move(on_peer_goaway));
+    effective_callbacks = callbacks_wrapper.get();
+  }
+
+  auto codec = createBaseCodec(connection, data, *effective_callbacks, overload_manager);
   if (codec == nullptr) {
     ENVOY_LOG_MISC(warn, "drain_aware_hcm: base createCodec returned nullptr for connection id={}",
                    connection.id());
@@ -30,8 +83,9 @@ Http::ServerConnectionPtr DrainAwareHttpConnectionManagerConfig::createCodec(
   // Use the listener-level DrainDecision, NOT serverFactoryContext().drainManager().
   // /drain_listeners fires the listener-level drain decision; the server-wide drain manager
   // only fires on hot-restart / full server shutdown.
-  return std::make_unique<DrainAwareServerConnection>(std::move(codec), connection.dispatcher(),
-                                                      factory_context_.drainDecision());
+  return std::make_unique<DrainAwareServerConnection>(
+      std::move(codec), connection.dispatcher(), factory_context_.drainDecision(),
+      std::move(on_local_drain), std::move(callbacks_wrapper));
 }
 
 absl::StatusOr<Network::FilterFactoryCb>
@@ -46,7 +100,8 @@ DrainAwareHttpConnectionManagerFilterConfigFactory::createFilterFactoryFromProto
   auto filter_config = std::make_shared<DrainAwareHttpConnectionManagerConfig>(
       hcm_config, context, *singletons.date_provider_, *singletons.route_config_provider_manager_,
       singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
-      *singletons.filter_config_provider_manager_, creation_status);
+      *singletons.filter_config_provider_manager_, proto_config.enable_drain_with_goaway(),
+      creation_status);
   RETURN_IF_NOT_OK(creation_status);
 
   return [singletons, filter_config, &context](Network::FilterManager& filter_manager) -> void {

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.h
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.h
@@ -25,12 +25,12 @@ public:
       Config::ConfigProviderManager* scoped_routes_config_provider_manager,
       Tracing::TracerManager& tracer_manager,
       HttpConnectionManager::FilterConfigProviderManager& filter_config_provider_manager,
-      absl::Status& creation_status)
+      bool enable_drain_with_goaway, absl::Status& creation_status)
       : HttpConnectionManager::HttpConnectionManagerConfig(
             config, context, date_provider, route_config_provider_manager,
             scoped_routes_config_provider_manager, tracer_manager, filter_config_provider_manager,
             creation_status),
-        factory_context_(context) {}
+        factory_context_(context), enable_drain_with_goaway_(enable_drain_with_goaway) {}
 
   Http::ServerConnectionPtr createCodec(Network::Connection& connection,
                                         const Buffer::Instance& data,
@@ -47,6 +47,7 @@ protected:
 
 private:
   Server::Configuration::FactoryContext& factory_context_;
+  const bool enable_drain_with_goaway_;
 };
 
 class DrainAwareHttpConnectionManagerFilterConfigFactory

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <utility>
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/http/codec.h"
@@ -13,6 +15,51 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ReverseTunnel {
 
+// Interposes between the HTTP/2 server codec and the HCM's ServerConnectionCallbacks so we can
+// observe a GOAWAY sent by the peer (the upstream's client codec). The default server
+// path ignores a received GOAWAY (ConnectionManagerImpl::onGoAway is a no-op for servers); for
+// reverse tunnels we treat it as "this tunnel is going away" and dial a replacement immediately,
+// while the old tunnel keeps serving in-flight streams until the peer's final GOAWAY closes it.
+//
+// All other callbacks are forwarded unchanged to the real HCM callbacks.
+class DrainAwareServerConnectionCallbacks : public Http::ServerConnectionCallbacks,
+                                            public Logger::Loggable<Logger::Id::filter> {
+public:
+  DrainAwareServerConnectionCallbacks(Http::ServerConnectionCallbacks& inner,
+                                      std::function<void()> on_peer_goaway)
+      : inner_(inner), on_peer_goaway_(std::move(on_peer_goaway)) {}
+
+  // Http::ServerConnectionCallbacks
+  Http::RequestDecoder& newStream(Http::ResponseEncoder& response_encoder,
+                                  bool is_internally_created = false) override {
+    return inner_.newStream(response_encoder, is_internally_created);
+  }
+
+  // Http::ConnectionCallbacks
+  void onGoAway(Http::GoAwayErrorCode error_code) override {
+    // Envoy's codec only delivers the first GOAWAY, but guard anyway so a re-dial fires at most
+    // once per tunnel from this path.
+    if (!peer_goaway_handled_ && on_peer_goaway_ != nullptr) {
+      peer_goaway_handled_ = true;
+      ENVOY_LOG(info,
+                "drain_aware_hcm: peer GOAWAY for connection (code={}); draining tunnel and "
+                "dialing replacement",
+                static_cast<int>(error_code));
+      on_peer_goaway_();
+    }
+    inner_.onGoAway(error_code);
+  }
+  void onSettings(Http::ReceivedSettings& settings) override { inner_.onSettings(settings); }
+  void onMaxStreamsChanged(uint32_t num_streams) override {
+    inner_.onMaxStreamsChanged(num_streams);
+  }
+
+private:
+  Http::ServerConnectionCallbacks& inner_;
+  std::function<void()> on_peer_goaway_;
+  bool peer_goaway_handled_{false};
+};
+
 // Wraps an Http::ServerConnection and proactively sends an HTTP/2 GOAWAY frame when
 // the listener that owns this connection begins draining. Drain is detected by polling
 // DrainDecision::drainClose() on a short timer; this avoids calling addOnDrainCloseCb()
@@ -20,9 +67,16 @@ namespace ReverseTunnel {
 class DrainAwareServerConnection : public Http::ServerConnection,
                                    public Logger::Loggable<Logger::Id::filter> {
 public:
-  DrainAwareServerConnection(Http::ServerConnectionPtr inner, Event::Dispatcher& dispatcher,
-                             const Network::DrainDecision& drain_decision)
-      : inner_(std::move(inner)), drain_decision_(drain_decision) {
+  // `on_local_drain` (optional) fires once when this connection begins draining locally (the HCM
+  // sends a shutdownNotice due to max_connection_duration/graceful shutdown, or the listener
+  // drains). For reverse tunnels this asks the initiator to dial a replacement tunnel immediately
+  // while the old one finishes in-flight streams.
+  DrainAwareServerConnection(
+      Http::ServerConnectionPtr inner, Event::Dispatcher& dispatcher,
+      const Network::DrainDecision& drain_decision, std::function<void()> on_local_drain = nullptr,
+      std::unique_ptr<DrainAwareServerConnectionCallbacks> callbacks_wrapper = nullptr)
+      : callbacks_wrapper_(std::move(callbacks_wrapper)), inner_(std::move(inner)),
+        drain_decision_(drain_decision), on_local_drain_(std::move(on_local_drain)) {
     ENVOY_LOG(debug, "drain_aware_hcm: created server connection wrapper, protocol={}",
               static_cast<int>(inner_->protocol()));
     drain_check_timer_ = dispatcher.createTimer([this]() { onDrainCheckTimer(); });
@@ -38,7 +92,23 @@ public:
   Http::Status dispatch(Buffer::Instance& data) override { return inner_->dispatch(data); }
   void goAway() override { inner_->goAway(); }
   Http::Protocol protocol() override { return inner_->protocol(); }
-  void shutdownNotice() override { inner_->shutdownNotice(); }
+  void shutdownNotice() override {
+    // The HCM calls this at the start of a graceful drain (e.g. max_connection_duration), before
+    // the final GOAWAY emitted at drain_timeout.
+    //
+    // For reverse tunnels (on_local_drain_ set) we use this as the "tunnel is draining" signal to
+    // dial a replacement tunnel NOW, but we deliberately SUPPRESS the early GOAWAY: not forwarding
+    // shutdownNotice() means the peer (upstream client) keeps sending new requests over this tunnel
+    // during the grace window. The HCM still emits the final GOAWAY at drain_timeout via goAway(),
+    // by which point the replacement tunnel is established -- so new requests migrate to it while
+    // in-flight requests finish on this one. This is the "have a replacement before we stop
+    // accepting requests" behavior.
+    if (on_local_drain_ != nullptr) {
+      notifyLocalDrain();
+      return;
+    }
+    inner_->shutdownNotice();
+  }
   bool wantsToWrite() override { return inner_->wantsToWrite(); }
 
   void onUnderlyingConnectionAboveWriteBufferHighWatermark() override {
@@ -57,16 +127,31 @@ private:
     if (drain_decision_.drainClose(Network::DrainDirection::All)) {
       ENVOY_LOG(info, "drain_aware_hcm: drain detected, sending GOAWAY");
       drain_goaway_sent_ = true;
+      notifyLocalDrain();
       inner_->goAway();
       return;
     }
     drain_check_timer_->enableTimer(std::chrono::milliseconds(100));
   }
 
+  // Fires the local-drain callback at most once.
+  void notifyLocalDrain() {
+    if (local_drain_notified_ || on_local_drain_ == nullptr) {
+      return;
+    }
+    local_drain_notified_ = true;
+    on_local_drain_();
+  }
+
+  // Declared before inner_ so the codec (which holds a reference to this wrapper) is destroyed
+  // before the wrapper. Null when the peer-GOAWAY re-dial path is disabled.
+  std::unique_ptr<DrainAwareServerConnectionCallbacks> callbacks_wrapper_;
   Http::ServerConnectionPtr inner_;
   const Network::DrainDecision& drain_decision_;
+  std::function<void()> on_local_drain_;
   Event::TimerPtr drain_check_timer_;
   bool drain_goaway_sent_{false};
+  bool local_drain_notified_{false};
 };
 
 } // namespace ReverseTunnel

--- a/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
+++ b/source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection.h
@@ -15,13 +15,11 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ReverseTunnel {
 
-// Interposes between the HTTP/2 server codec and the HCM's ServerConnectionCallbacks so we can
-// observe a GOAWAY sent by the peer (the upstream's client codec). The default server
-// path ignores a received GOAWAY (ConnectionManagerImpl::onGoAway is a no-op for servers); for
-// reverse tunnels we treat it as "this tunnel is going away" and dial a replacement immediately,
-// while the old tunnel keeps serving in-flight streams until the peer's final GOAWAY closes it.
-//
-// All other callbacks are forwarded unchanged to the real HCM callbacks.
+// Interposes between the HTTP/2 server codec and the HCM's ServerConnectionCallbacks to observe a
+// peer GOAWAY, which the default server path ignores (ConnectionManagerImpl::onGoAway is a no-op
+// for servers). For reverse tunnels we treat it as "this tunnel is going away" and dial a
+// replacement immediately, while the old tunnel serves in-flight streams until the peer's final
+// GOAWAY closes it. All other callbacks are forwarded unchanged.
 class DrainAwareServerConnectionCallbacks : public Http::ServerConnectionCallbacks,
                                             public Logger::Loggable<Logger::Id::filter> {
 public:
@@ -93,16 +91,11 @@ public:
   void goAway() override { inner_->goAway(); }
   Http::Protocol protocol() override { return inner_->protocol(); }
   void shutdownNotice() override {
-    // The HCM calls this at the start of a graceful drain (e.g. max_connection_duration), before
-    // the final GOAWAY emitted at drain_timeout.
-    //
-    // For reverse tunnels (on_local_drain_ set) we use this as the "tunnel is draining" signal to
-    // dial a replacement tunnel NOW, but we deliberately SUPPRESS the early GOAWAY: not forwarding
-    // shutdownNotice() means the peer (upstream client) keeps sending new requests over this tunnel
-    // during the grace window. The HCM still emits the final GOAWAY at drain_timeout via goAway(),
-    // by which point the replacement tunnel is established -- so new requests migrate to it while
-    // in-flight requests finish on this one. This is the "have a replacement before we stop
-    // accepting requests" behavior.
+    // The HCM calls this at the start of a graceful drain (e.g. max_connection_duration). For
+    // reverse tunnels (on_local_drain_ set) we use it as the "tunnel draining" signal to dial a
+    // replacement now, but SUPPRESS the early GOAWAY so the peer keeps using this tunnel during the
+    // grace window. The HCM's final GOAWAY at drain_timeout (via goAway()) then migrates new
+    // requests to the established replacement while in-flight requests finish here.
     if (on_local_drain_ != nullptr) {
       notifyLocalDrain();
       return;

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -190,6 +190,17 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, Setup) {
   } // Destructor called here
 }
 
+// When the parent ReverseConnectionIOHandle is destroyed first, it detaches its still-live children
+// so a surviving tunnel's parent() returns nullptr instead of a dangling pointer.
+TEST_F(DownstreamReverseConnectionIOHandleTest, ParentTeardownDetachesChild) {
+  auto child = createHandle(io_handle_.get(), "detach_key");
+  EXPECT_EQ(child->parent(), io_handle_.get());
+
+  // Destroying the parent runs cleanup(), which detaches its registered children.
+  io_handle_.reset();
+  EXPECT_EQ(child->parent(), nullptr);
+}
+
 // Test close() method and all edge cases.
 TEST_F(DownstreamReverseConnectionIOHandleTest, CloseMethod) {
   // Test with parent - should notify parent and reset socket.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -3311,6 +3311,74 @@ TEST_F(ReverseConnectionIOHandleTest, CloseNoDoubleCloseWithPipeFds) {
   io_handle_.reset();
 }
 
+// markTunnelDrainingAndDialReplacement() drops the draining tunnel from tracking and arms the
+// retry timer so the maintenance loop dials a replacement on the next dispatcher pass.
+TEST_F(ReverseConnectionIOHandleTest, MarkTunnelDrainingDropsKeyAndDialsReplacement) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  // Capture the retry timer created during initializeFileEvent so we can assert it is re-armed.
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  // Track a host with a single live tunnel.
+  const std::string host = "192.168.1.1";
+  const std::string connection_key = "192.168.1.1:12345";
+  addHostConnectionInfo(host, "remote-cluster", 1);
+  getMutableHostConnectionInfo(host).connection_keys.insert(connection_key);
+
+  // The replacement is dialed immediately (0ms) rather than waiting for the periodic tick.
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(0), _));
+
+  io_handle_->markTunnelDrainingAndDialReplacement(connection_key);
+
+  // The draining tunnel is no longer tracked, leaving a deficit for the maintenance loop to fill.
+  EXPECT_EQ(getHostConnectionInfo(host).connection_keys.count(connection_key), 0);
+}
+
+// Draining an unknown connection key is a benign no-op: nothing is dropped and no immediate
+// replacement dial is triggered.
+TEST_F(ReverseConnectionIOHandleTest, MarkTunnelDrainingUnknownKeyIsNoOp) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(_, _)).Times(testing::AnyNumber());
+  // An unknown key must not arm an immediate (0ms) replacement dial.
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(0), _)).Times(0);
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  io_handle_->markTunnelDrainingAndDialReplacement("203.0.113.9:9999");
+}
+
+// Closing a connection key that is no longer tracked (e.g. it was already dropped when the tunnel
+// began draining) is a benign no-op and must not crash.
+TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedUnknownKeyIsNoOp) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  io_handle_->onDownstreamConnectionClosed("203.0.113.9:9999");
+  EXPECT_TRUE(getHostToConnInfoMap().empty());
+}
+
 } // namespace ReverseConnection
 } // namespace Bootstrap
 } // namespace Extensions

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/BUILD
@@ -34,6 +34,8 @@ envoy_extension_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/stats:isolated_store_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/filters/http/router:config",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/filters/network/reverse_tunnel/drain_aware_hcm:drain_aware_config",
@@ -42,6 +44,7 @@ envoy_extension_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/server:overload_manager_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -110,7 +110,8 @@ TEST_F(DrainAwareConfigTest, CreateCodecReturnsNullptrWhenBaseReturnsNullptr) {
   auto config = std::make_shared<NullCodecDrainAwareConfig>(
       hcm_config, context_, *singletons.date_provider_, *singletons.route_config_provider_manager_,
       singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
-      *singletons.filter_config_provider_manager_, creation_status);
+      *singletons.filter_config_provider_manager_, /*enable_drain_with_goaway=*/false,
+      creation_status);
   ASSERT_TRUE(creation_status.ok()) << creation_status.message();
 
   NiceMock<Network::MockConnection> connection;

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -1,8 +1,13 @@
+#include "source/common/stats/isolated_store_impl.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config.h"
 
+#include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/server/overload_manager.h"
+#include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"
 
@@ -11,6 +16,8 @@
 
 using testing::_;
 using testing::NiceMock;
+using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -121,6 +128,106 @@ TEST_F(DrainAwareConfigTest, CreateCodecReturnsNullptrWhenBaseReturnsNullptr) {
 
   auto codec = config->createCodec(connection, data, callbacks, overload_manager);
   EXPECT_EQ(nullptr, codec);
+}
+
+// Subclass that returns a real (mock) codec from createBaseCodec, so createCodec() exercises the
+// drain-aware wrapping path rather than the defensive nullptr branch.
+class FakeCodecDrainAwareConfig : public DrainAwareHttpConnectionManagerConfig {
+public:
+  using DrainAwareHttpConnectionManagerConfig::DrainAwareHttpConnectionManagerConfig;
+
+  Http::ServerConnectionPtr createBaseCodec(Network::Connection&, const Buffer::Instance&,
+                                            Http::ServerConnectionCallbacks& callbacks,
+                                            Server::OverloadManager&) override {
+    last_callbacks_ = &callbacks;
+    auto codec = std::make_unique<NiceMock<Http::MockServerConnection>>();
+    ON_CALL(*codec, protocol()).WillByDefault(Return(Http::Protocol::Http2));
+    return codec;
+  }
+
+  Http::ServerConnectionCallbacks* last_callbacks_{nullptr};
+};
+
+// With drain_with_goaway enabled but a plain (non reverse-tunnel) socket, the typed cast yields no
+// initiator handle, so no re-dial wiring is installed; the drain-aware wrapper is still produced
+// and the codec callbacks are passed through unchanged (no GOAWAY-observing wrapper).
+TEST_F(DrainAwareConfigTest, CreateCodecDrainEnabledNonReverseSocket) {
+  auto proto_config = parseConfig(kMinimalConfig);
+  const auto& hcm_config = proto_config.hcm_config();
+  auto singletons = HttpConnectionManager::Utility::createSingletons(context_);
+
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::make_shared<FakeCodecDrainAwareConfig>(
+      hcm_config, context_, *singletons.date_provider_, *singletons.route_config_provider_manager_,
+      singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
+      *singletons.filter_config_provider_manager_, /*enable_drain_with_goaway=*/true,
+      creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status.message();
+
+  NiceMock<Network::MockConnection> connection;
+  // Default MockConnectionSocket exposes a stock IoSocketHandleImpl, which the typed cast rejects.
+  Network::ConnectionSocketPtr socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  ON_CALL(connection, getSocket()).WillByDefault(ReturnRef(socket));
+
+  NiceMock<Http::MockServerConnectionCallbacks> callbacks;
+  NiceMock<Server::MockOverloadManager> overload_manager;
+  Buffer::OwnedImpl data;
+
+  auto codec = config->createCodec(connection, data, callbacks, overload_manager);
+  EXPECT_NE(nullptr, codec);
+  // No peer-GOAWAY wrapper: the HCM callbacks are forwarded to the base codec directly.
+  EXPECT_EQ(&callbacks, config->last_callbacks_);
+}
+
+// With drain_with_goaway enabled and a reverse-tunnel socket whose IoHandle has a live parent
+// initiator, createCodec() installs both the local-drain re-dial closure and a GOAWAY-observing
+// callbacks wrapper interposed in front of the HCM callbacks.
+TEST_F(DrainAwareConfigTest, CreateCodecDrainEnabledReverseTunnelWiresRedial) {
+  auto proto_config = parseConfig(kMinimalConfig);
+  const auto& hcm_config = proto_config.hcm_config();
+  auto singletons = HttpConnectionManager::Utility::createSingletons(context_);
+
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::make_shared<FakeCodecDrainAwareConfig>(
+      hcm_config, context_, *singletons.date_provider_, *singletons.route_config_provider_manager_,
+      singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
+      *singletons.filter_config_provider_manager_, /*enable_drain_with_goaway=*/true,
+      creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status.message();
+
+  // Build a real initiator IoHandle to act as the tunnel's parent. The extension is unused during
+  // codec construction (the re-dial closure that would reach it is created but not invoked here).
+  NiceMock<Upstream::MockClusterManager> cluster_manager;
+  Stats::IsolatedStoreImpl stats_store;
+  Bootstrap::ReverseConnection::ReverseConnectionSocketConfig rc_config;
+  rc_config.src_node_id = "node";
+  rc_config.src_cluster_id = "cluster";
+  auto parent = std::make_unique<Bootstrap::ReverseConnection::ReverseConnectionIOHandle>(
+      ::socket(AF_INET, SOCK_STREAM, 0), rc_config, cluster_manager, /*extension=*/nullptr,
+      *stats_store.rootScope());
+
+  // The accepted socket's IoHandle is the reverse-tunnel handle owning an (unused) inner socket.
+  auto tunnel_handle =
+      std::make_unique<Bootstrap::ReverseConnection::DownstreamReverseConnectionIOHandle>(
+          std::make_unique<NiceMock<Network::MockConnectionSocket>>(), parent.get(),
+          "10.0.0.1:5000");
+  auto outer_mock = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  ON_CALL(*outer_mock, ioHandle()).WillByDefault(ReturnRef(*tunnel_handle));
+  ON_CALL(testing::Const(*outer_mock), ioHandle()).WillByDefault(ReturnRef(*tunnel_handle));
+  Network::ConnectionSocketPtr socket = std::move(outer_mock);
+
+  NiceMock<Network::MockConnection> connection;
+  ON_CALL(connection, getSocket()).WillByDefault(ReturnRef(socket));
+
+  NiceMock<Http::MockServerConnectionCallbacks> callbacks;
+  NiceMock<Server::MockOverloadManager> overload_manager;
+  Buffer::OwnedImpl data;
+
+  auto codec = config->createCodec(connection, data, callbacks, overload_manager);
+  EXPECT_NE(nullptr, codec);
+  // A GOAWAY-observing wrapper is interposed, so the base codec sees the wrapper, not the raw
+  // HCM callbacks.
+  EXPECT_NE(&callbacks, config->last_callbacks_);
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -130,6 +130,33 @@ TEST_F(DrainAwareConfigTest, CreateCodecReturnsNullptrWhenBaseReturnsNullptr) {
   EXPECT_EQ(nullptr, codec);
 }
 
+// Same defensive nullptr check, but with drain_with_goaway enabled: createCodec runs the re-dial
+// wiring block first (here a plain socket, so no wiring), then returns nullptr when the base codec
+// declines.
+TEST_F(DrainAwareConfigTest, CreateCodecReturnsNullptrWhenBaseReturnsNullptrDrainEnabled) {
+  auto proto_config = parseConfig(kMinimalConfig);
+  const auto& hcm_config = proto_config.hcm_config();
+  auto singletons = HttpConnectionManager::Utility::createSingletons(context_);
+
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::make_shared<NullCodecDrainAwareConfig>(
+      hcm_config, context_, *singletons.date_provider_, *singletons.route_config_provider_manager_,
+      singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
+      *singletons.filter_config_provider_manager_, /*enable_drain_with_goaway=*/true,
+      creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status.message();
+
+  NiceMock<Network::MockConnection> connection;
+  Network::ConnectionSocketPtr socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  ON_CALL(connection, getSocket()).WillByDefault(ReturnRef(socket));
+  NiceMock<Http::MockServerConnectionCallbacks> callbacks;
+  NiceMock<Server::MockOverloadManager> overload_manager;
+  Buffer::OwnedImpl data;
+
+  auto codec = config->createCodec(connection, data, callbacks, overload_manager);
+  EXPECT_EQ(nullptr, codec);
+}
+
 // Subclass that returns a real (mock) codec from createBaseCodec, so createCodec() exercises the
 // drain-aware wrapping path rather than the defensive nullptr branch.
 class FakeCodecDrainAwareConfig : public DrainAwareHttpConnectionManagerConfig {

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -157,6 +157,49 @@ TEST_F(DrainAwareConfigTest, CreateCodecReturnsNullptrWhenBaseReturnsNullptrDrai
   EXPECT_EQ(nullptr, codec);
 }
 
+// Exercises the real createBaseCodec (parent HCM codec construction) rather than a test override,
+// building an HTTP/1 server codec and wrapping it in the drain-aware connection.
+TEST_F(DrainAwareConfigTest, CreateCodecBuildsRealHttp1BaseCodec) {
+  constexpr absl::string_view kHttp1Config = R"EOF(
+hcm_config:
+  stat_prefix: test
+  codec_type: HTTP1
+  route_config:
+    virtual_hosts:
+    - name: local
+      domains: ["*"]
+      routes:
+      - match:
+          prefix: "/"
+        direct_response:
+          status: 200
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+)EOF";
+  auto proto_config = parseConfig(kHttp1Config);
+  const auto& hcm_config = proto_config.hcm_config();
+  auto singletons = HttpConnectionManager::Utility::createSingletons(context_);
+
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::make_shared<DrainAwareHttpConnectionManagerConfig>(
+      hcm_config, context_, *singletons.date_provider_, *singletons.route_config_provider_manager_,
+      singletons.scoped_routes_config_provider_manager_.get(), *singletons.tracer_manager_,
+      *singletons.filter_config_provider_manager_, /*enable_drain_with_goaway=*/false,
+      creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status.message();
+
+  NiceMock<Network::MockConnection> connection;
+  NiceMock<Http::MockServerConnectionCallbacks> callbacks;
+  NiceMock<Server::MockOverloadManager> overload_manager;
+  Buffer::OwnedImpl data;
+
+  auto codec = config->createCodec(connection, data, callbacks, overload_manager);
+  ASSERT_NE(nullptr, codec);
+  EXPECT_EQ(Http::Protocol::Http11, codec->protocol());
+}
+
 // Subclass that returns a real (mock) codec from createBaseCodec, so createCodec() exercises the
 // drain-aware wrapping path rather than the defensive nullptr branch.
 class FakeCodecDrainAwareConfig : public DrainAwareHttpConnectionManagerConfig {

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -298,6 +298,11 @@ TEST_F(DrainAwareConfigTest, CreateCodecDrainEnabledReverseTunnelWiresRedial) {
   // A GOAWAY-observing wrapper is interposed, so the base codec sees the wrapper, not the raw
   // HCM callbacks.
   EXPECT_NE(&callbacks, config->last_callbacks_);
+
+  // Firing the local drain runs the re-dial closure, which asks the (real) initiator IOHandle to
+  // dial a replacement tunnel. With no tunnels tracked this is a safe no-op, but it exercises the
+  // wired closure.
+  codec->shutdownNotice();
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
@@ -154,7 +154,8 @@ TEST_F(DrainAwareServerConnectionTest, TimerFiresAfterGoAwaySentIsNoop) {
 // With an on_local_drain callback set, shutdownNotice() fires the callback and SUPPRESSES the
 // inner shutdownNotice (the early GOAWAY), so the peer keeps using the tunnel during the grace
 // window while a replacement is dialed.
-TEST_F(DrainAwareServerConnectionTest, ShutdownNoticeWithLocalDrainFiresCallbackAndSuppressesInner) {
+TEST_F(DrainAwareServerConnectionTest,
+       ShutdownNoticeWithLocalDrainFiresCallbackAndSuppressesInner) {
   bool fired = false;
   EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(100), _));
   auto conn = std::make_unique<DrainAwareServerConnection>(

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
@@ -2,6 +2,8 @@
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/http/stream_decoder.h"
+#include "test/mocks/http/stream_encoder.h"
 #include "test/mocks/network/mocks.h"
 
 #include "gmock/gmock.h"
@@ -10,6 +12,7 @@
 using testing::_;
 using testing::NiceMock;
 using testing::Return;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -146,6 +149,83 @@ TEST_F(DrainAwareServerConnectionTest, TimerFiresAfterGoAwaySentIsNoop) {
   timer_->callback_();
 
   destroyConnection(conn);
+}
+
+// With an on_local_drain callback set, shutdownNotice() fires the callback and SUPPRESSES the
+// inner shutdownNotice (the early GOAWAY), so the peer keeps using the tunnel during the grace
+// window while a replacement is dialed.
+TEST_F(DrainAwareServerConnectionTest, ShutdownNoticeWithLocalDrainFiresCallbackAndSuppressesInner) {
+  bool fired = false;
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(100), _));
+  auto conn = std::make_unique<DrainAwareServerConnection>(
+      std::move(inner_), dispatcher_, drain_decision_, [&fired]() { fired = true; });
+  EXPECT_CALL(*inner_ptr_, shutdownNotice()).Times(0);
+  conn->shutdownNotice();
+  EXPECT_TRUE(fired);
+  destroyConnection(conn);
+}
+
+// on_local_drain fires at most once across shutdownNotice() and the drain timer.
+TEST_F(DrainAwareServerConnectionTest, LocalDrainFiresAtMostOnce) {
+  int fired = 0;
+  EXPECT_CALL(*timer_, enableTimer(std::chrono::milliseconds(100), _));
+  auto conn = std::make_unique<DrainAwareServerConnection>(
+      std::move(inner_), dispatcher_, drain_decision_, [&fired]() { ++fired; });
+  conn->shutdownNotice();
+  EXPECT_EQ(1, fired);
+
+  // The drain timer also detects drain and emits the final GOAWAY, but the once-guard prevents a
+  // second callback fire.
+  ON_CALL(drain_decision_, drainClose(_)).WillByDefault(Return(true));
+  EXPECT_CALL(*inner_ptr_, goAway());
+  timer_->invokeCallback();
+  EXPECT_EQ(1, fired);
+  destroyConnection(conn);
+}
+
+// Tests for the peer-GOAWAY interceptor that sits between the codec and the HCM callbacks.
+class DrainAwareServerConnectionCallbacksTest : public testing::Test {
+protected:
+  NiceMock<Http::MockServerConnectionCallbacks> inner_callbacks_;
+};
+
+// A received GOAWAY fires the re-dial closure exactly once and still delegates to the inner
+// callbacks; a second GOAWAY delegates but does not re-fire the closure.
+TEST_F(DrainAwareServerConnectionCallbacksTest, PeerGoAwayFiresClosureOnceAndDelegates) {
+  int fired = 0;
+  DrainAwareServerConnectionCallbacks wrapper(inner_callbacks_, [&fired]() { ++fired; });
+
+  EXPECT_CALL(inner_callbacks_, onGoAway(Http::GoAwayErrorCode::NoError));
+  wrapper.onGoAway(Http::GoAwayErrorCode::NoError);
+  EXPECT_EQ(1, fired);
+
+  EXPECT_CALL(inner_callbacks_, onGoAway(Http::GoAwayErrorCode::NoError));
+  wrapper.onGoAway(Http::GoAwayErrorCode::NoError);
+  EXPECT_EQ(1, fired);
+}
+
+// A null closure (peer-GOAWAY re-dial disabled) just delegates onGoAway.
+TEST_F(DrainAwareServerConnectionCallbacksTest, NullClosureJustDelegatesGoAway) {
+  DrainAwareServerConnectionCallbacks wrapper(inner_callbacks_, nullptr);
+  EXPECT_CALL(inner_callbacks_, onGoAway(Http::GoAwayErrorCode::NoError));
+  wrapper.onGoAway(Http::GoAwayErrorCode::NoError);
+}
+
+// newStream passes through to the inner callbacks unchanged.
+TEST_F(DrainAwareServerConnectionCallbacksTest, NewStreamDelegates) {
+  DrainAwareServerConnectionCallbacks wrapper(inner_callbacks_, nullptr);
+  NiceMock<Http::MockResponseEncoder> encoder;
+  NiceMock<Http::MockRequestDecoder> decoder;
+  EXPECT_CALL(inner_callbacks_, newStream(_, false)).WillOnce(ReturnRef(decoder));
+  EXPECT_EQ(&decoder, &wrapper.newStream(encoder, false));
+}
+
+// onSettings passes through to the inner callbacks unchanged.
+TEST_F(DrainAwareServerConnectionCallbacksTest, OnSettingsDelegates) {
+  DrainAwareServerConnectionCallbacks wrapper(inner_callbacks_, nullptr);
+  NiceMock<Http::MockReceivedSettings> settings;
+  EXPECT_CALL(inner_callbacks_, onSettings(_));
+  wrapper.onSettings(settings);
 }
 
 } // namespace

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_server_connection_test.cc
@@ -229,6 +229,14 @@ TEST_F(DrainAwareServerConnectionCallbacksTest, OnSettingsDelegates) {
   wrapper.onSettings(settings);
 }
 
+// onMaxStreamsChanged passes through to the inner callbacks unchanged. (onMaxStreamsChanged has a
+// default interface implementation, so it is not a gmock method; exercising the forwarding path is
+// enough for coverage.)
+TEST_F(DrainAwareServerConnectionCallbacksTest, OnMaxStreamsChangedDelegates) {
+  DrainAwareServerConnectionCallbacks wrapper(inner_callbacks_, nullptr);
+  wrapper.onMaxStreamsChanged(7);
+}
+
 } // namespace
 } // namespace ReverseTunnel
 } // namespace NetworkFilters


### PR DESCRIPTION
On a reverse tunnel the downstream is the HTTP/2 server. When the peer upstream drains it sends GOAWAY, but HCM ignores GOAWAY by default, so the tunnel lingers until the socket closes and the agent does not proactively restore capacity.

This makes the drain-aware HCM react to a peer GOAWAY by re-dialing a replacement tunnel, so capacity is restored before the draining tunnel closes while its in-flight streams finish. Opt-in via ``enable_drain_with_goaway`` on the drain-aware HCM config; default off, so unupgraded or disabled downstreams are unaffected (a received GOAWAY stays a no-op) -- a safe migration path.

Companion to #45874 (the upstream emits the drain GOAWAY); the two are independent and each is harmless alone.

**Commit Message:** reverse_tunnel: drain-aware HCM re-dials on peer GOAWAY
**Additional Description:** See above.
**Risk Level:** Low -- config-gated, default off; unchanged behavior when off.
**Testing:** unit tests (drain_aware_config_test, drain_aware_server_connection_test); manual end-to-end + mixed-version safety (an old downstream safely ignores the GOAWAY without crashing).
**Docs Changes:** drain_aware_hcm config field docs.
**Release Notes:** changelog fragment included.
**Platform Specific Features:** n/a
**Optional Runtime guard:** n/a (config-gated)
**Optional API Considerations:** adds ``enable_drain_with_goaway`` to ``DrainAwareHttpConnectionManager``.
