### PR TITLE
openssl compat: guard CNSA1 test with BORINGSSL_TEST_P

### DIFF
--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -6245,7 +6245,7 @@ BORINGSSL_TEST_P(SslSocketTest, CipherSuitesWithCNSA2Policy) {
   testUtilV2(error_test_options);
 }
 
-TEST_P(SslSocketTest, CipherSuitesWithCNSA1Policy) {
+BORINGSSL_TEST_P(SslSocketTest, CipherSuitesWithCNSA1Policy) {
   envoy::config::listener::v3::Listener listener;
   envoy::config::listener::v3::FilterChain* filter_chain = listener.add_filter_chains();
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;


### PR DESCRIPTION
The OpenSSL compat layer does not implement the
`ssl_compliance_policy_cnsa1_202603` policy (#46104), so `SSL_CTX_set_compliance_policy` returns 0 and the
`CipherSuitesWithCNSA1Policy` test fails on OpenSSL builds.

Guard it with `BORINGSSL_TEST_P`, matching the existing CNSA2 test.

Fixes the regression introduced by 7aa0e93a8f (#46089).
