### PR TITLE
cache: fix cyclic ABSL_ACQUIRED_BEFORE annotations in CacheEvictionThread

### DIFF
--- a/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.h
+++ b/source/extensions/http/cache/file_system_http_cache/cache_eviction_thread.h
@@ -93,13 +93,12 @@ private:
    */
   void terminate();
 
-  // These two mutexes are never held at the same time. We signify this by requiring
-  // that both be 'acquired before' the other, since there is no exclusion annotation.
-  absl::Mutex mu_ ABSL_ACQUIRED_BEFORE(cache_mu_);
+  // These two mutexes are never held at the same time; no ordering annotation is needed.
+  absl::Mutex mu_;
   bool signalled_ ABSL_GUARDED_BY(mu_) = false;
   bool terminating_ ABSL_GUARDED_BY(mu_) = false;
 
-  absl::Mutex cache_mu_ ABSL_ACQUIRED_BEFORE(mu_);
+  absl::Mutex cache_mu_;
   // We must store the caches as unowned references so they can be destroyed
   // during config changes - that destruction is the only signal that a cache
   // instance should be removed.


### PR DESCRIPTION
The two mutexes mu_ and cache_mu_ are never held simultaneously, so no lock ordering annotation is needed. The previous circular `ACQUIRED_BEFORE` hack (each pointing to the other) is rejected by clang 22's improved `-Wthread-safety-analysis`.

Remove the ordering annotations; the `GUARDED_BY` annotations on the protected fields remain and are sufficient.
