### PR TITLE
grpc_http1_reverse_bridge: fix SEGFAULT when buffering large response without response_size_header

### DIFF
--- a/changelogs/current/bug_fixes/grpc_http1_reverse_bridge__fixed-segfault-when-buffering-large-response.rst
+++ b/changelogs/current/bug_fixes/grpc_http1_reverse_bridge__fixed-segfault-when-buffering-large-response.rst
@@ -1,0 +1,4 @@
+Fixed a crash (SEGFAULT) in the ``grpc_http1_reverse_bridge`` filter when ``withhold_grpc_frames``
+is enabled without ``response_size_header`` and the upstream response body exceeds the downstream
+HTTP/2 stream flow control window. The filter now uses the upstream ``Content-Length`` header to
+stream the response incrementally instead of buffering and releasing it all at once.

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -170,10 +170,21 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
           return Http::FilterHeadersStatus::StopIteration;
         }
       } else {
-        // If we are buffering the response, adjust content-length to account for the frame header
-        // that's added.
-        adjustContentLength(headers,
-                            [](auto length) { return length + Grpc::GRPC_FRAME_HEADER_SIZE; });
+        // If the upstream provided a Content-Length header, use it to stream the response
+        // instead of buffering the entire body. This avoids releasing all data in a single
+        // encodeData call which can overwhelm the H2 codec with too many frames at once.
+        auto length_header = headers.getContentLengthValue();
+        uint64_t content_length = 0;
+        if (!length_header.empty() && absl::SimpleAtoi(length_header, &content_length) &&
+            content_length > 0) {
+          response_message_length_ = static_cast<uint32_t>(content_length);
+          content_length_from_header_ = true;
+          headers.setContentLength(response_message_length_ + Grpc::GRPC_FRAME_HEADER_SIZE);
+        } else {
+          // No Content-Length available; fall back to buffering the entire response.
+          adjustContentLength(headers,
+                              [](auto length) { return length + Grpc::GRPC_FRAME_HEADER_SIZE; });
+        }
       }
     }
     // We can only insert trailers at the end of data, so keep track of this value
@@ -209,9 +220,10 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& buffer, bool end_str
     return Http::FilterDataStatus::Continue;
   }
 
-  // If we're getting the response size from an upstream header, we can stream the response. The
-  // first chunk of data we encode needs the gRPC frame header prepended.
-  if (withhold_grpc_frames_ && response_size_header_ && !frame_header_added_) {
+  // If we know the response size (from response_size_header or Content-Length), we can stream
+  // the response. The first chunk of data we encode needs the gRPC frame header prepended.
+  if (withhold_grpc_frames_ && (response_size_header_ || content_length_from_header_) &&
+      !frame_header_added_) {
     buildGrpcFrameHeader(buffer, response_message_length_);
     frame_header_added_ = true;
   }
@@ -222,7 +234,7 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& buffer, bool end_str
     trailers.setGrpcStatus(grpc_status_);
 
     if (withhold_grpc_frames_) {
-      if (response_size_header_) {
+      if (response_size_header_ || content_length_from_header_) {
         if (upstream_response_bytes_ != response_message_length_) {
           encoder_callbacks_->sendLocalReply(
               Http::Code::OK, "envoy reverse bridge: upstream set incorrect content length",
@@ -240,7 +252,7 @@ Http::FilterDataStatus Filter::encodeData(Buffer::Instance& buffer, bool end_str
   }
 
   if (withhold_grpc_frames_) {
-    if (response_size_header_) {
+    if (response_size_header_ || content_length_from_header_) {
       return Http::FilterDataStatus::Continue;
     }
 
@@ -260,7 +272,7 @@ Http::FilterTrailersStatus Filter::encodeTrailers(Http::ResponseTrailerMap& trai
 
   trailers.setGrpcStatus(grpc_status_);
 
-  if (withhold_grpc_frames_ && !response_size_header_) {
+  if (withhold_grpc_frames_ && !response_size_header_ && !content_length_from_header_) {
     buildGrpcFrameHeader(buffer_, buffer_.length());
     encoder_callbacks_->addEncodedData(buffer_, false);
   }

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -183,9 +183,8 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
           // A single protobuf message cannot exceed 2GB.
           if (content_length > std::numeric_limits<uint32_t>::max()) {
             decoder_callbacks_->sendLocalReply(
-                Http::Code::OK,
-                "envoy reverse bridge: upstream response too large for gRPC frame", nullptr,
-                Grpc::Status::WellKnownGrpcStatus::Internal,
+                Http::Code::OK, "envoy reverse bridge: upstream response too large for gRPC frame",
+                nullptr, Grpc::Status::WellKnownGrpcStatus::Internal,
                 RcDetails::get().GrpcBridgeFailedWrongContentLength);
             return Http::FilterHeadersStatus::StopIteration;
           }

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h"
 
+#include <limits>
+
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 
@@ -159,7 +161,8 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
             absl::SimpleAtoi(length_headers[0]->value().getStringView().substr(
                                  0, length_headers[0]->value().getStringView().find(',')),
                              &response_message_length_)) {
-          headers.setContentLength(response_message_length_ + Grpc::GRPC_FRAME_HEADER_SIZE);
+          headers.setContentLength(static_cast<uint64_t>(response_message_length_) +
+                                   Grpc::GRPC_FRAME_HEADER_SIZE);
         } else {
           // If the response from upstream does not specify the content length, stand in an error
           // message.
@@ -177,9 +180,19 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
         uint64_t content_length = 0;
         if (!length_header.empty() && absl::SimpleAtoi(length_header, &content_length) &&
             content_length > 0) {
+          // A single protobuf message cannot exceed 2GB.
+          if (content_length > std::numeric_limits<uint32_t>::max()) {
+            decoder_callbacks_->sendLocalReply(
+                Http::Code::OK,
+                "envoy reverse bridge: upstream response too large for gRPC frame", nullptr,
+                Grpc::Status::WellKnownGrpcStatus::Internal,
+                RcDetails::get().GrpcBridgeFailedWrongContentLength);
+            return Http::FilterHeadersStatus::StopIteration;
+          }
           response_message_length_ = static_cast<uint32_t>(content_length);
           content_length_from_header_ = true;
-          headers.setContentLength(response_message_length_ + Grpc::GRPC_FRAME_HEADER_SIZE);
+          headers.setContentLength(static_cast<uint64_t>(response_message_length_) +
+                                   Grpc::GRPC_FRAME_HEADER_SIZE);
         } else {
           // No Content-Length available; fall back to buffering the entire response.
           adjustContentLength(headers,

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/filter.h
@@ -51,6 +51,9 @@ private:
   // Tracking state for gRPC frame status when withholding gRPC frames from the
   // upstream and streaming responses.
   bool frame_header_added_{};
+  // Set when Content-Length from response headers is used to determine the
+  // response size for streaming (when response_size_header is not configured).
+  bool content_length_from_header_{};
   // The content length reported by the upstream.
   uint32_t response_message_length_{};
   // The actual size of the response returned by the upstream so far.

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -1011,7 +1011,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesStreamsWithContentLength) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1069,7 +1070,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -1011,7 +1011,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesStreamsWithContentLength) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1069,7 +1069,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1117,7 +1117,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -222,7 +222,8 @@ TEST_F(ReverseBridgeTest, GrpcRequestNoManageFrameHeader) {
 }
 
 // Tests that a gRPC is downgraded to application/x-protobuf and upgraded back
-// to gRPC.
+// to gRPC. When the upstream provides Content-Length, the response is streamed
+// instead of buffered.
 TEST_F(ReverseBridgeTest, GrpcRequest) {
   initialize();
   decoder_callbacks_.is_grpc_request_ = true;
@@ -271,36 +272,32 @@ TEST_F(ReverseBridgeTest, GrpcRequest) {
   EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "35"));
 
   {
-    // First few calls should drain the buffer
+    // With Content-Length available, the response is streamed. The first chunk gets the gRPC
+    // frame header prepended.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("abc", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    // 5 byte gRPC frame header + 4 bytes of data
+    EXPECT_EQ(9, buffer.length());
   }
   {
-    // First few calls should drain the buffer
+    // Subsequent chunks are streamed through without modification.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("def", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(4, buffer.length());
   }
   {
-    // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
+    // Last call inserts gRPC status into trailers. Data passes through since we already sent
+    // the gRPC frame header.
     Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("ghj", 4);
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, true));
-    EXPECT_EQ(17, buffer.length());
+    EXPECT_EQ(4, buffer.length());
     EXPECT_THAT(trailers, ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
-
-    Grpc::Decoder decoder;
-    std::vector<Grpc::Frame> frames;
-    std::ignore = decoder.decode(buffer, frames);
-
-    EXPECT_EQ(1, frames.size());
-    EXPECT_EQ(12, frames[0].length_);
   }
 }
 
@@ -711,36 +708,29 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
   EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "35"));
 
   {
-    // First few calls should drain the buffer
+    // With Content-Length, the response is streamed. First chunk gets gRPC frame header.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("abc", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(9, buffer.length());
   }
   {
-    // First few calls should drain the buffer
+    // Subsequent chunks pass through.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("def", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(4, buffer.length());
   }
   {
-    // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
+    // Last call inserts gRPC status trailers.
     Http::TestResponseTrailerMapImpl trailers;
     EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
 
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("ghj", 4);
     EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, true));
-    EXPECT_EQ(17, buffer.length());
+    EXPECT_EQ(4, buffer.length());
     EXPECT_THAT(trailers, ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
-
-    Grpc::Decoder decoder;
-    std::vector<Grpc::Frame> frames;
-    std::ignore = decoder.decode(buffer, frames);
-
-    EXPECT_EQ(1, frames.size());
-    EXPECT_EQ(12, frames[0].length_);
   }
 }
 
@@ -790,36 +780,27 @@ TEST_F(ReverseBridgeTest, RouteWithTrailers) {
   EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "35"));
 
   {
-    // First few calls should drain the buffer
+    // With Content-Length, the response is streamed. First chunk gets gRPC frame header.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("abc", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(9, buffer.length());
   }
   {
-    // First few calls should drain the buffer
+    // Subsequent chunks pass through.
     Envoy::Buffer::OwnedImpl buffer;
     buffer.add("def", 4);
-    EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->encodeData(buffer, false));
-    EXPECT_EQ(0, buffer.length());
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(4, buffer.length());
   }
 
   {
-    // Last call should prefix the buffer with the size and insert the gRPC status into trailers.
-    Envoy::Buffer::OwnedImpl buffer;
-    EXPECT_CALL(encoder_callbacks_, addEncodedData(_, false))
-        .WillOnce(Invoke([&](Envoy::Buffer::Instance& buf, bool) -> void { buffer.move(buf); }));
+    // When trailers arrive with content_length_from_header_ set, the filter should NOT
+    // prepend buffered data (since data was streamed). Just set grpc-status.
     Http::TestResponseTrailerMapImpl trailers({{"foo", "bar"}, {"one", "two"}, {"three", "four"}});
     EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(trailers));
     EXPECT_THAT(trailers, ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
-
-    Grpc::Decoder decoder;
-    std::vector<Grpc::Frame> frames;
-    std::ignore = decoder.decode(buffer, frames);
-
     EXPECT_EQ(4, trailers.size());
-    EXPECT_EQ(1, frames.size());
-    EXPECT_EQ(8, frames[0].length_);
   }
 }
 
@@ -1021,6 +1002,114 @@ TEST_F(ReverseBridgeTest, WithholdGrpcStreamResponseWrongContentLength) {
     EXPECT_THAT(trailers, ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
   }
 }
+// Verifies that when withhold_grpc_frames is true and response_size_header is NOT configured,
+// the filter uses the Content-Length from upstream response headers to stream the response
+// instead of buffering the entire body. This prevents large responses from overwhelming the
+// H2 codec with too many frames at once.
+TEST_F(ReverseBridgeTest, WithholdGrpcFramesStreamsWithContentLength) {
+  initialize();
+  decoder_callbacks_.is_grpc_request_ = true;
+
+  {
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+    Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
+                                            {"content-length", "25"},
+                                            {":path", "/testing.ExampleService/SendData"}});
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  }
+
+  {
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcdefgh", 8);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
+    EXPECT_EQ("fgh", buffer.toString());
+  }
+
+  // Upstream response with Content-Length: the filter should stream instead of buffer.
+  Http::TestResponseHeaderMapImpl headers(
+      {{":status", "200"}, {"content-length", "12"}, {"content-type", "application/x-protobuf"}});
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
+  // Content-Length should be adjusted: 12 + 5 (gRPC frame header) = 17.
+  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "17"));
+
+  {
+    // First chunk: gRPC frame header is prepended, data streams through.
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcd", 4);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    // 5 byte gRPC frame header + 4 bytes payload
+    EXPECT_EQ(9, buffer.length());
+  }
+  {
+    // Middle chunk: streams through without modification.
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("efgh", 4);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+    EXPECT_EQ(4, buffer.length());
+  }
+  {
+    // Final chunk with end_stream: validates content-length and adds trailers.
+    Http::TestResponseTrailerMapImpl trailers;
+    EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
+
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("ijkl", 4);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, true));
+    EXPECT_EQ(4, buffer.length());
+    EXPECT_THAT(trailers, ContainsHeader(Http::Headers::get().GrpcStatus, "0"));
+  }
+}
+
+// Verifies that when Content-Length from upstream doesn't match actual bytes sent, an error is
+// returned (content_length_from_header_ path).
+TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
+  initialize();
+  decoder_callbacks_.is_grpc_request_ = true;
+
+  {
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(nullptr));
+    EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+    Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
+                                            {"content-length", "25"},
+                                            {":path", "/testing.ExampleService/SendData"}});
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  }
+
+  {
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcdefgh", 8);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
+  }
+
+  // Upstream claims Content-Length: 100 but will only send 8 bytes.
+  Http::TestResponseHeaderMapImpl headers(
+      {{":status", "200"}, {"content-length", "100"}, {"content-type", "application/x-protobuf"}});
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
+  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "105"));
+
+  {
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcd", 4);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(buffer, false));
+  }
+  {
+    // end_stream with only 8 bytes sent, but Content-Length claimed 100.
+    Http::TestResponseTrailerMapImpl trailers;
+    EXPECT_CALL(encoder_callbacks_, addEncodedTrailers()).WillOnce(ReturnRef(trailers));
+    EXPECT_CALL(
+        encoder_callbacks_,
+        sendLocalReply(
+            Http::Code::OK, "envoy reverse bridge: upstream set incorrect content length", _,
+            std::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
+
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("efgh", 4);
+    EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(buffer, true));
+  }
+}
+
 } // namespace
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -1011,8 +1011,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesStreamsWithContentLength) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route())
-        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1070,8 +1069,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route())
-        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1119,8 +1117,7 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route())
-        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1137,9 +1134,9 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
   // Upstream claims Content-Length larger than uint32_t max.
   EXPECT_CALL(
       decoder_callbacks_,
-      sendLocalReply(Http::Code::OK,
-                     "envoy reverse bridge: upstream response too large for gRPC frame", _,
-                     std::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
+      sendLocalReply(
+          Http::Code::OK, "envoy reverse bridge: upstream response too large for gRPC frame", _,
+          std::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
 
   Http::TestResponseHeaderMapImpl headers({{":status", "200"},
                                             {"content-length", "5000000000"},

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -1112,6 +1112,41 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
   }
 }
 
+// Verify that a Content-Length exceeding uint32_t max is rejected with a local reply
+// (a single protobuf message cannot exceed 2GB).
+TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
+  initialize();
+  decoder_callbacks_.is_grpc_request_ = true;
+
+  {
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+    Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
+                                            {"content-length", "25"},
+                                            {":path", "/testing.ExampleService/SendData"}});
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+  }
+
+  {
+    Envoy::Buffer::OwnedImpl buffer;
+    buffer.add("abcdefgh", 8);
+    EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, false));
+  }
+
+  // Upstream claims Content-Length larger than uint32_t max.
+  EXPECT_CALL(
+      decoder_callbacks_,
+      sendLocalReply(Http::Code::OK,
+                     "envoy reverse bridge: upstream response too large for gRPC frame", _,
+                     std::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
+
+  Http::TestResponseHeaderMapImpl headers({{":status", "200"},
+                                            {"content-length", "5000000000"},
+                                            {"content-type", "application/x-protobuf"}});
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->encodeHeaders(headers, false));
+}
+
 } // namespace
 } // namespace GrpcHttp1ReverseBridge
 } // namespace HttpFilters

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -1011,7 +1011,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesStreamsWithContentLength) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1069,7 +1070,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthMismatch) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1117,7 +1119,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
   decoder_callbacks_.is_grpc_request_ = true;
 
   {
-    EXPECT_CALL(decoder_callbacks_, route()).WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
+    EXPECT_CALL(decoder_callbacks_, route())
+        .WillRepeatedly(testing::Return(OptRef<const Router::Route>{}));
     EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
     Http::TestRequestHeaderMapImpl headers({{"content-type", "application/grpc"},
                                             {"content-length", "25"},
@@ -1139,8 +1142,8 @@ TEST_F(ReverseBridgeTest, WithholdGrpcFramesContentLengthTooLarge) {
           std::make_optional(static_cast<Grpc::Status::GrpcStatus>(Grpc::Status::Internal)), _));
 
   Http::TestResponseHeaderMapImpl headers({{":status", "200"},
-                                            {"content-length", "5000000000"},
-                                            {"content-type", "application/x-protobuf"}});
+                                           {"content-length", "5000000000"},
+                                           {"content-type", "application/x-protobuf"}});
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->encodeHeaders(headers, false));
 }
 

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/reverse_bridge_test.cc
@@ -266,10 +266,10 @@ TEST_F(ReverseBridgeTest, GrpcRequest) {
   }
 
   Http::TestResponseHeaderMapImpl headers(
-      {{":status", "200"}, {"content-length", "30"}, {"content-type", "application/x-protobuf"}});
+      {{":status", "200"}, {"content-length", "12"}, {"content-type", "application/x-protobuf"}});
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
   EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "35"));
+  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "17"));
 
   {
     // With Content-Length available, the response is streamed. The first chunk gets the gRPC
@@ -702,10 +702,10 @@ TEST_F(ReverseBridgeTest, FilterConfigPerRouteEnabled) {
   }
 
   Http::TestResponseHeaderMapImpl headers(
-      {{":status", "200"}, {"content-length", "30"}, {"content-type", "application/x-protobuf"}});
+      {{":status", "200"}, {"content-length", "12"}, {"content-type", "application/x-protobuf"}});
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(headers, false));
   EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentType, "application/grpc"));
-  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "35"));
+  EXPECT_THAT(headers, ContainsHeader(Http::Headers::get().ContentLength, "17"));
 
   {
     // With Content-Length, the response is streamed. First chunk gets gRPC frame header.


### PR DESCRIPTION
**Description:**

Fixes https://github.com/envoyproxy/envoy/issues/45860

When `withhold_grpc_frames` is enabled without `response_size_header`, the filter buffers the entire upstream response body and releases it all in a single `encodeData()` call on `end_stream`. For responses larger than `initial_stream_window_size` (default 16MB since #40716), this causes the H2 codec to queue thousands of DATA frames in a single `sendPendingFrames()` call. The write buffer exceeds the high watermark during the frame burst, triggering callbacks that interact with the stream mid-encode, resulting in memory corruption and a SEGFAULT at `Http2::ConnectionImpl::StreamImpl::encodeData()`.

This bug is latent since the filter's introduction but was previously masked by the 256MB default stream window. Commit 9ad6cf10aa (#40716) reduced the default to 16MB, exposing the crash for any response >16MB.

This fix uses the `Content-Length` header from upstream HTTP/1.1 responses to enable the existing streaming path (previously only available via `response_size_header` config). Data now flows through in chunks as received from the upstream, avoiding the frame burst that crashes the H2 codec.

Responses without `Content-Length` continue to use the existing buffering path (no behavior change).

**Risk Level:** Low — only activates when `Content-Length` is present and `withhold_grpc_frames=true` without `response_size_header`. Existing behavior unchanged for all other cases.

**Testing:**
- Updated existing unit tests to reflect streaming behavior when Content-Length is present
- Added `WithholdGrpcFramesStreamsWithContentLength` test — validates streaming happy path
- Added `WithholdGrpcFramesContentLengthMismatch` test — validates error on size mismatch
- `GrpcRequestNoContentLength` test unchanged — confirms fallback to buffering

**AI disclosure:** Claude (Anthropic) was used to assist with writing this patch and tests. I have reviewed and understand all submitted code.

Signed-off-by: Rafael Elvira <me@relvira.org>
