### PR TITLE
access_loggers: use configured formatters for OpenTelemetry custom_tags

### DIFF
--- a/changelogs/current/bug_fixes/open_telemetry__custom-tags-formatters.rst
+++ b/changelogs/current/bug_fixes/open_telemetry__custom-tags-formatters.rst
@@ -1,0 +1,6 @@
+Fixed the OpenTelemetry access loggers (both the gRPC and HTTP variants) ignoring configured
+:ref:`formatters <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.formatters>`
+when building :ref:`custom_tags <envoy_v3_api_field_extensions.access_loggers.open_telemetry.v3.OpenTelemetryAccessLogConfig.custom_tags>`.
+Previously a custom tag whose value used a formatter extension command failed with
+``Not supported field in StreamInfo``, even though the same command worked in ``body`` and
+``attributes``. The configured command parsers are now passed through to custom-tag creation.

--- a/source/extensions/access_loggers/open_telemetry/BUILD
+++ b/source/extensions/access_loggers/open_telemetry/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     hdrs = ["otlp_log_utils.h"],
     deps = [
         "//envoy/formatter:http_formatter_context_interface",
+        "//envoy/formatter:substitution_formatter_interface",
         "//envoy/local_info:local_info_interface",
         "//envoy/stats:stats_macros",
         "//envoy/stream_info:filter_state_interface",

--- a/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/access_log_impl.cc
@@ -41,7 +41,7 @@ AccessLog::AccessLog(
     : Common::ImplBase(std::move(filter)), tls_slot_(tls.allocateSlot()),
       access_logger_cache_(std::move(access_logger_cache)),
       filter_state_objects_to_log_(getFilterStateObjectsToLog(config)),
-      custom_tags_(getCustomTags(config)) {
+      custom_tags_(getCustomTags(config, commands)) {
 
   THROW_IF_NOT_OK(Envoy::Config::Utility::checkTransportVersion(config.common_config()));
   tls_slot_->set([this, config](Event::Dispatcher&) {

--- a/source/extensions/access_loggers/open_telemetry/http_access_log_impl.cc
+++ b/source/extensions/access_loggers/open_telemetry/http_access_log_impl.cc
@@ -222,7 +222,7 @@ HttpAccessLog::HttpAccessLog(
     : Common::ImplBase(std::move(filter)), tls_slot_(server_context.threadLocal().allocateSlot()),
       access_logger_cache_(std::move(access_logger_cache)), http_service_(config.http_service()),
       filter_state_objects_to_log_(getFilterStateObjectsToLog(config)),
-      custom_tags_(getCustomTags(config)) {
+      custom_tags_(getCustomTags(config, commands)) {
 
   // Get or create the headers applicator on the main thread. This is required because
   // DataSourceProvider (used by FILE_CONTENT formatter) allocates TLS slots,

--- a/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
+++ b/source/extensions/access_loggers/open_telemetry/otlp_log_utils.cc
@@ -113,10 +113,11 @@ std::vector<std::string> getFilterStateObjectsToLog(
 
 std::vector<Tracing::CustomTagConstSharedPtr> getCustomTags(
     const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&
-        config) {
+        config,
+    const Formatter::CommandParserPtrVector& command_parsers) {
   std::vector<Tracing::CustomTagConstSharedPtr> custom_tags;
   for (const auto& custom_tag : config.custom_tags()) {
-    custom_tags.push_back(Tracing::CustomTagUtility::createCustomTag(custom_tag));
+    custom_tags.push_back(Tracing::CustomTagUtility::createCustomTag(custom_tag, command_parsers));
   }
   return custom_tags;
 }

--- a/source/extensions/access_loggers/open_telemetry/otlp_log_utils.h
+++ b/source/extensions/access_loggers/open_telemetry/otlp_log_utils.h
@@ -6,6 +6,7 @@
 
 #include "envoy/extensions/access_loggers/open_telemetry/v3/logs_service.pb.h"
 #include "envoy/formatter/http_formatter_context.h"
+#include "envoy/formatter/substitution_formatter.h"
 #include "envoy/local_info/local_info.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/stream_info/filter_state.h"
@@ -93,7 +94,8 @@ std::vector<std::string> getFilterStateObjectsToLog(
 
 std::vector<Tracing::CustomTagConstSharedPtr> getCustomTags(
     const envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig&
-        config);
+        config,
+    const Formatter::CommandParserPtrVector& command_parsers = {});
 
 void addFilterStateToAttributes(const StreamInfo::StreamInfo& stream_info,
                                 const std::vector<std::string>& filter_state_objects_to_log,

--- a/test/extensions/access_loggers/open_telemetry/otlp_log_utils_test.cc
+++ b/test/extensions/access_loggers/open_telemetry/otlp_log_utils_test.cc
@@ -18,6 +18,31 @@ namespace {
 using testing::NiceMock;
 using testing::ReturnRef;
 
+// A minimal command parser that resolves the "%FAKE_COMMAND%" token to a fixed value, used to
+// verify that configured formatter command parsers are threaded into custom_tags creation.
+class FakeCommandParser : public Formatter::CommandParser {
+public:
+  class Provider : public Formatter::FormatterProvider {
+  public:
+    std::optional<std::string> format(const Formatter::Context&,
+                                      const StreamInfo::StreamInfo&) const override {
+      return "fake_value";
+    }
+    Protobuf::Value formatValue(const Formatter::Context&,
+                                const StreamInfo::StreamInfo&) const override {
+      return ValueUtil::stringValue("fake_value");
+    }
+  };
+
+  absl::StatusOr<Formatter::FormatterProviderPtr>
+  parse(absl::string_view command, absl::string_view, std::optional<size_t>) const override {
+    if (command == "FAKE_COMMAND") {
+      return std::make_unique<Provider>();
+    }
+    return {nullptr};
+  }
+};
+
 const std::string kTestZone = "test_zone";
 const std::string kTestCluster = "test_cluster";
 const std::string kTestNode = "test_node";
@@ -340,6 +365,33 @@ TEST(OtlpLogUtilsTest, AddCustomTagsToAttributesWithLiteralTags) {
   auto* attr = expected.add_attributes();
   attr->set_key("literal_tag");
   attr->mutable_value()->set_string_value("literal_value");
+
+  EXPECT_TRUE(TestUtility::protoEqual(log_entry, expected));
+}
+
+// Verifies that configured formatter command parsers are used when creating custom tags, so a
+// custom tag whose value uses a formatter extension command resolves (#45453).
+TEST(OtlpLogUtilsTest, CustomTagsUseConfiguredFormatters) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  opentelemetry::proto::logs::v1::LogRecord log_entry;
+
+  envoy::extensions::access_loggers::open_telemetry::v3::OpenTelemetryAccessLogConfig config;
+  auto* tag = config.add_custom_tags();
+  tag->set_tag("fmt_tag");
+  tag->set_value("%FAKE_COMMAND%");
+
+  std::vector<Formatter::CommandParserPtr> commands;
+  commands.push_back(std::make_unique<FakeCommandParser>());
+  auto custom_tags = getCustomTags(config, commands);
+
+  Http::TestRequestHeaderMapImpl request_headers;
+  Formatter::Context context(&request_headers);
+  addCustomTagsToAttributes(custom_tags, context, stream_info, log_entry);
+
+  opentelemetry::proto::logs::v1::LogRecord expected;
+  auto* attr = expected.add_attributes();
+  attr->set_key("fmt_tag");
+  attr->mutable_value()->set_string_value("fake_value");
 
   EXPECT_TRUE(TestUtility::protoEqual(log_entry, expected));
 }


### PR DESCRIPTION
The OpenTelemetry access loggers parse configured `formatters` into command parsers for the `body` and `attributes` formatters, but `getCustomTags()` dropped them. A custom tag whose value used a formatter extension (e.g. `FILE_CONTENT`) failed with "Not supported field in StreamInfo" even though the same command worked in `body`/`attributes`. This threads the command parsers through to `createCustomTag()`, for both the gRPC and HTTP loggers.

**Commit Message:** access_loggers: use configured formatters for OpenTelemetry custom_tags

**Additional Description:** see above

**Risk Level:** Low

**Testing:** New unit test, red before the fix and green after; existing OpenTelemetry access log unit and config tests pass.

**Docs Changes:** N/A

**Release Notes:** `changelogs/current/bug_fixes/open_telemetry__custom-tags-formatters.rst`

**Platform Specific Features:** N/A

Fixes #45453

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
