### PR TITLE
Http: add goaway_sent stat to HTTP/3 server session

### DIFF
--- a/source/common/http/http3/codec_stats.h
+++ b/source/common/http/http3/codec_stats.h
@@ -21,7 +21,8 @@ namespace Http3 {
   COUNTER(metadata_not_supported_error)                                                            \
   COUNTER(quic_version_h3_29)                                                                      \
   COUNTER(quic_version_rfc_v1)                                                                     \
-  COUNTER(tx_flush_timeout)
+  COUNTER(tx_flush_timeout)                                                                        \
+  COUNTER(goaway_sent)
 
 /**
  * Wrapper struct for the HTTP/3 codec stats. @see stats_macros.h

--- a/source/common/quic/client_codec_impl.cc
+++ b/source/common/quic/client_codec_impl.cc
@@ -26,6 +26,7 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
 }
 
 void QuicHttpClientConnectionImpl::goAway() {
+  stats_.goaway_sent_.inc();
   quic_client_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "client goaway");
 }
 

--- a/source/common/quic/client_codec_impl.cc
+++ b/source/common/quic/client_codec_impl.cc
@@ -26,7 +26,6 @@ QuicHttpClientConnectionImpl::QuicHttpClientConnectionImpl(
 }
 
 void QuicHttpClientConnectionImpl::goAway() {
-  stats_.goaway_sent_.inc();
   quic_client_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "client goaway");
 }
 

--- a/source/common/quic/server_codec_impl.cc
+++ b/source/common/quic/server_codec_impl.cc
@@ -57,6 +57,7 @@ void QuicHttpServerConnectionImpl::shutdownNotice() {
 }
 
 void QuicHttpServerConnectionImpl::goAway() {
+  stats_.goaway_sent_.inc();
   quic_server_session_.SendHttp3GoAway(quic::QUIC_PEER_GOING_AWAY, "server shutdown imminent");
 }
 

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -938,7 +938,9 @@ TEST_F(EnvoyQuicServerSessionTest, ShutdownNotice) {
   testing::NiceMock<quic::test::MockHttp3DebugVisitor> debug_visitor;
   envoy_quic_session_.set_debug_visitor(&debug_visitor);
   EXPECT_CALL(debug_visitor, OnGoAwayFrameSent(_));
+  EXPECT_EQ(0U, stats_.goaway_sent_.value());
   http_connection_->shutdownNotice();
+  EXPECT_EQ(0U, stats_.goaway_sent_.value());
 }
 
 TEST_F(EnvoyQuicServerSessionTest, GoAway) {
@@ -946,7 +948,9 @@ TEST_F(EnvoyQuicServerSessionTest, GoAway) {
   testing::NiceMock<quic::test::MockHttp3DebugVisitor> debug_visitor;
   envoy_quic_session_.set_debug_visitor(&debug_visitor);
   EXPECT_CALL(debug_visitor, OnGoAwayFrameSent(_));
+  EXPECT_EQ(0U, stats_.goaway_sent_.value());
   http_connection_->goAway();
+  EXPECT_EQ(1U, stats_.goaway_sent_.value());
 }
 
 TEST_F(EnvoyQuicServerSessionTest, ConnectedAfterHandshake) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Http: add goaway_sent stat to HTTP/3 server session
Additional Description: This change adds the goaway_sent counter to the HTTP/3 codec stats, bringing it to parity with the existing HTTP/2 implementation. The stat is incremented in both QuicHttpServerConnectionImpl::goAway() whenever a final GOAWAY sequence is initiated. 
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
