### PR TITLE
Null check filterManagerConnection to prevent segfaults

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -456,8 +456,10 @@ void EnvoyQuicClientStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
 void EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError error) {
   ENVOY_STREAM_LOG(debug, "sending reset code={}", *this, static_cast<int>(error.internal_code()));
   stats_.tx_reset_.inc();
-  filterManagerConnection()->incrementSentQuicResetStreamErrorStats(error, /*from_self*/ true,
-                                                                    /*is_upstream*/ true);
+  if (filterManagerConnection() != nullptr) {
+    filterManagerConnection()->incrementSentQuicResetStreamErrorStats(error, /*from_self*/ true,
+                                                                      /*is_upstream*/ true);
+  }
   // Upper layers expect calling resetStream() to immediately raise reset callbacks.
   runResetCallbacks(
       quicRstErrorToEnvoyLocalResetReason(error.internal_code()),

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -426,8 +426,10 @@ void EnvoyQuicServerStream::OnStreamReset(const quic::QuicRstStreamFrame& frame)
 void EnvoyQuicServerStream::ResetWithError(quic::QuicResetStreamError error) {
   ENVOY_STREAM_LOG(debug, "sending reset code={}", *this, static_cast<int>(error.internal_code()));
   stats_.tx_reset_.inc();
-  filterManagerConnection()->incrementSentQuicResetStreamErrorStats(error, /*from_self*/ true,
-                                                                    /*is_upstream*/ false);
+  if (filterManagerConnection() != nullptr) {
+    filterManagerConnection()->incrementSentQuicResetStreamErrorStats(error, /*from_self*/ true,
+                                                                      /*is_upstream*/ false);
+  }
   if (!local_end_stream_) {
     // Upper layers expect calling resetStream() to immediately raise reset callbacks.
     runResetCallbacks(


### PR DESCRIPTION
Commit Message: Null check filterManagerConnection to prevent segfaults
Additional Description: Test cleanup could cause filterManagerConnection() to return nullptr leads to a segmentation fault.
Risk Level: none
Testing: quic_protocol_integration_test
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
