### PR TITLE
deps: add missing #include <cstdint> to headers using fixed-width integer types

### DIFF
--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/common/pure.h"
 
 #include "openssl/ssl.h"

--- a/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
+++ b/contrib/cryptomb/private_key_providers/source/ipp_crypto_impl.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "contrib/cryptomb/private_key_providers/source/ipp_crypto.h"
 #include "crypto_mb/cpu_features.h"
 #include "crypto_mb/ec_nistp256.h"

--- a/contrib/kae/private_key_providers/source/libuadk.h
+++ b/contrib/kae/private_key_providers/source/libuadk.h
@@ -2,6 +2,7 @@
 
 #include <uadk/v1/wd_bmm.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "envoy/common/pure.h"

--- a/contrib/kafka/filters/network/source/broker/filter_config.h
+++ b/contrib/kafka/filters/network/source/broker/filter_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <utility>
 

--- a/contrib/kafka/filters/network/source/kafka_types.h
+++ b/contrib/kafka/filters/network/source/kafka_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/fetch_record_converter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers/produce_record_extractor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "contrib/kafka/filters/network/source/external/requests.h"
 #include "contrib/kafka/filters/network/source/mesh/outbound_record.h"
 

--- a/contrib/kafka/filters/network/source/mesh/inbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/inbound_record.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
+++ b/contrib/kafka/filters/network/source/mesh/librdkafka_utils_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"

--- a/contrib/kafka/filters/network/source/mesh/outbound_record.h
+++ b/contrib/kafka/filters/network/source/mesh/outbound_record.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <utility>

--- a/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
+++ b/contrib/kafka/filters/network/source/mesh/upstream_kafka_consumer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <utility>

--- a/contrib/kafka/filters/network/test/broker/mock_filter_config.h
+++ b/contrib/kafka/filters/network/test/broker/mock_filter_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include "contrib/kafka/filters/network/source/broker/filter_config.h"

--- a/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
+++ b/contrib/kafka/filters/network/test/mesh/kafka_mocks.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "contrib/kafka/filters/network/source/mesh/librdkafka_utils.h"
 #include "gmock/gmock.h"
 #include "librdkafka/rdkafkacpp.h"

--- a/envoy/common/random_generator.h
+++ b/envoy/common/random_generator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>

--- a/envoy/config/eds_resources_cache.h
+++ b/envoy/config/eds_resources_cache.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/common/optref.h"
 #include "envoy/common/pure.h"
 #include "envoy/config/endpoint/v3/endpoint.pb.h"

--- a/envoy/http/codec_runtime_overrides.h
+++ b/envoy/http/codec_runtime_overrides.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "absl/strings/string_view.h"
 
 namespace Envoy {

--- a/envoy/http/metadata_interface.h
+++ b/envoy/http/metadata_interface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <iosfwd>
 #include <memory>

--- a/envoy/ssl/connection.h
+++ b/envoy/ssl/connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/envoy/ssl/context.h
+++ b/envoy/ssl/context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/envoy/stream_info/stream_id_provider.h
+++ b/envoy/stream_info/stream_id_provider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 

--- a/source/common/common/random_generator.h
+++ b/source/common/common/random_generator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/common/random_generator.h"
 
 namespace Envoy {

--- a/source/common/common/scalar_to_byte_vector.h
+++ b/source/common/common/scalar_to_byte_vector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cinttypes>
+#include <cstdint>
 #include <vector>
 
 namespace Envoy {

--- a/source/common/jwt/simple_lru_cache_inl.h
+++ b/source/common/jwt/simple_lru_cache_inl.h
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <sstream>
 #include <string>

--- a/source/common/quic/quic_network_connectivity_observer.h
+++ b/source/common/quic/quic_network_connectivity_observer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #ifdef ENVOY_ENABLE_QUIC

--- a/source/common/quic/send_buffer_monitor.h
+++ b/source/common/quic/send_buffer_monitor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "quiche/quic/core/quic_stream.h"
 
 namespace Envoy {

--- a/source/common/stats/recent_lookups.h
+++ b/source/common/stats/recent_lookups.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <utility>

--- a/source/common/stream_info/stream_id_provider_impl.h
+++ b/source/common/stream_info/stream_id_provider_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "envoy/stream_info/stream_id_provider.h"

--- a/source/extensions/common/wasm/ext/envoy_null_plugin.h
+++ b/source/extensions/common/wasm/ext/envoy_null_plugin.h
@@ -4,6 +4,8 @@
 #define PROXY_WASM_PROTOBUF 1
 #define PROXY_WASM_PROTOBUF_FULL 1
 
+#include <cstdint>
+
 #include "envoy/config/core/v3/grpc_service.pb.h"
 
 #include "source/extensions/common/wasm/ext/declare_property.pb.h"

--- a/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
+++ b/source/extensions/common/wasm/ext/envoy_proxy_wasm_api.h
@@ -1,5 +1,7 @@
 // NOLINT(namespace-envoy)
 #pragma once
+#include <cstdint>
+
 
 // Note that this file is included in emscripten and NullVM environments and thus depends on
 // the context in which it is included, hence we need to disable clang-tidy warnings.

--- a/source/extensions/config_subscription/grpc/pausable_ack_queue.h
+++ b/source/extensions/config_subscription/grpc/pausable_ack_queue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <list>
 
 #include "source/extensions/config_subscription/grpc/update_ack.h"

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_listener.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_listener.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "sdk.h"
 
 namespace Envoy {

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_network.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_network.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "sdk.h"
 
 namespace Envoy {

--- a/source/extensions/filters/common/processing_effect/processing_effect.h
+++ b/source/extensions/filters/common/processing_effect/processing_effect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/source/extensions/filters/http/adaptive_concurrency/controller/controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/controller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <cstdint>
 
 #include "envoy/common/pure.h"
 #include "envoy/common/time.h"

--- a/source/extensions/filters/http/ext_proc/allowed_override_modes_set.h
+++ b/source/extensions/filters/http/ext_proc/allowed_override_modes_set.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/extensions/filters/http/ext_proc/v3/processing_mode.pb.h"
 
 #include "absl/container/flat_hash_set.h"

--- a/source/extensions/filters/http/original_src/config.h
+++ b/source/extensions/filters/http/original_src/config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/extensions/filters/http/original_src/v3/original_src.pb.h"
 
 namespace Envoy {

--- a/source/extensions/filters/listener/original_src/config.h
+++ b/source/extensions/filters/listener/original_src/config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/extensions/filters/listener/original_src/v3/original_src.pb.h"
 
 namespace Envoy {

--- a/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.h
+++ b/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "absl/strings/string_view.h"

--- a/source/extensions/filters/network/thrift_proxy/tracing.h
+++ b/source/extensions/filters/network/thrift_proxy/tracing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <optional>
 #include <string>

--- a/source/extensions/tracers/opentelemetry/otlp_utils.h
+++ b/source/extensions/tracers/opentelemetry/otlp_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h
+++ b/source/extensions/tracers/opentelemetry/samplers/dynatrace/trace_capture_reason.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/source/extensions/tracers/xray/sampling_strategy.h
+++ b/source/extensions/tracers/xray/sampling_strategy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "envoy/common/pure.h"

--- a/source/extensions/transport_sockets/alts/alts_proxy.h
+++ b/source/extensions/transport_sockets/alts/alts_proxy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "absl/status/statusor.h"

--- a/test/common/tls/cert_validator/default_validator_integration_test.h
+++ b/test/common/tls/cert_validator/default_validator_integration_test.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "test/integration/http_integration.h"

--- a/test/extensions/dynamic_modules/stat_sink/test_util.h
+++ b/test/extensions/dynamic_modules/stat_sink/test_util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "test/mocks/stats/mocks.h"
 
 #include "gmock/gmock.h"

--- a/test/extensions/filters/common/ratelimit/utils.h
+++ b/test/extensions/filters/common/ratelimit/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "envoy/service/ratelimit/v3/rls.pb.h"

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_integration_test.h
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_filter_integration_test.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "test/integration/http_integration.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/utility.h"

--- a/test/extensions/load_balancing_policies/common/zone_aware_load_balancer_fuzz_base.h
+++ b/test/extensions/load_balancing_policies/common/zone_aware_load_balancer_fuzz_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/config/cluster/v3/cluster.pb.h"
 
 #include "test/extensions/load_balancing_policies/common/load_balancer_fuzz_base.h"

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_integration_test.h
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_integration_test.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "test/integration/http_integration.h"

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "test/integration/fake_upstream.h"
 
 namespace Envoy {

--- a/test/integration/http_timeout_integration_test.h
+++ b/test/integration/http_timeout_integration_test.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/extensions/filters/http/router/v3/router.pb.h"
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 

--- a/test/mocks/config/eds_resources_cache.h
+++ b/test/mocks/config/eds_resources_cache.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "envoy/config/eds_resources_cache.h"
 
 #include "gmock/gmock.h"

--- a/test/server/config_validation/xds_fuzz.h
+++ b/test/server/config_validation/xds_fuzz.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>


### PR DESCRIPTION
Clang 22 no longer transitively provides `<cstdint>` through other standard library headers. Add the explicit include to all 55 headers that use `uint*_t` / `int*_t` types but cannot reach `<cstdint>` through their project include chain.
