### PR TITLE
stats: migrate to new stats API for WithTags

### DIFF
--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -231,7 +231,9 @@ public:
    * @param name The name of the stat, obtained from the SymbolTable.
    * @return a counter within the scope's namespace.
    */
-  Counter& counterFromStatName(const StatName& name) { return counterFromTaggedName(name, {}, {}); }
+  Counter& counterFromStatName(const StatName& name) {
+    return counterFromTaggedName(name, std::nullopt, StatName());
+  }
   /**
    * Creates a Counter from the stat name and tags. If tags are not provided, tag extraction
    * will be performed on the name.
@@ -257,7 +259,7 @@ public:
    * @return a gauge within the scope's namespace.
    */
   Gauge& gaugeFromStatName(const StatName& name, Gauge::ImportMode import_mode) {
-    return gaugeFromTaggedName(name, {}, {}, import_mode);
+    return gaugeFromTaggedName(name, std::nullopt, StatName(), import_mode);
   }
 
   /**
@@ -288,7 +290,7 @@ public:
    * @return a histogram within the scope's namespace with a particular value type.
    */
   Histogram& histogramFromStatName(const StatName& name, Histogram::Unit unit) {
-    return histogramFromTaggedName(name, {}, {}, unit);
+    return histogramFromTaggedName(name, std::nullopt, StatName(), unit);
   }
 
   /**
@@ -318,7 +320,7 @@ public:
    * @return a text readout within the scope's namespace.
    */
   TextReadout& textReadoutFromStatName(const StatName& name) {
-    return textReadoutFromTaggedName(name, {}, {});
+    return textReadoutFromTaggedName(name, std::nullopt, StatName());
   }
 
   /**

--- a/envoy/stats/scope.h
+++ b/envoy/stats/scope.h
@@ -231,9 +231,7 @@ public:
    * @param name The name of the stat, obtained from the SymbolTable.
    * @return a counter within the scope's namespace.
    */
-  Counter& counterFromStatName(const StatName& name) {
-    return counterFromStatNameWithTags(name, std::nullopt);
-  }
+  Counter& counterFromStatName(const StatName& name) { return counterFromTaggedName(name, {}, {}); }
   /**
    * Creates a Counter from the stat name and tags. If tags are not provided, tag extraction
    * will be performed on the name.
@@ -259,7 +257,7 @@ public:
    * @return a gauge within the scope's namespace.
    */
   Gauge& gaugeFromStatName(const StatName& name, Gauge::ImportMode import_mode) {
-    return gaugeFromStatNameWithTags(name, std::nullopt, import_mode);
+    return gaugeFromTaggedName(name, {}, {}, import_mode);
   }
 
   /**
@@ -290,7 +288,7 @@ public:
    * @return a histogram within the scope's namespace with a particular value type.
    */
   Histogram& histogramFromStatName(const StatName& name, Histogram::Unit unit) {
-    return histogramFromStatNameWithTags(name, std::nullopt, unit);
+    return histogramFromTaggedName(name, {}, {}, unit);
   }
 
   /**
@@ -320,7 +318,7 @@ public:
    * @return a text readout within the scope's namespace.
    */
   TextReadout& textReadoutFromStatName(const StatName& name) {
-    return textReadoutFromStatNameWithTags(name, std::nullopt);
+    return textReadoutFromTaggedName(name, {}, {});
   }
 
   /**

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -80,49 +80,54 @@ ScopeSharedPtr scopeFromStatNames(Scope& scope, const StatNameVec& elements) {
 Counter& counterFromElements(Scope& scope, const ElementVec& elements,
                              StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.counterFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {});
+  return scope.counterFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), StatName());
 }
 
 Counter& counterFromStatNames(Scope& scope, const StatNameVec& elements,
                               StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.counterFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {});
+  return scope.counterFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), StatName());
 }
 
 Gauge& gaugeFromElements(Scope& scope, const ElementVec& elements, Gauge::ImportMode import_mode,
                          StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.gaugeFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {}, import_mode);
+  return scope.gaugeFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), StatName(),
+                                   import_mode);
 }
 
 Gauge& gaugeFromStatNames(Scope& scope, const StatNameVec& elements, Gauge::ImportMode import_mode,
                           StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.gaugeFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {}, import_mode);
+  return scope.gaugeFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), StatName(),
+                                   import_mode);
 }
 
 Histogram& histogramFromElements(Scope& scope, const ElementVec& elements, Histogram::Unit unit,
                                  StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.histogramFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {}, unit);
+  return scope.histogramFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), StatName(),
+                                       unit);
 }
 
 Histogram& histogramFromStatNames(Scope& scope, const StatNameVec& elements, Histogram::Unit unit,
                                   StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.histogramFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {}, unit);
+  return scope.histogramFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), StatName(),
+                                       unit);
 }
 
 TextReadout& textReadoutFromElements(Scope& scope, const ElementVec& elements,
                                      StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.textReadoutFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {});
+  return scope.textReadoutFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), StatName());
 }
 
 TextReadout& textReadoutFromStatNames(Scope& scope, const StatNameVec& elements,
                                       StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.textReadoutFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {});
+  return scope.textReadoutFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags),
+                                         StatName());
 }
 
 } // namespace Utility

--- a/source/common/stats/utility.cc
+++ b/source/common/stats/utility.cc
@@ -80,49 +80,49 @@ ScopeSharedPtr scopeFromStatNames(Scope& scope, const StatNameVec& elements) {
 Counter& counterFromElements(Scope& scope, const ElementVec& elements,
                              StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.counterFromStatNameWithTags(visitor.statName(), tags);
+  return scope.counterFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {});
 }
 
 Counter& counterFromStatNames(Scope& scope, const StatNameVec& elements,
                               StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.counterFromStatNameWithTags(StatName(joined.get()), tags);
+  return scope.counterFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {});
 }
 
 Gauge& gaugeFromElements(Scope& scope, const ElementVec& elements, Gauge::ImportMode import_mode,
                          StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.gaugeFromStatNameWithTags(visitor.statName(), tags, import_mode);
+  return scope.gaugeFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {}, import_mode);
 }
 
 Gauge& gaugeFromStatNames(Scope& scope, const StatNameVec& elements, Gauge::ImportMode import_mode,
                           StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.gaugeFromStatNameWithTags(StatName(joined.get()), tags, import_mode);
+  return scope.gaugeFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {}, import_mode);
 }
 
 Histogram& histogramFromElements(Scope& scope, const ElementVec& elements, Histogram::Unit unit,
                                  StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.histogramFromStatNameWithTags(visitor.statName(), tags, unit);
+  return scope.histogramFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {}, unit);
 }
 
 Histogram& histogramFromStatNames(Scope& scope, const StatNameVec& elements, Histogram::Unit unit,
                                   StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.histogramFromStatNameWithTags(StatName(joined.get()), tags, unit);
+  return scope.histogramFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {}, unit);
 }
 
 TextReadout& textReadoutFromElements(Scope& scope, const ElementVec& elements,
                                      StatNameTagVectorOptConstRef tags) {
   ElementVisitor visitor(scope.symbolTable(), elements);
-  return scope.textReadoutFromStatNameWithTags(visitor.statName(), tags);
+  return scope.textReadoutFromTaggedName(visitor.statName(), Scope::toTagSpan(tags), {});
 }
 
 TextReadout& textReadoutFromStatNames(Scope& scope, const StatNameVec& elements,
                                       StatNameTagVectorOptConstRef tags) {
   SymbolTable::StoragePtr joined = scope.symbolTable().join(elements);
-  return scope.textReadoutFromStatNameWithTags(StatName(joined.get()), tags);
+  return scope.textReadoutFromTaggedName(StatName(joined.get()), Scope::toTagSpan(tags), {});
 }
 
 } // namespace Utility

--- a/source/extensions/access_loggers/stats/stats.cc
+++ b/source/extensions/access_loggers/stats/stats.cc
@@ -79,8 +79,8 @@ public:
 
 AccessLogState::~AccessLogState() {
   for (const auto& p : inflight_gauges_) {
-    Stats::Gauge& gauge_stat = parent_->scope().gaugeFromStatNameWithTags(
-        p.first.statName(), p.first.tags(), p.second.import_mode_);
+    Stats::Gauge& gauge_stat = parent_->scope().gaugeFromTaggedName(
+        p.first.statName(), Stats::Scope::toTagSpan(p.first.tags()), {}, p.second.import_mode_);
     gauge_stat.sub(p.second.value_);
   }
 }
@@ -103,7 +103,9 @@ void AccessLogState::addInflightGauge(Stats::StatName stat_name,
     it = new_it;
   }
   it->second.value_ += value;
-  parent_->scope().gaugeFromStatNameWithTags(stat_name, tags, import_mode).add(value);
+  parent_->scope()
+      .gaugeFromTaggedName(stat_name, Stats::Scope::toTagSpan(tags), {}, import_mode)
+      .add(value);
 }
 
 void AccessLogState::removeInflightGauge(Stats::StatName stat_name,
@@ -115,8 +117,8 @@ void AccessLogState::removeInflightGauge(Stats::StatName stat_name,
 
   GaugeKey key{stat_name, tags};
 
-  Stats::Gauge& gauge_stat =
-      parent_->scope().gaugeFromStatNameWithTags(stat_name, tags, import_mode);
+  Stats::Gauge& gauge_stat = parent_->scope().gaugeFromTaggedName(
+      stat_name, Stats::Scope::toTagSpan(tags), {}, import_mode);
 
   auto it = inflight_gauges_.find(key);
   const bool was_found = (it != inflight_gauges_.end());
@@ -386,8 +388,8 @@ void StatsAccessLog::emitLogConst(const Formatter::Context& context,
 
     uint64_t value = *computed_value_opt;
 
-    auto& histogram_stat =
-        scope_->histogramFromStatNameWithTags(histogram.stat_.name_, tags, histogram.unit_);
+    auto& histogram_stat = scope_->histogramFromTaggedName(
+        histogram.stat_.name_, Stats::Scope::toTagSpan(tags), {}, histogram.unit_);
     histogram_stat.recordValue(value);
   }
 
@@ -411,7 +413,8 @@ void StatsAccessLog::emitLogConst(const Formatter::Context& context,
       value = counter.value_fixed_;
     }
 
-    auto& counter_stat = scope_->counterFromStatNameWithTags(counter.stat_.name_, tags);
+    auto& counter_stat =
+        scope_->counterFromTaggedName(counter.stat_.name_, Stats::Scope::toTagSpan(tags), {});
     counter_stat.add(value);
   }
 
@@ -452,8 +455,8 @@ void StatsAccessLog::emitLogForGauge(const Gauge& gauge, const Formatter::Contex
                                              : Stats::Gauge::ImportMode::Accumulate;
 
   if (op == Gauge::OperationType::SET) {
-    Stats::Gauge& gauge_stat =
-        scope_->gaugeFromStatNameWithTags(gauge.stat_.name_, tags, import_mode);
+    Stats::Gauge& gauge_stat = scope_->gaugeFromTaggedName(
+        gauge.stat_.name_, Stats::Scope::toTagSpan(tags), {}, import_mode);
     gauge_stat.set(value);
   } else if (op == Gauge::OperationType::PAIRED_ADD ||
              op == Gauge::OperationType::PAIRED_SUBTRACT) {

--- a/test/common/stats/isolated_store_impl_test.cc
+++ b/test/common/stats/isolated_store_impl_test.cc
@@ -241,8 +241,7 @@ TEST_F(StatsIsolatedStoreImplTest, CounterWithTag) {
   EXPECT_EQ("counter.tag1.tag1Value2", c2.name());
   EXPECT_EQ("counter", c2.tagExtractedName());
   EXPECT_THAT(c2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
-  // Verify that counterFromStatNameWithTags with the same params returns
-  // the existing stat object.
+  // Verify that counterFromTaggedName with the same params returns the existing stat object.
   EXPECT_EQ(&c1, &scope_->counterFromTaggedName(base, StatNameTagSpan(tags), {}));
 }
 
@@ -262,8 +261,7 @@ TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
   EXPECT_EQ("gauge.tag2.tag2Value", g2.name());
   EXPECT_EQ("gauge", g2.tagExtractedName());
   EXPECT_THAT(g2.tags(), testing::ElementsAre(Tag{"tag2", "tag2Value"}));
-  // Verify that gaugeFromStatNameWithTags with the same params returns
-  // the existing stat object.
+  // Verify that gaugeFromTaggedName with the same params returns the existing stat object.
   EXPECT_EQ(&g1, &scope_->gaugeFromTaggedName(base, StatNameTagSpan(tags), {},
                                               Gauge::ImportMode::Accumulate));
 }
@@ -280,8 +278,7 @@ TEST_F(StatsIsolatedStoreImplTest, TextReadoutWithTag) {
   EXPECT_EQ("textreadout.tag1.tag1Value2", b2.name());
   EXPECT_EQ("textreadout", b2.tagExtractedName());
   EXPECT_THAT(b2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
-  // Verify that textReadoutFromStatNameWithTags with the same params returns
-  // the existing stat object.
+  // Verify that textReadoutFromTaggedName with the same params returns the existing stat object.
   EXPECT_EQ(&b1, &scope_->textReadoutFromTaggedName(base, StatNameTagSpan(tags), {}));
 }
 
@@ -299,8 +296,7 @@ TEST_F(StatsIsolatedStoreImplTest, HistogramWithTag) {
   EXPECT_EQ("histogram.tag1.tag1Value2", h2.name());
   EXPECT_EQ("histogram", h2.tagExtractedName());
   EXPECT_THAT(h2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
-  // Verify that histogramFromStatNameWithTags with the same params returns
-  // the existing stat object.
+  // Verify that histogramFromTaggedName with the same params returns the existing stat object.
   EXPECT_EQ(&h1, &scope_->histogramFromTaggedName(base, StatNameTagSpan(tags), {},
                                                   Stats::Histogram::Unit::Unspecified));
 }

--- a/test/common/stats/isolated_store_impl_test.cc
+++ b/test/common/stats/isolated_store_impl_test.cc
@@ -233,8 +233,8 @@ TEST_F(StatsIsolatedStoreImplTest, CounterWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
   StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
   StatName base = makeStatName("counter");
-  Counter& c1 = scope_->counterFromStatNameWithTags(base, tags);
-  Counter& c2 = scope_->counterFromStatNameWithTags(base, tags2);
+  Counter& c1 = scope_->counterFromTaggedName(base, StatNameTagSpan(tags), {});
+  Counter& c2 = scope_->counterFromTaggedName(base, StatNameTagSpan(tags2), {});
   EXPECT_EQ("counter.tag1.tag1Value", c1.name());
   EXPECT_EQ("counter", c1.tagExtractedName());
   EXPECT_THAT(c1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
@@ -243,7 +243,7 @@ TEST_F(StatsIsolatedStoreImplTest, CounterWithTag) {
   EXPECT_THAT(c2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
   // Verify that counterFromStatNameWithTags with the same params returns
   // the existing stat object.
-  EXPECT_EQ(&c1, &scope_->counterFromStatNameWithTags(base, tags));
+  EXPECT_EQ(&c1, &scope_->counterFromTaggedName(base, StatNameTagSpan(tags), {}));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
@@ -252,8 +252,10 @@ TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
   // tags2 being a subset of tags to ensure no collision in that case.
   StatNameTagVector tags2{{makeStatName("tag2"), makeStatName("tag2Value")}};
   StatName base = makeStatName("gauge");
-  Gauge& g1 = scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate);
-  Gauge& g2 = scope_->gaugeFromStatNameWithTags(base, tags2, Gauge::ImportMode::Accumulate);
+  Gauge& g1 =
+      scope_->gaugeFromTaggedName(base, StatNameTagSpan(tags), {}, Gauge::ImportMode::Accumulate);
+  Gauge& g2 =
+      scope_->gaugeFromTaggedName(base, StatNameTagSpan(tags2), {}, Gauge::ImportMode::Accumulate);
   EXPECT_EQ("gauge.tag1.tag1Value.tag2.tag2Value", g1.name());
   EXPECT_EQ("gauge", g1.tagExtractedName());
   EXPECT_THAT(g1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}, Tag{"tag2", "tag2Value"}));
@@ -262,15 +264,16 @@ TEST_F(StatsIsolatedStoreImplTest, GaugeWithTags) {
   EXPECT_THAT(g2.tags(), testing::ElementsAre(Tag{"tag2", "tag2Value"}));
   // Verify that gaugeFromStatNameWithTags with the same params returns
   // the existing stat object.
-  EXPECT_EQ(&g1, &scope_->gaugeFromStatNameWithTags(base, tags, Gauge::ImportMode::Accumulate));
+  EXPECT_EQ(&g1, &scope_->gaugeFromTaggedName(base, StatNameTagSpan(tags), {},
+                                              Gauge::ImportMode::Accumulate));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, TextReadoutWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
   StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
   StatName base = makeStatName("textreadout");
-  TextReadout& b1 = scope_->textReadoutFromStatNameWithTags(base, tags);
-  TextReadout& b2 = scope_->textReadoutFromStatNameWithTags(base, tags2);
+  TextReadout& b1 = scope_->textReadoutFromTaggedName(base, StatNameTagSpan(tags), {});
+  TextReadout& b2 = scope_->textReadoutFromTaggedName(base, StatNameTagSpan(tags2), {});
   EXPECT_EQ("textreadout.tag1.tag1Value", b1.name());
   EXPECT_EQ("textreadout", b1.tagExtractedName());
   EXPECT_THAT(b1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
@@ -279,17 +282,17 @@ TEST_F(StatsIsolatedStoreImplTest, TextReadoutWithTag) {
   EXPECT_THAT(b2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
   // Verify that textReadoutFromStatNameWithTags with the same params returns
   // the existing stat object.
-  EXPECT_EQ(&b1, &scope_->textReadoutFromStatNameWithTags(base, tags));
+  EXPECT_EQ(&b1, &scope_->textReadoutFromTaggedName(base, StatNameTagSpan(tags), {}));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, HistogramWithTag) {
   StatNameTagVector tags{{makeStatName("tag1"), makeStatName("tag1Value")}};
   StatNameTagVector tags2{{makeStatName("tag1"), makeStatName("tag1Value2")}};
   StatName base = makeStatName("histogram");
-  Histogram& h1 =
-      scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified);
-  Histogram& h2 =
-      scope_->histogramFromStatNameWithTags(base, tags2, Stats::Histogram::Unit::Unspecified);
+  Histogram& h1 = scope_->histogramFromTaggedName(base, StatNameTagSpan(tags), {},
+                                                  Stats::Histogram::Unit::Unspecified);
+  Histogram& h2 = scope_->histogramFromTaggedName(base, StatNameTagSpan(tags2), {},
+                                                  Stats::Histogram::Unit::Unspecified);
   EXPECT_EQ("histogram.tag1.tag1Value", h1.name());
   EXPECT_EQ("histogram", h1.tagExtractedName());
   EXPECT_THAT(h1.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value"}));
@@ -298,8 +301,8 @@ TEST_F(StatsIsolatedStoreImplTest, HistogramWithTag) {
   EXPECT_THAT(h2.tags(), testing::ElementsAre(Tag{"tag1", "tag1Value2"}));
   // Verify that histogramFromStatNameWithTags with the same params returns
   // the existing stat object.
-  EXPECT_EQ(
-      &h1, &scope_->histogramFromStatNameWithTags(base, tags, Stats::Histogram::Unit::Unspecified));
+  EXPECT_EQ(&h1, &scope_->histogramFromTaggedName(base, StatNameTagSpan(tags), {},
+                                                  Stats::Histogram::Unit::Unspecified));
 }
 
 TEST_F(StatsIsolatedStoreImplTest, ConstSymtabAccessor) {

--- a/test/common/stats/stat_test_utility_test.cc
+++ b/test/common/stats/stat_test_utility_test.cc
@@ -56,10 +56,14 @@ TEST_F(StatTestUtilityTest, Histograms) {
 TEST_F(StatTestUtilityTest, CountersWithTags) {
   StatNameTagVector dynamic_tags = {
       {dynamic_.add("dynamic_tag_name"), dynamic_.add("dynamic_tag_value")}};
-  test_scope_->counterFromStatNameWithTags(dynamic_.add("dynamic.stat"), dynamic_tags).inc();
+  test_scope_
+      ->counterFromTaggedName(dynamic_.add("dynamic.stat"), StatNameTagSpan(dynamic_tags), {})
+      .inc();
   StatNameTagVector symbolic_tags = {
       {symbolic_.add("symbolic_tag_name"), symbolic_.add("symbolic_tag_value")}};
-  test_scope_->counterFromStatNameWithTags(symbolic_.add("symbolic.stat"), symbolic_tags).inc();
+  test_scope_
+      ->counterFromTaggedName(symbolic_.add("symbolic.stat"), StatNameTagSpan(symbolic_tags), {})
+      .inc();
   EXPECT_EQ(1, test_store_.findCounterByString("dynamic.stat.dynamic_tag_name.dynamic_tag_value")
                    .value()
                    .get()

--- a/test/common/stats/thread_local_store_test.cc
+++ b/test/common/stats/thread_local_store_test.cc
@@ -425,25 +425,29 @@ TEST_F(StatsThreadLocalStoreTest, BasicScope) {
 
   {
     StatNameManagedStorage storage("c3", symbol_table_);
-    Counter& counter = scope1->counterFromStatNameWithTags(StatName(storage.statName()), tags);
+    Counter& counter =
+        scope1->counterFromTaggedName(StatName(storage.statName()), StatNameTagSpan(tags), {});
     EXPECT_EQ(expectedTags, counter.tags());
-    EXPECT_EQ(&counter, &scope1->counterFromStatNameWithTags(StatName(storage.statName()), tags));
+    EXPECT_EQ(&counter, &scope1->counterFromTaggedName(StatName(storage.statName()),
+                                                       StatNameTagSpan(tags), {}));
   }
   {
     StatNameManagedStorage storage("g3", symbol_table_);
-    Gauge& gauge = scope1->gaugeFromStatNameWithTags(StatName(storage.statName()), tags,
-                                                     Gauge::ImportMode::Accumulate);
+    Gauge& gauge = scope1->gaugeFromTaggedName(StatName(storage.statName()), StatNameTagSpan(tags),
+                                               {}, Gauge::ImportMode::Accumulate);
     EXPECT_EQ(expectedTags, gauge.tags());
-    EXPECT_EQ(&gauge, &scope1->gaugeFromStatNameWithTags(StatName(storage.statName()), tags,
-                                                         Gauge::ImportMode::Accumulate));
+    EXPECT_EQ(&gauge,
+              &scope1->gaugeFromTaggedName(StatName(storage.statName()), StatNameTagSpan(tags), {},
+                                           Gauge::ImportMode::Accumulate));
   }
   {
     StatNameManagedStorage storage("h3", symbol_table_);
-    Histogram& histogram = scope1->histogramFromStatNameWithTags(StatName(storage.statName()), tags,
-                                                                 Histogram::Unit::Unspecified);
+    Histogram& histogram = scope1->histogramFromTaggedName(
+        StatName(storage.statName()), StatNameTagSpan(tags), {}, Histogram::Unit::Unspecified);
     EXPECT_EQ(expectedTags, histogram.tags());
-    EXPECT_EQ(&histogram, &scope1->histogramFromStatNameWithTags(StatName(storage.statName()), tags,
-                                                                 Histogram::Unit::Unspecified));
+    EXPECT_EQ(&histogram,
+              &scope1->histogramFromTaggedName(StatName(storage.statName()), StatNameTagSpan(tags),
+                                               {}, Histogram::Unit::Unspecified));
   }
 
   tls_.shutdownGlobalThreading();

--- a/test/server/admin/stats_handler_test.cc
+++ b/test/server/admin/stats_handler_test.cc
@@ -1388,22 +1388,24 @@ public:
     Stats::StatNameTagVector c1Tags{{makeStat("cluster"), makeStat("c1")}};
     Stats::StatNameTagVector c2Tags{{makeStat("cluster"), makeStat("c2")}};
 
-    Stats::Counter& c1 = store_->rootScope()->counterFromStatNameWithTags(
-        makeStat("cluster.upstream.cx.total"), c1Tags);
+    Stats::Counter& c1 = store_->rootScope()->counterFromTaggedName(
+        makeStat("cluster.upstream.cx.total"), Stats::StatNameTagSpan(c1Tags), {});
     c1.add(10);
-    Stats::Counter& c2 = store_->rootScope()->counterFromStatNameWithTags(
-        makeStat("cluster.upstream.cx.total"), c2Tags);
+    Stats::Counter& c2 = store_->rootScope()->counterFromTaggedName(
+        makeStat("cluster.upstream.cx.total"), Stats::StatNameTagSpan(c2Tags), {});
     c2.add(20);
 
-    Stats::Gauge& g1 = store_->rootScope()->gaugeFromStatNameWithTags(
-        makeStat("cluster.upstream.cx.active"), c1Tags, Stats::Gauge::ImportMode::Accumulate);
+    Stats::Gauge& g1 = store_->rootScope()->gaugeFromTaggedName(
+        makeStat("cluster.upstream.cx.active"), Stats::StatNameTagSpan(c1Tags), {},
+        Stats::Gauge::ImportMode::Accumulate);
     g1.set(11);
-    Stats::Gauge& g2 = store_->rootScope()->gaugeFromStatNameWithTags(
-        makeStat("cluster.upstream.cx.active"), c2Tags, Stats::Gauge::ImportMode::Accumulate);
+    Stats::Gauge& g2 = store_->rootScope()->gaugeFromTaggedName(
+        makeStat("cluster.upstream.cx.active"), Stats::StatNameTagSpan(c2Tags), {},
+        Stats::Gauge::ImportMode::Accumulate);
     g2.set(12);
 
-    Stats::TextReadout& t1 = store_->rootScope()->textReadoutFromStatNameWithTags(
-        makeStat("control_plane.identifier"), c1Tags);
+    Stats::TextReadout& t1 = store_->rootScope()->textReadoutFromTaggedName(
+        makeStat("control_plane.identifier"), Stats::StatNameTagSpan(c1Tags), {});
     t1.set("cp-1");
   }
 };


### PR DESCRIPTION
Commit Message: stats: migrate to new stats API for WithTags
Additional Description:

This is the simplest migration because in both new mode/API and legacy mode/API, the behavior is completely same.

Parts of #20289. This migrate the previous stats creation to use new tags-friendly API. But note, before we merge https://github.com/envoyproxy/envoy/pull/45846 and enable it explicitly. This won't bring any changes to the final behavior because the legacy mode will ignore the provided tags but only use the flat name.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
