### PR TITLE
Prep for removing C++ exceptions from BuiltInHttpCommandParser

### DIFF
--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -256,7 +256,7 @@ public:
 
 private:
   using FormatterProviderCreateFunc =
-      std::function<FormatterProviderPtr(absl::string_view, std::optional<size_t>)>;
+      std::function<absl::StatusOr<FormatterProviderPtr>(absl::string_view, std::optional<size_t>)>;
 
   using FormatterProviderLookupTbl =
       absl::flat_hash_map<absl::string_view, std::pair<CommandSyntaxChecker::CommandSyntaxFlags,


### PR DESCRIPTION
Risk Level: none, noop. Exceptions still are used, this PR only changes return type to StatusOr.

Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
