### PR TITLE
fix format break on main

### DIFF
--- a/envoy/stats/refcount_ptr.h
+++ b/envoy/stats/refcount_ptr.h
@@ -161,9 +161,9 @@ struct RefcountHelper {
   // thread's accesses to the object happen-before the object's destruction,
   // so each decrement releases, and the final decrement (the one that takes
   // the count to zero and triggers destruction) also acquires. We use an
-  // acq_rel read-modify-write rather than the fence-based formulation from
-  // the Boost example because TSAN models RMW orderings precisely, while
-  // standalone fences are not as well supported. On x86 the difference from
+  // `acq_rel` read-modify-write rather than the fence-based formulation from
+  // the Boost example because TSAN models read-modify-write orderings precisely,
+  // while standalone fences are not as well supported. On x86 the difference from
   // the previous sequentially-consistent operations is minimal, but the
   // savings are real on weakly-ordered platforms such as ARM.
   void incRefCount() { ref_count_.fetch_add(1, std::memory_order_relaxed); }

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -15,6 +15,7 @@ addrlen
 defragmentation
 evictable
 flushdb
+interleavings
 itr
 STREQ
 htonl


### PR DESCRIPTION
There was a race between the commit re-adding spellchecker on `envoy/` and a commit adding some non-dictionary words.