### PR TITLE
Shard xds_failover_integration_test to avoid bazel timeouts

### DIFF
--- a/test/extensions/config_subscription/grpc/BUILD
+++ b/test/extensions/config_subscription/grpc/BUILD
@@ -279,6 +279,7 @@ envoy_cc_test(
     srcs =
         ["xds_failover_integration_test.cc"],
     rbe_pool = "6gig",
+    shard_count = 2,
     deps = [
         "//source/common/config:protobuf_link_hacks",
         "//source/common/protobuf:utility_lib",


### PR DESCRIPTION
Test suite became big enough to timeout under tsan. Sharding reduces run time by half.

Risk Level: none
Testing: unit test
Docs Changes: no
Release Notes: no
Platform Specific Features: no
