### PR TITLE
dynamic_modules: add runtime feature flag ABI callback

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -496,6 +496,21 @@ void envoy_dynamic_module_callback_log(envoy_dynamic_module_type_log_level level
  */
 bool envoy_dynamic_module_callback_log_enabled(envoy_dynamic_module_type_log_level level);
 
+// --------------------------------- Runtime -----------------------------------
+
+/**
+ * envoy_dynamic_module_callback_runtime_feature_enabled is called by the module to check if a
+ * runtime feature flag is enabled. This can be used to dynamically toggle module behavior without
+ * restarting Envoy by using RTDS or admin runtime overrides.
+ *
+ * This is thread-safe and can be called from any thread.
+ *
+ * @param key is the runtime feature key to check.
+ * @return true if the key exists and is set to a truthy value, false otherwise.
+ */
+bool envoy_dynamic_module_callback_runtime_feature_enabled(
+    envoy_dynamic_module_type_module_buffer key);
+
 // --------------------------------- Threading -----------------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -85,6 +85,19 @@ uint32_t envoy_dynamic_module_callback_get_concurrency() {
   return context->options().concurrency();
 }
 
+bool envoy_dynamic_module_callback_runtime_feature_enabled(
+    envoy_dynamic_module_type_module_buffer key) {
+  using namespace Envoy;
+  auto context = Server::Configuration::ServerFactoryContextInstance::getExisting();
+  if (context == nullptr) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_runtime_feature_enabled called before the server "
+                 "context was initialized");
+    return false;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  return context->runtime().snapshot().getBoolean(key_view, false);
+}
+
 bool envoy_dynamic_module_callback_is_validation_mode() {
   using namespace Envoy;
   if (!Thread::MainThread::isMainOrTestThread()) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -200,6 +200,28 @@ pub unsafe fn is_validation_mode() -> bool {
   unsafe { abi::envoy_dynamic_module_callback_is_validation_mode() }
 }
 
+/// Check if a runtime feature flag is enabled. Returns `true` if the key exists and is set to a
+/// truthy value, `false` otherwise.
+#[macro_export]
+macro_rules! runtime_feature_enabled {
+  ($key:expr) => {{
+    #[cfg(not(test))]
+    {
+      let key: &str = $key;
+      let buf = $crate::abi::envoy_dynamic_module_type_module_buffer {
+        ptr: key.as_ptr() as *const ::std::os::raw::c_char,
+        length: key.len(),
+      };
+      unsafe { $crate::abi::envoy_dynamic_module_callback_runtime_feature_enabled(buf) }
+    }
+    #[cfg(test)]
+    {
+      let _ = $key;
+      false
+    }
+  }};
+}
+
 /// Register a function pointer under a name in the process-wide function registry.
 ///
 /// This allows modules loaded in the same process to expose functions that other modules can
@@ -1185,8 +1207,8 @@ pub static NEW_FORMATTER_CONFIG_FUNCTION: OnceLock<NewFormatterConfigFunction> =
 /// # Example
 ///
 /// ```
-/// use envoy_proxy_dynamic_modules_rust_sdk::*;
 /// use envoy_proxy_dynamic_modules_rust_sdk::formatter::*;
+/// use envoy_proxy_dynamic_modules_rust_sdk::*;
 ///
 /// fn program_init() -> bool {
 ///   true

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -8091,3 +8091,8 @@ fn test_mock_envoy_transport_socket_fd_and_write_rearm() {
     IoResult::keep_open(0, false)
   );
 }
+
+#[test]
+fn test_runtime_feature_enabled() {
+  assert!(!runtime_feature_enabled!("some.feature.flag"));
+}

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -252,6 +252,37 @@ TEST(CommonAbiImplTest, SharedDataRegistryMultipleKeys) {
 }
 
 // =============================================================================
+// Runtime Feature Tests
+// =============================================================================
+
+TEST(CommonAbiImplTest, RuntimeFeatureEnabledReturnsTrue) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.runtime_loader_.snapshot_, getBoolean("my.feature.flag", false))
+      .WillByDefault(Return(true));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  envoy_dynamic_module_type_module_buffer key = {"my.feature.flag", 15};
+  EXPECT_TRUE(envoy_dynamic_module_callback_runtime_feature_enabled(key));
+}
+
+TEST(CommonAbiImplTest, RuntimeFeatureEnabledReturnsFalse) {
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  ON_CALL(context.runtime_loader_.snapshot_, getBoolean("my.feature.flag", false))
+      .WillByDefault(Return(false));
+
+  ScopedThreadLocalServerContextSetter setter(context);
+  envoy_dynamic_module_type_module_buffer key = {"my.feature.flag", 15};
+  EXPECT_FALSE(envoy_dynamic_module_callback_runtime_feature_enabled(key));
+}
+
+TEST(CommonAbiImplTest, RuntimeFeatureEnabledBeforeServerContextFailsClosed) {
+  envoy_dynamic_module_type_module_buffer key = {"my.feature.flag", 15};
+  EXPECT_ENVOY_BUG(EXPECT_FALSE(envoy_dynamic_module_callback_runtime_feature_enabled(key)),
+                   "envoy_dynamic_module_callback_runtime_feature_enabled called before the server "
+                   "context was initialized");
+}
+
+// =============================================================================
 // Weak symbol stub tests for network filter, listener filter, access logger, and
 // UDP listener filter callbacks. These verify that the weak stubs installed in
 // abi_impl.cc trigger ENVOY_BUG when called from a context that does not compile


### PR DESCRIPTION
Commit Message:
Add envoy_dynamic_module_callback_runtime_feature_enabled to allow dynamic modules to check runtime boolean flags via RTDS or admin overrides without restarting Envoy. 

Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
