### PR TITLE
abi: remove deprecated <cstdbool> include

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -47,7 +47,6 @@
 #define ENVOY_DYNAMIC_MODULES_ABI_VERSION "v0.1.0"
 
 #ifdef __cplusplus
-#include <cstdbool>
 #include <cstddef>
 #include <cstdint>
 


### PR DESCRIPTION
`<cstdbool>` is deprecated in C++17 and triggers `-Werror` with newer compilers (clang 22+). The include is unnecessary since `bool` is a built-in type in C++.
