### PR TITLE
dynamic_modules: add set_dynamic_metadata callbacks to cluster LB context

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-cluster-lb-context-set-dynamic-metadata.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-cluster-lb-context-set-dynamic-metadata.rst
@@ -1,0 +1,7 @@
+Added the ``envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number`` and
+``envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string`` ABI callbacks so
+custom cluster load balancers can annotate the current request with dynamic metadata at request
+time inside ``envoy_dynamic_module_on_cluster_lb_choose_host``, mirroring the existing HTTP filter
+setters. The metadata is readable later on the same request (for example via
+``%DYNAMIC_METADATA(namespace:key)%``). The Rust SDK exposes these as
+``ClusterLbContext::set_dynamic_metadata_number`` and ``ClusterLbContext::set_dynamic_metadata_string``.

--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -9,6 +9,7 @@
 #include "source/common/common/safe_memcpy.h"
 #include "source/common/common/thread.h"
 #include "source/common/http/message_impl.h"
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/clusters/dynamic_modules/cluster.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -922,6 +923,47 @@ uint64_t envoy_dynamic_module_callback_cluster_lb_context_get_host_stat(
   }
   const auto* host = static_cast<const Envoy::Upstream::Host*>(host_envoy_ptr);
   return readHostStat(host->stats(), stat);
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    double value) {
+  if (context_envoy_ptr == nullptr) {
+    return false;
+  }
+  auto* stream_info = getContext(context_envoy_ptr)->requestStreamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return false;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  Envoy::Protobuf::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_number_value(value);
+  stream_info->setDynamicMetadata(std::string(ns.ptr, ns.length), metadata_value);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_module_buffer value) {
+  if (context_envoy_ptr == nullptr) {
+    return false;
+  }
+  auto* stream_info = getContext(context_envoy_ptr)->requestStreamInfo();
+  if (!stream_info) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "stream info is not available");
+    return false;
+  }
+  absl::string_view key_view(key.ptr, key.length);
+  absl::string_view value_view(value.ptr, value.length);
+  Envoy::Protobuf::Struct metadata_value;
+  (*metadata_value.mutable_fields())[key_view].set_string_value(value_view);
+  stream_info->setDynamicMetadata(std::string(ns.ptr, ns.length), metadata_value);
+  return true;
 }
 
 envoy_dynamic_module_type_cluster_scheduler_module_ptr

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -10524,6 +10524,40 @@ uint64_t envoy_dynamic_module_callback_cluster_lb_context_get_host_stat(
     envoy_dynamic_module_type_host_stat stat);
 
 /**
+ * envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number sets the number
+ * value of the request's dynamic metadata under the given namespace and key, overwriting any
+ * existing value. This lets a dynamic-module cluster annotate the current request so the value is
+ * observable in the access log via %DYNAMIC_METADATA(namespace:key)%.
+ *
+ * @param context_envoy_ptr is the per-request load balancer context.
+ * @param ns is the namespace of the dynamic metadata.
+ * @param key is the key of the dynamic metadata.
+ * @param value is the number value to set.
+ * @return true if the value was set, false if the request has no stream info.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    double value);
+
+/**
+ * envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string sets the string
+ * value of the request's dynamic metadata under the given namespace and key, overwriting any
+ * existing value. This lets a dynamic-module cluster annotate the current request so the value is
+ * observable in the access log via %DYNAMIC_METADATA(namespace:key)%.
+ *
+ * @param context_envoy_ptr is the per-request load balancer context.
+ * @param ns is the namespace of the dynamic metadata.
+ * @param key is the key of the dynamic metadata.
+ * @param value is the string value to set.
+ * @return true if the value was set, false if the request has no stream info.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_module_buffer value);
+
+/**
  * envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete is called by the module
  * to deliver the result of an asynchronous host selection. This must be called exactly once for
  * each async handle returned from envoy_dynamic_module_on_cluster_lb_choose_host, unless

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -786,6 +786,24 @@ __attribute__((weak)) uint64_t envoy_dynamic_module_callback_cluster_lb_context_
   return 0;
 }
 
+__attribute__((weak)) bool
+envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, double) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool
+envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_cluster_scheduler_module_ptr
 envoy_dynamic_module_callback_cluster_scheduler_new(envoy_dynamic_module_type_cluster_envoy_ptr) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_scheduler_new: "

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -308,6 +308,20 @@ pub trait ClusterLbContext {
     stat: abi::envoy_dynamic_module_type_host_stat,
   ) -> u64;
 
+  /// Sets a number value on the request's dynamic metadata under `namespace` and `key`,
+  /// overwriting any existing value. The value is observable in the access log via
+  /// `%DYNAMIC_METADATA(namespace:key)%`.
+  ///
+  /// Returns `true` if the value was set, `false` if the request has no stream info.
+  fn set_dynamic_metadata_number(&self, namespace: &str, key: &str, value: f64) -> bool;
+
+  /// Sets a string value on the request's dynamic metadata under `namespace` and `key`,
+  /// overwriting any existing value. The value is observable in the access log via
+  /// `%DYNAMIC_METADATA(namespace:key)%`.
+  ///
+  /// Returns `true` if the value was set, `false` if the request has no stream info.
+  fn set_dynamic_metadata_string(&self, namespace: &str, key: &str, value: &str) -> bool;
+
   /// Creates a per-worker timer on this request's worker dispatcher.
   ///
   /// The worker dispatcher is captured on this load balancer for the duration of host selection,
@@ -2254,6 +2268,28 @@ impl ClusterLbContext for ClusterLbContextRef<'_> {
         self.raw_context,
         host,
         stat,
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_number(&self, namespace: &str, key: &str, value: f64) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+        self.raw_context,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        value,
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_string(&self, namespace: &str, key: &str, value: &str) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+        self.raw_context,
+        str_to_module_buffer(namespace),
+        str_to_module_buffer(key),
+        str_to_module_buffer(value),
       )
     }
   }

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -50,6 +50,7 @@ envoy_cc_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [
+        "//test/extensions/dynamic_modules/test_data/rust:cluster_dynamic_metadata_test",
         "//test/extensions/dynamic_modules/test_data/rust:cluster_filter_state_test",
         "//test/extensions/dynamic_modules/test_data/rust:cluster_integration_test",
     ],

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -2619,6 +2619,98 @@ TEST_F(DynamicModuleClusterTest, LbGetHostStatReadsValues) {
                    lb_ptr, 0, 0, envoy_dynamic_module_type_host_stat_RqActive));
 }
 
+// Test set_dynamic_metadata_number with nullptr context returns false.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataNumberNullContext) {
+  std::string ns = "n";
+  std::string key = "k";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+      nullptr, ns_buf, key_buf, 1.0));
+}
+
+// Test set_dynamic_metadata_number when the request has no stream info.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataNumberNoStreamInfo) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, requestStreamInfo()).WillByDefault(Return(nullptr));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+  std::string ns = "n";
+  std::string key = "k";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+      context_ptr, ns_buf, key_buf, 1.0));
+}
+
+// Test set_dynamic_metadata_number happy path: the number lands on the request's stream info.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataNumber) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(stream_info, setDynamicMetadata(_, _))
+      .WillByDefault(testing::Invoke([&](const std::string& name, const Protobuf::Struct& value) {
+        (*stream_info.metadata_.mutable_filter_metadata())[name].MergeFrom(value);
+      }));
+  ON_CALL(context, requestStreamInfo()).WillByDefault(Return(&stream_info));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+  std::string ns = "dynamic_modules.test";
+  std::string key = "number_key";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_number(
+      context_ptr, ns_buf, key_buf, 42.0));
+  const auto& fields = stream_info.metadata_.filter_metadata().at(ns).fields();
+  EXPECT_EQ(42.0, fields.at(key).number_value());
+}
+
+// Test set_dynamic_metadata_string with nullptr context returns false.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataStringNullContext) {
+  std::string ns = "n";
+  std::string key = "k";
+  std::string value = "v";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+      nullptr, ns_buf, key_buf, value_buf));
+}
+
+// Test set_dynamic_metadata_string when the request has no stream info.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataStringNoStreamInfo) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  ON_CALL(context, requestStreamInfo()).WillByDefault(Return(nullptr));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+  std::string ns = "n";
+  std::string key = "k";
+  std::string value = "v";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+      context_ptr, ns_buf, key_buf, value_buf));
+}
+
+// Test set_dynamic_metadata_string happy path: the string lands on the request's stream info.
+TEST_F(DynamicModuleClusterTest, LbContextSetDynamicMetadataString) {
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  ON_CALL(stream_info, setDynamicMetadata(_, _))
+      .WillByDefault(testing::Invoke([&](const std::string& name, const Protobuf::Struct& value) {
+        (*stream_info.metadata_.mutable_filter_metadata())[name].MergeFrom(value);
+      }));
+  ON_CALL(context, requestStreamInfo()).WillByDefault(Return(&stream_info));
+  auto* context_ptr = static_cast<Upstream::LoadBalancerContext*>(&context);
+  std::string ns = "dynamic_modules.test";
+  std::string key = "string_key";
+  std::string value = "test_value";
+  envoy_dynamic_module_type_module_buffer ns_buf = {ns.data(), ns.size()};
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_context_set_dynamic_metadata_string(
+      context_ptr, ns_buf, key_buf, value_buf));
+  const auto& fields = stream_info.metadata_.filter_metadata().at(ns).fields();
+  EXPECT_EQ("test_value", fields.at(key).string_value());
+}
+
 // =================================================================================================
 // Async Host Selection Tests
 // =================================================================================================

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -319,6 +319,75 @@ TEST_P(DynamicModuleClusterFilterStateIntegrationTest, ReadsFilterStateProducedB
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// =============================================================================
+// Dynamic-metadata set ABI: the dynamic-module cluster annotates the request
+// during host selection; the values are read back from the access log.
+// =============================================================================
+class DynamicModuleClusterDynamicMetadataIntegrationTest
+    : public testing::TestWithParam<Network::Address::IpVersion>,
+      public HttpIntegrationTest {
+public:
+  DynamicModuleClusterDynamicMetadataIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void initializeWithMetadataWriter() {
+    TestEnvironment::setEnvVar(
+        "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+        TestEnvironment::runfilesPath("test/extensions/dynamic_modules/test_data/rust"), 1);
+
+    // Log the two dynamic-metadata values the cluster writes during host selection.
+    useAccessLog("%DYNAMIC_METADATA(dynamic_modules.test:number_key)% "
+                 "%DYNAMIC_METADATA(dynamic_modules.test:string_key)%");
+
+    // Replace cluster_0 with a dynamic-module cluster whose Rust load balancer
+    // sets dynamic metadata on the request during host selection.
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+      const std::string upstream_address = fake_upstreams_[0]->localAddress()->asString();
+
+      cluster->set_name("cluster_0");
+      cluster->set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+      cluster->clear_load_assignment();
+
+      envoy::extensions::clusters::dynamic_modules::v3::ClusterConfig writer_config;
+      writer_config.mutable_dynamic_module_config()->set_name("cluster_dynamic_metadata_test");
+      writer_config.set_cluster_name("dynamic_metadata_writer");
+
+      Protobuf::StringValue config_proto;
+      config_proto.set_value(upstream_address);
+      std::ignore = writer_config.mutable_cluster_config()->PackFrom(config_proto);
+
+      cluster->mutable_cluster_type()->set_name("envoy.clusters.dynamic_modules");
+      std::ignore =
+          cluster->mutable_cluster_type()->mutable_typed_config()->PackFrom(writer_config);
+    });
+
+    HttpIntegrationTest::initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, DynamicModuleClusterDynamicMetadataIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+// Verifies that dynamic metadata set by the dynamic-module cluster during host
+// selection is attached to the request's stream info and observable in the
+// access log via %DYNAMIC_METADATA(namespace:key)%.
+TEST_P(DynamicModuleClusterDynamicMetadataIntegrationTest, SetsDynamicMetadataDuringHostSelection) {
+  initializeWithMetadataWriter();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  const std::string log = waitForAccessLog(access_log_name_);
+  EXPECT_EQ("1234 test_value", log);
+}
+
 } // namespace DynamicModules
 } // namespace Clusters
 } // namespace Extensions

--- a/test/extensions/dynamic_modules/test_data/rust/BUILD
+++ b/test/extensions/dynamic_modules/test_data/rust/BUILD
@@ -72,6 +72,8 @@ test_program(name = "cluster_integration_test")
 
 test_program(name = "cluster_filter_state_test")
 
+test_program(name = "cluster_dynamic_metadata_test")
+
 test_program(name = "stat_sink_integration_test")
 
 test_program(name = "transport_socket_integration_test")

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_dynamic_metadata_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_dynamic_metadata_test.rs
@@ -1,0 +1,100 @@
+//! Integration test for the cluster dynamic-metadata set ABI.
+//!
+//! Exposes a cluster whose load balancer, during ``choose_host``, annotates the current request
+//! with a number and a string under the ``dynamic_modules.test`` namespace, then returns its
+//! pre-registered upstream. The C++ harness reads the two values back from the access log via
+//! ``%DYNAMIC_METADATA(dynamic_modules.test:...)%``.
+
+use envoy_proxy_dynamic_modules_rust_sdk::*;
+use std::sync::{Arc, Mutex};
+
+const METADATA_NAMESPACE: &str = "dynamic_modules.test";
+const NUMBER_KEY: &str = "number_key";
+const STRING_KEY: &str = "string_key";
+const NUMBER_VALUE: f64 = 1234.0;
+const STRING_VALUE: &str = "test_value";
+
+declare_cluster_init_functions!(my_program_init, new_cluster_config_fn);
+
+fn my_program_init() -> bool {
+  true
+}
+
+struct HostList(Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>);
+// SAFETY: Host pointers are stable addresses managed by Envoy across threads.
+unsafe impl Send for HostList {}
+unsafe impl Sync for HostList {}
+
+type SharedHostList = Arc<Mutex<HostList>>;
+
+fn new_cluster_config_fn(
+  name: &str,
+  config: &[u8],
+  _envoy_cluster_metrics: Arc<dyn EnvoyClusterMetrics>,
+) -> Option<Box<dyn ClusterConfig>> {
+  let upstream_address = std::str::from_utf8(config).unwrap_or("").to_string();
+  match name {
+    "dynamic_metadata_writer" => Some(Box::new(DynamicMetadataWriterClusterConfig {
+      upstream_address,
+    })),
+    _ => None,
+  }
+}
+
+struct DynamicMetadataWriterClusterConfig {
+  upstream_address: String,
+}
+
+impl ClusterConfig for DynamicMetadataWriterClusterConfig {
+  fn new_cluster(&self, _envoy_cluster: &dyn EnvoyCluster) -> Box<dyn Cluster> {
+    Box::new(DynamicMetadataWriterCluster {
+      upstream_address: self.upstream_address.clone(),
+      hosts: Arc::new(Mutex::new(HostList(Vec::new()))),
+    })
+  }
+}
+
+struct DynamicMetadataWriterCluster {
+  upstream_address: String,
+  hosts: SharedHostList,
+}
+
+impl Cluster for DynamicMetadataWriterCluster {
+  fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
+    let addresses = vec![self.upstream_address.clone()];
+    let weights = vec![1u32];
+    if let Some(host_ptrs) = envoy_cluster.add_hosts(&addresses, &weights) {
+      self.hosts.lock().unwrap().0 = host_ptrs;
+    }
+    envoy_cluster.pre_init_complete();
+  }
+
+  fn new_load_balancer(&self, _envoy_lb: &dyn EnvoyClusterLoadBalancer) -> Box<dyn ClusterLb> {
+    Box::new(DynamicMetadataWriterLb {
+      hosts: self.hosts.clone(),
+    })
+  }
+}
+
+struct DynamicMetadataWriterLb {
+  hosts: SharedHostList,
+}
+
+impl ClusterLb for DynamicMetadataWriterLb {
+  fn choose_host(
+    &mut self,
+    context: Option<&dyn ClusterLbContext>,
+    _async_completion: Box<dyn EnvoyAsyncHostSelectionComplete>,
+  ) -> HostSelectionResult {
+    let Some(ctx) = context else {
+      return HostSelectionResult::NoHost;
+    };
+    ctx.set_dynamic_metadata_number(METADATA_NAMESPACE, NUMBER_KEY, NUMBER_VALUE);
+    ctx.set_dynamic_metadata_string(METADATA_NAMESPACE, STRING_KEY, STRING_VALUE);
+    let hosts = self.hosts.lock().unwrap();
+    if hosts.0.is_empty() {
+      return HostSelectionResult::NoHost;
+    }
+    HostSelectionResult::Selected(hosts.0[0])
+  }
+}


### PR DESCRIPTION
**Commit Message:** dynamic_modules: add set_dynamic_metadata callbacks to cluster LB context

**Additional Description:**

Companion to https://github.com/envoyproxy/envoy/pull/46084. Previously a value a cluster computed per request in choose_host could not be surfaced to the request's StreamInfo, and therefore could not reach the access log. This PR lets dynamic module clusters annotate the current request with dynamic metadata, adding a namespaced write path so a cluster can attach facts about how a request was handled, readable via %DYNAMIC_METADATA(namespace:key)%.

Risk Level: Low
Testing: Unit and Integration Tests
Docs Changes: ChangeLog
Release Notes: N.A
Platform Specific Features: N.A
