### PR TITLE
Disable WASM tests under UBSAN that intentionally trigger UB

### DIFF
--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -250,6 +250,11 @@ TEST_P(WasmCommonTest, BadSignature) {
 }
 
 TEST_P(WasmCommonTest, Segv) {
+#if defined(__has_feature)
+#if __has_feature(undefined_behavior_sanitizer)
+  GTEST_SKIP() << "This test is not expected to work with UBSAN.";
+#endif
+#endif
   if (std::get<0>(GetParam()) != "v8") {
     return;
   }
@@ -287,6 +292,11 @@ TEST_P(WasmCommonTest, Segv) {
 }
 
 TEST_P(WasmCommonTest, DivByZero) {
+#if defined(__has_feature)
+#if __has_feature(undefined_behavior_sanitizer)
+  GTEST_SKIP() << "This test is not expected to work with UBSAN.";
+#endif
+#endif
   if (std::get<0>(GetParam()) != "v8") {
     return;
   }


### PR DESCRIPTION
Two disabled tests trigger UB (div by zero and nullptr assignment) in WASM VM and can never succeed under UBSAN.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
