### PR TITLE
lua: split StreamHandleWrapper into request/response handle types

### DIFF
--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -28,48 +28,40 @@ namespace Lua {
 namespace {
 
 using OptionHandler =
-    std::function<void(lua_State* state, StreamHandleWrapper::HttpCallOptions& options)>;
+    std::function<void(lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options)>;
 using OptionHandlers = std::map<absl::string_view, OptionHandler>;
 
 const OptionHandlers& optionHandlers() {
-  CONSTRUCT_ON_FIRST_USE(OptionHandlers,
-                         {
-                             {"asynchronous",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["asynchronous"] =
-                                // <boolean>} entry.
-                                options.is_async_request_ = lua_toboolean(state, -1);
-                              }},
-                             {"timeout_ms",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["timeout_ms"] = <int>}
-                                // entry.
-                                const int timeout_ms = luaL_checkint(state, -1);
-                                if (timeout_ms < 0) {
-                                  luaL_error(state, "http call timeout must be >= 0");
-                                } else {
-                                  options.request_options_.setTimeout(
-                                      std::chrono::milliseconds(timeout_ms));
-                                }
-                              }},
-                             {"trace_sampled",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                const bool sampled = lua_toboolean(state, -1);
-                                options.request_options_.setSampled(sampled);
-                              }},
-                             {"return_duplicate_headers",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["return_duplicate_headers"]
-                                // = <boolean>} entry.
-                                options.return_duplicate_headers_ = lua_toboolean(state, -1);
-                              }},
-                             {"send_xff",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["send_xff"] =
-                                // <boolean>} entry.
-                                options.request_options_.setSendXff(lua_toboolean(state, -1));
-                              }},
-                         });
+  CONSTRUCT_ON_FIRST_USE(
+      OptionHandlers,
+      {
+          {"asynchronous",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             options.is_async_request_ = lua_toboolean(state, -1);
+           }},
+          {"timeout_ms",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             const int timeout_ms = luaL_checkint(state, -1);
+             if (timeout_ms < 0) {
+               luaL_error(state, "http call timeout must be >= 0");
+             } else {
+               options.request_options_.setTimeout(std::chrono::milliseconds(timeout_ms));
+             }
+           }},
+          {"trace_sampled",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             const bool sampled = lua_toboolean(state, -1);
+             options.request_options_.setSampled(sampled);
+           }},
+          {"return_duplicate_headers",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             options.return_duplicate_headers_ = lua_toboolean(state, -1);
+           }},
+          {"send_xff",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             options.request_options_.setSendXff(lua_toboolean(state, -1));
+           }},
+      });
 }
 
 constexpr int AsyncFlagIndex = 6;
@@ -82,7 +74,7 @@ using HttpResponseCodeDetails = ConstSingleton<HttpResponseCodeDetailValues>;
 
 // Parse http call options by inspecting the provided table.
 void parseOptionsFromTable(lua_State* state, int index,
-                           StreamHandleWrapper::HttpCallOptions& options) {
+                           StreamHandleWrapperBase::HttpCallOptions& options) {
   const auto& handlers = optionHandlers();
 
   lua_pushnil(state);
@@ -219,7 +211,8 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
   lua_state_.registerType<DynamicMetadataMapWrapper>();
   lua_state_.registerType<DynamicMetadataMapIterator>();
   lua_state_.registerType<FilterStateWrapper>();
-  lua_state_.registerType<StreamHandleWrapper>();
+  lua_state_.registerType<RequestStreamHandleWrapper>();
+  lua_state_.registerType<ResponseStreamHandleWrapper>();
   lua_state_.registerType<PublicKeyWrapper>();
   lua_state_.registerType<ConnectionStreamInfoWrapper>();
   lua_state_.registerType<ConnectionDynamicMetadataMapWrapper>();
@@ -258,10 +251,11 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
 
 PerLuaCodeSetup::~PerLuaCodeSetup() { vm_count_gauge_.sub(vm_count_delta_); }
 
-StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
-                                         Http::RequestOrResponseHeaderMap& headers, bool end_stream,
-                                         Filter& filter, FilterCallbacks& callbacks,
-                                         TimeSource& time_source)
+StreamHandleWrapperBase::StreamHandleWrapperBase(Filters::Common::Lua::Coroutine& coroutine,
+                                                 Http::RequestOrResponseHeaderMap& headers,
+                                                 bool end_stream, Filter& filter,
+                                                 FilterCallbacks& callbacks,
+                                                 TimeSource& time_source)
     : coroutine_(coroutine), headers_(headers), end_stream_(end_stream), filter_(filter),
       callbacks_(callbacks), yield_callback_([this]() {
         if (state_ == State::Running) {
@@ -270,7 +264,7 @@ StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& corout
       }),
       time_source_(time_source) {}
 
-Http::FilterHeadersStatus StreamHandleWrapper::start(int function_ref) {
+Http::FilterHeadersStatus StreamHandleWrapperBase::start(int function_ref) {
   // We are on the top of the stack.
   coroutine_.start(function_ref, 1, yield_callback_);
   Http::FilterHeadersStatus status =
@@ -285,7 +279,7 @@ Http::FilterHeadersStatus StreamHandleWrapper::start(int function_ref) {
   return status;
 }
 
-Http::FilterDataStatus StreamHandleWrapper::onData(Buffer::Instance& data, bool end_stream) {
+Http::FilterDataStatus StreamHandleWrapperBase::onData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!end_stream_);
   end_stream_ = end_stream;
   saw_body_ = true;
@@ -320,7 +314,7 @@ Http::FilterDataStatus StreamHandleWrapper::onData(Buffer::Instance& data, bool 
   }
 }
 
-Http::FilterTrailersStatus StreamHandleWrapper::onTrailers(Http::HeaderMap& trailers) {
+Http::FilterTrailersStatus StreamHandleWrapperBase::onTrailers(Http::HeaderMap& trailers) {
   ASSERT(!end_stream_);
   end_stream_ = true;
   trailers_ = &trailers;
@@ -352,7 +346,7 @@ Http::FilterTrailersStatus StreamHandleWrapper::onTrailers(Http::HeaderMap& trai
   return status;
 }
 
-int StreamHandleWrapper::luaRespond(lua_State* state) {
+int StreamHandleWrapperBase::luaRespond(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (headers_continued_) {
@@ -383,10 +377,10 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
   return lua_yield(state, 0);
 }
 
-int StreamHandleWrapper::luaHttpCall(lua_State* state) {
+int StreamHandleWrapperBase::luaHttpCall(lua_State* state) {
   ASSERT(state_ == State::Running);
 
-  StreamHandleWrapper::HttpCallOptions options;
+  StreamHandleWrapperBase::HttpCallOptions options;
   options.request_options_
       .setParentSpan(callbacks_.activeSpan())
       // By default, do not enforce a sampling decision on this `httpCall`'s span.
@@ -415,7 +409,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   return doHttpCall(state, options);
 }
 
-int StreamHandleWrapper::doHttpCall(lua_State* state, const HttpCallOptions& options) {
+int StreamHandleWrapperBase::doHttpCall(lua_State* state, const HttpCallOptions& options) {
   if (options.is_async_request_) {
     makeHttpCall(state, filter_, options.request_options_, noopCallbacks());
     return 0;
@@ -433,8 +427,8 @@ int StreamHandleWrapper::doHttpCall(lua_State* state, const HttpCallOptions& opt
   }
 }
 
-void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
-                                    Http::ResponseMessagePtr&& response) {
+void StreamHandleWrapperBase::onSuccess(const Http::AsyncClient::Request&,
+                                        Http::ResponseMessagePtr&& response) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP response complete");
   http_request_ = nullptr;
@@ -514,8 +508,8 @@ void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
   }
 }
 
-void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
-                                    Http::AsyncClient::FailureReason) {
+void StreamHandleWrapperBase::onFailure(const Http::AsyncClient::Request& request,
+                                        Http::AsyncClient::FailureReason) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP failure");
 
@@ -528,7 +522,7 @@ void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
   onSuccess(request, std::move(response_message));
 }
 
-int StreamHandleWrapper::luaHeaders(lua_State* state) {
+int StreamHandleWrapperBase::luaHeaders(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (headers_wrapper_.get() != nullptr) {
@@ -554,7 +548,7 @@ int StreamHandleWrapper::luaHeaders(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaBody(lua_State* state) {
+int StreamHandleWrapperBase::luaBody(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   bool always_wrap_body = false;
@@ -599,7 +593,7 @@ int StreamHandleWrapper::luaBody(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaBodyChunks(lua_State* state) {
+int StreamHandleWrapperBase::luaBodyChunks(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (saw_body_) {
@@ -607,11 +601,11 @@ int StreamHandleWrapper::luaBodyChunks(lua_State* state) {
   }
 
   // We are currently at the top of the stack. Push a closure that has us as the upvalue.
-  lua_pushcclosure(state, static_luaBodyIterator, 1);
+  lua_pushcclosure(state, bodyIteratorFn(), 1);
   return 1;
 }
 
-int StreamHandleWrapper::luaBodyIterator(lua_State* state) {
+int StreamHandleWrapperBase::luaBodyIterator(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (end_stream_) {
@@ -624,7 +618,7 @@ int StreamHandleWrapper::luaBodyIterator(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaTrailers(lua_State* state) {
+int StreamHandleWrapperBase::luaTrailers(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (end_stream_ && trailers_ == nullptr) {
@@ -645,7 +639,7 @@ int StreamHandleWrapper::luaTrailers(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaMetadata(lua_State* state) {
+int StreamHandleWrapperBase::luaMetadata(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (metadata_wrapper_.get() != nullptr) {
     metadata_wrapper_.pushStack();
@@ -656,7 +650,7 @@ int StreamHandleWrapper::luaMetadata(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaVirtualHost(lua_State* state) {
+int StreamHandleWrapperBase::luaVirtualHost(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (virtual_host_wrapper_.get() != nullptr) {
     virtual_host_wrapper_.pushStack();
@@ -668,7 +662,7 @@ int StreamHandleWrapper::luaVirtualHost(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaRoute(lua_State* state) {
+int StreamHandleWrapperBase::luaRoute(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (route_wrapper_.get() != nullptr) {
     route_wrapper_.pushStack();
@@ -679,7 +673,7 @@ int StreamHandleWrapper::luaRoute(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaStreamInfo(lua_State* state) {
+int StreamHandleWrapperBase::luaStreamInfo(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (stream_info_wrapper_.get() != nullptr) {
     stream_info_wrapper_.pushStack();
@@ -689,7 +683,7 @@ int StreamHandleWrapper::luaStreamInfo(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaConnectionStreamInfo(lua_State* state) {
+int StreamHandleWrapperBase::luaConnectionStreamInfo(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (connection_stream_info_wrapper_.get() != nullptr) {
     connection_stream_info_wrapper_.pushStack();
@@ -700,7 +694,7 @@ int StreamHandleWrapper::luaConnectionStreamInfo(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaConnection(lua_State* state) {
+int StreamHandleWrapperBase::luaConnection(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (connection_wrapper_.get() != nullptr) {
     connection_wrapper_.pushStack();
@@ -711,7 +705,7 @@ int StreamHandleWrapper::luaConnection(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
+int StreamHandleWrapperBase::luaVerifySignature(lua_State* state) {
   // Step 1: Get hash function.
   absl::string_view hash = luaL_checkstring(state, 2);
 
@@ -746,7 +740,7 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
   return 2;
 }
 
-int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
+int StreamHandleWrapperBase::luaImportPublicKey(lua_State* state) {
   // Get byte array and the length.
   const char* str = luaL_checkstring(state, 2);
   int n = luaL_checknumber(state, 3);
@@ -777,7 +771,7 @@ int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaBase64Escape(lua_State* state) {
+int StreamHandleWrapperBase::luaBase64Escape(lua_State* state) {
   absl::string_view input = Filters::Common::Lua::getStringViewFromLuaString(state, 2);
   auto output = absl::Base64Escape(input);
   lua_pushlstring(state, output.data(), output.size());
@@ -785,7 +779,7 @@ int StreamHandleWrapper::luaBase64Escape(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaTimestamp(lua_State* state) {
+int StreamHandleWrapperBase::luaTimestamp(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
   absl::string_view unit_parameter = luaL_optstring(state, 2, "");
@@ -806,7 +800,7 @@ int StreamHandleWrapper::luaTimestamp(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaTimestampString(lua_State* state) {
+int StreamHandleWrapperBase::luaTimestampString(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
   absl::string_view unit_parameter = luaL_optstring(state, 2, "");
@@ -828,7 +822,7 @@ int StreamHandleWrapper::luaTimestampString(lua_State* state) {
 }
 
 enum Timestamp::Resolution
-StreamHandleWrapper::getTimestampResolution(absl::string_view unit_parameter) {
+StreamHandleWrapperBase::getTimestampResolution(absl::string_view unit_parameter) {
   auto resolution = Timestamp::Resolution::Undefined;
 
   absl::uint128 resolution_as_int_from_state = 0;
@@ -913,19 +907,44 @@ void Filter::onDestroy() {
   }
 }
 
-Http::FilterHeadersStatus
-Filter::doHeaders(StreamHandleRef& handle, Filters::Common::Lua::CoroutinePtr& coroutine,
-                  FilterCallbacks& callbacks, int function_ref, PerLuaCodeSetup* setup,
-                  Http::RequestOrResponseHeaderMap& headers, bool end_stream) {
+Http::FilterHeadersStatus Filter::doRequestHeaders(Http::RequestOrResponseHeaderMap& headers,
+                                                   bool end_stream, int function_ref,
+                                                   PerLuaCodeSetup* setup) {
   if (function_ref == LUA_REFNIL) {
     return Http::FilterHeadersStatus::Continue;
   }
   ASSERT(setup);
-  coroutine = setup->createCoroutine();
+  request_coroutine_ = setup->createCoroutine();
 
-  handle.reset(StreamHandleWrapper::create(coroutine->luaState(), *coroutine, headers, end_stream,
-                                           *this, callbacks, time_source_),
-               true);
+  request_stream_wrapper_.reset(RequestStreamHandleWrapper::create(
+                                    request_coroutine_->luaState(), *request_coroutine_, headers,
+                                    end_stream, *this, decoder_callbacks_, time_source_),
+                                true);
+
+  Http::FilterHeadersStatus status = Http::FilterHeadersStatus::Continue;
+  TRY_NEEDS_AUDIT {
+    stats_.executions_.inc();
+    status = request_stream_wrapper_.get()->start(function_ref);
+    request_stream_wrapper_.markDead();
+  }
+  END_TRY catch (const Filters::Common::Lua::LuaException& e) { scriptError(e); }
+
+  return status;
+}
+
+Http::FilterHeadersStatus Filter::doResponseHeaders(Http::RequestOrResponseHeaderMap& headers,
+                                                    bool end_stream, int function_ref,
+                                                    PerLuaCodeSetup* setup) {
+  if (function_ref == LUA_REFNIL) {
+    return Http::FilterHeadersStatus::Continue;
+  }
+  ASSERT(setup);
+  response_coroutine_ = setup->createCoroutine();
+
+  response_stream_wrapper_.reset(ResponseStreamHandleWrapper::create(
+                                     response_coroutine_->luaState(), *response_coroutine_, headers,
+                                     end_stream, *this, encoder_callbacks_, time_source_),
+                                 true);
 
   Http::FilterHeadersStatus status = Http::FilterHeadersStatus::Continue;
   TRY_NEEDS_AUDIT {
@@ -933,16 +952,16 @@ Filter::doHeaders(StreamHandleRef& handle, Filters::Common::Lua::CoroutinePtr& c
     // handles. This is intentionally kept so as to provide consistency with the way the 'errors'
     // counter is incremented.
     stats_.executions_.inc();
-    status = handle.get()->start(function_ref);
-    handle.markDead();
+    status = response_stream_wrapper_.get()->start(function_ref);
+    response_stream_wrapper_.markDead();
   }
   END_TRY catch (const Filters::Common::Lua::LuaException& e) { scriptError(e); }
 
   return status;
 }
 
-Http::FilterDataStatus Filter::doData(StreamHandleRef& handle, Buffer::Instance& data,
-                                      bool end_stream) {
+template <typename HandleRef>
+Http::FilterDataStatus Filter::doData(HandleRef& handle, Buffer::Instance& data, bool end_stream) {
   Http::FilterDataStatus status = Http::FilterDataStatus::Continue;
   if (handle.get() != nullptr) {
     TRY_NEEDS_AUDIT {
@@ -956,7 +975,8 @@ Http::FilterDataStatus Filter::doData(StreamHandleRef& handle, Buffer::Instance&
   return status;
 }
 
-Http::FilterTrailersStatus Filter::doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers) {
+template <typename HandleRef>
+Http::FilterTrailersStatus Filter::doTrailers(HandleRef& handle, Http::HeaderMap& trailers) {
   Http::FilterTrailersStatus status = Http::FilterTrailersStatus::Continue;
   if (handle.get() != nullptr) {
     TRY_NEEDS_AUDIT {
@@ -970,6 +990,20 @@ Http::FilterTrailersStatus Filter::doTrailers(StreamHandleRef& handle, Http::Hea
   return status;
 }
 
+// Explicit instantiations to avoid linker errors (templates defined in .cc).
+template Http::FilterDataStatus
+Filter::doData<Filter::RequestStreamHandleRef>(Filter::RequestStreamHandleRef&, Buffer::Instance&,
+                                               bool);
+template Http::FilterDataStatus
+Filter::doData<Filter::ResponseStreamHandleRef>(Filter::ResponseStreamHandleRef&, Buffer::Instance&,
+                                                bool);
+template Http::FilterTrailersStatus
+Filter::doTrailers<Filter::RequestStreamHandleRef>(Filter::RequestStreamHandleRef&,
+                                                   Http::HeaderMap&);
+template Http::FilterTrailersStatus
+Filter::doTrailers<Filter::ResponseStreamHandleRef>(Filter::ResponseStreamHandleRef&,
+                                                    Http::HeaderMap&);
+
 void Filter::scriptError(const Filters::Common::Lua::LuaException& e) {
   stats_.errors_.inc();
   scriptLog(spdlog::level::err, e.what());
@@ -977,7 +1011,7 @@ void Filter::scriptError(const Filters::Common::Lua::LuaException& e) {
   response_stream_wrapper_.reset();
 }
 
-int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
+int StreamHandleWrapperBase::luaSetUpstreamOverrideHost(lua_State* state) {
   // Get the host address argument
   size_t len;
   const char* host = luaL_checklstring(state, 2, &len);
@@ -1003,12 +1037,12 @@ int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
   return 0;
 }
 
-int StreamHandleWrapper::luaClearRouteCache(lua_State*) {
+int StreamHandleWrapperBase::luaClearRouteCache(lua_State*) {
   callbacks_.clearRouteCache();
   return 0;
 }
 
-int StreamHandleWrapper::luaFilterContext(lua_State* state) {
+int StreamHandleWrapperBase::luaFilterContext(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (filter_context_wrapper_.get() != nullptr) {
     filter_context_wrapper_.pushStack();
@@ -1019,7 +1053,7 @@ int StreamHandleWrapper::luaFilterContext(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaStats(lua_State* state) {
+int StreamHandleWrapperBase::luaStats(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (stats_scope_wrapper_.get() != nullptr) {
     stats_scope_wrapper_.pushStack();

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -154,12 +154,34 @@ public:
 
 class Filter;
 
+// Generates only the static thunk for a Lua function (userdata at stack slot 1). The concrete
+// handle wrapper types use this to forward calls to implementations inherited from
+// StreamHandleWrapperBase without needing to repeat the int Name(lua_State*) signature.
+#define FORWARD_LUA_FUNCTION(Class, Name)                                                          \
+  static int static_##Name(lua_State* state) {                                                     \
+    Class* object = ::Envoy::Extensions::Filters::Common::Lua::alignAndCast<Class>(                \
+        luaL_checkudata(state, 1, typeid(Class).name()));                                          \
+    object->checkDead(state);                                                                      \
+    return object->Name(state);                                                                    \
+  }
+
+// Same as FORWARD_LUA_FUNCTION but for closures where userdata is in upvalue slot 1.
+#define FORWARD_LUA_CLOSURE(Class, Name)                                                           \
+  static int static_##Name(lua_State* state) {                                                     \
+    Class* object = ::Envoy::Extensions::Filters::Common::Lua::alignAndCast<Class>(                \
+        luaL_checkudata(state, lua_upvalueindex(1), typeid(Class).name()));                        \
+    object->checkDead(state);                                                                      \
+    return object->Name(state);                                                                    \
+  }
+
 /**
- * A wrapper for a currently running request/response. This is the primary handle passed to Lua.
- * The script interacts with Envoy entirely through this handle.
+ * Base class for request and response stream handle wrappers. Contains all state and Lua function
+ * implementations shared between the two paths. Not a BaseLuaObject itself — the concrete
+ * subclasses RequestStreamHandleWrapper and ResponseStreamHandleWrapper provide the Lua type
+ * identity and exported function tables.
  */
-class StreamHandleWrapper : public Filters::Common::Lua::BaseLuaObject<StreamHandleWrapper>,
-                            public Http::AsyncClient::Callbacks {
+class StreamHandleWrapperBase : public Http::AsyncClient::Callbacks,
+                                public Filters::Common::Lua::LuaLoggable {
 public:
   /**
    * The state machine for a stream handler. In the current implementation everything the filter
@@ -189,9 +211,9 @@ public:
     bool return_duplicate_headers_{false};
   };
 
-  StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
-                      Http::RequestOrResponseHeaderMap& headers, bool end_stream, Filter& filter,
-                      FilterCallbacks& callbacks, TimeSource& time_source);
+  StreamHandleWrapperBase(Filters::Common::Lua::Coroutine& coroutine,
+                          Http::RequestOrResponseHeaderMap& headers, bool end_stream,
+                          Filter& filter, FilterCallbacks& callbacks, TimeSource& time_source);
 
   Http::FilterHeadersStatus start(int function_ref);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream);
@@ -205,31 +227,7 @@ public:
     on_reset_called_ = true;
   }
 
-  static ExportedFunctions exportedFunctions() {
-    return {{"headers", static_luaHeaders},
-            {"body", static_luaBody},
-            {"bodyChunks", static_luaBodyChunks},
-            {"trailers", static_luaTrailers},
-            {"metadata", static_luaMetadata},
-            {"httpCall", static_luaHttpCall},
-            {"respond", static_luaRespond},
-            {"streamInfo", static_luaStreamInfo},
-            {"connection", static_luaConnection},
-            {"importPublicKey", static_luaImportPublicKey},
-            {"verifySignature", static_luaVerifySignature},
-            {"base64Escape", static_luaBase64Escape},
-            {"timestamp", static_luaTimestamp},
-            {"timestampString", static_luaTimestampString},
-            {"connectionStreamInfo", static_luaConnectionStreamInfo},
-            {"setUpstreamOverrideHost", static_luaSetUpstreamOverrideHost},
-            {"clearRouteCache", static_luaClearRouteCache},
-            {"filterContext", static_luaFilterContext},
-            {"virtualHost", static_luaVirtualHost},
-            {"route", static_luaRoute},
-            {"stats", static_luaStats}};
-  }
-
-private:
+protected:
   /**
    * Perform an HTTP call to an upstream host.
    * @param 1 (string): The name of the upstream cluster to call. This cluster must be configured.
@@ -240,7 +238,7 @@ private:
    * from upstream service. False/synchronous by default.
    * @return headers (table), body (string/nil)
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaHttpCall);
+  int luaHttpCall(lua_State* state);
 
   /**
    * Perform an inline response. This call is currently only valid on the request path. Further
@@ -248,12 +246,12 @@ private:
    * @param 1 (table): A table of HTTP headers. :status must be defined.
    * @param 2 (string): Body. Can be nil.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRespond);
+  int luaRespond(lua_State* state);
 
   /**
    * @return a handle to the headers.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaHeaders);
+  int luaHeaders(lua_State* state);
 
   /**
    * @return a handle to the full body or nil if there is no body. This call will cause the script
@@ -262,40 +260,40 @@ private:
    *         NOTE: This call causes Envoy to buffer the body. The max buffer size is configured
    *         based on the currently active flow control settings.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBody);
+  int luaBody(lua_State* state);
 
   /**
    * @return an iterator that allows the script to iterate through all body chunks as they are
    *         received. The iterator will yield between body chunks. Envoy *will not* buffer
    *         the body chunks in this case, but the script can look at them as they go by.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBodyChunks);
+  int luaBodyChunks(lua_State* state);
 
   /**
    * @return a handle to the trailers or nil if there are no trailers. This call will cause the
    *         script to yield if Envoy does not yet know if there are trailers or not.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTrailers);
+  int luaTrailers(lua_State* state);
 
   /**
    * @return a handle to the metadata.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaMetadata);
+  int luaMetadata(lua_State* state);
 
   /**
    * @return a handle to the stream info.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaStreamInfo);
+  int luaStreamInfo(lua_State* state);
 
   /**
    * @return a handle to the network connection.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnection);
+  int luaConnection(lua_State* state);
 
   /**
    * @return a handle to the network connection's stream info.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnectionStreamInfo);
+  int luaConnectionStreamInfo(lua_State* state);
 
   /**
    * Verify cryptographic signatures.
@@ -308,7 +306,7 @@ private:
    * @return (bool, string) If the first element is true, the second element is empty; otherwise,
    * the second element stores the error message
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVerifySignature);
+  int luaVerifySignature(lua_State* state);
 
   /**
    * Import public key.
@@ -316,19 +314,37 @@ private:
    * @param 2 (int)    length of keyder string
    * @return pointer to public key
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaImportPublicKey);
+  int luaImportPublicKey(lua_State* state);
 
   /**
-   * This is the closure/iterator returned by luaBodyChunks() above.
+   * This is the body iterator invoked by the closure returned from luaBodyChunks().
    */
-  DECLARE_LUA_CLOSURE(StreamHandleWrapper, luaBodyIterator);
+  int luaBodyIterator(lua_State* state);
+
+  /**
+   * Returns the concrete type's static body iterator function pointer, used by luaBodyChunks()
+   * to push the closure. Implemented by each concrete subclass via FORWARD_LUA_CLOSURE.
+   */
+  virtual lua_CFunction bodyIteratorFn() const = 0;
+
+  /**
+   * Mark this object as live (callable). Delegates to BaseLuaObject<T>::markLive() on the
+   * concrete subclass.
+   */
+  virtual void markLive() = 0;
+
+  /**
+   * Mark this object as dead (not callable). Delegates to BaseLuaObject<T>::markDead() on the
+   * concrete subclass.
+   */
+  virtual void markDead() = 0;
 
   /**
    * Base64 escape a string.
    * @param1 (string) string to be base64 escaped.
    * @return (string) base64 escaped string.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBase64Escape);
+  int luaBase64Escape(lua_State* state);
 
   /**
    * Timestamp.
@@ -336,7 +352,7 @@ private:
    * Defaults to milliseconds_from_epoch.
    * @return timestamp
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestamp);
+  int luaTimestamp(lua_State* state);
 
   /**
    * TimestampString.
@@ -344,39 +360,39 @@ private:
    * Defaults to milliseconds_from_epoch.
    * @return (string) timestamp.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestampString);
+  int luaTimestampString(lua_State* state);
 
   /**
    * Set the upstream override host.
    * @param 1 (string): The host address to override with.
    * @param 2 (bool): Optional strict flag. Defaults to false.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaSetUpstreamOverrideHost);
+  int luaSetUpstreamOverrideHost(lua_State* state);
 
   /**
    * Clear the route cache explicitly.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaClearRouteCache);
+  int luaClearRouteCache(lua_State* state);
 
   /**
    * Get the filter context.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaFilterContext);
+  int luaFilterContext(lua_State* state);
 
   /**
    * @return a handle to the virtual host.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVirtualHost);
+  int luaVirtualHost(lua_State* state);
 
   /**
    * @return a handle to the route.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRoute);
+  int luaRoute(lua_State* state);
 
   /**
    * @return a handle to the stats scope for creating custom stats.
    */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaStats);
+  int luaStats(lua_State* state);
 
   enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
 
@@ -387,24 +403,6 @@ private:
     if (!on_reset_called_) {
       coroutine_.resume(num_args, yield_callback);
     }
-  }
-
-  // Filters::Common::Lua::BaseLuaObject
-  void onMarkDead() override {
-    // Headers/body/trailers wrappers do not survive any yields. The user can request them
-    // again across yields if needed.
-    headers_wrapper_.reset();
-    body_wrapper_.reset();
-    trailers_wrapper_.reset();
-    metadata_wrapper_.reset();
-    filter_context_wrapper_.reset();
-    stream_info_wrapper_.reset();
-    connection_wrapper_.reset();
-    public_key_wrapper_.reset();
-    connection_stream_info_wrapper_.reset();
-    virtual_host_wrapper_.reset();
-    route_wrapper_.reset();
-    stats_scope_wrapper_.reset();
   }
 
   // Http::AsyncClient::Callbacks
@@ -444,6 +442,176 @@ private:
 
   // The inserted crypto object pointers will not be removed from this map.
   absl::flat_hash_map<std::string, Envoy::Common::Crypto::PKeyObjectPtr> public_key_storage_;
+};
+
+/**
+ * Lua handle passed to envoy_on_request. Exposes the request path API.
+ */
+class RequestStreamHandleWrapper
+    : public StreamHandleWrapperBase,
+      public Filters::Common::Lua::BaseLuaObject<RequestStreamHandleWrapper> {
+public:
+  using StreamHandleWrapperBase::StreamHandleWrapperBase;
+
+  static ExportedFunctions exportedFunctions() {
+    return {{"headers", static_luaHeaders},
+            {"body", static_luaBody},
+            {"bodyChunks", static_luaBodyChunks},
+            {"trailers", static_luaTrailers},
+            {"metadata", static_luaMetadata},
+            {"httpCall", static_luaHttpCall},
+            {"respond", static_luaRespond},
+            {"streamInfo", static_luaStreamInfo},
+            {"connection", static_luaConnection},
+            {"importPublicKey", static_luaImportPublicKey},
+            {"verifySignature", static_luaVerifySignature},
+            {"base64Escape", static_luaBase64Escape},
+            {"timestamp", static_luaTimestamp},
+            {"timestampString", static_luaTimestampString},
+            {"connectionStreamInfo", static_luaConnectionStreamInfo},
+            {"setUpstreamOverrideHost", static_luaSetUpstreamOverrideHost},
+            {"clearRouteCache", static_luaClearRouteCache},
+            {"filterContext", static_luaFilterContext},
+            {"virtualHost", static_luaVirtualHost},
+            {"route", static_luaRoute},
+            {"stats", static_luaStats}};
+  }
+
+  lua_CFunction bodyIteratorFn() const override { return static_luaBodyIterator; }
+  void markLive() override {
+    Filters::Common::Lua::BaseLuaObject<RequestStreamHandleWrapper>::markLive();
+  }
+  void markDead() override {
+    Filters::Common::Lua::BaseLuaObject<RequestStreamHandleWrapper>::markDead();
+  }
+
+private:
+  // Filters::Common::Lua::BaseLuaObject
+  // NOTE: This must be kept in sync with ResponseStreamHandleWrapper::onMarkDead() below.
+  // Both reset every LuaDeathRef field declared in StreamHandleWrapperBase. If a new wrapper
+  // field is added to the base, it must be reset in both subclass onMarkDead() overrides.
+  void onMarkDead() override {
+    headers_wrapper_.reset();
+    body_wrapper_.reset();
+    trailers_wrapper_.reset();
+    metadata_wrapper_.reset();
+    filter_context_wrapper_.reset();
+    stream_info_wrapper_.reset();
+    connection_wrapper_.reset();
+    public_key_wrapper_.reset();
+    connection_stream_info_wrapper_.reset();
+    virtual_host_wrapper_.reset();
+    route_wrapper_.reset();
+    stats_scope_wrapper_.reset();
+  }
+
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaHeaders)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaBody)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaBodyChunks)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaTrailers)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaMetadata)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaHttpCall)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaRespond)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaStreamInfo)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaConnection)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaImportPublicKey)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaVerifySignature)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaBase64Escape)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaTimestamp)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaTimestampString)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaConnectionStreamInfo)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaSetUpstreamOverrideHost)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaClearRouteCache)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaFilterContext)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaVirtualHost)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaRoute)
+  FORWARD_LUA_FUNCTION(RequestStreamHandleWrapper, luaStats)
+  FORWARD_LUA_CLOSURE(RequestStreamHandleWrapper, luaBodyIterator)
+};
+
+/**
+ * Lua handle passed to envoy_on_response. Exposes the same API as the request handle.
+ */
+class ResponseStreamHandleWrapper
+    : public StreamHandleWrapperBase,
+      public Filters::Common::Lua::BaseLuaObject<ResponseStreamHandleWrapper> {
+public:
+  using StreamHandleWrapperBase::StreamHandleWrapperBase;
+
+  static ExportedFunctions exportedFunctions() {
+    return {{"headers", static_luaHeaders},
+            {"body", static_luaBody},
+            {"bodyChunks", static_luaBodyChunks},
+            {"trailers", static_luaTrailers},
+            {"metadata", static_luaMetadata},
+            {"httpCall", static_luaHttpCall},
+            {"respond", static_luaRespond},
+            {"streamInfo", static_luaStreamInfo},
+            {"connection", static_luaConnection},
+            {"importPublicKey", static_luaImportPublicKey},
+            {"verifySignature", static_luaVerifySignature},
+            {"base64Escape", static_luaBase64Escape},
+            {"timestamp", static_luaTimestamp},
+            {"timestampString", static_luaTimestampString},
+            {"connectionStreamInfo", static_luaConnectionStreamInfo},
+            {"setUpstreamOverrideHost", static_luaSetUpstreamOverrideHost},
+            {"clearRouteCache", static_luaClearRouteCache},
+            {"filterContext", static_luaFilterContext},
+            {"virtualHost", static_luaVirtualHost},
+            {"route", static_luaRoute},
+            {"stats", static_luaStats}};
+  }
+
+  lua_CFunction bodyIteratorFn() const override { return static_luaBodyIterator; }
+  void markLive() override {
+    Filters::Common::Lua::BaseLuaObject<ResponseStreamHandleWrapper>::markLive();
+  }
+  void markDead() override {
+    Filters::Common::Lua::BaseLuaObject<ResponseStreamHandleWrapper>::markDead();
+  }
+
+private:
+  // Filters::Common::Lua::BaseLuaObject
+  // NOTE: This must be kept in sync with RequestStreamHandleWrapper::onMarkDead() above.
+  // Both reset every LuaDeathRef field declared in StreamHandleWrapperBase. If a new wrapper
+  // field is added to the base, it must be reset in both subclass onMarkDead() overrides.
+  void onMarkDead() override {
+    headers_wrapper_.reset();
+    body_wrapper_.reset();
+    trailers_wrapper_.reset();
+    metadata_wrapper_.reset();
+    filter_context_wrapper_.reset();
+    stream_info_wrapper_.reset();
+    connection_wrapper_.reset();
+    public_key_wrapper_.reset();
+    connection_stream_info_wrapper_.reset();
+    virtual_host_wrapper_.reset();
+    route_wrapper_.reset();
+    stats_scope_wrapper_.reset();
+  }
+
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaHeaders)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaBody)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaBodyChunks)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaTrailers)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaMetadata)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaHttpCall)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaRespond)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaStreamInfo)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaConnection)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaImportPublicKey)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaVerifySignature)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaBase64Escape)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaTimestamp)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaTimestampString)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaConnectionStreamInfo)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaSetUpstreamOverrideHost)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaClearRouteCache)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaFilterContext)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaVirtualHost)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaRoute)
+  FORWARD_LUA_FUNCTION(ResponseStreamHandleWrapper, luaStats)
+  FORWARD_LUA_CLOSURE(ResponseStreamHandleWrapper, luaBodyIterator)
 };
 
 /**
@@ -541,8 +709,7 @@ public:
                                           bool end_stream) override {
     PerLuaCodeSetup* setup = getPerLuaCodeSetup();
     const int function_ref = setup ? setup->requestFunctionRef() : LUA_REFNIL;
-    return doHeaders(request_stream_wrapper_, request_coroutine_, decoder_callbacks_, function_ref,
-                     setup, headers, end_stream);
+    return doRequestHeaders(headers, end_stream, function_ref, setup);
   }
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override {
     return doData(request_stream_wrapper_, data, end_stream);
@@ -562,8 +729,7 @@ public:
                                           bool end_stream) override {
     PerLuaCodeSetup* setup = getPerLuaCodeSetup();
     const int function_ref = setup ? setup->responseFunctionRef() : LUA_REFNIL;
-    return doHeaders(response_stream_wrapper_, response_coroutine_, encoder_callbacks_,
-                     function_ref, setup, headers, end_stream);
+    return doResponseHeaders(headers, end_stream, function_ref, setup);
   }
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override {
     return doData(response_stream_wrapper_, data, end_stream);
@@ -658,7 +824,8 @@ private:
     Http::StreamEncoderFilterCallbacks* callbacks_{};
   };
 
-  using StreamHandleRef = Filters::Common::Lua::LuaDeathRef<StreamHandleWrapper>;
+  using RequestStreamHandleRef = Filters::Common::Lua::LuaDeathRef<RequestStreamHandleWrapper>;
+  using ResponseStreamHandleRef = Filters::Common::Lua::LuaDeathRef<ResponseStreamHandleWrapper>;
 
   PerLuaCodeSetup* getPerLuaCodeSetup() {
     if (decoder_callbacks_.callbacks_ != nullptr) {
@@ -689,13 +856,18 @@ private:
                                         : per_route_config_->filterContext();
   }
 
-  Http::FilterHeadersStatus doHeaders(StreamHandleRef& handle,
-                                      Filters::Common::Lua::CoroutinePtr& coroutine,
-                                      FilterCallbacks& callbacks, int function_ref,
-                                      PerLuaCodeSetup* setup,
-                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream);
-  Http::FilterDataStatus doData(StreamHandleRef& handle, Buffer::Instance& data, bool end_stream);
-  Http::FilterTrailersStatus doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers);
+  Http::FilterHeadersStatus doRequestHeaders(Http::RequestOrResponseHeaderMap& headers,
+                                             bool end_stream, int function_ref,
+                                             PerLuaCodeSetup* setup);
+  Http::FilterHeadersStatus doResponseHeaders(Http::RequestOrResponseHeaderMap& headers,
+                                              bool end_stream, int function_ref,
+                                              PerLuaCodeSetup* setup);
+
+  template <typename HandleRef>
+  Http::FilterDataStatus doData(HandleRef& handle, Buffer::Instance& data, bool end_stream);
+
+  template <typename HandleRef>
+  Http::FilterTrailersStatus doTrailers(HandleRef& handle, Http::HeaderMap& trailers);
 
   FilterConfigConstSharedPtr config_;
   const FilterConfigPerRoute* per_route_config_{};
@@ -720,8 +892,8 @@ private:
 
   DecoderCallbacks decoder_callbacks_{*this};
   EncoderCallbacks encoder_callbacks_{*this};
-  StreamHandleRef request_stream_wrapper_;
-  StreamHandleRef response_stream_wrapper_;
+  RequestStreamHandleRef request_stream_wrapper_;
+  ResponseStreamHandleRef response_stream_wrapper_;
   bool destroyed_{};
 };
 


### PR DESCRIPTION
This is a pure mechanical refactor, no behavior change. It splits the single `StreamHandleWrapper` class into a `StreamHandleWrapperBase` holding all the shared state and Lua function implementations, plus two concrete leaf types (`RequestStreamHandleWrapper` / `ResponseStreamHandleWrapper`) passed to `envoy_on_request` and `envoy_on_response` respectively. `Filter::doHeaders` becomes `doRequestHeaders`/`doResponseHeaders` to construct the matching type per path.

The motivation is #44594, which wants to add a request-only accessor to the response handle -- not possible today since both paths share one class and one exported-function table. This is meant to land first so that follow-up's diff shrinks to just the new accessor.

A couple of known tradeoffs worth flagging for review:
- The two leaf classes are currently 100% identical (same `exportedFunctions()`, same `onMarkDead()`, same forwarding overrides) since nothing has diverged yet -- that's expected to change in the follow-up.
- The split means both leaf classes now inherit `LuaLoggable` twice (once via `StreamHandleWrapperBase`, once via `BaseLuaObject<T>`). It's a harmless non-virtual diamond today (nothing calls an ambiguous member unqualified), but worth a look. Fixing it properly means touching `BaseLuaObject<T>`, which is shared by every Lua wrapper type in the codebase, so I left it alone for this PR.

## Test Plan
- `bazel test //test/extensions/filters/http/lua:lua_filter_test //test/extensions/filters/http/lua:wrappers_test` -- both pass
- No test changes needed: `lua_filter_test` drives everything through `Filter`'s public decode/encode API rather than referencing the wrapper classes by name, so existing coverage is unaffected by the rename/split

Risk Level: low, no behavior change
Testing: existing lua_filter_test, wrappers_test
Docs Changes: none
Release Notes: none
Platform Specific Features: none