### PR TITLE
chore: fix "callabck" typo in callback variable names and docs

### DIFF
--- a/docs/root/intro/arch_overview/http/http_filters.rst
+++ b/docs/root/intro/arch_overview/http/http_filters.rst
@@ -104,7 +104,7 @@ cluster by invoking ``refreshRouteCluster()`` if the cluster specifier of route 
 the :ref:`matcher based cluster specifier <config_http_cluster_specifier_matcher>` support the
 ``refreshRouteCluster()`` callback.
 
-This callabck will not update the cached route but only refresh the target cluster name. This is
+This callback will not update the cached route but only refresh the target cluster name. This is
 suggested to replace ``clearRouteCache()`` if you only want to determine the target cluster based on
 the latest request attributes that have been updated by the filters and do not want to configure
 multiple similar routes at the route table.

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -198,9 +198,9 @@ DynamicModuleHttpFilter::sendHttpCallout(uint64_t* callout_id_out, absl::string_
 
   // Prepare the callback and the ID.
   const uint64_t callout_id = getNextCalloutId();
-  auto http_callout_callabck =
+  auto http_callout_callback =
       std::make_unique<DynamicModuleHttpFilter::HttpCalloutCallback>(*this, callout_id);
-  DynamicModuleHttpFilter::HttpCalloutCallback& callback = *http_callout_callabck;
+  DynamicModuleHttpFilter::HttpCalloutCallback& callback = *http_callout_callback;
 
   auto request = cluster->httpAsyncClient().send(std::move(message), callback, options);
   if (!request) {
@@ -209,7 +209,7 @@ DynamicModuleHttpFilter::sendHttpCallout(uint64_t* callout_id_out, absl::string_
 
   // Register the callout.
   callback.request_ = request;
-  http_callouts_.emplace(callout_id, std::move(http_callout_callabck));
+  http_callouts_.emplace(callout_id, std::move(http_callout_callback));
   *callout_id_out = callout_id;
 
   return envoy_dynamic_module_type_http_callout_init_result_Success;

--- a/test/extensions/filters/network/generic_proxy/integration_test.cc
+++ b/test/extensions/filters/network/generic_proxy/integration_test.cc
@@ -198,8 +198,8 @@ public:
 
     test_encoding_context_ = std::make_shared<TestEncodingContext>();
 
-    client_codec_callabcks_ = std::make_shared<TestClientCodecCallbacks>(*this);
-    client_codec_->setCodecCallbacks(*client_codec_callabcks_);
+    client_codec_callbacks_ = std::make_shared<TestClientCodecCallbacks>(*this);
+    client_codec_->setCodecCallbacks(*client_codec_callbacks_);
 
     server_codec_callbacks_ = std::make_shared<TestServerCodecCallbacks>(*this);
     server_codec_->setCodecCallbacks(*server_codec_callbacks_);
@@ -364,14 +364,14 @@ public:
   AssertionResult waitDownstreamResponseForTest(std::chrono::milliseconds timeout,
                                                 uint64_t stream_id) {
     bool timer_fired = false;
-    if (!client_codec_callabcks_->responses_[stream_id].end_stream_) {
+    if (!client_codec_callbacks_->responses_[stream_id].end_stream_) {
       Envoy::Event::TimerPtr timer(
           integration_->dispatcher_->createTimer([this, &timer_fired]() -> void {
             timer_fired = true;
             integration_->dispatcher_->exit();
           }));
       timer->enableTimer(timeout);
-      client_codec_callabcks_->waiting_for_stream_id_ = stream_id;
+      client_codec_callbacks_->waiting_for_stream_id_ = stream_id;
       integration_->dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
       if (timer_fired) {
         return AssertionFailure() << "Timed out waiting for response";
@@ -380,7 +380,7 @@ public:
         timer->disableTimer();
       }
     }
-    if (!client_codec_callabcks_->responses_[stream_id].end_stream_) {
+    if (!client_codec_callbacks_->responses_[stream_id].end_stream_) {
       return AssertionFailure() << "No response or response not complete";
     }
     return AssertionSuccess();
@@ -405,7 +405,7 @@ public:
   ClientCodecPtr client_codec_;
 
   TestEncodingContextSharedPtr test_encoding_context_;
-  TestClientCodecCallbacksSharedPtr client_codec_callabcks_;
+  TestClientCodecCallbacksSharedPtr client_codec_callbacks_;
   TestServerCodecCallbacksSharedPtr server_codec_callbacks_;
 
   // Integration test server.
@@ -450,8 +450,8 @@ TEST_P(IntegrationTest, RequestRouteNotFound) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(),
+  EXPECT_NE(client_codec_callbacks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[0].response_->status().code(),
             static_cast<uint32_t>(absl::StatusCode::kNotFound));
 
   cleanup();
@@ -489,9 +489,9 @@ TEST_P(IntegrationTest, RequestAndResponse) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 0);
-  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->get("zzzz"), "xxxx");
+  EXPECT_NE(client_codec_callbacks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[0].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callbacks_->responses_[0].response_->get("zzzz"), "xxxx");
 
   cleanup();
 }
@@ -523,8 +523,8 @@ TEST_P(IntegrationTest, RequestTimeout) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 0),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[0].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[0].response_->status().code(), 4);
+  EXPECT_NE(client_codec_callbacks_->responses_[0].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[0].response_->status().code(), 4);
 
   cleanup();
 }
@@ -630,10 +630,10 @@ TEST_P(IntegrationTest, MultipleRequests) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 2),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[2].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->status().code(), 0);
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->get("zzzz"), "xxxx");
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->frameFlags().streamId(), 2);
+  EXPECT_NE(client_codec_callbacks_->responses_[2].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->get("zzzz"), "xxxx");
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->frameFlags().streamId(), 2);
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
@@ -646,10 +646,10 @@ TEST_P(IntegrationTest, MultipleRequests) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 1),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[1].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->status().code(), 0);
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->get("zzzz"), "yyyy");
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->frameFlags().streamId(), 1);
+  EXPECT_NE(client_codec_callbacks_->responses_[1].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->get("zzzz"), "yyyy");
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->frameFlags().streamId(), 1);
 
   cleanup();
 }
@@ -763,10 +763,10 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 2),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[2].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->status().code(), 0);
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->get("zzzz"), "xxxx");
-  EXPECT_EQ(client_codec_callabcks_->responses_[2].response_->frameFlags().streamId(), 2);
+  EXPECT_NE(client_codec_callbacks_->responses_[2].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->get("zzzz"), "xxxx");
+  EXPECT_EQ(client_codec_callbacks_->responses_[2].response_->frameFlags().streamId(), 2);
 
   FakeStreamCodecFactory::FakeResponse response_1;
   response_1.protocol_ = "fake_fake_fake";
@@ -783,10 +783,10 @@ TEST_P(IntegrationTest, MultipleRequestsWithMultipleFrames) {
   RELEASE_ASSERT(waitDownstreamResponseForTest(TestUtility::DefaultTimeout, 1),
                  "unexpected timeout");
 
-  EXPECT_NE(client_codec_callabcks_->responses_[1].response_, nullptr);
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->status().code(), 0);
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->get("zzzz"), "yyyy");
-  EXPECT_EQ(client_codec_callabcks_->responses_[1].response_->frameFlags().streamId(), 1);
+  EXPECT_NE(client_codec_callbacks_->responses_[1].response_, nullptr);
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->status().code(), 0);
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->get("zzzz"), "yyyy");
+  EXPECT_EQ(client_codec_callbacks_->responses_[1].response_->frameFlags().streamId(), 1);
 
   cleanup();
 }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Fix a typo where "callback" was misspelled as "callabck" in a local variable name in the dynamic_modules HTTP filter, in a member variable name in the generic_proxy network filter integration test and docs.
No functional change; purely a rename for readability.

Additional Description:
Generative AI (Claude Code) was used to check for remaining occurrences of the typo across the repository and to assist with code review of the changes.

Risk Level: low
Testing: Ran the affected targets locally:
- //test/extensions/dynamic_modules/http:filter_test
- //test/extensions/filters/network/generic_proxy:integration_test


Docs Changes: Fix typo
Release Notes:N/A
Platform Specific Features:N/A


