### PR TITLE
router: classify remote resets as external-origin failures

### DIFF
--- a/changelogs/current/bug_fixes/router__classify-upstream-http-resets-as-external.rst
+++ b/changelogs/current/bug_fixes/router__classify-upstream-http-resets-as-external.rst
@@ -1,0 +1,3 @@
+Fixed upstream HTTP resets being reported as locally originated failures to outlier detection.
+Peer-generated resets and upstream protocol errors are now reported as externally originated
+failures when split external and local origin errors are enabled.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1665,13 +1665,15 @@ void Filter::onUpstreamReset(Http::StreamResetReason reset_reason,
   // Therefore removing an upstream in the case of an overloaded cluster
   // would make the situation even worse.
   // https://github.com/envoyproxy/envoy/issues/25487
-  if (!dropped) {
-    // TODO: The reset may also come from upstream over the wire. In this case it should be
-    // treated as external origin error and distinguished from local origin error.
-    // This matters only when running OutlierDetection with split_external_local_origin_errors
-    // config param set to true.
-    updateOutlierDetection(Upstream::Outlier::Result::LocalOriginConnectFailed, upstream_request,
-                           std::nullopt);
+  const auto outlier_result = streamResetReasonToOutlierResult(reset_reason);
+  if (outlier_result.has_value()) {
+    // Preserve the legacy 503 mapping in non-split mode when a peer-generated reset is reported as
+    // an external-origin failure.
+    const std::optional<uint64_t> response_code =
+        outlier_result.value() == Upstream::Outlier::Result::ExtOriginRequestFailed
+            ? std::optional<uint64_t>(enumToInt(Http::Code::ServiceUnavailable))
+            : std::nullopt;
+    updateOutlierDetection(outlier_result.value(), upstream_request, response_code);
   }
 
   if (maybeRetryReset(reset_reason, upstream_request, TimeoutRetry::No)) {
@@ -1767,6 +1769,31 @@ Filter::streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason) {
     return StreamInfo::CoreResponseFlag::UpstreamRemoteReset;
   case Http::StreamResetReason::OverloadManager:
     return StreamInfo::CoreResponseFlag::OverloadManager;
+  }
+
+  PANIC_DUE_TO_CORRUPT_ENUM;
+}
+
+std::optional<Upstream::Outlier::Result>
+Filter::streamResetReasonToOutlierResult(Http::StreamResetReason reset_reason) {
+  switch (reset_reason) {
+  case Http::StreamResetReason::RemoteReset:
+  case Http::StreamResetReason::RemoteRefusedStreamReset:
+  case Http::StreamResetReason::ProtocolError:
+    return Upstream::Outlier::Result::ExtOriginRequestFailed;
+  case Http::StreamResetReason::Overflow:
+  case Http::StreamResetReason::RemoteResetNoError:
+    return std::nullopt;
+  case Http::StreamResetReason::LocalReset:
+  case Http::StreamResetReason::LocalRefusedStreamReset:
+  case Http::StreamResetReason::LocalConnectionFailure:
+  case Http::StreamResetReason::RemoteConnectionFailure:
+  case Http::StreamResetReason::ConnectionTimeout:
+  case Http::StreamResetReason::ConnectionTermination:
+  case Http::StreamResetReason::ConnectError:
+  case Http::StreamResetReason::OverloadManager:
+  case Http::StreamResetReason::Http1PrematureUpstreamHalfClose:
+    return Upstream::Outlier::Result::LocalOriginConnectFailed;
   }
 
   PANIC_DUE_TO_CORRUPT_ENUM;

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -312,6 +312,9 @@ public:
   static StreamInfo::CoreResponseFlag
   streamResetReasonToResponseFlag(Http::StreamResetReason reset_reason);
 
+  static std::optional<Upstream::Outlier::Result>
+  streamResetReasonToOutlierResult(Http::StreamResetReason reset_reason);
+
   // Http::StreamFilterBase
   void onDestroy() override;
 

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -407,7 +407,8 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
 
   // This should not trigger a retry as the retry state has been deleted.
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
   EXPECT_EQ(callbacks_.details(), "upstream_reset_before_response_started{remote_reset}");
 }

--- a/test/common/router/router_outlier_detection_test.cc
+++ b/test/common/router/router_outlier_detection_test.cc
@@ -69,5 +69,46 @@ INSTANTIATE_TEST_SUITE_P(
         // to the outlier detection.
         std::make_tuple(503, std::optional<bool>(false), std::optional<uint64_t>(200))));
 
+using ResetOutlierDetectionTestCase =
+    std::tuple<Http::StreamResetReason, std::optional<Upstream::Outlier::Result>>;
+
+class RouterResetOutlierDetectionTest
+    : public ::testing::TestWithParam<ResetOutlierDetectionTestCase> {};
+
+TEST_P(RouterResetOutlierDetectionTest, ClassifiesResetOrigin) {
+  EXPECT_EQ(std::get<1>(GetParam()),
+            Filter::streamResetReasonToOutlierResult(std::get<0>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RouterOutlierDetectionTestSuite, RouterResetOutlierDetectionTest,
+    ::testing::Values(
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::LocalReset,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::LocalRefusedStreamReset,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::RemoteReset,
+                                      Upstream::Outlier::Result::ExtOriginRequestFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::RemoteRefusedStreamReset,
+                                      Upstream::Outlier::Result::ExtOriginRequestFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::LocalConnectionFailure,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::RemoteConnectionFailure,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::ConnectionTimeout,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::ConnectionTermination,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::Overflow, std::nullopt},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::ConnectError,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::ProtocolError,
+                                      Upstream::Outlier::Result::ExtOriginRequestFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::OverloadManager,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::Http1PrematureUpstreamHalfClose,
+                                      Upstream::Outlier::Result::LocalOriginConnectFailed},
+        ResetOutlierDetectionTestCase{Http::StreamResetReason::RemoteResetNoError, std::nullopt}));
+
 } // namespace Router
 } // namespace Envoy

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -1715,7 +1715,8 @@ TEST_F(RouterTest, ResetDuringEncodeHeaders) {
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
                         std::optional<uint64_t>(std::nullopt)));
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _))
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)))
       .Times(0);
   // The reset will be converted into a local reply.
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::ServiceUnavailable, testing::Eq(""), _, _,
@@ -2306,7 +2307,8 @@ TEST_F(RouterTest, GrpcReset) {
   response_decoder->decodeHeaders(std::move(response_headers), false);
   EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
   EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
   EXPECT_EQ(1UL, stats_store_.counter("test.rq_reset_after_downstream_response_started").value());
@@ -4049,7 +4051,8 @@ TEST_F(RouterTest, HedgingRetriesProceedAfterReset) {
 
   // First is reset
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
               putResult(Upstream::Outlier::Result::LocalOriginConnectSuccess,
                         std::optional<uint64_t>(std::nullopt)))
@@ -4282,7 +4285,8 @@ TEST_F(RouterTest, RetryUpstreamReset) {
         return RetryStatus::Yes;
       }));
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
 
   // We expect this reset to kick off a new request.
@@ -4355,7 +4359,8 @@ TEST_F(RouterTest, RetryHttp3UpstreamReset) {
       }));
 
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
 
   // We expect this reset to kick off a new request.
@@ -4710,7 +4715,8 @@ TEST_F(RouterTest, RetryUpstreamResetResponseStarted) {
               putResult(_, std::optional<uint64_t>(200)));
   response_decoder->decodeHeaders(std::move(response_headers), false);
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   // Normally, sendLocalReply will actually send the reply, but in this case the
   // HCM will detect the headers have already been sent and not route through
   // the encoder again.
@@ -4749,7 +4755,8 @@ TEST_F(RouterTest, RetryUpstreamReset1xxResponseStarted) {
       1U,
       cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_100").value());
   EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
-              putResult(Upstream::Outlier::Result::LocalOriginConnectFailed, _));
+              putResult(Upstream::Outlier::Result::ExtOriginRequestFailed,
+                        std::optional<uint64_t>(503)));
   encoder1.stream_.resetStream(Http::StreamResetReason::RemoteReset);
   EXPECT_EQ(1U,
             callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());


### PR DESCRIPTION
Treat peer-generated HTTP resets as external-origin failures while preserving existing behavior when origin splitting is disabled.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
