### PR TITLE
Set external build to use C++20

### DIFF
--- a/bazel/tests/external/.bazelrc
+++ b/bazel/tests/external/.bazelrc
@@ -21,7 +21,7 @@ build --workspace_status_command="bash get_workspace_status"
 build --incompatible_strict_action_env
 build --action_env=SPHINX_RUNNER_ARGS
 build --copt=-Wno-deprecated-declarations
-build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+build --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
 build --action_env=BUILD_DOCS_SHA
 build --jobs=HOST_CPUS*.8
 build --verbose_failures


### PR DESCRIPTION
docs build imports top level .bazelrc and does not need to be changed.

Risk Level: none
Testing: build
Docs Changes: no
Release Notes: no
Platform Specific Features: no
