### PR TITLE
hot_restart: fix integer overflow in IPC message length handling

### DIFF
--- a/changelogs/current/bug_fixes/hot_restart__fixed-integer-overflow-in-ipc-message-length.rst
+++ b/changelogs/current/bug_fixes/hot_restart__fixed-integer-overflow-in-ipc-message-length.rst
@@ -1,0 +1,4 @@
+Fixed an integer overflow in the hot restart IPC message length handling. An
+attacker-controlled wire length could wrap when computing the receive buffer size,
+causing a zero-length allocation and undefined behavior. The fix adds an overflow
+check before resizing the buffer.

--- a/source/server/hot_restarting_base.cc
+++ b/source/server/hot_restarting_base.cc
@@ -248,7 +248,10 @@ std::unique_ptr<HotRestartMessage> RpcStream::receiveHotRestartMessage(Blocking 
       expected_proto_length_ = be64toh(*reinterpret_cast<uint64_t*>(recv_buf_.data()));
       // Expand the buffer from its default 4096 if this message is going to be longer.
       if (expected_proto_length_.value() > MaxSendmsgSize - sizeof(uint64_t)) {
-        recv_buf_.resize(expected_proto_length_.value() + sizeof(uint64_t));
+        const uint64_t new_size = expected_proto_length_.value() + sizeof(uint64_t);
+        RELEASE_ASSERT(new_size > expected_proto_length_.value(),
+                       "hot restart message length overflow");
+        recv_buf_.resize(new_size);
         cur_msg_recvd_bytes_ = recv_result.return_value_;
       }
     }

--- a/test/server/hot_restarting_base_test.cc
+++ b/test/server/hot_restarting_base_test.cc
@@ -1,5 +1,11 @@
 #include "source/server/hot_restarting_base.h"
 
+#include <endian.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <vector>
+
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
@@ -79,6 +85,60 @@ TEST_F(HotRestartingBaseTest, SendMsgRetrySucceedsEventually) {
   EXPECT_TRUE(retried);
 }
 
+// Tests that receiveHotRestartMessage asserts when the wire length wraps uint64.
+TEST_F(HotRestartingBaseTest, OverflowDeathUint64Max) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_DGRAM, 0, fds));
+
+  RpcStream stream(0);
+  stream.domain_socket_ = fds[0];
+
+  const uint64_t network_len = htobe64(0xFFFFFFFFFFFFFFFFULL);
+  ASSERT_EQ(8, write(fds[1], &network_len, 8));
+
+  EXPECT_DEATH(stream.receiveHotRestartMessage(RpcStream::Blocking::No), "");
+  close(fds[1]);
+}
+
+// Tests that receiveHotRestartMessage asserts when 0xFFFFFFFFFFFFFFF8 + 8 = 0.
+TEST_F(HotRestartingBaseTest, OverflowDeathMaxMinus7) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_DGRAM, 0, fds));
+
+  RpcStream stream(0);
+  stream.domain_socket_ = fds[0];
+
+  const uint64_t network_len = htobe64(0xFFFFFFFFFFFFFFF8ULL);
+  ASSERT_EQ(8, write(fds[1], &network_len, 8));
+
+  EXPECT_DEATH(stream.receiveHotRestartMessage(RpcStream::Blocking::No), "");
+  close(fds[1]);
+}
+
+// Tests that a normal small message is received successfully (no assert).
+TEST_F(HotRestartingBaseTest, NormalLengthSuccess) {
+  int fds[2];
+  ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_DGRAM, 0, fds));
+
+  RpcStream stream(0);
+  stream.domain_socket_ = fds[0];
+
+  HotRestartMessage msg;
+  msg.mutable_request()->mutable_stats();
+  std::string serialized = msg.SerializeAsString();
+  const uint64_t total_size = sizeof(uint64_t) + serialized.size();
+
+  std::vector<uint8_t> buf(total_size);
+  const uint64_t network_len = htobe64(serialized.size());
+  memcpy(buf.data(), &network_len, sizeof(uint64_t));
+  memcpy(buf.data() + sizeof(uint64_t), serialized.data(), serialized.size());
+
+  ASSERT_EQ(static_cast<ssize_t>(total_size), write(fds[1], buf.data(), buf.size()));
+
+  auto result = stream.receiveHotRestartMessage(RpcStream::Blocking::No);
+  EXPECT_NE(result, nullptr);
+  close(fds[1]);
+}
 } // namespace
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Description:

The hot restart IPC protocol reads a uint64_t message length from the
first 8 bytes of an incoming datagram and uses it to compute the
required receive buffer size.

When expected_proto_length_ is close to UINT64_MAX, adding
sizeof(uint64_t) may wrap around due to unsigned integer overflow,
producing an invalid buffer size value. Add an explicit overflow check
before resizing the receive buffer, matching existing overflow-detection
patterns used elsewhere in the Envoy codebase.

Also adds unit tests covering overflow edge cases and normal message
processing.

Risk Level: Low

Testing:

* Added unit tests for UINT64_MAX
* Added unit tests for UINT64_MAX - 7
* Added unit tests for normal-length messages

Docs Changes: N/A

Release Notes: Included
Fixes #45872