### PR TITLE
dynamic_modules: persist module-owned filter state objects across stream recreates

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -2435,7 +2435,10 @@ typedef enum envoy_dynamic_module_type_filter_state_life_span {
 typedef void* envoy_dynamic_module_type_filter_state_object_module_ptr;
 
 // Destructor for a filter state object. Envoy calls it exactly once, on the worker thread, when the
-// entry is destroyed (stream/connection end per life_span, or overwrite of the same key).
+// entry is destroyed (stream/connection end per life_span, or overwrite of the same key). It runs
+// on the teardown path outside any module callback guard, so it must not unwind: a panic crossing
+// this boundary is undefined behavior. The Rust SDK enforces this by requiring an
+// ``extern "C"`` destructor, which aborts on unwind.
 typedef void (*envoy_dynamic_module_type_filter_state_object_destructor)(
     envoy_dynamic_module_type_filter_state_object_module_ptr module_object);
 
@@ -2452,10 +2455,12 @@ typedef void (*envoy_dynamic_module_type_filter_state_object_destructor)(
  * @param key is the key of the filter state.
  * @param module_object is the opaque object to store. Ownership transfers to Envoy.
  * @param destructor is called exactly once with module_object when the entry is destroyed, or
- * before returning false so a failed store never leaks the object.
- * @param life_span is the lifespan of the entry.
- * @return true if the operation is successful, false if the stream info is not available or the key
- * already exists and is marked as read-only.
+ * before returning false so a failed store never leaks the object. It must not unwind; see the
+ * destructor typedef.
+ * @param life_span is the lifespan of the entry. A Connection-lifespan entry may outlive the
+ * stream, so its object and destructor must remain valid until the connection ends.
+ * @return true if stored. Returns false, after running the destructor, if the stream info or filter
+ * state is not available, or if the key already holds an entry at a different life_span.
  */
 bool envoy_dynamic_module_callback_http_set_filter_state_object(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -2420,6 +2420,68 @@ bool envoy_dynamic_module_callback_http_get_filter_state_typed(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* result);
 
+// Lifespan of a filter state entry. Mirrors StreamInfo::FilterState::LifeSpan. Entries at Request
+// or Connection lifespan are carried into the new stream on recreate_stream; FilterChain entries
+// are not.
+typedef enum envoy_dynamic_module_type_filter_state_life_span {
+  envoy_dynamic_module_type_filter_state_life_span_FilterChain = 0,
+  envoy_dynamic_module_type_filter_state_life_span_Request = 1,
+  envoy_dynamic_module_type_filter_state_life_span_Connection = 2,
+} envoy_dynamic_module_type_filter_state_life_span;
+
+// OWNERSHIP: module-owned opaque object stored in filter state. Envoy never dereferences it; it
+// calls the supplied destructor exactly once when the entry is destroyed. THREADING: created and
+// accessed on the worker thread owning the stream.
+typedef void* envoy_dynamic_module_type_filter_state_object_module_ptr;
+
+// Destructor for a filter state object. Envoy calls it exactly once, on the worker thread, when the
+// entry is destroyed (stream/connection end per life_span, or overwrite of the same key).
+typedef void (*envoy_dynamic_module_type_filter_state_object_destructor)(
+    envoy_dynamic_module_type_filter_state_object_module_ptr module_object);
+
+/**
+ * envoy_dynamic_module_callback_http_set_filter_state_object is called by the module to store an
+ * opaque, module-owned object in the filter state under the given key. Envoy never interprets the
+ * object; it wraps it in a non-serializable FilterState::Object and calls destructor(module_object)
+ * exactly once when that wrapper is destroyed. Objects stored at Request or Connection lifespan
+ * survive recreate_stream (carried into the new stream's parent filter state); FilterChain-lifespan
+ * objects do not.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param key is the key of the filter state.
+ * @param module_object is the opaque object to store. Ownership transfers to Envoy.
+ * @param destructor is called exactly once with module_object when the entry is destroyed, or
+ * before returning false so a failed store never leaks the object.
+ * @param life_span is the lifespan of the entry.
+ * @return true if the operation is successful, false if the stream info is not available or the key
+ * already exists and is marked as read-only.
+ */
+bool envoy_dynamic_module_callback_http_set_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_filter_state_object_module_ptr module_object,
+    envoy_dynamic_module_type_filter_state_object_destructor destructor,
+    envoy_dynamic_module_type_filter_state_life_span life_span);
+
+/**
+ * envoy_dynamic_module_callback_http_get_filter_state_object is called by the module to borrow the
+ * opaque object previously stored under the given key. Ownership stays with Envoy; the module must
+ * not free the returned pointer. After a recreate_stream, the rebuilt filter calls this with the
+ * same key to recover the carried-over object.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param key is the key of the filter state.
+ * @return the stored object, or NULL if the stream info is not available, the key does not exist,
+ * or the entry was not stored via set_filter_state_object. Valid until the entry is destroyed or
+ * overwritten.
+ */
+envoy_dynamic_module_type_filter_state_object_module_ptr
+envoy_dynamic_module_callback_http_get_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key);
+
 // ---------------------- Other HTTP filter callbacks ----------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4184,6 +4184,26 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_http_get_filter_state_t
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_http_set_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_filter_state_object_module_ptr,
+    envoy_dynamic_module_type_filter_state_object_destructor,
+    envoy_dynamic_module_type_filter_state_life_span) {
+  IS_ENVOY_BUG(
+      "envoy_dynamic_module_callback_http_set_filter_state_object: not implemented in this "
+      "context");
+  return false;
+}
+
+__attribute__((weak)) envoy_dynamic_module_type_filter_state_object_module_ptr
+envoy_dynamic_module_callback_http_get_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG(
+      "envoy_dynamic_module_callback_http_get_filter_state_object: not implemented in this "
+      "context");
+  return nullptr;
+}
+
 __attribute__((weak)) void
 envoy_dynamic_module_callback_http_add_custom_flag(envoy_dynamic_module_type_http_filter_envoy_ptr,
                                                    envoy_dynamic_module_type_module_buffer) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1321,9 +1321,15 @@ pub trait EnvoyHttpFilter {
   /// Ownership transfers to Envoy on every path: the destructor runs exactly once, either when the
   /// entry is destroyed or before this returns `false`, so a failed store never leaks the object.
   ///
-  /// Returns true if the operation is successful, false if the filter state is not accessible or
-  /// the key already exists and is read-only.
-  fn set_filter_state_object(
+  /// Returns true if stored. Returns false, after running the destructor, if the filter state is
+  /// not accessible or the key already holds an entry at a different `life_span`.
+  ///
+  /// # Safety
+  ///
+  /// `object` must be a valid pointer that `destructor` can free, and `destructor` must free it
+  /// without unwinding: it runs on the teardown path, and a panic crossing the FFI boundary is
+  /// undefined behavior. Use an `extern "C"` destructor, which aborts rather than unwinds.
+  unsafe fn set_filter_state_object(
     &mut self,
     key: &[u8],
     object: *mut c_void,
@@ -1333,6 +1339,11 @@ pub trait EnvoyHttpFilter {
 
   /// Borrow the opaque object previously stored under `key`, or `None` if absent. Ownership stays
   /// with Envoy; the module must not free the returned pointer.
+  ///
+  /// The pointer is valid only on the worker thread owning the stream, and only until the entry is
+  /// destroyed or overwritten. It is shared: the rebuilt filter after a `recreate_stream`, or
+  /// another filter on the same stream, can hold it too, so the module must synchronize any
+  /// interior mutability through it.
   fn get_filter_state_object(&self, key: &[u8]) -> Option<*mut c_void>;
 
   /// Get the received request body (the request body pieces received in the latest event).
@@ -2989,9 +3000,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  // Envoy takes ownership of `object` and only stores it; the caller transfers a valid pointer.
-  #[allow(clippy::not_unsafe_ptr_arg_deref)]
-  fn set_filter_state_object(
+  unsafe fn set_filter_state_object(
     &mut self,
     key: &[u8],
     object: *mut c_void,

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use mockall::*;
 use std::any::Any;
+use std::ffi::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 /// The trait that represents the configuration for an Envoy Http filter configuration.
@@ -1308,6 +1309,31 @@ pub trait EnvoyHttpFilter {
   /// Returns None if the key does not exist, the object does not support serialization, or the
   /// filter state is not accessible.
   fn get_filter_state_typed<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
+
+  /// Store an opaque, module-owned object in the filter state under `key`. Envoy never interprets
+  /// the object; it calls `destructor` exactly once when the entry is destroyed. Objects stored at
+  /// `Request` or `Connection` lifespan survive `recreate_stream`; `FilterChain` objects do not.
+  ///
+  /// Typical use: `Box::into_raw(Box::new(state)) as *mut c_void`, with a destructor that calls
+  /// `drop(Box::from_raw(ptr as *mut State))`. The module must only recover the object via
+  /// [`EnvoyHttpFilter::get_filter_state_object`] and never free it itself.
+  ///
+  /// Ownership transfers to Envoy on every path: the destructor runs exactly once, either when the
+  /// entry is destroyed or before this returns `false`, so a failed store never leaks the object.
+  ///
+  /// Returns true if the operation is successful, false if the filter state is not accessible or
+  /// the key already exists and is read-only.
+  fn set_filter_state_object(
+    &mut self,
+    key: &[u8],
+    object: *mut c_void,
+    destructor: extern "C" fn(*mut c_void),
+    life_span: abi::envoy_dynamic_module_type_filter_state_life_span,
+  ) -> bool;
+
+  /// Borrow the opaque object previously stored under `key`, or `None` if absent. Ownership stays
+  /// with Envoy; the module must not free the returned pointer.
+  fn get_filter_state_object(&self, key: &[u8]) -> Option<*mut c_void>;
 
   /// Get the received request body (the request body pieces received in the latest event).
   /// This should only be used in the [`HttpFilter::on_request_body`] callback.
@@ -2960,6 +2986,41 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
     } else {
       None
+    }
+  }
+
+  // Envoy takes ownership of `object` and only stores it; the caller transfers a valid pointer.
+  #[allow(clippy::not_unsafe_ptr_arg_deref)]
+  fn set_filter_state_object(
+    &mut self,
+    key: &[u8],
+    object: *mut c_void,
+    destructor: extern "C" fn(*mut c_void),
+    life_span: abi::envoy_dynamic_module_type_filter_state_life_span,
+  ) -> bool {
+    let destructor: unsafe extern "C" fn(*mut c_void) = destructor;
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_filter_state_object(
+        self.raw_ptr,
+        bytes_to_module_buffer(key),
+        object,
+        Some(destructor),
+        life_span,
+      )
+    }
+  }
+
+  fn get_filter_state_object(&self, key: &[u8]) -> Option<*mut c_void> {
+    let object = unsafe {
+      abi::envoy_dynamic_module_callback_http_get_filter_state_object(
+        self.raw_ptr,
+        bytes_to_module_buffer(key),
+      )
+    };
+    if object.is_null() {
+      None
+    } else {
+      Some(object)
     }
   }
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3905,6 +3905,66 @@ pub extern "C" fn envoy_dynamic_module_callback_http_filter_reset_stream(
   RESET_STREAM_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
 }
 
+// Single-slot store backing the filter state object FFI stubs below.
+static FILTER_STATE_OBJECT: std::sync::atomic::AtomicPtr<std::ffi::c_void> =
+  std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_http_set_filter_state_object(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+  _key: abi::envoy_dynamic_module_type_module_buffer,
+  module_object: abi::envoy_dynamic_module_type_filter_state_object_module_ptr,
+  _destructor: abi::envoy_dynamic_module_type_filter_state_object_destructor,
+  _life_span: abi::envoy_dynamic_module_type_filter_state_life_span,
+) -> bool {
+  FILTER_STATE_OBJECT.store(module_object, std::sync::atomic::Ordering::SeqCst);
+  true
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_http_get_filter_state_object(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+  _key: abi::envoy_dynamic_module_type_module_buffer,
+) -> abi::envoy_dynamic_module_type_filter_state_object_module_ptr {
+  FILTER_STATE_OBJECT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[test]
+fn test_http_filter_state_object_round_trip() {
+  use std::sync::atomic::Ordering;
+  static DROPPED: AtomicUsize = AtomicUsize::new(0);
+  struct Live;
+  impl Drop for Live {
+    fn drop(&mut self) {
+      DROPPED.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+  extern "C" fn destructor(object: *mut std::ffi::c_void) {
+    drop(unsafe { Box::from_raw(object as *mut Live) });
+  }
+
+  let mut envoy_filter = http::EnvoyHttpFilterImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+  let object = Box::into_raw(Box::new(Live)) as *mut std::ffi::c_void;
+  assert!(envoy_filter.set_filter_state_object(
+    b"key",
+    object,
+    destructor,
+    abi::envoy_dynamic_module_type_filter_state_life_span::Request,
+  ));
+
+  // The rebuilt filter recovers the same pointer across recreate_stream.
+  let recovered = envoy_filter.get_filter_state_object(b"key");
+  assert_eq!(recovered, Some(object));
+  assert_eq!(DROPPED.load(Ordering::SeqCst), 0);
+
+  // Envoy calls the destructor once when the entry is destroyed; the boxed value is freed exactly
+  // once with no double free.
+  destructor(recovered.unwrap());
+  assert_eq!(DROPPED.load(Ordering::SeqCst), 1);
+}
+
 static NETWORK_CLOSE_CALLED: AtomicBool = AtomicBool::new(false);
 
 #[no_mangle]

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3947,12 +3947,16 @@ fn test_http_filter_state_object_round_trip() {
     raw_ptr: std::ptr::null_mut(),
   };
   let object = Box::into_raw(Box::new(Live)) as *mut std::ffi::c_void;
-  assert!(envoy_filter.set_filter_state_object(
-    b"key",
-    object,
-    destructor,
-    abi::envoy_dynamic_module_type_filter_state_life_span::Request,
-  ));
+  // SAFETY: `object` is a freshly boxed Live and `destructor` frees exactly that type without
+  // unwinding.
+  assert!(unsafe {
+    envoy_filter.set_filter_state_object(
+      b"key",
+      object,
+      destructor,
+      abi::envoy_dynamic_module_type_filter_state_life_span::Request,
+    )
+  });
 
   // The rebuilt filter recovers the same pointer across recreate_stream.
   let recovered = envoy_filter.get_filter_state_object(b"key");

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -474,13 +474,15 @@ getMutableDynamicMetadataListValue(envoy_dynamic_module_type_http_filter_envoy_p
 
 // Wraps an opaque, module-owned object in filter state and calls the module destructor exactly once
 // on destruction. Non-serializable: it declines serialization and field support so it is never
-// written to bytes.
+// written to bytes. Holds a shared_ptr to the filter config so the module .so cannot unload while
+// this live destructor pointer into it exists; a Connection-lifespan entry may outlive the stream.
 class DynamicModuleFilterStateObject : public StreamInfo::FilterState::Object {
 public:
   DynamicModuleFilterStateObject(
+      DynamicModuleHttpFilterConfigSharedPtr config,
       envoy_dynamic_module_type_filter_state_object_module_ptr object,
       envoy_dynamic_module_type_filter_state_object_destructor destructor)
-      : object_(object), destructor_(destructor) {}
+      : config_(std::move(config)), object_(object), destructor_(destructor) {}
   ~DynamicModuleFilterStateObject() override {
     if (destructor_ != nullptr) {
       destructor_(object_);
@@ -489,6 +491,7 @@ public:
   envoy_dynamic_module_type_filter_state_object_module_ptr object() const { return object_; }
 
 private:
+  const DynamicModuleHttpFilterConfigSharedPtr config_;
   envoy_dynamic_module_type_filter_state_object_module_ptr object_;
   envoy_dynamic_module_type_filter_state_object_destructor destructor_;
 };
@@ -496,13 +499,15 @@ private:
 StreamInfo::FilterState::LifeSpan
 toFilterStateLifeSpan(envoy_dynamic_module_type_filter_state_life_span life_span) {
   switch (life_span) {
+  case envoy_dynamic_module_type_filter_state_life_span_FilterChain:
+    return StreamInfo::FilterState::LifeSpan::FilterChain;
   case envoy_dynamic_module_type_filter_state_life_span_Request:
     return StreamInfo::FilterState::LifeSpan::Request;
   case envoy_dynamic_module_type_filter_state_life_span_Connection:
     return StreamInfo::FilterState::LifeSpan::Connection;
-  default:
-    return StreamInfo::FilterState::LifeSpan::FilterChain;
   }
+  IS_ENVOY_BUG("unknown filter state life_span");
+  return StreamInfo::FilterState::LifeSpan::FilterChain;
 }
 
 } // namespace
@@ -1609,20 +1614,35 @@ bool envoy_dynamic_module_callback_http_set_filter_state_object(
     envoy_dynamic_module_type_filter_state_life_span life_span) {
   auto* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
   auto* stream_info = filter->streamInfo();
-  if (!stream_info) {
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
-                        "stream info is not available");
-    // Ownership transferred to Envoy; free the object rather than leak it.
+  // Ownership transferred to Envoy; on every failure path free the object rather than leak it.
+  auto free_object = [&]() {
     if (destructor != nullptr) {
       destructor(module_object);
     }
+  };
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    free_object();
+    return false;
+  }
+  const auto& filter_state = stream_info->filterState();
+  if (!filter_state) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "filter state is not available");
+    free_object();
     return false;
   }
   absl::string_view key_view(key.ptr, key.length);
-  stream_info->filterState()->setData(
-      key_view, std::make_shared<DynamicModuleFilterStateObject>(module_object, destructor),
-      toFilterStateLifeSpan(life_span));
-  return true;
+  filter_state->setData(key_view,
+                        std::make_shared<DynamicModuleFilterStateObject>(
+                            filter->getFilterConfigSharedPtr(), module_object, destructor),
+                        toFilterStateLifeSpan(life_span));
+  // setData is a no-op when the key already exists at a conflicting life_span. The wrapper is then
+  // destroyed and the destructor has already freed the object. Confirm our object was stored by
+  // pointer identity (an address compare, never a dereference) and report a failed store otherwise.
+  auto* stored = filter_state->getDataMutable<DynamicModuleFilterStateObject>(key_view);
+  return stored != nullptr && stored->object() == module_object;
 }
 
 envoy_dynamic_module_type_filter_state_object_module_ptr
@@ -1636,9 +1656,14 @@ envoy_dynamic_module_callback_http_get_filter_state_object(
                         "stream info is not available");
     return nullptr;
   }
+  const auto& filter_state = stream_info->filterState();
+  if (!filter_state) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "filter state is not available");
+    return nullptr;
+  }
   absl::string_view key_view(key.ptr, key.length);
-  auto* object =
-      stream_info->filterState()->getDataMutable<DynamicModuleFilterStateObject>(key_view);
+  auto* object = filter_state->getDataMutable<DynamicModuleFilterStateObject>(key_view);
   if (object == nullptr) {
     return nullptr;
   }

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -472,6 +472,39 @@ getMutableDynamicMetadataListValue(envoy_dynamic_module_type_http_filter_envoy_p
   return nullptr;
 }
 
+// Wraps an opaque, module-owned object in filter state and calls the module destructor exactly once
+// on destruction. Non-serializable: it declines serialization and field support so it is never
+// written to bytes.
+class DynamicModuleFilterStateObject : public StreamInfo::FilterState::Object {
+public:
+  DynamicModuleFilterStateObject(
+      envoy_dynamic_module_type_filter_state_object_module_ptr object,
+      envoy_dynamic_module_type_filter_state_object_destructor destructor)
+      : object_(object), destructor_(destructor) {}
+  ~DynamicModuleFilterStateObject() override {
+    if (destructor_ != nullptr) {
+      destructor_(object_);
+    }
+  }
+  envoy_dynamic_module_type_filter_state_object_module_ptr object() const { return object_; }
+
+private:
+  envoy_dynamic_module_type_filter_state_object_module_ptr object_;
+  envoy_dynamic_module_type_filter_state_object_destructor destructor_;
+};
+
+StreamInfo::FilterState::LifeSpan
+toFilterStateLifeSpan(envoy_dynamic_module_type_filter_state_life_span life_span) {
+  switch (life_span) {
+  case envoy_dynamic_module_type_filter_state_life_span_Request:
+    return StreamInfo::FilterState::LifeSpan::Request;
+  case envoy_dynamic_module_type_filter_state_life_span_Connection:
+    return StreamInfo::FilterState::LifeSpan::Connection;
+  default:
+    return StreamInfo::FilterState::LifeSpan::FilterChain;
+  }
+}
+
 } // namespace
 
 extern "C" {
@@ -1566,6 +1599,50 @@ bool envoy_dynamic_module_callback_http_get_filter_state_typed(
   result->ptr = const_cast<char*>(filter->last_serialized_filter_state_->data());
   result->length = filter->last_serialized_filter_state_->size();
   return true;
+}
+
+bool envoy_dynamic_module_callback_http_set_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_filter_state_object_module_ptr module_object,
+    envoy_dynamic_module_type_filter_state_object_destructor destructor,
+    envoy_dynamic_module_type_filter_state_life_span life_span) {
+  auto* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto* stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    // Ownership transferred to Envoy; free the object rather than leak it.
+    if (destructor != nullptr) {
+      destructor(module_object);
+    }
+    return false;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  stream_info->filterState()->setData(
+      key_view, std::make_shared<DynamicModuleFilterStateObject>(module_object, destructor),
+      toFilterStateLifeSpan(life_span));
+  return true;
+}
+
+envoy_dynamic_module_type_filter_state_object_module_ptr
+envoy_dynamic_module_callback_http_get_filter_state_object(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key) {
+  auto* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto* stream_info = filter->streamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return nullptr;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  auto* object =
+      stream_info->filterState()->getDataMutable<DynamicModuleFilterStateObject>(key_view);
+  if (object == nullptr) {
+    return nullptr;
+  }
+  return object->object();
 }
 
 void envoy_dynamic_module_callback_http_clear_route_cache(

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -244,6 +244,7 @@ public:
 
   bool hasConfig() const { return config_ != nullptr; }
   const DynamicModuleHttpFilterConfig& getFilterConfig() const { return *config_; }
+  const DynamicModuleHttpFilterConfigSharedPtr& getFilterConfigSharedPtr() const { return config_; }
   Stats::StatNameDynamicPool& getStatNamePool() { return stat_name_pool_; }
 
   /**

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1507,6 +1507,12 @@ WEAK_STUB(HttpSetFilterStateTyped,
                                                                     {nullptr, 0}))
 WEAK_STUB(HttpGetFilterStateTyped,
           envoy_dynamic_module_callback_http_get_filter_state_typed(nullptr, {nullptr, 0}, nullptr))
+WEAK_STUB(HttpSetFilterStateObject,
+          envoy_dynamic_module_callback_http_set_filter_state_object(
+              nullptr, {nullptr, 0}, nullptr, nullptr,
+              envoy_dynamic_module_type_filter_state_life_span_FilterChain))
+WEAK_STUB(HttpGetFilterStateObject,
+          envoy_dynamic_module_callback_http_get_filter_state_object(nullptr, {nullptr, 0}))
 WEAK_STUB(HttpAddCustomFlag,
           envoy_dynamic_module_callback_http_add_custom_flag(nullptr, {nullptr, 0}))
 WEAK_STUB(HttpFilterSchedulerNew, envoy_dynamic_module_callback_http_filter_scheduler_new(nullptr))

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1752,6 +1752,63 @@ TEST(ABIImpl, filter_state_object_destructor_runs_once) {
   EXPECT_EQ(2, filter_state_object_destructor_calls);
 }
 
+TEST(ABIImpl, filter_state_object_conflicting_life_span) {
+  filter_state_object_destructor_calls = 0;
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  // Leaf filter state is at FilterChain (the production leaf), so Request and Connection resolve to
+  // distinct parent levels and re-storing the same key at a different one is a genuine conflict.
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  const std::string key_str = "envoy.test.object";
+  auto* first = new int(1);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, first, filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Request));
+
+  // Re-storing the same key at a different life_span does not store (an ENVOY_BUG in FilterState).
+  // The new object is freed, the call reports failure, and the original entry is untouched. All
+  // assertions live inside EXPECT_ENVOY_BUG because in debug the ENVOY_BUG aborts inside setData,
+  // so the graceful-return path only exists in release/coverage where the macro runs in-process.
+  EXPECT_ENVOY_BUG(
+      {
+        EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_object(
+            &filter, {key_str.data(), key_str.size()}, new int(2), filterStateObjectDestructor,
+            envoy_dynamic_module_type_filter_state_life_span_Connection));
+        EXPECT_EQ(1, filter_state_object_destructor_calls);
+        EXPECT_EQ(first, envoy_dynamic_module_callback_http_get_filter_state_object(
+                             &filter, {key_str.data(), key_str.size()}));
+      },
+      "conflicting life_span");
+}
+
+TEST(ABIImpl, filter_state_object_no_filter_state) {
+  filter_state_object_destructor_calls = 0;
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  // Null filter state: set frees the object and fails, get returns null; neither dereferences it.
+  stream_info.filter_state_ = nullptr;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  const std::string key_str = "envoy.test.object";
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, new int(1), filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Request));
+  EXPECT_EQ(1, filter_state_object_destructor_calls);
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_http_get_filter_state_object(
+                         &filter, {key_str.data(), key_str.size()}));
+}
+
 std::string
 bufferVectorToString(const std::vector<envoy_dynamic_module_type_envoy_buffer>& buffer_vector) {
   std::string result;

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1648,6 +1648,110 @@ TEST(ABIImpl, filter_state_typed_non_serializable) {
       &filter, {key_str.data(), key_str.size()}, &result_buffer));
 }
 
+// Incremented by filterStateObjectDestructor; reset at the start of each test that uses it.
+int filter_state_object_destructor_calls = 0;
+void filterStateObjectDestructor(void* object) {
+  filter_state_object_destructor_calls++;
+  delete static_cast<int*>(object);
+}
+
+TEST(ABIImpl, filter_state_object) {
+  filter_state_object_destructor_calls = 0;
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  const std::string key_str = "envoy.test.object";
+
+  // No stream info: set fails, but ownership transferred to Envoy so the object is freed (not
+  // leaked), and get returns null.
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, new int(42), filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Request));
+  EXPECT_EQ(1, filter_state_object_destructor_calls);
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_http_get_filter_state_object(
+                         &filter, {key_str.data(), key_str.size()}));
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  // Store at Request lifespan and read the same pointer back.
+  auto* stored = new int(7);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, stored, filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Request));
+  EXPECT_EQ(stored, envoy_dynamic_module_callback_http_get_filter_state_object(
+                        &filter, {key_str.data(), key_str.size()}));
+
+  // Missing key returns null.
+  const std::string missing = "missing";
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_http_get_filter_state_object(
+                         &filter, {missing.data(), missing.size()}));
+
+  // A key holding a non-object (bytes) entry returns null.
+  const std::string bytes_key = "bytes";
+  const std::string bytes_value = "value";
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_bytes(
+      &filter, {bytes_key.data(), bytes_key.size()}, {bytes_value.data(), bytes_value.size()}));
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_http_get_filter_state_object(
+                         &filter, {bytes_key.data(), bytes_key.size()}));
+}
+
+TEST(ABIImpl, filter_state_object_lifespans) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.filter_state_ =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  for (auto life_span : {envoy_dynamic_module_type_filter_state_life_span_FilterChain,
+                         envoy_dynamic_module_type_filter_state_life_span_Request,
+                         envoy_dynamic_module_type_filter_state_life_span_Connection}) {
+    const std::string key_str = "envoy.test.object." + std::to_string(life_span);
+    auto* object = new int(life_span);
+    EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_object(
+        &filter, {key_str.data(), key_str.size()}, object, filterStateObjectDestructor, life_span));
+    EXPECT_EQ(object, envoy_dynamic_module_callback_http_get_filter_state_object(
+                          &filter, {key_str.data(), key_str.size()}));
+  }
+}
+
+TEST(ABIImpl, filter_state_object_destructor_runs_once) {
+  filter_state_object_destructor_calls = 0;
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.filter_state_ =
+      std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, filterState())
+      .WillRepeatedly(testing::ReturnRef(stream_info.filter_state_));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  const std::string key_str = "envoy.test.object";
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, new int(1), filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Connection));
+
+  // Overwriting the key destroys the previous object exactly once.
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_set_filter_state_object(
+      &filter, {key_str.data(), key_str.size()}, new int(2), filterStateObjectDestructor,
+      envoy_dynamic_module_type_filter_state_life_span_Connection));
+  EXPECT_EQ(1, filter_state_object_destructor_calls);
+
+  // Destroying the filter state runs the destructor for the surviving object exactly once.
+  stream_info.filter_state_.reset();
+  EXPECT_EQ(2, filter_state_object_destructor_calls);
+}
+
 std::string
 bufferVectorToString(const std::vector<envoy_dynamic_module_type_envoy_buffer>& buffer_vector) {
   std::string result;

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -425,6 +425,26 @@ TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnRequestHeaders) {
       response->headers().get(Http::LowerCaseString("some_header"))[0]->value().getStringView());
 }
 
+// A live, non-serializable object stored in filter state at Request lifespan is carried across
+// recreate_stream: the rebuilt filter recovers the same object and echoes its value.
+TEST_P(DynamicModulesIntegrationTest, FilterStateObjectSurvivesRecreateStream) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the filter_state_object_recreate filter is only in the rust test module";
+  }
+  initializeFilter("filter_state_object_recreate");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("0xabcd", response->headers()
+                          .get(Http::LowerCaseString("x-live-object-value"))[0]
+                          ->value()
+                          .getStringView());
+}
+
 TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnRequestBody) {
   initializeFilter("send_response", "on_request_body");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -153,6 +153,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       Some(Box::new(ConfigStreamConfig { stream_done }))
     },
     "list_metadata_callbacks" => Some(Box::new(ListMetadataCallbacksFilterConfig {})),
+    "filter_state_object_recreate" => Some(Box::new(FilterStateObjectRecreateFilterConfig {})),
     _ => panic!("Unknown filter name: {name}"),
   }
 }
@@ -163,6 +164,78 @@ fn new_http_filter_per_route_config_fn(name: &str, config: &[u8]) -> Option<Box<
       value: String::from_utf8(config.to_owned()).unwrap(),
     })),
     _ => panic!("Unknown filter name: {name}"),
+  }
+}
+
+/// A live, non-serializable object: the endpoints of an in-flight async exchange. Live channel
+/// handles cannot be reduced to bytes, so the byte-oriented filter state API cannot carry them;
+/// they must survive recreate_stream as a live object.
+struct LiveExchange {
+  sender: std::sync::mpsc::Sender<u64>,
+  receiver: std::sync::mpsc::Receiver<u64>,
+}
+
+const LIVE_OBJECT_KEY: &[u8] = b"envoy.dynamic_modules.test.live_object";
+
+/// Frees the boxed [`LiveExchange`] exactly once when Envoy destroys the filter state entry.
+extern "C" fn drop_live_exchange(object: *mut std::ffi::c_void) {
+  drop(unsafe { Box::from_raw(object as *mut LiveExchange) });
+}
+
+/// A HTTP filter that keeps a live object alive across recreate_stream, the way a filter holding the
+/// endpoints of an async exchange would. The first instance queues a token on the live channel and
+/// parks it in filter state at Request lifespan, then recreates the stream, which destroys the
+/// instance. The rebuilt instance re-attaches to the same live object and drains the queued token,
+/// proving the live handles survived the recreate (a serialized copy would not carry the message).
+struct FilterStateObjectRecreateFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for FilterStateObjectRecreateFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(FilterStateObjectRecreateFilter {})
+  }
+}
+
+struct FilterStateObjectRecreateFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FilterStateObjectRecreateFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    match envoy_filter.get_filter_state_object(LIVE_OBJECT_KEY) {
+      None => {
+        let (sender, receiver) = std::sync::mpsc::channel::<u64>();
+        // Queue a token on the live channel before this instance is destroyed by the recreate.
+        sender.send(0xABCD).unwrap();
+        let object =
+          Box::into_raw(Box::new(LiveExchange { sender, receiver })) as *mut std::ffi::c_void;
+        assert!(envoy_filter.set_filter_state_object(
+          LIVE_OBJECT_KEY,
+          object,
+          drop_live_exchange,
+          abi::envoy_dynamic_module_type_filter_state_life_span::Request,
+        ));
+        assert!(envoy_filter.recreate_stream(None));
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+      },
+      Some(object) => {
+        // The rebuilt instance re-attaches to the same live object and drains the token the
+        // destroyed instance queued, then round-trips it to show both endpoints are still live.
+        let exchange = unsafe { &*(object as *const LiveExchange) };
+        let token = exchange.receiver.recv().unwrap();
+        exchange.sender.send(token).unwrap();
+        let token = exchange.receiver.recv().unwrap();
+        let token_str = format!("{token:#x}");
+        envoy_filter.send_response(
+          200,
+          &[("x-live-object-value", token_str.as_bytes())],
+          None,
+          None,
+        );
+        abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+      },
+    }
   }
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -210,12 +210,16 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FilterStateObjectRecreateFilter {
         sender.send(0xABCD).unwrap();
         let object =
           Box::into_raw(Box::new(LiveExchange { sender, receiver })) as *mut std::ffi::c_void;
-        assert!(envoy_filter.set_filter_state_object(
-          LIVE_OBJECT_KEY,
-          object,
-          drop_live_exchange,
-          abi::envoy_dynamic_module_type_filter_state_life_span::Request,
-        ));
+        // SAFETY: `object` is a freshly boxed LiveExchange and `drop_live_exchange` frees exactly
+        // that type without unwinding.
+        assert!(unsafe {
+          envoy_filter.set_filter_state_object(
+            LIVE_OBJECT_KEY,
+            object,
+            drop_live_exchange,
+            abi::envoy_dynamic_module_type_filter_state_life_span::Request,
+          )
+        });
         assert!(envoy_filter.recreate_stream(None));
         abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
       },


### PR DESCRIPTION
**Commit Message:** persist module-owned filter state objects across stream recreates
**Additional Description:**

This adds a dynamic-modules HTTP-filter ABI that lets a module store an opaque, module-owned, non-serializable object in StreamInfo::FilterState at a lifespan that survives recreate_stream, with a module-supplied destructor. It is purely additive to the dynamic-modules extension.

**Motivation:** A dynamic-module HTTP filter sometimes needs to keep a live, per-stream object graph (channel handles, task handles for an in-flight async exchange) alive across an Envoy recreate_stream(). recreate_stream() destroys the current filter instance and builds a fresh one, so any state the instance held in native memory dies with it. The existing filter-state ABI can't carry it: it's byte-oriented (no way to serialize live handles) and hardcoded to FilterChain lifespan.

This adds two HTTP-filter ABI callbacks plus Rust SDK wrappers:

- set_filter_state_object(key, obj, destructor, life_span): store an opaque, module-owned void* with a lifespan and a module destructor.
- get_filter_state_object(key):  borrow it back on any later hook, including the rebuilt instance after a recreate.

Objects stored at Request/Connection lifespan are carried into the new stream by the connection manager; FilterChain objects are not.

The module keys the object under a fixed, well-known name. On a fresh request the key is absent, so the filter creates the object and stores it; after recreate_stream the same key is present on the rebuilt instance, which is the signal to re-attach to the surviving object instead of starting over. The per-stream filter state is the entire handoff ; no request header, random id, or external registry needed.

Risk Level: Low
Testing: Unit and Integration Tests
Docs Changes: N.A
Release Notes: N.A
Platform Specific Features: N.A
