### PR TITLE
Fix format issue: s/absl::nullopt/std::nullopt

### DIFF
--- a/test/extensions/access_loggers/common/grpc_access_logger_test.cc
+++ b/test/extensions/access_loggers/common/grpc_access_logger_test.cc
@@ -434,7 +434,7 @@ public:
   StreamingGrpcAccessLogClientTest() {
     client_ =
         std::make_unique<Common::StreamingGrpcAccessLogClient<Protobuf::Struct, Protobuf::Struct>>(
-            Grpc::RawAsyncClientSharedPtr{async_client_}, mockMethodDescriptor(), absl::nullopt);
+            Grpc::RawAsyncClientSharedPtr{async_client_}, mockMethodDescriptor(), std::nullopt);
   }
 
   Grpc::MockAsyncClient* async_client_{new Grpc::MockAsyncClient()};


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Fix format issue in test/extensions/access_loggers/common/grpc_access_logger_test.cc. it uses absl::nullopt which breaks CI
Additional Description:
Risk Level: low
Testing: ran code format
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
