### PR TITLE
orca: decouple OOB report delivery from CSWRR weight manager

### DIFF
--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -355,22 +354,6 @@ public:
 
 using HostDescriptionConstSharedPtr = std::shared_ptr<const HostDescription>;
 using HostDescriptionOptConstRef = OptRef<const Upstream::HostDescription>;
-
-using OrcaLoadReportRecipientCb = std::function<void(HostLbPolicyData&)>;
-
-/**
- * Invokes `callback(HostLbPolicyData&)` for each load-balancing-policy data entry on `host` whose
- * receivesOrcaLoadReport() is true.
- */
-inline void forEachOrcaLoadReportRecipient(const HostDescription& host,
-                                           const OrcaLoadReportRecipientCb& callback) {
-  for (size_t i = 0; i < host.lbPolicyDataCount(); ++i) {
-    OptRef<HostLbPolicyData> data = host.lbPolicyDataAt(i);
-    if (data.has_value() && data->receivesOrcaLoadReport()) {
-      callback(*data);
-    }
-  }
-}
 
 #define ALL_TRANSPORT_SOCKET_MATCH_STATS(COUNTER) COUNTER(total_match_count)
 

--- a/envoy/upstream/host_description.h
+++ b/envoy/upstream/host_description.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -114,10 +115,11 @@ public:
    * Please ensure that the implementation is thread-safe.
    *
    * @param report supplies the ORCA load report of this upstream host.
-   * @param stream_info supplies the downstream stream info.
+   * @param stream_info carries the downstream stream info for in-band reports and is empty for
+   *        out-of-band (OOB) reports.
    */
   virtual absl::Status onOrcaLoadReport(const OrcaLoadReport& /*report*/,
-                                        const StreamInfo::StreamInfo& /*stream_info*/) {
+                                        OptRef<const StreamInfo::StreamInfo> /*stream_info*/) {
     return absl::OkStatus();
   }
 };
@@ -353,6 +355,22 @@ public:
 
 using HostDescriptionConstSharedPtr = std::shared_ptr<const HostDescription>;
 using HostDescriptionOptConstRef = OptRef<const Upstream::HostDescription>;
+
+using OrcaLoadReportRecipientCb = std::function<void(HostLbPolicyData&)>;
+
+/**
+ * Invokes `callback(HostLbPolicyData&)` for each load-balancing-policy data entry on `host` whose
+ * receivesOrcaLoadReport() is true.
+ */
+inline void forEachOrcaLoadReportRecipient(const HostDescription& host,
+                                           const OrcaLoadReportRecipientCb& callback) {
+  for (size_t i = 0; i < host.lbPolicyDataCount(); ++i) {
+    OptRef<HostLbPolicyData> data = host.lbPolicyDataAt(i);
+    if (data.has_value() && data->receivesOrcaLoadReport()) {
+      callback(*data);
+    }
+  }
+}
 
 #define ALL_TRANSPORT_SOCKET_MATCH_STATS(COUNTER) COUNTER(total_match_count)
 

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -422,6 +422,7 @@ envoy_cc_library(
         "//source/common/orca:orca_load_metrics_lib",
         "//source/common/orca:orca_parser",
         "//source/common/stream_info:uint32_accessor_lib",
+        "//source/common/upstream:host_utility_lib",
         "//source/common/upstream:load_balancer_context_base_lib",
         "//source/common/upstream:upstream_factory_context_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -2565,12 +2565,8 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
 
   // Inline capacity of 2 covers the typical case of 1-2 LB policies per host.
   absl::InlinedVector<Upstream::HostLbPolicyData*, 2> orca_recipients;
-  for (size_t i = 0; i < upstream_host->lbPolicyDataCount(); ++i) {
-    auto host_lb_policy_data = upstream_host->lbPolicyDataAt(i);
-    if (host_lb_policy_data.has_value() && host_lb_policy_data->receivesOrcaLoadReport()) {
-      orca_recipients.push_back(host_lb_policy_data.ptr());
-    }
-  }
+  Upstream::forEachOrcaLoadReportRecipient(
+      *upstream_host, [&](Upstream::HostLbPolicyData& data) { orca_recipients.push_back(&data); });
 
   if (!cluster_->lrsReportMetricNames().has_value() && orca_recipients.empty()) {
     // If the cluster doesn't have LRS metric names configured then there is no need to

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -38,6 +38,7 @@
 #include "source/common/router/retry_state_impl.h"
 #include "source/common/runtime/runtime_features.h"
 #include "source/common/stream_info/uint32_accessor_impl.h"
+#include "source/common/upstream/host_utility.h"
 
 #include "absl/container/inlined_vector.h"
 
@@ -2565,7 +2566,7 @@ void Filter::maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or
 
   // Inline capacity of 2 covers the typical case of 1-2 LB policies per host.
   absl::InlinedVector<Upstream::HostLbPolicyData*, 2> orca_recipients;
-  Upstream::forEachOrcaLoadReportRecipient(
+  Upstream::HostUtility::forEachOrcaLoadReportRecipient(
       *upstream_host, [&](Upstream::HostLbPolicyData& data) { orca_recipients.push_back(&data); });
 
   if (!cluster_->lrsReportMetricNames().has_value() && orca_recipients.empty()) {

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -252,6 +252,7 @@ envoy_cc_library(
         "//envoy/upstream:upstream_interface",
         "//source/common/config:well_known_names",
         "//source/common/runtime:runtime_lib",
+        "@abseil-cpp//absl/functional:function_ref",
     ],
 )
 

--- a/source/common/upstream/host_utility.cc
+++ b/source/common/upstream/host_utility.cc
@@ -245,5 +245,15 @@ void HostUtility::forEachHostMetric(
   });
 }
 
+void HostUtility::forEachOrcaLoadReportRecipient(
+    const HostDescription& host, absl::FunctionRef<void(HostLbPolicyData&)> callback) {
+  for (size_t i = 0; i < host.lbPolicyDataCount(); ++i) {
+    OptRef<HostLbPolicyData> data = host.lbPolicyDataAt(i);
+    if (data.has_value() && data->receivesOrcaLoadReport()) {
+      callback(*data);
+    }
+  }
+}
+
 } // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/host_utility.h
+++ b/source/common/upstream/host_utility.h
@@ -6,6 +6,8 @@
 #include "envoy/upstream/load_balancer.h"
 #include "envoy/upstream/upstream.h"
 
+#include "absl/functional/function_ref.h"
+
 namespace Envoy {
 namespace Upstream {
 
@@ -60,6 +62,13 @@ public:
   forEachHostMetric(const ClusterManager& cluster_manager,
                     const std::function<void(Stats::PrimitiveCounterSnapshot&& metric)>& counter_cb,
                     const std::function<void(Stats::PrimitiveGaugeSnapshot&& metric)>& gauge_cb);
+
+  /**
+   * Invokes `callback(HostLbPolicyData&)` for each load-balancing-policy data entry on `host` whose
+   * receivesOrcaLoadReport() is true.
+   */
+  static void forEachOrcaLoadReportRecipient(const HostDescription& host,
+                                             absl::FunctionRef<void(HostLbPolicyData&)> callback);
 };
 
 } // namespace Upstream

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.cc
@@ -132,8 +132,7 @@ ClientSideWeightedRoundRobinLoadBalancer::ClientSideWeightedRoundRobinLoadBalanc
     orca_oob_manager_ =
         std::make_unique<Extensions::LoadBalancingPolicies::Common::ProdOrcaOobManager>(
             typed_lb_config->oob_manager_config, priority_set,
-            typed_lb_config->main_thread_dispatcher_, random, cluster_info.statsScope(),
-            orca_weight_manager_->reportHandler());
+            typed_lb_config->main_thread_dispatcher_, random, cluster_info.statsScope());
   }
 }
 

--- a/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
+++ b/source/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb.h
@@ -132,8 +132,8 @@ private:
       orca_weight_manager_;
 
   // ORCA out-of-band manager. Constructed only when enable_oob_load_report is true; null
-  // otherwise. Shares the OrcaWeightManager's report handler so OOB reports feed the same
-  // per-host atomics as in-band reports.
+  // otherwise. Delivers decoded OOB reports through each host's HostLbPolicyData::onOrcaLoadReport,
+  // so policies receive OOB and in-band reports through the same callback path.
   std::unique_ptr<Extensions::LoadBalancingPolicies::Common::OrcaOobManager> orca_oob_manager_;
 };
 

--- a/source/extensions/load_balancing_policies/common/BUILD
+++ b/source/extensions/load_balancing_policies/common/BUILD
@@ -66,7 +66,6 @@ envoy_cc_library(
     srcs = ["orca_oob_manager.cc"],
     hdrs = ["orca_oob_manager.h"],
     deps = [
-        ":orca_weight_manager_lib",
         "//envoy/common:random_generator_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/event:timer_interface",

--- a/source/extensions/load_balancing_policies/common/BUILD
+++ b/source/extensions/load_balancing_policies/common/BUILD
@@ -90,6 +90,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/network:transport_socket_options_lib",
         "//source/common/network:utility_lib",
+        "//source/common/upstream:host_utility_lib",
         "@abseil-cpp//absl/container:node_hash_map",
         "@abseil-cpp//absl/status",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
+++ b/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
@@ -71,11 +71,9 @@ void applyOrcaOobConnectionOverrides(
 OrcaOobManager::OrcaOobManager(OrcaOobManagerConfig config,
                                const Upstream::PrioritySet& priority_set,
                                Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
-                               Stats::Scope& stats_scope,
-                               OrcaLoadReportHandlerSharedPtr report_handler)
+                               Stats::Scope& stats_scope)
     : dispatcher_(dispatcher), random_(random), config_(sanitizeConfig(std::move(config))),
-      priority_set_(priority_set), report_handler_(std::move(report_handler)),
-      oob_stats_(generateOrcaOobStats(stats_scope)) {}
+      priority_set_(priority_set), oob_stats_(generateOrcaOobStats(stats_scope)) {}
 
 OrcaOobManager::~OrcaOobManager() {
   for (auto& [host, session] : oob_sessions_) {
@@ -385,14 +383,17 @@ void OrcaOobManager::OobSession::onReport(const xds::data::orca::v3::OrcaLoadRep
   parent_.oob_stats_.reports_received_.inc();
   backoff_->reset();
   inactivity_timer_->enableTimer(parent_.config_.reporting_period * kInactivityWatchdogMultiplier);
-  auto data_opt = host_->typedLbPolicyData<OrcaHostLbPolicyData>();
-  if (!data_opt.has_value()) {
-    parent_.oob_stats_.report_errors_.inc();
-    return;
-  }
-  const absl::Status status =
-      parent_.report_handler_->updateClientSideDataFromOrcaLoadReport(report, *data_opt);
-  if (!status.ok()) {
+  // Deliver to every ORCA-interested HostLbPolicyData (empty stream_info; OOB has no downstream
+  // stream). No recipient, or any recipient rejecting, counts as a report error.
+  bool had_recipient = false;
+  bool apply_failed = false;
+  Upstream::forEachOrcaLoadReportRecipient(*host_, [&](Upstream::HostLbPolicyData& data) {
+    had_recipient = true;
+    if (!data.onOrcaLoadReport(report, {}).ok()) {
+      apply_failed = true;
+    }
+  });
+  if (!had_recipient || apply_failed) {
     parent_.oob_stats_.report_errors_.inc();
   }
 }

--- a/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
+++ b/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
@@ -13,6 +13,7 @@
 #include "source/common/network/transport_socket_options_impl.h"
 #include "source/common/network/utility.h"
 #include "source/common/protobuf/protobuf.h"
+#include "source/common/upstream/host_utility.h"
 
 #include "xds/service/orca/v3/orca.pb.h"
 
@@ -387,12 +388,13 @@ void OrcaOobManager::OobSession::onReport(const xds::data::orca::v3::OrcaLoadRep
   // stream). No recipient, or any recipient rejecting, counts as a report error.
   bool had_recipient = false;
   bool apply_failed = false;
-  Upstream::forEachOrcaLoadReportRecipient(*host_, [&](Upstream::HostLbPolicyData& data) {
-    had_recipient = true;
-    if (!data.onOrcaLoadReport(report, {}).ok()) {
-      apply_failed = true;
-    }
-  });
+  Upstream::HostUtility::forEachOrcaLoadReportRecipient(
+      *host_, [&](Upstream::HostLbPolicyData& data) {
+        had_recipient = true;
+        if (!data.onOrcaLoadReport(report, std::nullopt).ok()) {
+          apply_failed = true;
+        }
+      });
   if (!had_recipient || apply_failed) {
     parent_.oob_stats_.report_errors_.inc();
   }

--- a/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
+++ b/source/extensions/load_balancing_policies/common/orca_oob_manager.cc
@@ -391,8 +391,12 @@ void OrcaOobManager::OobSession::onReport(const xds::data::orca::v3::OrcaLoadRep
   Upstream::HostUtility::forEachOrcaLoadReportRecipient(
       *host_, [&](Upstream::HostLbPolicyData& data) {
         had_recipient = true;
-        if (!data.onOrcaLoadReport(report, std::nullopt).ok()) {
+        const absl::Status status = data.onOrcaLoadReport(report, std::nullopt);
+        if (!status.ok()) {
           apply_failed = true;
+          ENVOY_LOG_PERIODIC(error, std::chrono::seconds(10),
+                             "OOB onOrcaLoadReport failed: {} for host {}", status.message(),
+                             host_->address()->asString());
         }
       });
   if (!had_recipient || apply_failed) {

--- a/source/extensions/load_balancing_policies/common/orca_oob_manager.h
+++ b/source/extensions/load_balancing_policies/common/orca_oob_manager.h
@@ -21,7 +21,6 @@
 #include "source/common/grpc/codec.h"
 #include "source/common/http/codec_client.h"
 #include "source/common/http/response_decoder_impl_base.h"
-#include "source/extensions/load_balancing_policies/common/orca_weight_manager.h"
 
 #include "absl/container/node_hash_map.h"
 #include "absl/status/status.h"
@@ -65,20 +64,21 @@ void applyOrcaOobConnectionOverrides(
  * Cluster-level manager owning per-host ORCA OOB streams. Modeled on
  * source/extensions/health_checkers/grpc/health_checker_impl.h: per-host nested OobSession holds
  * a CodecClient and Http stream callbacks; the manager reacts to PrioritySet::addMemberUpdateCb
- * to add/remove sessions. All activity runs on the supplied dispatcher's thread; the only
- * cross-thread surface is OrcaHostLbPolicyData atomics (workers read; this manager writes via the
- * shared OrcaLoadReportHandler).
+ * to add/remove sessions. All activity runs on the supplied dispatcher's thread. Each decoded
+ * report is delivered to the host's `HostLbPolicyData` via `onOrcaLoadReport`, the same entry point
+ * as the in-band request path.
  */
 class OrcaOobManager : protected Logger::Loggable<Logger::Id::upstream> {
 public:
   OrcaOobManager(OrcaOobManagerConfig config, const Upstream::PrioritySet& priority_set,
                  Event::Dispatcher& dispatcher, Random::RandomGenerator& random,
-                 Stats::Scope& stats_scope, OrcaLoadReportHandlerSharedPtr report_handler);
+                 Stats::Scope& stats_scope);
   virtual ~OrcaOobManager();
 
   // Iterate priority set, open a session per existing host, register member-update callback.
-  // Init order constraint: caller must invoke OrcaWeightManager::initialize() FIRST so the
-  // OrcaHostLbPolicyData attachment exists before sessions decode their first report.
+  // Init order: recipients' per-host data must be attached before the first report is decoded
+  // (for ClientSideWeightedRoundRobin, call OrcaWeightManager::initialize() first); a report that
+  // finds no recipient is counted as a report error.
   absl::Status initialize();
 
 protected:
@@ -173,7 +173,6 @@ private:
 
   const OrcaOobManagerConfig config_;
   const Upstream::PrioritySet& priority_set_;
-  OrcaLoadReportHandlerSharedPtr report_handler_;
   Envoy::Common::CallbackHandlePtr member_update_cb_;
   // node_hash_map for pointer/reference stability across rehash.
   absl::node_hash_map<Upstream::HostConstSharedPtr, OobSessionPtr> oob_sessions_;

--- a/source/extensions/load_balancing_policies/common/orca_weight_manager.cc
+++ b/source/extensions/load_balancing_policies/common/orca_weight_manager.cc
@@ -116,7 +116,7 @@ absl::Status OrcaLoadReportHandler::updateClientSideDataFromOrcaLoadReport(
 }
 
 absl::Status OrcaHostLbPolicyData::onOrcaLoadReport(const Upstream::OrcaLoadReport& report,
-                                                    const StreamInfo::StreamInfo&) {
+                                                    OptRef<const StreamInfo::StreamInfo>) {
   ASSERT(report_handler_ != nullptr);
   return report_handler_->updateClientSideDataFromOrcaLoadReport(report, *this);
 }

--- a/source/extensions/load_balancing_policies/common/orca_weight_manager.h
+++ b/source/extensions/load_balancing_policies/common/orca_weight_manager.h
@@ -86,7 +86,7 @@ struct OrcaHostLbPolicyData : public Envoy::Upstream::HostLbPolicyData {
 
   bool receivesOrcaLoadReport() const override { return true; }
   absl::Status onOrcaLoadReport(const Upstream::OrcaLoadReport& report,
-                                const StreamInfo::StreamInfo& stream_info) override;
+                                OptRef<const StreamInfo::StreamInfo> stream_info) override;
 
   // Update the weight and timestamps for first and last update time.
   void updateWeightNow(uint32_t weight, const MonotonicTime& now) {

--- a/source/extensions/load_balancing_policies/common/orca_weight_manager.h
+++ b/source/extensions/load_balancing_policies/common/orca_weight_manager.h
@@ -150,9 +150,6 @@ public:
   // Core weight update (blackout, expiration, median default). Returns true if any weight changed.
   bool updateWeightsOnHosts(const Upstream::HostVector& hosts);
 
-  // Accessor for the report handler (used by tests and for creating host data).
-  OrcaLoadReportHandlerSharedPtr reportHandler() { return report_handler_; }
-
   // Get weight based on host LB policy data if valid, otherwise return nullopt.
   static std::optional<uint32_t> getWeightIfValidFromHost(const Upstream::Host& host,
                                                           MonotonicTime max_non_empty_since,

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -8448,7 +8448,7 @@ class TestOrcaLoadReportLbData : public Upstream::HostLbPolicyData {
 public:
   bool receivesOrcaLoadReport() const override { return true; }
   MOCK_METHOD(absl::Status, onOrcaLoadReport,
-              (const Upstream::OrcaLoadReport&, const StreamInfo::StreamInfo&), (override));
+              (const Upstream::OrcaLoadReport&, OptRef<const StreamInfo::StreamInfo>), (override));
 };
 
 TEST_F(RouterTest, OrcaLoadReportCallbacks) {
@@ -8472,7 +8472,7 @@ TEST_F(RouterTest, OrcaLoadReportCallbacks) {
   xds::data::orca::v3::OrcaLoadReport received_orca_load_report;
   EXPECT_CALL(*host_lb_policy_data_raw_ptr, onOrcaLoadReport(_, _))
       .WillOnce(Invoke([&](const xds::data::orca::v3::OrcaLoadReport& orca_load_report,
-                           const StreamInfo::StreamInfo&) {
+                           OptRef<const StreamInfo::StreamInfo>) {
         received_orca_load_report = orca_load_report;
         return absl::OkStatus();
       }));
@@ -8526,7 +8526,7 @@ TEST_F(RouterTest, OrcaLoadReportCallbackReturnsError) {
   xds::data::orca::v3::OrcaLoadReport received_orca_load_report;
   EXPECT_CALL(*host_lb_policy_data_raw_ptr, onOrcaLoadReport(_, _))
       .WillOnce(Invoke([&](const xds::data::orca::v3::OrcaLoadReport& orca_load_report,
-                           const StreamInfo::StreamInfo&) {
+                           OptRef<const StreamInfo::StreamInfo>) {
         received_orca_load_report = orca_load_report;
         // Return an error that gets logged by router filter.
         return absl::InvalidArgumentError("Unexpected ORCA load Report");
@@ -8628,7 +8628,8 @@ TEST_F(RouterTest, OrcaLoadReportSkipsEntriesNotInterestedInOrca) {
   public:
     bool receivesOrcaLoadReport() const override { return false; }
     MOCK_METHOD(absl::Status, onOrcaLoadReport,
-                (const Upstream::OrcaLoadReport&, const StreamInfo::StreamInfo&), (override));
+                (const Upstream::OrcaLoadReport&, OptRef<const StreamInfo::StreamInfo>),
+                (override));
   };
 
   auto non_orca_data = std::make_unique<NonOrcaLbData>();

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -8444,13 +8444,6 @@ TEST_F(RouterTest, OrcaLoadReport_NoConfiguredMetricNames) {
   ASSERT_EQ(load_metric_stats_map, nullptr);
 }
 
-class TestOrcaLoadReportLbData : public Upstream::HostLbPolicyData {
-public:
-  bool receivesOrcaLoadReport() const override { return true; }
-  MOCK_METHOD(absl::Status, onOrcaLoadReport,
-              (const Upstream::OrcaLoadReport&, OptRef<const StreamInfo::StreamInfo>), (override));
-};
-
 TEST_F(RouterTest, OrcaLoadReportCallbacks) {
   EXPECT_CALL(callbacks_.route_->route_entry_, timeout())
       .WillOnce(Return(std::chrono::milliseconds(0)));
@@ -8465,7 +8458,7 @@ TEST_F(RouterTest, OrcaLoadReportCallbacks) {
   router_->decodeHeaders(headers, true);
 
   // Configure the HostLbData to receive the report.
-  auto host_lb_policy_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto host_lb_policy_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto host_lb_policy_data_raw_ptr = host_lb_policy_data.get();
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(host_lb_policy_data));
 
@@ -8519,7 +8512,7 @@ TEST_F(RouterTest, OrcaLoadReportCallbackReturnsError) {
   router_->decodeHeaders(headers, true);
 
   // Configure the HostLbData to receive the report.
-  auto host_lb_policy_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto host_lb_policy_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto host_lb_policy_data_raw_ptr = host_lb_policy_data.get();
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(host_lb_policy_data));
 
@@ -8560,7 +8553,7 @@ TEST_F(RouterTest, OrcaLoadReportInvalidHeaderValue) {
 
   // Configure the HostLbData to receive the report, but don't expect it to be
   // called for invalid orca header.
-  auto host_lb_policy_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto host_lb_policy_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto host_lb_policy_data_raw_ptr = host_lb_policy_data.get();
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(host_lb_policy_data));
   EXPECT_CALL(*host_lb_policy_data_raw_ptr, onOrcaLoadReport(_, _)).Times(0);
@@ -8587,9 +8580,9 @@ TEST_F(RouterTest, OrcaLoadReportCallbacksFanOutToMultipleHostDataEntries) {
   HttpTestUtility::addDefaultHeaders(headers);
   router_->decodeHeaders(headers, true);
 
-  auto first_lb_policy_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto first_lb_policy_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto* first_lb_policy_data_raw_ptr = first_lb_policy_data.get();
-  auto second_lb_policy_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto second_lb_policy_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto* second_lb_policy_data_raw_ptr = second_lb_policy_data.get();
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(first_lb_policy_data));
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(second_lb_policy_data));
@@ -8624,17 +8617,10 @@ TEST_F(RouterTest, OrcaLoadReportSkipsEntriesNotInterestedInOrca) {
   router_->decodeHeaders(headers, true);
 
   // First entry opts out of ORCA reports.
-  class NonOrcaLbData : public Upstream::HostLbPolicyData {
-  public:
-    bool receivesOrcaLoadReport() const override { return false; }
-    MOCK_METHOD(absl::Status, onOrcaLoadReport,
-                (const Upstream::OrcaLoadReport&, OptRef<const StreamInfo::StreamInfo>),
-                (override));
-  };
-
-  auto non_orca_data = std::make_unique<NonOrcaLbData>();
+  auto non_orca_data =
+      std::make_unique<Upstream::MockHostLbPolicyData>(/*receives_orca_load_report=*/false);
   auto* non_orca_data_raw_ptr = non_orca_data.get();
-  auto orca_data = std::make_unique<TestOrcaLoadReportLbData>();
+  auto orca_data = std::make_unique<Upstream::MockHostLbPolicyData>();
   auto* orca_data_raw_ptr = orca_data.get();
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(non_orca_data));
   cm_.thread_local_cluster_.conn_pool_.host_->addLbPolicyData(std::move(orca_data));

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
@@ -22,10 +22,12 @@ using OrcaWeightManager = Extensions::LoadBalancingPolicies::Common::OrcaWeightM
 
 class ClientSideWeightedRoundRobinLoadBalancerFriend {
 public:
-  explicit ClientSideWeightedRoundRobinLoadBalancerFriend(
+  ClientSideWeightedRoundRobinLoadBalancerFriend(
       std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer> lb,
-      std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb> worker_lb)
-      : lb_(std::move(lb)), worker_lb_(std::move(worker_lb)) {}
+      std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb> worker_lb,
+      Extensions::LoadBalancingPolicies::Common::OrcaLoadReportHandlerSharedPtr report_handler)
+      : lb_(std::move(lb)), worker_lb_(std::move(worker_lb)),
+        report_handler_(std::move(report_handler)) {}
 
   HostSelectionResponse chooseHost(LoadBalancerContext* context) {
     return worker_lb_->chooseHost(context);
@@ -78,7 +80,7 @@ public:
                                long long non_empty_since_seconds,
                                long long last_update_time_seconds) {
     auto client_side_data = std::make_unique<OrcaHostLbPolicyData>(
-        lb_->orca_weight_manager_->reportHandler(), weight, /*non_empty_since=*/
+        report_handler_, weight, /*non_empty_since=*/
         MonotonicTime(std::chrono::seconds(non_empty_since_seconds)),
         /*last_update_time=*/
         MonotonicTime(std::chrono::seconds(last_update_time_seconds)));
@@ -87,12 +89,13 @@ public:
 
   Extensions::LoadBalancingPolicies::Common::OrcaLoadReportHandlerSharedPtr
   orcaLoadReportHandler() {
-    return lb_->orca_weight_manager_->reportHandler();
+    return report_handler_;
   }
 
 private:
   std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer> lb_;
   std::shared_ptr<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb> worker_lb_;
+  Extensions::LoadBalancingPolicies::Common::OrcaLoadReportHandlerSharedPtr report_handler_;
 };
 
 namespace {
@@ -119,12 +122,20 @@ public:
         "metric2");
 
     EXPECT_CALL(mock_tls_, allocateSlot());
+    // Handler equivalent to the one the LB builds internally from the same config.
+    auto report_handler = std::make_shared<OrcaLoadReportHandler>(
+        Extensions::LoadBalancingPolicies::Common::OrcaWeightManagerConfig{
+            lb_config_.metric_names_for_computing_utilization,
+            lb_config_.error_utilization_penalty, lb_config_.blackout_period,
+            lb_config_.weight_expiration_period, lb_config_.weight_update_period},
+        simTime());
     lb_ = std::make_shared<ClientSideWeightedRoundRobinLoadBalancerFriend>(
         std::make_shared<ClientSideWeightedRoundRobinLoadBalancer>(
             lb_config_, cluster_info_, priority_set_, runtime_, random_, simTime()),
         std::make_shared<ClientSideWeightedRoundRobinLoadBalancer::WorkerLocalLb>(
             priority_set_, local_priority_set_.get(), stats_, runtime_, random_, common_config_,
-            lb_config_.round_robin_overrides_, simTime(), /*tls_shim=*/std::nullopt));
+            lb_config_.round_robin_overrides_, simTime(), /*tls_shim=*/std::nullopt),
+        std::move(report_handler));
 
     // Initialize the thread aware load balancer from config.
     ASSERT_EQ(lb_->initialize(), absl::OkStatus());

--- a/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
+++ b/test/extensions/load_balancing_policies/client_side_weighted_round_robin/client_side_weighted_round_robin_lb_test.cc
@@ -125,9 +125,9 @@ public:
     // Handler equivalent to the one the LB builds internally from the same config.
     auto report_handler = std::make_shared<OrcaLoadReportHandler>(
         Extensions::LoadBalancingPolicies::Common::OrcaWeightManagerConfig{
-            lb_config_.metric_names_for_computing_utilization,
-            lb_config_.error_utilization_penalty, lb_config_.blackout_period,
-            lb_config_.weight_expiration_period, lb_config_.weight_update_period},
+            lb_config_.metric_names_for_computing_utilization, lb_config_.error_utilization_penalty,
+            lb_config_.blackout_period, lb_config_.weight_expiration_period,
+            lb_config_.weight_update_period},
         simTime());
     lb_ = std::make_shared<ClientSideWeightedRoundRobinLoadBalancerFriend>(
         std::make_shared<ClientSideWeightedRoundRobinLoadBalancer>(

--- a/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
+++ b/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
@@ -43,7 +43,8 @@ using ::testing::Return;
 // HostLbPolicyData (not just OrcaHostLbPolicyData) via the standard onOrcaLoadReport entry point.
 class RecordingLbPolicyData : public Upstream::HostLbPolicyData {
 public:
-  explicit RecordingLbPolicyData(absl::Status status = absl::OkStatus()) : status_(status) {}
+  explicit RecordingLbPolicyData(absl::Status status = absl::OkStatus())
+      : status_(std::move(status)) {}
   bool receivesOrcaLoadReport() const override { return true; }
   absl::Status onOrcaLoadReport(const Upstream::OrcaLoadReport& report,
                                 OptRef<const StreamInfo::StreamInfo>) override {

--- a/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
+++ b/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
@@ -39,6 +39,23 @@ using ::testing::AtLeast;
 using ::testing::NiceMock;
 using ::testing::Return;
 
+// Minimal HostLbPolicyData that records delivered reports; proves the OOB manager delivers to any
+// HostLbPolicyData (not just OrcaHostLbPolicyData) via the standard onOrcaLoadReport entry point.
+class RecordingLbPolicyData : public Upstream::HostLbPolicyData {
+public:
+  explicit RecordingLbPolicyData(absl::Status status = absl::OkStatus()) : status_(status) {}
+  bool receivesOrcaLoadReport() const override { return true; }
+  absl::Status onOrcaLoadReport(const Upstream::OrcaLoadReport& report,
+                                OptRef<const StreamInfo::StreamInfo>) override {
+    ++calls_;
+    last_util_ = report.application_utilization();
+    return status_;
+  }
+  int calls_ = 0;
+  double last_util_ = -1.0;
+  absl::Status status_;
+};
+
 // MOCK_METHOD returns a raw Http::CodecClient*; createCodecClient wraps in unique_ptr to
 // transfer ownership to OobSession.
 class TestOrcaOobManager : public OrcaOobManager {
@@ -90,7 +107,7 @@ protected:
 
   std::unique_ptr<TestOrcaOobManager> makeManager(const OrcaOobManagerConfig& config) {
     return std::make_unique<TestOrcaOobManager>(config, priority_set_, dispatcher_, random_,
-                                                *stats_store_.rootScope(), report_handler_);
+                                                *stats_store_.rootScope());
   }
 
   uint64_t activeOobSessions() {
@@ -505,9 +522,9 @@ TEST_F(OrcaOobManagerWireTest, GoAwayOtherIsImmediateTransient) {
 }
 
 TEST_F(OrcaOobManagerWireTest, ReportWithoutLbPolicyDataIncrementsReportErrors) {
-  // Host has no OrcaHostLbPolicyData attached (would be done by OrcaWeightManager
-  // in production; this test simulates the init-order race the architecture
-  // documents as v1-acceptable). onReport increments report_errors and bails.
+  // A report that finds no ORCA-interested recipient on the host is counted as a report error
+  // (e.g. an init-order gap where interested data is not yet attached). reports_received still
+  // bumps before the delivery attempt.
   auto manager = makeManager();
   ASSERT_OK(manager->initialize());
 
@@ -525,8 +542,70 @@ TEST_F(OrcaOobManagerWireTest, ReportWithoutLbPolicyDataIncrementsReportErrors) 
   report.set_application_utilization(0.5);
   report.set_rps_fractional(1000);
   respondReport(*attempt, report);
+  EXPECT_EQ(oobCounter("reports_received"), 1);
   EXPECT_EQ(oobCounter("report_errors"), 1);
-  EXPECT_EQ(oobCounter("reports_received"), 1); // counter still bumps before the data check
+
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(AtLeast(1));
+  manager.reset();
+}
+
+TEST_F(OrcaOobManagerWireTest, ReportDeliveredToArbitraryLbPolicyData) {
+  // The manager is policy-agnostic: any HostLbPolicyData attached to the host (not just
+  // OrcaHostLbPolicyData or the weight manager) receives every decoded report via the standard
+  // onOrcaLoadReport entry point.
+  auto manager = makeManager();
+  ASSERT_OK(manager->initialize());
+
+  auto* attempt_timer = installAttemptTimer();
+  auto host = makeWiredHost();
+  auto data = std::make_unique<RecordingLbPolicyData>();
+  auto* data_ptr = data.get();
+  host->addLbPolicyData(std::move(data));
+  priority_set_.runUpdateCallbacks(0, {host}, {});
+
+  auto attempt = makeAttempt();
+  wireConnectionFor(host, *attempt);
+  expectCreateCodecClient(*manager, *attempt);
+  attempt_timer->invokeCallback();
+
+  respondHeadersOk(*attempt);
+  xds::data::orca::v3::OrcaLoadReport report;
+  report.set_application_utilization(0.75);
+  respondReport(*attempt, report);
+
+  EXPECT_EQ(data_ptr->calls_, 1);
+  EXPECT_DOUBLE_EQ(data_ptr->last_util_, 0.75);
+  EXPECT_EQ(oobCounter("reports_received"), 1);
+  EXPECT_EQ(oobCounter("report_errors"), 0);
+
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(AtLeast(1));
+  manager.reset();
+}
+
+TEST_F(OrcaOobManagerWireTest, LbPolicyDataErrorIncrementsReportErrors) {
+  // Any non-OK onOrcaLoadReport return is counted as a report_error; the manager does not
+  // inspect the reason.
+  auto manager = makeManager();
+  ASSERT_OK(manager->initialize());
+
+  auto* attempt_timer = installAttemptTimer();
+  auto host = makeWiredHost();
+  host->addLbPolicyData(
+      std::make_unique<RecordingLbPolicyData>(absl::InternalError("sink rejected report")));
+  priority_set_.runUpdateCallbacks(0, {host}, {});
+
+  auto attempt = makeAttempt();
+  wireConnectionFor(host, *attempt);
+  expectCreateCodecClient(*manager, *attempt);
+  attempt_timer->invokeCallback();
+
+  respondHeadersOk(*attempt);
+  xds::data::orca::v3::OrcaLoadReport report;
+  report.set_application_utilization(0.5);
+  respondReport(*attempt, report);
+
+  EXPECT_EQ(oobCounter("reports_received"), 1);
+  EXPECT_EQ(oobCounter("report_errors"), 1);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(AtLeast(1));
   manager.reset();

--- a/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
+++ b/test/extensions/load_balancing_policies/common/orca_oob_manager_test.cc
@@ -36,26 +36,10 @@ namespace {
 
 using ::testing::_;
 using ::testing::AtLeast;
+using ::testing::DoAll;
 using ::testing::NiceMock;
 using ::testing::Return;
-
-// Minimal HostLbPolicyData that records delivered reports; proves the OOB manager delivers to any
-// HostLbPolicyData (not just OrcaHostLbPolicyData) via the standard onOrcaLoadReport entry point.
-class RecordingLbPolicyData : public Upstream::HostLbPolicyData {
-public:
-  explicit RecordingLbPolicyData(absl::Status status = absl::OkStatus())
-      : status_(std::move(status)) {}
-  bool receivesOrcaLoadReport() const override { return true; }
-  absl::Status onOrcaLoadReport(const Upstream::OrcaLoadReport& report,
-                                OptRef<const StreamInfo::StreamInfo>) override {
-    ++calls_;
-    last_util_ = report.application_utilization();
-    return status_;
-  }
-  int calls_ = 0;
-  double last_util_ = -1.0;
-  absl::Status status_;
-};
+using ::testing::SaveArg;
 
 // MOCK_METHOD returns a raw Http::CodecClient*; createCodecClient wraps in unique_ptr to
 // transfer ownership to OobSession.
@@ -559,8 +543,10 @@ TEST_F(OrcaOobManagerWireTest, ReportDeliveredToArbitraryLbPolicyData) {
 
   auto* attempt_timer = installAttemptTimer();
   auto host = makeWiredHost();
-  auto data = std::make_unique<RecordingLbPolicyData>();
-  auto* data_ptr = data.get();
+  auto data = std::make_unique<Upstream::MockHostLbPolicyData>();
+  xds::data::orca::v3::OrcaLoadReport delivered;
+  EXPECT_CALL(*data, onOrcaLoadReport(_, _))
+      .WillOnce(DoAll(SaveArg<0>(&delivered), Return(absl::OkStatus())));
   host->addLbPolicyData(std::move(data));
   priority_set_.runUpdateCallbacks(0, {host}, {});
 
@@ -574,8 +560,7 @@ TEST_F(OrcaOobManagerWireTest, ReportDeliveredToArbitraryLbPolicyData) {
   report.set_application_utilization(0.75);
   respondReport(*attempt, report);
 
-  EXPECT_EQ(data_ptr->calls_, 1);
-  EXPECT_DOUBLE_EQ(data_ptr->last_util_, 0.75);
+  EXPECT_DOUBLE_EQ(delivered.application_utilization(), 0.75);
   EXPECT_EQ(oobCounter("reports_received"), 1);
   EXPECT_EQ(oobCounter("report_errors"), 0);
 
@@ -591,8 +576,44 @@ TEST_F(OrcaOobManagerWireTest, LbPolicyDataErrorIncrementsReportErrors) {
 
   auto* attempt_timer = installAttemptTimer();
   auto host = makeWiredHost();
-  host->addLbPolicyData(
-      std::make_unique<RecordingLbPolicyData>(absl::InternalError("sink rejected report")));
+  auto data = std::make_unique<Upstream::MockHostLbPolicyData>();
+  EXPECT_CALL(*data, onOrcaLoadReport(_, _))
+      .WillOnce(Return(absl::InternalError("sink rejected report")));
+  host->addLbPolicyData(std::move(data));
+  priority_set_.runUpdateCallbacks(0, {host}, {});
+
+  auto attempt = makeAttempt();
+  wireConnectionFor(host, *attempt);
+  expectCreateCodecClient(*manager, *attempt);
+  attempt_timer->invokeCallback();
+
+  respondHeadersOk(*attempt);
+  xds::data::orca::v3::OrcaLoadReport report;
+  report.set_application_utilization(0.5);
+  respondReport(*attempt, report);
+
+  EXPECT_EQ(oobCounter("reports_received"), 1);
+  EXPECT_EQ(oobCounter("report_errors"), 1);
+
+  EXPECT_CALL(dispatcher_, deferredDelete_(_)).Times(AtLeast(1));
+  manager.reset();
+}
+
+TEST_F(OrcaOobManagerWireTest, FanOutContinuesPastFailingRecipient) {
+  // A failing recipient must not short-circuit delivery to the remaining recipients, and a
+  // mixed OK/failure result increments report_errors exactly once.
+  auto manager = makeManager();
+  ASSERT_OK(manager->initialize());
+
+  auto* attempt_timer = installAttemptTimer();
+  auto host = makeWiredHost();
+  auto failing = std::make_unique<Upstream::MockHostLbPolicyData>();
+  auto ok = std::make_unique<Upstream::MockHostLbPolicyData>();
+  EXPECT_CALL(*failing, onOrcaLoadReport(_, _))
+      .WillOnce(Return(absl::InternalError("sink rejected report")));
+  EXPECT_CALL(*ok, onOrcaLoadReport(_, _)).WillOnce(Return(absl::OkStatus()));
+  host->addLbPolicyData(std::move(failing));
+  host->addLbPolicyData(std::move(ok));
   priority_set_.runUpdateCallbacks(0, {host}, {});
 
   auto attempt = makeAttempt();

--- a/test/extensions/load_balancing_policies/common/orca_weight_manager_test.cc
+++ b/test/extensions/load_balancing_policies/common/orca_weight_manager_test.cc
@@ -296,9 +296,11 @@ protected:
     config_.blackout_period = std::chrono::milliseconds(10000);
     config_.weight_expiration_period = std::chrono::milliseconds(180000);
     config_.weight_update_period = std::chrono::milliseconds(1000);
+    report_handler_ = std::make_shared<OrcaLoadReportHandler>(config_, time_system_);
   }
 
   OrcaWeightManagerConfig config_;
+  OrcaLoadReportHandlerSharedPtr report_handler_;
   NiceMock<Upstream::MockPrioritySet> priority_set_;
   NiceMock<Event::MockDispatcher> dispatcher_;
   Event::SimulatedTimeSystem time_system_;
@@ -313,7 +315,7 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnHosts_AllValid) {
   for (int i = 0; i < 3; ++i) {
     auto host = makeWeightTrackingMockHost();
     host->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-        manager->reportHandler(), 40 + i,
+        report_handler_, 40 + i,
         /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
         /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
     hosts.push_back(host);
@@ -335,7 +337,7 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnHosts_Mixed) {
   // First host has valid weight.
   auto h1 = makeWeightTrackingMockHost();
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 42,
+      report_handler_, 42,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
   hosts.push_back(h1);
@@ -378,14 +380,14 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnHosts_EvenMedian) {
   Upstream::HostVector hosts;
   auto h1 = makeWeightTrackingMockHost();
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 5,
+      report_handler_, 5,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
   hosts.push_back(h1);
 
   auto h2 = makeWeightTrackingMockHost();
   h2->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 42,
+      report_handler_, 42,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
   hosts.push_back(h2);
@@ -503,7 +505,7 @@ TEST_F(OrcaWeightManagerTest, TimerCallback_UpdatesWeightsAndReenablesTimer) {
   Upstream::HostVector hosts;
   auto h1 = makeWeightTrackingMockHost();
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 100,
+      report_handler_, 100,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(50))));
   hosts.push_back(h1);
@@ -529,7 +531,7 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnMainThread_CallbackFiredOnChange) {
   Upstream::HostVector hosts;
   auto h1 = makeWeightTrackingMockHost(/*initial_weight=*/1);
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 200,
+      report_handler_, 200,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(50))));
   hosts.push_back(h1);
@@ -570,7 +572,7 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnMainThread_MultiplePriorities) {
   auto* host_set0 = priority_set_.getMockHostSet(0);
   auto h0 = makeWeightTrackingMockHost(/*initial_weight=*/1);
   h0->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 50,
+      report_handler_, 50,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(50))));
   host_set0->hosts_ = {h0};
@@ -579,7 +581,7 @@ TEST_F(OrcaWeightManagerTest, UpdateWeightsOnMainThread_MultiplePriorities) {
   auto* host_set1 = priority_set_.getMockHostSet(1);
   auto h1 = makeWeightTrackingMockHost(/*initial_weight=*/1);
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 75,
+      report_handler_, 75,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(1)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(50))));
   host_set1->hosts_ = {h1};
@@ -603,7 +605,7 @@ TEST_F(OrcaWeightManagerTest, AddLbPolicyDataToHosts_SkipsHostsWithExistingData)
   // Host with existing data.
   auto h1 = makeWeightTrackingMockHost();
   h1->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-      manager->reportHandler(), 42,
+      report_handler_, 42,
       /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
       /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
   hosts.push_back(h1);
@@ -639,7 +641,7 @@ TEST_F(OrcaWeightManagerTest, OddMedian) {
   for (uint32_t w : {10u, 20u, 30u}) {
     auto h = makeWeightTrackingMockHost();
     h->addLbPolicyData(std::make_unique<OrcaHostLbPolicyData>(
-        manager->reportHandler(), w,
+        report_handler_, w,
         /*non_empty_since=*/MonotonicTime(std::chrono::seconds(5)),
         /*last_update_time=*/MonotonicTime(std::chrono::seconds(10))));
     hosts.push_back(h);

--- a/test/mocks/upstream/host.cc
+++ b/test/mocks/upstream/host.cc
@@ -30,6 +30,10 @@ MockDetector::~MockDetector() = default;
 MockHealthCheckHostMonitor::MockHealthCheckHostMonitor() = default;
 MockHealthCheckHostMonitor::~MockHealthCheckHostMonitor() = default;
 
+MockHostLbPolicyData::MockHostLbPolicyData(bool receives_orca_load_report)
+    : receives_orca_load_report_(receives_orca_load_report) {}
+MockHostLbPolicyData::~MockHostLbPolicyData() = default;
+
 MockHostDescription::MockHostDescription()
     : address_(*Network::Utility::resolveUrl("tcp://10.0.0.1:443")),
       socket_factory_(new testing::NiceMock<Network::MockTransportSocketFactory>) {

--- a/test/mocks/upstream/host.h
+++ b/test/mocks/upstream/host.h
@@ -77,6 +77,19 @@ public:
   MOCK_METHOD(void, setUnhealthy, (UnhealthyType));
 };
 
+class MockHostLbPolicyData : public HostLbPolicyData {
+public:
+  explicit MockHostLbPolicyData(bool receives_orca_load_report = true);
+  ~MockHostLbPolicyData() override;
+
+  bool receivesOrcaLoadReport() const override { return receives_orca_load_report_; }
+  MOCK_METHOD(absl::Status, onOrcaLoadReport,
+              (const OrcaLoadReport& report, OptRef<const StreamInfo::StreamInfo> stream_info),
+              (override));
+
+  const bool receives_orca_load_report_;
+};
+
 class MockHostDescription : public HostDescription {
 public:
   MockHostDescription();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: orca: decouple OOB report delivery from CSWRR weight manager

Additional Description: Previously OOB report delivery was hardcoded to CSWRR's `OrcaLoadReportHandler`. This reroutes it through the generic `HostLbPolicyData::onOrcaLoadReport` (which the in-band path already uses), so that any LB policy can consume OOB reports such as [LoadAwareLocality LB policy](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_aware_locality) which I'm starting to implement.

Risk Level: Low
Testing: Added new ones and existing CSWRR tests continue to pass
Docs Changes: N/A
Release Notes: N/A - no user-visible behavior changes
Platform Specific Features: N/A
xRef: #44318
xRef: #43665
