### PR TITLE
stats: enable tag-extraction check for metrics_service integration test

### DIFF
--- a/test/common/stats/tag_extractor_impl_test.cc
+++ b/test/common/stats/tag_extractor_impl_test.cc
@@ -314,6 +314,14 @@ TEST(TagExtractorTest, DefaultTagExtractors) {
   regex_tester.testRegex("cluster.grpc_cluster.grpc.grpc_service_1.grpc_method_1.success",
                          "cluster.grpc.success", {grpc_cluster, grpc_method, grpc_service});
 
+  // Google gRPC client stats: grpc.(<client_prefix>.)<base_stat>
+  Tag google_grpc_prefix;
+  google_grpc_prefix.name_ = tag_names.GOOGLE_GRPC_CLIENT_PREFIX;
+  google_grpc_prefix.value_ = "metrics_service";
+
+  regex_tester.testRegex("grpc.metrics_service.streams_closed_14", "grpc.streams_closed_14",
+                         {google_grpc_prefix});
+
   // Virtual host and cluster
   Tag vhost;
   vhost.name_ = tag_names.VIRTUAL_HOST;

--- a/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
+++ b/test/extensions/stats_sinks/metrics_service/metrics_service_integration_test.cc
@@ -24,10 +24,9 @@ class MetricsServiceIntegrationTest : public Grpc::GrpcClientIntegrationParamTes
                                       public HttpIntegrationTest {
 public:
   MetricsServiceIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, ipVersion()) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'grpc.metrics_service.streams_closed_14' and
-    // stat_prefix 'metrics_service'.
-    skip_tag_extraction_rule_check_ = true;
+    // grpc.metrics_service.streams_closed_* is now covered by the grpc.$.** rule (#36673), so
+    // the tag-extraction check can be enabled here. Toward #21595.
+    skip_tag_extraction_rule_check_ = false;
   }
 
   void createUpstreams() override {


### PR DESCRIPTION
The metrics_service stats-sink integration test skipped the missing-tag-extraction-rule check with a stale TODO. That stat (`grpc.metrics_service.streams_closed_*`) is now covered by the `grpc.$.**` rule from #36673, so this enables the check and adds direct unit coverage for the google_grpc client prefix.

Risk Level: Low (test only)
Testing: `tag_extractor_impl_test` and the metrics_service integration test pass with the check enabled.
Docs Changes: n/a
Release Notes: n/a

Partially addresses #21595.