### PR TITLE
DNS-UDP: Return error status instead of nullptr formatter

### DIFF
--- a/source/extensions/filters/udp/dns_filter/dns_filter_access_log.cc
+++ b/source/extensions/filters/udp/dns_filter/dns_filter_access_log.cc
@@ -89,7 +89,7 @@ public:
     const auto& provider_table = providerFuncTable();
     const auto func_it = provider_table.find(std::string(command));
     if (func_it == provider_table.end()) {
-      return nullptr;
+      return absl::InvalidArgumentError(absl::StrCat("Invalid format substitution: ", command));
     }
     return func_it->second(command_arg, max_length);
   }

--- a/test/extensions/filters/udp/dns_filter/dns_filter_access_log_test.cc
+++ b/test/extensions/filters/udp/dns_filter/dns_filter_access_log_test.cc
@@ -24,6 +24,7 @@ namespace UdpFilters {
 namespace DnsFilter {
 namespace {
 
+using Envoy::StatusHelpers::HasStatus;
 using Envoy::StatusHelpers::IsOkAndHolds;
 using ResponseValidator = Utils::DnsResponseValidator;
 using testing::_;
@@ -590,8 +591,9 @@ TEST(DnsFilterCommandParserTest, QueryClassFormatter) {
 
 TEST(DnsFilterCommandParserTest, UnknownCommand) {
   auto parser = createDnsFilterCommandParser();
-  auto formatter = parser->parse("UNKNOWN_COMMAND", "", std::nullopt).value();
-  EXPECT_EQ(formatter, nullptr);
+  EXPECT_THAT(parser->parse("UNKNOWN_COMMAND", "", std::nullopt),
+              HasStatus(absl::StatusCode::kInvalidArgument,
+                        "Invalid format substitution: UNKNOWN_COMMAND"));
 }
 
 TEST(DnsFilterCommandParserTest, EmptyCommandArg) {
@@ -611,9 +613,15 @@ TEST(DnsFilterCommandParserTest, CaseSensitiveCommands) {
 
   // Commands should be case-sensitive
   ASSERT_THAT(parser->parse("QUERY_NAME", "", std::nullopt), IsOkAndHolds(NotNull()));
-  ASSERT_THAT(parser->parse("query_name", "", std::nullopt), IsOkAndHolds(IsNull()));
-  ASSERT_THAT(parser->parse("Query_Name", "", std::nullopt), IsOkAndHolds(IsNull()));
-  ASSERT_THAT(parser->parse("QUERYNAME", "", std::nullopt), IsOkAndHolds(IsNull()));
+  ASSERT_THAT(
+      parser->parse("query_name", "", std::nullopt),
+      HasStatus(absl::StatusCode::kInvalidArgument, "Invalid format substitution: query_name"));
+  ASSERT_THAT(
+      parser->parse("Query_Name", "", std::nullopt),
+      HasStatus(absl::StatusCode::kInvalidArgument, "Invalid format substitution: Query_Name"));
+  ASSERT_THAT(
+      parser->parse("QUERYNAME", "", std::nullopt),
+      HasStatus(absl::StatusCode::kInvalidArgument, "Invalid format substitution: QUERYNAME"));
 }
 
 TEST(DnsFilterCommandParserTest, FormatValueStringType) {


### PR DESCRIPTION
The change is safe and should result in a better error message during config ingestion. There is already a defense-in-depth check for nullptr formatter, which is converted to a generic error status.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
