### PR TITLE
Push status errors from stream info formatters one level up

### DIFF
--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2623,7 +2623,7 @@ public:
         (*it).second.first, command, sub_command, max_length));
 
     StreamInfoFormatterResult result = (*it).second.second(sub_command, max_length);
-    THROW_IF_NOT_OK_REF(result.status());
+    RETURN_IF_NOT_OK_REF(result.status());
 
     return (std::move(result)).value();
   }

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -57,7 +57,11 @@ public:
                       std::optional<size_t> max_length = std::nullopt) {
     DefaultBuiltInStreamInfoCommandParserFactory factory;
     auto parser = factory.createCommandParser();
-    formatter_ = parser->parse(command, sub_command, max_length).value();
+    auto formatter_or = parser->parse(command, sub_command, max_length);
+    if (!formatter_or.ok()) {
+      throwEnvoyExceptionOrPanic(std::string(formatter_or.status().message()));
+    }
+    formatter_ = std::move(formatter_or).value();
     if (formatter_ == nullptr) {
       throwEnvoyExceptionOrPanic(fmt::format("Not supported command in StreamInfo: {}", command));
     }


### PR DESCRIPTION
The change should be safe as all callers of the `parse` method check the status.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
