### PR TITLE
http: new exception free method for server context only filter factory creation

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -358,6 +358,7 @@ public:
    * @param context supplies the filter's ServerFactoryContext.
    * @return Http::FilterFactoryCb the factory creation function.
    */
+  [[deprecated("Use createHttpFilterFactoryFromProto instead")]]
   virtual Http::FilterFactoryCb
   createFilterFactoryFromProtoWithServerContext(const Protobuf::Message&, const std::string&,
                                                 Server::Configuration::ServerFactoryContext&) {

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -326,6 +326,30 @@ public:
 
   /**
    * Create a particular http filter factory implementation. If the implementation is unable to
+   * produce a factory with the provided parameters, it should return an error status.
+   * The returned callback should always be initialized.
+   *
+   * NOTE: for backwards compatibility, this method will default to calling
+   * createFilterFactoryFromProtoWithServerContext, which will throw an exception if not
+   * implemented. This new method will be used to replace
+   * createFilterFactoryFromProtoWithServerContext in the future and this delegation will be
+   * removed.
+   *
+   * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+   * configuration.
+   * @param stat_prefix prefix for stat logging
+   * @param context supplies the filter's context.
+   * @return Http::FilterFactoryCb the factory creation function.
+   */
+  virtual absl::StatusOr<Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
+                                   Server::Configuration::ServerFactoryContext& context) {
+    // Delegate to createFilterFactoryFromProtoWithServerContext for backwards compatibility.
+    return createFilterFactoryFromProtoWithServerContext(config, stat_prefix, context);
+  }
+
+  /**
+   * Create a particular http filter factory implementation. If the implementation is unable to
    * produce a factory with the provided parameters or this method is not supported, it should throw
    * an EnvoyException. The returned callback should always be initialized.
    * @param config supplies the general Protobuf message to be marshaled into a filter-specific

--- a/source/extensions/filters/http/adaptive_concurrency/config.h
+++ b/source/extensions/filters/http/adaptive_concurrency/config.h
@@ -26,7 +26,7 @@ public:
     return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
                                context.scope());
   }
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       const std::string& stats_prefix,

--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -25,8 +25,8 @@ AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
   return createFilterFactory(config, stats_prefix, context, dual_info.scope);
 }
 
-Http::FilterFactoryCb
-AdmissionControlFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AdmissionControlFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
   auto cb = createFilterFactory(proto_config, stats_prefix, context, context.scope());

--- a/source/extensions/filters/http/admission_control/config.h
+++ b/source/extensions/filters/http/admission_control/config.h
@@ -24,7 +24,7 @@ public:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -28,8 +28,8 @@ Http::FilterFactoryCb AlternateProtocolsCacheFilterFactory::createFilterFactoryF
   };
 }
 
-Http::FilterFactoryCb
-AlternateProtocolsCacheFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AlternateProtocolsCacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
         proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/alternate_protocols_cache/config.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.h
@@ -27,7 +27,7 @@ private:
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
           proto_config,
       const std::string& stats_prefix,

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -134,7 +134,7 @@ AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
   return filter_settings;
 }
 
-Http::FilterFactoryCb AwsLambdaFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   auto result = createFilterFactoryFromProtoHelper(proto_config, stats_prefix, server_context,

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -40,7 +40,7 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -51,8 +51,8 @@ AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
   return createFilterFactoryFromProtoHelper(config, stats_prefix, server_context, dual_info.scope);
 }
 
-Http::FilterFactoryCb
-AwsRequestSigningFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AwsRequestSigningFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const AwsRequestSigningProtoConfig& config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& server_context) {
   auto result = createFilterFactoryFromProtoHelper(config, stats_prefix, server_context,

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -39,7 +39,7 @@ private:
                                     const std::string& stats_prefix, DualInfo dual_info,
                                     Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const AwsRequestSigningProtoConfig& proto_config, const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -76,7 +76,7 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const BasicAuth& proto_config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& context) {
   UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -22,7 +22,7 @@ private:
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -26,8 +26,8 @@ absl::StatusOr<Http::FilterFactoryCb> BufferFilterFactory::createFilterFactoryFr
   };
 }
 
-Envoy::Http::FilterFactoryCb
-BufferFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb>
+BufferFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext&) {
   ASSERT(proto_config.has_max_request_bytes());

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -25,7 +25,7 @@ private:
       const std::string& stats_prefix, DualInfo,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
       const std::string& stats, Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -87,6 +87,23 @@ public:
         stats_prefix, server_context);
   }
 
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                   const std::string& stats_prefix,
+                                   Server::Configuration::ServerFactoryContext& context) override {
+    return createHttpFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
+                                                             context.messageValidationVisitor()),
+        stats_prefix, context);
+  }
+  virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                        const std::string& stats_prefix,
+                                        Server::Configuration::ServerFactoryContext& context) {
+    // Delegate to createFilterFactoryFromProtoWithServerContextTyped for backwards compatibility.
+    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix, context);
+  }
+
   virtual Envoy::Http::FilterFactoryCb
   createFilterFactoryFromProtoWithServerContextTyped(const ConfigProto&, const std::string&,
                                                      Server::Configuration::ServerFactoryContext&) {
@@ -115,6 +132,26 @@ public:
   createFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) PURE;
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                   const std::string& stats_prefix,
+                                   Server::Configuration::ServerFactoryContext& context) override {
+    return createHttpFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
+                                                             context.messageValidationVisitor()),
+        stats_prefix, context);
+  }
+  virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                        const std::string& stats_prefix,
+                                        Server::Configuration::ServerFactoryContext& context) {
+    UNREFERENCED_PARAMETER(proto_config);
+    UNREFERENCED_PARAMETER(stats_prefix);
+    UNREFERENCED_PARAMETER(context);
+    return absl::InvalidArgumentError(
+        "Creating HTTP filter factory from server factory context is not supported");
+  }
 };
 
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
@@ -169,6 +206,23 @@ public:
         MessageUtil::downcastAndValidate<const ConfigProto&>(
             proto_config, server_context.messageValidationVisitor()),
         stats_prefix, server_context);
+  }
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                   const std::string& stats_prefix,
+                                   Server::Configuration::ServerFactoryContext& context) override {
+    return createHttpFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
+                                                             context.messageValidationVisitor()),
+        stats_prefix, context);
+  }
+  virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
+                                        const std::string& stats_prefix,
+                                        Server::Configuration::ServerFactoryContext& context) {
+    // Delegate to createFilterFactoryFromProtoWithServerContextTyped for backwards compatibility.
+    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix, context);
   }
 
 private:

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -78,6 +78,7 @@ public:
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) PURE;
 
+  [[deprecated("Use createHttpFilterFactoryFromProto instead")]]
   Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContext(
       const Protobuf::Message& proto_config, const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override {
@@ -104,6 +105,7 @@ public:
     return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix, context);
   }
 
+  [[deprecated("Use createHttpFilterFactoryFromProtoTyped instead")]]
   virtual Envoy::Http::FilterFactoryCb
   createFilterFactoryFromProtoWithServerContextTyped(const ConfigProto&, const std::string&,
                                                      Server::Configuration::ServerFactoryContext&) {
@@ -199,6 +201,7 @@ public:
 
   // This method is for dual filter to create filter from server context when it is configured
   // in downstream. It won't be called if a dual filter is in upstream.
+  [[deprecated("Use createHttpFilterFactoryFromProto instead")]]
   Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContext(
       const Protobuf::Message& proto_config, const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override {
@@ -226,6 +229,7 @@ public:
   }
 
 private:
+  [[deprecated("Use createHttpFilterFactoryFromProtoTyped instead")]]
   virtual Envoy::Http::FilterFactoryCb
   createFilterFactoryFromProtoWithServerContextTyped(const ConfigProto&, const std::string&,
                                                      Server::Configuration::ServerFactoryContext&) {

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -160,8 +160,10 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionDown
   // If above failed, for downstream case, try to create the filter factory creation function
   // from server factory context if exists.
   if (callback == nullptr && context.server_factory_context_.has_value()) {
-    callback = factory.createFilterFactoryFromProtoWithServerContext(
+    auto callback_or_status = factory.createHttpFilterFactoryFromProto(
         *message, context.stat_prefix_, context.server_factory_context_.value());
+    THROW_IF_NOT_OK_REF(callback_or_status.status());
+    callback = callback_or_status.value();
   }
 
   return createActionCommon(composite_action, context, callback, true);
@@ -224,8 +226,10 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
 
       // If above failed, try server factory context.
       if (callback == nullptr && context.server_factory_context_.has_value()) {
-        callback = factory.createFilterFactoryFromProtoWithServerContext(
+        auto callback_or_status = factory.createHttpFilterFactoryFromProto(
             *message, context.stat_prefix_, context.server_factory_context_.value());
+        THROW_IF_NOT_OK_REF(callback_or_status.status());
+        callback = callback_or_status.value();
       }
 
       if (callback == nullptr) {

--- a/source/extensions/filters/http/connect_grpc_bridge/config.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.cc
@@ -19,8 +19,8 @@ Http::FilterFactoryCb ConnectGrpcFilterConfigFactory::createFilterFactoryFromPro
   };
 }
 
-Http::FilterFactoryCb
-ConnectGrpcFilterConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+ConnectGrpcFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig&,
     const std::string&, Server::Configuration::ServerFactoryContext&) {
   return [](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/source/extensions/filters/http/connect_grpc_bridge/config.h
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.h
@@ -22,7 +22,7 @@ private:
       const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
       const std::string&, Server::Configuration::FactoryContext&) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext&) override;
 };

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -27,7 +27,7 @@ Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb CorsFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> CorsFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cors::v3::Cors&, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& context) {
   CorsFilterConfigSharedPtr config =

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -23,7 +23,7 @@ public:
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/credential_injector/config.cc
+++ b/source/extensions/filters/http/credential_injector/config.cc
@@ -55,8 +55,8 @@ CredentialInjectorFilterFactory::createFilterFactoryFromProtoTyped(
                                             dual_info.init_manager);
 }
 
-Envoy::Http::FilterFactoryCb
-CredentialInjectorFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb>
+CredentialInjectorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector&
         proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/credential_injector/config.h
+++ b/source/extensions/filters/http/credential_injector/config.h
@@ -28,7 +28,7 @@ private:
       const std::string& stats_prefix, DualInfo dual_info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -21,7 +21,7 @@ Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb CsrfFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> CsrfFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
   CsrfFilterConfigSharedPtr config =

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -23,7 +23,7 @@ private:
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -146,8 +146,8 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
   };
 }
 
-Envoy::Http::FilterFactoryCb
-DynamicModuleConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb>
+DynamicModuleConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const FilterConfig& proto_config, const std::string& stat_prefix,
     Server::Configuration::ServerFactoryContext& context) {
   auto cb_or_error = createFilterFactory(proto_config, stat_prefix, context, context.scope());

--- a/source/extensions/filters/http/dynamic_modules/factory.h
+++ b/source/extensions/filters/http/dynamic_modules/factory.h
@@ -26,7 +26,7 @@ public:
     return createFilterFactory(proto_config, stat_prefix, context, dual_info.scope,
                                dual_info.init_manager);
   }
-  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const FilterConfig& proto_config, const std::string& stat_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -20,7 +20,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ExtAuthz {
 
-Http::FilterFactoryCb ExtAuthzFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> ExtAuthzFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   const auto filter_config = std::make_shared<FilterConfig>(proto_config, server_context.scope(),

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -26,11 +26,12 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix,
-                                                              context.serverFactoryContext());
+    return THROW_OR_RETURN_VALUE(createHttpFilterFactoryFromProtoTyped(
+                                     proto_config, stats_prefix, context.serverFactoryContext()),
+                                 Http::FilterFactoryCb);
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -126,8 +126,8 @@ ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
 }
 
 // This method will only be called when the filter is in downstream.
-Http::FilterFactoryCb
-ExternalProcessingFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+ExternalProcessingFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   // Verify configuration before creating FilterConfig

--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -35,7 +35,7 @@ private:
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -23,7 +23,7 @@ Http::FilterFactoryCb FaultFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb FaultFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> FaultFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::fault::v3::HTTPFault& config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   FaultFilterConfigSharedPtr filter_config(std::make_shared<FaultFilterConfig>(

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -23,7 +23,7 @@ private:
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;

--- a/source/extensions/filters/http/file_system_buffer/config.cc
+++ b/source/extensions/filters/http/file_system_buffer/config.cc
@@ -34,8 +34,8 @@ Http::FilterFactoryCb FileSystemBufferFilterFactory::createFilterFactoryFromProt
   };
 }
 
-Http::FilterFactoryCb
-FileSystemBufferFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+FileSystemBufferFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const ProtoFileSystemBufferFilterConfig& config,
     const std::string& stats_prefix ABSL_ATTRIBUTE_UNUSED,
     Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/file_system_buffer/config.h
+++ b/source/extensions/filters/http/file_system_buffer/config.h
@@ -28,7 +28,7 @@ public:
           config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&
           config,
       const std::string& stats_prefix,

--- a/source/extensions/filters/http/filter_chain/filter.cc
+++ b/source/extensions/filters/http/filter_chain/filter.cc
@@ -33,11 +33,12 @@ FilterFactoriesVector createFilterFactoriesFromConfig(
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         filter_config, context.messageValidationVisitor(), factory);
     auto callback_or_error =
-        factory.createFilterFactoryFromProtoWithServerContext(*message, stats_prefix, context);
+        factory.createHttpFilterFactoryFromProto(*message, stats_prefix, context);
+    THROW_IF_NOT_OK_REF(callback_or_error.status());
 
     auto filter_config_provider =
         Http::FilterChainUtility::createSingletonDownstreamFilterConfigProviderManager(context)
-            ->createStaticFilterConfigProvider(callback_or_error, filter_config.name());
+            ->createStaticFilterConfigProvider(callback_or_error.value(), filter_config.name());
     filter_factories.push_back({std::move(filter_config_provider)});
   }
   return filter_factories;

--- a/source/extensions/filters/http/grpc_field_extraction/config.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/config.cc
@@ -31,8 +31,8 @@ Envoy::Http::FilterFactoryCb FilterFactoryCreator::createFilterFactoryFromProtoT
   };
 }
 
-Envoy::Http::FilterFactoryCb
-FilterFactoryCreator::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb>
+FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
         proto_config,
     const std::string&, Envoy::Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/grpc_field_extraction/config.h
+++ b/source/extensions/filters/http/grpc_field_extraction/config.h
@@ -27,7 +27,7 @@ private:
           proto_config,
       const std::string&, Envoy::Server::Configuration::FactoryContext&) override;
 
-  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
           proto_config,
       const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override;

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -18,8 +18,8 @@ Http::FilterFactoryCb GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoT
   };
 }
 
-Http::FilterFactoryCb
-GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+GrpcHttp1BridgeFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& factory_context) {
   return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/source/extensions/filters/http/grpc_http1_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.h
@@ -23,7 +23,7 @@ public:
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& factory_context) override;

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb Config::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb Config::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> Config::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
     const std::string&, Server::Configuration::ServerFactoryContext&) {
   return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -23,7 +23,7 @@ public:
       const std::string& stat_prefix,
       Envoy::Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
       const std::string& stat_prefix,
       Envoy::Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
@@ -24,8 +24,8 @@ Http::FilterFactoryCb GrpcJsonReverseTranscoderFactory::createFilterFactoryFromP
   };
 }
 
-Http::FilterFactoryCb
-GrpcJsonReverseTranscoderFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+GrpcJsonReverseTranscoderFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
         GrpcJsonReverseTranscoder& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
@@ -23,7 +23,7 @@ private:
           GrpcJsonReverseTranscoder& proto_config,
       const std::string&, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
           GrpcJsonReverseTranscoder& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -24,8 +24,8 @@ Http::FilterFactoryCb GrpcJsonTranscoderFilterConfig::createFilterFactoryFromPro
   };
 }
 
-Http::FilterFactoryCb
-GrpcJsonTranscoderFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+GrpcJsonTranscoderFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -25,7 +25,7 @@ private:
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
           proto_config,
       const std::string& stats_prefix,

--- a/source/extensions/filters/http/grpc_web/config.cc
+++ b/source/extensions/filters/http/grpc_web/config.cc
@@ -18,7 +18,7 @@ Http::FilterFactoryCb GrpcWebFilterConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb GrpcWebFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> GrpcWebFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb&, const std::string&,
     Server::Configuration::ServerFactoryContext& factory_context) {
   return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {

--- a/source/extensions/filters/http/grpc_web/config.h
+++ b/source/extensions/filters/http/grpc_web/config.h
@@ -21,7 +21,7 @@ private:
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& factory_context) override;

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -22,8 +22,8 @@ HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb
-HeaderMutationFactoryConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+HeaderMutationFactoryConfig::createHttpFilterFactoryFromProtoTyped(
     const ProtoConfig& config, const std::string&,
     Server::Configuration::ServerFactoryContext& context) {
   absl::Status creation_status = absl::OkStatus();

--- a/source/extensions/filters/http/header_mutation/config.h
+++ b/source/extensions/filters/http/header_mutation/config.h
@@ -25,7 +25,7 @@ private:
                                     const std::string& stats_prefix, DualInfo info,
                                     Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ProtoConfig& proto_config, const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -68,7 +68,8 @@ Http::FilterFactoryCb HealthCheckFilterConfig::createFilterFactoryFromProtoTyped
                                    context.scope());
 }
 
-Http::FilterFactoryCb HealthCheckFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+HealthCheckFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
   return createFilterFactoryHelper(proto_config, stats_prefix, context, context.scope());

--- a/source/extensions/filters/http/health_check/config.h
+++ b/source/extensions/filters/http/health_check/config.h
@@ -20,7 +20,7 @@ private:
       const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -23,8 +23,8 @@ Http::FilterFactoryCb LocalRateLimitFilterConfig::createFilterFactoryFromProtoTy
   };
 }
 
-Http::FilterFactoryCb
-LocalRateLimitFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+LocalRateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {
 

--- a/source/extensions/filters/http/local_ratelimit/config.h
+++ b/source/extensions/filters/http/local_ratelimit/config.h
@@ -23,7 +23,7 @@ private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -25,7 +25,7 @@ absl::StatusOr<Http::FilterFactoryCb> LuaFilterConfig::createFilterFactoryFromPr
   };
 }
 
-Envoy::Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb> LuaFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
   FilterConfigConstSharedPtr filter_config(

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -25,7 +25,7 @@ private:
       const std::string& stats_prefix, DualInfo info,
       Server::Configuration::ServerFactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/mcp/config.cc
+++ b/source/extensions/filters/http/mcp/config.cc
@@ -21,7 +21,7 @@ Http::FilterFactoryCb McpFilterConfigFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb McpFilterConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> McpFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
 

--- a/source/extensions/filters/http/mcp/config.h
+++ b/source/extensions/filters/http/mcp/config.h
@@ -25,7 +25,7 @@ private:
       const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/on_demand/config.cc
+++ b/source/extensions/filters/http/on_demand/config.cc
@@ -20,7 +20,7 @@ Http::FilterFactoryCb OnDemandFilterFactory::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb OnDemandFilterFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> OnDemandFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {
   OnDemandFilterConfigSharedPtr config = std::make_shared<OnDemandFilterConfig>(

--- a/source/extensions/filters/http/on_demand/config.h
+++ b/source/extensions/filters/http/on_demand/config.h
@@ -25,7 +25,7 @@ private:
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
       const std::string&, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/proto_message_extraction/config.cc
+++ b/source/extensions/filters/http/proto_message_extraction/config.cc
@@ -31,8 +31,8 @@ Envoy::Http::FilterFactoryCb FilterFactoryCreator::createFilterFactoryFromProtoT
   };
 }
 
-Envoy::Http::FilterFactoryCb
-FilterFactoryCreator::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Envoy::Http::FilterFactoryCb>
+FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::proto_message_extraction::v3::
         ProtoMessageExtractionConfig& proto_config,
     const std::string&, Envoy::Server::Configuration::ServerFactoryContext& context) {

--- a/source/extensions/filters/http/proto_message_extraction/config.h
+++ b/source/extensions/filters/http/proto_message_extraction/config.h
@@ -27,7 +27,7 @@ private:
           ProtoMessageExtractionConfig& proto_config,
       const std::string&, Envoy::Server::Configuration::FactoryContext&) override;
 
-  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::proto_message_extraction::v3::
           ProtoMessageExtractionConfig& proto_config,
       const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override;

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -24,8 +24,8 @@ Http::FilterFactoryCb RoleBasedAccessControlFilterConfigFactory::createFilterFac
   };
 }
 
-Http::FilterFactoryCb
-RoleBasedAccessControlFilterConfigFactory::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+RoleBasedAccessControlFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
 

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -24,7 +24,7 @@ private:
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;

--- a/source/extensions/filters/http/set_filter_state/config.cc
+++ b/source/extensions/filters/http/set_filter_state/config.cc
@@ -60,13 +60,13 @@ SetFilterStateConfig::createRouteSpecificFilterConfigTyped(
       generic_context, proto_config.clear_route_cache());
 }
 
-Http::FilterFactoryCb SetFilterStateConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> SetFilterStateConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {
 
   // TODO(wbpcode): these is a potential bug of message validation. The validation visitor
   // of server context should not be used here directly. But this is bug of
-  // 'createFilterFactoryFromProtoWithServerContext' and will be fixed in the future.
+  // 'createHttpFilterFactoryFromProto' and will be fixed in the future.
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
 
   const auto filter_config = std::make_shared<Filters::Common::SetFilterState::Config>(

--- a/source/extensions/filters/http/set_filter_state/config.h
+++ b/source/extensions/filters/http/set_filter_state/config.h
@@ -43,7 +43,7 @@ private:
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;

--- a/source/extensions/filters/http/set_metadata/config.cc
+++ b/source/extensions/filters/http/set_metadata/config.cc
@@ -26,7 +26,7 @@ Http::FilterFactoryCb SetMetadataConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb SetMetadataConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> SetMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
   ConfigSharedPtr filter_config(

--- a/source/extensions/filters/http/set_metadata/config.h
+++ b/source/extensions/filters/http/set_metadata/config.h
@@ -23,7 +23,7 @@ private:
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& server_context) override;

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -21,8 +21,8 @@ Http::FilterFactoryCb StatefulSessionFactoryConfig::createFilterFactoryFromProto
   };
 }
 
-Http::FilterFactoryCb
-StatefulSessionFactoryConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+StatefulSessionFactoryConfig::createHttpFilterFactoryFromProtoTyped(
     const ProtoConfig& proto_config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& context) {
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());

--- a/source/extensions/filters/http/stateful_session/config.h
+++ b/source/extensions/filters/http/stateful_session/config.h
@@ -24,7 +24,7 @@ private:
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ProtoConfig& proto_config, const std::string& stats_prefix,
       Server::Configuration::ServerFactoryContext& context) override;
 

--- a/source/extensions/filters/http/thrift_to_metadata/config.cc
+++ b/source/extensions/filters/http/thrift_to_metadata/config.cc
@@ -25,7 +25,7 @@ Http::FilterFactoryCb ThriftToMetadataConfig::createFilterFactoryFromProtoTyped(
   };
 }
 
-Http::FilterFactoryCb ThriftToMetadataConfig::createFilterFactoryFromProtoWithServerContextTyped(
+absl::StatusOr<Http::FilterFactoryCb> ThriftToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata& proto_config,
     const std::string&, Server::Configuration::ServerFactoryContext& context) {
   std::shared_ptr<FilterConfig> config =

--- a/source/extensions/filters/http/thrift_to_metadata/config.h
+++ b/source/extensions/filters/http/thrift_to_metadata/config.h
@@ -23,7 +23,7 @@ private:
       const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
       const std::string&, Server::Configuration::FactoryContext&) override;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
       const std::string&, Server::Configuration::ServerFactoryContext&) override;
 };

--- a/source/extensions/filters/http/wasm/config.h
+++ b/source/extensions/filters/http/wasm/config.h
@@ -46,9 +46,10 @@ public:
         stats_prefix, context, context.serverFactoryContext());
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContext(
-      const Protobuf::Message& proto_config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override {
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                                   const std::string& stats_prefix,
+                                   Server::Configuration::ServerFactoryContext& context) override {
     return createFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const envoy::extensions::filters::http::wasm::v3::Wasm&>(
             proto_config, context.messageValidationVisitor()),

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -146,9 +146,11 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceWithoutInitManagerThrows) {
 
   // The ServerFactoryContext path has no init manager, so remote sources should be rejected.
   DynamicModuleConfigFactory factory;
-  EXPECT_THROW_WITH_REGEX(factory.createFilterFactoryFromProtoWithServerContext(
-                              proto_config, "stats", context_.server_factory_context_),
-                          EnvoyException, "Remote module sources require an init manager");
+  EXPECT_THROW_WITH_REGEX(
+      factory
+          .createHttpFilterFactoryFromProto(proto_config, "stats", context_.server_factory_context_)
+          .value(),
+      EnvoyException, "Remote module sources require an init manager");
 }
 
 TEST_F(DynamicModuleFilterConfigTest, RemoteSourceRegistersInitTarget) {

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -261,8 +261,9 @@ filter_config:
       .WillByDefault(testing::Return(1));
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
-  auto factory_cb = factory.createFilterFactoryFromProtoWithServerContext(
-      proto_config, "", context.server_factory_context_);
+  auto factory_cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "", context.server_factory_context_)
+          .value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
   NiceMock<Event::MockDispatcher> dispatcher{"worker_0"};

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_config_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_config_test.cc
@@ -64,8 +64,10 @@ enabled:
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(testing::AnyNumber());
-  Http::FilterFactoryCb cb = factory.createFilterFactoryFromProtoWithServerContext(
-      *proto_config, "stats", context.server_factory_context_);
+  Http::FilterFactoryCb cb =
+      factory
+          .createHttpFilterFactoryFromProto(*proto_config, "stats", context.server_factory_context_)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -240,9 +240,11 @@ success_criteria:
   AdmissionControlProto proto;
   TestUtility::loadFromYamlAndValidate(yaml, proto);
 
-  // createFilterFactoryFromProtoWithServerContext returns FilterFactoryCb directly
-  auto cb = admission_control_filter_factory.createFilterFactoryFromProtoWithServerContext(
-      proto, "stats_prefix", context_.serverFactoryContext());
+  // createHttpFilterFactoryFromProto returns a StatusOr<FilterFactoryCb>; unwrap with value().
+  auto cb =
+      admission_control_filter_factory
+          .createHttpFilterFactoryFromProto(proto, "stats_prefix", context_.serverFactoryContext())
+          .value();
 
   EXPECT_TRUE(cb != nullptr);
 

--- a/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
@@ -32,7 +32,7 @@ TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterWithS
   AlternateProtocolsCacheFilterFactory factory;
   envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig proto_config;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   NiceMock<Event::MockDispatcher> dispatcher;
   EXPECT_CALL(filter_callback, dispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -397,7 +397,7 @@ invocation_mode: asynchronous
   AwsLambdaFilterFactory factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   auto has_expected_settings = [](std::shared_ptr<Envoy::Http::StreamFilter> stream_filter) {
     auto filter = std::static_pointer_cast<Filter>(stream_filter);

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -774,7 +774,7 @@ match_excluded_headers:
   AwsRequestSigningFilterFactory factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -164,8 +164,7 @@ TEST(Factory, ValidConfigWithServerContext) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  auto callback =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  auto callback = factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -124,7 +124,7 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProtoWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   BufferFilterFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/common/BUILD
+++ b/test/extensions/filters/http/common/BUILD
@@ -56,6 +56,20 @@ envoy_extension_cc_test(
 )
 
 envoy_cc_test(
+    name = "factory_base_test",
+    srcs = ["factory_base_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//envoy/http:filter_interface",
+        "//source/extensions/filters/http/common:factory_base_lib",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "stream_rate_limiter_test",
     srcs = ["stream_rate_limiter_test.cc"],
     rbe_pool = "6gig",

--- a/test/extensions/filters/http/common/factory_base_test.cc
+++ b/test/extensions/filters/http/common/factory_base_test.cc
@@ -1,0 +1,180 @@
+#include "envoy/extensions/filters/http/router/v3/router.pb.h"
+#include "envoy/extensions/filters/http/router/v3/router.pb.validate.h"
+#include "envoy/http/filter.h"
+
+#include "source/extensions/filters/http/common/factory_base.h"
+
+#include "test/mocks/server/factory_context.h"
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace Common {
+namespace {
+
+using RouterProto = envoy::extensions::filters::http::router::v3::Router;
+
+// A minimal concrete filter factory used to test the default (non-overridden) behavior of
+// FactoryBase. It only implements the pure `createFilterFactoryFromProtoTyped` method and relies on
+// the base class defaults for everything else.
+class TestFactoryBase : public FactoryBase<RouterProto> {
+public:
+  TestFactoryBase() : FactoryBase("test.factory_base") {}
+
+  Envoy::Http::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const RouterProto&, const std::string&,
+                                    Server::Configuration::FactoryContext&) override {
+    return [](Envoy::Http::FilterChainFactoryCallbacks&) {};
+  }
+};
+
+// A concrete filter factory used to test the default behavior of ExceptionFreeFactoryBase.
+class TestExceptionFreeFactoryBase : public ExceptionFreeFactoryBase<RouterProto> {
+public:
+  TestExceptionFreeFactoryBase() : ExceptionFreeFactoryBase("test.exception_free_factory_base") {}
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createFilterFactoryFromProtoTyped(const RouterProto&, const std::string&,
+                                    Server::Configuration::FactoryContext&) override {
+    return [](Envoy::Http::FilterChainFactoryCallbacks&) {};
+  }
+};
+
+// A concrete filter factory used to test the default behavior of DualFactoryBase.
+class TestDualFactoryBase : public DualFactoryBase<RouterProto> {
+public:
+  TestDualFactoryBase() : DualFactoryBase("test.dual_factory_base") {}
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createFilterFactoryFromProtoTyped(const RouterProto&, const std::string&, DualInfo,
+                                    Server::Configuration::ServerFactoryContext&) override {
+    return [](Envoy::Http::FilterChainFactoryCallbacks&) {};
+  }
+};
+
+// Exercises the shared CommonFactoryBase helpers: proto factory methods, name and the default
+// terminal-filter and route-config behaviors.
+TEST(FactoryBaseTest, CommonBehavior) {
+  TestFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  EXPECT_EQ("test.factory_base", factory.name());
+
+  // Empty config/route-config protos are created with the templated proto types.
+  EXPECT_NE(nullptr, factory.createEmptyConfigProto());
+  EXPECT_NE(nullptr, factory.createEmptyRouteConfigProto());
+
+  // The default terminal-filter implementation returns false.
+  RouterProto proto_config;
+  EXPECT_FALSE(factory.isTerminalFilterByProto(proto_config, server_context));
+
+  // The default route-specific config implementation returns a nullptr config.
+  auto route_config = factory.createRouteSpecificFilterConfig(
+      proto_config, server_context, server_context.messageValidationVisitor());
+  ASSERT_TRUE(route_config.ok());
+  EXPECT_EQ(nullptr, route_config.value());
+}
+
+// FactoryBase falls back to createFilterFactoryFromProtoWithServerContextTyped for the
+// server-context based creation, which by default throws.
+TEST(FactoryBaseTest, ServerContextNotSupported) {
+  TestFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  RouterProto proto_config;
+
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", server_context),
+      EnvoyException, "Creating filter factory from server factory context is not supported");
+
+  // createHttpFilterFactoryFromProto delegates to the typed variant, which in turn delegates to the
+  // (throwing) server-context implementation.
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).IgnoreError(),
+      EnvoyException, "Creating filter factory from server factory context is not supported");
+}
+
+// FactoryBase's downstream FactoryContext path works and returns a valid factory callback.
+TEST(FactoryBaseTest, FactoryContextCreation) {
+  TestFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  RouterProto proto_config;
+
+  auto cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  ASSERT_TRUE(cb.ok());
+  EXPECT_NE(nullptr, cb.value());
+}
+
+// ExceptionFreeFactoryBase returns an error status (rather than throwing) when server-context based
+// creation is not supported.
+TEST(FactoryBaseTest, ExceptionFreeServerContextNotSupported) {
+  TestExceptionFreeFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  RouterProto proto_config;
+
+  EXPECT_EQ("test.exception_free_factory_base", factory.name());
+
+  auto result = factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(absl::StatusCode::kInvalidArgument, result.status().code());
+  EXPECT_EQ("Creating HTTP filter factory from server factory context is not supported",
+            result.status().message());
+}
+
+// ExceptionFreeFactoryBase's downstream FactoryContext path works.
+TEST(FactoryBaseTest, ExceptionFreeFactoryContextCreation) {
+  TestExceptionFreeFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  RouterProto proto_config;
+
+  auto cb = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  ASSERT_TRUE(cb.ok());
+  EXPECT_NE(nullptr, cb.value());
+}
+
+// DualFactoryBase's downstream and upstream FactoryContext paths both work.
+TEST(FactoryBaseTest, DualFactoryContextCreation) {
+  TestDualFactoryBase factory;
+  RouterProto proto_config;
+
+  EXPECT_EQ("test.dual_factory_base", factory.name());
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> downstream_context;
+  auto downstream_cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", downstream_context);
+  ASSERT_TRUE(downstream_cb.ok());
+  EXPECT_NE(nullptr, downstream_cb.value());
+
+  testing::NiceMock<Server::Configuration::MockUpstreamFactoryContext> upstream_context;
+  auto upstream_cb = factory.createFilterFactoryFromProto(proto_config, "stats", upstream_context);
+  ASSERT_TRUE(upstream_cb.ok());
+  EXPECT_NE(nullptr, upstream_cb.value());
+}
+
+// DualFactoryBase falls back to the (throwing) server-context typed implementation for both the
+// server-context and HTTP filter factory creation paths.
+TEST(FactoryBaseTest, DualServerContextNotSupported) {
+  TestDualFactoryBase factory;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  RouterProto proto_config;
+
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", server_context),
+      EnvoyException,
+      "DualFactoryBase: creating filter factory from server factory context is not supported");
+
+  EXPECT_THROW_WITH_MESSAGE(
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).IgnoreError(),
+      EnvoyException,
+      "DualFactoryBase: creating filter factory from server factory context is not supported");
+}
+
+} // namespace
+} // namespace Common
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -381,7 +381,7 @@ TEST(ConfigTest, TestDynamicConfigInUpstream) {
 }
 
 // For dual filter in downstream, if not overriding
-// createFilterFactoryFromProtoWithServerContext(), Envoy exception will be thrown if only
+// createHttpFilterFactoryFromProto(), Envoy exception will be thrown if only
 // server_factory_context is provided in action_context.
 TEST(ConfigTest, CreateFilterFromServerContextDual) {
   const std::string yaml_string = R"EOF(
@@ -463,7 +463,7 @@ TEST(ConfigTest, DownstreamFilterNoFactoryContext) {
 }
 
 // For downstream filter, if not overriding
-// createFilterFactoryFromProtoWithServerContext(), Envoy exception will be thrown if only
+// createHttpFilterFactoryFromProto(), Envoy exception will be thrown if only
 // server_factory_context is provided in the action_context.
 TEST(ConfigTest, TestDownstreamFilterNoOverridingServerContext) {
   const std::string yaml_string = R"EOF(
@@ -1716,9 +1716,9 @@ public:
                                Server::Configuration::FactoryContext&) override {
     return absl::InvalidArgumentError("boom");
   }
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContext(
-      const Protobuf::Message&, const std::string&,
-      Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
+                                   Server::Configuration::ServerFactoryContext&) override {
     return nullptr;
   }
 };

--- a/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
@@ -32,7 +32,7 @@ TEST(ConnectGrpcBridgeFilterConfigTest, ConnectGrpcBridgeFilterWithServerContext
   ConnectGrpcFilterConfigFactory factory;
   envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig config;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_)).Times(AtLeast(1));
   cb(filter_callback);

--- a/test/extensions/filters/http/cors/config_test.cc
+++ b/test/extensions/filters/http/cors/config_test.cc
@@ -29,7 +29,7 @@ TEST(CorsFilterConfigTest, CorsFilterWithServerContext) {
   CorsFilterFactory factory;
   envoy::extensions::filters::http::cors::v3::Cors config;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/credential_injector/config_test.cc
+++ b/test/extensions/filters/http/credential_injector/config_test.cc
@@ -52,7 +52,7 @@ TEST(Factory, ValidConfigWithServerContext) {
   CredentialInjectorFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_THROW_WITH_REGEX(
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context),
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value(),
       EnvoyException,
       ".*Didn't find a registered implementation for 'undefined_credential' with "
       "type URL: 'test.mock_credential.Unregistered'.*");

--- a/test/extensions/filters/http/csrf/csrf_config_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_config_test.cc
@@ -37,7 +37,7 @@ TEST(CsrfFilterConfigTest, ServerContextOnlyFactory) {
   CsrfFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  auto cb = factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+  auto cb = factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   EXPECT_NE(cb, nullptr);
 
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -213,7 +213,7 @@ TEST_F(ExtAuthzFilterHttpTest, FilterWithServerContext) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -105,7 +105,7 @@ TEST(HttpExtProcConfigTest, CorrectGrpcServiceConfigServerContext) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -132,7 +132,7 @@ TEST(HttpExtProcConfigTest, CorrectHttpServiceConfigServerContext) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(testing::AtLeast(1));
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -332,7 +332,7 @@ TEST(HttpExtProcConfigTest, InvalidServiceConfigServerContext) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context),
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value(),
       EnvoyException, "One and only one of grpc_service or http_service must be configured");
 }
 
@@ -402,7 +402,7 @@ TEST(HttpExtProcConfigTest, UpstreamConfig) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -63,7 +63,7 @@ TEST(FaultFilterConfigTest, FaultFilterCorrectJsonWithServerContext) {
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FaultFilterFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/file_system_buffer/config_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/config_test.cc
@@ -320,7 +320,7 @@ TEST_F(FileSystemBufferFilterConfigTest, ValidConfigWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FileSystemBufferFilterFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/filter_chain/filter_test.cc
+++ b/test/extensions/filters/http/filter_chain/filter_test.cc
@@ -45,9 +45,9 @@ public:
     };
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContext(
-      const Protobuf::Message&, const std::string&,
-      Server::Configuration::ServerFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
+                                   Server::Configuration::ServerFactoryContext&) override {
     return [this](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(std::make_shared<Http::MockStreamDecoderFilter>());
       filter_added_++;

--- a/test/extensions/filters/http/grpc_field_extraction/config_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/config_test.cc
@@ -47,7 +47,7 @@ TEST_F(GrpcFieldExtractionFilterFactoryTest, CreateFilterFactoryFromProtoWithSer
   FilterFactoryCreator factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config_, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
@@ -28,7 +28,7 @@ TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilterWithServerContext) {
   GrpcHttp1BridgeFilterConfig factory;
   envoy::extensions::filters::http::grpc_http1_bridge::v3::Config config;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -68,7 +68,7 @@ withhold_grpc_frames: true
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Config config_factory;
   Http::FilterFactoryCb cb =
-      config_factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      config_factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
@@ -31,10 +31,12 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
 
 TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFailWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_THROW(GrpcJsonReverseTranscoderFactory().createFilterFactoryFromProtoWithServerContext(
-                   envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
-                       GrpcJsonReverseTranscoder(),
-                   "stats", context),
+  EXPECT_THROW(GrpcJsonReverseTranscoderFactory()
+                   .createHttpFilterFactoryFromProto(
+                       envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
+                           GrpcJsonReverseTranscoder(),
+                       "stats", context)
+                   .value(),
                ProtoValidationException);
 }
 
@@ -71,7 +73,7 @@ TEST_F(GrpcJsonReverseTranscoderFilterFactoryTest, CreateFilterFactoryFromProtoW
   GrpcJsonReverseTranscoderFactory factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config_, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
@@ -31,10 +31,13 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
 
 TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFailWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_THROW(GrpcJsonTranscoderFilterConfig().createFilterFactoryFromProtoWithServerContext(
-                   envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder(),
-                   "stats", context),
-               ProtoValidationException);
+  EXPECT_THROW(
+      GrpcJsonTranscoderFilterConfig()
+          .createHttpFilterFactoryFromProto(
+              envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder(),
+              "stats", context)
+          .value(),
+      ProtoValidationException);
 }
 
 class GrpcJsonTranscoderFilterFactoryTest : public testing::Test {
@@ -70,7 +73,7 @@ TEST_F(GrpcJsonTranscoderFilterFactoryTest, CreateFilterFactoryFromProtoWithServ
   GrpcJsonTranscoderFilterConfig factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config_, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_web/config_test.cc
+++ b/test/extensions/filters/http/grpc_web/config_test.cc
@@ -28,7 +28,7 @@ TEST(GrpcWebFilterConfigTest, GrpcWebFilterWithServerContext) {
   GrpcWebFilterConfig factory;
   envoy::extensions::filters::http::grpc_web::v3::GrpcWeb config;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/header_mutation/config_test.cc
+++ b/test/extensions/filters/http/header_mutation/config_test.cc
@@ -206,8 +206,13 @@ TEST(FactoryTest, FactoryTestWithServerContext) {
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config, proto_config);
 
-  auto cb = factory->createFilterFactoryFromProtoWithServerContext(proto_config, "test",
-                                                                   mock_server_context);
+  // The typed createHttpFilterFactoryFromProto overload is only visible on the concrete factory
+  // type (the base NamedHttpFilterConfigFactory pointer exposes only the Protobuf::Message
+  // overload, which routes through the legacy path).
+  HeaderMutationFactoryConfig header_mutation_factory;
+  auto cb = header_mutation_factory
+                .createHttpFilterFactoryFromProto(proto_config, "test", mock_server_context)
+                .value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -297,7 +297,7 @@ TEST(HealthCheckFilterConfig, HealthCheckFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   HealthCheckFilterConfig factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -425,8 +425,7 @@ stat_prefix: test
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  auto callback =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+  auto callback = factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -62,7 +62,7 @@ TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCodeWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   LuaFilterConfig factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/mcp/config_test.cc
+++ b/test/extensions/filters/http/mcp/config_test.cc
@@ -57,8 +57,8 @@ TEST_F(McpFilterConfigTest, CreateFilterWithServerContext) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
 
-  Http::FilterFactoryCb cb = factory_->createFilterFactoryFromProtoWithServerContext(
-      proto_config, "stats", server_context);
+  Http::FilterFactoryCb cb =
+      factory_->createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
 
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));

--- a/test/extensions/filters/http/on_demand/config_test.cc
+++ b/test/extensions/filters/http/on_demand/config_test.cc
@@ -31,7 +31,7 @@ TEST(OnDemandFilterConfigTest, OnDemandFilterWithServerContext) {
   envoy::extensions::filters::http::on_demand::v3::OnDemand config;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/proto_message_extraction/filter_config_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/filter_config_test.cc
@@ -512,7 +512,7 @@ TEST(FilterFactoryCreatorTest, CreateFilterFactoryFromProtoWithServerContext) {
           .value();
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   testing::NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(testing::_));
   cb(filter_callback);

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -133,7 +133,7 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidProtoWithServerContext)
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   RoleBasedAccessControlFilterConfigFactory factory;
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/set_filter_state/integration_test.cc
+++ b/test/extensions/filters/http/set_filter_state/integration_test.cc
@@ -47,8 +47,10 @@ public:
     {
       SetFilterStateConfig factory;
       auto cb_1 = factory.createFilterFactoryFromProto(proto_config, "", context_);
-      auto cb_2 = factory.createFilterFactoryFromProtoWithServerContext(
-          proto_config, "", context_.server_factory_context_);
+      auto cb_2 =
+          factory
+              .createHttpFilterFactoryFromProto(proto_config, "", context_.server_factory_context_)
+              .value();
 
       NiceMock<Http::MockFilterChainFactoryCallbacks> filter_chain_factory_callbacks;
 

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -77,7 +77,7 @@ metadata:
   SetMetadataConfig factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -107,7 +107,7 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTestWithServerContext) {
   StatefulSessionFactoryConfig factory;
 
   Http::FilterFactoryCb cb =
-      factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", context);
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/thrift_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/thrift_to_metadata/config_test.cc
@@ -185,8 +185,7 @@ request_rules:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
-  auto callback =
-      factory.createFilterFactoryFromProtoWithServerContext(*proto_config, "stats", context);
+  auto callback = factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -187,11 +187,15 @@ TEST_P(WasmFilterConfigTest, CreateFilterFactoryFromProtoWithServerContext) {
   WasmFilterConfig factory;
   Http::FilterFactoryCb cb;
   if (std::get<2>(GetParam())) {
-    cb = factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats",
-                                                               context_.server_factory_context_);
+    cb = factory
+             .createHttpFilterFactoryFromProto(proto_config, "stats",
+                                               context_.server_factory_context_)
+             .value();
   } else {
-    cb = factory.createFilterFactoryFromProtoWithServerContext(
-        proto_config, "stats", upstream_factory_context_.server_factory_context_);
+    cb = factory
+             .createHttpFilterFactoryFromProto(proto_config, "stats",
+                                               upstream_factory_context_.server_factory_context_)
+             .value();
   }
 
   EXPECT_CALL(init_watcher_, ready());

--- a/test/integration/filters/server_factory_context_filter.cc
+++ b/test/integration/filters/server_factory_context_filter.cc
@@ -136,7 +136,7 @@ private:
     return nullptr;
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::ServerFactoryContextFilterConfig& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& server_context) override {
     FilterConfigSharedPtr filter_config =
@@ -175,7 +175,7 @@ private:
     };
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::ServerFactoryContextFilterConfigDual& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& server_context) override {
     auto filter_config =

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -95,7 +95,7 @@ private:
       callbacks.addStreamFilter(std::make_shared<SetResponseCodeFilter>(filter_config));
     };
   }
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::SetResponseCodeFilterConfig& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& context) override {
     auto filter_config = std::make_shared<SetResponseCodeFilterConfig>(
@@ -136,7 +136,7 @@ private:
     };
   }
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoWithServerContextTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::SetResponseCodeFilterConfigDual& proto_config,
       const std::string&, Server::Configuration::ServerFactoryContext& context) override {
     auto filter_config = std::make_shared<SetResponseCodeFilterConfig>(
@@ -163,7 +163,7 @@ REGISTER_FACTORY(UpstreamSetResponseCodeFilterFactoryDual,
                  Server::Configuration::UpstreamHttpFilterConfigFactory);
 
 // Adding below factory to test downstream filter without overriding method
-// createFilterFactoryFromProtoWithServerContextTyped().
+// createHttpFilterFactoryFromProtoTyped().
 class SetResponseCodeFilterFactoryNoServerContext
     : public Extensions::HttpFilters::Common::FactoryBase<
           test::integration::filters::SetResponseCodeFilterConfigNoServerContext,
@@ -189,7 +189,7 @@ REGISTER_FACTORY(SetResponseCodeFilterFactoryNoServerContext,
                  Server::Configuration::NamedHttpFilterConfigFactory);
 
 // Adding below factory to test dual filter without overriding method
-// createFilterFactoryFromProtoWithServerContextTyped().
+// createHttpFilterFactoryFromProtoTyped().
 class SetResponseCodeFilterFactoryDualNoServerContext
     : public Extensions::HttpFilters::Common::DualFactoryBase<
           test::integration::filters::SetResponseCodeFilterConfigDualNoServerContext,


### PR DESCRIPTION
Commit Message: http: new exception free method for server context only filter factory creation
Additional Description:

This added a new `createHttpFilterFactoryFromProto` method to replace the previous `createFilterFactoryFromProtoWithServerContext` for exception free migration.

This PR kept the backwards compatibility and won't break any forks.

Risk Level: low.
Testing: unit/integration.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.