### PR TITLE
Add the CNSA1_202603 compliance policy

### DIFF
--- a/api/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/api/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -77,6 +77,24 @@ message TlsParameters {
     //   Please refer to the `BoringSSL CNSA2_202603 compliance policy <https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20260413.0/include/openssl/ssl.h#6293>`_
     //   for details.
     CNSA2_202603 = 1;
+
+    // CNSA1_202603 configures a TLS connection to use:
+    //   * TLS 1.2 or TLS 1.3.
+    //   * For TLS 1.2, only TLS_ECDHE_[ECDSA|RSA]_WITH_AES_256_GCM_SHA384.
+    //   * For TLS 1.3, only AES-256-GCM.
+    //   * ML-KEM-1024 or P-384 for key agreement, preferring ML-KEM-1024 if the
+    //     client supports it.
+    //   * For handshake signatures, only ECDSA with P-384 and SHA-384, or RSA
+    //     with SHA-384.
+    //
+    // Note: this setting aids with compliance with CNSA requirements but does not
+    // guarantee it. Careful reading of RFC 9151 is recommended.
+    //
+    // .. attention::
+    //
+    //   Please refer to the `BoringSSL CNSA1_202603 compliance policy <https://boringssl.googlesource.com/boringssl/+/refs/tags/0.20260413.0/include/openssl/ssl.h#6280>`_
+    //   for details.
+    CNSA1_202603 = 2;
   }
 
   // Minimum TLS protocol version. By default, it's ``TLSv1_2`` for both clients and servers.

--- a/changelogs/current/new_features/tls__added-cnsa1-compliance-policy.rst
+++ b/changelogs/current/new_features/tls__added-cnsa1-compliance-policy.rst
@@ -1,0 +1,2 @@
+Added ``CNSA1_202603`` as an accepted :ref:`TLS compliance policy
+<envoy_v3_api_field_extensions.transport_sockets.tls.v3.TlsParameters.compliance_policies>`.

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -390,6 +390,12 @@ ContextImpl::ContextImpl(
         return;
       }
       break;
+    case ProtoPolicy::CNSA1_202603:
+      creation_status = setCompliancePolicy(ssl_compliance_policy_cnsa1_202603);
+      if (!creation_status.ok()) {
+        return;
+      }
+      break;
     default:
       creation_status = absl::InvalidArgumentError("Unknown compliance policy");
       return;

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -6245,6 +6245,44 @@ BORINGSSL_TEST_P(SslSocketTest, CipherSuitesWithCNSA2Policy) {
   testUtilV2(error_test_options);
 }
 
+TEST_P(SslSocketTest, CipherSuitesWithCNSA1Policy) {
+  envoy::config::listener::v3::Listener listener;
+  envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+
+  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* server_cert =
+      tls_context.mutable_common_tls_context()->add_tls_certificates();
+  server_cert->mutable_certificate_chain()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_cert.pem"));
+  server_cert->mutable_private_key()->set_filename(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/san_dns_key.pem"));
+  updateFilterChain(tls_context, *filter_chain);
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client;
+  envoy::extensions::transport_sockets::tls::v3::TlsParameters* client_params =
+      client.mutable_common_tls_context()->mutable_tls_params();
+  envoy::extensions::transport_sockets::tls::v3::TlsParameters* server_params =
+      tls_context.mutable_common_tls_context()->mutable_tls_params();
+
+  // Connection using a common cipher (client & server) succeeds.
+  client_params->clear_cipher_suites();
+  client_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
+  server_params->clear_cipher_suites();
+  server_params->add_cipher_suites("ECDHE-RSA-CHACHA20-POLY1305");
+  server_params->add_cipher_suites("AES256-GCM-SHA384");
+  updateFilterChain(tls_context, *filter_chain);
+  TestUtilOptionsV2 test_options(listener, client, true, version_);
+  testUtilV2(test_options);
+
+  // Client connects with an unsupported client cipher suite for a server policy, connection fails.
+  server_params->add_compliance_policies(
+      envoy::extensions::transport_sockets::tls::v3::TlsParameters::CNSA1_202603);
+  updateFilterChain(tls_context, *filter_chain);
+  TestUtilOptionsV2 error_test_options(listener, client, false, version_);
+  error_test_options.setExpectedServerStats("ssl.connection_error");
+  testUtilV2(error_test_options);
+}
+
 TEST_P(SslSocketTest, EcdhCurves) {
   envoy::config::listener::v3::Listener listener;
   envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

**Commit Message**: tls: Add the CNSA1_202603 compliance policy to TLS context
**Additional Description**: Allows configuring the TLS context to use the CNSA1 compliance policy to transition to post-quantum cryptography requirements (CNSA2 from #45624).
**Risk Level**: Low
**Testing**: Added
**Docs Changes**: Added
**Release Notes**: Added
**Platform Specific Features**: None

@ggreenway I realized this needs to be a follow-on for #45624 by allowing users a transition path to CNSA2 compliance. CNSA1 and CNSA2 replace the original CNSA (cnsa_202407) policy, so I don't see a need to expose that in this PR.

A local build confirms the policy is in effect and produces the expected ciphers/ciphersuites. Spell checking is also clean.