### PR TITLE
geoip: support additional maxmind database fields

### DIFF
--- a/api/envoy/extensions/geoip_providers/common/v3/common.proto
+++ b/api/envoy/extensions/geoip_providers/common/v3/common.proto
@@ -98,7 +98,7 @@ message CommonGeoipProviderConfig {
   // - The :ref:`Network GeoIP filter <config_network_filters_geoip>` stores results in the
   //   connection's filter state under the well-known key ``envoy.geoip``.
   //
-  // [#next-free-field: 13]
+  // [#next-free-field: 24]
   message GeolocationFieldKeys {
     // If set, the key will be used to populate the country ISO code associated with the IP address.
     string country = 1;
@@ -147,6 +147,51 @@ message CommonGeoipProviderConfig {
     // and the result will be stored with this key. Value will be set to either ``true`` or ``false``
     // depending on the check result.
     string apple_private_relay = 11;
+
+    // If set, the key will be used to populate the `GeoNames <https://www.geonames.org/>`_ ID of the
+    // city associated with the IP address.
+    string city_geoname_id = 13;
+
+    // If set, the key will be used to populate the approximate WGS84 latitude of the location
+    // associated with the IP address.
+    string latitude = 14;
+
+    // If set, the key will be used to populate the approximate WGS84 longitude of the location
+    // associated with the IP address.
+    string longitude = 15;
+
+    // If set, the key will be used to populate the time zone associated with the IP address as
+    // found in the `IANA Time Zone Database <https://www.iana.org/time-zones>`_ (e.g. ``Europe/London``).
+    string time_zone = 16;
+
+    // If set, the key will be used to populate the postal code associated with the IP address.
+    string postal_code = 17;
+
+    // If set, the key will be used to populate the English name of the region associated with the
+    // IP address. The least specific subdivision will be selected as the region value.
+    string region_name = 18;
+
+    // If set, the key will be used to populate the `GeoNames <https://www.geonames.org/>`_ ID of the
+    // region associated with the IP address. The least specific subdivision will be selected as the
+    // region value.
+    string region_geoname_id = 19;
+
+    // If set, the key will be used to populate the `GeoNames <https://www.geonames.org/>`_ ID of the
+    // subregion associated with the IP address. The second least specific subdivision will be
+    // selected as the subregion value.
+    string subregion_geoname_id = 20;
+
+    // If set, the key will be used to populate the `GeoNames <https://www.geonames.org/>`_ ID of the
+    // country associated with the IP address.
+    string country_geoname_id = 21;
+
+    // If set, the key will be used to populate the `GeoNames <https://www.geonames.org/>`_ ID of the
+    // continent associated with the IP address.
+    string continent_geoname_id = 22;
+
+    // If set, the key will be used to populate the metro code (DMA code in the US) associated with
+    // the IP address.
+    string metro_code = 23;
   }
 
   // Configuration for geolocation headers to add to HTTP requests.

--- a/changelogs/current/new_features/geoip__added-extended-maxmind-city-db-fields.rst
+++ b/changelogs/current/new_features/geoip__added-extended-maxmind-city-db-fields.rst
@@ -1,0 +1,23 @@
+Added support for additional MaxMind database fields in the common geolocation provider
+configuration: :ref:`city_geoname_id
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.city_geoname_id>`,
+:ref:`latitude
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.latitude>`,
+:ref:`longitude
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.longitude>`,
+:ref:`time_zone
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.time_zone>`,
+:ref:`postal_code
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.postal_code>`,
+:ref:`region_name
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.region_name>`,
+:ref:`region_geoname_id
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.region_geoname_id>`,
+:ref:`subregion_geoname_id
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.subregion_geoname_id>`,
+:ref:`country_geoname_id
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.country_geoname_id>`,
+:ref:`continent_geoname_id
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.continent_geoname_id>` and
+:ref:`metro_code
+<envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.metro_code>`.

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -20,6 +20,19 @@ static constexpr const char* MMDB_ISP_ORG_LOOKUP_ARGS[] = {"organization"};
 static constexpr const char* MMDB_ANON_LOOKUP_ARGS[] = {"is_anonymous", "is_anonymous_vpn",
                                                         "is_hosting_provider", "is_tor_exit_node",
                                                         "is_public_proxy"};
+static constexpr const char* MMDB_CITY_GEONAME_ID_LOOKUP_ARGS[] = {"city", "geoname_id"};
+static constexpr const char* MMDB_LATITUDE_LOOKUP_ARGS[] = {"location", "latitude"};
+static constexpr const char* MMDB_LONGITUDE_LOOKUP_ARGS[] = {"location", "longitude"};
+static constexpr const char* MMDB_TIME_ZONE_LOOKUP_ARGS[] = {"location", "time_zone"};
+static constexpr const char* MMDB_POSTAL_CODE_LOOKUP_ARGS[] = {"postal", "code"};
+static constexpr const char* MMDB_REGION_NAME_LOOKUP_ARGS[] = {"subdivisions", "0", "names", "en"};
+static constexpr const char* MMDB_REGION_GEONAME_ID_LOOKUP_ARGS[] = {"subdivisions", "0",
+                                                                     "geoname_id"};
+static constexpr const char* MMDB_SUBREGION_GEONAME_ID_LOOKUP_ARGS[] = {"subdivisions", "1",
+                                                                        "geoname_id"};
+static constexpr const char* MMDB_COUNTRY_GEONAME_ID_LOOKUP_ARGS[] = {"country", "geoname_id"};
+static constexpr const char* MMDB_CONTINENT_GEONAME_ID_LOOKUP_ARGS[] = {"continent", "geoname_id"};
+static constexpr const char* MMDB_METRO_CODE_LOOKUP_ARGS[] = {"location", "metro_code"};
 
 static constexpr absl::string_view CITY_DB_TYPE = "city_db";
 static constexpr absl::string_view ISP_DB_TYPE = "isp_db";
@@ -60,6 +73,17 @@ GeoipProviderConfig::GeoipProviderConfig(
     anon_proxy_header_ = getOptionalString(keys.anon_proxy());
     isp_header_ = getOptionalString(keys.isp());
     apple_private_relay_header_ = getOptionalString(keys.apple_private_relay());
+    city_geoname_id_header_ = getOptionalString(keys.city_geoname_id());
+    latitude_header_ = getOptionalString(keys.latitude());
+    longitude_header_ = getOptionalString(keys.longitude());
+    time_zone_header_ = getOptionalString(keys.time_zone());
+    postal_code_header_ = getOptionalString(keys.postal_code());
+    region_name_header_ = getOptionalString(keys.region_name());
+    region_geoname_id_header_ = getOptionalString(keys.region_geoname_id());
+    subregion_geoname_id_header_ = getOptionalString(keys.subregion_geoname_id());
+    country_geoname_id_header_ = getOptionalString(keys.country_geoname_id());
+    continent_geoname_id_header_ = getOptionalString(keys.continent_geoname_id());
+    metro_code_header_ = getOptionalString(keys.metro_code());
   } else if (common_config.has_geo_headers_to_add()) {
     // Fall back to deprecated geo_headers_to_add for backward compatibility.
     const auto& headers = common_config.geo_headers_to_add();
@@ -205,11 +229,24 @@ void GeoipProvider::lookup(Geolocation::LookupRequest&& request,
 void GeoipProvider::lookupInCityDb(
     const Network::Address::InstanceConstSharedPtr& remote_address,
     absl::flat_hash_map<std::string, std::string>& lookup_result) const {
-  // Country lookup falls back to City DB only if Country DB is not configured.
+  // Country-level lookups fall back to City DB only if Country DB is not configured.
   const bool should_lookup_country_from_city_db =
-      !config_->isCountryDbPathSet() && config_->isLookupEnabledForHeader(config_->countryHeader());
+      !config_->isCountryDbPathSet() &&
+      (config_->isLookupEnabledForHeader(config_->countryHeader()) ||
+       config_->isLookupEnabledForHeader(config_->countryGeonameIdHeader()) ||
+       config_->isLookupEnabledForHeader(config_->continentGeonameIdHeader()));
+  const bool city_extra_fields_enabled =
+      config_->isLookupEnabledForHeader(config_->cityGeonameIdHeader()) ||
+      config_->isLookupEnabledForHeader(config_->latitudeHeader()) ||
+      config_->isLookupEnabledForHeader(config_->longitudeHeader()) ||
+      config_->isLookupEnabledForHeader(config_->timeZoneHeader()) ||
+      config_->isLookupEnabledForHeader(config_->postalCodeHeader()) ||
+      config_->isLookupEnabledForHeader(config_->regionNameHeader()) ||
+      config_->isLookupEnabledForHeader(config_->regionGeonameIdHeader()) ||
+      config_->isLookupEnabledForHeader(config_->subregionGeonameIdHeader()) ||
+      config_->isLookupEnabledForHeader(config_->metroCodeHeader());
   if (config_->isLookupEnabledForHeader(config_->cityHeader()) ||
-      config_->isLookupEnabledForHeader(config_->regionHeader()) ||
+      config_->isLookupEnabledForHeader(config_->regionHeader()) || city_extra_fields_enabled ||
       should_lookup_country_from_city_db) {
     int mmdb_error;
     auto city_db_ptr = getCityDb();
@@ -238,11 +275,72 @@ void GeoipProvider::lookupInCityDb(
                                   config_->regionHeader().value(), MMDB_REGION_LOOKUP_ARGS[0],
                                   MMDB_REGION_LOOKUP_ARGS[1], MMDB_REGION_LOOKUP_ARGS[2]);
         }
-        // Country lookup from City DB only when Country DB is not configured.
-        if (should_lookup_country_from_city_db) {
+        if (config_->isLookupEnabledForHeader(config_->cityGeonameIdHeader())) {
           populateGeoLookupResult(mmdb_lookup_result, lookup_result,
-                                  config_->countryHeader().value(), MMDB_COUNTRY_LOOKUP_ARGS[0],
-                                  MMDB_COUNTRY_LOOKUP_ARGS[1]);
+                                  config_->cityGeonameIdHeader().value(),
+                                  MMDB_CITY_GEONAME_ID_LOOKUP_ARGS[0],
+                                  MMDB_CITY_GEONAME_ID_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->latitudeHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->latitudeHeader().value(), MMDB_LATITUDE_LOOKUP_ARGS[0],
+                                  MMDB_LATITUDE_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->longitudeHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->longitudeHeader().value(), MMDB_LONGITUDE_LOOKUP_ARGS[0],
+                                  MMDB_LONGITUDE_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->timeZoneHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->timeZoneHeader().value(), MMDB_TIME_ZONE_LOOKUP_ARGS[0],
+                                  MMDB_TIME_ZONE_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->postalCodeHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->postalCodeHeader().value(),
+                                  MMDB_POSTAL_CODE_LOOKUP_ARGS[0], MMDB_POSTAL_CODE_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->regionNameHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->regionNameHeader().value(),
+                                  MMDB_REGION_NAME_LOOKUP_ARGS[0], MMDB_REGION_NAME_LOOKUP_ARGS[1],
+                                  MMDB_REGION_NAME_LOOKUP_ARGS[2], MMDB_REGION_NAME_LOOKUP_ARGS[3]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->regionGeonameIdHeader())) {
+          populateGeoLookupResult(
+              mmdb_lookup_result, lookup_result, config_->regionGeonameIdHeader().value(),
+              MMDB_REGION_GEONAME_ID_LOOKUP_ARGS[0], MMDB_REGION_GEONAME_ID_LOOKUP_ARGS[1],
+              MMDB_REGION_GEONAME_ID_LOOKUP_ARGS[2]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->subregionGeonameIdHeader())) {
+          populateGeoLookupResult(
+              mmdb_lookup_result, lookup_result, config_->subregionGeonameIdHeader().value(),
+              MMDB_SUBREGION_GEONAME_ID_LOOKUP_ARGS[0], MMDB_SUBREGION_GEONAME_ID_LOOKUP_ARGS[1],
+              MMDB_SUBREGION_GEONAME_ID_LOOKUP_ARGS[2]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->metroCodeHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->metroCodeHeader().value(),
+                                  MMDB_METRO_CODE_LOOKUP_ARGS[0], MMDB_METRO_CODE_LOOKUP_ARGS[1]);
+        }
+        // Country-level lookups from City DB only when Country DB is not configured.
+        if (should_lookup_country_from_city_db) {
+          if (config_->isLookupEnabledForHeader(config_->countryHeader())) {
+            populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                    config_->countryHeader().value(), MMDB_COUNTRY_LOOKUP_ARGS[0],
+                                    MMDB_COUNTRY_LOOKUP_ARGS[1]);
+          }
+          if (config_->isLookupEnabledForHeader(config_->countryGeonameIdHeader())) {
+            populateGeoLookupResult(
+                mmdb_lookup_result, lookup_result, config_->countryGeonameIdHeader().value(),
+                MMDB_COUNTRY_GEONAME_ID_LOOKUP_ARGS[0], MMDB_COUNTRY_GEONAME_ID_LOOKUP_ARGS[1]);
+          }
+          if (config_->isLookupEnabledForHeader(config_->continentGeonameIdHeader())) {
+            populateGeoLookupResult(
+                mmdb_lookup_result, lookup_result, config_->continentGeonameIdHeader().value(),
+                MMDB_CONTINENT_GEONAME_ID_LOOKUP_ARGS[0], MMDB_CONTINENT_GEONAME_ID_LOOKUP_ARGS[1]);
+          }
         }
         if (lookup_result.size() > n_prev_hits) {
           config_->incHit(CITY_DB_TYPE);
@@ -421,7 +519,9 @@ void GeoipProvider::lookupInIspDb(
 void GeoipProvider::lookupInCountryDb(
     const Network::Address::InstanceConstSharedPtr& remote_address,
     absl::flat_hash_map<std::string, std::string>& lookup_result) const {
-  if (config_->isLookupEnabledForHeader(config_->countryHeader())) {
+  if (config_->isLookupEnabledForHeader(config_->countryHeader()) ||
+      config_->isLookupEnabledForHeader(config_->countryGeonameIdHeader()) ||
+      config_->isLookupEnabledForHeader(config_->continentGeonameIdHeader())) {
     // Country DB takes precedence if configured, otherwise fall back to City DB.
     if (!config_->isCountryDbPathSet()) {
       // Country lookup will be handled by lookupInCityDb.
@@ -449,8 +549,21 @@ void GeoipProvider::lookupInCountryDb(
       MMDB_entry_data_list_s* entry_data_list;
       int status = MMDB_get_entry_data_list(&mmdb_lookup_result.entry, &entry_data_list);
       if (status == MMDB_SUCCESS) {
-        populateGeoLookupResult(mmdb_lookup_result, lookup_result, config_->countryHeader().value(),
-                                MMDB_COUNTRY_LOOKUP_ARGS[0], MMDB_COUNTRY_LOOKUP_ARGS[1]);
+        if (config_->isLookupEnabledForHeader(config_->countryHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result,
+                                  config_->countryHeader().value(), MMDB_COUNTRY_LOOKUP_ARGS[0],
+                                  MMDB_COUNTRY_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->countryGeonameIdHeader())) {
+          populateGeoLookupResult(
+              mmdb_lookup_result, lookup_result, config_->countryGeonameIdHeader().value(),
+              MMDB_COUNTRY_GEONAME_ID_LOOKUP_ARGS[0], MMDB_COUNTRY_GEONAME_ID_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->continentGeonameIdHeader())) {
+          populateGeoLookupResult(
+              mmdb_lookup_result, lookup_result, config_->continentGeonameIdHeader().value(),
+              MMDB_CONTINENT_GEONAME_ID_LOOKUP_ARGS[0], MMDB_CONTINENT_GEONAME_ID_LOOKUP_ARGS[1]);
+        }
         if (lookup_result.size() > n_prev_hits) {
           config_->incHit(COUNTRY_DB_TYPE);
         }
@@ -585,8 +698,15 @@ void GeoipProvider::populateGeoLookupResult(
     } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32 &&
                entry_data.uint32 > 0) {
       result_value = std::to_string(entry_data.uint32);
+    } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT16 &&
+               entry_data.uint16 > 0) {
+      // Used for the metro code.
+      result_value = std::to_string(entry_data.uint16);
     } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_BOOLEAN) {
       result_value = entry_data.boolean ? "true" : "false";
+    } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_DOUBLE) {
+      // Used for latitude/longitude; fmt produces the shortest round-trip representation.
+      result_value = fmt::format("{}", entry_data.double_value);
     }
     if (!result_value.empty()) {
       lookup_result.insert(std::make_pair(result_key, result_value));

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.h
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.h
@@ -37,6 +37,26 @@ public:
   const std::optional<std::string>& asnHeader() const { return asn_header_; }
   const std::optional<std::string>& asnOrgHeader() const { return asn_org_header_; }
 
+  const std::optional<std::string>& cityGeonameIdHeader() const { return city_geoname_id_header_; }
+  const std::optional<std::string>& latitudeHeader() const { return latitude_header_; }
+  const std::optional<std::string>& longitudeHeader() const { return longitude_header_; }
+  const std::optional<std::string>& timeZoneHeader() const { return time_zone_header_; }
+  const std::optional<std::string>& postalCodeHeader() const { return postal_code_header_; }
+  const std::optional<std::string>& regionNameHeader() const { return region_name_header_; }
+  const std::optional<std::string>& regionGeonameIdHeader() const {
+    return region_geoname_id_header_;
+  }
+  const std::optional<std::string>& subregionGeonameIdHeader() const {
+    return subregion_geoname_id_header_;
+  }
+  const std::optional<std::string>& countryGeonameIdHeader() const {
+    return country_geoname_id_header_;
+  }
+  const std::optional<std::string>& continentGeonameIdHeader() const {
+    return continent_geoname_id_header_;
+  }
+  const std::optional<std::string>& metroCodeHeader() const { return metro_code_header_; }
+
   const std::optional<std::string>& anonHeader() const { return anon_header_; }
   const std::optional<std::string>& anonVpnHeader() const { return anon_vpn_header_; }
   const std::optional<std::string>& anonHostingHeader() const { return anon_hosting_header_; }
@@ -93,6 +113,18 @@ private:
   std::optional<std::string> region_header_;
   std::optional<std::string> asn_header_;
   std::optional<std::string> asn_org_header_;
+
+  std::optional<std::string> city_geoname_id_header_;
+  std::optional<std::string> latitude_header_;
+  std::optional<std::string> longitude_header_;
+  std::optional<std::string> time_zone_header_;
+  std::optional<std::string> postal_code_header_;
+  std::optional<std::string> region_name_header_;
+  std::optional<std::string> region_geoname_id_header_;
+  std::optional<std::string> subregion_geoname_id_header_;
+  std::optional<std::string> country_geoname_id_header_;
+  std::optional<std::string> continent_geoname_id_header_;
+  std::optional<std::string> metro_code_header_;
 
   std::optional<std::string> anon_header_;
   std::optional<std::string> anon_vpn_header_;

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -252,6 +252,92 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndAsnDbsSuccessfulLookup) {
   expectStats("asn_db");
 }
 
+TEST_F(GeoipProviderTest, ValidConfigCityDbExtendedFieldsSuccessfulLookup) {
+  const std::string config_yaml = R"EOF(
+    common_provider_config:
+      geo_field_keys:
+        city_geoname_id: "x-geo-city-geoname-id"
+        latitude: "x-geo-latitude"
+        longitude: "x-geo-longitude"
+        time_zone: "x-geo-time-zone"
+        postal_code: "x-geo-postal-code"
+        region_name: "x-geo-region-name"
+        region_geoname_id: "x-geo-region-geoname-id"
+        subregion_geoname_id: "x-geo-subregion-geoname-id"
+        country_geoname_id: "x-geo-country-geoname-id"
+        continent_geoname_id: "x-geo-continent-geoname-id"
+        metro_code: "x-geo-metro-code"
+    city_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoLite2-City-Test.mmdb"
+  )EOF";
+  initializeProvider(config_yaml, cb_added_nullopt);
+  // 2.125.160.216 is present in the test database with all of the extended
+  // fields (including the postal code and a second-level subdivision) except
+  // for the metro code. Country-level GeoNames IDs are looked up from the
+  // city database because no country database is configured.
+  Network::Address::InstanceConstSharedPtr remote_address =
+      Network::Utility::parseInternetAddressNoThrow("2.125.160.216");
+  Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
+  testing::MockFunction<void(Geolocation::LookupResult&&)> lookup_cb;
+  auto lookup_cb_std = lookup_cb.AsStdFunction();
+  EXPECT_CALL(lookup_cb, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
+  provider_->lookup(std::move(lookup_rq), std::move(lookup_cb_std));
+  EXPECT_EQ(10, captured_lookup_response_.size());
+  EXPECT_EQ("2655045", captured_lookup_response_.find("x-geo-city-geoname-id")->second);
+  EXPECT_EQ("51.75", captured_lookup_response_.find("x-geo-latitude")->second);
+  EXPECT_EQ("-1.25", captured_lookup_response_.find("x-geo-longitude")->second);
+  EXPECT_EQ("Europe/London", captured_lookup_response_.find("x-geo-time-zone")->second);
+  EXPECT_EQ("OX1", captured_lookup_response_.find("x-geo-postal-code")->second);
+  EXPECT_EQ("England", captured_lookup_response_.find("x-geo-region-name")->second);
+  EXPECT_EQ("6269131", captured_lookup_response_.find("x-geo-region-geoname-id")->second);
+  EXPECT_EQ("3333217", captured_lookup_response_.find("x-geo-subregion-geoname-id")->second);
+  EXPECT_EQ("2635167", captured_lookup_response_.find("x-geo-country-geoname-id")->second);
+  EXPECT_EQ("6255148", captured_lookup_response_.find("x-geo-continent-geoname-id")->second);
+  EXPECT_EQ(captured_lookup_response_.end(), captured_lookup_response_.find("x-geo-metro-code"));
+  expectStats("city_db");
+
+  // 216.160.83.56 has a metro code in the test database but no postal code
+  // and no second-level subdivision: the corresponding keys must be absent
+  // from the lookup result.
+  captured_lookup_response_.clear();
+  remote_address = Network::Utility::parseInternetAddressNoThrow("216.160.83.56");
+  Geolocation::LookupRequest lookup_rq2{std::move(remote_address)};
+  testing::MockFunction<void(Geolocation::LookupResult&&)> lookup_cb2;
+  auto lookup_cb_std2 = lookup_cb2.AsStdFunction();
+  EXPECT_CALL(lookup_cb2, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
+  provider_->lookup(std::move(lookup_rq2), std::move(lookup_cb_std2));
+  EXPECT_EQ("819", captured_lookup_response_.find("x-geo-metro-code")->second);
+  EXPECT_EQ("5815135", captured_lookup_response_.find("x-geo-region-geoname-id")->second);
+  EXPECT_EQ("6252001", captured_lookup_response_.find("x-geo-country-geoname-id")->second);
+  EXPECT_EQ("6255149", captured_lookup_response_.find("x-geo-continent-geoname-id")->second);
+  EXPECT_EQ(captured_lookup_response_.end(), captured_lookup_response_.find("x-geo-postal-code"));
+  EXPECT_EQ(captured_lookup_response_.end(),
+            captured_lookup_response_.find("x-geo-subregion-geoname-id"));
+}
+
+TEST_F(GeoipProviderTest, ValidConfigCountryDbGeonameIdsSuccessfulLookup) {
+  const std::string config_yaml = R"EOF(
+    common_provider_config:
+      geo_field_keys:
+        country: "x-geo-country"
+        country_geoname_id: "x-geo-country-geoname-id"
+        continent_geoname_id: "x-geo-continent-geoname-id"
+    country_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoIP2-Country-Test.mmdb"
+  )EOF";
+  initializeProvider(config_yaml, cb_added_nullopt);
+  Network::Address::InstanceConstSharedPtr remote_address =
+      Network::Utility::parseInternetAddressNoThrow("216.160.83.56");
+  Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
+  testing::MockFunction<void(Geolocation::LookupResult&&)> lookup_cb;
+  auto lookup_cb_std = lookup_cb.AsStdFunction();
+  EXPECT_CALL(lookup_cb, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
+  provider_->lookup(std::move(lookup_rq), std::move(lookup_cb_std));
+  EXPECT_EQ(3, captured_lookup_response_.size());
+  EXPECT_EQ("US", captured_lookup_response_.find("x-geo-country")->second);
+  EXPECT_EQ("6252001", captured_lookup_response_.find("x-geo-country-geoname-id")->second);
+  EXPECT_EQ("6255149", captured_lookup_response_.find("x-geo-continent-geoname-id")->second);
+  expectStats("country_db");
+}
+
 TEST_F(GeoipProviderTest, ValidConfigAsnDbsSuccessfulLookup) {
   const std::string config_yaml = R"EOF(
     common_provider_config:


### PR DESCRIPTION


<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: geoip: support additional maxmind database fields
Additional Description:
```
Adds new geolocation field keys to the common geoip provider config and their extraction in the maxmind provider: city_geoname_id, latitude, longitude, time_zone, postal_code, region_name, region_geoname_id, subregion_geoname_id, country_geoname_id, continent_geoname_id and metro_code. 
Country-level GeoNames IDs follow the existing country ISO code semantics: the country database is preferred with a fallback to the city database. Adds UINT16 (metro code) and DOUBLE (latitude/longitude) entry data type support to the lookup result population.

Motivation: parity with the nginx geoip2 module headers when migrating ingress from nginx to Envoy.
```

Risk Level: low?
Testing: tests addded
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
