### PR TITLE
[chore] http2: fix integer overflow in unconsumed_bytes_

### DIFF
--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -426,7 +426,7 @@ protected:
     const StreamInfo::BytesMeterSharedPtr& bytesMeter() override { return bytes_meter_; }
     ConnectionImpl& parent_;
     int32_t stream_id_{-1};
-    uint32_t unconsumed_bytes_{0};
+    uint64_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
     StreamInfo::BytesMeterSharedPtr bytes_meter_{std::make_shared<StreamInfo::BytesMeter>()};
 

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -299,6 +299,8 @@ protected:
       Headers, // Signifies additional headers after the initial request/response set.
     };
 
+    friend class Http2CodecImplTestFixture;
+
     StreamImpl(ConnectionImpl& parent, uint32_t buffer_limit);
 
     // Http::MultiplexedStreamImplBase

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -2595,6 +2595,28 @@ TEST_P(Http2CodecImplFlowControlTest, RstStreamOnPendingFlushTimeoutFlood) {
   EXPECT_EQ(1, server_stats_store_.counter("http2.outbound_flood").value());
 }
 
+// Verify that unconsumed_bytes_ is 64-bit and does not overflow.
+TEST_P(Http2CodecImplFlowControlTest, UnconsumedBytesOverflowPrevention) {
+  initialize();
+
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  EXPECT_TRUE(request_encoder_->encodeHeaders(request_headers, false).ok());
+  driveToCompletion();
+
+  auto* stream = server_->getStream(1);
+  ASSERT_NE(stream, nullptr);
+
+  // Directly set unconsumed_bytes_ to a value close to UINT32_MAX.
+  stream->unconsumed_bytes_ = static_cast<uint64_t>(UINT32_MAX) - 100;
+
+  // Add more bytes to simulate receiving data while read-disabled.
+  stream->unconsumed_bytes_ += 200;
+
+  // Verify that it has successfully held a value larger than UINT32_MAX without overflow/wrap-around.
+  EXPECT_EQ(stream->unconsumed_bytes_, static_cast<uint64_t>(UINT32_MAX) + 100);
+}
+
 TEST_P(Http2CodecImplTest, WatermarkUnderEndStream) {
   initialize();
   MockStreamCallbacks callbacks;

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -120,6 +120,8 @@ namespace CommonUtility = ::Envoy::Http2::Utility;
 
 class Http2CodecImplTestFixture {
 public:
+  static uint64_t& unconsumedBytes(StreamImpl* stream) { return stream->unconsumed_bytes_; }
+
   static bool slowContainsStreamId(int id, ConnectionImpl& connection) {
     return connection.slowContainsStreamId(id);
   }
@@ -2608,13 +2610,13 @@ TEST_P(Http2CodecImplFlowControlTest, UnconsumedBytesOverflowPrevention) {
   ASSERT_NE(stream, nullptr);
 
   // Directly set unconsumed_bytes_ to a value close to UINT32_MAX.
-  stream->unconsumed_bytes_ = static_cast<uint64_t>(UINT32_MAX) - 100;
+  Http2CodecImplTestFixture::unconsumedBytes(stream) = static_cast<uint64_t>(UINT32_MAX) - 100;
 
   // Add more bytes to simulate receiving data while read-disabled.
-  stream->unconsumed_bytes_ += 200;
+  Http2CodecImplTestFixture::unconsumedBytes(stream) += 200;
 
   // Verify that it has successfully held a value larger than UINT32_MAX without overflow/wrap-around.
-  EXPECT_EQ(stream->unconsumed_bytes_, static_cast<uint64_t>(UINT32_MAX) + 100);
+  EXPECT_EQ(Http2CodecImplTestFixture::unconsumedBytes(stream), static_cast<uint64_t>(UINT32_MAX) + 100);
 }
 
 TEST_P(Http2CodecImplTest, WatermarkUnderEndStream) {


### PR DESCRIPTION
Commit Message: http2: fix integer overflow in unconsumed_bytes_

Change the type of `unconsumed_bytes_` from `uint32_t` to `uint64_t` in `ConnectionImpl::StreamImpl` to prevent flow control state corruption due to integer overflow on read-disabled streams.

Additional Description:
When a stream is read-disabled, Envoy accumulates the number of unconsumed bytes received on the stream. When the stream is later read-enabled, Envoy reports the accumulated unconsumed bytes back to the HTTP/2 codec to restore the peer's flow control window. Because `unconsumed_bytes_` was declared as a `uint32_t`, it could overflow if the peer sent more than 4 GB of data before the stream was read-enabled, leading to connection/stream flow control corruption (stalls or data floods). Changing the type to `uint64_t` prevents this overflow.

Risk Level: Low (Simple type conversion, fully backward-compatible)

Testing: Added a unit test `UnconsumedBytesOverflowPrevention` in `codec_impl_test.cc` that simulates the addition of bytes beyond `UINT32_MAX` and verifies it doesn't wrap around.

Docs Changes: N/A
Release Notes: N/A
