### PR TITLE
openssl: prevent interactive passphrase prompt on encrypted PEM keys

### DIFF
--- a/compat/openssl/source/PEM_read_bio_PrivateKey.cc
+++ b/compat/openssl/source/PEM_read_bio_PrivateKey.cc
@@ -1,6 +1,11 @@
 #include <openssl/pem.h>
 #include <ossl.h>
 
+static int no_password_cb(char*, int, int, void*) { return 0; }
+
 extern "C" EVP_PKEY* PEM_read_bio_PrivateKey(BIO* bp, EVP_PKEY** x, pem_password_cb* cb, void* u) {
+  if (cb == nullptr && u == nullptr) {
+    cb = no_password_cb;
+  }
   return ossl.ossl_PEM_read_bio_PrivateKey(bp, x, cb, u);
 }


### PR DESCRIPTION
When `PEM_read_bio_PrivateKey` is called with both callback and userdata set to `nullptr` (no password supplied), OpenSSL falls back to its default callback which tries to read from `/dev/tty`. This causes test hangs in RBE environments where `/dev/tty` is available, while locally it fails immediately when no controlling terminal exists.

Supply a no-op callback that returns 0 (no password) to match BoringSSL behavior of returning an error immediately.
