### PR TITLE
listener: implement support for multiple API listeners in Envoy native

### DIFF
--- a/api/envoy/config/listener/v3/listener.proto
+++ b/api/envoy/config/listener/v3/listener.proto
@@ -364,7 +364,7 @@ message Listener {
   //
   // .. note::
   //
-  //  Currently only one ApiListener can be installed; and it can only be done via bootstrap config,
+  //  Multiple API listeners can be installed, but they can only be configured via bootstrap config,
   //  not LDS.
   //
   // [#next-major-version: In the v3 API, instead of this messy approach where the socket

--- a/changelogs/current/new_features/listener__support-multiple-api-listeners.rst
+++ b/changelogs/current/new_features/listener__support-multiple-api-listeners.rst
@@ -1,0 +1,1 @@
+Added support for multiple API listeners. Multiple API listeners can be added via bootstrap configuration and retrieved by name.

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -531,7 +531,8 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
           "error adding listener named '{}': api_listener and internal_listener cannot be both set",
           name));
     }
-    if (!api_listener_ && !added_via_api) {
+
+    if (!added_via_api) {
       auto* api_listener_factory =
           Registry::FactoryRegistry<Server::ApiListenerFactory>::getFactory(
               "envoy.http_api_listener");
@@ -539,13 +540,16 @@ ListenerManagerImpl::addOrUpdateListener(const envoy::config::listener::v3::List
         return absl::InvalidArgumentError(fmt::format(
             "error adding listener named '{}': missing the API listener extension", name));
       }
-      auto listener_or_error = api_listener_factory->create(config, server_, config.name());
+      auto listener_or_error = api_listener_factory->create(config, server_, name);
       RETURN_IF_NOT_OK_REF(listener_or_error.status());
-      api_listener_ = std::move(listener_or_error.value());
+
+      api_listeners_[name] = std::move(listener_or_error.value());
       return true;
     } else {
-      ENVOY_LOG(warn, "listener {} can not be added because currently only one ApiListener is "
-                      "allowed, and it can only be added via bootstrap configuration");
+      ENVOY_LOG(warn,
+                "listener {} can not be added because currently API listeners "
+                "can only be added via bootstrap configuration",
+                name);
       return false;
     }
   }
@@ -1321,7 +1325,19 @@ void ListenerManagerImpl::maybeCloseSocketsForListener(ListenerImpl& listener) {
 }
 
 ApiListenerOptRef ListenerManagerImpl::apiListener() {
-  return api_listener_ ? ApiListenerOptRef(std::ref(*api_listener_)) : std::nullopt;
+  if (api_listeners_.empty()) {
+    return std::nullopt;
+  }
+  ASSERT(api_listeners_.size() == 1);
+  return ApiListenerOptRef(std::ref(*api_listeners_.begin()->second));
+}
+
+ApiListenerOptRef ListenerManagerImpl::apiListener(absl::string_view name) {
+  auto it = api_listeners_.find(name);
+  if (it != api_listeners_.end()) {
+    return ApiListenerOptRef(std::ref(*it->second));
+  }
+  return std::nullopt;
 }
 
 ListenerUpdateCallbacksHandlePtr

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -245,6 +245,7 @@ public:
   Http::Context& httpContext() { return server_.httpContext(); }
   using ListenerManager::apiListener;
   ApiListenerOptRef apiListener() override;
+  ApiListenerOptRef apiListener(absl::string_view name) override;
   ListenerUpdateCallbacksHandlePtr
   addListenerUpdateCallbacks(ListenerUpdateCallbacks& callbacks) override;
 
@@ -368,7 +369,7 @@ private:
   absl::Status setupSocketFactoryForListener(ListenerImpl& new_listener,
                                              const ListenerImpl& existing_listener);
 
-  ApiListenerPtr api_listener_;
+  absl::flat_hash_map<std::string, ApiListenerPtr> api_listeners_;
   // Active listeners are listeners that are currently accepting new connections on the workers.
   ListenerList active_listeners_;
   // Warming listeners are listeners that may need further initialization via the listener's init

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -7492,7 +7492,7 @@ api_listener:
   ASSERT_FALSE(manager_->apiListener().has_value());
 }
 
-TEST_P(ListenerManagerImplWithRealFiltersTest, ApiListenerOnlyOneApiListener) {
+TEST_P(ListenerManagerImplWithRealFiltersTest, MultipleApiListeners) {
   const std::string yaml = R"EOF(
 name: test_api_listener
 address:
@@ -7544,14 +7544,20 @@ api_listener:
   ASSERT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", false));
   EXPECT_EQ(0U, manager_->listeners().size());
   ASSERT_TRUE(manager_->apiListener().has_value());
+  // When there are multiple, apiListener() returns the first one in the map.
+  // Before adding the second one, it should be test_api_listener.
   EXPECT_EQ("test_api_listener", manager_->apiListener()->get().name());
 
-  // Only one ApiListener is added.
-  ASSERT_FALSE(addOrUpdateListener(parseListenerFromV3Yaml(yaml), "", false));
+  // Multiple ApiListeners can be added
+  ASSERT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(yaml2), "", false));
   EXPECT_EQ(0U, manager_->listeners().size());
-  // The original ApiListener is there.
-  ASSERT_TRUE(manager_->apiListener().has_value());
-  EXPECT_EQ("test_api_listener", manager_->apiListener()->get().name());
+
+  // Both ApiListeners can be looked up by name
+  ASSERT_TRUE(manager_->apiListener("test_api_listener").has_value());
+  EXPECT_EQ("test_api_listener", manager_->apiListener("test_api_listener")->get().name());
+
+  ASSERT_TRUE(manager_->apiListener("test_api_listener_2").has_value());
+  EXPECT_EQ("test_api_listener_2", manager_->apiListener("test_api_listener_2")->get().name());
 }
 
 TEST_P(ListenerManagerImplWithRealFiltersTest, AddOrUpdateInternalListener) {

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -46,6 +46,34 @@ public:
     )EOF");
   }
 
+  static std::string apiListener2Config() {
+    return R"EOF(
+name: api_listener_2
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 2
+api_listener:
+  api_listener:
+    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+    stat_prefix: hcm2
+    route_config:
+      virtual_hosts:
+        name: integration
+        routes:
+          route:
+            cluster: cluster_0
+          match:
+            prefix: "/"
+        domains: "*"
+      name: route_config_0
+    http_filters:
+      - name: router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      )EOF";
+  }
+
   static std::string apiListenerConfig() {
     return R"EOF(
 name: api_listener
@@ -207,6 +235,57 @@ TEST_P(ApiListenerIntegrationTest, FromWorkerThread) {
     http_api_listener.reset();
     cleanup_done.Notify();
   });
+  ASSERT_TRUE(cleanup_done.WaitForNotificationWithTimeout(absl::Seconds(1)));
+}
+
+TEST_P(ApiListenerIntegrationTest, MultipleApiListeners) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    bootstrap.mutable_static_resources()->add_listeners()->MergeFrom(
+        Server::parseListenerFromV3Yaml(apiListener2Config()));
+  });
+  BaseIntegrationTest::initialize();
+
+  absl::Notification done;
+  Http::ApiListenerPtr http_api_listener;
+  Http::ApiListenerPtr http_api_listener_2;
+
+  test_server_->server().dispatcher().post([this, &done, &http_api_listener,
+                                            &http_api_listener_2]() -> void {
+    EXPECT_DEBUG_DEATH(test_server_->server().listenerManager().apiListener(), ".*");
+
+    // First listener
+    ASSERT_TRUE(test_server_->server().listenerManager().apiListener("api_listener").has_value());
+    ASSERT_EQ("api_listener",
+              test_server_->server().listenerManager().apiListener("api_listener")->get().name());
+    http_api_listener = test_server_->server()
+                            .listenerManager()
+                            .apiListener("api_listener")
+                            ->get()
+                            .createHttpApiListener(test_server_->server().dispatcher());
+    ASSERT_TRUE(http_api_listener != nullptr);
+
+    // Second listener
+    ASSERT_TRUE(test_server_->server().listenerManager().apiListener("api_listener_2").has_value());
+    ASSERT_EQ("api_listener_2",
+              test_server_->server().listenerManager().apiListener("api_listener_2")->get().name());
+    http_api_listener_2 = test_server_->server()
+                              .listenerManager()
+                              .apiListener("api_listener_2")
+                              ->get()
+                              .createHttpApiListener(test_server_->server().dispatcher());
+    ASSERT_TRUE(http_api_listener_2 != nullptr);
+
+    done.Notify();
+  });
+  ASSERT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(1)));
+
+  absl::Notification cleanup_done;
+  test_server_->server().dispatcher().post(
+      [&cleanup_done, &http_api_listener, &http_api_listener_2]() {
+        http_api_listener.reset();
+        http_api_listener_2.reset();
+        cleanup_done.Notify();
+      });
   ASSERT_TRUE(cleanup_done.WaitForNotificationWithTimeout(absl::Seconds(1)));
 }
 


### PR DESCRIPTION
Commit Message: listener: implement support for multiple API listeners in Envoy native
Additional Description:
- Refactors ListenerManagerImpl to use a map of API listeners instead of a single instance.
- Adds apiListener(name) lookup method.
- Modifies addOrUpdateListenerInternal to support adding multiple listeners via bootstrap, returning false if added_via_api to retain future LDS compatibility.
- Updates unit tests to verify multiple listener behaviors.

One of the goals here is to get to a point where we can use API Listeners instead of Internal Listeners for some cases. Upcoming PR implements "loopback to API Listener".

Risk Level: low
Testing: unit, integration
Docs Changes: comment changes in listener.proto.
Release Notes: yes
AI Usage: yes, and I stand by the changes.