### PR TITLE
Prep for removing C++ exceptions from access log filters

### DIFF
--- a/envoy/access_log/BUILD
+++ b/envoy/access_log/BUILD
@@ -32,5 +32,6 @@ envoy_cc_library(
         "//envoy/formatter:substitution_formatter_interface",
         "//envoy/server:factory_context_interface",
         "//source/common/protobuf",
+        "@abseil-cpp//absl/status:statusor",
     ],
 )

--- a/envoy/access_log/access_log_config.h
+++ b/envoy/access_log/access_log_config.h
@@ -11,6 +11,8 @@
 
 #include "source/common/protobuf/protobuf.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
 namespace AccessLog {
 
@@ -27,8 +29,9 @@ public:
    * @param context supplies the factory context.
    * @return an instance of extension filter implementation from a config proto.
    */
-  virtual FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                                 Server::Configuration::GenericFactoryContext& context) PURE;
+  virtual absl::StatusOr<FilterPtr>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+               Server::Configuration::GenericFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.access_loggers.extension_filters"; }
 };

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -91,7 +91,8 @@ FilterPtr FilterFactory::fromProto(const envoy::config::accesslog::v3::AccessLog
     {
       auto& factory =
           Config::Utility::getAndCheckFactory<ExtensionFilterFactory>(config.extension_filter());
-      return factory.createFilter(config.extension_filter(), context);
+      return THROW_OR_RETURN_VALUE(factory.createFilter(config.extension_filter(), context),
+                                   FilterPtr);
     }
   case envoy::config::accesslog::v3::AccessLogFilter::FilterSpecifierCase::FILTER_SPECIFIER_NOT_SET:
     PANIC_DUE_TO_PROTO_UNSET;

--- a/source/extensions/access_loggers/filters/cel/config.cc
+++ b/source/extensions/access_loggers/filters/cel/config.cc
@@ -14,7 +14,7 @@ namespace AccessLoggers {
 namespace Filters {
 namespace CEL {
 
-Envoy::AccessLog::FilterPtr CELAccessLogExtensionFilterFactory::createFilter(
+absl::StatusOr<Envoy::AccessLog::FilterPtr> CELAccessLogExtensionFilterFactory::createFilter(
     const envoy::config::accesslog::v3::ExtensionFilter& config,
     Server::Configuration::GenericFactoryContext& context) {
 

--- a/source/extensions/access_loggers/filters/cel/config.h
+++ b/source/extensions/access_loggers/filters/cel/config.h
@@ -20,7 +20,7 @@ namespace CEL {
 
 class CELAccessLogExtensionFilterFactory : public Envoy::AccessLog::ExtensionFilterFactory {
 public:
-  Envoy::AccessLog::FilterPtr
+  absl::StatusOr<Envoy::AccessLog::FilterPtr>
   createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
                Server::Configuration::GenericFactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;

--- a/source/extensions/access_loggers/filters/process_ratelimit/config.cc
+++ b/source/extensions/access_loggers/filters/process_ratelimit/config.cc
@@ -12,7 +12,7 @@ namespace AccessLoggers {
 namespace Filters {
 namespace ProcessRateLimit {
 
-AccessLog::FilterPtr ProcessRateLimitFilterFactory::createFilter(
+absl::StatusOr<AccessLog::FilterPtr> ProcessRateLimitFilterFactory::createFilter(
     const envoy::config::accesslog::v3::ExtensionFilter& config,
     Server::Configuration::GenericFactoryContext& context) {
   auto factory_config =

--- a/source/extensions/access_loggers/filters/process_ratelimit/config.h
+++ b/source/extensions/access_loggers/filters/process_ratelimit/config.h
@@ -13,8 +13,9 @@ namespace ProcessRateLimit {
 
 class ProcessRateLimitFilterFactory : public AccessLog::ExtensionFilterFactory {
 public:
-  AccessLog::FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                                    Server::Configuration::GenericFactoryContext& context) override;
+  absl::StatusOr<AccessLog::FilterPtr>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+               Server::Configuration::GenericFactoryContext& context) override;
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
   std::string name() const override {
     return "envoy.access_loggers.extension_filters.process_ratelimit";

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -1630,8 +1630,9 @@ class TestHeaderFilterFactory : public ExtensionFilterFactory {
 public:
   ~TestHeaderFilterFactory() override = default;
 
-  FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::GenericFactoryContext& context) override {
+  absl::StatusOr<FilterPtr>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+               Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
     const auto& header_config =
@@ -1725,8 +1726,9 @@ class SampleExtensionFilterFactory : public ExtensionFilterFactory {
 public:
   ~SampleExtensionFilterFactory() override = default;
 
-  FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
-                         Server::Configuration::GenericFactoryContext& context) override {
+  absl::StatusOr<FilterPtr>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter& config,
+               Server::Configuration::GenericFactoryContext& context) override {
     auto factory_config = Config::Utility::translateToFactoryConfig(
         config, context.messageValidationVisitor(), *this);
 

--- a/test/extensions/filters/network/generic_proxy/fake_codec.h
+++ b/test/extensions/filters/network/generic_proxy/fake_codec.h
@@ -439,8 +439,9 @@ class FakeAccessLogExtensionFilter : public AccessLog::Filter {
 class FakeAccessLogExtensionFilterFactory : public AccessLog::ExtensionFilterFactory {
 public:
   // AccessLogFilterFactory
-  AccessLog::FilterPtr createFilter(const envoy::config::accesslog::v3::ExtensionFilter&,
-                                    Server::Configuration::GenericFactoryContext&) override {
+  absl::StatusOr<AccessLog::FilterPtr>
+  createFilter(const envoy::config::accesslog::v3::ExtensionFilter&,
+               Server::Configuration::GenericFactoryContext&) override {
     return std::make_unique<FakeAccessLogExtensionFilter>();
   }
 

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -91,6 +91,7 @@ paths:
     # valid situation identified so far is template functions used for config
     # processing.
     - envoy/common/exception.h
+    - source/common/access_log/access_log_impl.cc
     - source/common/filter/config_discovery_impl.h
     - source/common/config/utility.h
     - source/common/matcher/matcher.h


### PR DESCRIPTION
Just changing return values to StatusOr. Exceptions are still in use and will be removed in subsequent PRs.

Temporarily allow C++ exceptions in source/common/access_log/access_log_impl.cc while filter exceptions are bubbled up to the top of the call stack.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
