### PR TITLE
LibeventScheduler: add dynamic evwatch observer support

### DIFF
--- a/envoy/event/BUILD
+++ b/envoy/event/BUILD
@@ -41,6 +41,14 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "evwatch_interface",
+    hdrs = ["evwatch.h"],
+    deps = [
+        "//envoy/common:time_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "file_event_interface",
     hdrs = ["file_event.h"],
 )

--- a/envoy/event/evwatch.h
+++ b/envoy/event/evwatch.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include "envoy/common/time.h"
+
+namespace Envoy {
+namespace Event {
+namespace Evwatch {
+
+/**
+ * An interface for observing timing and latency metrics across event loop iterations on
+ * dispatchers. This hook is invoked by LibeventScheduler on every epoll check and prepare cycle.
+ */
+class Observer {
+public:
+  virtual ~Observer() = default;
+
+  /**
+   * Called during epoll/event loop prepare phase (before sleeping/polling for events).
+   * @param prepare_time monotonic time at prepare.
+   * @param timeout the duration of the timeout if a timeout was set on the epoll wait.
+   */
+  virtual void onPrepare(MonotonicTime prepare_time,
+                         std::optional<MonotonicTime::duration> timeout) = 0;
+
+  /**
+   * Called during epoll/event loop check phase (after waking up from polling for events).
+   * @param check_time monotonic time at check.
+   */
+  virtual void onCheck(MonotonicTime check_time) = 0;
+};
+
+using ObserverPtr = std::unique_ptr<Observer>;
+using ObserverWeakPtr = std::weak_ptr<Observer>;
+
+/**
+ * Handle returned when registering an Evwatch::Observer with a Dispatcher.
+ * When this handle is destructed (on any thread), the associated observer is automatically
+ * unregistered and lazily pruned from the dispatcher's event loop.
+ */
+class ObserverHandle {
+public:
+  virtual ~ObserverHandle() = default;
+
+  /**
+   * Returns a weak reference to the underlying observer. This allows ad-hoc tracking lists
+   * (such as periodic metric readers) to safely reference the observer without interfering
+   * with RAII handle ownership and lifecycle unregistration.
+   */
+  virtual ObserverWeakPtr observer() const = 0;
+};
+
+using ObserverHandlePtr = std::unique_ptr<ObserverHandle>;
+
+} // namespace Evwatch
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -150,6 +150,7 @@ envoy_cc_library(
         ":timer_lib",
         "//bazel/foreign_cc:event",
         "//envoy/event:dispatcher_interface",
+        "//envoy/event:evwatch_interface",
         "//envoy/event:timer_interface",
         "//source/common/common:assert_lib",
     ],

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -69,7 +69,7 @@ DispatcherImpl::DispatcherImpl(const std::string& name, Thread::ThreadFactory& t
                                const ScaledRangeTimerManagerFactory& scaled_timer_factory,
                                const Buffer::WatermarkFactorySharedPtr& watermark_factory)
     : name_(name), thread_factory_(thread_factory), time_source_(time_source),
-      file_system_(file_system), buffer_factory_(watermark_factory),
+      file_system_(file_system), buffer_factory_(watermark_factory), base_scheduler_(time_source),
       scheduler_(time_system.createScheduler(base_scheduler_, base_scheduler_)),
       thread_local_delete_cb_(
           base_scheduler_.createSchedulableCallback([this]() -> void { runThreadLocalDelete(); })),

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -1,5 +1,8 @@
 #include "source/common/event/libevent_scheduler.h"
 
+#include <algorithm>
+#include <chrono>
+
 #include "source/common/common/assert.h"
 #include "source/common/event/schedulable_cb_impl.h"
 #include "source/common/event/timer_impl.h"
@@ -13,9 +16,25 @@ namespace {
 void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
   histogram.recordValue(tv.tv_sec * 1000000 + tv.tv_usec);
 }
+
+void pruneExpiredObservers(std::vector<std::weak_ptr<Evwatch::Observer>>& observers) {
+  observers.erase(std::remove_if(observers.begin(), observers.end(),
+                                 [](const auto& entry) { return entry.expired(); }),
+                  observers.end());
+}
+
+class ObserverHandleImpl : public Evwatch::ObserverHandle {
+public:
+  explicit ObserverHandleImpl(Evwatch::ObserverPtr observer) : observer_(std::move(observer)) {}
+
+  Evwatch::ObserverWeakPtr observer() const override { return observer_; }
+
+private:
+  std::shared_ptr<Evwatch::Observer> observer_;
+};
 } // namespace
 
-LibeventScheduler::LibeventScheduler() {
+LibeventScheduler::LibeventScheduler(TimeSource& time_source) : time_source_(time_source) {
 #ifdef WIN32
   event_config* event_config = event_config_new();
   RELEASE_ASSERT(event_config != nullptr,
@@ -140,6 +159,62 @@ void LibeventScheduler::onCheckForStats(evwatch*, const evwatch_check_cb_info*, 
       recordTimeval(self->stats_->poll_delay_us_, delay);
     }
   }
+}
+
+void LibeventScheduler::onPrepareForObserver(evwatch*, const evwatch_prepare_cb_info* info,
+                                             void* arg) {
+  auto self = static_cast<LibeventScheduler*>(arg);
+  if (self->evwatch_observers_.empty()) {
+    return;
+  }
+  timeval timeout;
+  const bool timeout_set = evwatch_prepare_get_timeout(info, &timeout);
+  const std::optional<MonotonicTime::duration> timeout_duration =
+      timeout_set
+          ? std::optional<MonotonicTime::duration>(std::chrono::seconds(timeout.tv_sec) +
+                                                   std::chrono::microseconds(timeout.tv_usec))
+          : std::nullopt;
+
+  const MonotonicTime prepare_time = self->time_source_.monotonicTime();
+
+  const size_t size = self->evwatch_observers_.size();
+  for (size_t i = 0; i < size; ++i) {
+    if (auto observer = self->evwatch_observers_[i].lock()) {
+      observer->onPrepare(prepare_time, timeout_duration);
+    }
+  }
+  pruneExpiredObservers(self->evwatch_observers_);
+}
+
+void LibeventScheduler::onCheckForObserver(evwatch*, const evwatch_check_cb_info*, void* arg) {
+  auto self = static_cast<LibeventScheduler*>(arg);
+  if (self->evwatch_observers_.empty()) {
+    return;
+  }
+  const MonotonicTime check_time = self->time_source_.monotonicTime();
+
+  const size_t size = self->evwatch_observers_.size();
+  for (size_t i = 0; i < size; ++i) {
+    if (auto observer = self->evwatch_observers_[i].lock()) {
+      observer->onCheck(check_time);
+    }
+  }
+  pruneExpiredObservers(self->evwatch_observers_);
+}
+
+Evwatch::ObserverHandlePtr
+LibeventScheduler::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
+  if (observer == nullptr) {
+    return nullptr;
+  }
+  if (!evwatch_observers_registered_) {
+    evwatch_observers_registered_ = true;
+    evwatch_prepare_new(libevent_.get(), &onPrepareForObserver, this);
+    evwatch_check_new(libevent_.get(), &onCheckForObserver, this);
+  }
+  auto handle = std::make_unique<ObserverHandleImpl>(std::move(observer));
+  evwatch_observers_.push_back(handle->observer());
+  return handle;
 }
 
 } // namespace Event

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/event/evwatch.h"
 #include "envoy/event/schedulable_cb.h"
 #include "envoy/event/timer.h"
 
@@ -59,7 +61,9 @@ public:
   using OnPrepareCallback = std::function<void()>;
   using OnCheckCallback = std::function<void()>;
 
-  LibeventScheduler();
+  explicit LibeventScheduler(TimeSource& time_source);
+
+  Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer);
 
   // Scheduler
   TimerPtr createTimer(const TimerCb& cb, Dispatcher& dispatcher) override;
@@ -114,6 +118,8 @@ private:
   static void onCheckForCallback(evwatch*, const evwatch_check_cb_info* info, void* arg);
   static void onPrepareForStats(evwatch*, const evwatch_prepare_cb_info* info, void* arg);
   static void onCheckForStats(evwatch*, const evwatch_check_cb_info*, void* arg);
+  static void onPrepareForObserver(evwatch*, const evwatch_prepare_cb_info* info, void* arg);
+  static void onCheckForObserver(evwatch*, const evwatch_check_cb_info* info, void* arg);
 
   static constexpr int flagsBasedOnEventType() {
     if constexpr (Event::PlatformDefaultTriggerType == FileTriggerType::Level) {
@@ -125,6 +131,7 @@ private:
     return EVLOOP_NONBLOCK;
   }
 
+  TimeSource& time_source_;
   Libevent::BasePtr libevent_;
   DispatcherStats* stats_{}; // stats owned by the containing DispatcherImpl
   bool timeout_set_{};       // whether there is a poll timeout in the current event loop iteration
@@ -133,6 +140,8 @@ private:
   timeval check_time_{};     // timestamp immediately after polling
   OnPrepareCallback prepare_callback_; // callback to be called from onPrepareForCallback()
   OnCheckCallback check_callback_;     // callback to be called from onCheckForCallback()
+  std::vector<std::weak_ptr<Evwatch::Observer>> evwatch_observers_;
+  bool evwatch_observers_registered_{false};
 };
 
 } // namespace Event

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -28,6 +28,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "libevent_scheduler_test",
+    srcs = ["libevent_scheduler_test.cc"],
+    deps = [
+        "//source/common/event:libevent_scheduler_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "file_event_impl_test",
     srcs = ["file_event_impl_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/event/libevent_scheduler_test.cc
+++ b/test/common/event/libevent_scheduler_test.cc
@@ -1,0 +1,156 @@
+#include "source/common/event/libevent_scheduler.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/test_common/test_time.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::StrictMock;
+
+namespace Envoy {
+namespace Event {
+namespace {
+
+class LibeventSchedulerTest : public testing::Test {
+protected:
+  LibeventSchedulerTest() : scheduler_(time_system_) {}
+
+  void cycleScheduler() {
+    auto cb = scheduler_.createSchedulableCallback([]() {});
+    cb->scheduleCallbackCurrentIteration();
+    scheduler_.run(Dispatcher::RunType::NonBlock);
+  }
+
+  Event::TestRealTimeSystem time_system_;
+  LibeventScheduler scheduler_;
+};
+
+class MockEvwatchObserver : public Evwatch::Observer {
+public:
+  MOCK_METHOD(void, onPrepare,
+              (MonotonicTime prepare_time, std::optional<MonotonicTime::duration> timeout));
+  MOCK_METHOD(void, onCheck, (MonotonicTime check_time));
+};
+
+TEST_F(LibeventSchedulerTest, RegisterMultipleObserversAndLazyPruning) {
+  auto observer1 = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto observer2 = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto* observer1_ptr = observer1.get();
+  auto* observer2_ptr = observer2.get();
+
+  EXPECT_CALL(*observer1_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(*observer1_ptr, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(*observer2_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(*observer2_ptr, onCheck(_)).Times(testing::AtLeast(1));
+
+  // First observer registers libevent watchers (evwatch_observers_registered_ == false)
+  auto handle1 = scheduler_.registerEvwatchObserver(std::move(observer1));
+  EXPECT_NE(nullptr, handle1);
+
+  // Second observer appends to vector without re-registering libevent watchers
+  // (evwatch_observers_registered_ == true)
+  auto handle2 = scheduler_.registerEvwatchObserver(std::move(observer2));
+  EXPECT_NE(nullptr, handle2);
+
+  cycleScheduler();
+
+  // Reset handle1; observer1 will hit the erase branch in both onPrepare and onCheck, while
+  // observer2 continues
+  handle1.reset();
+  cycleScheduler();
+
+  // Reset handle2; observer2 is erased, leaving evwatch_observers_ empty
+  handle2.reset();
+  cycleScheduler();
+
+  // Cycle again when evwatch_observers_ is already empty at the start of onPrepare and onCheck
+  cycleScheduler();
+}
+
+TEST_F(LibeventSchedulerTest, RegisterNullObserver) {
+  auto handle = scheduler_.registerEvwatchObserver(nullptr);
+  EXPECT_EQ(nullptr, handle);
+  cycleScheduler();
+}
+
+TEST_F(LibeventSchedulerTest, DestructionDuringPrepareCallback) {
+  auto observer1 = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto observer2 = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto* observer1_ptr = observer1.get();
+  auto* observer2_ptr = observer2.get();
+
+  Evwatch::ObserverHandlePtr handle1, handle2;
+
+  EXPECT_CALL(*observer1_ptr, onPrepare(_, _))
+      .Times(testing::AtLeast(1))
+      .WillRepeatedly(testing::InvokeWithoutArgs([&]() {
+        // Destroy handle2 during onPrepare, causing observer2's lock() to fail during onCheck in
+        // the same iteration!
+        handle2.reset();
+      }));
+  EXPECT_CALL(*observer1_ptr, onCheck(_)).Times(testing::AtLeast(1));
+
+  // observer2 should receive onPrepare, but NOT onCheck since it gets reset during observer1's
+  // onPrepare
+  EXPECT_CALL(*observer2_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
+
+  // Register observer2 first so it receives onPrepare before observer1's onPrepare resets handle2!
+  handle2 = scheduler_.registerEvwatchObserver(std::move(observer2));
+  handle1 = scheduler_.registerEvwatchObserver(std::move(observer1));
+
+  cycleScheduler();
+
+  handle1.reset();
+  cycleScheduler();
+}
+
+TEST_F(LibeventSchedulerTest, ObserverHandleWeakPtrRef) {
+  auto observer = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto* observer_ptr = observer.get();
+
+  auto handle = scheduler_.registerEvwatchObserver(std::move(observer));
+  ASSERT_NE(nullptr, handle);
+
+  Evwatch::ObserverWeakPtr weak_ref = handle->observer();
+  EXPECT_FALSE(weak_ref.expired());
+  EXPECT_EQ(observer_ptr, weak_ref.lock().get());
+
+  handle.reset();
+  EXPECT_TRUE(weak_ref.expired());
+  EXPECT_EQ(nullptr, weak_ref.lock());
+}
+
+class MockTimeSource : public TimeSource {
+public:
+  MOCK_METHOD(SystemTime, systemTime, (), (override));
+  MOCK_METHOD(MonotonicTime, monotonicTime, (), (override));
+};
+
+TEST_F(LibeventSchedulerTest, CustomTimeSourceUsedForObserverCallbacks) {
+  StrictMock<MockTimeSource> time_source;
+  LibeventScheduler scheduler(time_source);
+
+  auto observer = std::make_unique<StrictMock<MockEvwatchObserver>>();
+  auto* observer_ptr = observer.get();
+
+  const MonotonicTime mock_time = MonotonicTime(std::chrono::nanoseconds(123456789));
+
+  EXPECT_CALL(time_source, monotonicTime()).Times(2).WillRepeatedly(testing::Return(mock_time));
+  EXPECT_CALL(*observer_ptr, onPrepare(mock_time, _));
+  EXPECT_CALL(*observer_ptr, onCheck(mock_time));
+
+  auto handle = scheduler.registerEvwatchObserver(std::move(observer));
+
+  auto cb = scheduler.createSchedulableCallback([]() {});
+  cb->scheduleCallbackCurrentIteration();
+  scheduler.run(Dispatcher::RunType::NonBlock);
+
+  handle.reset();
+}
+
+} // namespace
+} // namespace Event
+} // namespace Envoy

--- a/test/test_common/simulated_time_system_test.cc
+++ b/test/test_common/simulated_time_system_test.cc
@@ -18,7 +18,8 @@ namespace {
 class SimulatedTimeSystemTest : public testing::Test {
 protected:
   SimulatedTimeSystemTest()
-      : scheduler_(time_system_.createScheduler(base_scheduler_, base_scheduler_)),
+      : base_scheduler_(time_system_),
+        scheduler_(time_system_.createScheduler(base_scheduler_, base_scheduler_)),
         start_monotonic_time_(time_system_.monotonicTime()),
         start_system_time_(time_system_.systemTime()) {}
 
@@ -57,8 +58,8 @@ protected:
   }
 
   Event::MockDispatcher dispatcher_;
-  LibeventScheduler base_scheduler_;
   SimulatedTimeSystem time_system_;
+  LibeventScheduler base_scheduler_;
   SchedulerPtr scheduler_;
   std::string output_;
   std::vector<TimerPtr> timers_;


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: LibeventScheduler: add dynamic evwatch observer support
Additional Description:

Adds dynamic evwatch support to the LibeventScheduler.

This is a step toward allowing arbitrary extensions (esp. resource monitors) to register libevent evwatch callbacks.

This also allows us to clean up the existing ad-hoc evwatch callbacks (in a future PR) since the Observer interface supports the same use cases in a more envoy-native way.

This is zero-cost when unused.

Risk Level: low / none
Testing: tests added
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

I used generative AI to help write this change.
