### PR TITLE
docs: sync SECURITY-INSIGHTS.yml with OWNERS.md maintainers

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,8 +1,8 @@
 header:
   schema-version: '1.0.0'
-  expiration-date: '2025-01-24T01:00:00.000Z'
-  last-updated: '2024-01-24'
-  last-reviewed: '2024-01-24'
+  expiration-date: '2027-07-03T01:00:00.000Z'
+  last-updated: '2026-07-03'
+  last-reviewed: '2026-07-03'
   project-url: https://github.com/envoyproxy/envoy
   changelog: https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history#version-history
   license: https://github.com/envoyproxy/envoy/blob/main/LICENSE
@@ -11,6 +11,8 @@ project-lifecycle:
   bug-fixes-only: false
   core-maintainers:  # from https://github.com/envoyproxy/envoy/blob/main/OWNERS.md
   # Senior maintainers
+  - github:agrawroh
+  - github:botengyao
   - github:ggreenway
   - github:mattklein123
   - github:phlax
@@ -20,8 +22,6 @@ project-lifecycle:
   - github:zuercher
   # Maintainers
   - github:adisuissa
-  - github:agrawroh
-  - github:botengyao
   - github:jwendell
   - github:KBaichoo
   - github:keith


### PR DESCRIPTION
Move agrawroh and botengyao into the senior-maintainers group to match OWNERS.md, and refresh the header expiration/last-updated/last-reviewed dates.

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
