### PR TITLE
http: replace per-request ODCDS filter virtual dispatch with variant

### DIFF
--- a/source/extensions/filters/http/on_demand/BUILD
+++ b/source/extensions/filters/http/on_demand/BUILD
@@ -27,6 +27,7 @@ envoy_cc_library(
         "//source/common/http:header_map_lib",
         "//source/common/upstream:od_cds_api_lib",
         "//source/extensions/filters/http:well_known_names",
+        "@abseil-cpp//absl/types:variant",
         "@envoy_api//envoy/extensions/filters/http/on_demand/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/on_demand/on_demand_update.cc
+++ b/source/extensions/filters/http/on_demand/on_demand_update.cc
@@ -10,50 +10,39 @@
 #include "source/common/upstream/od_cds_api_impl.h"
 #include "source/extensions/filters/http/well_known_names.h"
 
+#include "absl/types/variant.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace OnDemand {
 
-namespace {
+void DecodeHeadersBehavior::Rds::decodeHeaders(OnDemandRouteUpdate& filter) const {
+  filter.handleMissingRoute();
+}
 
-class RdsDecodeHeadersBehavior : public DecodeHeadersBehavior {
-public:
-  void decodeHeaders(OnDemandRouteUpdate& filter) override { filter.handleMissingRoute(); }
-};
-
-class RdsCdsDecodeHeadersBehavior : public DecodeHeadersBehavior {
-public:
-  RdsCdsDecodeHeadersBehavior(Upstream::OdCdsApiHandlePtr odcds, std::chrono::milliseconds timeout)
-      : odcds_(std::move(odcds)), timeout_(timeout) {}
-
-  void decodeHeaders(OnDemandRouteUpdate& filter) override {
-    auto route = filter.handleMissingRoute();
-    if (!route.has_value()) {
-      return;
-    }
-    filter.handleOnDemandCds(route.value(), *odcds_, timeout_);
+void DecodeHeadersBehavior::CdsRds::decodeHeaders(OnDemandRouteUpdate& filter) const {
+  auto route = filter.handleMissingRoute();
+  if (!route.has_value()) {
+    return;
   }
-
-private:
-  Upstream::OdCdsApiHandlePtr odcds_;
-  std::chrono::milliseconds timeout_;
-};
-
-} // namespace
-
-DecodeHeadersBehaviorPtr DecodeHeadersBehavior::rds() {
-  return std::make_unique<RdsDecodeHeadersBehavior>();
+  filter.handleOnDemandCds(route.value(), *odcds, timeout);
 }
 
-DecodeHeadersBehaviorPtr DecodeHeadersBehavior::cdsRds(Upstream::OdCdsApiHandlePtr odcds,
-                                                       std::chrono::milliseconds timeout) {
-  return std::make_unique<RdsCdsDecodeHeadersBehavior>(std::move(odcds), timeout);
+void DecodeHeadersBehavior::decodeHeaders(OnDemandRouteUpdate& filter) const {
+  absl::visit([&filter](const auto& behavior) { behavior.decodeHeaders(filter); }, behavior_);
+}
+
+DecodeHeadersBehavior DecodeHeadersBehavior::rds() { return DecodeHeadersBehavior(Rds{}); }
+
+DecodeHeadersBehavior DecodeHeadersBehavior::cdsRds(Upstream::OdCdsApiHandlePtr odcds,
+                                                    std::chrono::milliseconds timeout) {
+  return DecodeHeadersBehavior(CdsRds{std::move(odcds), timeout});
 }
 
 namespace {
 
-DecodeHeadersBehaviorPtr createDecodeHeadersBehavior(
+DecodeHeadersBehavior createDecodeHeadersBehavior(
     OptRef<const envoy::extensions::filters::http::on_demand::v3::OnDemandCds> odcds_config,
     Upstream::ClusterManager& cm, ProtobufMessage::ValidationVisitor& validation_visitor) {
   if (!odcds_config.has_value()) {
@@ -121,7 +110,7 @@ getOdCdsConfig(const ProtoConfig& proto_config) {
 
 } // namespace
 
-OnDemandFilterConfig::OnDemandFilterConfig(DecodeHeadersBehaviorPtr behavior)
+OnDemandFilterConfig::OnDemandFilterConfig(DecodeHeadersBehavior behavior)
     : behavior_(std::move(behavior)) {}
 
 OnDemandFilterConfig::OnDemandFilterConfig(

--- a/source/extensions/filters/http/on_demand/on_demand_update.h
+++ b/source/extensions/filters/http/on_demand/on_demand_update.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <chrono>
+
 #include "envoy/extensions/filters/http/on_demand/v3/on_demand.pb.h"
 #include "envoy/extensions/filters/http/on_demand/v3/on_demand.pb.validate.h"
 #include "envoy/http/filter.h"
 #include "envoy/upstream/cluster_manager.h"
+
+#include "absl/types/variant.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -11,34 +15,46 @@ namespace HttpFilters {
 namespace OnDemand {
 
 class OnDemandRouteUpdate;
-class DecodeHeadersBehavior;
-using DecodeHeadersBehaviorPtr = std::unique_ptr<DecodeHeadersBehavior>;
 
-// DecodeHeadersBehavior implementations are used by OnDemandRouteUpdate in its decodeHeaders
-// method.
 class DecodeHeadersBehavior {
 public:
   // The returned object will only perform route discovery if it's missing.
-  static DecodeHeadersBehaviorPtr rds();
+  static DecodeHeadersBehavior rds();
   // The returned object will perform route discovery if it's missing,
   // then after route is successfully discovered, it will proceed to
   // on-demand cluster discovery if the cluster is missing. The latter
   // discovery will be done with the passed OdCdsApi and timeout.
-  static DecodeHeadersBehaviorPtr cdsRds(Upstream::OdCdsApiHandlePtr odcds,
-                                         std::chrono::milliseconds timeout);
+  static DecodeHeadersBehavior cdsRds(Upstream::OdCdsApiHandlePtr odcds,
+                                      std::chrono::milliseconds timeout);
 
-  virtual ~DecodeHeadersBehavior() = default;
+  void decodeHeaders(OnDemandRouteUpdate& filter) const;
 
-  virtual void decodeHeaders(OnDemandRouteUpdate& filter) PURE;
+private:
+  // Performs only on-demand route discovery.
+  struct Rds {
+    void decodeHeaders(OnDemandRouteUpdate& filter) const;
+  };
+
+  // Performs on-demand route discovery followed by on-demand cluster discovery.
+  struct CdsRds {
+    void decodeHeaders(OnDemandRouteUpdate& filter) const;
+
+    Upstream::OdCdsApiHandlePtr odcds;
+    std::chrono::milliseconds timeout;
+  };
+
+  using Behavior = absl::variant<Rds, CdsRds>;
+
+  explicit DecodeHeadersBehavior(Behavior behavior) : behavior_(std::move(behavior)) {}
+
+  Behavior behavior_;
 };
-
-using DecodeHeadersBehaviorPtr = std::unique_ptr<DecodeHeadersBehavior>;
 
 // OnDemandFilterConfig contains information from either the extension's
 // proto config or the extension's per-route proto config.
 class OnDemandFilterConfig : public Router::RouteSpecificFilterConfig {
 public:
-  explicit OnDemandFilterConfig(DecodeHeadersBehaviorPtr behavior);
+  explicit OnDemandFilterConfig(DecodeHeadersBehavior behavior);
   // Constructs config from extension's proto config.
   OnDemandFilterConfig(
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
@@ -48,10 +64,10 @@ public:
       const envoy::extensions::filters::http::on_demand::v3::PerRouteConfig& proto_config,
       Upstream::ClusterManager& cm, ProtobufMessage::ValidationVisitor& validation_visitor);
 
-  DecodeHeadersBehavior& decodeHeadersBehavior() const { return *behavior_; }
+  const DecodeHeadersBehavior& decodeHeadersBehavior() const { return behavior_; }
 
 private:
-  DecodeHeadersBehaviorPtr behavior_;
+  DecodeHeadersBehavior behavior_;
 };
 
 using OnDemandFilterConfigSharedPtr = std::shared_ptr<OnDemandFilterConfig>;


### PR DESCRIPTION
Commit Message:
Make DecodeHeadersBehavior a thin wrapper around a variant<Rds, CdsRds> and dispatch decodeHeaders via visit instead of a virtual call, avoiding the vtable indirection on the decode-headers hot path.

Additional Description:
This also removes one heap allocation on filter construction. It does so by moving storage inline into the filter.

This change was implemented with AI but is approximately what I would have written myself.

Risk Level: low
Testing: ran unit tests
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A