### PR TITLE
Use mcp prefix and lower case in mcp filter status

### DIFF
--- a/changelogs/current/new_features/mcp__added-status-to-dynamic-metadata.rst
+++ b/changelogs/current/new_features/mcp__added-status-to-dynamic-metadata.rst
@@ -1,5 +1,5 @@
 Added status information to dynamic metadata and filter state for the MCP filter. This provides
 visibility into request processing results, such as whether a request was rejected due to
 body size limits, parsing errors, or duplicate keys. The status message is kept in lower case,
-as is prefixed by the mcp_, to indicate the filter name. Added checks in integration tests to
-verify the new status (and other mcp related fields) are logged correctly.
+as is prefixed by the ``mcp_``, to indicate the filter name. Added checks in integration tests
+to verify the new status (and other mcp related fields) are logged correctly.

--- a/changelogs/current/new_features/mcp__added-status-to-dynamic-metadata.rst
+++ b/changelogs/current/new_features/mcp__added-status-to-dynamic-metadata.rst
@@ -1,3 +1,5 @@
 Added status information to dynamic metadata and filter state for the MCP filter. This provides
 visibility into request processing results, such as whether a request was rejected due to
-body size limits, parsing errors, or duplicate keys.
+body size limits, parsing errors, or duplicate keys. The status message is kept in lower case,
+as is prefixed by the mcp_, to indicate the filter name. Added checks in integration tests to
+verify the new status (and other mcp related fields) are logged correctly.

--- a/source/extensions/filters/common/mcp/constants.h
+++ b/source/extensions/filters/common/mcp/constants.h
@@ -55,12 +55,12 @@ constexpr absl::string_view IS_EXCEEDING_LIMIT = "is_exceeding_limit";
 constexpr absl::string_view STATUS = "status";
 
 namespace StatusValues {
-constexpr absl::string_view OK = "OK";
-constexpr absl::string_view PARSE_ERROR = "PARSE_ERROR";
-constexpr absl::string_view NO_MCP = "REJECT_NO_MCP";
-constexpr absl::string_view NOT_JSONRPC = "NOT_JSONRPC";
-constexpr absl::string_view DUPLICATE_KEYS = "DUPLICATE_KEYS";
-constexpr absl::string_view BODY_TOO_LARGE = "BODY_TOO_LARGE";
+constexpr absl::string_view OK = "mcp_ok";
+constexpr absl::string_view PARSE_ERROR = "mcp_parse_error";
+constexpr absl::string_view REJECT_NO_MCP = "mcp_reject_no_mcp";
+constexpr absl::string_view NOT_JSONRPC = "mcp_not_jsonrpc";
+constexpr absl::string_view DUPLICATE_KEYS = "mcp_duplicate_keys";
+constexpr absl::string_view BODY_TOO_LARGE = "mcp_body_too_large";
 } // namespace StatusValues
 
 // HTTP header names

--- a/source/extensions/filters/common/mcp/filter_state.h
+++ b/source/extensions/filters/common/mcp/filter_state.h
@@ -30,7 +30,7 @@ inline absl::string_view statusToString(Status status) {
   case Status::ParseError:
     return McpConstants::StatusValues::PARSE_ERROR;
   case Status::NoMcp:
-    return McpConstants::StatusValues::NO_MCP;
+    return McpConstants::StatusValues::REJECT_NO_MCP;
   case Status::NotJsonRpc:
     return McpConstants::StatusValues::NOT_JSONRPC;
   case Status::DuplicateKeys:

--- a/test/extensions/filters/http/mcp/BUILD
+++ b/test/extensions/filters/http/mcp/BUILD
@@ -35,8 +35,12 @@ envoy_cc_test(
     name = "mcp_filter_integration_test",
     srcs = ["mcp_filter_integration_test.cc"],
     deps = [
+        "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/mcp:config",
+        "//test/integration:fake_access_log_lib",
         "//test/integration:http_integration_lib",
+        "//test/test_common:registry_lib",
+        "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/mcp/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -1,6 +1,11 @@
 #include "envoy/extensions/filters/http/mcp/v3/mcp.pb.h"
 
+#include "source/common/protobuf/utility.h"
+
+#include "test/integration/fake_access_log.h"
 #include "test/integration/http_integration.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -19,6 +24,7 @@ public:
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
         traffic_mode: PASS_THROUGH
+        request_storage_mode: DYNAMIC_METADATA
     )EOF"
                                                      : config;
 
@@ -50,15 +56,56 @@ TEST_P(McpFilterIntegrationTest, NonPostRequestIgnored) {
 
 // Test that a valid JSON-RPC POST request passes through successfully.
 TEST_P(McpFilterIntegrationTest, ValidJsonRpcPostRequest) {
+  FakeAccessLogFactory factory;
+  Registry::InjectFactory<AccessLog::AccessLogInstanceFactory> factory_register(factory);
+
+  bool metadata_verified = false;
+  factory.setLogCallback(
+      [&metadata_verified](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        const auto& dynamic_metadata = stream_info.dynamicMetadata().filter_metadata();
+        auto it = dynamic_metadata.find("envoy.filters.http.mcp");
+        if (it == dynamic_metadata.end()) {
+          it = dynamic_metadata.find("mcp_proxy");
+        }
+        if (it != dynamic_metadata.end()) {
+          Protobuf::Struct expected_metadata;
+          MessageUtil::loadFromJson(R"json({
+            "status": "mcp_ok",
+            "is_mcp_request": true,
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+              "name": "test_tool"
+            }
+          })json",
+                                    expected_metadata);
+          EXPECT_TRUE(TestUtility::protoEqual(expected_metadata, it->second))
+              << "got:\n"
+              << it->second.DebugString() << "\nexpected:\n"
+              << expected_metadata.DebugString();
+          metadata_verified = true;
+        }
+      });
+
+  config_helper_.addConfigModifier([](ConfigHelper::HttpConnectionManager& hcm) {
+    auto* access_log = hcm.add_access_log();
+    access_log->set_name("envoy.access_loggers.test");
+    test::integration::accesslog::FakeAccessLog access_log_config;
+    std::ignore = access_log->mutable_typed_config()->PackFrom(access_log_config);
+  });
+
   initializeFilter();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  const std::string request_body = R"({"jsonrpc": "2.0", "method": "test"})";
+  const std::string request_body =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "test_tool"}})";
   auto response = codec_client_->makeRequestWithBody(
       Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                      {":path", "/"},
                                      {":scheme", "http"},
                                      {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
                                      {"content-type", "application/json"}},
       request_body);
 
@@ -69,10 +116,44 @@ TEST_P(McpFilterIntegrationTest, ValidJsonRpcPostRequest) {
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ(request_body, upstream_request_->body().toString());
   EXPECT_EQ("200", response->headers().getStatusValue());
+  EXPECT_TRUE(metadata_verified);
 }
 
 // Test that an MCP request with malformed JSON is rejected with a 400.
 TEST_P(McpFilterIntegrationTest, InvalidJsonBodyRejected) {
+  FakeAccessLogFactory factory;
+  Registry::InjectFactory<AccessLog::AccessLogInstanceFactory> factory_register(factory);
+
+  bool metadata_verified = false;
+  factory.setLogCallback(
+      [&metadata_verified](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        const auto& dynamic_metadata = stream_info.dynamicMetadata().filter_metadata();
+        auto it = dynamic_metadata.find("envoy.filters.http.mcp");
+        if (it == dynamic_metadata.end()) {
+          it = dynamic_metadata.find("mcp_proxy");
+        }
+        if (it != dynamic_metadata.end()) {
+          Protobuf::Struct expected_metadata;
+          MessageUtil::loadFromJson(R"json({
+            "status": "mcp_parse_error",
+            "is_mcp_request": false
+          })json",
+                                    expected_metadata);
+          EXPECT_TRUE(TestUtility::protoEqual(expected_metadata, it->second))
+              << "got:\n"
+              << it->second.DebugString() << "\nexpected:\n"
+              << expected_metadata.DebugString();
+          metadata_verified = true;
+        }
+      });
+
+  config_helper_.addConfigModifier([](ConfigHelper::HttpConnectionManager& hcm) {
+    auto* access_log = hcm.add_access_log();
+    access_log->set_name("envoy.access_loggers.test");
+    test::integration::accesslog::FakeAccessLog access_log_config;
+    std::ignore = access_log->mutable_typed_config()->PackFrom(access_log_config);
+  });
+
   initializeFilter();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -90,6 +171,7 @@ TEST_P(McpFilterIntegrationTest, InvalidJsonBodyRejected) {
   // The upstream should NOT receive a request because the filter sends a local reply.
   EXPECT_FALSE(upstream_request_ != nullptr);
   EXPECT_EQ("400", response->headers().getStatusValue());
+  EXPECT_TRUE(metadata_verified);
 }
 
 // Test no-MCP traffic is passed through without the JSON_RPC 2.0
@@ -184,11 +266,45 @@ TEST_P(McpFilterIntegrationTest, NoAcceptHeaderReject) {
 
 // Test REJECT_NO_MCP mode - non-MCP traffic rejected
 TEST_P(McpFilterIntegrationTest, RejectNoMcpModeRejectsNonMcp) {
+  FakeAccessLogFactory factory;
+  Registry::InjectFactory<AccessLog::AccessLogInstanceFactory> factory_register(factory);
+
+  bool metadata_verified = false;
+  factory.setLogCallback(
+      [&metadata_verified](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        const auto& dynamic_metadata = stream_info.dynamicMetadata().filter_metadata();
+        auto it = dynamic_metadata.find("envoy.filters.http.mcp");
+        if (it == dynamic_metadata.end()) {
+          it = dynamic_metadata.find("mcp_proxy");
+        }
+        if (it != dynamic_metadata.end()) {
+          Protobuf::Struct expected_metadata;
+          MessageUtil::loadFromJson(R"json({
+            "status": "mcp_reject_no_mcp",
+            "is_mcp_request": false
+          })json",
+                                    expected_metadata);
+          EXPECT_TRUE(TestUtility::protoEqual(expected_metadata, it->second))
+              << "got:\n"
+              << it->second.DebugString() << "\nexpected:\n"
+              << expected_metadata.DebugString();
+          metadata_verified = true;
+        }
+      });
+
+  config_helper_.addConfigModifier([](ConfigHelper::HttpConnectionManager& hcm) {
+    auto* access_log = hcm.add_access_log();
+    access_log->set_name("envoy.access_loggers.test");
+    test::integration::accesslog::FakeAccessLog access_log_config;
+    std::ignore = access_log->mutable_typed_config()->PackFrom(access_log_config);
+  });
+
   initializeFilter(R"EOF(
     name: envoy.filters.http.mcp
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
       traffic_mode: REJECT_NO_MCP
+      request_storage_mode: DYNAMIC_METADATA
   )EOF");
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -203,6 +319,7 @@ TEST_P(McpFilterIntegrationTest, RejectNoMcpModeRejectsNonMcp) {
   EXPECT_FALSE(upstream_request_);
   EXPECT_EQ("400", response->headers().getStatusValue());
   EXPECT_THAT(response->body(), testing::HasSubstr("Only MCP"));
+  EXPECT_TRUE(metadata_verified);
 }
 
 // Test REJECT_NO_MCP mode - SSE request passes

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -145,16 +145,16 @@ TEST_F(McpFilterTest, RejectNoMcpMode) {
 
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {"accept", "text/html"}};
 
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(Http::Code::BadRequest, "Only MCP traffic is allowed", _, _, "REJECT_NO_MCP"));
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest, "Only MCP traffic is allowed", _, _,
+                             "mcp_reject_no_mcp"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(
-                Contains(Pair("status", Property(&Protobuf::Value::string_value, "REJECT_NO_MCP"))),
-                Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
+            AllOf(Contains(Pair("status",
+                                Property(&Protobuf::Value::string_value, "mcp_reject_no_mcp"))),
+                  Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
       });
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
@@ -172,9 +172,9 @@ TEST_F(McpFilterTest, RejectNoMcpModePopulatesFilterState) {
 
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {"accept", "text/html"}};
 
-  EXPECT_CALL(
-      decoder_callbacks_,
-      sendLocalReply(Http::Code::BadRequest, "Only MCP traffic is allowed", _, _, "REJECT_NO_MCP"));
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest, "Only MCP traffic is allowed", _, _,
+                             "mcp_reject_no_mcp"));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 
@@ -214,12 +214,13 @@ TEST_F(McpFilterTest, RejectModeRejectsNonJsonRpc) {
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
                              "request must be a valid JSON-RPC 2.0 message for MCP", _, _,
-                             "NOT_JSONRPC"));
+                             "mcp_not_jsonrpc"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(Contains(Pair("status", Property(&Protobuf::Value::string_value, "NOT_JSONRPC"))),
+            AllOf(Contains(
+                      Pair("status", Property(&Protobuf::Value::string_value, "mcp_not_jsonrpc"))),
                   Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
       });
 
@@ -309,12 +310,13 @@ TEST_F(McpFilterTest, PartialNoJsonData) {
   Buffer::OwnedImpl buffer("partial data");
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Http::Code::BadRequest, "not a valid JSON", _, _, "NOT_JSONRPC"));
+              sendLocalReply(Http::Code::BadRequest, "not a valid JSON", _, _, "mcp_not_jsonrpc"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(Contains(Pair("status", Property(&Protobuf::Value::string_value, "NOT_JSONRPC"))),
+            AllOf(Contains(
+                      Pair("status", Property(&Protobuf::Value::string_value, "mcp_not_jsonrpc"))),
                   Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
       });
 
@@ -338,12 +340,13 @@ TEST_F(McpFilterTest, IncompleteJsonParseError) {
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
                              "reached end_stream or configured body size, don't get enough data.",
-                             _, _, "PARSE_ERROR"));
+                             _, _, "mcp_parse_error"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(Contains(Pair("status", Property(&Protobuf::Value::string_value, "PARSE_ERROR"))),
+            AllOf(Contains(
+                      Pair("status", Property(&Protobuf::Value::string_value, "mcp_parse_error"))),
                   Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
       });
 
@@ -509,13 +512,13 @@ TEST_F(McpFilterTest, RequestBodyExceedingLimitRejectWhenNotEnoughData) {
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
                              "reached end_stream or configured body size, don't get enough data.",
-                             _, _, "BODY_TOO_LARGE"));
+                             _, _, "mcp_body_too_large"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(Contains(
-                      Pair("status", Property(&Protobuf::Value::string_value, "BODY_TOO_LARGE"))),
+            AllOf(Contains(Pair("status",
+                                Property(&Protobuf::Value::string_value, "mcp_body_too_large"))),
                   Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false))),
                   Contains(
                       Pair("is_exceeding_limit", Property(&Protobuf::Value::bool_value, true)))));
@@ -666,13 +669,13 @@ TEST_F(McpFilterTest, BodyLimitPassThroughWithoutMetadata) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
 
   // Verify that dynamic metadata still contains is_exceeding_limit, is_mcp_request, and status
-  EXPECT_THAT(
-      captured_metadata.fields(),
-      AllOf(Contains(Pair(std::string(IS_EXCEEDING_LIMIT),
-                          Property(&Protobuf::Value::bool_value, true))),
-            Contains(
-                Pair(std::string(IS_MCP_REQUEST), Property(&Protobuf::Value::bool_value, false))),
-            Contains(Pair(std::string(STATUS), Property(&Protobuf::Value::string_value, "OK")))));
+  EXPECT_THAT(captured_metadata.fields(),
+              AllOf(Contains(Pair(std::string(IS_EXCEEDING_LIMIT),
+                                  Property(&Protobuf::Value::bool_value, true))),
+                    Contains(Pair(std::string(IS_MCP_REQUEST),
+                                  Property(&Protobuf::Value::bool_value, false))),
+                    Contains(Pair(std::string(STATUS),
+                                  Property(&Protobuf::Value::string_value, "mcp_ok")))));
 
   // Verify that FilterStateObject still exists and is populated with the exceeding limit state and
   // status
@@ -709,13 +712,13 @@ TEST_F(McpFilterTest, DuplicateKeyRejectionEnabledConfig) {
   // Expect request to be rejected with BadRequest due to duplicate keys
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest, "duplicate JSON keys detected", _, _,
-                             "DUPLICATE_KEYS"));
+                             "mcp_duplicate_keys"));
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
         EXPECT_THAT(
             metadata.fields(),
-            AllOf(Contains(
-                      Pair("status", Property(&Protobuf::Value::string_value, "DUPLICATE_KEYS"))),
+            AllOf(Contains(Pair("status",
+                                Property(&Protobuf::Value::string_value, "mcp_duplicate_keys"))),
                   Contains(Pair("is_mcp_request", Property(&Protobuf::Value::bool_value, false)))));
       });
 


### PR DESCRIPTION
Commit Message: updated status constants to use lowercase strings with the mcp_ prefix for consistency.

Risk Level: low

Testing: updated unit tests and added integration test coverage using FakeAccessLog in mcp_filter_integration_test.cc to verify the dynamic metadata is correctly populated.

Docs Changes: updated changelog

I used GenAI to help write this code and I fully understand the changes.