### PR TITLE
http: migrate aws_lambda/admission_control/... to exception free

### DIFF
--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -29,9 +29,7 @@ absl::StatusOr<Http::FilterFactoryCb>
 AdmissionControlFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  auto cb = createFilterFactory(proto_config, stats_prefix, context, context.scope());
-  THROW_IF_NOT_OK_REF(cb.status());
-  return cb.value();
+  return createFilterFactory(proto_config, stats_prefix, context, context.scope());
 }
 
 absl::StatusOr<Http::FilterFactoryCb> AdmissionControlFilterFactory::createFilterFactory(

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -137,12 +137,8 @@ AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
 absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
     const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
-  auto result = createFilterFactoryFromProtoHelper(proto_config, stats_prefix, server_context,
-                                                   server_context.scope(), false);
-  if (!result.ok()) {
-    ExceptionUtil::throwEnvoyException(std::string(result.status().message()));
-  }
-  return std::move(result.value());
+  return createFilterFactoryFromProtoHelper(proto_config, stats_prefix, server_context,
+                                            server_context.scope(), false);
 }
 
 /*

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -55,12 +55,8 @@ absl::StatusOr<Http::FilterFactoryCb>
 AwsRequestSigningFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const AwsRequestSigningProtoConfig& config, const std::string& stats_prefix,
     Server::Configuration::ServerFactoryContext& server_context) {
-  auto result = createFilterFactoryFromProtoHelper(config, stats_prefix, server_context,
-                                                   server_context.scope());
-  if (!result.ok()) {
-    ExceptionUtil::throwEnvoyException(std::string(result.status().message()));
-  }
-  return std::move(result.value());
+  return createFilterFactoryFromProtoHelper(config, stats_prefix, server_context,
+                                            server_context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>


### PR DESCRIPTION
Commit Message: http: migrate aws_lambda/admission_control/... to exception free
Additional Description:
Migrate exceptions of these filters to absl::Status and absl::StatusOr.

NOTE: This is AI assisted. But I reviewed all the changes and tests, and also did some manually update.

Risk Level: low.
Testing: unit/integration.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
