### PR TITLE
deps: update Wasmtime to 45.0.3

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -573,7 +573,7 @@ wasmtime:
   project_name: "wasmtime"
   project_desc: "A standalone runtime for WebAssembly"
   project_url: "https://github.com/bytecodealliance/wasmtime"
-  release_date: "2026-04-09"
+  release_date: "2026-06-15"
   use_category:
   - dataplane_ext
   extensions:
@@ -1233,7 +1233,7 @@ proxy_wasm_cpp_host:
   project_name: "WebAssembly for Proxies (C++ host implementation)"
   project_desc: "WebAssembly for Proxies (C++ host implementation)"
   project_url: "https://github.com/proxy-wasm/proxy-wasm-cpp-host"
-  release_date: "2026-06-22"
+  release_date: "2026-06-23"
   use_category:
   - dataplane_ext
   extensions:

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -519,8 +519,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/bytecodealliance/wasm-micro-runtime/archive/{version}.tar.gz"],
     ),
     wasmtime = dict(
-        version = "42.0.2",
-        sha256 = "96b94e150a3877d98cdc2e27bcd65ba89155ad67fa16c48fad6216664cb60d29",
+        version = "45.0.2",
+        sha256 = "a95cf57008b87dbe1cdaba220ea58b75bb0b53369e166fe21e729011bd25e9e8",
         strip_prefix = "wasmtime-{version}",
         urls = ["https://github.com/bytecodealliance/wasmtime/archive/v{version}.tar.gz"],
     ),
@@ -623,8 +623,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/{version}.tar.gz"],
     ),
     proxy_wasm_cpp_host = dict(
-        version = "09e5f8d6658fdb77f3d5859b27141e79514e371c",
-        sha256 = "366e7598d4931a96fd1c5b0482f87076d863810049aa3a8ce921616592ed3e8c",
+        version = "f2db56af443571e92a31c0b877106d9ea96e19ef",
+        sha256 = "34dac5bcebf0b156e435bf8dd9bdac5be60b95f967c420c680578d73af28c604",
         strip_prefix = "proxy-wasm-cpp-host-{version}",
         urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/{version}.tar.gz"],
     ),


### PR DESCRIPTION
Update Wasmtime to 44.0.3 to pick up the CVE-2026-54786 fix.

The proxy-wasm-host generated Wasmtime prefix patch was tied to the older Wasmtime source layout and no longer applies to 44.0.3. Run the same prefixing transform as repository patch commands instead so new C API symbols added by Wasmtime are handled with the rest of the C API.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
