### PR TITLE
fix(listener): filter chain gradually drains connections with drain manager

### DIFF
--- a/changelogs/current/bug_fixes/xds__lds-gradual-drain.rst
+++ b/changelogs/current/bug_fixes/xds__lds-gradual-drain.rst
@@ -1,0 +1,1 @@
+xds: fixed a bug where filter chain draining during LDS updates was immediate instead of gradual when configured with gradual drain strategy. Filter chain draining now respects the gradual drain strategy.

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -83,9 +83,21 @@ PerFilterChainFactoryContextImpl::PerFilterChainFactoryContextImpl(
     Configuration::FactoryContext& parent_context, Init::Manager& init_manager)
     : parent_context_(parent_context), scope_(parent_context_.scope().createScope("")),
       prefixed_scope_(parent_context_.prefixedScope().createScope("")),
-      init_manager_(init_manager) {}
+      init_manager_(init_manager),
+      drain_manager_(parent_context_.serverFactoryContext().drainManager().createChildManager(
+          parent_context_.serverFactoryContext().mainThreadDispatcher())) {}
+
+void PerFilterChainFactoryContextImpl::startDraining() {
+  if (drain_manager_ != nullptr) {
+    drain_manager_->startDrainSequence(Network::DrainDirection::All, [] {});
+  }
+  is_draining_.store(true);
+}
 
 bool PerFilterChainFactoryContextImpl::drainClose(Network::DrainDirection scope) const {
+  if (drain_manager_ != nullptr) {
+    return drain_manager_->drainClose(scope) || parent_context_.drainDecision().drainClose(scope);
+  }
   return is_draining_.load() || parent_context_.drainDecision().drainClose(scope);
 }
 

--- a/source/common/listener_manager/filter_chain_manager_impl.h
+++ b/source/common/listener_manager/filter_chain_manager_impl.h
@@ -10,6 +10,7 @@
 #include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/drain_manager.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
@@ -71,7 +72,7 @@ public:
   bool isQuic() const override;
   bool shouldBypassOverloadManager() const override;
 
-  void startDraining() override { is_draining_.store(true); }
+  void startDraining() override;
 
 private:
   Configuration::FactoryContext& parent_context_;
@@ -79,6 +80,7 @@ private:
   Stats::ScopeSharedPtr scope_;
   Stats::ScopeSharedPtr prefixed_scope_;
   Init::Manager& init_manager_;
+  Server::DrainManagerPtr drain_manager_;
   std::atomic<bool> is_draining_{false};
 };
 

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -155,6 +155,7 @@ envoy_cc_test(
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
         "//source/common/tls:ssl_socket_lib",
+        "//source/server:drain_manager_lib",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/matching/network/common:inputs_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",

--- a/test/common/listener_manager/BUILD
+++ b/test/common/listener_manager/BUILD
@@ -157,6 +157,7 @@ envoy_cc_test(
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
         "//source/common/tls:ssl_socket_lib",
+        "//source/server:drain_manager_lib",
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/matching/network/common:inputs_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -21,6 +21,7 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/tls/ssl_socket.h"
 #include "source/server/configuration_impl.h"
+#include "source/server/drain_manager_impl.h"
 
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/drain_manager.h"
@@ -327,6 +328,87 @@ TEST_P(FilterChainManagerImplTest, CreatedFilterChainFactoryContextHasIndependen
 
   EXPECT_TRUE(context0->drainDecision().drainClose(Network::DrainDirection::All));
   EXPECT_FALSE(context1->drainDecision().drainClose(Network::DrainDirection::All));
+}
+
+TEST_P(FilterChainManagerImplTest, DrainingShouldBeGradual) {
+  // Create filter chain
+  std::vector<envoy::config::listener::v3::FilterChain> filter_chain_messages;
+  filter_chain_messages.push_back(filter_chain_template_);
+  filter_chain_messages[0].set_name("gradual_chain");
+
+  EXPECT_CALL(filter_chain_factory_builder_, buildFilterChain(_, _, _));
+  EXPECT_TRUE(filter_chain_manager_
+                  ->addFilterChains(nullptr,
+                                    std::vector<const envoy::config::listener::v3::FilterChain*>{
+                                        &filter_chain_messages[0]},
+                                    nullptr, filter_chain_factory_builder_, *filter_chain_manager_)
+                  .ok());
+
+  // Set up a drain manager
+  Event::SimulatedTimeSystem time_system;
+  Api::ApiPtr api = Api::createApiForTest(time_system);
+  NiceMock<Server::MockInstance> server;
+  EXPECT_CALL(server, api()).WillRepeatedly(ReturnRef(server.api_));
+  uint64_t random_counter = 0;
+  ON_CALL(server.api_.random_, random())
+      .WillByDefault(Invoke([&random_counter]() -> uint64_t { return random_counter++; }));
+  EXPECT_CALL(server, healthCheckFailed()).WillRepeatedly(Return(false));
+
+  // Configure 100s drain time and gradual strategy
+  EXPECT_CALL(server.options_, drainTime()).WillRepeatedly(Return(std::chrono::seconds(100)));
+  EXPECT_CALL(server.options_, drainStrategy()).WillRepeatedly(Return(Server::DrainStrategy::Gradual));
+
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
+  DrainManagerImpl listener_drain_manager(server, envoy::config::listener::v3::Listener::DEFAULT, *dispatcher);
+
+  // Connect listener and drain manager
+  EXPECT_CALL(parent_context_.server_factory_context_, drainManager()).WillRepeatedly(ReturnRef(listener_drain_manager));
+  EXPECT_CALL(parent_context_.server_factory_context_, mainThreadDispatcher()).WillRepeatedly(ReturnRef(*dispatcher));
+  auto context = filter_chain_manager_->createFilterChainFactoryContext(&filter_chain_messages[0]);
+  auto* context_impl = dynamic_cast<PerFilterChainFactoryContextImpl*>(context.get());
+  ASSERT_NE(context_impl, nullptr);
+
+  // Not draining yet
+  EXPECT_FALSE(context->drainDecision().drainClose(Network::DrainDirection::All));
+
+  // Start draining
+  context_impl->startDraining();
+
+  // At zero seconds, no connections are closed yet
+  int true_count_t0 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t0++;
+    }
+  }
+  EXPECT_EQ(true_count_t0, 0);
+
+  // Progress the clock to 50% of drain time
+  time_system.advanceTimeAndRun(std::chrono::seconds(50), *dispatcher,
+                                Event::Dispatcher::RunType::NonBlock);
+
+  // Expect some to be drained, others not
+  int true_count_t50 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t50++;
+    }
+  }
+  EXPECT_GT(true_count_t50, 400);
+  EXPECT_LT(true_count_t50, 600);
+
+  // Progress past the drain time
+  time_system.advanceTimeAndRun(std::chrono::seconds(101), *dispatcher,
+                                Event::Dispatcher::RunType::NonBlock);
+
+  // All connections should drain
+  int true_count_t100 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t100++;
+    }
+  }
+  EXPECT_EQ(true_count_t100, 1000);
 }
 
 TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {

--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -22,6 +22,7 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/tls/ssl_socket.h"
 #include "source/server/configuration_impl.h"
+#include "source/server/drain_manager_impl.h"
 
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/drain_manager.h"
@@ -343,6 +344,87 @@ TEST_P(FilterChainManagerImplTest, FilterChainFactoryContextDelegatesAccessors) 
   EXPECT_ENVOY_BUG(std::ignore = context->drainDecision().addOnDrainCloseCb(
                        Network::DrainDirection::All, nullptr),
                    "Unexpected function call");
+}
+
+TEST_P(FilterChainManagerImplTest, DrainingShouldBeGradual) {
+  // Create filter chain
+  std::vector<envoy::config::listener::v3::FilterChain> filter_chain_messages;
+  filter_chain_messages.push_back(filter_chain_template_);
+  filter_chain_messages[0].set_name("gradual_chain");
+
+  EXPECT_CALL(filter_chain_factory_builder_, buildFilterChain(_, _, _));
+  EXPECT_TRUE(filter_chain_manager_
+                  ->addFilterChains(nullptr,
+                                    std::vector<const envoy::config::listener::v3::FilterChain*>{
+                                        &filter_chain_messages[0]},
+                                    nullptr, filter_chain_factory_builder_, *filter_chain_manager_)
+                  .ok());
+
+  // Set up a drain manager
+  Event::SimulatedTimeSystem time_system;
+  Api::ApiPtr api = Api::createApiForTest(time_system);
+  NiceMock<Server::MockInstance> server;
+  EXPECT_CALL(server, api()).WillRepeatedly(ReturnRef(server.api_));
+  uint64_t random_counter = 0;
+  ON_CALL(server.api_.random_, random())
+      .WillByDefault(Invoke([&random_counter]() -> uint64_t { return random_counter++; }));
+  EXPECT_CALL(server, healthCheckFailed()).WillRepeatedly(Return(false));
+
+  // Configure 100s drain time and gradual strategy
+  EXPECT_CALL(server.options_, drainTime()).WillRepeatedly(Return(std::chrono::seconds(100)));
+  EXPECT_CALL(server.options_, drainStrategy()).WillRepeatedly(Return(Server::DrainStrategy::Gradual));
+
+  Event::DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
+  DrainManagerImpl listener_drain_manager(server, envoy::config::listener::v3::Listener::DEFAULT, *dispatcher);
+
+  // Connect listener and drain manager
+  EXPECT_CALL(parent_context_.server_factory_context_, drainManager()).WillRepeatedly(ReturnRef(listener_drain_manager));
+  EXPECT_CALL(parent_context_.server_factory_context_, mainThreadDispatcher()).WillRepeatedly(ReturnRef(*dispatcher));
+  auto context = filter_chain_manager_->createFilterChainFactoryContext(&filter_chain_messages[0]);
+  auto* context_impl = dynamic_cast<PerFilterChainFactoryContextImpl*>(context.get());
+  ASSERT_NE(context_impl, nullptr);
+
+  // Not draining yet
+  EXPECT_FALSE(context->drainDecision().drainClose(Network::DrainDirection::All));
+
+  // Start draining
+  context_impl->startDraining();
+
+  // At zero seconds, no connections are closed yet
+  int true_count_t0 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t0++;
+    }
+  }
+  EXPECT_EQ(true_count_t0, 0);
+
+  // Progress the clock to 50% of drain time
+  time_system.advanceTimeAndRun(std::chrono::seconds(50), *dispatcher,
+                                Event::Dispatcher::RunType::NonBlock);
+
+  // Expect some to be drained, others not
+  int true_count_t50 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t50++;
+    }
+  }
+  EXPECT_GT(true_count_t50, 400);
+  EXPECT_LT(true_count_t50, 600);
+
+  // Progress past the drain time
+  time_system.advanceTimeAndRun(std::chrono::seconds(101), *dispatcher,
+                                Event::Dispatcher::RunType::NonBlock);
+
+  // All connections should drain
+  int true_count_t100 = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (context->drainDecision().drainClose(Network::DrainDirection::All)) {
+      true_count_t100++;
+    }
+  }
+  EXPECT_EQ(true_count_t100, 1000);
 }
 
 TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {

--- a/test/mocks/server/drain_manager.cc
+++ b/test/mocks/server/drain_manager.cc
@@ -10,11 +10,34 @@ namespace Server {
 
 using ::testing::_;
 using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::NiceMock;
 using ::testing::SaveArg;
 
 MockDrainManager::MockDrainManager() {
+  // force `draining_ = true` when drain starts
   ON_CALL(*this, startDrainSequence(_, _))
-      .WillByDefault(DoAll(SaveArg<0>(&drain_direction_), SaveArg<1>(&drain_sequence_completion_)));
+      .WillByDefault(
+          Invoke([this](Network::DrainDirection direction, std::function<void()> completion) {
+            drain_direction_ = direction;
+            drain_sequence_completion_ = completion;
+            draining_ = true;
+          }));
+
+  // Return draining_ state for draining() and drainClose() by default
+  ON_CALL(*this, draining(_)).WillByDefault(Invoke([this](Network::DrainDirection) { return draining_; }));
+  ON_CALL(*this, drainClose(_)).WillByDefault(Invoke([this](Network::DrainDirection) { return draining_; }));
+
+  // instantiate a mock drain manager when createChildManager() is called
+  ON_CALL(*this, createChildManager(_))
+      .WillByDefault(Invoke([](Event::Dispatcher&) -> DrainManagerPtr {
+        return std::make_unique<NiceMock<MockDrainManager>>();
+      }));
+  ON_CALL(*this, createChildManager(_, _))
+      .WillByDefault(
+          Invoke([](Event::Dispatcher&, envoy::config::listener::v3::Listener::DrainType) -> DrainManagerPtr {
+            return std::make_unique<NiceMock<MockDrainManager>>();
+          }));
 }
 
 MockDrainManager::~MockDrainManager() = default;

--- a/test/mocks/server/drain_manager.h
+++ b/test/mocks/server/drain_manager.h
@@ -35,6 +35,7 @@ public:
 
   std::function<void()> drain_sequence_completion_;
   Network::DrainDirection drain_direction_;
+  bool draining_{false};
 };
 } // namespace Server
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: fix(listener): filter chain gradually drains connections with drain manager

Additional Description:
* Before: immediate return with true if the listener is draining.
* After: create a drain manager on drain, return true based on % of drain-time passed

Risk Level: low
Testing:
Docs Changes: no
Release Notes: added

Fixes #35085

Disclosure of AI usage:

Gemini 3.5 Flash (high effort) was used to generate the first pass of this PR.
I then scrutinized the changes - the fix itself remains unchanged from what was originally generated. The tests are the main area that I changed, going from a basic test that only verifies the wiring to a test that simulates the behavior of the draining using a simulated clock.