### PR TITLE
wasm: add gauge stats from vm count

### DIFF
--- a/changelogs/current/new_features/wasm__added-wasm-vm-count-gauge-stat.rst
+++ b/changelogs/current/new_features/wasm__added-wasm-vm-count-gauge-stat.rst
@@ -1,0 +1,3 @@
+Added a process-wide ``wasm.wasm_vm_count`` gauge stat, documented under :ref:`Wasm runtime
+<config_wasm_runtime>`, that tracks the number of active Wasm VMs across every runtime and plugin
+configuration.

--- a/docs/root/configuration/other_features/wasm.rst
+++ b/docs/root/configuration/other_features/wasm.rst
@@ -24,3 +24,4 @@ Wasm runtime emits the following statistics:
 
   wasm.<runtime>.created, Counter, Total number of execution instances created
   wasm.<runtime>.active, Gauge, Number of active execution instances
+  wasm.wasm_vm_count, Gauge, "Process-wide number of active Wasm VMs, across every runtime"

--- a/source/extensions/common/wasm/stats_handler.cc
+++ b/source/extensions/common/wasm/stats_handler.cc
@@ -66,14 +66,21 @@ CreateStatsHandler& getCreateStatsHandler() { MUTABLE_CONSTRUCT_ON_FIRST_USE(Cre
 
 std::atomic<int64_t> active_wasms;
 
+Stats::Gauge& lookupWasmVmCountGauge(Stats::Scope& server_scope) {
+  Stats::StatNameManagedStorage stat_name("wasm.wasm_vm_count", server_scope.symbolTable());
+  return server_scope.gaugeFromStatName(stat_name.statName(), Stats::Gauge::ImportMode::Accumulate);
+}
+
 void LifecycleStatsHandler::onEvent(WasmEvent event) {
   switch (event) {
   case WasmEvent::VmShutDown:
     lifecycle_stats_.active_.set(--active_wasms);
+    vm_count_gauge_.dec();
     break;
   case WasmEvent::VmCreated:
     lifecycle_stats_.active_.set(++active_wasms);
     lifecycle_stats_.created_.inc();
+    vm_count_gauge_.inc();
     break;
   default:
     break;

--- a/source/extensions/common/wasm/stats_handler.h
+++ b/source/extensions/common/wasm/stats_handler.h
@@ -90,12 +90,19 @@ protected:
 
 CreateStatsHandler& getCreateStatsHandler();
 
+// Looks up (creating if necessary) the process-wide `wasm.wasm_vm_count` gauge directly on the
+// given server root scope, so the stat name is always identical regardless of the
+// filter/plugin-specific stat prefix used for the per-runtime `wasm.<runtime>.active` gauge.
+Stats::Gauge& lookupWasmVmCountGauge(Stats::Scope& server_scope);
+
 class LifecycleStatsHandler {
 public:
-  LifecycleStatsHandler(const Stats::ScopeSharedPtr& scope, std::string runtime)
+  LifecycleStatsHandler(const Stats::ScopeSharedPtr& scope, std::string runtime,
+                        Stats::Gauge& vm_count_gauge)
       : lifecycle_stats_(LifecycleStats{
             LIFECYCLE_STATS(POOL_COUNTER_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")),
-                            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")))}) {};
+                            POOL_GAUGE_PREFIX(*scope, absl::StrCat("wasm.", runtime, ".")))}),
+        vm_count_gauge_(vm_count_gauge) {};
   ~LifecycleStatsHandler() = default;
 
   void onEvent(WasmEvent event);
@@ -103,6 +110,7 @@ public:
 
 protected:
   LifecycleStats lifecycle_stats_;
+  Stats::Gauge& vm_count_gauge_;
 };
 
 // TODO(wbpcode): refactor all these stats handlers into a single one.

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -76,8 +76,9 @@ Wasm::Wasm(WasmConfig& config, absl::string_view vm_key, const Stats::ScopeShare
       scope_(scope), api_(api), stat_name_pool_(scope_->symbolTable()),
       custom_stat_namespace_(stat_name_pool_.add(CustomStatNamespace)),
       cluster_manager_(cluster_manager), dispatcher_(dispatcher),
-      time_source_(dispatcher.timeSource()), lifecycle_stats_handler_(LifecycleStatsHandler(
-                                                 scope, config.config().vm_config().runtime())) {
+      time_source_(dispatcher.timeSource()),
+      lifecycle_stats_handler_(LifecycleStatsHandler(scope, config.config().vm_config().runtime(),
+                                                     lookupWasmVmCountGauge(api.rootScope()))) {
   lifecycle_stats_handler_.onEvent(WasmEvent::VmCreated);
   ENVOY_LOG(debug, "Base Wasm created {} now active", lifecycle_stats_handler_.getActiveVmCount());
 }

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -483,18 +483,17 @@ TEST_P(WasmCommonTest, WasmVmCountGauge) {
       plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info_);
   auto vm_key = proxy_wasm::makeVmKey("", vm_configuration, code);
 
-  EXPECT_EQ(
-      0, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+  EXPECT_EQ(nullptr, TestUtility::findGauge(stats_store_, "wasm.wasm_vm_count"));
 
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       plugin->wasmConfig(), vm_key, scope_, *api_, cluster_manager_, *dispatcher_);
   EXPECT_NE(wasm, nullptr);
-  EXPECT_EQ(
-      1, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+  auto gauge = TestUtility::findGauge(stats_store_, "wasm.wasm_vm_count");
+  ASSERT_NE(nullptr, gauge);
+  EXPECT_EQ(1, gauge->value());
 
   wasm.reset();
-  EXPECT_EQ(
-      0, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+  EXPECT_EQ(0, gauge->value());
 }
 
 TEST_P(WasmCommonTest, Foreign) {

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -460,6 +460,43 @@ TEST_P(WasmCommonTest, Stats) {
   wasm->start(plugin);
 }
 
+// The wasm_vm_count gauge is process-wide, updated once per Wasm VM instance regardless of the
+// runtime or the scope/prefix the plugin config uses.
+TEST_P(WasmCommonTest, WasmVmCountGauge) {
+  auto vm_configuration = "vm_count_gauge";
+
+  envoy::extensions::wasm::v3::PluginConfig plugin_config;
+  *plugin_config.mutable_vm_config()->mutable_runtime() =
+      absl::StrCat("envoy.wasm.runtime.", std::get<0>(GetParam()));
+  plugin_config.mutable_vm_config()->mutable_configuration()->set_value(vm_configuration);
+
+  std::string code;
+  if (std::get<0>(GetParam()) != "null") {
+    code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+        absl::StrCat("{{ test_rundir }}/test/extensions/common/wasm/test_data/test_cpp.wasm")));
+  } else {
+    // The name of the Null VM plugin.
+    code = "CommonWasmTestCpp";
+  }
+  EXPECT_FALSE(code.empty());
+  auto plugin = std::make_shared<Extensions::Common::Wasm::Plugin>(
+      plugin_config, envoy::config::core::v3::TrafficDirection::UNSPECIFIED, local_info_);
+  auto vm_key = proxy_wasm::makeVmKey("", vm_configuration, code);
+
+  EXPECT_EQ(
+      0, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+
+  auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
+      plugin->wasmConfig(), vm_key, scope_, *api_, cluster_manager_, *dispatcher_);
+  EXPECT_NE(wasm, nullptr);
+  EXPECT_EQ(
+      1, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+
+  wasm.reset();
+  EXPECT_EQ(
+      0, stats_store_.gauge("wasm.wasm_vm_count", Stats::Gauge::ImportMode::Accumulate).value());
+}
+
 TEST_P(WasmCommonTest, Foreign) {
   auto vm_configuration = "foreign";
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: like https://github.com/envoyproxy/envoy/pull/45871, but for wasm.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
