### PR TITLE
Fix posix thread crash for EMSCRIPTEN and wasm in posix

### DIFF
--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -28,6 +28,8 @@ int64_t getCurrentThreadIdBase() {
   uint64_t tid;
   pthread_threadid_np(nullptr, &tid);
   return tid;
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  return static_cast<int64_t>(pthread_self());
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
@@ -58,6 +60,9 @@ void setThreadPriority(const int64_t tid, const int priority) {
       reinterpret_cast<void (*)(id, SEL, double)>(objc_msgSend);
   double ns_priority = static_cast<double>(priority) / 100.0;
   setNSThreadPriority(current_thread, sel_registerName("setThreadPriority:"), ns_priority);
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  UNREFERENCED_PARAMETER(tid);
+  UNREFERENCED_PARAMETER(priority);
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
@@ -161,7 +166,7 @@ bool PosixThread::joinable() const { return !joined_; }
 
 ThreadId PosixThread::pthreadId() const {
   ASSERT(!joined_);
-#if defined(__linux__)
+#if defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__wasm__)
   return ThreadId(static_cast<int64_t>(thread_handle_->handle()));
 #elif defined(__APPLE__)
   uint64_t tid;
@@ -236,13 +241,15 @@ int PosixThreadFactory::currentThreadPriority() const {
       reinterpret_cast<double (*)(Class, SEL)>(objc_msgSend);
   double thread_priority = getNSThreadPriority(nsthread, selector);
   return static_cast<int>(std::round(thread_priority * 100.0));
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  return 0;
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
 }
 
 ThreadId PosixThreadFactory::currentPthreadId() const {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__wasm__)
   return static_cast<ThreadId>(static_cast<int64_t>(pthread_self()));
 #elif defined(__APPLE__)
   uint64_t tid;

--- a/source/common/common/posix/thread_impl.cc
+++ b/source/common/common/posix/thread_impl.cc
@@ -28,6 +28,8 @@ int64_t getCurrentThreadIdBase() {
   uint64_t tid;
   pthread_threadid_np(nullptr, &tid);
   return tid;
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  return static_cast<int64_t>(pthread_self());
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
@@ -51,6 +53,9 @@ void setThreadPriority(const int64_t tid, const int priority) {
       reinterpret_cast<void (*)(id, SEL, double)>(objc_msgSend);
   double ns_priority = static_cast<double>(priority) / 100.0;
   setNSThreadPriority(current_thread, sel_registerName("setThreadPriority:"), ns_priority);
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  UNREFERENCED_PARAMETER(tid);
+  UNREFERENCED_PARAMETER(priority);
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
@@ -161,7 +166,7 @@ bool PosixThread::joinable() const { return !joined_; }
 
 ThreadId PosixThread::pthreadId() const {
   ASSERT(!joined_);
-#if defined(__linux__)
+#if defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__wasm__)
   return ThreadId(static_cast<int64_t>(thread_handle_->handle()));
 #elif defined(__APPLE__)
   uint64_t tid;
@@ -236,13 +241,15 @@ int PosixThreadFactory::currentThreadPriority() const {
       reinterpret_cast<double (*)(Class, SEL)>(objc_msgSend);
   double thread_priority = getNSThreadPriority(nsthread, selector);
   return static_cast<int>(std::round(thread_priority * 100.0));
+#elif defined(__EMSCRIPTEN__) || defined(__wasm__)
+  return 0;
 #else
 #error "Enable and test pthread id retrieval code for you arch in pthread/thread_impl.cc"
 #endif
 }
 
 ThreadId PosixThreadFactory::currentPthreadId() const {
-#if defined(__linux__)
+#if defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__wasm__)
   return static_cast<ThreadId>(static_cast<int64_t>(pthread_self()));
 #elif defined(__APPLE__)
   uint64_t tid;


### PR DESCRIPTION
Commit Message: Fix posix thread crash for EMSCRIPTEN and wasm in posix
Additional Description: No OS Scheduler APIs in wasm/Emscripten causes errors from thread_impl. Use the calling thread id from pthread_self for such cases.
Risk Level: low
Testing: Unit tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a