### PR TITLE
Deflake OauthUseRefreshTokenDisabled.FailRefreshTokenFlow

### DIFF
--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -471,6 +471,8 @@ typed_config:
 
     waitForOAuth2Response(token_secret, expect_failure);
     if (expect_failure) {
+      EXPECT_TRUE(response->waitForEndStream());
+      cleanup();
       return;
     }
 


### PR DESCRIPTION
Test cleanup was racing with request completion, occasionally crashing.

Risk Level: no
Testing: unit test
Docs Changes: no
Release Notes: no
Platform Specific Features: no
