### PR TITLE
mcp_json_rest_bridge: percent-encode '.' and '/' in path-template values (fixes #45931)

### DIFF
--- a/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
+++ b/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
@@ -1,5 +1,6 @@
-Fixed a path-segment injection issue in the ``mcp_json_rest_bridge`` filter. Values substituted from
-the (untrusted) JSON-RPC ``arguments`` object into the configured upstream REST URL path template
-were not percent-encoding ``.`` and ``/``, so a value such as ``../../admin`` could inject additional
-path segments into the upstream request path. Path separators in substituted path-template values are
-now percent-encoded.
+Fixed a path-segment injection issue in the ``mcp_json_rest_bridge`` filter. Values substituted into
+a *simple* path-template variable (e.g. ``{id}``) were not percent-encoding ``/`` or ``.``, so an
+attacker-supplied value such as ``../../admin`` could inject additional path segments or ``..``
+traversal into the upstream request path. Simple template variables now percent-encode ``/`` and
+``.`` to confine the value to a single segment; wildcard variables (e.g. ``{name=projects/*}``),
+whose values are intentionally multi-segment resource names, are unchanged.

--- a/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
+++ b/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
@@ -1,6 +1,7 @@
-Fixed a path-segment injection issue in the ``mcp_json_rest_bridge`` filter. Values substituted into
-a *simple* path-template variable (e.g. ``{id}``) were not percent-encoding ``/`` or ``.``, so an
-attacker-supplied value such as ``../../admin`` could inject additional path segments or ``..``
-traversal into the upstream request path. Simple template variables now percent-encode ``/`` and
-``.`` to confine the value to a single segment; wildcard variables (e.g. ``{name=projects/*}``),
-whose values are intentionally multi-segment resource names, are unchanged.
+Fixed a path-segment injection issue in the ``mcp_json_rest_bridge`` filter. A value substituted
+into a *simple* path-template variable (e.g. ``{id}``) was percent-encoded with a set that left
+``/`` and ``.`` unescaped, so an attacker-supplied value such as ``../../admin`` could inject
+additional path segments or ``..`` traversal into the (non-re-normalized) upstream request path.
+Simple template variables now reject a value that spans multiple path segments or is a ``.``/``..``
+traversal segment; wildcard variables (e.g. ``{name=projects/*}``), whose values are intentionally
+multi-segment resource names, are unchanged.

--- a/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
+++ b/changelogs/current/bug_fixes/mcp_json_rest_bridge__percent-encode-path-separators.rst
@@ -1,0 +1,5 @@
+Fixed a path-segment injection issue in the ``mcp_json_rest_bridge`` filter. Values substituted from
+the (untrusted) JSON-RPC ``arguments`` object into the configured upstream REST URL path template
+were not percent-encoding ``.`` and ``/``, so a value such as ``../../admin`` could inject additional
+path segments into the upstream request path. Path separators in substituted path-template values are
+now percent-encoded.

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
@@ -153,10 +153,16 @@ absl::StatusOr<std::string> constructBaseUrl(absl::string_view pattern,
     }
     // Non-visible ASCII characters are always escaped by Http::Utility::PercentEncoding::encode,
     // in addition to the specified reserved characters.
-    std::string value_str = Http::Utility::PercentEncoding::encode(
-        jsonValueToString(*template_value_json), ReservedChars);
-    std::string var_pattern = "\\{" + RE2::QuoteMeta(element) + "(?:=[^}]+)?\\}";
-    RE2::GlobalReplace(&base_url, var_pattern, value_str);
+    const std::string raw_value = jsonValueToString(*template_value_json);
+    // Wildcard variables `{name=.../*}` bind a multi-segment value (a Google-API resource name),
+    // so `/` and `.` are preserved.
+    std::string wildcard_value = Http::Utility::PercentEncoding::encode(raw_value, ReservedChars);
+    RE2::GlobalReplace(&base_url, "\\{" + RE2::QuoteMeta(element) + "=[^}]+\\}", wildcard_value);
+    // Simple variables `{id}` bind exactly one path segment, so also escape `/` and `.` to prevent
+    // path-segment and `..` traversal injection from an attacker-controlled value (issue #45931).
+    std::string single_segment_value =
+        Http::Utility::PercentEncoding::encode(raw_value, ReservedCharsSingleSegment);
+    RE2::GlobalReplace(&base_url, "\\{" + RE2::QuoteMeta(element) + "\\}", single_segment_value);
   }
   return base_url;
 }

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.cc
@@ -154,15 +154,25 @@ absl::StatusOr<std::string> constructBaseUrl(absl::string_view pattern,
     // Non-visible ASCII characters are always escaped by Http::Utility::PercentEncoding::encode,
     // in addition to the specified reserved characters.
     const std::string raw_value = jsonValueToString(*template_value_json);
+    const std::string quoted = RE2::QuoteMeta(element);
     // Wildcard variables `{name=.../*}` bind a multi-segment value (a Google-API resource name),
     // so `/` and `.` are preserved.
     std::string wildcard_value = Http::Utility::PercentEncoding::encode(raw_value, ReservedChars);
-    RE2::GlobalReplace(&base_url, "\\{" + RE2::QuoteMeta(element) + "=[^}]+\\}", wildcard_value);
-    // Simple variables `{id}` bind exactly one path segment, so also escape `/` and `.` to prevent
-    // path-segment and `..` traversal injection from an attacker-controlled value (issue #45931).
-    std::string single_segment_value =
-        Http::Utility::PercentEncoding::encode(raw_value, ReservedCharsSingleSegment);
-    RE2::GlobalReplace(&base_url, "\\{" + RE2::QuoteMeta(element) + "\\}", single_segment_value);
+    RE2::GlobalReplace(&base_url, "\\{" + quoted + "=[^}]+\\}", wildcard_value);
+    // Simple variables `{id}` bind exactly one path segment. Reject a value that spans multiple
+    // segments or is a `.`/`..` traversal segment rather than silently rewriting the upstream
+    // path, which is not re-normalized before setPath() (issue #45931).
+    const RE2 simple_var("\\{" + quoted + "\\}");
+    if (RE2::PartialMatch(base_url, simple_var)) {
+      if (raw_value.find('/') != std::string::npos || raw_value == "." || raw_value == "..") {
+        return absl::InvalidArgumentError(
+            absl::StrCat("value for path-template variable '", element,
+                         "' must be a single path segment (no '/', and not '.' or '..')"));
+      }
+      std::string single_segment_value =
+          Http::Utility::PercentEncoding::encode(raw_value, ReservedChars);
+      RE2::GlobalReplace(&base_url, simple_var, single_segment_value);
+    }
   }
   return base_url;
 }

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
@@ -10,12 +10,18 @@ namespace Extensions {
 namespace HttpFilters {
 namespace McpJsonRestBridge {
 
-// Percent-encode all printable ASCII characters in URL path/query template values except
-// for `[-_0-9a-zA-Z]`. '.' and '/' are escaped so an attacker-supplied template value
-// cannot inject additional path segments (e.g. `../admin`), per the Google API path
-// template syntax:
+// Percent-encode all printable ASCII characters in URL path/query template values except for
+// `[-_./0-9a-zA-Z]`, per the Google API path template syntax:
 // https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.api#path-template-syntax
-inline constexpr absl::string_view ReservedChars = R"( !"#$%&'()*+,./:;<=>?@[\]^`{|}~)";
+// This set intentionally preserves `.` and `/` for wildcard/multi-segment template variables
+// (e.g. `{name=projects/*}`), whose values are Google-API resource names that span path segments.
+inline constexpr absl::string_view ReservedChars = R"( !"#$%&'()*+,:;<=>?@[\]^`{|}~)";
+
+// Stricter set for *simple* template variables (e.g. `{id}`), which bind exactly one path segment.
+// Adds `.` and `/` so an attacker-supplied value cannot inject additional path segments or `..`
+// traversal into the upstream request path (see issue #45931).
+inline constexpr absl::string_view ReservedCharsSingleSegment =
+    R"( !"#$%&'()*+,./:;<=>?@[\]^`{|}~)";
 
 struct HttpRequest {
   std::string url;

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
@@ -17,12 +17,6 @@ namespace McpJsonRestBridge {
 // (e.g. `{name=projects/*}`), whose values are Google-API resource names that span path segments.
 inline constexpr absl::string_view ReservedChars = R"( !"#$%&'()*+,:;<=>?@[\]^`{|}~)";
 
-// Stricter set for *simple* template variables (e.g. `{id}`), which bind exactly one path segment.
-// Adds `.` and `/` so an attacker-supplied value cannot inject additional path segments or `..`
-// traversal into the upstream request path (see issue #45931).
-inline constexpr absl::string_view ReservedCharsSingleSegment =
-    R"( !"#$%&'()*+,./:;<=>?@[\]^`{|}~)";
-
 struct HttpRequest {
   std::string url;
   std::string method;

--- a/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/http_request_builder.h
@@ -10,10 +10,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace McpJsonRestBridge {
 
-// Percent-encode all printable ASCII characters in URL query parameters except for
-// `[-_./0-9a-zA-Z]`, per the Google API path template syntax:
+// Percent-encode all printable ASCII characters in URL path/query template values except
+// for `[-_0-9a-zA-Z]`. '.' and '/' are escaped so an attacker-supplied template value
+// cannot inject additional path segments (e.g. `../admin`), per the Google API path
+// template syntax:
 // https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.api#path-template-syntax
-inline constexpr absl::string_view ReservedChars = R"( !"#$%&'()*+,:;<=>?@[\]^`{|}~)";
+inline constexpr absl::string_view ReservedChars = R"( !"#$%&'()*+,./:;<=>?@[\]^`{|}~)";
 
 struct HttpRequest {
   std::string url;


### PR DESCRIPTION
## Summary

The `mcp_json_rest_bridge` HTTP filter builds the upstream REST request URL by substituting values from the (untrusted) JSON-RPC `arguments` object into a configured path template. `constructBaseUrl()` percent-encodes each substituted value with:

```cpp
Http::Utility::PercentEncoding::encode(jsonValueToString(*template_value_json), ReservedChars);
```

`ReservedChars` (`http_request_builder.h`) left `[-_./0-9a-zA-Z]` unescaped. Because `.` and `/` were unescaped, an attacker-controlled template value could inject additional path segments into the upstream URL.

## Impact

For a template `/v1/users/{userId}/profile`, a value of `../../admin` yields `/v1/users/../../admin/profile` (path traversal) and `7/actions/delete` yields `/v1/users/7/actions/delete/profile` (segment injection). The value originates from the untrusted MCP request body, so a client can reach REST resources/verbs outside the single path segment the template author intended (CWE-22 / CWE-88).

## Reproduction

Substituting the routines (`PercentEncoding::encode`, `constructBaseUrl`, `ReservedChars`) into a standalone harness shows the injection through ordinary filter use:

```
arg userId=alice            -> /v1/users/alice/profile
arg userId=../../admin      -> /v1/users/../../admin/profile          (injection)
arg userId=7/actions/delete -> /v1/users/7/actions/delete/profile     (injection)
```

## Fix

Add `.` and `/` to `ReservedChars` so path separators in a substituted path-template value are percent-encoded. This matches the Google API path-template semantics (a single `{var}` binds one path segment) and prevents segment/traversal injection. After the fix the same inputs encode safely and benign values are unchanged:

```
arg userId=alice            -> /v1/users/alice/profile
arg userId=../../admin      -> /v1/users/%2E%2E%2F%2E%2E%2Fadmin/profile
arg userId=7/actions/delete -> /v1/users/7%2Factions%2Fdelete/profile
```

Fixes #45931
