### PR TITLE
dynamic_modules: expose upstream connection ID in HTTP and network Rust SDK

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -3268,6 +3268,15 @@ bool envoy_dynamic_module_callback_http_set_upstream_override_host(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer host, bool strict);
 
+/**
+ * Get the upstream connection ID.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @return the upstream connection ID, or 0 if not available.
+ */
+uint64_t envoy_dynamic_module_callback_http_get_upstream_connection_id(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr);
+
 // ------------------- Stream Control Callbacks -------------------------
 
 /**
@@ -4642,6 +4651,15 @@ bool envoy_dynamic_module_callback_network_filter_get_upstream_host_cluster(
  * @return true if an upstream host is set, false otherwise.
  */
 bool envoy_dynamic_module_callback_network_filter_has_upstream_host(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * Get the upstream connection ID.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return the upstream connection ID, or 0 if not available.
+ */
+uint64_t envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
 
 // ---------------------- StartTLS Support Callbacks ---------------------------

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -1747,6 +1747,14 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_network_filter_has_upst
   return false;
 }
 
+__attribute__((weak)) uint64_t
+envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
+    envoy_dynamic_module_type_network_filter_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_get_upstream_connection_id: "
+               "not implemented in this context");
+  return 0;
+}
+
 __attribute__((weak)) bool
 envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
     envoy_dynamic_module_type_network_filter_envoy_ptr) {
@@ -4589,6 +4597,13 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_http_set_upstream_overr
   IS_ENVOY_BUG("envoy_dynamic_module_callback_http_set_upstream_override_host: not implemented in "
                "this context");
   return false;
+}
+
+__attribute__((weak)) uint64_t envoy_dynamic_module_callback_http_get_upstream_connection_id(
+    envoy_dynamic_module_type_http_filter_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_get_upstream_connection_id: not "
+               "implemented in this context");
+  return 0;
 }
 
 __attribute__((weak)) void envoy_dynamic_module_callback_http_filter_reset_stream(

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1952,6 +1952,9 @@ pub trait EnvoyHttpFilter {
   /// Returns `true` if the override was set successfully, `false` if the host address is invalid.
   fn set_upstream_override_host(&mut self, host: &str, strict: bool) -> bool;
 
+  /// Get the upstream connection ID, or 0 if not available.
+  fn get_upstream_connection_id(&self) -> u64;
+
   // ------------------- Stream Control methods -------------------------
 
   /// Reset the HTTP stream with the specified reason.
@@ -3942,6 +3945,10 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         strict,
       )
     }
+  }
+
+  fn get_upstream_connection_id(&self) -> u64 {
+    unsafe { abi::envoy_dynamic_module_callback_http_get_upstream_connection_id(self.raw_ptr) }
   }
 
   fn reset_stream(

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -1527,11 +1527,14 @@ struct MockUpstreamHost {
 }
 
 static MOCK_UPSTREAM_HOST: std::sync::Mutex<Option<MockUpstreamHost>> = std::sync::Mutex::new(None);
+static MOCK_UPSTREAM_CONNECTION_ID: std::sync::atomic::AtomicU64 =
+  std::sync::atomic::AtomicU64::new(0);
 static MOCK_START_TLS_RESULT: std::sync::atomic::AtomicBool =
   std::sync::atomic::AtomicBool::new(false);
 
 fn reset_upstream_host_mock() {
   *MOCK_UPSTREAM_HOST.lock().unwrap() = None;
+  MOCK_UPSTREAM_CONNECTION_ID.store(0, std::sync::atomic::Ordering::SeqCst);
   MOCK_START_TLS_RESULT.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
@@ -1665,6 +1668,13 @@ pub extern "C" fn envoy_dynamic_module_callback_network_filter_has_upstream_host
   _filter_envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
 ) -> bool {
   MOCK_UPSTREAM_HOST.lock().unwrap().is_some()
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
+) -> u64 {
+  MOCK_UPSTREAM_CONNECTION_ID.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 #[no_mangle]
@@ -1835,6 +1845,62 @@ fn test_has_upstream_host_false() {
   };
 
   assert!(!filter.has_upstream_host());
+}
+
+#[test]
+fn test_get_upstream_connection_id() {
+  reset_upstream_host_mock();
+  MOCK_UPSTREAM_CONNECTION_ID.store(54321, std::sync::atomic::Ordering::SeqCst);
+
+  let filter = EnvoyNetworkFilterImpl {
+    raw: std::ptr::null_mut(),
+  };
+
+  assert_eq!(filter.get_upstream_connection_id(), 54321);
+}
+
+#[test]
+fn test_get_upstream_connection_id_unavailable() {
+  reset_upstream_host_mock();
+
+  let filter = EnvoyNetworkFilterImpl {
+    raw: std::ptr::null_mut(),
+  };
+
+  assert_eq!(filter.get_upstream_connection_id(), 0);
+}
+
+static MOCK_HTTP_UPSTREAM_CONNECTION_ID: std::sync::atomic::AtomicU64 =
+  std::sync::atomic::AtomicU64::new(0);
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_http_get_upstream_connection_id(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+) -> u64 {
+  MOCK_HTTP_UPSTREAM_CONNECTION_ID.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[test]
+fn test_http_get_upstream_connection_id() {
+  MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(98765, std::sync::atomic::Ordering::SeqCst);
+
+  let filter = http::EnvoyHttpFilterImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+
+  assert_eq!(filter.get_upstream_connection_id(), 98765);
+  MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
+#[test]
+fn test_http_get_upstream_connection_id_unavailable() {
+  MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(0, std::sync::atomic::Ordering::SeqCst);
+
+  let filter = http::EnvoyHttpFilterImpl {
+    raw_ptr: std::ptr::null_mut(),
+  };
+
+  assert_eq!(filter.get_upstream_connection_id(), 0);
 }
 
 // =============================================================================

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -479,6 +479,9 @@ pub trait EnvoyNetworkFilter {
   /// Check if an upstream host has been selected for this connection.
   fn has_upstream_host(&self) -> bool;
 
+  /// Get the upstream connection ID, or 0 if not available.
+  fn get_upstream_connection_id(&self) -> u64;
+
   /// Signal to the filter manager to enable secure transport mode in upstream connection.
   /// This is done when upstream connection's transport socket is of startTLS type.
   /// Returns true if the upstream transport was successfully converted to secure mode.
@@ -1711,6 +1714,12 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
 
   fn has_upstream_host(&self) -> bool {
     unsafe { abi::envoy_dynamic_module_callback_network_filter_has_upstream_host(self.raw) }
+  }
+
+  fn get_upstream_connection_id(&self) -> u64 {
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(self.raw)
+    }
   }
 
   fn start_upstream_secure_transport(&mut self) -> bool {

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -2701,6 +2701,16 @@ bool envoy_dynamic_module_callback_http_set_upstream_override_host(
   return true;
 }
 
+uint64_t envoy_dynamic_module_callback_http_get_upstream_connection_id(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  const auto* upstream_info = filter->upstreamInfo();
+  if (upstream_info == nullptr || !upstream_info->upstreamConnectionId().has_value()) {
+    return 0;
+  }
+  return upstream_info->upstreamConnectionId().value();
+}
+
 // ------------------- Stream Control Callbacks -------------------------
 
 void envoy_dynamic_module_callback_http_filter_reset_stream(

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -1151,6 +1151,19 @@ bool envoy_dynamic_module_callback_network_filter_has_upstream_host(
   return filter->readCallbacks()->upstreamHost() != nullptr;
 }
 
+uint64_t envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    return 0;
+  }
+  const auto upstream = filter->connection().streamInfo().upstreamInfo();
+  if (!upstream || !upstream->upstreamConnectionId().has_value()) {
+    return 0;
+  }
+  return upstream->upstreamConnectionId().value();
+}
+
 // -----------------------------------------------------------------------------
 // StartTLS Support Callbacks
 // -----------------------------------------------------------------------------

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -717,6 +717,8 @@ WEAK_STUB(NetworkFilterGetUpstreamHostCluster,
           envoy_dynamic_module_callback_network_filter_get_upstream_host_cluster(nullptr, nullptr))
 WEAK_STUB(NetworkFilterHasUpstreamHost,
           envoy_dynamic_module_callback_network_filter_has_upstream_host(nullptr))
+WEAK_STUB(NetworkFilterGetUpstreamConnectionId,
+          envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(nullptr))
 WEAK_STUB(NetworkFilterStartUpstreamSecureTransport,
           envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(nullptr))
 WEAK_STUB(NetworkFilterReadEnabled,
@@ -1625,6 +1627,8 @@ WEAK_STUB(HttpGetClusterHostCount,
 WEAK_STUB(HttpSetUpstreamOverrideHost,
           envoy_dynamic_module_callback_http_set_upstream_override_host(nullptr, {nullptr, 0},
                                                                         false))
+WEAK_STUB(HttpGetUpstreamConnectionId,
+          envoy_dynamic_module_callback_http_get_upstream_connection_id(nullptr))
 WEAK_STUB(HttpFilterResetStream,
           envoy_dynamic_module_callback_http_filter_reset_stream(
               nullptr, envoy_dynamic_module_type_http_filter_stream_reset_reason_LocalReset,

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -3468,6 +3468,33 @@ TEST_F(DynamicModuleHttpFilterTest, SetUpstreamOverrideHostNonStrict) {
       filter_.get(), {host.data(), host.size()}, false));
 }
 
+TEST_F(DynamicModuleHttpFilterTest, GetUpstreamConnectionId) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  auto upstream_info = std::make_shared<NiceMock<StreamInfo::MockUpstreamInfo>>();
+  upstream_info->setUpstreamConnectionId(98765);
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(upstream_info));
+
+  EXPECT_EQ(98765, envoy_dynamic_module_callback_http_get_upstream_connection_id(filter_.get()));
+}
+
+TEST_F(DynamicModuleHttpFilterTest, GetUpstreamConnectionIdMissing) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  auto upstream_info = std::make_shared<NiceMock<StreamInfo::MockUpstreamInfo>>();
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(upstream_info));
+
+  EXPECT_EQ(0, envoy_dynamic_module_callback_http_get_upstream_connection_id(filter_.get()));
+}
+
+TEST_F(DynamicModuleHttpFilterTest, GetUpstreamConnectionIdNoUpstreamInfo) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(decoder_callbacks_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(nullptr));
+
+  EXPECT_EQ(0, envoy_dynamic_module_callback_http_get_upstream_connection_id(filter_.get()));
+}
+
 // Test GetClusterHostCount with a properly configured filter and mocked cluster manager.
 // This fixture creates a filter with a real config that has a mocked cluster manager.
 class DynamicModuleHttpFilterWithConfigTest : public testing::Test {

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -172,6 +172,25 @@ TEST_P(DynamicModulesIntegrationTest, PassThrough) {
   EXPECT_EQ(10U, response->body().size());
 }
 
+TEST_P(DynamicModulesIntegrationTest, UpstreamConnectionId) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the upstream_connection_id filter is only in the rust test module";
+  }
+
+  initializeFilter("upstream_connection_id");
+
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
 TEST_P(DynamicModulesIntegrationTest, HeaderCallbacks) { runHeaderCallbacksTest(false); }
 
 TEST_P(DynamicModulesIntegrationTest, HeaderCallbacksWithUpstreamFilter) {

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2305,6 +2305,47 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, HasUpstreamHostNullCallbacks) 
 }
 
 // =============================================================================
+// Tests for get_upstream_connection_id.
+// =============================================================================
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetUpstreamConnectionId) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  auto upstream_info = std::make_shared<NiceMock<StreamInfo::MockUpstreamInfo>>();
+  upstream_info->setUpstreamConnectionId(54321);
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(upstream_info));
+  EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+
+  EXPECT_EQ(54321,
+            envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(filterPtr()));
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetUpstreamConnectionIdMissing) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  auto upstream_info = std::make_shared<NiceMock<StreamInfo::MockUpstreamInfo>>();
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(upstream_info));
+  EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+
+  EXPECT_EQ(0,
+            envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(filterPtr()));
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetUpstreamConnectionIdNoUpstreamInfo) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(testing::Return(nullptr));
+  EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+
+  EXPECT_EQ(0,
+            envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(filterPtr()));
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetUpstreamConnectionIdNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+
+  EXPECT_EQ(0, envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
+                   static_cast<void*>(filter.get())));
+}
+
+// =============================================================================
 // Tests for startUpstreamSecureTransport (StartTLS).
 // =============================================================================
 

--- a/test/extensions/dynamic_modules/network/integration_test.cc
+++ b/test/extensions/dynamic_modules/network/integration_test.cc
@@ -288,4 +288,30 @@ TEST_P(DynamicModulesNetworkSdkIntegrationTest, DynamicMetadataBatch) {
   tcp_client->close();
 }
 
+TEST_P(DynamicModulesNetworkSdkIntegrationTest, UpstreamConnectionId) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the upstream_connection_id filter is only in the rust test module";
+  }
+
+  initializeSdkFilter("upstream_connection_id");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->connected());
+
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+
+  ASSERT_TRUE(tcp_client->write("hello", false));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+
+  ASSERT_TRUE(fake_upstream_connection->write("world"));
+  tcp_client->waitForData("world");
+
+  ASSERT_TRUE(tcp_client->write("", true));
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_connection->close());
+  tcp_client->waitForHalfClose();
+  tcp_client->close();
+}
+
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -154,6 +154,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     },
     "list_metadata_callbacks" => Some(Box::new(ListMetadataCallbacksFilterConfig {})),
     "filter_state_object_recreate" => Some(Box::new(FilterStateObjectRecreateFilterConfig {})),
+    "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig {})),
     _ => panic!("Unknown filter name: {name}"),
   }
 }
@@ -413,6 +414,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for PassthroughHttpFilter {
     envoy_log_error!("on_request_headers called");
     envoy_log_critical!("on_request_headers called");
     envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+}
+
+struct UpstreamConnectionIdFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for UpstreamConnectionIdFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(UpstreamConnectionIdFilter {})
+  }
+}
+
+struct UpstreamConnectionIdFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamConnectionIdFilter {
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    assert!(envoy_filter.get_upstream_connection_id() > 0);
+    envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
@@ -29,6 +29,7 @@ fn new_network_filter_config_fn<EC: EnvoyNetworkFilterConfig, ENF: EnvoyNetworkF
     "half_close" => Some(Box::new(HalfCloseFilterConfig)),
     "buffer_limits" => Some(Box::new(BufferLimitsFilterConfig)),
     "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
+    "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -373,6 +374,32 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for DynamicMetadataFilter {
       Some(vec![0xff, 0x00, 0xfe])
     );
 
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+  }
+}
+
+// =============================================================================
+// Upstream Connection ID Test Filter
+// =============================================================================
+
+struct UpstreamConnectionIdFilterConfig;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for UpstreamConnectionIdFilterConfig {
+  fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+    Box::new(UpstreamConnectionIdFilter)
+  }
+}
+
+struct UpstreamConnectionIdFilter;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for UpstreamConnectionIdFilter {
+  fn on_write(
+    &mut self,
+    envoy_filter: &mut ENF,
+    _data_length: usize,
+    _end_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+    assert!(envoy_filter.get_upstream_connection_id() > 0);
     abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
   }
 }


### PR DESCRIPTION
## Description

This PR adds ABI callbacks and Rust SDK methods to read the upstream connection ID from HTTP and network dynamic module filters. 

We return `0` when upstream info or the connection ID is not available.

---

**Commit Message:** dynamic_modules: expose upstream connection ID in HTTP and network Rust SDK
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A