### PR TITLE
protodoc: render map fields as map<K, V> instead of repeated map<K, V>

### DIFF
--- a/docs/tools/protodoc/protodoc.py
+++ b/docs/tools/protodoc/protodoc.py
@@ -533,6 +533,7 @@ class RstFormatVisitor(visitor.Visitor):
         return dict(
             anchor=field_cross_ref_label(normalize_type_context_name(ctx.name)),
             field=field,
+            is_map=type_name_from_fqn(field.type_name) in ctx.map_typenames,
             field_name=field.name,
             comment=self._field_type(ctx.map_typenames, field.type, field.type_name),
             field_annotations=",".join(field_annotations),

--- a/docs/tools/protodoc/templates/message.rst.tpl
+++ b/docs/tools/protodoc/templates/message.rst.tpl
@@ -16,7 +16,7 @@
 {{ msg.anchor | rst_anchor }}
 
 {{ msg.field_name }}
-  ({{ pretty_label_names[msg.field.label] }}{{ msg.comment }}{% if msg.field_annotations %}, {{ msg.field_annotations }}{% endif %}) {{ msg.formatted_leading_comment | indent(2)}}
+  ({% if not msg.is_map %}{{ pretty_label_names[msg.field.label] }}{% endif %}{{ msg.comment }}{% if msg.field_annotations %}, {{ msg.field_annotations }}{% endif %}) {{ msg.formatted_leading_comment | indent(2)}}
 {%- if msg.formatted_oneof_comment %}
   {{ msg.formatted_oneof_comment | indent(2) }}
 {%- endif %}


### PR DESCRIPTION
protoc represents a `map<K, V>` field as a repeated MapEntry message, so its label is `LABEL_REPEATED` and the docs template prefixed the (already correct) `map<K, V>` rendering with "repeated". This suppresses the label prefix for map fields, using the same `map_typenames` check `_json_value` already uses.

Risk Level: Low (doc tooling only)
Testing: regenerated the route/v3 API docs — the 4 `repeated map<>` renderings become `map<>`; genuine repeated fields keep their prefix.
Docs Changes: generated API docs only
Release Notes: n/a

Fixes #32523