### PR TITLE
access_log: add %LISTENER_NAME% command operator

### DIFF
--- a/changelogs/current/new_features/access_log__added-listener-name-formatter.rst
+++ b/changelogs/current/new_features/access_log__added-listener-name-formatter.rst
@@ -1,0 +1,2 @@
+Added the ``%LISTENER_NAME%`` access log command operator, which logs the name of the listener
+that accepted the downstream connection.

--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -1565,6 +1565,9 @@ Current supported substitution commands include:
 ``%FILTER_CHAIN_NAME%``
   The :ref:`network filter chain name <envoy_v3_api_field_config.listener.v3.FilterChain.name>` of the downstream connection.
 
+``%LISTENER_NAME%``
+  The :ref:`name <envoy_v3_api_field_config.listener.v3.Listener.name>` of the listener that accepted the downstream connection.
+
 .. _config_access_log_format_access_log_type:
 
 ``%ACCESS_LOG_TYPE%``

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -22,6 +22,8 @@
 
 #include "source/common/common/interval_value.h"
 
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -140,6 +142,11 @@ using InternalListenerConfigOptRef = OptRef<InternalListenerConfig>;
 class ListenerInfo {
 public:
   virtual ~ListenerInfo() = default;
+
+  /**
+   * @return absl::string_view the name of the listener as set in configuration.
+   */
+  virtual absl::string_view name() const PURE;
 
   /**
    * @return const envoy::config::core::v3::Metadata& the config metadata associated with this

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2399,12 +2399,10 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                  return std::make_unique<StreamInfoStringFormatterProvider>(
                                      [](const StreamInfo::StreamInfo& stream_info)
                                          -> std::optional<std::string> {
-                                       if (const auto info = stream_info.downstreamAddressProvider()
-                                                                 .listenerInfo();
-                                           info.has_value()) {
-                                         if (!info->name().empty()) {
-                                           return std::string(info->name());
-                                         }
+                                       const auto info =
+                                           stream_info.downstreamAddressProvider().listenerInfo();
+                                       if (info.has_value() && !info->name().empty()) {
+                                         return std::string(info->name());
                                        }
                                        return std::nullopt;
                                      });

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2393,6 +2393,22 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                        return std::nullopt;
                                      });
                                }}},
+                             {"LISTENER_NAME",
+                              {CommandSyntaxChecker::COMMAND_ONLY,
+                               [](absl::string_view, std::optional<size_t>) {
+                                 return std::make_unique<StreamInfoStringFormatterProvider>(
+                                     [](const StreamInfo::StreamInfo& stream_info)
+                                         -> std::optional<std::string> {
+                                       if (const auto info = stream_info.downstreamAddressProvider()
+                                                                 .listenerInfo();
+                                           info.has_value()) {
+                                         if (!info->name().empty()) {
+                                           return std::string(info->name());
+                                         }
+                                       }
+                                       return std::nullopt;
+                                     });
+                               }}},
                              {"VIRTUAL_CLUSTER_NAME",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {

--- a/source/common/listener_manager/listener_info_impl.h
+++ b/source/common/listener_manager/listener_info_impl.h
@@ -14,12 +14,13 @@ using ListenerMetadataPack =
 class ListenerInfoImpl : public Network::ListenerInfo {
 public:
   explicit ListenerInfoImpl(const envoy::config::listener::v3::Listener& config)
-      : metadata_(config.metadata()), direction_(config.traffic_direction()),
+      : name_(config.name()), metadata_(config.metadata()), direction_(config.traffic_direction()),
         is_quic_(config.udp_listener_config().has_quic_options()),
         bypass_overload_manager_(config.bypass_overload_manager()) {}
   ListenerInfoImpl() = default;
 
   // Network::ListenerInfo
+  absl::string_view name() const override { return name_; }
   const envoy::config::core::v3::Metadata& metadata() const override;
   const Envoy::Config::TypedMetadata& typedMetadata() const override;
   envoy::config::core::v3::TrafficDirection direction() const override { return direction_; }
@@ -27,6 +28,7 @@ public:
   bool isQuic() const override { return is_quic_; }
 
 private:
+  const std::string name_;
   const ListenerMetadataPack metadata_;
   const envoy::config::core::v3::TrafficDirection direction_{};
   const bool is_quic_{};

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -1883,6 +1883,36 @@ TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
+
+    auto listener_info = std::make_shared<NiceMock<Network::MockListenerInfo>>();
+    ON_CALL(*listener_info, name()).WillByDefault(Return("mock_listener_name"));
+    stream_info.downstream_connection_info_provider_->setListenerInfo(listener_info);
+
+    StreamInfoFormatter upstream_format("LISTENER_NAME");
+
+    EXPECT_EQ("mock_listener_name", upstream_format.format({}, stream_info));
+  }
+
+  {
+    // No listener info set: the operator yields std::nullopt.
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    stream_info.downstream_connection_info_provider_->setListenerInfo(nullptr);
+    StreamInfoFormatter upstream_format("LISTENER_NAME");
+    EXPECT_EQ(std::nullopt, upstream_format.format({}, stream_info));
+  }
+
+  {
+    // Empty listener name: the operator yields std::nullopt.
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    auto listener_info = std::make_shared<NiceMock<Network::MockListenerInfo>>();
+    ON_CALL(*listener_info, name()).WillByDefault(Return(""));
+    stream_info.downstream_connection_info_provider_->setListenerInfo(listener_info);
+    StreamInfoFormatter upstream_format("LISTENER_NAME");
+    EXPECT_EQ(std::nullopt, upstream_format.format({}, stream_info));
+  }
+
+  {
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
     StreamInfoFormatter upstream_format("VIRTUAL_CLUSTER_NAME");
     std::string virtual_cluster_name = "authN";
     stream_info.setVirtualClusterName(virtual_cluster_name);

--- a/test/extensions/filters/network/common/fuzz/utils/fakes.h
+++ b/test/extensions/filters/network/common/fuzz/utils/fakes.h
@@ -11,10 +11,11 @@ namespace Configuration {
 class FakeListenerInfo : public Network::ListenerInfo {
 public:
   explicit FakeListenerInfo(const envoy::config::listener::v3::Listener& config)
-      : metadata_(config.metadata()), direction_(config.traffic_direction()),
+      : name_(config.name()), metadata_(config.metadata()), direction_(config.traffic_direction()),
         is_quic_(config.udp_listener_config().has_quic_options()),
         bypass_overload_manager_(config.bypass_overload_manager()) {}
   FakeListenerInfo() = default;
+  absl::string_view name() const override { return name_; }
   const envoy::config::core::v3::Metadata& metadata() const override {
     return metadata_.proto_metadata_;
   }
@@ -26,6 +27,7 @@ public:
   bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; }
 
 private:
+  const std::string name_;
   Envoy::Config::MetadataPack<Envoy::Network::ListenerTypedMetadataFactory> metadata_;
   envoy::config::core::v3::TrafficDirection direction_ = envoy::config::core::v3::UNSPECIFIED;
   const bool is_quic_ = false;

--- a/test/integration/access_log_integration_test.cc
+++ b/test/integration/access_log_integration_test.cc
@@ -40,6 +40,22 @@ TEST_P(AccessLogIntegrationTest, CoalesceFormatterFirstValueAvailable) {
   EXPECT_THAT(log, HasSubstr("host=sni.lyft.com"));
 }
 
+// The LISTENER_NAME formatter logs the name of the listener that accepted the connection.
+TEST_P(AccessLogIntegrationTest, ListenerName) {
+  useAccessLog("LISTENER_NAME=%LISTENER_NAME%");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  std::string log = waitForAccessLog(access_log_name_);
+  // The default HttpIntegrationTest listener is named "http".
+  EXPECT_THAT(log, HasSubstr("LISTENER_NAME=http"));
+}
+
 // Test COALESCE formatter with fallback when first operator returns null.
 TEST_P(AccessLogIntegrationTest, CoalesceFormatterFallback) {
   // Use a header that won't be present as first operator, fallback to :authority.

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -498,6 +498,7 @@ public:
 
 class MockListenerInfo : public ListenerInfo {
 public:
+  MOCK_METHOD(absl::string_view, name, (), (const));
   MOCK_METHOD(const envoy::config::core::v3::Metadata&, metadata, (), (const));
   MOCK_METHOD(const Envoy::Config::TypedMetadata&, typedMetadata, (), (const));
   MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));


### PR DESCRIPTION
Commit Message: access_log: add %LISTENER_NAME% command operator

Additional Description:
%LISTENER_NAME% logs the name of the listener that accepted the downstream connection. It reads ListenerInfo::name(), and yields an empty value when no listener info is present or the name is unset. It parallels %FILTER_CHAIN_NAME%, which exposes the matched filter chain's name.

Risk Level: Low
Testing: Unit and Integration Tests
Docs Changes: Added
Release Notes: N.A
Platform Specific Features: N.A