### PR TITLE
outlier detection: guard degrade path against removed hosts

### DIFF
--- a/changelogs/current/bug_fixes/outlier_detection__degraded-host-null-monitor-guard.rst
+++ b/changelogs/current/bug_fixes/outlier_detection__degraded-host-null-monitor-guard.rst
@@ -1,0 +1,4 @@
+Fixed a crash (null-pointer dereference) in outlier detection where the cross-thread degrade path
+(``setHostDegradedMainThread``) could dereference a null host monitor when a host was removed from
+the cluster after a worker thread posted a degrade event but before the main thread ran it. The
+degrade path now skips a removed host, mirroring the existing guard in the eject path.

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -659,6 +659,13 @@ void DetectorImpl::setHostDegraded(HostSharedPtr host) {
 }
 
 void DetectorImpl::setHostDegradedMainThread(HostSharedPtr host) {
+  // The host may have been removed from host_monitors_ between the worker thread
+  // posting this degrade event and the main thread running it; if so, ignore it
+  // (mirrors the guard in the eject path) so host_monitors_[host] does not
+  // default-insert a null monitor that is then dereferenced.
+  if (host_monitors_.count(host) == 0) {
+    return;
+  }
   if (!host->healthFlagGet(Host::HealthFlag::DEGRADED_OUTLIER_DETECTION)) {
     updateDetectedEjectionStats(envoy::data::cluster::v3::DEGRADED);
 

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1826,6 +1826,54 @@ TEST_F(OutlierDetectorImplTest, EjectionActiveValueIsAccountedWithoutMetricStora
             cluster_.info_->stats_store_.counter("outlier_detection.ejections_overflow").value());
 }
 
+// Regression test for the degraded-host outlier-detection null-deref when a host is removed
+// while a cross-thread degrade post is in flight. setHostDegraded() posts to the main thread;
+// setHostDegradedMainThread() then does host_monitors_[host]->degrade(...). Unlike the eject path
+// (which guards `if (host_monitors_.count(host) == 0) return;`), the degrade path had no such
+// guard, so if a cluster update removes the host (host_monitors_.erase) before the posted callback
+// runs, host_monitors_[host] default-inserts a null monitor and ->degrade() dereferences it. We
+// reproduce the interleaving deterministically (no real threads) by intercepting the post, removing
+// the host, then firing the captured callback.
+// PRE-fix: ->degrade() on a null DetectorHostMonitorImpl -> crash. POST-fix: the removed host is
+// skipped and the test completes cleanly.
+TEST_F(OutlierDetectorImplTest, CrossThreadDegradeRemoveRace) {
+  const std::string yaml = R"EOF(
+interval: 10s
+base_ejection_time: 30s
+consecutive_5xx: 5
+detect_degraded_hosts: true
+  )EOF";
+  envoy::config::cluster::v3::OutlierDetection outlier_detection;
+  TestUtility::loadFromYaml(yaml, outlier_detection);
+
+  EXPECT_CALL(cluster_.prioritySet(), addMemberUpdateCb(_));
+  addHosts({"tcp://127.0.0.1:80"});
+  EXPECT_CALL(*interval_timer_, enableTimer(std::chrono::milliseconds(10000), _));
+  std::shared_ptr<DetectorImpl> detector(DetectorImpl::create(cluster_, outlier_detection,
+                                                              dispatcher_, runtime_, time_system_,
+                                                              event_logger_, random_)
+                                             .value());
+  detector->addChangedStateCb([&](HostSharedPtr host) -> void { checker_.check(host); });
+
+  // Report a degraded response; capture (do not run) the resulting main-thread post.
+  Event::PostCb post_cb;
+  EXPECT_CALL(dispatcher_, post(_)).WillOnce([&post_cb](Event::PostCb cb) {
+    post_cb = std::move(cb);
+  });
+  hosts_[0]->outlierDetector().putResult(Result::ExtOriginRequestDegraded, 200);
+
+  // Remove the host before the cross-thread degrade event is delivered (host_monitors_.erase).
+  HostVector old_hosts = std::move(hosts_);
+  cluster_.prioritySet().getMockHostSet(0)->runCallbacks({}, old_hosts);
+
+  // Fire the deferred degrade callback against the now-removed host.
+  // PRE-fix this dereferences a null monitor and crashes; POST-fix it is a no-op.
+  ASSERT_TRUE(post_cb != nullptr);
+  post_cb();
+
+  EXPECT_EQ(0UL, outlier_detection_ejections_active_.value());
+}
+
 TEST_F(OutlierDetectorImplTest, CrossThreadRemoveRace) {
   EXPECT_CALL(cluster_.prioritySet(), addMemberUpdateCb(_));
   addHosts({"tcp://127.0.0.1:80"});

--- a/test/common/upstream/outlier_detection_impl_test.cc
+++ b/test/common/upstream/outlier_detection_impl_test.cc
@@ -1826,7 +1826,7 @@ TEST_F(OutlierDetectorImplTest, EjectionActiveValueIsAccountedWithoutMetricStora
             cluster_.info_->stats_store_.counter("outlier_detection.ejections_overflow").value());
 }
 
-// Regression test for the degraded-host outlier-detection null-deref when a host is removed
+// Regression test for the degraded-host outlier-detection null dereference when a host is removed
 // while a cross-thread degrade post is in flight. setHostDegraded() posts to the main thread;
 // setHostDegradedMainThread() then does host_monitors_[host]->degrade(...). Unlike the eject path
 // (which guards `if (host_monitors_.count(host) == 0) return;`), the degrade path had no such


### PR DESCRIPTION
### Description

The cross-thread degrade path in outlier detection dereferences a null host monitor when a host is removed from the cluster before a deferred degrade callback runs.

`DetectorImpl::setHostDegraded()` posts to the main thread via `dispatcher_.post(...)`. Before the posted callback (`setHostDegradedMainThread`) runs, a cluster update can deliver `hosts_removed` and execute `host_monitors_.erase(host)`. When the deferred callback then runs, `host_monitors_[host]` (an `absl::flat_hash_map::operator[]`) **default-inserts a null `DetectorHostMonitorImpl`**, and the subsequent `->degrade(...)` dereferences null, crashing the process.

The eject path already guards exactly this case in `onConsecutiveErrorWorker`:

```cpp
// Ejections come in cross thread. There is a chance that the host has already been removed from
// the set. If so, just ignore it.
if (host_monitors_.count(host) == 0) {
  return;
}
```

The degrade path had no such guard.

This is reachable under ordinary, non-adversarial churn — autoscaling, rolling deploys, and health-check-driven host removal — whenever a degraded host is removed in the window between the worker thread posting the degrade event and the main thread running it. No attacker or deliberate control-plane timing is required to hit it by chance.

### Fix

Add the removed-host guard at the top of `setHostDegradedMainThread`, mirroring the eject path, so `host_monitors_[host]` cannot default-insert a null monitor that is then dereferenced.

### Test

Adds a deterministic regression test, `OutlierDetectorImplTest.CrossThreadDegradeRemoveRace`, that reproduces the interleaving without real threads: it intercepts the degrade `dispatcher_.post`, removes the host (`runCallbacks({}, old_hosts)` -> `host_monitors_.erase`), then fires the captured callback. Pre-fix this dereferences a null monitor and crashes; post-fix the removed host is skipped and the test passes cleanly. This mirrors the existing `CrossThreadRemoveRace` / `CrossThreadDestroyRace` tests.

Adds a `bug_fixes` changelog fragment.

### Notes

Reported privately as GHSA-rf7j-pmr2-gf7r; opening per @yanavlasov's go-ahead to fix in the open.