### PR TITLE
docs: fix capitalization of proper nouns and acronyms (#20238)

### DIFF
--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -173,7 +173,7 @@ Current supported substitution commands include:
 ``%RESPONSE_CODE_DETAILS(X)%``
   HTTP
     HTTP response code details provides additional information about the response code, such as
-    who set it (the upstream or envoy) and why. The string will not contain any whitespaces, which
+    who set it (the upstream or Envoy) and why. The string will not contain any whitespaces, which
     will be converted to underscore '_', unless optional parameter ``X`` is ``ALLOW_WHITESPACES``.
 
   TCP/UDP

--- a/docs/root/configuration/http/http_conn_man/traffic_splitting.rst
+++ b/docs/root/configuration/http/http_conn_man/traffic_splitting.rst
@@ -33,7 +33,7 @@ configuration, traffic to a particular route in a virtual host can be
 gradually shifted from one cluster to another. Consider the following
 example configuration, where two versions ``helloworld_v1`` and
 ``helloworld_v2`` of a service named ``helloworld`` are declared in the
-envoy configuration file.
+Envoy configuration file.
 
 .. code-block:: yaml
 

--- a/docs/root/configuration/http/http_filters/json_to_metadata_filter.rst
+++ b/docs/root/configuration/http/http_filters/json_to_metadata_filter.rst
@@ -6,7 +6,7 @@ Envoy Json-To-Metadata Filter
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.json_to_metadata.v3.JsonToMetadata>`
 
 This filter is configured with rules that will be matched against requests and responses.
-Each rule has either a series of selectors and can be triggered either when the json attribute
+Each rule has either a series of selectors and can be triggered either when the JSON attribute
 is present or missing.
 
 When a rule is triggered, dynamic metadata will be added based on the configuration of the rule.
@@ -15,12 +15,12 @@ on missing case is triggered and the value specified is used for adding metadata
 
 The metadata can then be used for load balancing decisions, consumed from logs, etc.
 
-A typical use case for this filter is to dynamically match a specified json attribute of requests
+A typical use case for this filter is to dynamically match a specified JSON attribute of requests
 with rate limit. For this, a given value of the JSON keys would be extracted and attached
 to the request as dynamic metadata which would then be used to match a rate limit action on metadata.
 
-The Json to metadata filter stops iterating to next filter until we have the whole payload to extract
-the Json attributes or encounter error.
+The JSON to metadata filter stops iterating to next filter until we have the whole payload to extract
+the JSON attributes or encounter error.
 
 Example
 -------
@@ -58,11 +58,11 @@ comes from the owning HTTP connection manager.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  rq_success, Counter, Total requests that succeed to parse the json body. Note that a pure string or number body is treated as a successful json body which increases this counter.
+  rq_success, Counter, Total requests that succeed to parse the JSON body. Note that a pure string or number body is treated as a successful JSON body which increases this counter.
   rq_mismatched_content_type, Counter, Total requests that mismatch the content type
   rq_no_body, Counter, Total requests without content body
-  rq_invalid_json_body, Counter, Total requests with invalid json body
-  resp_success, Counter, Total responses that succeed to parse the json body. Note that a pure string or number body is treated as a successful json body which increases this counter.
+  rq_invalid_json_body, Counter, Total requests with invalid JSON body
+  resp_success, Counter, Total responses that succeed to parse the JSON body. Note that a pure string or number body is treated as a successful JSON body which increases this counter.
   resp_mismatched_content_type, Counter, Total responses that mismatch the content type
   resp_no_body, Counter, Total responses without content body
-  resp_invalid_json_body, Counter, Total responses with invalid json body
+  resp_invalid_json_body, Counter, Total responses with invalid JSON body

--- a/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
@@ -152,13 +152,13 @@ The redis proxy filter supports authentication with AWS IAM credentials, to Elas
 additional fields are provided in the cluster Redis settings.
 If `region` is not specified, the region will be deduced using the region provider chain as described in  :ref:`config_http_filters_aws_request_signing_region`.
 `cache_name` is required and is set to the name of your cache. Both `auth_username` and `cache_name` are used when calculating the IAM authentication token.
-`auth_password` is not used in AWS IAM configuration and the password value is automatically calculated by envoy.
+`auth_password` is not used in AWS IAM configuration and the password value is automatically calculated by Envoy.
 In your upstream cluster, the `auth_username` field must be configured with the user that has been added to your cache, as per
 `Setup <https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html#auth-iam-setup>`_. Different upstreams may use different usernames and different
 cache names, credentials will be generated correctly based on the cluster the traffic is destined to.
 The `service_name` should be `elasticache` for an Amazon ElastiCache cache in valkey or Redis OSS mode, or `memorydb` for an Amazon MemoryDB cluster. The `service_name`
 matches the service which is added to the IAM Policy for the associated IAM principal being used to make the connection. For example, `service_name: memorydb` matches
-an AWS IAM Policy containing the Action `memorydb:Connect`, and that policy must be attached to the IAM principal being used by envoy.
+an AWS IAM Policy containing the Action `memorydb:Connect`, and that policy must be attached to the IAM principal being used by Envoy.
 
 .. literalinclude:: _include/redis-aws-iam-auth.yaml
    :language: yaml

--- a/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
@@ -149,7 +149,7 @@ AWS IAM Authentication
 ----------------------
 
 The redis proxy filter supports authentication with AWS IAM credentials, to ElastiCache and MemoryDB instances. To configure AWS IAM Authentication,
-additional fields are provided in the cluster redis settings.
+additional fields are provided in the cluster Redis settings.
 If `region` is not specified, the region will be deduced using the region provider chain as described in  :ref:`config_http_filters_aws_request_signing_region`.
 `cache_name` is required and is set to the name of your cache. Both `auth_username` and `cache_name` are used when calculating the IAM authentication token.
 `auth_password` is not used in AWS IAM configuration and the password value is automatically calculated by envoy.

--- a/docs/root/configuration/observability/application_logging.rst
+++ b/docs/root/configuration/observability/application_logging.rst
@@ -28,7 +28,7 @@ Printing logs in JSON format
 ----------------------------
 
 It is possible to use the bootstrap config :ref:`json_format <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.ApplicationLogConfig.LogFormat.json_format>`
-to print the logs in custom JSON format. The json format struct can support all the format flags that are specified in :ref:`command line options <operations_cli>`,
+to print the logs in custom JSON format. The JSON format struct can support all the format flags that are specified in :ref:`command line options <operations_cli>`,
 except for the ``%v`` and ``%_`` flags, as they may break the JSON structure log. Instead, use the ``%j`` flag. Example:
 
 .. code-block:: yaml

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -16,7 +16,7 @@ virtual host name, manual path rewrite, manual host rewrite, path redirect, and
 header field matches. Extensions for other test cases can be added. Details about installing the tool
 and sample tool input/output can be found at :ref:`installation <install_tools_route_table_check_tool>`.
 
-The route table check tool config is composed of an array of json test objects. Each test object is composed of
+The route table check tool config is composed of an array of JSON test objects. Each test object is composed of
 three parts.
 
 Test name
@@ -163,10 +163,10 @@ input
     simulate the route being disabled.
 
   ssl
-    *(optional, boolean)* A flag that determines whether to set x-forwarded-proto to https or http.
+    *(optional, boolean)* A flag that determines whether to set x-forwarded-proto to https or HTTP.
     By setting x-forwarded-proto to a given protocol, the tool is able to simulate the behavior of
     a client issuing a request via HTTP or HTTPS. By default ssl is false which corresponds to
-    x-forwarded-proto set to http.
+    x-forwarded-proto set to HTTP.
 
   runtime
     *(optional, string)* A string representing the runtime setting to enable for the test. The runtime

--- a/docs/root/configuration/operations/tools/router_check.rst
+++ b/docs/root/configuration/operations/tools/router_check.rst
@@ -163,10 +163,10 @@ input
     simulate the route being disabled.
 
   ssl
-    *(optional, boolean)* A flag that determines whether to set x-forwarded-proto to https or HTTP.
+    *(optional, boolean)* A flag that determines whether to set x-forwarded-proto to https or http.
     By setting x-forwarded-proto to a given protocol, the tool is able to simulate the behavior of
     a client issuing a request via HTTP or HTTPS. By default ssl is false which corresponds to
-    x-forwarded-proto set to HTTP.
+    x-forwarded-proto set to http.
 
   runtime
     *(optional, string)* A string representing the runtime setting to enable for the test. The runtime

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -173,9 +173,9 @@ stream timeouts already introduced above.
 Scaled timeouts
 ^^^^^^^^^^^^^^^
 
-In situations where envoy is under high load, Envoy can dynamically configure timeouts using scaled timeouts.
+In situations where Envoy is under high load, Envoy can dynamically configure timeouts using scaled timeouts.
 Envoy supports scaled timeouts through the :ref:`Overload Manager <envoy_v3_api_msg_config.overload.v3.OverloadManager>`, configured
-in envoy :ref:`bootstrap configuration <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.overload_manager>`.
+in Envoy :ref:`bootstrap configuration <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.overload_manager>`.
 Using a :ref:`reduce timeouts <config_overload_manager_reducing_timeouts>` overload action,
 the Overload Manager can be configured to monitor :ref:`resources <envoy_v3_api_msg_config.overload.v3.ResourceMonitor>`
 and scale timeouts accordingly. For example, a common use case may be to monitor the Envoy :ref:`heap size <envoy_v3_api_msg_extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig>`

--- a/docs/root/intro/arch_overview/advanced/attributes.rst
+++ b/docs/root/intro/arch_overview/advanced/attributes.rst
@@ -42,7 +42,7 @@ Request attributes
 The following request attributes are generally available upon initial request
 processing, which makes them suitable for RBAC policies.
 
-``request.*`` attributes are only available in http filters.
+``request.*`` attributes are only available in HTTP filters.
 
 .. csv-table::
    :header: Attribute, Type, Description
@@ -80,7 +80,7 @@ Response attributes
 
 Response attributes are only available after the request completes.
 
-``response.*`` attributes are only available in http filters.
+``response.*`` attributes are only available in HTTP filters.
 
 .. csv-table::
    :header: Attribute, Type, Description

--- a/docs/root/intro/arch_overview/http/http_filters.rst
+++ b/docs/root/intro/arch_overview/http/http_filters.rst
@@ -149,14 +149,14 @@ The per filter config map can be used to provide
 :ref:`route <envoy_v3_api_field_config.route.v3.Route.typed_per_filter_config>` or
 :ref:`virtual host <envoy_v3_api_field_config.route.v3.VirtualHost.typed_per_filter_config>` or
 :ref:`route configuration <envoy_v3_api_field_config.route.v3.RouteConfiguration.typed_per_filter_config>`
-specific config for http filters.
+specific config for HTTP filters.
 
 
 The key of the per filter config map should match the :ref:`filter config name
 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.name>`.
 
 
-For example, given following http filter config:
+For example, given following HTTP filter config:
 
 .. code-block:: yaml
 
@@ -190,7 +190,7 @@ and setting the :ref:`disabled field <envoy_v3_api_field_config.route.v3.FilterC
 per filter config map in the route configuration. See the
 :ref:`Route specific config <arch_overview_http_filters_per_filter_config>` section for more details.
 
-For example, given following http filter config:
+For example, given following HTTP filter config:
 
 .. code-block:: yaml
 
@@ -214,7 +214,7 @@ In addition, we can set a filter to be disabled by default by setting the :ref:`
 <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.disabled>`
 in the HttpFilter configuration and then enable it for specific routes if needed.
 
-For example, given following http filter config:
+For example, given following HTTP filter config:
 
 .. code-block:: yaml
 

--- a/docs/root/intro/arch_overview/operations/hot_restart.rst
+++ b/docs/root/intro/arch_overview/operations/hot_restart.rst
@@ -7,7 +7,7 @@ Ease of operation is one of the primary goals of Envoy. In addition to robust st
 administration interface, Envoy has the ability to “hot” or “live” restart itself. This means that
 Envoy can fully reload itself (both code and configuration) without dropping existing connections
 during the :ref:`drain process <arch_overview_draining>`. However, existing connections are not
-transferred to the new envoy process: they must complete during the drain process or be terminated.
+transferred to the new Envoy process: they must complete during the drain process or be terminated.
 The hot restart functionality has the following general architecture:
 
 * The two active processes communicate with each other over unix domain sockets using a basic RPC
@@ -26,7 +26,7 @@ The hot restart functionality has the following general architecture:
   itself down. This time is configurable via the :option:`--parent-shutdown-time-s` option. Note
   that the `--parent-shutdown-time-s` option is independent of the `--drain-time-s` value, and so
   the parent shutdown time should be set to a larger value.
-* Any remaining connections to the old envoy process are closed. The hot restart functionality
+* Any remaining connections to the old Envoy process are closed. The hot restart functionality
   does not transfer existing connections to the new process.
 * Envoy’s hot restart support was designed so that it will work correctly even if the new Envoy
   process and the old Envoy process are running inside different containers. Communication between

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -72,7 +72,7 @@ When using Envoy as a sidecar proxy for a Redis Cluster, the service can use a n
 implemented in any language to connect to the proxy as if it's a single node Redis instance.
 The Envoy proxy will keep track of the cluster topology and send commands to the correct Redis node in the
 cluster according to the `spec <https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/>`_. Advance features such as reading
-from replicas can also be added to the Envoy proxy instead of updating redis clients in each language.
+from replicas can also be added to the Envoy proxy instead of updating Redis clients in each language.
 
 Envoy proxy tracks the topology of the cluster by sending periodic
 `cluster slots <https://redis.io/commands/cluster-slots>`_ commands to a random node in the cluster, and maintains the
@@ -146,12 +146,12 @@ original Redis command except possibly in failure scenarios.
 
 RESP Protocol
 ^^^^^^^^^^^^^
-Envoy redis proxy supports only RESP2 protocol for now. Clients should connect to Envoy using RESP2 protocol.
+Envoy Redis proxy supports only RESP2 protocol for now. Clients should connect to Envoy using RESP2 protocol.
 hello command with only hello 2 argument is supported, hello 3 will result in error response from Envoy.
 
 INFO command
 ^^^^^^^^^^^^
-INFO command is handled by envoy differently it aggregates metrics across all shards and returns consolidated cluster-wide statistics.
+INFO command is handled by Envoy differently it aggregates metrics across all shards and returns consolidated cluster-wide statistics.
 An optional section parameter can be provided to filter the output (e.g., INFO memory).
 INFO.SHARD is an Envoy-specific command introduced for debugging purposes that queries a specific shard by index
 and returns that shard's complete INFO response (e.g., INFO.SHARD 0 memory).


### PR DESCRIPTION
Additional Description:
Fix incorrect lowercase usage of proper nouns and acronyms in documentation as described in #20238.

Changes:
- http → HTTP in prose text (not URLs, code blocks, or file paths)
- envoy → Envoy when referring to the project name in descriptions
- json/Json → JSON in prose text (not URLs, code blocks, or file paths)
- redis → Redis when referring to the project name

Files changed:
- docs/root/configuration/advanced/substitution_formatter.rst
- docs/root/configuration/http/http_conn_man/traffic_splitting.rst
- docs/root/configuration/http/http_filters/json_to_metadata_filter.rst
- docs/root/configuration/listeners/network_filters/redis_proxy_filter.rst
- docs/root/configuration/observability/application_logging.rst
- docs/root/configuration/operations/tools/router_check.rst
- docs/root/faq/configuration/timeouts.rst
- docs/root/intro/arch_overview/advanced/attributes.rst
- docs/root/intro/arch_overview/http/http_filters.rst
- docs/root/intro/arch_overview/operations/hot_restart.rst
- docs/root/intro/arch_overview/other_protocols/redis.rst

Risk Level: Low
Testing: N/A (docs-only change)
Docs Changes: Yes, see above.
Release Notes: N/A

Partial fix for: #20238