### PR TITLE
http: migrate a2a/adaptive_concurrency/cache/basic_auth/... to exception free

### DIFF
--- a/source/extensions/filters/http/a2a/config.cc
+++ b/source/extensions/filters/http/a2a/config.cc
@@ -9,7 +9,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace A2a {
 
-Http::FilterFactoryCb A2aFilterConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 

--- a/source/extensions/filters/http/a2a/config.h
+++ b/source/extensions/filters/http/a2a/config.h
@@ -11,12 +11,12 @@ namespace HttpFilters {
 namespace A2a {
 
 class A2aFilterConfigFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::a2a::v3::A2a> {
+    : public Common::ExceptionFreeFactoryBase<envoy::extensions::filters::http::a2a::v3::A2a> {
 public:
-  A2aFilterConfigFactory() : FactoryBase("envoy.filters.http.a2a") {}
+  A2aFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.a2a") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/source/extensions/filters/http/adaptive_concurrency/config.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/config.cc
@@ -12,7 +12,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AdaptiveConcurrency {
 
-Http::FilterFactoryCb AdaptiveConcurrencyFilterFactory::createFilterFactory(
+absl::StatusOr<Http::FilterFactoryCb> AdaptiveConcurrencyFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency& config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context,
     Stats::Scope& scope) {
@@ -23,8 +23,10 @@ Http::FilterFactoryCb AdaptiveConcurrencyFilterFactory::createFilterFactory(
   using Proto = envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency;
   ASSERT(config.concurrency_controller_config_case() ==
          Proto::ConcurrencyControllerConfigCase::kGradientControllerConfig);
+  absl::Status creation_status = absl::OkStatus();
   auto gradient_controller_config = Controller::GradientControllerConfig(
-      config.gradient_controller_config(), server_context.runtime());
+      config.gradient_controller_config(), server_context.runtime(), creation_status);
+  RETURN_IF_NOT_OK_REF(creation_status);
   controller = std::make_shared<Controller::GradientController>(
       std::move(gradient_controller_config), server_context.mainThreadDispatcher(),
       server_context.runtime(), acc_stats_prefix + "gradient_controller.", scope,

--- a/source/extensions/filters/http/adaptive_concurrency/config.h
+++ b/source/extensions/filters/http/adaptive_concurrency/config.h
@@ -14,12 +14,13 @@ namespace AdaptiveConcurrency {
  * Config registration for the adaptive concurrency limit filter. @see NamedHttpFilterConfigFactory.
  */
 class AdaptiveConcurrencyFilterFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency> {
 public:
-  AdaptiveConcurrencyFilterFactory() : FactoryBase("envoy.filters.http.adaptive_concurrency") {}
+  AdaptiveConcurrencyFilterFactory()
+      : ExceptionFreeFactoryBase("envoy.filters.http.adaptive_concurrency") {}
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
@@ -35,7 +36,7 @@ public:
   }
 
 private:
-  Http::FilterFactoryCb createFilterFactory(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -25,7 +25,7 @@ namespace Controller {
 GradientControllerConfig::GradientControllerConfig(
     const envoy::extensions::filters::http::adaptive_concurrency::v3::GradientControllerConfig&
         proto_config,
-    Runtime::Loader& runtime)
+    Runtime::Loader& runtime, absl::Status& creation_status)
     : runtime_(runtime),
       min_rtt_calc_interval_(std::chrono::milliseconds(
           DurationUtil::durationToMilliseconds(proto_config.min_rtt_calc_params().interval()))),
@@ -48,8 +48,9 @@ GradientControllerConfig::GradientControllerConfig(
 
   if (min_rtt_calc_interval_ < std::chrono::milliseconds(1) &&
       fixed_value_ <= std::chrono::milliseconds::zero()) {
-    throw EnvoyException(
+    creation_status = absl::InvalidArgumentError(
         "adaptive_concurrency: neither `concurrency_update_interval` nor `fixed_value` set");
+    return;
   }
 }
 GradientController::GradientController(GradientControllerConfig config,

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -48,7 +48,7 @@ public:
   GradientControllerConfig(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::GradientControllerConfig&
           proto_config,
-      Runtime::Loader& runtime);
+      Runtime::Loader& runtime, absl::Status& creation_status);
 
   std::chrono::milliseconds minRTTCalcInterval() const {
     const auto ms = runtime_.snapshot().getInteger(RuntimeKeys::get().MinRTTCalcIntervalKey,

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -11,7 +11,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AlternateProtocolsCache {
 
-Http::FilterFactoryCb AlternateProtocolsCacheFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AlternateProtocolsCacheFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
         proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {

--- a/source/extensions/filters/http/alternate_protocols_cache/config.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.h
@@ -15,14 +15,14 @@ namespace AlternateProtocolsCache {
  * Config registration for the alternate protocols cache filter.
  */
 class AlternateProtocolsCacheFilterFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig> {
 public:
   AlternateProtocolsCacheFilterFactory()
-      : FactoryBase(HttpFilterNames::get().AlternateProtocolsCache) {}
+      : ExceptionFreeFactoryBase(HttpFilterNames::get().AlternateProtocolsCache) {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
           proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -13,7 +13,7 @@ using envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute;
 
 namespace {
 
-UserMap readHtpasswd(const std::string& htpasswd) {
+absl::StatusOr<UserMap> readHtpasswd(const std::string& htpasswd) {
   UserMap users;
 
   std::istringstream htpsswd_ss(htpasswd);
@@ -29,28 +29,31 @@ UserMap readHtpasswd(const std::string& htpasswd) {
 
     const size_t colon_pos = line.find(':');
     if (colon_pos == std::string::npos) {
-      throw EnvoyException("basic auth: invalid htpasswd format, username:password is expected");
+      return absl::InvalidArgumentError(
+          "basic auth: invalid htpasswd format, username:password is expected");
     }
 
     std::string name = line.substr(0, colon_pos);
     std::string hash = line.substr(colon_pos + 1);
 
     if (name.empty() || hash.empty()) {
-      throw EnvoyException("basic auth: empty user name or password");
+      return absl::InvalidArgumentError("basic auth: empty user name or password");
     }
 
     if (users.contains(name)) {
-      throw EnvoyException("basic auth: duplicate users");
+      return absl::InvalidArgumentError("basic auth: duplicate users");
     }
 
     if (!absl::StartsWith(hash, "{SHA}")) {
-      throw EnvoyException("basic auth: unsupported htpasswd format: please use {SHA}");
+      return absl::InvalidArgumentError(
+          "basic auth: unsupported htpasswd format: please use {SHA}");
     }
 
     hash = hash.substr(5);
     // The base64 encoded SHA1 hash is 28 bytes long
     if (hash.length() != 28) {
-      throw EnvoyException("basic auth: invalid htpasswd format, invalid SHA hash length");
+      return absl::InvalidArgumentError(
+          "basic auth: invalid htpasswd format, invalid SHA hash length");
     }
 
     users.insert({name, {name, hash}});
@@ -61,14 +64,16 @@ UserMap readHtpasswd(const std::string& htpasswd) {
 
 } // namespace
 
-Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
     const BasicAuth& proto_config, const std::string& stats_prefix,
     Server::Configuration::FactoryContext& context) {
-  UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
-      Config::DataSource::read(proto_config.users(), false, context.serverFactoryContext().api()),
-      std::string));
+  auto htpasswd_or =
+      Config::DataSource::read(proto_config.users(), false, context.serverFactoryContext().api());
+  RETURN_IF_NOT_OK_REF(htpasswd_or.status());
+  auto users_or = readHtpasswd(htpasswd_or.value());
+  RETURN_IF_NOT_OK_REF(users_or.status());
   FilterConfigConstSharedPtr config = std::make_unique<FilterConfig>(
-      std::move(users), proto_config.forward_username_header(),
+      std::move(users_or.value()), proto_config.forward_username_header(),
       proto_config.authentication_header(), proto_config.allow_missing(),
       proto_config.emit_dynamic_metadata(), stats_prefix, context.scope());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -79,10 +84,12 @@ Http::FilterFactoryCb BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const BasicAuth& proto_config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& context) {
-  UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
-      Config::DataSource::read(proto_config.users(), false, context.api()), std::string));
+  auto htpasswd_or = Config::DataSource::read(proto_config.users(), false, context.api());
+  RETURN_IF_NOT_OK_REF(htpasswd_or.status());
+  auto users_or = readHtpasswd(htpasswd_or.value());
+  RETURN_IF_NOT_OK_REF(users_or.status());
   FilterConfigConstSharedPtr config = std::make_unique<FilterConfig>(
-      std::move(users), proto_config.forward_username_header(),
+      std::move(users_or.value()), proto_config.forward_username_header(),
       proto_config.authentication_header(), proto_config.allow_missing(),
       proto_config.emit_dynamic_metadata(), stats_prefix, context.scope());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -94,9 +101,11 @@ absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 BasicAuthFilterFactory::createRouteSpecificFilterConfigTyped(
     const BasicAuthPerRoute& proto_config, Server::Configuration::ServerFactoryContext& context,
     ProtobufMessage::ValidationVisitor&) {
-  UserMap users = readHtpasswd(THROW_OR_RETURN_VALUE(
-      Config::DataSource::read(proto_config.users(), true, context.api()), std::string));
-  return std::make_unique<FilterConfigPerRoute>(std::move(users));
+  auto htpasswd_or = Config::DataSource::read(proto_config.users(), true, context.api());
+  RETURN_IF_NOT_OK_REF(htpasswd_or.status());
+  auto users_or = readHtpasswd(htpasswd_or.value());
+  RETURN_IF_NOT_OK_REF(users_or.status());
+  return std::make_unique<FilterConfigPerRoute>(std::move(users_or.value()));
 }
 
 REGISTER_FACTORY(BasicAuthFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -11,14 +11,14 @@ namespace HttpFilters {
 namespace BasicAuth {
 
 class BasicAuthFilterFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::basic_auth::v3::BasicAuth,
           envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute> {
 public:
-  BasicAuthFilterFactory() : FactoryBase("envoy.filters.http.basic_auth") {}
+  BasicAuthFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.basic_auth") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -7,19 +7,19 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
-Http::FilterFactoryCb CacheFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
     const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
   std::shared_ptr<HttpCache> cache;
   if (!config.disabled().value()) {
     if (!config.has_typed_config()) {
-      throw EnvoyException("at least one of typed_config or disabled must be set");
+      return absl::InvalidArgumentError("at least one of typed_config or disabled must be set");
     }
     const std::string type{TypeUtil::typeUrlToDescriptorFullName(config.typed_config().type_url())};
     HttpCacheFactory* const http_cache_factory =
         Registry::FactoryRegistry<HttpCacheFactory>::getFactoryByType(type);
     if (http_cache_factory == nullptr) {
-      throw EnvoyException(
+      return absl::InvalidArgumentError(
           fmt::format("Didn't find a registered implementation for type: '{}'", type));
     }
 

--- a/source/extensions/filters/http/cache/config.h
+++ b/source/extensions/filters/http/cache/config.h
@@ -10,13 +10,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
-class CacheFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::cache::v3::CacheConfig> {
+class CacheFilterFactory : public Common::ExceptionFreeFactoryBase<
+                               envoy::extensions::filters::http::cache::v3::CacheConfig> {
 public:
-  CacheFilterFactory() : FactoryBase("envoy.filters.http.cache") {}
+  CacheFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.cache") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -34,7 +34,10 @@ GradientControllerConfig makeConfig(const std::string& yaml_config,
                                     NiceMock<Runtime::MockLoader>& runtime) {
   envoy::extensions::filters::http::adaptive_concurrency::v3::GradientControllerConfig proto;
   TestUtility::loadFromYamlAndValidate(yaml_config, proto);
-  return GradientControllerConfig{proto, runtime};
+  absl::Status creation_status = absl::OkStatus();
+  GradientControllerConfig config{proto, runtime, creation_status};
+  EXPECT_TRUE(creation_status.ok());
+  return config;
 }
 
 class GradientControllerConfigTest : public testing::Test {
@@ -158,9 +161,13 @@ TEST_F(GradientControllerConfigTest, MissingMinRTTValues) {
     min_concurrency: 8
   )EOF";
 
-  EXPECT_THROW_WITH_MESSAGE(
-      makeConfig(yaml, runtime_), EnvoyException,
-      "adaptive_concurrency: neither `concurrency_update_interval` nor `fixed_value` set");
+  envoy::extensions::filters::http::adaptive_concurrency::v3::GradientControllerConfig proto;
+  TestUtility::loadFromYamlAndValidate(yaml, proto);
+  absl::Status creation_status = absl::OkStatus();
+  GradientControllerConfig config{proto, runtime_, creation_status};
+  EXPECT_FALSE(creation_status.ok());
+  EXPECT_EQ(creation_status.message(),
+            "adaptive_concurrency: neither `concurrency_update_interval` nor `fixed_value` set");
 }
 
 TEST_F(GradientControllerConfigTest, Clamping) {

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -50,9 +50,10 @@ TEST(Factory, InvalidConfigNoColon) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException);
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(),
+            "basic auth: invalid htpasswd format, username:password is expected");
 }
 
 TEST(Factory, InvalidConfigDuplicateUsers) {
@@ -69,9 +70,9 @@ TEST(Factory, InvalidConfigDuplicateUsers) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, "basic auth: duplicate users");
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(), "basic auth: duplicate users");
 }
 
 TEST(Factory, InvalidConfigNoUser) {
@@ -88,9 +89,9 @@ TEST(Factory, InvalidConfigNoUser) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, "basic auth: empty user name or password");
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(), "basic auth: empty user name or password");
 }
 
 TEST(Factory, InvalidConfigNoPassword) {
@@ -107,9 +108,9 @@ TEST(Factory, InvalidConfigNoPassword) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, "basic auth: empty user name or password");
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(), "basic auth: empty user name or password");
 }
 
 TEST(Factory, InvalidConfigNoHash) {
@@ -126,9 +127,10 @@ TEST(Factory, InvalidConfigNoHash) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, "basic auth: invalid htpasswd format, invalid SHA hash length");
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(),
+            "basic auth: invalid htpasswd format, invalid SHA hash length");
 }
 
 TEST(Factory, InvalidConfigNotSHA) {
@@ -145,9 +147,10 @@ TEST(Factory, InvalidConfigNotSHA) {
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, "basic auth: unsupported htpasswd format: please use {SHA}");
+  auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(),
+            "basic auth: unsupported htpasswd format: please use {SHA}");
 }
 
 TEST(Factory, ValidConfigWithServerContext) {

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/utility.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -46,17 +47,18 @@ TEST_F(CacheFilterFactoryTest, Disabled) {
 }
 
 TEST_F(CacheFilterFactoryTest, NoTypedConfig) {
-  EXPECT_THROW(
-      factory_.createFilterFactoryFromProto(config_, "stats", context_).status().IgnoreError(),
-      EnvoyException);
+  auto status_or = factory_.createFilterFactoryFromProto(config_, "stats", context_);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_EQ(status_or.status().message(), "at least one of typed_config or disabled must be set");
 }
 
 TEST_F(CacheFilterFactoryTest, UnregisteredTypedConfig) {
   std::ignore = config_.mutable_typed_config()->PackFrom(
       envoy::extensions::filters::http::cache::v3::CacheConfig());
-  EXPECT_THROW(
-      factory_.createFilterFactoryFromProto(config_, "stats", context_).status().IgnoreError(),
-      EnvoyException);
+  auto status_or = factory_.createFilterFactoryFromProto(config_, "stats", context_);
+  EXPECT_FALSE(status_or.ok());
+  EXPECT_THAT(status_or.status().message(),
+              testing::HasSubstr("Didn't find a registered implementation for type"));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: http: migrate a2a/adaptive_concurrency/cache/basic_auth/... to exception free
Additional Description:

Make HTTP filters' exception free. 

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.