### PR TITLE
stats: enable tag-extraction check for ratelimit, scoped_rds, open_telemetry tests

### DIFF
--- a/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
+++ b/test/extensions/filters/http/ratelimit/ratelimit_integration_test.cc
@@ -31,8 +31,7 @@ class RatelimitIntegrationTest : public Grpc::GrpcClientIntegrationParamTest,
                                  public HttpIntegrationTest {
 public:
   RatelimitIntegrationTest() : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, ipVersion()) {
-    // TODO(ggreenway): add tag extraction rules.
-    skip_tag_extraction_rule_check_ = true;
+    skip_tag_extraction_rule_check_ = false;
   }
 
   void createUpstreams() override {

--- a/test/extensions/stats_sinks/open_telemetry/open_telemetry_integration_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/open_telemetry_integration_test.cc
@@ -52,10 +52,7 @@ public:
 
   OpenTelemetryIntegrationTest()
       : HttpIntegrationTest(Http::CodecType::HTTP1, std::get<0>(GetParam())) {
-    // TODO(ohadvano): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat 'grpc.otlp_collector.streams_closed_x' and
-    // stat_prefix 'otlp_collector'.
-    skip_tag_extraction_rule_check_ = true;
+    skip_tag_extraction_rule_check_ = false;
     driver_ = (std::get<2>(GetParam()) == ExporterType::GRPC) ? makeGrpcDriver(clientType())
                                                               : makeHttpDriver();
   }
@@ -502,7 +499,7 @@ class OpenTelemetryFormatterHeaderTest : public testing::TestWithParam<Network::
                                          public HttpIntegrationTest {
 public:
   OpenTelemetryFormatterHeaderTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
-    skip_tag_extraction_rule_check_ = true;
+    skip_tag_extraction_rule_check_ = false;
   }
 
   void initialize() override {

--- a/test/integration/scoped_rds.h
+++ b/test/integration/scoped_rds.h
@@ -31,11 +31,7 @@ protected:
   };
 
   ScopedRdsIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, ipVersion()) {
-    // TODO(ggreenway): add tag extraction rules.
-    // Missing stat tag-extraction rule for stat
-    // 'http.scoped_rds.foo-scoped-routes.grpc.srds_cluster.streams_closed_16' and stat_prefix
-    // 'srds_cluster'.
-    skip_tag_extraction_rule_check_ = true;
+    skip_tag_extraction_rule_check_ = false;
 
     config_helper_.addRuntimeOverride("envoy.reloadable_features.unified_mux",
                                       (sotwOrDelta() == Grpc::SotwOrDelta::UnifiedSotw ||

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -29,7 +29,9 @@ class InlineScopedRoutesIntegrationTest
     : public HttpIntegrationTest,
       public testing::TestWithParam<Network::Address::IpVersion> {
 protected:
-  InlineScopedRoutesIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+  InlineScopedRoutesIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {
+    skip_tag_extraction_rule_check_ = false;
+  }
 
   void setScopedRoutesConfig(absl::string_view config_yaml) {
     config_helper_.addConfigModifier(


### PR DESCRIPTION
These integration tests skipped the missing-tag-extraction-rule check with 2022-era TODOs citing stats that lacked rules at the time. Those rules now exist (e.g. `grpc.$.**` from #36673 covers the open_telemetry gRPC-client stats; scoped_rds gRPC-client stats are extracted by `SCOPED_RDS_CONFIG`). This enables the check in ratelimit, scoped_rds (and the shared `InlineScopedRoutes` fixture), and the open_telemetry stats sink. Since `scoped_rds.h` is shared, the on_demand and odcds tests are covered too.

Risk Level: Low (test only)
Testing: all five affected targets (ratelimit, scoped_rds, open_telemetry, on_demand, odcds) pass with the check enabled.
Docs Changes: n/a
Release Notes: n/a

Partially addresses #21595.