### PR TITLE
uhv: validate repeated content-length values

### DIFF
--- a/source/extensions/http/header_validators/envoy_default/BUILD
+++ b/source/extensions/http/header_validators/envoy_default/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         ":path_normalizer",
         "//envoy/http:header_validator_errors",
         "//envoy/http:header_validator_interface",
+        "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "@abseil-cpp//absl/container:node_hash_map",
         "@abseil-cpp//absl/container:node_hash_set",

--- a/source/extensions/http/header_validators/envoy_default/header_validator.cc
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.cc
@@ -4,6 +4,7 @@
 
 #include "envoy/http/header_validator_errors.h"
 
+#include "source/common/http/header_utility.h"
 #include "source/common/http/path_utility.h"
 #include "source/common/runtime/runtime_features.h"
 
@@ -252,21 +253,12 @@ HeaderValidator::validateGenericHeaderValue(const HeaderString& value) {
 
 HeaderValidator::HeaderValueValidationResult
 HeaderValidator::validateContentLengthHeader(const HeaderString& value) {
-  // From RFC 9110, https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6:
-  //
-  // Content-Length = 1*DIGIT
-  // TODO(#23315) - Validate multiple Content-Length values
-  const auto value_string_view = value.getStringView();
-
-  if (value_string_view.empty()) {
-    return {HeaderValueValidationResult::Action::Reject,
-            UhvResponseCodeDetail::get().InvalidContentLength};
-  }
-
-  std::uint64_t int_value{};
-  auto result = fromChars(value_string_view, int_value);
-  if (result.ec != std::errc() ||
-      result.ptr != (value_string_view.data() + value_string_view.size())) {
+  bool should_close_connection = false;
+  size_t unused_content_length = 0;
+  const auto result = ::Envoy::Http::HeaderUtility::validateContentLength(
+      value.getStringView(), true /*override_stream_error_on_invalid_http_message*/,
+      should_close_connection, unused_content_length);
+  if (result != ::Envoy::Http::HeaderUtility::HeaderValidationResult::ACCEPT) {
     return {HeaderValueValidationResult::Action::Reject,
             UhvResponseCodeDetail::get().InvalidContentLength};
   }

--- a/source/extensions/http/header_validators/envoy_default/header_validator.h
+++ b/source/extensions/http/header_validators/envoy_default/header_validator.h
@@ -55,11 +55,8 @@ public:
   HeaderValueValidationResult validateGenericHeaderValue(const ::Envoy::Http::HeaderString& value);
 
   /*
-   * Validate the Content-Length request and response header as a whole number integer. The RFC
-   * states that multiple Content-Length values are acceptable if they are all the same value.
-   * However, UHV does not allow multiple values currently because the comma character will be
-   * rejected. We can add an option to allow multiple Content-Length values in the future if
-   * needed.
+   * Validate the Content-Length request and response header. RFC 9110 Section 8.6 states that
+   * multiple Content-Length values are acceptable if they are all the same value.
    */
   HeaderValueValidationResult validateContentLengthHeader(const ::Envoy::Http::HeaderString& value);
 

--- a/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/base_header_validator_test.cc
@@ -158,11 +158,22 @@ TEST_F(BaseHeaderValidatorTest, ValidateGenericHeaderValue) {
 TEST_F(BaseHeaderValidatorTest, ValidateContentLength) {
   HeaderString valid{"100"};
   HeaderString invalid{"10a2"};
+  HeaderString valid_multiple{"100,100"};
+  HeaderString invalid_multiple{"100,101"};
+  HeaderString invalid_multiple_empty_first{",100"};
+  HeaderString invalid_multiple_empty_last{"100,"};
   HeaderString invalid_overflow{"18446744073709551618"}; // UINT64_MAX + 1
   auto uhv = createBase(empty_config);
 
   EXPECT_ACCEPT(uhv->validateContentLengthHeader(valid));
+  EXPECT_ACCEPT(uhv->validateContentLengthHeader(valid_multiple));
   EXPECT_REJECT_WITH_DETAILS(uhv->validateContentLengthHeader(invalid),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateContentLengthHeader(invalid_multiple),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateContentLengthHeader(invalid_multiple_empty_first),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateContentLengthHeader(invalid_multiple_empty_last),
                              UhvResponseCodeDetail::get().InvalidContentLength);
   EXPECT_REJECT_WITH_DETAILS(uhv->validateContentLengthHeader(invalid_overflow),
                              UhvResponseCodeDetail::get().InvalidContentLength);

--- a/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http1_header_validator_test.cc
@@ -125,6 +125,13 @@ TEST_F(Http1HeaderValidatorTest, ValidateRequestContentLength) {
   request_headers.setContentLength("100");
   EXPECT_ACCEPT(uhv->validateRequestHeaders(request_headers));
 
+  request_headers.setContentLength("100,100");
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(request_headers));
+
+  request_headers.setContentLength("100,101");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaders(request_headers),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+
   request_headers.setContentLength("10a2");
   EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaders(request_headers),
                              UhvResponseCodeDetail::get().InvalidContentLength);
@@ -391,6 +398,13 @@ TEST_F(Http1HeaderValidatorTest, ResponseContentLengthNoTransferEncoding) {
   // The transform method should keep content-length
   EXPECT_ACCEPT(uhv->transformResponseHeaders(headers));
   EXPECT_EQ(headers.getContentLengthValue(), "10");
+
+  headers.setContentLength("10,10");
+  EXPECT_ACCEPT(uhv->validateResponseHeaders(headers));
+
+  headers.setContentLength("10,11");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaders(headers),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
 }
 
 TEST_F(Http1HeaderValidatorTest, ValidateRequestHeaderMapConnectRegNameMissingPort) {

--- a/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
+++ b/test/extensions/http/header_validators/envoy_default/http2_header_validator_test.cc
@@ -506,6 +506,13 @@ TEST_F(Http2HeaderValidatorTest, ValidateRequestHeaderContentLength) {
   request_headers.setContentLength("100");
   EXPECT_ACCEPT(uhv->validateRequestHeaders(request_headers));
 
+  request_headers.setContentLength("100,100");
+  EXPECT_ACCEPT(uhv->validateRequestHeaders(request_headers));
+
+  request_headers.setContentLength("100,101");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaders(request_headers),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
+
   request_headers.setContentLength("10a2");
   EXPECT_REJECT_WITH_DETAILS(uhv->validateRequestHeaders(request_headers),
                              UhvResponseCodeDetail::get().InvalidContentLength);
@@ -516,6 +523,13 @@ TEST_F(Http2HeaderValidatorTest, ValidateResponseHeaderContentLength) {
   TestResponseHeaderMapImpl response_headers = makeGoodResponseHeaders();
   response_headers.setContentLength("100");
   EXPECT_ACCEPT(uhv->validateResponseHeaders(response_headers));
+
+  response_headers.setContentLength("100,100");
+  EXPECT_ACCEPT(uhv->validateResponseHeaders(response_headers));
+
+  response_headers.setContentLength("100,101");
+  EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaders(response_headers),
+                             UhvResponseCodeDetail::get().InvalidContentLength);
 
   response_headers.setContentLength("10a2");
   EXPECT_REJECT_WITH_DETAILS(uhv->validateResponseHeaders(response_headers),


### PR DESCRIPTION
Reuse the shared Content-Length validation helper in Envoy's default header validator so comma-joined duplicate Content-Length values are accepted only when each value matches.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: uhv: validate repeated content-length values
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
