### PR TITLE
Update CODEOWNERS for Redis extensions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -92,13 +92,13 @@ extensions/filters/common/original_src @klarose @mattklein123
 # UDP packet writer
 /*/extensions/udp_packet_writer/ @danzh2010 @ryantheoptimist
 # redis cluster extension
-/*/extensions/clusters/redis @msukalski @henryyyang @mattklein123 @nezdolik @dinesh-murugiah
+/*/extensions/clusters/redis @msukalski @henryyyang @mattklein123 @dinesh-murugiah
 # reverse conn cluster extension
 /*/extensions/clusters/reverse_connection @agrawroh @basundhara-c @botengyao @yanavlasov
-/*/extensions/common/redis @msukalski @henryyyang @mattklein123 @nezdolik @dinesh-murugiah
-/*/extensions/health_checkers/redis @mattklein123 @nezdolik @dinesh-murugiah
-/*/extensions/filters/network/redis_proxy @mattklein123 @nezdolik @dinesh-murugiah
-/*/extensions/filters/network/common/redis @mattklein123 @nezdolik @dinesh-murugiah
+/*/extensions/common/redis @msukalski @henryyyang @mattklein123 @dinesh-murugiah
+/*/extensions/health_checkers/redis @mattklein123 @dinesh-murugiah
+/*/extensions/filters/network/redis_proxy @mattklein123 @dinesh-murugiah
+/*/extensions/filters/network/common/redis @mattklein123 @dinesh-murugiah
 # dynamic forward proxy
 /*/extensions/clusters/dynamic_forward_proxy @mattklein123 @ryantheoptimist
 /*/extensions/common/dynamic_forward_proxy @mattklein123 @ryantheoptimist


### PR DESCRIPTION
Removing myself as codeowner for redis extension. 

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
