### PR TITLE
quic: check PackFrom result in integration test

### DIFF
--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -2191,7 +2191,7 @@ public:
       auto* common_tls =
           quic_transport.mutable_downstream_tls_context()->mutable_common_tls_context();
       ConfigHelper::initializeTlsKeyLog(*common_tls, options);
-      ts->mutable_typed_config()->PackFrom(quic_transport);
+      ASSERT_TRUE(ts->mutable_typed_config()->PackFrom(quic_transport));
     });
   }
 


### PR DESCRIPTION
Commit Message: quic: check PackFrom result in integration test

Additional Description:
The QUIC TLS key log setup repacks a modified `QuicDownstreamTransport` into the listener transport socket typed config. Protobuf `Any::PackFrom()` is now `nodiscard`, so ignoring its return value breaks stricter CI builds.

This checks the return value with a test assertion. A failed pack would make the test setup invalid, so failing the test at configuration setup is preferable to silently continuing.

This is intended to address CI failures seen on #45982, including the GCC and ASAN jobs:

- https://github.com/envoyproxy/envoy/pull/45982/checks?check_run_id=85192902675
- https://github.com/envoyproxy/envoy/actions/runs/28828603506/job/85497340466

Both failed with the unchecked `PackFrom(quic_transport)` call:

```
test/integration/quic_http_integration_test.cc:2194:7: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
      ts->mutable_typed_config()->PackFrom(quic_transport);
```

Prepared with AI assistance and reviewed by the submitter.

Risk Level: Low

Testing:
- Envoy/Prechecks: pass
- Envoy/Checks: pass
- Envoy/macOS: pass

Docs Changes: N/A

Release Notes: N/A
