### PR TITLE
stats: enable tag-extraction check for http_grpc_access_log integration test

### DIFF
--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_integration_test.cc
@@ -26,10 +26,9 @@ class AccessLogIntegrationTest : public Grpc::GrpcClientIntegrationParamTest,
                                  public HttpIntegrationTest {
 public:
   AccessLogIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, ipVersion()) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'grpc.accesslog.streams_closed_11' and stat_prefix
-    // 'accesslog'.
-    skip_tag_extraction_rule_check_ = true;
+    // grpc.accesslog.streams_closed_* is now covered by the grpc.$.** rule (#36673), so the
+    // tag-extraction check can be enabled here. Toward #21595.
+    skip_tag_extraction_rule_check_ = false;
   }
 
   void createUpstreams() override {


### PR DESCRIPTION
The http_grpc access-log integration test skipped the missing-tag-extraction-rule check with a stale TODO. That stat (`grpc.accesslog.streams_closed_*`) is now covered by the `grpc.$.**` rule from #36673, so this enables the check.

Risk Level: Low (test only)
Testing: the http_grpc_access_log integration test passes with the check enabled.
Docs Changes: n/a
Release Notes: n/a

Partially addresses #21595.