### PR TITLE
dynamic_modules: add attribute getters to network and listener filters

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-network-and-listener-filter-attribute-getters.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-network-and-listener-filter-attribute-getters.rst
@@ -1,0 +1,4 @@
+Added ``get_attribute_string``, ``get_attribute_int`` and ``get_attribute_bool`` to dynamic
+module network and listener filters, backed by new ABI callbacks and exposed by the Rust SDK
+on ``EnvoyNetworkFilter`` and ``EnvoyListenerFilter``. The shared attribute accessor now also
+serves the ``response.flags`` and ``response.size`` integer attributes.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -4899,6 +4899,61 @@ void envoy_dynamic_module_callback_network_filter_config_scheduler_commit(
 uint32_t envoy_dynamic_module_callback_network_filter_get_worker_index(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
 
+/**
+ * envoy_dynamic_module_callback_network_filter_get_attribute_string is called by the module to get
+ * the string attribute value. If the attribute is not accessible or the
+ * value is not a string, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object of the
+ * corresponding network filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the pointer variable where the pointer to the buffer
+ * of the string value will be stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_attribute_string(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_attribute_int is called by the module to get
+ * an integer attribute value. If the attribute is not accessible or the
+ * value is not an integer, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object of the
+ * corresponding network filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the variable where the integer value of the attribute will be
+ * stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_attribute_int(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result);
+
+/**
+ * envoy_dynamic_module_callback_network_filter_get_attribute_bool is called by the module to get
+ * a boolean attribute value. If the attribute is not accessible or the
+ * value is not a boolean, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object of the
+ * corresponding network filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the variable where the bool value of the attribute will be
+ * stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, bool* result);
+
 // =============================================================================
 // ============================= Listener Filter ===============================
 // =============================================================================
@@ -6138,6 +6193,61 @@ void envoy_dynamic_module_callback_listener_filter_config_scheduler_commit(
  */
 uint32_t envoy_dynamic_module_callback_listener_filter_get_worker_index(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr);
+
+/**
+ * envoy_dynamic_module_callback_listener_filter_get_attribute_string is called by the module to get
+ * the string attribute value. If the attribute is not accessible or the
+ * value is not a string, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object of the
+ * corresponding listener filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the pointer variable where the pointer to the buffer
+ * of the string value will be stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_listener_filter_get_attribute_int is called by the module to get
+ * an integer attribute value. If the attribute is not accessible or the
+ * value is not an integer, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object of the
+ * corresponding listener filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the variable where the integer value of the attribute will be
+ * stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result);
+
+/**
+ * envoy_dynamic_module_callback_listener_filter_get_attribute_bool is called by the module to get
+ * a boolean attribute value. If the attribute is not accessible or the
+ * value is not a boolean, this returns false.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object of the
+ * corresponding listener filter.
+ * @param attribute_id is the ID of the attribute.
+ * @param result is the pointer to the variable where the bool value of the attribute will be
+ * stored.
+ * @return true if the operation is successful, false otherwise.
+ *
+ * Note: currently, not all attributes are implemented.
+ */
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, bool* result);
 
 // =============================================================================
 // ========================== UDP Listener Filter ==============================

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -411,6 +411,18 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
     }
     break;
   }
+  case envoy_dynamic_module_type_attribute_id_ResponseFlags: {
+    // Unlike the response code, the flags are always available as a bitmask (0 when none are set),
+    // matching the value exposed by the response.flags CEL attribute.
+    *result = stream_info.legacyResponseFlags();
+    ok = true;
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_ResponseSize: {
+    *result = stream_info.bytesSent();
+    ok = true;
+    break;
+  }
   case envoy_dynamic_module_type_attribute_id_ConnectionId: {
     *result = stream_info.downstreamAddressProvider().connectionID().value_or(0);
     ok = true;

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4324,6 +4324,54 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_http_filter_get_attribu
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_network_filter_get_attribute_string(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_get_attribute_string: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_network_filter_get_attribute_int(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    uint64_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_get_attribute_int: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_get_attribute_bool: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_get_attribute_string: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    uint64_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_get_attribute_int: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_attribute_id,
+    bool*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_get_attribute_bool: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_http_callout_init_result
 envoy_dynamic_module_callback_http_filter_http_callout(
     envoy_dynamic_module_type_http_filter_envoy_ptr, uint64_t*,

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -278,6 +278,30 @@ pub trait EnvoyListenerFilter {
   /// Returns None if SNI is not available.
   fn get_requested_server_name<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
 
+  /// Get the value of the attribute with the given ID as a string.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_string<'a>(
+    &'a self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<EnvoyBuffer<'a>>;
+
+  /// Get the value of the attribute with the given ID as an integer.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_int(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<i64>;
+
+  /// Get the value of the attribute with the given ID as a boolean.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_bool(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<bool>;
+
   /// Set the requested server name (SNI) on the connection socket.
   fn set_requested_server_name(&mut self, name: &str);
 
@@ -1053,6 +1077,66 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     };
     if success && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_string(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<EnvoyBuffer<'_>> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_int(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<i64> {
+    let mut result: i64 = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_bool(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<bool> {
+    let mut result: bool = false;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(result)
     } else {
       None
     }

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -272,6 +272,30 @@ pub trait EnvoyNetworkFilter {
   /// Returns None if SNI is not available.
   fn get_requested_server_name<'a>(&'a self) -> Option<EnvoyBuffer<'a>>;
 
+  /// Get the value of the attribute with the given ID as a string.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_string<'a>(
+    &'a self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<EnvoyBuffer<'a>>;
+
+  /// Get the value of the attribute with the given ID as an integer.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_int(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<i64>;
+
+  /// Get the value of the attribute with the given ID as a boolean.
+  ///
+  /// If the attribute is not found, not supported or is the wrong type, this returns `None`.
+  fn get_attribute_bool(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<bool>;
+
   /// Get the direct remote (client) address and port without considering proxy protocol.
   /// Returns None if the address is not available or not an IP address.
   fn get_direct_remote_address<'a>(&'a self) -> Option<(EnvoyBuffer<'a>, u32)>;
@@ -1093,6 +1117,66 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
     };
     if success && !result.ptr.is_null() && result.length > 0 {
       Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_string(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<EnvoyBuffer<'_>> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_get_attribute_string(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_int(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<i64> {
+    let mut result: i64 = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_get_attribute_int(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(result)
+    } else {
+      None
+    }
+  }
+
+  fn get_attribute_bool(
+    &self,
+    attribute_id: abi::envoy_dynamic_module_type_attribute_id,
+  ) -> Option<bool> {
+    let mut result: bool = false;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+        self.raw,
+        attribute_id,
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success {
+      Some(result)
     } else {
       None
     }

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -63,6 +63,7 @@ envoy_cc_library(
         "//source/common/router:string_accessor_lib",
         "//source/common/tracing:null_span_lib",
         "//source/common/tracing:tracer_lib",
+        "//source/extensions/dynamic_modules:abi_context_accessors_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -13,6 +13,7 @@
 #include "source/common/tracing/null_span_impl.h"
 #include "source/common/tracing/tracer_impl.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/abi_context_accessors.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 
 namespace Envoy {
@@ -1910,11 +1911,14 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
           return ssl->uriSanPeerCertificate().front();
         },
         result);
-  default:
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
-                        "Unsupported attribute ID {} as string",
-                        static_cast<int64_t>(attribute_id));
+  default: {
+    // Fall back to the shared context accessor for stream-info-based attributes that are not
+    // served from the live request state above.
+    if (const auto stream_info = filter->streamInfo(); stream_info != nullptr) {
+      ok = ContextAccessor::getAttributeString(*stream_info, attribute_id, result);
+    }
     break;
+  }
   }
   return ok;
 }
@@ -1980,9 +1984,14 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
     }
     break;
   }
-  default:
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
-                        "Unsupported attribute ID {} as int", static_cast<int64_t>(attribute_id));
+  default: {
+    // Fall back to the shared context accessor for stream-info-based attributes that are not
+    // served from the live request state above.
+    if (const auto stream_info = filter->streamInfo(); stream_info != nullptr) {
+      ok = ContextAccessor::getAttributeInt(*stream_info, attribute_id, result);
+    }
+    break;
+  }
   }
   return ok;
 }
@@ -2001,9 +2010,14 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_bool(
     }
     break;
   }
-  default:
-    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
-                        "Unsupported attribute ID {} as bool", static_cast<int64_t>(attribute_id));
+  default: {
+    // Fall back to the shared context accessor for stream-info-based attributes that are not
+    // served from the live request state above.
+    if (const auto stream_info = filter->streamInfo(); stream_info != nullptr) {
+      ok = ContextAccessor::getAttributeBool(*stream_info, attribute_id, result);
+    }
+    break;
+  }
   }
   return ok;
 }

--- a/source/extensions/filters/listener/dynamic_modules/BUILD
+++ b/source/extensions/filters/listener/dynamic_modules/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/router:string_accessor_lib",
         "//source/common/stats:utility_lib",
+        "//source/extensions/dynamic_modules:abi_context_accessors_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
     ],
 )

--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -12,6 +12,7 @@
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/abi_context_accessors.h"
 #include "source/extensions/filters/listener/dynamic_modules/filter.h"
 #include "source/extensions/filters/listener/dynamic_modules/filter_config.h"
 
@@ -1242,6 +1243,40 @@ uint32_t envoy_dynamic_module_callback_listener_filter_get_worker_index(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
   return filter->workerIndex();
+}
+
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+  if (callbacks == nullptr) {
+    return false;
+  }
+  return ContextAccessor::getAttributeString(callbacks->streamInfo(), attribute_id, result);
+}
+
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+  if (callbacks == nullptr) {
+    return false;
+  }
+  return ContextAccessor::getAttributeInt(callbacks->streamInfo(), attribute_id, result);
+}
+
+bool envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, bool* result) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+  if (callbacks == nullptr) {
+    return false;
+  }
+  return ContextAccessor::getAttributeBool(callbacks->streamInfo(), attribute_id, result);
 }
 
 } // extern "C"

--- a/source/extensions/filters/network/dynamic_modules/BUILD
+++ b/source/extensions/filters/network/dynamic_modules/BUILD
@@ -44,6 +44,7 @@ envoy_cc_library(
         "//source/common/network:upstream_socket_options_filter_state_lib",
         "//source/common/protobuf",
         "//source/common/router:string_accessor_lib",
+        "//source/extensions/dynamic_modules:abi_context_accessors_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -13,6 +13,7 @@
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/dynamic_modules/abi_context_accessors.h"
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
 #include "source/extensions/filters/network/dynamic_modules/filter_config.h"
 
@@ -1315,6 +1316,29 @@ uint32_t envoy_dynamic_module_callback_network_filter_get_worker_index(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
   return filter->workerIndex();
+}
+
+bool envoy_dynamic_module_callback_network_filter_get_attribute_string(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return ContextAccessor::getAttributeString(filter->connection().streamInfo(), attribute_id,
+                                             result);
+}
+
+bool envoy_dynamic_module_callback_network_filter_get_attribute_int(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return ContextAccessor::getAttributeInt(filter->connection().streamInfo(), attribute_id, result);
+}
+
+bool envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_attribute_id attribute_id, bool* result) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  return ContextAccessor::getAttributeBool(filter->connection().streamInfo(), attribute_id, result);
 }
 
 } // extern "C"

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1547,6 +1547,24 @@ WEAK_STUB(HttpFilterGetAttributeInt,
 WEAK_STUB(HttpFilterGetAttributeBool,
           envoy_dynamic_module_callback_http_filter_get_attribute_bool(
               nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(NetworkFilterGetAttributeString,
+          envoy_dynamic_module_callback_network_filter_get_attribute_string(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(NetworkFilterGetAttributeInt,
+          envoy_dynamic_module_callback_network_filter_get_attribute_int(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(NetworkFilterGetAttributeBool,
+          envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(ListenerFilterGetAttributeString,
+          envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(ListenerFilterGetAttributeInt,
+          envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
+WEAK_STUB(ListenerFilterGetAttributeBool,
+          envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+              nullptr, envoy_dynamic_module_type_attribute_id_RequestPath, nullptr))
 WEAK_STUB(HttpFilterHttpCallout,
           envoy_dynamic_module_callback_http_filter_http_callout(nullptr, nullptr, {nullptr, 0},
                                                                  nullptr, 0, {nullptr, 0}, 0))

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -1506,6 +1506,12 @@ TEST(ABIImpl, attribute_bool) {
       &filter, envoy_dynamic_module_type_attribute_id_ConnectionMtls, &result));
   EXPECT_FALSE(result);
 
+  // HealthCheck is not handled locally and is served by delegating to the shared ContextAccessor.
+  EXPECT_CALL(stream_info, healthCheck()).WillRepeatedly(testing::Return(true));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_bool(
+      &filter, envoy_dynamic_module_type_attribute_id_HealthCheck, &result));
+  EXPECT_TRUE(result);
+
   // Unsupported attribute.
   EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_bool(
       &filter, envoy_dynamic_module_type_attribute_id_RequestPath, &result));
@@ -2530,6 +2536,17 @@ TEST(ABIImpl, GetAttributes) {
       &filter, envoy_dynamic_module_type_attribute_id_ResponseCode, &result_number));
   EXPECT_EQ(result_number, 200);
 
+  // envoy_dynamic_module_type_attribute_id_ResponseFlags
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter_without_callbacks, envoy_dynamic_module_type_attribute_id_ResponseFlags,
+      &result_number));
+  // NoHealthyUpstream (bit 1) and DnsResolutionFailed (bit 26).
+  const uint64_t response_flags = (1ULL << 1) | (1ULL << 26);
+  EXPECT_CALL(stream_info, legacyResponseFlags()).WillRepeatedly(testing::Return(response_flags));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_ResponseFlags, &result_number));
+  EXPECT_EQ(result_number, response_flags);
+
   // envoy_dynamic_module_type_attribute_id_UpstreamPort
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_UpstreamPort, &result_number));
@@ -2550,6 +2567,12 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_ConnectionId, &result_number));
   EXPECT_EQ(result_number, 8386);
+
+  // envoy_dynamic_module_type_attribute_id_UpstreamRequestAttemptCount
+  EXPECT_CALL(stream_info, attemptCount()).WillRepeatedly(testing::Return(3));
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_UpstreamRequestAttemptCount, &result_number));
+  EXPECT_EQ(result_number, 3);
 }
 
 // When the request header map is present but a typed header is absent, the attribute must be

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -2944,6 +2944,65 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, ConfigStatsOperate) {
                 config, invalid_id, 1));
 }
 
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeInt) {
+  const uint64_t response_flags = (1ULL << 1) | (1ULL << 26);
+  EXPECT_CALL(callbacks_.stream_info_, legacyResponseFlags())
+      .WillRepeatedly(testing::Return(response_flags));
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
+  EXPECT_EQ(response_flags, result);
+
+  // A request attribute that is not backed by stream info returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeBool) {
+  EXPECT_CALL(callbacks_.stream_info_, healthCheck()).WillRepeatedly(testing::Return(true));
+  bool result = false;
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_HealthCheck, &result));
+  EXPECT_TRUE(result);
+
+  // An unsupported bool attribute returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeString) {
+  const absl::optional<std::string> details = "via_upstream";
+  EXPECT_CALL(callbacks_.stream_info_, responseCodeDetails())
+      .WillRepeatedly(testing::ReturnRef(details));
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseCodeDetails, &result));
+  EXPECT_EQ("via_upstream", std::string(result.ptr, result.length));
+
+  // An int attribute requested as string returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  filter->onAccept(callbacks_);
+  filter->setCallbacksForTest(nullptr);
+
+  envoy_dynamic_module_type_envoy_buffer str_result = {nullptr, 0};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+      static_cast<void*>(filter.get()), envoy_dynamic_module_type_attribute_id_ResponseCodeDetails,
+      &str_result));
+  uint64_t int_result = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+      static_cast<void*>(filter.get()), envoy_dynamic_module_type_attribute_id_ResponseFlags,
+      &int_result));
+  bool bool_result = false;
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_bool(
+      static_cast<void*>(filter.get()), envoy_dynamic_module_type_attribute_id_HealthCheck,
+      &bool_result));
+}
+
 } // namespace ListenerFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -2971,7 +2971,7 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeBool) {
 }
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeString) {
-  const absl::optional<std::string> details = "via_upstream";
+  const std::optional<std::string> details = "via_upstream";
   EXPECT_CALL(callbacks_.stream_info_, responseCodeDetails())
       .WillRepeatedly(testing::ReturnRef(details));
   envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};

--- a/test/extensions/dynamic_modules/listener/integration_test.cc
+++ b/test/extensions/dynamic_modules/listener/integration_test.cc
@@ -68,6 +68,18 @@ TEST_P(DynamicModulesListenerSdkIntegrationTest, WriteToSocket) {
   tcp_client->close();
 }
 
+TEST_P(DynamicModulesListenerSdkIntegrationTest, ReadAttributes) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the read_attributes filter is only in the rust test module";
+  }
+  initializeFilter("read_attributes");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("ping"));
+  tcp_client->waitForData("ping");
+  tcp_client->close();
+}
+
 TEST_P(DynamicModulesListenerSdkIntegrationTest, BufferRead) {
   initializeFilter("buffer_read");
 

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2733,6 +2733,51 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, ConfigStatsOperate) {
                 config, invalid_id, 1));
 }
 
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeInt) {
+  const uint64_t response_flags = (1ULL << 1) | (1ULL << 26);
+  EXPECT_CALL(connection_.stream_info_, legacyResponseFlags())
+      .WillRepeatedly(testing::Return(response_flags));
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
+  EXPECT_EQ(response_flags, result);
+
+  EXPECT_CALL(connection_.stream_info_, bytesSent()).WillRepeatedly(testing::Return(4096));
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseSize, &result));
+  EXPECT_EQ(4096, result);
+
+  // A request attribute that is not backed by stream info returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeBool) {
+  EXPECT_CALL(connection_.stream_info_, healthCheck()).WillRepeatedly(testing::Return(true));
+  bool result = false;
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_HealthCheck, &result));
+  EXPECT_TRUE(result);
+
+  // An unsupported bool attribute returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeString) {
+  const absl::optional<std::string> details = "via_upstream";
+  EXPECT_CALL(connection_.stream_info_, responseCodeDetails())
+      .WillRepeatedly(testing::ReturnRef(details));
+  envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseCodeDetails, &result));
+  EXPECT_EQ("via_upstream", std::string(result.ptr, result.length));
+
+  // An int attribute requested as string returns false.
+  EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
+}
+
 } // namespace NetworkFilters
 } // namespace DynamicModules
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2765,7 +2765,7 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeBool) {
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeString) {
-  const absl::optional<std::string> details = "via_upstream";
+  const std::optional<std::string> details = "via_upstream";
   EXPECT_CALL(connection_.stream_info_, responseCodeDetails())
       .WillRepeatedly(testing::ReturnRef(details));
   envoy_dynamic_module_type_envoy_buffer result = {nullptr, 0};

--- a/test/extensions/dynamic_modules/network/integration_test.cc
+++ b/test/extensions/dynamic_modules/network/integration_test.cc
@@ -314,4 +314,29 @@ TEST_P(DynamicModulesNetworkSdkIntegrationTest, UpstreamConnectionId) {
   tcp_client->close();
 }
 
+TEST_P(DynamicModulesNetworkSdkIntegrationTest, ReadAttributes) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the read_attributes filter is only in the rust test module";
+  }
+
+  initializeSdkFilter("read_attributes");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->connected());
+
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+
+  // The filter reads source address and connection id on new connection and asserts in the module.
+  // A failure there stops the chain and the upstream never sees data.
+  ASSERT_TRUE(tcp_client->write("hello", false));
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5));
+
+  ASSERT_TRUE(tcp_client->write("", true));
+  ASSERT_TRUE(fake_upstream_connection->waitForHalfClose());
+  ASSERT_TRUE(fake_upstream_connection->close());
+  tcp_client->waitForHalfClose();
+  tcp_client->close();
+}
+
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -54,6 +54,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
     "filter_state_callbacks" => Some(Box::new(FilterStateCallbacksFilterConfig {})),
     "body_callbacks" => Some(Box::new(BodyCallbacksFilterConfig {})),
+    "response_flags_callbacks" => Some(Box::new(ResponseFlagsCallbacksFilterConfig {})),
     "config_init_failure" => None,
     _ => panic!("Unknown filter name: {name}"),
   }
@@ -1383,5 +1384,107 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for BodyCallbacksFilter {
     }
 
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
+  }
+}
+
+/// Response flags surfaced as response headers by the `response_flags_callbacks` filter.
+struct ResponseFlags {
+  failed_local_health_check: bool,
+  no_healthy_upstream: bool,
+  upstream_request_timeout: bool,
+  local_reset: bool,
+  upstream_remote_reset: bool,
+  upstream_connection_failure: bool,
+  upstream_connection_termination: bool,
+  upstream_overflow: bool,
+  dns_resolution_failed: bool,
+}
+
+impl ResponseFlags {
+  /// Pairs each flag with the response header key used to surface it when set.
+  fn as_headers(&self) -> [(&'static str, bool); 9] {
+    [
+      (
+        "x-response-flag-failed-local-health-check",
+        self.failed_local_health_check,
+      ),
+      (
+        "x-response-flag-no-healthy-upstream",
+        self.no_healthy_upstream,
+      ),
+      (
+        "x-response-flag-upstream-request-timeout",
+        self.upstream_request_timeout,
+      ),
+      ("x-response-flag-local-reset", self.local_reset),
+      (
+        "x-response-flag-upstream-remote-reset",
+        self.upstream_remote_reset,
+      ),
+      (
+        "x-response-flag-upstream-connection-failure",
+        self.upstream_connection_failure,
+      ),
+      (
+        "x-response-flag-upstream-connection-termination",
+        self.upstream_connection_termination,
+      ),
+      ("x-response-flag-upstream-overflow", self.upstream_overflow),
+      (
+        "x-response-flag-dns-resolution-failed",
+        self.dns_resolution_failed,
+      ),
+    ]
+  }
+}
+
+/// Reads the `response.flags` bitmask through the attribute API and maps each bit. The bit
+/// positions come from the ABI `response_flag` enum so no magic numbers are needed.
+fn map_response_flags<EHF: EnvoyHttpFilter>(envoy_filter: &EHF) -> ResponseFlags {
+  use abi::envoy_dynamic_module_type_response_flag as Flag;
+  let flags = envoy_filter
+    .get_attribute_int(abi::envoy_dynamic_module_type_attribute_id::ResponseFlags)
+    .map_or(0u64, |v| v as u64);
+  let is_set = |flag: Flag| (flags & (1u64 << (flag as u64))) != 0;
+  ResponseFlags {
+    failed_local_health_check: is_set(Flag::FailedLocalHealthCheck),
+    no_healthy_upstream: is_set(Flag::NoHealthyUpstream),
+    upstream_request_timeout: is_set(Flag::UpstreamRequestTimeout),
+    local_reset: is_set(Flag::LocalReset),
+    upstream_remote_reset: is_set(Flag::UpstreamRemoteReset),
+    upstream_connection_failure: is_set(Flag::UpstreamConnectionFailure),
+    upstream_connection_termination: is_set(Flag::UpstreamConnectionTermination),
+    upstream_overflow: is_set(Flag::UpstreamOverflow),
+    dns_resolution_failed: is_set(Flag::DnsResolutionFailed),
+  }
+}
+
+/// A HTTP filter configuration that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] to test reading the response flags
+/// via the attribute API and surfacing the set ones as response headers.
+struct ResponseFlagsCallbacksFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for ResponseFlagsCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(ResponseFlagsCallbacksFilter {})
+  }
+}
+
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
+struct ResponseFlagsCallbacksFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ResponseFlagsCallbacksFilter {
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    let response_flags = map_response_flags(envoy_filter);
+    for (header_key, is_set) in response_flags.as_headers() {
+      if is_set {
+        envoy_filter.set_response_header(header_key, b"true");
+      }
+    }
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -615,3 +615,54 @@ fn test_dynamic_metadata_callbacks_on_response_body() {
     abi::envoy_dynamic_module_type_on_http_filter_response_body_status::Continue
   );
 }
+
+#[test]
+fn test_response_flags_callbacks_filter() {
+  let mut f = ResponseFlagsCallbacksFilter {};
+  let mut envoy_filter = MockEnvoyHttpFilter::default();
+
+  // Craft a bitmask with NoHealthyUpstream (bit 1), UpstreamOverflow (bit 7) and
+  // DnsResolutionFailed (bit 26) set. The unset bits must not produce any header.
+  envoy_filter
+    .expect_get_attribute_int()
+    .withf(|id| *id == abi::envoy_dynamic_module_type_attribute_id::ResponseFlags)
+    .return_const(Some((1i64 << 1) | (1i64 << 7) | (1i64 << 26)))
+    .once();
+
+  // Only the three set flags should be surfaced as response headers.
+  envoy_filter
+    .expect_set_response_header()
+    .withf(|key, value| key == "x-response-flag-no-healthy-upstream" && value == b"true")
+    .return_const(true)
+    .once();
+  envoy_filter
+    .expect_set_response_header()
+    .withf(|key, value| key == "x-response-flag-upstream-overflow" && value == b"true")
+    .return_const(true)
+    .once();
+  envoy_filter
+    .expect_set_response_header()
+    .withf(|key, value| key == "x-response-flag-dns-resolution-failed" && value == b"true")
+    .return_const(true)
+    .once();
+
+  assert_eq!(
+    f.on_response_headers(&mut envoy_filter, false),
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  );
+}
+
+#[test]
+fn test_map_response_flags_none_when_unavailable() {
+  let mut envoy_filter = MockEnvoyHttpFilter::default();
+
+  // When the attribute is unavailable the getter returns None, which must map to all-false flags.
+  envoy_filter
+    .expect_get_attribute_int()
+    .withf(|id| *id == abi::envoy_dynamic_module_type_attribute_id::ResponseFlags)
+    .returning(|_| None)
+    .once();
+
+  let flags = map_response_flags(&envoy_filter);
+  assert!(flags.as_headers().iter().all(|(_, is_set)| !is_set));
+}

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -19,6 +19,7 @@ fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListen
     "buffer_read" => Some(Box::new(BufferReadFilterConfig)),
     "http_callout_on_accept" => Some(Box::new(HttpCalloutOnAcceptFilterConfig)),
     "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
+    "read_attributes" => Some(Box::new(ReadAttributesFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -210,6 +211,37 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for DynamicMetadataFilter {
       Some(vec![0xff, 0x00, 0xfe])
     );
 
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+}
+
+// =============================================================================
+// Read Attributes Test Filter
+// =============================================================================
+
+// Reads connection stream info attributes through the generic attribute getters and asserts the
+// downstream addresses resolve at accept time.
+struct ReadAttributesFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for ReadAttributesFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(ReadAttributesFilter)
+  }
+}
+
+struct ReadAttributesFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for ReadAttributesFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    assert!(envoy_filter
+      .get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::SourceAddress)
+      .is_some());
+    assert!(envoy_filter
+      .get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::DestinationAddress)
+      .is_some());
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/network_integration_test.rs
@@ -30,6 +30,7 @@ fn new_network_filter_config_fn<EC: EnvoyNetworkFilterConfig, ENF: EnvoyNetworkF
     "buffer_limits" => Some(Box::new(BufferLimitsFilterConfig)),
     "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
     "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig)),
+    "read_attributes" => Some(Box::new(ReadAttributesFilterConfig)),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -400,6 +401,38 @@ impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for UpstreamConnectionIdFilter 
     _end_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
     assert!(envoy_filter.get_upstream_connection_id() > 0);
+    abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
+  }
+}
+
+// =============================================================================
+// Read Attributes Test Filter
+// =============================================================================
+
+// Reads connection stream info attributes through the generic attribute getters and asserts they
+// resolve once the connection is established.
+struct ReadAttributesFilterConfig;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilterConfig<ENF> for ReadAttributesFilterConfig {
+  fn new_network_filter(&self, _envoy: &mut ENF) -> Box<dyn NetworkFilter<ENF>> {
+    Box::new(ReadAttributesFilter)
+  }
+}
+
+struct ReadAttributesFilter;
+
+impl<ENF: EnvoyNetworkFilter> NetworkFilter<ENF> for ReadAttributesFilter {
+  fn on_new_connection(
+    &mut self,
+    envoy_filter: &mut ENF,
+  ) -> abi::envoy_dynamic_module_type_on_network_filter_data_status {
+    assert!(envoy_filter
+      .get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::SourceAddress)
+      .is_some());
+    let connection_id = envoy_filter
+      .get_attribute_int(abi::envoy_dynamic_module_type_attribute_id::ConnectionId)
+      .unwrap_or(0);
+    assert!(connection_id > 0);
     abi::envoy_dynamic_module_type_on_network_filter_data_status::Continue
   }
 }


### PR DESCRIPTION
## Description

Today, the network and listener dynamic-module filters had no way to read generic `StreamInfo` attributes. This PR adds `get_attribute_string`, `get_attribute_int` and `get_attribute_bool` ABI callbacks and Rust SDK methods for both, delegating to the shared ContextAccessor already used by the HTTP filter and access logger.

The HTTP filter previously kept its own partial attribute switch that had drifted from the shared accessor (`response.flags` was unreachable), so it now falls back to `ContextAccessor` for stream-info attributes and drops the duplication.

The shared accessor also gains the `response.flags` and `response.size` integer attributes.

---

**Commit Message:** dynamic_modules: add attribute getters to network and listener filters
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes**: Added