### PR TITLE
fix kafka filters allow remote memory exhaustion via unbounded tagged field allocation

### DIFF
--- a/contrib/kafka/filters/network/source/tagged_fields.h
+++ b/contrib/kafka/filters/network/source/tagged_fields.h
@@ -67,9 +67,8 @@ public:
     if (!length_consumed_) {
       required_ = length_deserializer_.get();
       if (required_ > MAX_TAGGED_FIELD_DATA_SIZE) {
-        throw EnvoyException(fmt::format(
-            "Tagged field data length {} exceeds maximum allowed {}", required_,
-            MAX_TAGGED_FIELD_DATA_SIZE));
+        throw EnvoyException(fmt::format("Tagged field data length {} exceeds maximum allowed {}",
+                                         required_, MAX_TAGGED_FIELD_DATA_SIZE));
       }
       data_buffer_.reserve(required_);
       length_consumed_ = true;
@@ -148,9 +147,8 @@ public:
     if (!children_setup_) {
       const uint32_t field_count = count_deserializer_.get();
       if (field_count > MAX_TAGGED_FIELD_COUNT) {
-        throw EnvoyException(fmt::format(
-            "Tagged field count {} exceeds maximum allowed {}", field_count,
-            MAX_TAGGED_FIELD_COUNT));
+        throw EnvoyException(fmt::format("Tagged field count {} exceeds maximum allowed {}",
+                                         field_count, MAX_TAGGED_FIELD_COUNT));
       }
       children_ = std::vector<TaggedFieldDeserializer>(field_count);
       children_setup_ = true;

--- a/contrib/kafka/filters/network/source/tagged_fields.h
+++ b/contrib/kafka/filters/network/source/tagged_fields.h
@@ -50,6 +50,9 @@ struct TaggedField {
  */
 class TaggedFieldDeserializer : public Deserializer<TaggedField> {
 public:
+  // protects against memory exhaustion via attacker controlled field data length.
+  static constexpr uint32_t MAX_TAGGED_FIELD_DATA_SIZE = 64 * 1024; // 64 kb
+
   TaggedFieldDeserializer() = default;
 
   uint32_t feed(absl::string_view& data) override {
@@ -63,14 +66,18 @@ public:
 
     if (!length_consumed_) {
       required_ = length_deserializer_.get();
-      data_buffer_ = std::vector<unsigned char>(required_);
+      if (required_ > MAX_TAGGED_FIELD_DATA_SIZE) {
+        throw EnvoyException(fmt::format(
+            "Tagged field data length {} exceeds maximum allowed {}", required_,
+            MAX_TAGGED_FIELD_DATA_SIZE));
+      }
+      data_buffer_.reserve(required_);
       length_consumed_ = true;
     }
 
     const uint32_t data_consumed = std::min<uint32_t>(required_, data.size());
-    const uint32_t written = data_buffer_.size() - required_;
     if (data_consumed > 0) {
-      memcpy(data_buffer_.data() + written, data.data(), data_consumed); // NOLINT(safe-memcpy)
+      data_buffer_.insert(data_buffer_.end(), data.data(), data.data() + data_consumed);
       required_ -= data_consumed;
       data = {data.data() + data_consumed, data.size() - data_consumed};
     }
@@ -128,6 +135,9 @@ struct TaggedFields {
  */
 class TaggedFieldsDeserializer : public Deserializer<TaggedFields> {
 public:
+  // protects against memory exhaustion via attacker controlled tagged field count.
+  static constexpr uint32_t MAX_TAGGED_FIELD_COUNT = 64;
+
   uint32_t feed(absl::string_view& data) override {
 
     const uint32_t count_consumed = count_deserializer_.feed(data);
@@ -137,6 +147,11 @@ public:
 
     if (!children_setup_) {
       const uint32_t field_count = count_deserializer_.get();
+      if (field_count > MAX_TAGGED_FIELD_COUNT) {
+        throw EnvoyException(fmt::format(
+            "Tagged field count {} exceeds maximum allowed {}", field_count,
+            MAX_TAGGED_FIELD_COUNT));
+      }
       children_ = std::vector<TaggedFieldDeserializer>(field_count);
       children_setup_ = true;
     }

--- a/contrib/kafka/filters/network/test/serialization_test.cc
+++ b/contrib/kafka/filters/network/test/serialization_test.cc
@@ -578,7 +578,7 @@ TEST(TaggedFieldDeserializer, ShouldConsumeCorrectAmountOfData) {
 
 TEST(TaggedFieldsDeserializer, ShouldConsumeCorrectAmountOfData) {
   std::vector<TaggedField> fields;
-  for (uint32_t i = 0; i < 200; ++i) {
+  for (uint32_t i = 0; i < 10; ++i) {
     const TaggedField tagged_field = {i, Bytes{1, 2, 3, 4}};
     fields.push_back(tagged_field);
   }

--- a/contrib/kafka/filters/network/test/serialization_test.cc
+++ b/contrib/kafka/filters/network/test/serialization_test.cc
@@ -576,6 +576,49 @@ TEST(TaggedFieldDeserializer, ShouldConsumeCorrectAmountOfData) {
   serializeCompactThenDeserializeAndCheckEquality<TaggedFieldDeserializer>(value);
 }
 
+TEST(TaggedFieldDeserializer, ShouldConsumeEmptyData) {
+  const TaggedField value{0, Bytes{}};
+  serializeCompactThenDeserializeAndCheckEquality<TaggedFieldDeserializer>(value);
+}
+
+TEST(TaggedFieldDeserializer, ShouldConsumeDataInChunks) {
+  const TaggedField value{42, Bytes{10, 20, 30, 40, 50}};
+  serializeCompactThenDeserializeAndCheckEqualityWithChunks<TaggedFieldDeserializer>(value);
+}
+
+TEST(TaggedFieldDeserializer, ShouldThrowOnExcessiveDataLength) {
+  // given
+  TaggedFieldDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t tag = 0;
+  encoder.encodeCompact(tag, buffer);
+  const uint32_t oversized_length = TaggedFieldDeserializer::MAX_TAGGED_FIELD_DATA_SIZE + 1;
+  encoder.encodeCompact(oversized_length, buffer);
+
+  absl::string_view data = {getRawData(buffer), buffer.length()};
+
+  // when, then
+  EXPECT_THROW_WITH_REGEX(testee.feed(data), EnvoyException, "exceeds maximum allowed");
+}
+
+TEST(TaggedFieldDeserializer, ShouldAcceptDataLengthAtLimit) {
+  // given
+  TaggedFieldDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t tag = 0;
+  encoder.encodeCompact(tag, buffer);
+  const uint32_t max_length = TaggedFieldDeserializer::MAX_TAGGED_FIELD_DATA_SIZE;
+  encoder.encodeCompact(max_length, buffer);
+
+  absl::string_view data = {getRawData(buffer), buffer.length()};
+
+  // when, then
+  EXPECT_NO_THROW(testee.feed(data));
+  ASSERT_EQ(testee.ready(), false);
+}
+
 TEST(TaggedFieldsDeserializer, ShouldConsumeCorrectAmountOfData) {
   std::vector<TaggedField> fields;
   for (uint32_t i = 0; i < 10; ++i) {
@@ -584,6 +627,40 @@ TEST(TaggedFieldsDeserializer, ShouldConsumeCorrectAmountOfData) {
   }
   const TaggedFields value{fields};
   serializeCompactThenDeserializeAndCheckEquality<TaggedFieldsDeserializer>(value);
+}
+
+TEST(TaggedFieldsDeserializer, ShouldConsumeZeroFields) {
+  const TaggedFields value{{}};
+  serializeCompactThenDeserializeAndCheckEquality<TaggedFieldsDeserializer>(value);
+}
+
+TEST(TaggedFieldsDeserializer, ShouldThrowOnExcessiveFieldCount) {
+  // given
+  TaggedFieldsDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t oversized_count = TaggedFieldsDeserializer::MAX_TAGGED_FIELD_COUNT + 1;
+  encoder.encodeCompact(oversized_count, buffer);
+
+  absl::string_view data = {getRawData(buffer), buffer.length()};
+
+  // when, then
+  EXPECT_THROW_WITH_REGEX(testee.feed(data), EnvoyException, "exceeds maximum allowed");
+}
+
+TEST(TaggedFieldsDeserializer, ShouldAcceptFieldCountAtLimit) {
+  // given
+  TaggedFieldsDeserializer testee;
+  Buffer::OwnedImpl buffer;
+
+  const uint32_t max_count = TaggedFieldsDeserializer::MAX_TAGGED_FIELD_COUNT;
+  encoder.encodeCompact(max_count, buffer);
+
+  absl::string_view data = {getRawData(buffer), buffer.length()};
+
+  // when, then
+  EXPECT_NO_THROW(testee.feed(data));
+  ASSERT_EQ(testee.ready(), false);
 }
 
 // Just a helper to write shorter tests.


### PR DESCRIPTION
_Commit Message:_
fix memory exhaustion via unbounded tagged field allocation in flexible-version request headers.

_Additional Description:_
the Envoy contrib Kafka network filter was vulnerable to a memory exhaustion attack through the flexible-version request header parser. Kafka's flexible version protocol extends request headers with optional tagged fields, each encoded as a VarUInt32 count followed by per-field VarUInt32 tag, VarUInt32 data-length, and data bytes.
added MAX_TAGGED_FIELD_COUNT = 64 and MAX_TAGGED_FIELD_DATA_SIZE = 64 kb guard here to mitigate the issue.

_Risk Level:_
low

_Testing:_
will update test cases soon

Fixes #45859

