### PR TITLE
redis_proxy: allow custom commands within transactions

### DIFF
--- a/changelogs/current/bug_fixes/redis_proxy__custom-commands-in-transactions.rst
+++ b/changelogs/current/bug_fixes/redis_proxy__custom-commands-in-transactions.rst
@@ -1,0 +1,4 @@
+Fixed a bug where commands configured via :ref:`custom_commands
+<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.custom_commands>` were rejected
+within ``MULTI``/``EXEC`` transactions. Custom commands are now treated as simple commands within
+transactions, matching their behavior outside of transactions.

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -116,6 +116,9 @@ Transactions
 Transactions (MULTI) are supported. Their use is no different from regular Redis: you start a transaction with MULTI,
 and you execute it with EXEC. Within the transaction, from the list of commands supported by Envoy (see below), only single-key
 commands (e.g. GET, SET), multi-key commands (e.g. DEL, MSET) and transaction commands (e.g. WATCH, UNWATCH, DISCARD, EXEC) are supported.
+Commands configured via :ref:`custom_commands
+<envoy_v3_api_field_extensions.filters.network.redis_proxy.v3.RedisProxy.custom_commands>` are also supported within
+transactions and are treated as single-key commands.
 
 
 When working in Redis Cluster mode, Envoy will relay all the commands in the transaction to the node handling the first

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -827,21 +827,24 @@ void SplitKeysSumResultRequest::onChildResponse(Common::Redis::RespValuePtr&& va
   }
 }
 
-SplitRequestPtr TransactionRequest::create(Router& router,
-                                           Common::Redis::RespValuePtr&& incoming_request,
-                                           SplitCallbacks& callbacks, CommandStats& command_stats,
-                                           TimeSource& time_source, bool delay_command_latency,
-                                           const StreamInfo::StreamInfo& stream_info) {
+SplitRequestPtr
+TransactionRequest::create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                           SplitCallbacks& callbacks, CommandStats& command_stats,
+                           TimeSource& time_source, bool delay_command_latency,
+                           const StreamInfo::StreamInfo& stream_info,
+                           const absl::flat_hash_set<std::string>& custom_commands) {
   Common::Redis::Client::Transaction& transaction = callbacks.transaction();
   std::string command_name = absl::AsciiStrToLower(incoming_request->asArray()[0].asString());
 
-  // Within transactions we only support simple commands.
-  // So if this is not a transaction command or a simple command, it is an error.
+  // Within transactions we only support simple commands, including configured custom commands
+  // which are treated as simple commands.
+  // So if this is not a transaction command, a simple command or a custom command, it is an error.
   // We also support multi-key commands, but will leave it to the client to handle the case where
   // the keys provided are not from the same shard.
   if (Common::Redis::SupportedCommands::transactionCommands().count(command_name) == 0 &&
       Common::Redis::SupportedCommands::simpleCommands().count(command_name) == 0 &&
-      Common::Redis::SupportedCommands::multiKeyCommands().count(command_name) == 0) {
+      Common::Redis::SupportedCommands::multiKeyCommands().count(command_name) == 0 &&
+      custom_commands.count(command_name) == 0) {
     callbacks.onResponse(Common::Redis::Utility::makeError(
         fmt::format("'{}' command is not supported within transaction",
                     incoming_request->asArray()[0].asString())));
@@ -967,14 +970,14 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
                            TimeSource& time_source, bool latency_in_micros,
                            Common::Redis::FaultManagerPtr&& fault_manager,
                            absl::flat_hash_set<std::string>&& custom_commands)
-    : router_(std::move(router)), simple_command_handler_(*router_),
-      eval_command_handler_(*router_), object_command_handler_(*router_), mget_handler_(*router_),
-      mset_handler_(*router_), scan_handler_(*router_), shard_info_handler_(*router_),
-      random_shard_handler_(*router_), split_keys_sum_result_handler_(*router_),
-      transaction_handler_(*router_), cluster_scope_handler_(*router_),
+    : router_(std::move(router)), custom_commands_(std::move(custom_commands)),
+      simple_command_handler_(*router_), eval_command_handler_(*router_),
+      object_command_handler_(*router_), mget_handler_(*router_), mset_handler_(*router_),
+      scan_handler_(*router_), shard_info_handler_(*router_), random_shard_handler_(*router_),
+      split_keys_sum_result_handler_(*router_), transaction_handler_(*router_, custom_commands_),
+      cluster_scope_handler_(*router_),
       stats_{ALL_COMMAND_SPLITTER_STATS(POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))},
-      time_source_(time_source), fault_manager_(std::move(fault_manager)),
-      custom_commands_(std::move(custom_commands)) {
+      time_source_(time_source), fault_manager_(std::move(fault_manager)) {
   for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {
     addHandler(scope, stat_prefix, command, latency_in_micros, simple_command_handler_);
   }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -970,12 +970,12 @@ InstanceImpl::InstanceImpl(RouterPtr&& router, Stats::Scope& scope, const std::s
                            TimeSource& time_source, bool latency_in_micros,
                            Common::Redis::FaultManagerPtr&& fault_manager,
                            absl::flat_hash_set<std::string>&& custom_commands)
-    : router_(std::move(router)), custom_commands_(std::move(custom_commands)),
-      simple_command_handler_(*router_), eval_command_handler_(*router_),
-      object_command_handler_(*router_), mget_handler_(*router_), mset_handler_(*router_),
-      scan_handler_(*router_), shard_info_handler_(*router_), random_shard_handler_(*router_),
-      split_keys_sum_result_handler_(*router_), transaction_handler_(*router_, custom_commands_),
-      cluster_scope_handler_(*router_),
+    : router_(std::move(router)), simple_command_handler_(*router_),
+      eval_command_handler_(*router_), object_command_handler_(*router_), mget_handler_(*router_),
+      mset_handler_(*router_), scan_handler_(*router_), shard_info_handler_(*router_),
+      random_shard_handler_(*router_), split_keys_sum_result_handler_(*router_),
+      custom_commands_(std::move(custom_commands)),
+      transaction_handler_(*router_, custom_commands_), cluster_scope_handler_(*router_),
       stats_{ALL_COMMAND_SPLITTER_STATS(POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))},
       time_source_(time_source), fault_manager_(std::move(fault_manager)) {
   for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -559,8 +559,6 @@ private:
   void onInvalidRequest(SplitCallbacks& callbacks);
 
   RouterPtr router_;
-  // Initialized before the command handlers, which may keep a reference to it.
-  absl::flat_hash_set<std::string> custom_commands_;
   CommandHandlerFactory<SimpleRequest> simple_command_handler_;
   CommandHandlerFactory<EvalRequest> eval_command_handler_;
   CommandHandlerFactory<ObjectRequest> object_command_handler_;
@@ -570,6 +568,8 @@ private:
   CommandHandlerFactory<ShardInfoRequest> shard_info_handler_;
   CommandHandlerFactory<RandomShardRequest> random_shard_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
+  // Initialized before transaction_handler_, which keeps a reference to it.
+  absl::flat_hash_set<std::string> custom_commands_;
   TransactionCommandHandlerFactory transaction_handler_;
   CommandHandlerFactory<ClusterScopeCmdRequest> cluster_scope_handler_;
   RadixTree<HandlerDataPtr> handler_lookup_table_;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -19,6 +19,8 @@
 #include "source/extensions/filters/network/redis_proxy/conn_pool_impl.h"
 #include "source/extensions/filters/network/redis_proxy/router.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -232,7 +234,8 @@ public:
   static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source, bool delay_command_latency,
-                                const StreamInfo::StreamInfo& stream_info);
+                                const StreamInfo::StreamInfo& stream_info,
+                                const absl::flat_hash_set<std::string>& custom_commands);
 
 private:
   TransactionRequest(SplitCallbacks& callbacks, CommandStats& command_stats,
@@ -494,6 +497,28 @@ public:
 };
 
 /**
+ * CommandHandlerFactory for transaction requests, which additionally provides the set of
+ * commands configured via custom_commands so they can be accepted within transactions.
+ */
+class TransactionCommandHandlerFactory : public CommandHandler, CommandHandlerBase {
+public:
+  TransactionCommandHandlerFactory(Router& router,
+                                   const absl::flat_hash_set<std::string>& custom_commands)
+      : CommandHandlerBase(router), custom_commands_(custom_commands) {}
+  SplitRequestPtr startRequest(Common::Redis::RespValuePtr&& request, SplitCallbacks& callbacks,
+                               CommandStats& command_stats, TimeSource& time_source,
+                               bool delay_command_latency,
+                               const StreamInfo::StreamInfo& stream_info) override {
+    return TransactionRequest::create(router_, std::move(request), callbacks, command_stats,
+                                      time_source, delay_command_latency, stream_info,
+                                      custom_commands_);
+  }
+
+private:
+  const absl::flat_hash_set<std::string>& custom_commands_;
+};
+
+/**
  * All splitter stats. @see stats_macros.h
  */
 #define ALL_COMMAND_SPLITTER_STATS(COUNTER)                                                        \
@@ -534,6 +559,8 @@ private:
   void onInvalidRequest(SplitCallbacks& callbacks);
 
   RouterPtr router_;
+  // Initialized before the command handlers, which may keep a reference to it.
+  absl::flat_hash_set<std::string> custom_commands_;
   CommandHandlerFactory<SimpleRequest> simple_command_handler_;
   CommandHandlerFactory<EvalRequest> eval_command_handler_;
   CommandHandlerFactory<ObjectRequest> object_command_handler_;
@@ -543,13 +570,12 @@ private:
   CommandHandlerFactory<ShardInfoRequest> shard_info_handler_;
   CommandHandlerFactory<RandomShardRequest> random_shard_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
-  CommandHandlerFactory<TransactionRequest> transaction_handler_;
+  TransactionCommandHandlerFactory transaction_handler_;
   CommandHandlerFactory<ClusterScopeCmdRequest> cluster_scope_handler_;
   RadixTree<HandlerDataPtr> handler_lookup_table_;
   InstanceStats stats_;
   TimeSource& time_source_;
   Common::Redis::FaultManagerPtr fault_manager_;
-  absl::flat_hash_set<std::string> custom_commands_;
 };
 
 } // namespace CommandSplitter

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -937,6 +937,76 @@ TEST_F(RedisSingleServerRequestTest, CustomCommand) {
   respond();
 }
 
+TEST_F(RedisSingleServerRequestTest, CustomCommandInTransaction) {
+  absl::flat_hash_set<std::string> cmds = {"example"};
+  auto splitter = getSplitter(std::move(cmds));
+
+  // Simulate a transaction that was already started by a previous command.
+  callbacks_.transaction().start();
+  callbacks_.transaction().key_ = "test";
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"example", "test"});
+
+  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  EXPECT_CALL(*conn_pool_, makeRequest_("test", RespVariantEq(*request), _))
+      .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callbacks_)), Return(&pool_request_)));
+
+  handle_ = splitter.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+  EXPECT_NE(nullptr, handle_);
+
+  respond();
+}
+
+TEST_F(RedisSingleServerRequestTest, CustomCommandStartsTransaction) {
+  absl::flat_hash_set<std::string> cmds = {"example"};
+  auto splitter = getSplitter(std::move(cmds));
+
+  callbacks_.transaction().start();
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"example", "test"});
+
+  Common::Redis::Client::MultiRequest multi_request;
+  Common::Redis::Client::MockPoolRequest multi_pool_request;
+
+  InSequence s;
+  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  // A MULTI command is sent upstream before the first command of the transaction.
+  EXPECT_CALL(*conn_pool_, makeRequest_("test", RespVariantEq(multi_request), _))
+      .WillOnce(Return(&multi_pool_request));
+  EXPECT_CALL(*conn_pool_, makeRequest_("test", RespVariantEq(*request), _))
+      .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callbacks_)), Return(&pool_request_)));
+
+  handle_ = splitter.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+  EXPECT_NE(nullptr, handle_);
+
+  respond();
+
+  // The mocked connection pool does not populate the transaction's clients, so
+  // reset the flag to keep the transaction destructor from closing them.
+  callbacks_.transaction().connection_established_ = false;
+}
+
+TEST_F(RedisSingleServerRequestTest, NonSimpleCommandInTransactionRejected) {
+  // "scan" is a supported command but not a simple, multi-key or transaction
+  // command, so it is rejected within a transaction.
+  callbacks_.transaction().start();
+  callbacks_.transaction().key_ = "test";
+
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"scan", "0"});
+
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
+  response.asString() = "'scan' command is not supported within transaction";
+
+  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
+  handle_ = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+  EXPECT_EQ(nullptr, handle_);
+}
+
 MATCHER_P(CompositeArrayEq, rhs, "CompositeArray should be equal") {
   const ConnPool::RespVariant& obj = arg;
   const auto& lhs = absl::get<const Common::Redis::RespValue>(obj);

--- a/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
+++ b/test/extensions/filters/network/redis_proxy/redis_proxy_integration_test.cc
@@ -102,6 +102,12 @@ const std::string CONFIG_WITH_BATCHING = CONFIG + R"EOF(
             buffer_flush_timeout: 0.003s
 )EOF";
 
+// This is a configuration with custom commands.
+const std::string CONFIG_WITH_CUSTOM_COMMANDS = CONFIG + R"EOF(
+          custom_commands:
+          - json.set
+)EOF";
+
 const std::string CONFIG_WITH_ROUTES_BASE = fmt::format(R"EOF(
 admin:
   access_log:
@@ -858,6 +864,12 @@ public:
       : RedisProxyIntegrationTest(CONFIG_WITH_COMMAND_STATS, 2) {}
 };
 
+class RedisProxyWithCustomCommandsIntegrationTest : public RedisProxyIntegrationTest {
+public:
+  RedisProxyWithCustomCommandsIntegrationTest()
+      : RedisProxyIntegrationTest(CONFIG_WITH_CUSTOM_COMMANDS, 2) {}
+};
+
 class RedisProxyWithFaultInjectionIntegrationTest : public RedisProxyIntegrationTest {
 public:
   RedisProxyWithFaultInjectionIntegrationTest()
@@ -948,6 +960,10 @@ public:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, RedisProxyWithCustomCommandsIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
@@ -2208,6 +2224,29 @@ TEST_P(RedisProxyWithCommandStatsIntegrationTest, PipelinedTransactionTest) {
       makeBulkStringArray({"MULTI"}) + makeBulkStringArray({"set", "foo", "bar"}) +
       makeBulkStringArray({"get", "foo"}) + makeBulkStringArray({"exec"});
   const std::string& response = "+OK\r\n+QUEUED\r\n+QUEUED\r\n*2\r\n+OK\r\n$3\r\nbar\r\n";
+  IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
+  ASSERT_TRUE(redis_client->write(transaction_commands));
+
+  expectUpstreamRequestResponse(fake_upstreams_[0], transaction_commands, response,
+                                fake_upstream_connection[0]);
+
+  redis_client->waitForData(response);
+  EXPECT_EQ(response, redis_client->data());
+
+  EXPECT_TRUE(fake_upstream_connection[0]->close());
+  redis_client->close();
+}
+
+// This test verifies that a configured custom command is treated as a simple
+// command and can be used within a transaction.
+TEST_P(RedisProxyWithCustomCommandsIntegrationTest, PipelinedTransactionWithCustomCommand) {
+  initialize();
+
+  std::array<FakeRawConnectionPtr, 1> fake_upstream_connection;
+  std::string transaction_commands = makeBulkStringArray({"MULTI"}) +
+                                     makeBulkStringArray({"json.set", "foo", "$", "1"}) +
+                                     makeBulkStringArray({"exec"});
+  const std::string& response = "+OK\r\n+QUEUED\r\n*1\r\n+OK\r\n";
   IntegrationTcpClientPtr redis_client = makeTcpConnection(lookupPort("redis_proxy"));
   ASSERT_TRUE(redis_client->write(transaction_commands));
 


### PR DESCRIPTION
Commit Message: redis_proxy: allow custom commands within transactions

Commands configured via :ref:`custom_commands` are registered with the simple command handler and work as standalone commands, but were rejected with `'<command>' command is not supported within transaction` when used inside a MULTI/EXEC transaction, because `TransactionRequest::create()` only checked the static transaction/simple/multi-key command sets. This PR plumbs the configured custom commands into `TransactionRequest::create()` via a dedicated transaction command handler factory, and accepts them within transactions, treating them as simple commands to match their behavior outside of transactions.

Additional Description:
The command splitter already treats custom commands as simple commands for standalone execution (`InstanceImpl` registers them with the simple command handler). When a transaction is active, however, all commands are routed to the transaction handler, whose `TransactionRequest::create()` had no knowledge of the configured custom commands and rejected them. The fix introduces a small `TransactionCommandHandlerFactory` that holds a reference to the configured `custom_commands` set and passes it to `TransactionRequest::create()`, where it is consulted alongside the existing simple/multi-key command set checks. Custom commands inside transactions get the same treatment as simple commands, including the caveat that already applies to multi-key commands in transactions (keys must map to the same upstream).

No runtime guard was added: the change only affects commands explicitly opted in via `custom_commands`, and only inside transactions, where they previously always failed with a hard error.

Disclosure per the generative AI policy: this change was developed with the assistance of generative AI (Claude Code by Anthropic).

Risk Level: Low — a small bug fix; only affects commands explicitly configured via `custom_commands`, and only within MULTI/EXEC transactions, where such commands previously always returned an error.

Testing:
- New unit tests in `command_splitter_impl_test.cc`: custom command forwarded within an active transaction; custom command as the first command of a transaction (MULTI sent upstream first); regression test that a supported-but-not-simple command (`scan`) is still rejected within a transaction (this rejection path previously had no coverage).
- New integration test `PipelinedTransactionWithCustomCommand` with a `custom_commands`-enabled config, reproducing the scenario from the issue (MULTI → `json.set` → EXEC) end to end.
- All tests under `//test/extensions/filters/network/redis_proxy/...` and `//test/extensions/filters/network/common/redis/...` pass locally (macOS arm64). The new tests were verified to fail without the source change.

Docs Changes: Updated the Transactions section of the Redis architecture overview (`docs/root/intro/arch_overview/other_protocols/redis.rst`) to document that configured custom commands are supported within transactions and treated as single-key commands.

Release Notes: `changelogs/current/bug_fixes/redis_proxy__custom-commands-in-transactions.rst`

Platform Specific Features: N/A

Fixes #42094


Co-authored-by: David Vo <davidvo@lyft.com>