### PR TITLE
CEL formatter: Replace C++ exceptions with status errors

### DIFF
--- a/source/extensions/formatter/cel/cel.cc
+++ b/source/extensions/formatter/cel/cel.cc
@@ -83,7 +83,8 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
   if (command == "CEL" || command == "TYPED_CEL") {
     auto parse_status = google::api::expr::parser::Parse(subcommand);
     if (!parse_status.ok()) {
-      throw EnvoyException("Not able to parse expression: " + parse_status.status().ToString());
+      return absl::InvalidArgumentError(
+          absl::StrCat("Not able to parse expression: ", parse_status.status().ToString()));
     }
     Server::Configuration::ServerFactoryContext& context =
         Server::Configuration::ServerFactoryContextInstance::get();
@@ -94,7 +95,7 @@ CELFormatterCommandParser::parse(absl::string_view command, absl::string_view su
 
   return nullptr;
 #else
-  throw EnvoyException("CEL is not available for use in this environment.");
+  return absl::UnimplementedError("CEL is not available for use in this environment.");
 #endif
 }
 

--- a/test/extensions/formatter/cel/BUILD
+++ b/test/extensions/formatter/cel/BUILD
@@ -31,7 +31,8 @@ envoy_extension_cc_test(
         "//source/extensions/formatter/cel:config",
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
-        "//test/test_common:test_runtime_lib",
+        "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ] + select(
         {

--- a/test/extensions/formatter/cel/cel_test.cc
+++ b/test/extensions/formatter/cel/cel_test.cc
@@ -7,6 +7,7 @@
 
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "fmt/format.h"
@@ -16,6 +17,9 @@
 namespace Envoy {
 namespace Extensions {
 namespace Formatter {
+
+using ::Envoy::StatusHelpers::HasStatus;
+using ::testing::HasSubstr;
 
 class CELFormatterTest : public ::testing::Test {
 public:
@@ -601,9 +605,9 @@ TEST_F(CELFormatterTest, TestUntypedInvalidExpression) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW_WITH_REGEX(
-      *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-      EnvoyException, "Not able to parse expression: .*");
+  EXPECT_THAT(
+      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
+      HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr("Not able to parse expression:")));
 }
 
 TEST_F(CELFormatterTest, TestTypedInvalidExpression) {
@@ -613,9 +617,9 @@ TEST_F(CELFormatterTest, TestTypedInvalidExpression) {
 )EOF";
   TestUtility::loadFromYaml(yaml, config_);
 
-  EXPECT_THROW_WITH_REGEX(
-      *Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
-      EnvoyException, "Not able to parse expression: .*");
+  EXPECT_THAT(
+      Envoy::Formatter::SubstitutionFormatStringUtils::fromProtoConfig(config_, context_),
+      HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr("Not able to parse expression:")));
 }
 
 TEST_F(CELFormatterTest, TestInvalidSemanticExpression) {


### PR DESCRIPTION
Status error validation is present at all callsites of the `parse` method.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
