### PR TITLE
openssl compat: fix validated chain and CNSA2 test failures

### DIFF
--- a/compat/openssl/source/X509_verify_cert.c
+++ b/compat/openssl/source/X509_verify_cert.c
@@ -9,6 +9,33 @@ int X509_verify_cert(X509_STORE_CTX *ctx) {
     if (ossl.ossl_X509_STORE_CTX_get_error(ctx) == ossl_X509_V_ERR_CERT_CHAIN_TOO_LONG) {
       ossl.ossl_X509_STORE_CTX_set_error(ctx, ossl_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY);
     }
+    return result;
+  }
+
+  // BoringSSL always includes the root CA in the verified chain, but OpenSSL
+  // with X509_V_FLAG_PARTIAL_CHAIN may stop at the first trusted cert.
+  // Walk the chain upward through the trust store until we reach a self-signed root.
+  STACK_OF(X509) *chain = (STACK_OF(X509) *)ossl.ossl_X509_STORE_CTX_get0_chain(ctx);
+  if (chain && sk_X509_num(chain) > 0 &&
+      ossl.ossl_X509_check_issued && ossl.ossl_X509_STORE_CTX_get1_issuer) {
+    X509 *last = sk_X509_value(chain, sk_X509_num(chain) - 1);
+    for (int depth = 0;
+         depth < 32 && ossl.ossl_X509_check_issued(last, last) != ossl_X509_V_OK;
+         depth++) {
+      X509 *issuer = NULL;
+      if (ossl.ossl_X509_STORE_CTX_get1_issuer(&issuer, ctx, last) != 1 || !issuer) {
+        break;
+      }
+      if (issuer == last) {
+        X509_free(issuer);
+        break;
+      }
+      if (sk_X509_push(chain, issuer) == 0) {
+        X509_free(issuer);
+        break;
+      }
+      last = issuer;
+    }
   }
 
   return result;

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -6207,7 +6207,7 @@ TEST_P(SslSocketTest, CipherSuitesWithPolicy) {
   testUtilV2(error_test_options);
 }
 
-TEST_P(SslSocketTest, CipherSuitesWithCNSA2Policy) {
+BORINGSSL_TEST_P(SslSocketTest, CipherSuitesWithCNSA2Policy) {
   envoy::config::listener::v3::Listener listener;
   envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;


### PR DESCRIPTION
PR #46061 introduced `GetValidatedPeerCertChainWithIntermediate` which expects the root CA in the verified chain. OpenSSL with X509_V_FLAG_PARTIAL_CHAIN stops at the first trusted cert, while BoringSSL always builds to the self-signed root. The `X509_verify_cert` wrapper now walks the chain upward through the trust store via `X509_STORE_CTX_get1_issuer` until a self-signed root is reached.

PR #45624 introduced `CipherSuitesWithCNSA2Policy`. CNSA2 compliance policy requires ML-KEM (post-quantum) which OpenSSL does not support, so the test is disabled under OpenSSL builds via BORINGSSL_TEST_P.
