### PR TITLE
Allow more ping frames for slower builds

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -629,7 +629,8 @@ TEST_P(QuicHttpIntegrationTest, Http3ClientKeepalive) {
   EXPECT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   // First 6 PING frames should be sent every 1s, and the following ones less frequently.
-  EXPECT_LE(quic_connection_->GetStats().ping_frames_sent, 8u);
+  constexpr uint64_t expected_pings = 9u * TIMEOUT_FACTOR;
+  EXPECT_LE(quic_connection_->GetStats().ping_frames_sent, expected_pings);
 }
 
 TEST_P(QuicHttpIntegrationTest, Http3ClientKeepaliveDisabled) {


### PR DESCRIPTION
Tests using slower builds (like ASAN) can produce more ping frames. Also bump number of expected frames on base builds by 1 as they were flaky as well, sometimes producing 9 frames.

Risk Level: none
Testing: unit test
Docs Changes: no
Release Notes: no
Platform Specific Features: no
