### PR TITLE
Adds a benchmark for the EDS resources cache

### DIFF
--- a/test/extensions/config_subscription/grpc/BUILD
+++ b/test/extensions/config_subscription/grpc/BUILD
@@ -1,5 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_benchmark_test",
+    "envoy_cc_benchmark_binary",
     "envoy_cc_mock",
     "envoy_cc_test",
     "envoy_cc_test_library",
@@ -289,4 +291,19 @@ envoy_cc_test(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
+)
+
+envoy_cc_benchmark_binary(
+    name = "eds_resources_cache_impl_benchmark",
+    srcs = ["eds_resources_cache_impl_benchmark.cc"],
+    deps = [
+        "//source/extensions/config_subscription/grpc:eds_resources_cache_lib",
+        "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_benchmark_test(
+    name = "eds_resources_cache_impl_benchmark_test",
+    benchmark_binary = "eds_resources_cache_impl_benchmark",
 )

--- a/test/extensions/config_subscription/grpc/eds_resources_cache_impl_benchmark.cc
+++ b/test/extensions/config_subscription/grpc/eds_resources_cache_impl_benchmark.cc
@@ -1,0 +1,107 @@
+#include "source/common/event/libevent.h"
+#include "source/extensions/config_subscription/grpc/eds_resources_cache_impl.h"
+
+#include "test/benchmark/main.h"
+#include "test/test_common/simulated_time_system.h"
+#include "test/test_common/utility.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Config {
+namespace {
+
+static bool initLibevent() {
+  if (!Event::Libevent::Global::initialized()) {
+    Event::Libevent::Global::initialize();
+  }
+  return true;
+}
+
+envoy::config::endpoint::v3::ClusterLoadAssignment
+buildComplexClusterLoadAssignment(int num_localities, int num_endpoints_per_locality,
+                                  int num_metadata_fields) {
+  envoy::config::endpoint::v3::ClusterLoadAssignment cla;
+  cla.set_cluster_name("test_cluster");
+
+  for (int i = 0; i < num_localities; ++i) {
+    auto* locality_endpoints = cla.add_endpoints();
+    locality_endpoints->mutable_locality()->set_region("region");
+    locality_endpoints->mutable_locality()->set_zone(absl::StrCat("zone_", i));
+
+    for (int j = 0; j < num_endpoints_per_locality; ++j) {
+      auto* lb_endpoint = locality_endpoints->add_lb_endpoints();
+      auto* endpoint = lb_endpoint->mutable_endpoint();
+      auto* address = endpoint->mutable_address()->mutable_socket_address();
+      address->set_address(absl::StrCat("10.0.", i, ".", j));
+      address->set_port_value(80);
+
+      // Add some metadata to make it complex
+      auto* metadata = lb_endpoint->mutable_metadata();
+      auto* fields = (*metadata->mutable_filter_metadata())["envoy.lb"].mutable_fields();
+      for (int k = 0; k < num_metadata_fields; ++k) {
+        (*fields)[absl::StrCat("key_", k)].set_string_value(absl::StrCat("value_", k));
+      }
+    }
+  }
+  return cla;
+}
+
+class EdsResourcesCacheImplBenchmark {
+public:
+  EdsResourcesCacheImplBenchmark()
+      : api_((initLibevent(), Api::createApiForTest(time_system_))),
+        dispatcher_(api_->allocateDispatcher("benchmark_thread")), resources_cache_(*dispatcher_) {}
+
+  Event::SimulatedTimeSystemHelper time_system_;
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  EdsResourcesCacheImpl resources_cache_;
+};
+
+void bmSetResource(::benchmark::State& state) {
+  EdsResourcesCacheImplBenchmark benchmark_env;
+  const int num_localities = state.range(0);
+  const int num_endpoints = state.range(1);
+  const int num_metadata_fields = 5;
+
+  auto cla = buildComplexClusterLoadAssignment(num_localities, num_endpoints, num_metadata_fields);
+
+  for (auto _ : state) {
+    benchmark_env.resources_cache_.setResource("test_resource", cla);
+  }
+}
+
+// Benchmark arguments: {num_localities, num_endpoints_per_locality}
+BENCHMARK(bmSetResource)
+    ->Args({1, 1})
+    ->Args({1, 10})
+    ->Args({10, 10})
+    ->Args({10, 100})
+    ->Args({100, 100});
+
+void bmGetResource(::benchmark::State& state) {
+  EdsResourcesCacheImplBenchmark benchmark_env;
+  const int num_localities = state.range(0);
+  const int num_endpoints = state.range(1);
+  const int num_metadata_fields = 5;
+
+  auto cla = buildComplexClusterLoadAssignment(num_localities, num_endpoints, num_metadata_fields);
+  benchmark_env.resources_cache_.setResource("test_resource", cla);
+
+  for (auto _ : state) {
+    auto fetched = benchmark_env.resources_cache_.getResource("test_resource", nullptr);
+    ::benchmark::DoNotOptimize(fetched);
+  }
+}
+
+BENCHMARK(bmGetResource)
+    ->Args({1, 1})
+    ->Args({1, 10})
+    ->Args({10, 10})
+    ->Args({10, 100})
+    ->Args({100, 100});
+
+} // namespace
+} // namespace Config
+} // namespace Envoy


### PR DESCRIPTION
This benchmark demonstrates how the cost of `EdsResourcesCacheImpl` operations scales with increasingly complex `ClusterLoadAssignment` messages.

I used the Gemini AI model to generate the benchmark. The file itself looks reasonable to me.

Here are the results from an example run on my workstation:
```
Run on (12 X 4500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1024 KiB (x6)
  L3 Unified 8448 KiB (x1)
Load Average: 8.13, 5.26, 3.11
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
bmSetResource/1/1            800 ns          800 ns       978841
bmSetResource/1/10          6635 ns         6634 ns       105646
bmSetResource/10/10        66568 ns        66565 ns         9212
bmSetResource/10/100      668162 ns       668139 ns          927
bmSetResource/100/100   11704205 ns     11703982 ns           66
bmGetResource/1/1           11.1 ns         11.1 ns     64584407
bmGetResource/1/10          11.1 ns         11.1 ns     64811719
bmGetResource/10/10         12.3 ns         12.3 ns     61295787
bmGetResource/10/100        11.7 ns         11.7 ns     65544985
bmGetResource/100/100       11.1 ns         11.1 ns     63082759
```

Commit Message:
Additional Description:
Risk Level: none
Testing: ran the benchmark locally
Docs Changes:
Release Notes:
Platform Specific Features:
