### PR TITLE
cluster: switch const std::string& method arguments to string_view

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -287,7 +287,7 @@ public:
    */
   virtual absl::StatusOr<bool>
   addOrUpdateCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                     const std::string& version_info, const bool avoid_cds_removal = false) PURE;
+                     absl::string_view version_info, const bool avoid_cds_removal = false) PURE;
 
   /**
    * Set a callback that will be invoked when all primary clusters have been initialized.
@@ -356,7 +356,7 @@ public:
    *
    * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
    */
-  virtual OptRef<const Cluster> getActiveCluster(const std::string& cluster_name) const PURE;
+  virtual OptRef<const Cluster> getActiveCluster(absl::string_view cluster_name) const PURE;
 
   /**
    * Receives a cluster name and returns an active or warming cluster (if found).
@@ -366,7 +366,7 @@ public:
    * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
    */
   virtual OptRef<const Cluster>
-  getActiveOrWarmingCluster(const std::string& cluster_name) const PURE;
+  getActiveOrWarmingCluster(absl::string_view cluster_name) const PURE;
 
   /**
    * Returns true iff the given cluster name is known in the cluster-manager
@@ -376,7 +376,7 @@ public:
    *
    * NOTE: This method is only thread safe on the main thread. It should not be called elsewhere.
    */
-  virtual bool hasCluster(const std::string& cluster_name) const PURE;
+  virtual bool hasCluster(absl::string_view cluster_name) const PURE;
 
   /**
    * Returns true iff there's an active cluster in the cluster-manager.
@@ -419,7 +419,7 @@ public:
    * can be removed by setting `remove_ignored` to true while removeCluster().
    * @return true if the action results in the removal of a cluster.
    */
-  virtual bool removeCluster(const std::string& cluster, const bool remove_ignored = false) PURE;
+  virtual bool removeCluster(absl::string_view cluster, const bool remove_ignored = false) PURE;
 
   /**
    * Shutdown the cluster manager prior to destroying connection pools and other thread local data.
@@ -515,7 +515,7 @@ public:
    * @param predicate supplies the optional drain connections host predicate. If not supplied, all
    *                  hosts are drained.
    */
-  virtual void drainConnections(const std::string& cluster,
+  virtual void drainConnections(absl::string_view cluster,
                                 DrainConnectionsHostPredicate predicate) PURE;
 
   /**
@@ -538,7 +538,7 @@ public:
    * Check if the cluster is active and statically configured, and if not, return an error
    * @param cluster, the cluster to check.
    */
-  virtual absl::Status checkActiveStaticCluster(const std::string& cluster) PURE;
+  virtual absl::Status checkActiveStaticCluster(absl::string_view cluster) PURE;
 
   /**
    * Allocates an on-demand CDS API provider from configuration proto or locator.

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -78,7 +78,7 @@ public:
    * onClusterRemoval is called when a cluster is removed; the argument is the cluster name.
    * @param cluster_name is the name of the removed cluster.
    */
-  virtual void onClusterRemoval(const std::string& cluster_name) PURE;
+  virtual void onClusterRemoval(absl::string_view cluster_name) PURE;
 };
 
 /**

--- a/source/common/upstream/cluster_discovery_manager.cc
+++ b/source/common/upstream/cluster_discovery_manager.cc
@@ -19,7 +19,7 @@ public:
     cb_(cluster_name);
   };
 
-  void onClusterRemoval(const std::string&) override {}
+  void onClusterRemoval(absl::string_view) override {}
 
 private:
   ClusterAddedCb cb_;

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -725,7 +725,7 @@ void ClusterManagerImpl::applyUpdates(ClusterManagerCluster& cluster, uint32_t p
 
 absl::StatusOr<bool>
 ClusterManagerImpl::addOrUpdateCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                                       const std::string& version_info,
+                                       absl::string_view version_info,
                                        const bool avoid_cds_removal) {
   // First we need to see if this new config is new or an update to an existing dynamic cluster.
   // We don't allow updates to statically configured clusters in the main configuration. We check
@@ -776,7 +776,7 @@ ClusterManagerImpl::addOrUpdateCluster(const envoy::config::cluster::v3::Cluster
   // Preserve the previous cluster data to avoid early destroy. The same cluster should be added
   // before destroy to avoid early initialization complete.
   auto status_or_cluster =
-      loadCluster(cluster, new_hash, version_info, /*added_via_api=*/true,
+      loadCluster(cluster, new_hash, std::string(version_info), /*added_via_api=*/true,
                   /*required_for_ads=*/false, warming_clusters_, avoid_cds_removal);
   RETURN_IF_NOT_OK_REF(status_or_cluster.status());
   const ClusterDataPtr previous_cluster = std::move(status_or_cluster.value());
@@ -811,7 +811,7 @@ void ClusterManagerImpl::clusterWarmingToActive(const std::string& cluster_name)
   warming_clusters_.erase(warming_it);
 }
 
-bool ClusterManagerImpl::removeCluster(const std::string& cluster_name, const bool remove_ignored) {
+bool ClusterManagerImpl::removeCluster(absl::string_view cluster_name, const bool remove_ignored) {
   bool removed = false;
   auto existing_active_cluster = active_clusters_.find(cluster_name);
   if (existing_active_cluster != active_clusters_.end() &&
@@ -822,7 +822,8 @@ bool ClusterManagerImpl::removeCluster(const std::string& cluster_name, const bo
     active_clusters_.erase(existing_active_cluster);
 
     ENVOY_LOG(debug, "removing cluster {}", cluster_name);
-    tls_.runOnAllThreads([cluster_name](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+    tls_.runOnAllThreads([cluster_name = std::string(cluster_name)](
+                             OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
       ASSERT(cluster_manager->thread_local_clusters_.contains(cluster_name) ||
              cluster_manager->thread_local_deferred_clusters_.contains(cluster_name));
       ENVOY_LOG(debug, "removing TLS cluster {}", cluster_name);
@@ -1080,11 +1081,12 @@ ClusterManagerImpl::ThreadLocalClusterManagerImpl::ClusterEntry::tcpConnPool(
   return tcpConnPool(host, priority, context);
 }
 
-void ClusterManagerImpl::drainConnections(const std::string& cluster,
+void ClusterManagerImpl::drainConnections(absl::string_view cluster,
                                           DrainConnectionsHostPredicate predicate) {
   ENVOY_LOG_EVENT(debug, "drain_connections_call", "drainConnections called for cluster {}",
                   cluster);
-  tls_.runOnAllThreads([cluster, predicate](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
+  tls_.runOnAllThreads([cluster = std::string(cluster),
+                        predicate](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {
     auto cluster_entry = cluster_manager->thread_local_clusters_.find(cluster);
     if (cluster_entry != cluster_manager->thread_local_clusters_.end()) {
       cluster_entry->second->drainConnPools(
@@ -1115,7 +1117,7 @@ void ClusterManagerImpl::drainOrCloseConnPools(DrainConnectionsPoolPredicate pre
       });
 }
 
-absl::Status ClusterManagerImpl::checkActiveStaticCluster(const std::string& cluster) {
+absl::Status ClusterManagerImpl::checkActiveStaticCluster(absl::string_view cluster) {
   const auto& it = active_clusters_.find(cluster);
   if (it == active_clusters_.end()) {
     return absl::InvalidArgumentError(fmt::format("Unknown gRPC client cluster '{}'", cluster));

--- a/source/common/upstream/cluster_manager_impl.h
+++ b/source/common/upstream/cluster_manager_impl.h
@@ -241,7 +241,7 @@ public:
 
   // Upstream::ClusterManager
   absl::StatusOr<bool> addOrUpdateCluster(const envoy::config::cluster::v3::Cluster& cluster,
-                                          const std::string& version_info,
+                                          absl::string_view version_info,
                                           const bool avoid_cds_removal = false) override;
 
   void setPrimaryClustersInitializedCb(PrimaryClustersReadyCallback callback) override {
@@ -280,7 +280,7 @@ public:
     }
   }
 
-  OptRef<const Cluster> getActiveCluster(const std::string& cluster_name) const override {
+  OptRef<const Cluster> getActiveCluster(absl::string_view cluster_name) const override {
     ASSERT_IS_MAIN_OR_TEST_THREAD();
     if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
       return *it->second->cluster_;
@@ -288,7 +288,7 @@ public:
     return std::nullopt;
   }
 
-  OptRef<const Cluster> getActiveOrWarmingCluster(const std::string& cluster_name) const override {
+  OptRef<const Cluster> getActiveOrWarmingCluster(absl::string_view cluster_name) const override {
     ASSERT_IS_MAIN_OR_TEST_THREAD();
     if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
       return *it->second->cluster_;
@@ -299,7 +299,7 @@ public:
     return std::nullopt;
   }
 
-  bool hasCluster(const std::string& cluster_name) const override {
+  bool hasCluster(absl::string_view cluster_name) const override {
     ASSERT_IS_MAIN_OR_TEST_THREAD();
     return active_clusters_.contains(cluster_name) || warming_clusters_.contains(cluster_name);
   }
@@ -312,7 +312,7 @@ public:
   const ClusterSet& primaryClusters() override { return primary_clusters_; }
   ThreadLocalCluster* getThreadLocalCluster(absl::string_view cluster) override;
 
-  bool removeCluster(const std::string& cluster, const bool remove_ignored = false) override;
+  bool removeCluster(absl::string_view cluster, const bool remove_ignored = false) override;
   void shutdown() override {
     shutdown_ = true;
     if (resume_cds_ != nullptr) {
@@ -379,7 +379,7 @@ public:
     return cluster_timeout_budget_stat_names_;
   }
 
-  void drainConnections(const std::string& cluster,
+  void drainConnections(absl::string_view cluster,
                         DrainConnectionsHostPredicate predicate) override;
 
   void drainConnections(DrainConnectionsHostPredicate predicate,
@@ -388,7 +388,7 @@ public:
   void drainOrCloseConnPools(DrainConnectionsPoolPredicate predicate,
                              ConnectionPool::DrainBehavior drain_behavior) override;
 
-  absl::Status checkActiveStaticCluster(const std::string& cluster) override;
+  absl::Status checkActiveStaticCluster(absl::string_view cluster) override;
 
   // Upstream::MissingClusterNotifier
   void notifyMissingCluster(absl::string_view name) override;

--- a/source/common/upstream/cluster_update_tracker.cc
+++ b/source/common/upstream/cluster_update_tracker.cc
@@ -20,7 +20,7 @@ void ClusterUpdateTracker::onClusterAddOrUpdate(absl::string_view cluster_name,
   thread_local_cluster_ = get_cluster();
 }
 
-void ClusterUpdateTracker::onClusterRemoval(const std::string& cluster) {
+void ClusterUpdateTracker::onClusterRemoval(absl::string_view cluster) {
   if (cluster != cluster_name_) {
     return;
   }

--- a/source/common/upstream/cluster_update_tracker.h
+++ b/source/common/upstream/cluster_update_tracker.h
@@ -19,7 +19,7 @@ public:
   // ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
                             ThreadLocalClusterCommand& get_cluster) override;
-  void onClusterRemoval(const std::string& cluster) override;
+  void onClusterRemoval(absl::string_view cluster) override;
 
 private:
   const std::string cluster_name_;

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.cc
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.cc
@@ -75,7 +75,7 @@ void DynamicModuleBootstrapExtensionConfig::onClusterAddOrUpdate(
   }
 }
 
-void DynamicModuleBootstrapExtensionConfig::onClusterRemoval(const std::string& cluster_name) {
+void DynamicModuleBootstrapExtensionConfig::onClusterRemoval(absl::string_view cluster_name) {
   if (in_module_config_ != nullptr && on_bootstrap_extension_cluster_removal_ != nullptr) {
     on_bootstrap_extension_cluster_removal_(thisAsVoidPtr(), in_module_config_,
                                             {cluster_name.data(), cluster_name.size()});

--- a/source/extensions/bootstrap/dynamic_modules/extension_config.h
+++ b/source/extensions/bootstrap/dynamic_modules/extension_config.h
@@ -142,7 +142,7 @@ public:
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
                             Upstream::ThreadLocalClusterCommand& get_cluster) override;
-  void onClusterRemoval(const std::string& cluster_name) override;
+  void onClusterRemoval(absl::string_view cluster_name) override;
 
   /**
    * Sets the listener manager reference. Must be called during onServerInitialized before

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -123,14 +123,16 @@ void AggregateClusterLoadBalancer::onClusterAddOrUpdate(
   }
 }
 
-void AggregateClusterLoadBalancer::onClusterRemoval(const std::string& cluster_name) {
+void AggregateClusterLoadBalancer::onClusterRemoval(absl::string_view cluster_name) {
   //  The onClusterRemoval callback is called before the thread local cluster is removed. There
   //  will be a dangling pointer to the thread local cluster if the deleted cluster is not skipped
   //  when we refresh the load balancer.
   if (std::find(clusters_->begin(), clusters_->end(), cluster_name) != clusters_->end()) {
     ENVOY_LOG(debug, "removing cluster '{}' from aggregate cluster '{}'", cluster_name,
               parent_info_->name());
-    refresh(cluster_name);
+    // refresh() takes OptRef<const std::string>; materialize once for the (rare) removal path.
+    const std::string excluded_cluster{cluster_name};
+    refresh(excluded_cluster);
   }
 }
 

--- a/source/extensions/clusters/aggregate/cluster.cc
+++ b/source/extensions/clusters/aggregate/cluster.cc
@@ -52,8 +52,8 @@ void AggregateClusterLoadBalancer::addMemberUpdateCallbackForCluster(
           });
 }
 
-PriorityContextPtr
-AggregateClusterLoadBalancer::linearizePrioritySet(OptRef<const std::string> excluded_cluster) {
+PriorityContextPtr AggregateClusterLoadBalancer::linearizePrioritySet(
+    std::optional<absl::string_view> excluded_cluster) {
   PriorityContextPtr priority_context = std::make_unique<PriorityContext>();
   uint32_t next_priority_after_linearizing = 0;
 
@@ -65,7 +65,7 @@ AggregateClusterLoadBalancer::linearizePrioritySet(OptRef<const std::string> exc
   //    [C_0.P_0, C_0.P_1, C_0.P_2, C_1.P_0, C_1.P_1, C_2.P_0, C_2.P_1, C_2.P_2, C_2.P_3]
   // and the traffic will be distributed among these priorities.
   for (const auto& cluster : *clusters_) {
-    if (excluded_cluster.has_value() && excluded_cluster.value().get() == cluster) {
+    if (excluded_cluster.has_value() && excluded_cluster.value() == cluster) {
       continue;
     }
     auto tlc = cluster_manager_.getThreadLocalCluster(cluster);
@@ -101,7 +101,7 @@ AggregateClusterLoadBalancer::linearizePrioritySet(OptRef<const std::string> exc
   return priority_context;
 }
 
-void AggregateClusterLoadBalancer::refresh(OptRef<const std::string> excluded_cluster) {
+void AggregateClusterLoadBalancer::refresh(std::optional<absl::string_view> excluded_cluster) {
   PriorityContextPtr priority_context = linearizePrioritySet(excluded_cluster);
   if (!priority_context->priority_set_.hostSetsPerPriority().empty()) {
     load_balancer_ = std::make_unique<LoadBalancerImpl>(
@@ -130,9 +130,7 @@ void AggregateClusterLoadBalancer::onClusterRemoval(absl::string_view cluster_na
   if (std::find(clusters_->begin(), clusters_->end(), cluster_name) != clusters_->end()) {
     ENVOY_LOG(debug, "removing cluster '{}' from aggregate cluster '{}'", cluster_name,
               parent_info_->name());
-    // refresh() takes OptRef<const std::string>; materialize once for the (rare) removal path.
-    const std::string excluded_cluster{cluster_name};
-    refresh(excluded_cluster);
+    refresh(cluster_name);
   }
 }
 

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -128,8 +128,8 @@ private:
   using LoadBalancerImplPtr = std::unique_ptr<LoadBalancerImpl>;
 
   void addMemberUpdateCallbackForCluster(Upstream::ThreadLocalCluster& thread_local_cluster);
-  PriorityContextPtr linearizePrioritySet(OptRef<const std::string> excluded_cluster);
-  void refresh(OptRef<const std::string> excluded_cluster = OptRef<const std::string>());
+  PriorityContextPtr linearizePrioritySet(std::optional<absl::string_view> excluded_cluster);
+  void refresh(std::optional<absl::string_view> excluded_cluster = std::nullopt);
 
   LoadBalancerImplPtr load_balancer_;
   Upstream::ClusterInfoConstSharedPtr parent_info_;

--- a/source/extensions/clusters/aggregate/cluster.h
+++ b/source/extensions/clusters/aggregate/cluster.h
@@ -79,7 +79,7 @@ public:
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
                             Upstream::ThreadLocalClusterCommand& get_cluster) override;
-  void onClusterRemoval(const std::string& cluster_name) override;
+  void onClusterRemoval(absl::string_view cluster_name) override;
 
   // Upstream::LoadBalancer
   Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;

--- a/source/extensions/clusters/composite/cluster.cc
+++ b/source/extensions/clusters/composite/cluster.cc
@@ -92,7 +92,7 @@ void CompositeClusterLoadBalancer::onClusterAddOrUpdate(
   }
 }
 
-void CompositeClusterLoadBalancer::onClusterRemoval(const std::string& cluster_name) {
+void CompositeClusterLoadBalancer::onClusterRemoval(absl::string_view cluster_name) {
   if (std::find(clusters_->begin(), clusters_->end(), cluster_name) != clusters_->end()) {
     ENVOY_LOG(debug, "cluster '{}' removed from composite cluster '{}'", cluster_name,
               parent_info_->name());

--- a/source/extensions/clusters/composite/cluster.h
+++ b/source/extensions/clusters/composite/cluster.h
@@ -57,7 +57,7 @@ public:
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
                             Upstream::ThreadLocalClusterCommand& get_cluster) override;
-  void onClusterRemoval(const std::string& cluster_name) override;
+  void onClusterRemoval(absl::string_view cluster_name) override;
 
   // Upstream::LoadBalancer
   Upstream::HostSelectionResponse chooseHost(Upstream::LoadBalancerContext* context) override;

--- a/source/extensions/common/aws/aws_cluster_manager.cc
+++ b/source/extensions/common/aws/aws_cluster_manager.cc
@@ -64,7 +64,7 @@ void AwsClusterManagerImpl::onClusterAddOrUpdate(absl::string_view cluster_name,
 }
 
 // No removal handler required, as we are using avoid_cds_removal flag
-void AwsClusterManagerImpl::onClusterRemoval(const std::string&) {};
+void AwsClusterManagerImpl::onClusterRemoval(absl::string_view){};
 
 void AwsClusterManagerImpl::createQueuedClusters() {
   std::vector<std::string> failed_clusters;

--- a/source/extensions/common/aws/aws_cluster_manager.h
+++ b/source/extensions/common/aws/aws_cluster_manager.h
@@ -120,7 +120,7 @@ public:
 private:
   // Callbacks for cluster manager
   void onClusterAddOrUpdate(absl::string_view, Upstream::ThreadLocalClusterCommand&) override;
-  void onClusterRemoval(const std::string&) override;
+  void onClusterRemoval(absl::string_view) override;
 
   /**
    * Create all queued clusters, if we were unable to create them in real time due to envoy cluster

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -159,7 +159,7 @@ void ProxyFilterConfig::ThreadLocalClusterInfo::onClusterAddOrUpdate(
   }
 }
 
-void ProxyFilterConfig::ThreadLocalClusterInfo::onClusterRemoval(const std::string&) {
+void ProxyFilterConfig::ThreadLocalClusterInfo::onClusterRemoval(absl::string_view) {
   // do nothing, should have no pending clusters.
 }
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
@@ -90,7 +90,7 @@ private:
 
     void onClusterAddOrUpdate(absl::string_view cluster_name,
                               Upstream::ThreadLocalClusterCommand& command) override;
-    void onClusterRemoval(const std::string& name) override;
+    void onClusterRemoval(absl::string_view name) override;
 
     absl::flat_hash_map<std::string, std::list<LoadClusterEntryHandleImpl*>> pending_clusters_;
     Upstream::ClusterUpdateCallbacksHandlePtr handle_;

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -195,7 +195,7 @@ void InstanceImpl::ThreadLocalPool::onClusterAddOrUpdateNonVirtual(
   is_redis_cluster_ = cluster_type.has_value() && cluster_type->name() == "envoy.clusters.redis";
 }
 
-void InstanceImpl::ThreadLocalPool::onClusterRemoval(const std::string& cluster_name) {
+void InstanceImpl::ThreadLocalPool::onClusterRemoval(absl::string_view cluster_name) {
   if (cluster_name != cluster_name_) {
     return;
   }

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -187,7 +187,7 @@ private:
                               Upstream::ThreadLocalClusterCommand& get_cluster) override {
       onClusterAddOrUpdateNonVirtual(cluster_name, get_cluster);
     }
-    void onClusterRemoval(const std::string& cluster_name) override;
+    void onClusterRemoval(absl::string_view cluster_name) override;
 
     void onRequestCompleted();
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -72,7 +72,7 @@ void UdpProxyFilter::onClusterAddOrUpdate(absl::string_view cluster_name,
       std::make_unique<ClusterInfo>(*this, cluster, absl::flat_hash_set<ActiveSession*>{}));
 }
 
-void UdpProxyFilter::onClusterRemoval(const std::string& cluster) {
+void UdpProxyFilter::onClusterRemoval(absl::string_view cluster) {
   if (!cluster_infos_.contains(cluster)) {
     return;
   }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -920,7 +920,7 @@ private:
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
                             Upstream::ThreadLocalClusterCommand& get_cluster) final;
-  void onClusterRemoval(const std::string& cluster_name) override;
+  void onClusterRemoval(absl::string_view cluster_name) override;
 
   const Upstream::ClusterUpdateCallbacksHandlePtr cluster_update_callbacks_;
   // Map for looking up cluster info with its name.

--- a/test/common/grpc/async_client_manager_impl_test.cc
+++ b/test/common/grpc/async_client_manager_impl_test.cc
@@ -353,7 +353,7 @@ TEST_F(AsyncClientManagerImplTest, EnvoyGrpcInvalid) {
   initialize();
   envoy::config::core::v3::GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("foo");
-  EXPECT_CALL(cm_, checkActiveStaticCluster("foo")).WillOnce(Invoke([](const std::string&) {
+  EXPECT_CALL(cm_, checkActiveStaticCluster("foo")).WillOnce(Invoke([](absl::string_view) {
     return absl::InvalidArgumentError("failure");
   }));
   EXPECT_EQ(

--- a/test/extensions/common/aws/aws_cluster_manager_test.cc
+++ b/test/extensions/common/aws/aws_cluster_manager_test.cc
@@ -36,7 +36,7 @@ public:
     return aws_cluster_manager_->onClusterAddOrUpdate(cluster_name, command);
   }
 
-  void onClusterRemoval(const std::string& cluster_name) {
+  void onClusterRemoval(absl::string_view cluster_name) {
     return aws_cluster_manager_->onClusterRemoval(cluster_name);
   }
 

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -69,14 +69,14 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
         }
       }));
   ON_CALL(*this, getActiveCluster(_))
-      .WillByDefault(Invoke([this](const std::string& cluster_name) -> OptRef<const Cluster> {
+      .WillByDefault(Invoke([this](absl::string_view cluster_name) -> OptRef<const Cluster> {
         if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
           return *it->second;
         }
         return std::nullopt;
       }));
   ON_CALL(*this, getActiveOrWarmingCluster(_))
-      .WillByDefault(Invoke([this](const std::string& cluster_name) -> OptRef<const Cluster> {
+      .WillByDefault(Invoke([this](absl::string_view cluster_name) -> OptRef<const Cluster> {
         if (const auto& it = active_clusters_.find(cluster_name); it != active_clusters_.end()) {
           return *it->second;
         }
@@ -86,7 +86,7 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
         return std::nullopt;
       }));
   ON_CALL(*this, hasCluster(_))
-      .WillByDefault(Invoke([this](const std::string& cluster_name) -> bool {
+      .WillByDefault(Invoke([this](absl::string_view cluster_name) -> bool {
         return active_clusters_.find(cluster_name) != active_clusters_.end() ||
                warming_clusters_.find(cluster_name) != warming_clusters_.end();
       }));

--- a/test/mocks/upstream/cluster_manager.h
+++ b/test/mocks/upstream/cluster_manager.h
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD(absl::Status, initialize, (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
   MOCK_METHOD(bool, initialized, ());
   MOCK_METHOD(absl::StatusOr<bool>, addOrUpdateCluster,
-              (const envoy::config::cluster::v3::Cluster& cluster, const std::string& version_info,
+              (const envoy::config::cluster::v3::Cluster& cluster, absl::string_view version_info,
                const bool avoid_cds_removal));
   MOCK_METHOD(void, setPrimaryClustersInitializedCb, (PrimaryClustersReadyCallback));
   MOCK_METHOD(void, setInitializedCb, (InitializationCompleteCallback));
@@ -44,15 +44,15 @@ public:
               (const envoy::config::bootstrap::v3::Bootstrap& bootstrap));
   MOCK_METHOD(ClusterInfoMaps, clusters, (), (const));
   MOCK_METHOD(void, forEachActiveCluster, (std::function<void(const Cluster&)>), (const));
-  MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (const std::string& cluster_name), (const));
-  MOCK_METHOD(OptRef<const Cluster>, getActiveOrWarmingCluster, (const std::string& cluster_name),
+  MOCK_METHOD(OptRef<const Cluster>, getActiveCluster, (absl::string_view cluster_name), (const));
+  MOCK_METHOD(OptRef<const Cluster>, getActiveOrWarmingCluster, (absl::string_view cluster_name),
               (const));
-  MOCK_METHOD(bool, hasCluster, (const std::string& cluster_name), (const));
+  MOCK_METHOD(bool, hasCluster, (absl::string_view cluster_name), (const));
   MOCK_METHOD(bool, hasActiveClusters, (), (const));
 
   MOCK_METHOD(const ClusterSet&, primaryClusters, ());
   MOCK_METHOD(ThreadLocalCluster*, getThreadLocalCluster, (absl::string_view cluster));
-  MOCK_METHOD(bool, removeCluster, (const std::string& cluster, const bool remove_ignored));
+  MOCK_METHOD(bool, removeCluster, (absl::string_view cluster, const bool remove_ignored));
   MOCK_METHOD(void, shutdown, ());
   MOCK_METHOD(bool, isShutdown, ());
   MOCK_METHOD(const std::optional<envoy::config::core::v3::BindConfig>&, bindConfig, (), (const));
@@ -86,14 +86,14 @@ public:
     return cluster_timeout_budget_stat_names_;
   }
   MOCK_METHOD(void, drainConnections,
-              (const std::string& cluster, DrainConnectionsHostPredicate predicate));
+              (absl::string_view cluster, DrainConnectionsHostPredicate predicate));
   MOCK_METHOD(void, drainConnections,
               (DrainConnectionsHostPredicate predicate,
                ConnectionPool::DrainBehavior drain_behavior));
   MOCK_METHOD(void, drainOrCloseConnPools,
               (DrainConnectionsPoolPredicate predicate,
                ConnectionPool::DrainBehavior drain_behavior));
-  MOCK_METHOD(absl::Status, checkActiveStaticCluster, (const std::string& cluster));
+  MOCK_METHOD(absl::Status, checkActiveStaticCluster, (absl::string_view cluster));
   MOCK_METHOD(absl::StatusOr<OdCdsApiHandlePtr>, allocateOdCdsApi,
               (OdCdsCreationFunction creation_function,
                const envoy::config::core::v3::ConfigSource& odcds_config,

--- a/test/mocks/upstream/cluster_update_callbacks.h
+++ b/test/mocks/upstream/cluster_update_callbacks.h
@@ -16,7 +16,7 @@ public:
 
   MOCK_METHOD(void, onClusterAddOrUpdate,
               (absl::string_view cluster_name, ThreadLocalClusterCommand& command));
-  MOCK_METHOD(void, onClusterRemoval, (const std::string& cluster_name));
+  MOCK_METHOD(void, onClusterRemoval, (absl::string_view cluster_name));
 };
 } // namespace Upstream
 } // namespace Envoy

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -1739,7 +1739,7 @@ public:
 
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view, Upstream::ThreadLocalClusterCommand&) override {}
-  void onClusterRemoval(const std::string&) override {}
+  void onClusterRemoval(absl::string_view) override {}
 
 private:
   Upstream::ClusterUpdateCallbacksHandlePtr cluster_removal_cb_handle_;


### PR DESCRIPTION
Commit Message:
Replace const std::string& arguments with absl::string_view in methods that don't need an owned string or that already perform a copy internally. This doesn't change performance characteristics on its own but it allows custom extensions that can cheaply produce a string_view but not a const std::string& to avoid an unnecessary allocation just to fit method signatures.

Additional Description:
This was generated with AI but is a mechanical change. No behavior changes are expected.

Risk Level: low
Testing: built all targets
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Towards #11693