### PR TITLE
api: fix description for ORCA utilization precedence and document weight derivation

### DIFF
--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -34,11 +34,11 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // For a load report to update an endpoint's weight it must set :ref:`rps_fractional
 // <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.rps_fractional>` (used as
-// qps) greater than 0 and provide a utilization signal greater than 0 (see
+// qps) greater than 0, and the resolved utilization (see
 // :ref:`metric_names_for_computing_utilization
-// <envoy_v3_api_field_extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin.metric_names_for_computing_utilization>`).
-// Reports that fail to do so are ignored, and an endpoint with no valid weight is
-// assigned the median weight of the endpoints that have one.
+// <envoy_v3_api_field_extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin.metric_names_for_computing_utilization>`)
+// must be greater than 0. Reports that fail to do so are ignored, and an endpoint
+// with no valid weight is assigned the median weight of the endpoints that have one.
 //
 // Note that Envoy will forward the ORCA response headers/trailers from the upstream
 // cluster to the downstream client. This means that if the downstream client is also

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -32,12 +32,13 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // endpoint weights using eps and qps. The weight of a given endpoint is computed
 // as: ``qps / (utilization + eps/qps * error_utilization_penalty)``.
 //
-// For a load report to update an endpoint's weight it must set :ref:`rps_fractional
+// For a load report to update an endpoint's weight, it must set :ref:`rps_fractional
 // <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.rps_fractional>` (used as
-// qps) greater than 0, and the resolved utilization (see
+// qps) greater than 0, and the final utilization (resolved utilization plus any
+// error penalty) must be greater than 0. Resolved utilization (see
 // :ref:`metric_names_for_computing_utilization
 // <envoy_v3_api_field_extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin.metric_names_for_computing_utilization>`)
-// must be greater than 0. Reports that fail to do so are ignored, and an endpoint
+// is used as the baseline. Reports that fail to do so are ignored, and an endpoint
 // with no valid weight is assigned the median weight of the endpoints that have one.
 //
 // Note that Envoy will forward the ORCA response headers/trailers from the upstream

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -79,10 +79,11 @@ message ClientSideWeightedRoundRobin {
   // Default is 1.0.
   google.protobuf.FloatValue error_utilization_penalty = 6 [(validate.rules).float = {gte: 0.0}];
 
-  // By default, endpoint weight is computed based on the :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>` field reported by the endpoint.
-  // If that field is not set, then utilization will instead be computed by taking the max of the values of the metrics specified here.
+  // Specifies the metrics used to compute the endpoint utilization from which weight is derived.
   // For map fields in the ORCA proto, the string will be of the form ``<map_field_name>.<map_key>``. For example, the string ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA :ref:`named_metrics <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.named_metrics>` field.
-  // If none of the specified metrics are present in the load report, then :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>` is used instead.
+  // Utilization is the max of the values of the metrics specified here, when that max is greater than 0.
+  // Otherwise :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>` is used if greater than 0, with :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>` as the final fallback.
+  // Disabling the runtime flag ``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first`` restores the legacy order, preferring ``application_utilization`` over these metrics.
   repeated string metric_names_for_computing_utilization = 7;
 
   // Configuration for slow start mode.

--- a/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
+++ b/api/envoy/extensions/load_balancing_policies/client_side_weighted_round_robin/v3/client_side_weighted_round_robin.proto
@@ -26,13 +26,19 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // the endpoint weights are sent by the control plane via EDS. However,
 // in this policy, the endpoint weights are instead determined via qps (queries
 // per second), eps (errors per second), and utilization metrics sent by the
-// endpoint using the Open Request Cost Aggregation (ORCA) protocol. Utilization
-// is determined by using the ORCA application_utilization field, if set, or
-// else falling back to the cpu_utilization field. All queries count toward qps,
-// regardless of result. Only failed queries count toward eps. A config
-// parameter error_utilization_penalty controls the penalty to adjust endpoint
-// weights using eps and qps. The weight of a given endpoint is computed as:
-// ``qps / (utilization + eps/qps * error_utilization_penalty)``.
+// endpoint using the Open Request Cost Aggregation (ORCA) protocol. All queries
+// count toward qps, regardless of result. Only failed queries count toward eps.
+// A config parameter error_utilization_penalty controls the penalty to adjust
+// endpoint weights using eps and qps. The weight of a given endpoint is computed
+// as: ``qps / (utilization + eps/qps * error_utilization_penalty)``.
+//
+// For a load report to update an endpoint's weight it must set :ref:`rps_fractional
+// <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.rps_fractional>` (used as
+// qps) greater than 0 and provide a utilization signal greater than 0 (see
+// :ref:`metric_names_for_computing_utilization
+// <envoy_v3_api_field_extensions.load_balancing_policies.client_side_weighted_round_robin.v3.ClientSideWeightedRoundRobin.metric_names_for_computing_utilization>`).
+// Reports that fail to do so are ignored, and an endpoint with no valid weight is
+// assigned the median weight of the endpoints that have one.
 //
 // Note that Envoy will forward the ORCA response headers/trailers from the upstream
 // cluster to the downstream client. This means that if the downstream client is also

--- a/api/envoy/extensions/load_balancing_policies/load_aware_locality/v3/load_aware_locality.proto
+++ b/api/envoy/extensions/load_balancing_policies/load_aware_locality/v3/load_aware_locality.proto
@@ -32,17 +32,20 @@ message LoadAwareLocality {
   google.protobuf.Duration weight_update_period = 2
       [(validate.rules).duration = {gte {nanos: 100000000}}];
 
-  // By default, endpoint utilization is computed based on the
-  // :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>`
-  // field reported by the endpoint. If that field is not set, then utilization
-  // will instead be computed by taking the max of the values of the metrics
-  // specified here. For map fields in the ORCA proto, the string will be of
-  // the form ``<map_field_name>.<map_key>``. For example, the string
+  // Specifies the metrics used to compute endpoint utilization. For map
+  // fields in the ORCA proto, the string will be of the form
+  // ``<map_field_name>.<map_key>``. For example, the string
   // ``named_metrics.foo`` will mean to look for the key ``foo`` in the ORCA
   // :ref:`named_metrics <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.named_metrics>`
-  // field. If none of the specified metrics are present in the load report,
-  // then :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>`
-  // is used instead.
+  // field. Utilization is the max of the values of the metrics specified
+  // here, when that max is greater than 0. Otherwise
+  // :ref:`application_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.application_utilization>`
+  // is used if greater than 0, with
+  // :ref:`cpu_utilization <envoy_v3_api_field_.xds.data.orca.v3.OrcaLoadReport.cpu_utilization>`
+  // as the final fallback. Disabling the runtime flag
+  // ``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first``
+  // restores the legacy order, preferring ``application_utilization`` over
+  // these metrics.
   repeated string metric_names_for_computing_utilization = 3;
 
   // When the local locality's utilization is at most this threshold above the

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_aware_locality.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_aware_locality.rst
@@ -136,10 +136,9 @@ extraction as CSWRR (precedence may be flipped by the
 ``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first``
 runtime feature). By default:
 
-1. ``application_utilization`` -- value in [0, 1], used when reported and
-   greater than 0.
-2. Named metrics via ``metric_names_for_computing_utilization`` -- max of
-   present values, used when ``application_utilization`` is not reported.
+1. Named metrics via ``metric_names_for_computing_utilization`` -- max of
+   present values, used when that max is greater than 0.
+2. ``application_utilization`` -- value in [0, 1], used when greater than 0.
 3. ``cpu_utilization`` -- final fallback.
 
 .. _load_aware_locality_weight_computation:
@@ -317,10 +316,10 @@ Configuration parameters
        least 100 ms.
    * - ``metric_names_for_computing_utilization``
      - (unset)
-     - Named ORCA metrics used to compute utilization when
-       ``application_utilization`` is not reported. The max of matching
-       values is taken. Map entries use ``<map_field_name>.<map_key>`` (e.g.
-       ``named_metrics.foo``). See
+     - Named ORCA metrics used to compute utilization. By default the max of
+       matching values takes precedence over ``application_utilization`` when
+       that max is greater than 0. Map entries use ``<map_field_name>.<map_key>``
+       (e.g. ``named_metrics.foo``). See
        :ref:`Weight computation <load_aware_locality_weight_computation>` for
        precedence.
    * - ``utilization_variance_threshold``

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_aware_locality.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_aware_locality.rst
@@ -132,13 +132,14 @@ per-endpoint capacity. Each consumer attaches independent
 ``HostLbPolicyData`` entries, so the two policies do not interfere.
 
 Utilization is derived from each host's ORCA report using the same
-extraction as CSWRR (precedence may be flipped by the
+extraction as CSWRR, which takes the first source whose value is greater
+than 0 (precedence may be flipped by the
 ``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first``
 runtime feature). By default:
 
 1. Named metrics via ``metric_names_for_computing_utilization`` -- max of
-   present values, used when that max is greater than 0.
-2. ``application_utilization`` -- value in [0, 1], used when greater than 0.
+   present values.
+2. ``application_utilization``.
 3. ``cpu_utilization`` -- final fallback.
 
 .. _load_aware_locality_weight_computation:

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
@@ -37,12 +37,12 @@ errors-per-second (EPS) and utilization to adaptively balance load.
 
 Endpoint weights are recomputed periodically from each endpoint's most recent ORCA
 report as ``qps / (utilization + eps/qps * error_utilization_penalty)``, where
-``qps`` is the report's ``rps_fractional`` field. Both ``qps`` and the resolved
-``utilization`` must be greater than 0; a report that fails either requirement is
-ignored. Utilization is resolved in the following order, taking the first source whose
-value is greater than 0 (precedence may be flipped by the
-``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first`` runtime
-feature). By default:
+``qps`` is the report's ``rps_fractional`` field. Both ``qps`` and the final
+``utilization`` (resolved utilization plus any error penalty) must be greater than 0;
+a report that fails either requirement is ignored. Utilization is resolved in the
+following order, taking the first source whose value is greater than 0 (precedence
+may be flipped by the ``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first``
+runtime feature). By default:
 
 1. Named metrics via ``metric_names_for_computing_utilization`` -- max of present
    values.
@@ -51,8 +51,8 @@ feature). By default:
 
 While an endpoint has no valid weight -- because its reports are being ignored, or
 during the initial ``blackout_period``, or after ``weight_expiration_period`` has
-elapsed -- it is assigned the median of the endpoints that currently have a valid
-weight (or 1 if none are valid).
+elapsed -- it is assigned the median weight of the endpoints that currently have a
+valid weight (or 1 if none are valid).
 
 This policy supports:
 

--- a/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/load_balancers.rst
@@ -35,6 +35,25 @@ Unlike classic round robin, endpoint weights are derived from load reports sent 
 upstreams via ORCA (Open Request Cost Aggregation), incorporating queries-per-second (QPS),
 errors-per-second (EPS) and utilization to adaptively balance load.
 
+Endpoint weights are recomputed periodically from each endpoint's most recent ORCA
+report as ``qps / (utilization + eps/qps * error_utilization_penalty)``, where
+``qps`` is the report's ``rps_fractional`` field. Both ``qps`` and the resolved
+``utilization`` must be greater than 0; a report that fails either requirement is
+ignored. Utilization is resolved in the following order, taking the first source whose
+value is greater than 0 (precedence may be flipped by the
+``envoy.reloadable_features.orca_weight_manager_use_named_metrics_first`` runtime
+feature). By default:
+
+1. Named metrics via ``metric_names_for_computing_utilization`` -- max of present
+   values.
+2. ``application_utilization``.
+3. ``cpu_utilization`` -- final fallback.
+
+While an endpoint has no valid weight -- because its reports are being ignored, or
+during the initial ``blackout_period``, or after ``weight_expiration_period`` has
+elapsed -- it is assigned the median of the endpoints that currently have a valid
+weight (or 1 if none are valid).
+
 This policy supports:
 
 - :ref:`Slow start <arch_overview_load_balancing_slow_start>` via


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: api: fix description for ORCA utilization precedence

Additional Description:
The `metric_names_for_computing_utilization` field comments in client_side_weighted_round_robin/load_aware_locality still describe the legacy utilization-precedence order. After #44196, `envoy.reloadable_features.orca_weight_manager_use_named_metrics_first` now defaults to true so the described order and gating was incorrect. They now match the runtime-dependent behavior of the shared `getUtilizationFromOrcaReport` helper:
  1. max of the named metrics, used when that max is > 0
  2. else `application_utilization`, used when > 0
  3. else `cpu_utilization`

Also includes clarification about [rps_fractional requirement](https://github.com/envoyproxy/envoy/blob/ced632b3df6a74bd88c8a98cf59b4e5ff3e90b38/source/extensions/load_balancing_policies/common/orca_weight_manager.cc#L81-L84) and weight derivation.

Risk Level: Low
Testing: N/A
Docs Changes: Updated load_aware_locality docs
Release Notes: None
Platform Specific Features: N/A
API Considerations: Comment only changes