### PR TITLE
Add max cap to guard against malicious number token input

### DIFF
--- a/source/common/json/wuffs_json/wuffs_json_cursor.cc
+++ b/source/common/json/wuffs_json/wuffs_json_cursor.cc
@@ -204,18 +204,23 @@ absl::Status WuffsJsonCursor::feed(absl::string_view chunk, bool closed) {
           absl::StrCat("wuffs json: ", wuffs_base__status__message(&status)));
     }
     if (status.repr == wuffs_base__suspension__short_read) {
-      // Wuffs rewound iop_a_src to before the incomplete token before
-      // suspending (the iop_a_src-- unread loop for NUMBER; no-op for
-      // LITERAL since match7 is peek-only). Save those bytes so the next
-      // feed() call can prepend them and give Wuffs a contiguous view.
+      // When Wuffs suspends mid-token it resets its read cursor to before the
+      // incomplete token, so source_buf.meta.ri points back to the token start.
+      // For NUMBER, Wuffs walks the cursor back byte-by-byte after reading digits since
+      // Wuffs need to read digits greedily, advancing iop_a_src until it sees a
+      // terminator character (whitespace, ,, }, ]) which means number is done.
+      // For LITERAL(null/true/false), Wuffs knows the exact length before reading so it checks the
+      // keyword without advancing the cursor at all, so no rewind is needed.
       if (source_buf.meta.ri < effective_chunk.size()) {
         // LITERAL is always 4–5 bytes (null/true/false) — completely bounded.
-        // NUMBER, in real-world, its values is also bounded: a 64-bit integer is at most 20 digits;
-        // a float with sign, decimal, and exponent at most ~25 chars.
-        // TODO(tyxia): cap pending_bytes_ for malicious inputs that send arbitrarily large NUMBER
-        // tokens one byte at a time.
-        pending_bytes_.assign(effective_chunk.data() + source_buf.meta.ri,
-                              effective_chunk.size() - source_buf.meta.ri);
+        // For NUMBER split across chunks: cap pending_bytes_ to kMaxPendingBytes (see its
+        // declaration). Numbers that arrive complete with their terminator in the same chunk
+        // never reach this path and are bounded by the upstream max_body_bytes limit instead.
+        const size_t leftover = effective_chunk.size() - source_buf.meta.ri;
+        if (leftover > kMaxPendingBytes) {
+          return absl::InvalidArgumentError("wuffs json: number token too large");
+        }
+        pending_bytes_.assign(effective_chunk.data() + source_buf.meta.ri, leftover);
       }
       break;
     }

--- a/source/common/json/wuffs_json/wuffs_json_cursor.h
+++ b/source/common/json/wuffs_json/wuffs_json_cursor.h
@@ -261,6 +261,12 @@ private:
   // (longest observed ~25B, e.g. "input_audio_transcription") while bounding
   // per-key allocation and guarding against DoS via unbounded key lengths.
   static constexpr size_t kMaxKeyBytes = 256;
+  // kMaxPendingBytes is a hard limit against the byte-at-a-time DoS when a NUMBER token is split
+  // across chunk boundaries, NUMBER tokens that arrive complete with their terminator in one chunk
+  // bypass this path entirely — those are bounded by the max_body_bytes limit instead. A legitimate
+  // number is at most ~25 chars (64-bit int ≤ 20 digits; float with sign/decimal/exponent ≤ ~25).
+  // 64 bytes gives generous headroom.
+  static constexpr size_t kMaxPendingBytes = 64;
   int depth_{0};
   bool is_dict_[kMaxTrackedDepth]{};
   bool expecting_key_[kMaxTrackedDepth]{};

--- a/test/common/json/wuffs_json/wuffs_json_cursor_test.cc
+++ b/test/common/json/wuffs_json/wuffs_json_cursor_test.cc
@@ -725,6 +725,34 @@ TEST(WuffsJsonCursorTest, UnicodeEscapeSplitChunkCorrectValue) {
   EXPECT_EQ(h.fields[0].str_val, "aAb"); // U+0041 = 'A'
 }
 
+// A NUMBER token that straddles a chunk boundary causes Wuffs to rewind its
+// read cursor and the cursor to save the unread bytes in pending_bytes_.
+// If those bytes exceed kMaxPendingBytes the cursor must reject immediately.
+
+// A number whose in-flight byte count equals kMaxPendingBytes (64) must not
+// trigger the cap: the next chunk completes it normally.
+TEST(WuffsJsonCursorTest, NumberAtPendingCapAccepted) {
+  CapturingHandler h;
+  WuffsJsonCursor cursor(h);
+  // Feed structure first; no number in flight yet.
+  ASSERT_TRUE(cursor.feed("{\"n\":", /*closed=*/false).ok());
+  // Feed exactly 64 digit bytes with no terminator — pending_bytes_ = 64, not over cap.
+  ASSERT_TRUE(cursor.feed(std::string(64, '1'), /*closed=*/false).ok());
+  // Close with '}': Wuffs now sees terminator and completes the NUMBER token.
+  ASSERT_TRUE(cursor.feed("}", /*closed=*/true).ok());
+  ASSERT_EQ(h.fields.size(), 1u);
+  EXPECT_EQ(h.fields[0].raw_val, std::string(64, '1'));
+}
+
+// A number with 65 in-flight bytes (one over kMaxPendingBytes) must be rejected.
+TEST(WuffsJsonCursorTest, NumberOverPendingCapRejected) {
+  CapturingHandler h;
+  WuffsJsonCursor cursor(h);
+  ASSERT_TRUE(cursor.feed("{\"n\":", /*closed=*/false).ok());
+  // 65 digit bytes with no terminator — leftover = 65 > 64 → error.
+  EXPECT_FALSE(cursor.feed(std::string(65, '1'), /*closed=*/false).ok());
+}
+
 } // namespace
 } // namespace Wuffs
 } // namespace Json


### PR DESCRIPTION
For Number token, there are two cases, this cap is only applicable to the case 2
(1) Huge Number token that arrive complete with their terminator in the same chunk: This is not subject to attack vector here, hence the limit in this PR here is not applicable, as it is bounded by the max_body_bytes limit in the upper layer

(2) Huge Number token is split and sent via many small data chunks by attacker, when NUMBER token straddles a chunk boundary, it will cause Wuffs to rewind its ead cursor and the cursor to save the unread bytes in pending_bytes_. Thus we need to cap the pending_bytes here.

Tests have been added.

https://github.com/envoyproxy/envoy/issues/44681


