### PR TITLE
fix(filter): create filter chain before calling onLocalReply

### DIFF
--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -957,27 +957,14 @@ TEST_P(ClientIntegrationTest, ClearTextNotPermitted) {
   default_request_headers_.addCopy(AutonomousStream::EXPECT_REQUEST_SIZE_BYTES,
                                    std::to_string(request_data.length()));
 
-  EnvoyStreamCallbacks stream_callbacks = createDefaultStreamCallbacks();
-  stream_callbacks.on_data_ = [this](const Buffer::Instance& buffer, uint64_t length,
-                                     bool end_stream, envoy_stream_intel) {
-    if (end_stream) {
-      std::string response_body(length, ' ');
-      buffer.copyOut(0, length, response_body.data());
-      EXPECT_EQ(response_body, "Cleartext is not permitted");
-    }
-    cc_.on_data_calls_++;
-  };
-
-  stream_ = createNewStream(std::move(stream_callbacks));
+  stream_ = createNewStream(createDefaultStreamCallbacks());
   stream_->sendHeaders(std::make_unique<Http::TestRequestHeaderMapImpl>(default_request_headers_),
                        true);
 
   terminal_callback_.waitReady();
 
-  ASSERT_EQ(cc_.on_headers_calls_, 1);
-  ASSERT_EQ(cc_.status_, "400");
-  ASSERT_EQ(cc_.on_data_calls_, 1);
-  ASSERT_EQ(cc_.on_complete_calls_, 1);
+  ASSERT_EQ(cc_.on_error_calls_, 1);
+  ASSERT_EQ(cc_.on_headers_calls_, 0);
 }
 
 TEST_P(ClientIntegrationTest, BasicHttps) {

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
@@ -1344,9 +1344,9 @@ public class CronetUrlRequestContextTest {
   /**
    * Runs {@code r} on {@code engine}'s network thread.
    */
-  private static void postToNetworkThread(final CronetEngine engine, final Runnable r) {
-    // Works by requesting an invalid URL which results in onFailed() being called, which is
-    // done through a direct executor which causes onFailed to be run on the network thread.
+  private void postToNetworkThread(final CronetEngine engine, final Runnable r) {
+    // Works by requesting an URL that returns a 500 status, which results in onFailed() being called,
+    // which is done through a direct executor which causes onFailed to be run on the network thread.
     Executor directExecutor = new Executor() {
       @Override
       public void execute(Runnable runnable) {
@@ -1371,7 +1371,7 @@ public class CronetUrlRequestContextTest {
         r.run();
       }
     };
-    engine.newUrlRequestBuilder("http://invalid", callback, directExecutor).build().start();
+    engine.newUrlRequestBuilder(mUrl500, callback, directExecutor).build().start();
   }
 
   /**

--- a/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
+++ b/mobile/test/java/org/chromium/net/CronetUrlRequestContextTest.java
@@ -1345,8 +1345,9 @@ public class CronetUrlRequestContextTest {
    * Runs {@code r} on {@code engine}'s network thread.
    */
   private void postToNetworkThread(final CronetEngine engine, final Runnable r) {
-    // Works by requesting an URL that returns a 500 status, which results in onFailed() being called,
-    // which is done through a direct executor which causes onFailed to be run on the network thread.
+    // Works by requesting an URL that returns a 500 status, which results in onFailed() being
+    // called, which is done through a direct executor which causes onFailed to be run on the
+    // network thread.
     Executor directExecutor = new Executor() {
       @Override
       public void execute(Runnable runnable) {

--- a/mobile/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/mobile/test/kotlin/integration/SetEventTrackerTest.kt
@@ -91,7 +91,7 @@ class SetEventTrackerTest {
 
     client
       .newStreamPrototype()
-      .setOnResponseData { _, _, _ -> countDownLatch.countDown() }
+      .setOnError { _, _ -> countDownLatch.countDown() }
       .start()
       .close(ByteBuffer.allocate(1))
 

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1042,6 +1042,10 @@ void DownstreamFilterManager::sendLocalReply(
   if (filter_manager_callbacks_.isHalfCloseEnabled()) {
     state_.decoder_filter_chain_aborted_ = true;
   }
+  // For early error handling, do a best-effort attempt to create a filter chain
+  // to ensure access logging. If the filter chain already exists this will be
+  // a no-op.
+  createDownstreamFilterChain();
 
   streamInfo().setResponseCodeDetails(details);
   StreamFilterBase::LocalReplyData data{code, grpc_status, details, false};
@@ -1108,10 +1112,6 @@ void DownstreamFilterManager::prepareLocalReplyViaFilterChain(
     const std::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
   ENVOY_STREAM_LOG(debug, "Preparing local reply with details {}", *this, details);
   ASSERT(!filter_manager_callbacks_.responseHeaders().has_value());
-  // For early error handling, do a best-effort attempt to create a filter chain
-  // to ensure access logging. If the filter chain already exists this will be
-  // a no-op.
-  createDownstreamFilterChain();
 
   if (prepared_local_reply_) {
     return;
@@ -1160,10 +1160,6 @@ void DownstreamFilterManager::sendLocalReplyViaFilterChain(
     const std::optional<Grpc::Status::GrpcStatus> grpc_status, absl::string_view details) {
   ENVOY_STREAM_LOG(debug, "Sending local reply with details {}", *this, details);
   ASSERT(!filter_manager_callbacks_.responseHeaders().has_value());
-  // For early error handling, do a best-effort attempt to create a filter chain
-  // to ensure access logging. If the filter chain already exists this will be
-  // a no-op.
-  createDownstreamFilterChain();
 
   Utility::sendLocalReply(
       state_.destroyed_,

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -605,6 +605,7 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
 
+  EXPECT_CALL(*filter, onLocalReply(_));
   EXPECT_CALL(*filter, encodeHeaders(_, true));
   EXPECT_CALL(*filter, encodeComplete());
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
@@ -652,6 +653,7 @@ TEST_F(HttpConnectionManagerImplTest, PathFailedtoSanitize) {
       }));
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, onLocalReply(_));
   EXPECT_CALL(*filter, encodeHeaders(_, true));
   EXPECT_CALL(*filter, encodeComplete());
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))

--- a/test/common/http/conn_manager_impl_test_3.cc
+++ b/test/common/http/conn_manager_impl_test_3.cc
@@ -2055,6 +2055,7 @@ TEST_F(HttpConnectionManagerImplTest, HeaderValidatorRejectHttp1) {
       }));
   EXPECT_CALL(*filter, setDecoderFilterCallbacks(_));
   EXPECT_CALL(*filter, setEncoderFilterCallbacks(_));
+  EXPECT_CALL(*filter, onLocalReply(_));
   EXPECT_CALL(*filter, encodeHeaders(_, true));
   EXPECT_CALL(*filter, encodeComplete());
   EXPECT_CALL(response_encoder_, encodeHeaders(_, true))

--- a/test/common/http/conn_manager_misc_test.cc
+++ b/test/common/http/conn_manager_misc_test.cc
@@ -39,6 +39,7 @@ public:
     // codec stream error
     EXPECT_CALL(response_encoder_, streamErrorOnInvalidHttpMessage())
         .WillOnce(Return(stream_error_on_invalid_http_message));
+    EXPECT_CALL(*filter, onLocalReply(_));
     EXPECT_CALL(*filter, encodeComplete());
     EXPECT_CALL(*filter, encodeHeaders(_, true));
     if (!stream_error_on_invalid_http_message) {

--- a/test/integration/filter_integration_test.cc
+++ b/test/integration/filter_integration_test.cc
@@ -104,6 +104,20 @@ TEST_P(FilterIntegrationTest, OnLocalReply) {
     ASSERT_TRUE(response->waitForReset());
     ASSERT_FALSE(response->complete());
   }
+  // The illegal Content-Length value will cause a local reply to be sent before the
+  // filter chain is constructed. In that case the filter manager will construct the filter chain
+  // just before calling onLocalReply.
+  // HTTP2 just resets the stream instead, so we don't test it.
+  if (downstreamProtocol() == Http::CodecType::HTTP2) {
+    return;
+  }
+  {
+    default_request_headers_.addCopy("Content-Length", "-1");
+    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+    ASSERT_TRUE(response->waitForEndStream());
+    ASSERT_TRUE(response->complete());
+    EXPECT_FALSE(response->headers().get(Http::LowerCaseString{"saw-on-local-reply"}).empty());
+  }
 }
 
 TEST_P(FilterIntegrationTest, AddInvalidDecodedData) {

--- a/test/integration/filters/on_local_reply_filter.cc
+++ b/test/integration/filters/on_local_reply_filter.cc
@@ -25,16 +25,21 @@ public:
     return Http::FilterHeadersStatus::StopIteration;
   }
 
-  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& response_headers,
+                                          bool) override {
     if (dual_reply_) {
       decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "second_reply", nullptr,
                                          std::nullopt, "second_reply");
       return Http::FilterHeadersStatus::StopIteration;
     }
+    if (saw_on_local_reply_) {
+      response_headers.addCopy(Http::LowerCaseString{"saw-on-local-reply"}, "yes");
+    }
     return Http::FilterHeadersStatus::Continue;
   }
 
   Http::LocalErrorStatus onLocalReply(const LocalReplyData&) override {
+    saw_on_local_reply_ = true;
     if (reset_) {
       return Http::LocalErrorStatus::ContinueAndResetStream;
     }
@@ -43,6 +48,7 @@ public:
 
   bool reset_{};
   bool dual_reply_{};
+  bool saw_on_local_reply_{};
 };
 
 class OnLocalReplyFilterConfig


### PR DESCRIPTION
Commit Message:
fix(filter): create filter chain before calling onLocalReply
Additional Description:

If a local reply is generated sufficiently early, the filterchain might not exist yet. In that case the previous implementation would create it immediately before encoding the local reply, but after trying to call onLocalReply on the filters.
This PR moves the creation of the chain before the onLocalReply call.

Risk Level: Low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

Fixes #29771

