### PR TITLE
header_mutation: add formatter configuration

### DIFF
--- a/api/envoy/extensions/filters/http/header_mutation/v3/header_mutation.proto
+++ b/api/envoy/extensions/filters/http/header_mutation/v3/header_mutation.proto
@@ -4,6 +4,7 @@ package envoy.extensions.filters.http.header_mutation.v3;
 
 import "envoy/config/common/mutation_rules/v3/mutation_rules.proto";
 import "envoy/config/core/v3/base.proto";
+import "envoy/config/core/v3/extension.proto";
 
 import "udpa/annotations/status.proto";
 
@@ -17,7 +18,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Mutate HTTP headers and trailers in requests and responses.
 // [#extension: envoy.filters.http.header_mutation]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message Mutations {
   // The request mutations are applied before the request is forwarded to the upstream cluster.
   repeated config.common.mutation_rules.v3.HeaderMutation request_mutations = 1;
@@ -34,6 +35,12 @@ message Mutations {
 
   // The request trailer mutations are applied before the request is sent to the upstream cluster.
   repeated config.common.mutation_rules.v3.HeaderMutation request_trailers_mutations = 5;
+
+  // Formatter command parsers used for mutation values. Built-in command parsers are available
+  // without this field; use it to add extension parsers or override a built-in parser's
+  // configuration.
+  // [#extension-category: envoy.formatter]
+  repeated config.core.v3.TypedExtensionConfig formatters = 6;
 }
 
 // Per route configuration for the header mutation filter.

--- a/api/envoy/extensions/formatter/cel/v3/BUILD
+++ b/api/envoy/extensions/formatter/cel/v3/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@xds//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/config/core/v3:pkg",
+        "@xds//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/extensions/formatter/cel/v3/cel.proto
+++ b/api/envoy/extensions/formatter/cel/v3/cel.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.formatter.cel.v3;
 
+import "envoy/config/core/v3/cel.proto";
+
 import "udpa/annotations/status.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.formatter.cel.v3";
@@ -50,7 +52,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for the CEL formatter.
 //
 // .. warning::
-//   This extension is treated as built-in extension and will be enabled by default now.
-//   It is unnecessary to configure this extension.
+//   This extension is treated as a built-in extension and is enabled by default.
+//   It is unnecessary to configure this extension unless overriding the CEL expression runtime
+//   via ``cel_config``.
 message Cel {
+  // Configuration for the CEL expression runtime used by this formatter.
+  config.core.v3.CelExpressionConfig cel_config = 1;
 }

--- a/changelogs/current/new_features/formatter__added-cel-expression-config.rst
+++ b/changelogs/current/new_features/formatter__added-cel-expression-config.rst
@@ -1,0 +1,3 @@
+Exposed :ref:`cel_config <envoy_v3_api_field_extensions.formatter.cel.v3.Cel.cel_config>` on the
+``envoy.formatter.cel`` formatter configuration, allowing CEL runtime options such as string
+functions to be enabled for configured CEL formatters.

--- a/changelogs/current/new_features/header_mutation__added-formatters-config.rst
+++ b/changelogs/current/new_features/header_mutation__added-formatters-config.rst
@@ -1,0 +1,3 @@
+Added :ref:`formatters <envoy_v3_api_field_extensions.filters.http.header_mutation.v3.Mutations.formatters>`
+to the header mutation filter, allowing extension formatter command parsers to be configured for
+header mutation substitution values.

--- a/source/extensions/filters/http/header_mutation/BUILD
+++ b/source/extensions/filters/http/header_mutation/BUILD
@@ -14,12 +14,15 @@ envoy_cc_library(
     srcs = ["header_mutation.cc"],
     hdrs = ["header_mutation.h"],
     deps = [
+        "//envoy/protobuf:message_validator_interface",
         "//envoy/server:filter_config_interface",
         "//source/common/config:utility_lib",
+        "//source/common/formatter:substitution_format_string_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:header_mutation_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//envoy/extensions/filters/http/header_mutation/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -40,10 +40,10 @@ HeaderMutationFactoryConfig::createFilterFactoryFromProtoWithServerContextTyped(
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 HeaderMutationFactoryConfig::createRouteSpecificFilterConfigTyped(
     const PerRouteProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
-    ProtobufMessage::ValidationVisitor&) {
+    ProtobufMessage::ValidationVisitor& validation_visitor) {
   absl::Status creation_status = absl::OkStatus();
-  auto route_config =
-      std::make_shared<PerRouteHeaderMutation>(proto_config, context, creation_status);
+  auto route_config = std::make_shared<PerRouteHeaderMutation>(proto_config, context,
+                                                               validation_visitor, creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
   return route_config;
 }

--- a/source/extensions/filters/http/header_mutation/header_mutation.cc
+++ b/source/extensions/filters/http/header_mutation/header_mutation.cc
@@ -3,10 +3,11 @@
 #include <cstdint>
 #include <memory>
 
-#include "source/common/config/utility.h"
+#include "source/common/formatter/substitution_format_string.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/runtime/runtime_features.h"
+#include "source/server/generic_factory_context.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -54,22 +55,32 @@ void QueryParameterMutationAppend::mutateQueryParameter(
 
 Mutations::Mutations(const MutationsProto& config,
                      Server::Configuration::ServerFactoryContext& context,
+                     ProtobufMessage::ValidationVisitor& validation_visitor,
                      absl::Status& creation_status) {
-  auto request_mutations_or_error = HeaderMutations::create(config.request_mutations(), context);
+  Server::GenericFactoryContextImpl generic_context(context, validation_visitor);
+  auto command_parsers_or_error =
+      Formatter::SubstitutionFormatStringUtils::parseFormatters(config.formatters(), generic_context);
+  SET_AND_RETURN_IF_NOT_OK(command_parsers_or_error.status(), creation_status);
+  Formatter::CommandParserPtrVector command_parsers =
+      std::move(command_parsers_or_error.value());
+
+  auto request_mutations_or_error =
+      HeaderMutations::create(config.request_mutations(), context, command_parsers);
   SET_AND_RETURN_IF_NOT_OK(request_mutations_or_error.status(), creation_status);
   request_mutations_ = std::move(request_mutations_or_error.value());
 
-  auto response_mutations_or_error = HeaderMutations::create(config.response_mutations(), context);
+  auto response_mutations_or_error =
+      HeaderMutations::create(config.response_mutations(), context, command_parsers);
   SET_AND_RETURN_IF_NOT_OK(response_mutations_or_error.status(), creation_status);
   response_mutations_ = std::move(response_mutations_or_error.value());
 
   auto response_trailers_mutations_or_error =
-      HeaderMutations::create(config.response_trailers_mutations(), context);
+      HeaderMutations::create(config.response_trailers_mutations(), context, command_parsers);
   SET_AND_RETURN_IF_NOT_OK(response_trailers_mutations_or_error.status(), creation_status);
   response_trailers_mutations_ = std::move(response_trailers_mutations_or_error.value());
 
   auto request_trailers_mutations_or_error =
-      HeaderMutations::create(config.request_trailers_mutations(), context);
+      HeaderMutations::create(config.request_trailers_mutations(), context, command_parsers);
   SET_AND_RETURN_IF_NOT_OK(request_trailers_mutations_or_error.status(), creation_status);
   request_trailers_mutations_ = std::move(request_trailers_mutations_or_error.value());
 
@@ -92,8 +103,8 @@ Mutations::Mutations(const MutationsProto& config,
         return;
       }
 
-      auto value_or_error =
-          Formatter::FormatterImpl::create(mutation.append().record().value().string_value(), true);
+      auto value_or_error = Formatter::FormatterImpl::create(
+          mutation.append().record().value().string_value(), true, command_parsers);
       SET_AND_RETURN_IF_NOT_OK(value_or_error.status(), creation_status);
       query_query_parameter_mutations_.emplace_back(std::make_unique<QueryParameterMutationAppend>(
           mutation.append().record().key(), std::move(value_or_error.value()),
@@ -145,15 +156,15 @@ void Mutations::mutateRequestTrailers(Http::RequestTrailerMap& trailers,
   request_trailers_mutations_->evaluateHeaders(trailers, context, stream_info);
 }
 
-PerRouteHeaderMutation::PerRouteHeaderMutation(const PerRouteProtoConfig& config,
-                                               Server::Configuration::ServerFactoryContext& context,
-                                               absl::Status& creation_status)
-    : mutations_(config.mutations(), context, creation_status) {}
+PerRouteHeaderMutation::PerRouteHeaderMutation(
+    const PerRouteProtoConfig& config, Server::Configuration::ServerFactoryContext& context,
+    ProtobufMessage::ValidationVisitor& validation_visitor, absl::Status& creation_status)
+    : mutations_(config.mutations(), context, validation_visitor, creation_status) {}
 
 HeaderMutationConfig::HeaderMutationConfig(const ProtoConfig& config,
                                            Server::Configuration::ServerFactoryContext& context,
                                            absl::Status& creation_status)
-    : mutations_(config.mutations(), context, creation_status),
+    : mutations_(config.mutations(), context, context.messageValidationVisitor(), creation_status),
       most_specific_header_mutations_wins_(config.most_specific_header_mutations_wins()) {}
 
 void HeaderMutation::maybeInitializeRouteConfigs(Http::StreamFilterCallbacks* callbacks) {

--- a/source/extensions/filters/http/header_mutation/header_mutation.h
+++ b/source/extensions/filters/http/header_mutation/header_mutation.h
@@ -7,6 +7,7 @@
 
 #include "envoy/extensions/filters/http/header_mutation/v3/header_mutation.pb.h"
 #include "envoy/http/query_params.h"
+#include "envoy/protobuf/message_validator.h"
 
 #include "source/common/common/logger.h"
 #include "source/common/formatter/substitution_formatter.h"
@@ -83,7 +84,7 @@ public:
   using HeaderMutations = Http::HeaderMutations;
 
   Mutations(const MutationsProto& config, Server::Configuration::ServerFactoryContext& context,
-            absl::Status& creation_status);
+            ProtobufMessage::ValidationVisitor& validation_visitor, absl::Status& creation_status);
 
   void mutateRequestHeaders(Http::RequestHeaderMap& headers, const Formatter::Context& context,
                             const StreamInfo::StreamInfo& stream_info) const;
@@ -107,6 +108,7 @@ class PerRouteHeaderMutation : public Router::RouteSpecificFilterConfig {
 public:
   PerRouteHeaderMutation(const PerRouteProtoConfig& config,
                          Server::Configuration::ServerFactoryContext& context,
+                         ProtobufMessage::ValidationVisitor& validation_visitor,
                          absl::Status& creation_status);
 
   const Mutations& mutations() const { return mutations_; }

--- a/source/extensions/formatter/cel/BUILD
+++ b/source/extensions/formatter/cel/BUILD
@@ -50,6 +50,8 @@ envoy_cc_extension(
     ],
     deps = [
         "//envoy/registry",
+        "//source/common/protobuf:utility_lib",
+        "//source/extensions/filters/common/expr:evaluator_lib",
         "//source/extensions/formatter/cel:cel_lib",
         "@envoy_api//envoy/extensions/formatter/cel/v3:pkg_cc_proto",
     ] + select(

--- a/source/extensions/formatter/cel/cel.cc
+++ b/source/extensions/formatter/cel/cel.cc
@@ -76,6 +76,13 @@ Protobuf::Value CELFormatter::formatValue(const Envoy::Formatter::Context& conte
   }
 }
 
+CELFormatterCommandParser::CELFormatterCommandParser(
+    const ::Envoy::LocalInfo::LocalInfo& local_info,
+    Expr::BuilderInstanceSharedConstPtr expr_builder)
+    : configured_state_(ConfiguredState{local_info, std::move(expr_builder)}) {
+  ASSERT(configured_state_->expr_builder != nullptr);
+}
+
 absl::StatusOr<Envoy::Formatter::FormatterProviderPtr>
 CELFormatterCommandParser::parse(absl::string_view command, absl::string_view subcommand,
                                  std::optional<size_t> max_length) const {
@@ -85,10 +92,18 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
     if (!parse_status.ok()) {
       throw EnvoyException("Not able to parse expression: " + parse_status.status().ToString());
     }
-    Server::Configuration::ServerFactoryContext& context =
-        Server::Configuration::ServerFactoryContextInstance::get();
+
+    // Lazily resolve the active server context at CEL-command parse time: built-in command parsers
+    // are process-global, so they cannot capture server-owned CEL state.
+    if (!configured_state_.has_value()) {
+      Server::Configuration::ServerFactoryContext& context =
+          Server::Configuration::ServerFactoryContextInstance::get();
+      return std::make_unique<CELFormatter>(context.localInfo(), Expr::getBuilder(context),
+                                            parse_status.value().expr(), max_length,
+                                            command == "TYPED_CEL");
+    }
     return std::make_unique<CELFormatter>(
-        context.localInfo(), Extensions::Filters::Common::Expr::getBuilder(context),
+        configured_state_->local_info.get(), configured_state_->expr_builder,
         parse_status.value().expr(), max_length, command == "TYPED_CEL");
   }
 

--- a/source/extensions/formatter/cel/cel.h
+++ b/source/extensions/formatter/cel/cel.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+#include <optional>
 #include <string>
 
 #include "envoy/config/typed_config.h"
@@ -33,9 +35,23 @@ private:
 class CELFormatterCommandParser : public ::Envoy::Formatter::CommandParser {
 public:
   CELFormatterCommandParser() = default;
+  CELFormatterCommandParser(
+      const ::Envoy::LocalInfo::LocalInfo& local_info,
+      Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr expr_builder);
   absl::StatusOr<Envoy::Formatter::FormatterProviderPtr>
   parse(absl::string_view command, absl::string_view subcommand,
         std::optional<size_t> max_length) const override;
+
+private:
+  struct ConfiguredState {
+    std::reference_wrapper<const ::Envoy::LocalInfo::LocalInfo> local_info;
+    Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr expr_builder;
+  };
+
+  // Present only for parsers created from explicit `envoy.formatter.cel` config. Keeping the
+  // server-owned values together avoids a half-configured parser; absence means built-in parser
+  // mode, where `parse()` resolves the active server context for each CEL command.
+  std::optional<ConfiguredState> configured_state_;
 };
 
 } // namespace Formatter

--- a/source/extensions/formatter/cel/config.cc
+++ b/source/extensions/formatter/cel/config.cc
@@ -1,22 +1,29 @@
 #include "source/extensions/formatter/cel/config.h"
 
 #include "envoy/extensions/formatter/cel/v3/cel.pb.h"
+#include "envoy/extensions/formatter/cel/v3/cel.pb.validate.h"
 
+#include "source/common/protobuf/utility.h"
 #include "source/extensions/formatter/cel/cel.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace Formatter {
 
-::Envoy::Formatter::CommandParserPtr
-CELFormatterFactory::createCommandParserFromProto(const Protobuf::Message&,
-                                                  Server::Configuration::GenericFactoryContext&) {
+::Envoy::Formatter::CommandParserPtr CELFormatterFactory::createCommandParserFromProto(
+    const Protobuf::Message& proto_config, Server::Configuration::GenericFactoryContext& context) {
 #if defined(USE_CEL_PARSER)
-  ENVOY_LOG_TO_LOGGER(Logger::Registry::getLog(Logger::Id::config), warn,
-                      "'CEL' formatter is treated as a built-in formatter and does not "
-                      "require configuration.");
-  return std::make_unique<CELFormatterCommandParser>();
+  const auto& config =
+      MessageUtil::downcastAndValidate<const envoy::extensions::formatter::cel::v3::Cel&>(
+          proto_config, context.messageValidationVisitor());
+  const auto config_ref = config.has_cel_config()
+                              ? Envoy::makeOptRef(config.cel_config())
+                              : Envoy::OptRef<const envoy::config::core::v3::CelExpressionConfig>{};
+  return std::make_unique<CELFormatterCommandParser>(
+      context.serverFactoryContext().localInfo(),
+      Filters::Common::Expr::getBuilder(context.serverFactoryContext(), config_ref));
 #else
+  UNREFERENCED_PARAMETER(proto_config);
   UNREFERENCED_PARAMETER(context);
   throw EnvoyException("CEL is not available for use in this environment.");
 #endif

--- a/test/extensions/filters/http/header_mutation/BUILD
+++ b/test/extensions/filters/http/header_mutation/BUILD
@@ -16,7 +16,16 @@ envoy_extension_cc_test(
     srcs = [
         "header_mutation_test.cc",
     ],
-    extension_names = ["envoy.filters.http.header_mutation"],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "-DUSE_CEL_PARSER",
+        ],
+    }),
+    extension_names = [
+        "envoy.filters.http.header_mutation",
+        "envoy.formatter.cel",
+    ],
     rbe_pool = "6gig",
     deps = [
         "//source/common/formatter:formatter_extension_lib",
@@ -25,7 +34,12 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
         "//test/test_common:utility_lib",
-    ],
+    ] + select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "//source/extensions/formatter/cel:config",
+        ],
+    }),
 )
 
 envoy_extension_cc_test(

--- a/test/extensions/filters/http/header_mutation/header_mutation_test.cc
+++ b/test/extensions/filters/http/header_mutation/header_mutation_test.cc
@@ -66,14 +66,14 @@ TEST(HeaderMutationFilterTest, RequestMutationTest) {
         append_action: "ADD_IF_ABSENT"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -132,6 +132,168 @@ TEST(HeaderMutationFilterTest, RequestMutationTest) {
   }
 }
 
+#if defined(USE_CEL_PARSER)
+
+// Each mutation site formats a string-function expression that only a configured CEL parser
+// (`cel_config`) can build, so a site that didn't get the parser fails config load instead of
+// passing silently. Confirms the parser reaches every site.
+TEST(HeaderMutationFilterTest, CelConfigAppliedToAllMutationSites) {
+  const std::string config_yaml = R"EOF(
+  mutations:
+    request_mutations:
+    - append:
+        header:
+          key: "flag-request-header"
+          value: "%CEL('prefix-old-suffix'.replace('old', 'new'))%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    response_mutations:
+    - append:
+        header:
+          key: "flag-response-header"
+          value: "%CEL('prefix-old-suffix'.replace('old', 'new'))%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    request_trailers_mutations:
+    - append:
+        header:
+          key: "flag-request-trailer"
+          value: "%CEL('prefix-old-suffix'.replace('old', 'new'))%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    response_trailers_mutations:
+    - append:
+        header:
+          key: "flag-response-trailer"
+          value: "%CEL('prefix-old-suffix'.replace('old', 'new'))%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    query_parameter_mutations:
+    - append:
+        record:
+          key: "flag-query"
+          value: "%CEL('prefix-old-suffix'.replace('old', 'new'))%"
+        action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    formatters:
+    - name: envoy.formatter.cel
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel
+        cel_config:
+          enable_string_functions: true
+  )EOF";
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  ProtoConfig proto_config;
+  TestUtility::loadFromYaml(config_yaml, proto_config);
+
+  absl::Status creation_status = absl::OkStatus();
+  HeaderMutationConfigSharedPtr global_config =
+      std::make_shared<HeaderMutationConfig>(proto_config, context, creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status;
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+
+  HeaderMutation filter{global_config};
+  filter.setDecoderFilterCallbacks(decoder_callbacks);
+  filter.setEncoderFilterCallbacks(encoder_callbacks);
+
+  EXPECT_CALL(*decoder_callbacks.route_, perFilterConfigs(_))
+      .WillOnce(
+          Invoke([&](absl::string_view) -> Router::RouteSpecificFilterConfigs { return {}; }));
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers = {
+      {":method", "GET"},
+      {":path", "/path?flag-query=old"},
+      {":scheme", "http"},
+      {":authority", "host"}};
+  Envoy::Http::TestRequestTrailerMapImpl request_trailers{{"placeholder", "value"}};
+  Envoy::Http::TestResponseHeaderMapImpl response_headers = {{":status", "200"}};
+  Envoy::Http::TestResponseTrailerMapImpl response_trailers{{"placeholder", "value"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter.decodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter.decodeTrailers(request_trailers));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter.encodeHeaders(response_headers, true));
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter.encodeTrailers(response_trailers));
+
+  EXPECT_EQ("prefix-new-suffix", request_headers.get_("flag-request-header"));
+  EXPECT_EQ("prefix-new-suffix", response_headers.get_("flag-response-header"));
+  EXPECT_EQ("prefix-new-suffix", request_trailers.get_("flag-request-trailer"));
+  EXPECT_EQ("prefix-new-suffix", response_trailers.get_("flag-response-trailer"));
+  auto params =
+      Http::Utility::QueryParamsMulti::parseAndDecodeQueryString(request_headers.getPathValue());
+  EXPECT_EQ("prefix-new-suffix", params.data().at("flag-query").front());
+}
+
+TEST(HeaderMutationFilterTest, StringFunctionExpressionRejectedWhenDisabled) {
+  const std::string config_yaml = R"EOF(
+  mutations:
+    request_mutations:
+    - append:
+        header:
+          key: "flag-header"
+          value: "%CEL(request.headers['source-header'].replace('old', 'new'))%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+    formatters:
+    - name: envoy.formatter.cel
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel
+        cel_config:
+          enable_string_functions: false
+  )EOF";
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  ProtoConfig proto_config;
+  TestUtility::loadFromYaml(config_yaml, proto_config);
+
+  absl::Status creation_status = absl::OkStatus();
+  EXPECT_THROW(HeaderMutationConfig config(proto_config, context, creation_status), EnvoyException);
+}
+
+TEST(HeaderMutationFilterTest, BuiltInCelWorksWithoutFormatters) {
+  const std::string config_yaml = R"EOF(
+  mutations:
+    request_mutations:
+    - append:
+        header:
+          key: "flag-header"
+          value: "%CEL(request.headers[':method'])%"
+        append_action: "OVERWRITE_IF_EXISTS_OR_ADD"
+  )EOF";
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ScopedThreadLocalServerContextSetter server_context_singleton_setter(context);
+
+  ProtoConfig proto_config;
+  TestUtility::loadFromYaml(config_yaml, proto_config);
+
+  absl::Status creation_status = absl::OkStatus();
+  HeaderMutationConfigSharedPtr global_config =
+      std::make_shared<HeaderMutationConfig>(proto_config, context, creation_status);
+  ASSERT_TRUE(creation_status.ok()) << creation_status;
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+
+  HeaderMutation filter{global_config};
+  filter.setDecoderFilterCallbacks(decoder_callbacks);
+  filter.setEncoderFilterCallbacks(encoder_callbacks);
+
+  EXPECT_CALL(*decoder_callbacks.route_, perFilterConfigs(_))
+      .WillOnce(
+          Invoke([&](absl::string_view) -> Router::RouteSpecificFilterConfigs { return {}; }));
+
+  Envoy::Http::TestRequestHeaderMapImpl headers = {
+      {":method", "GET"},
+      {":path", "/path"},
+      {":scheme", "http"},
+      {":authority", "host"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter.decodeHeaders(headers, true));
+
+  EXPECT_EQ("GET", headers.get_("flag-header"));
+}
+
+#endif // USE_CEL_PARSER
+
 TEST(HeaderMutationFilterTest, ResponseMutationTest) {
   const std::string route_config_yaml = R"EOF(
   mutations:
@@ -180,14 +342,14 @@ TEST(HeaderMutationFilterTest, ResponseMutationTest) {
     - remove: "global-flag-header"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -358,14 +520,14 @@ TEST(HeaderMutationFilterTest, ResponseTrailerMutationTest) {
     - remove: "global-flag-header"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -538,14 +700,14 @@ TEST(HeaderMutationFilterTest, HybridMutationTest) {
     - remove: "global-flag-header"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -670,14 +832,14 @@ TEST(HeaderMutationFilterTest, QueryParameterMutationTest) {
     - remove: "global-flag-header"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -784,14 +946,14 @@ TEST(HeaderMutationFilterTest, RequestTrailerMutationTest) {
     - remove: "global-flag-header"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   PerRouteProtoConfig per_route_proto_config;
   TestUtility::loadFromYaml(route_config_yaml, per_route_proto_config);
 
   absl::Status creation_status = absl::OkStatus();
-  PerRouteHeaderMutationSharedPtr config =
-      std::make_shared<PerRouteHeaderMutation>(per_route_proto_config, context, creation_status);
+  PerRouteHeaderMutationSharedPtr config = std::make_shared<PerRouteHeaderMutation>(
+      per_route_proto_config, context, context.messageValidationVisitor(), creation_status);
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);
@@ -918,7 +1080,7 @@ TEST(HeaderMutationFilterTest, QueryParameterMutationUrlEncodingTest) {
         action: "APPEND_IF_EXISTS_OR_ADD"
   )EOF";
 
-  Server::Configuration::MockServerFactoryContext context;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config_yaml, proto_config);

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -327,7 +327,7 @@ TEST_F(CELFormatterTest, TestFormatConversionV1AlphaToDevCel) {
               ProtoEq(ValueUtil::stringValue("true")));
 }
 
-TEST_F(CELFormatterTest, TestRequestHeaderWithLegacyConfiguration) {
+TEST_F(CELFormatterTest, TestConfiguredFormatterWithoutCelConfig) {
   const std::string yaml = R"EOF(
   text_format_source:
     inline_string: "%CEL(request.headers[':method'])%"
@@ -341,6 +341,42 @@ TEST_F(CELFormatterTest, TestRequestHeaderWithLegacyConfiguration) {
   auto formatter =
       *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
   EXPECT_EQ("GET", formatter->format(formatter_context_, stream_info_));
+}
+
+TEST_F(CELFormatterTest, TestCelConfigEnablesStringFunctions) {
+  const std::string yaml = R"EOF(
+  text_format_source:
+    inline_string: "%CEL(request.headers['x-envoy-original-path'].replace('/original', '/mutated'))%"
+  formatters:
+    - name: envoy.formatter.cel
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel
+        cel_config:
+          enable_string_functions: true
+)EOF";
+  TestUtility::loadFromYaml(yaml, config_);
+
+  auto formatter =
+      *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_);
+  EXPECT_EQ("/mutated/path?secret=parameter", formatter->format(formatter_context_, stream_info_));
+}
+
+// Without `cel_config`, string functions default off, so `replace()` is
+// unregistered and building the expression fails.
+TEST_F(CELFormatterTest, TestStringFunctionExpressionRejectedWithoutCelConfig) {
+  const std::string yaml = R"EOF(
+  text_format_source:
+    inline_string: "%CEL(request.headers['x-envoy-original-path'].replace('/original', '/mutated'))%"
+  formatters:
+    - name: envoy.formatter.cel
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.formatter.cel.v3.Cel
+)EOF";
+  TestUtility::loadFromYaml(yaml, config_);
+
+  EXPECT_THROW_WITH_REGEX(
+      *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
+      EnvoyException, "failed to create an expression: .*");
 }
 
 TEST_F(CELFormatterTest, TestRequestHeader) {


### PR DESCRIPTION
This is broken out from #45815 after reviewers suggested splitting it up. That PR had lgtm on the API.

**NOTE:** This PR is stacked on top of #45934. See the [incremental diff from #45934](https://github.com/kamalmarhubi/envoy/compare/push-rsuqmovnovno...kamalmarhubi:envoy:push-utkqwspvllnr).

**Commit Message:**
header_mutation: add formatter configuration

Allow formatter extensions to be configured for header and query parameter
mutation values at both filter and per-route scopes. This enables
formatter-specific options such as CEL string functions while preserving
built-in formatters when no configuration is provided.

Part of #45420

**Additional Description:** See #45420 for motivation: enabling CEL string functions in header mutations.
**AI Disclosure:** This was developed by iterating with OpenAI Codex (GPT-5.5), with review and further iteration using Claude Code (Opus 4.8) and Amp (GPT 5.6-sol). I reviewed and edited the generated output, understand the submitted changes, and take responsibility for them.
**Risk Level:** Low
**Testing:**
```
bazel test \
  //test/extensions/filters/http/header_mutation:header_mutation_test \
  //test/extensions/filters/http/header_mutation:config_test
```
**Docs Changes:** Inline proto documentation for the new `formatters` field.
**Release Notes:** Added (header_mutation).
**Platform Specific Features:** N/A. (The CEL formatter is already excluded on Windows [via WINDOWS_SKIP_TARGETS](https://github.com/envoyproxy/envoy/blob/33840def0d7447551bb6c9fa3b6e522a9aeed230/bazel/repositories.bzl#L22); I haven't changed that.)
[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md): adds `formatters` (`repeated config.core.v3.TypedExtensionConfig`) to the header mutation `Mutations` message. This is additive; omitting it preserves existing behaviour.
