### PR TITLE
connection_limit: only decrement active connections when incremented

### DIFF
--- a/changelogs/current/bug_fixes/connection_limit__only-decrement-active-connections-when-incremented.rst
+++ b/changelogs/current/bug_fixes/connection_limit__only-decrement-active-connections-when-incremented.rst
@@ -1,0 +1,6 @@
+Fixed a bug in the ``connection_limit`` network filter where the connection accounting (the
+``active_connections`` gauge and the internal connection counter) was decremented on connection
+close even when it was never incremented, e.g. when the filter was runtime disabled or when an
+earlier filter in the chain stopped iteration before this filter ran. The resulting unsigned
+underflow caused the gauge to report huge values and could cause all subsequent connections to be
+wrongly rejected as over the limit. See https://github.com/envoyproxy/envoy/issues/22127.

--- a/source/extensions/filters/network/connection_limit/connection_limit.cc
+++ b/source/extensions/filters/network/connection_limit/connection_limit.cc
@@ -65,6 +65,9 @@ Network::FilterStatus Filter::onNewConnection() {
   }
 
   config_->stats().active_connections_.inc();
+  // Both the accepted and the rejected paths below increment the connection counter, so from
+  // this point on the close event must decrement the accounting.
+  is_incremented_ = true;
 
   if (!config_->incrementConnectionWithinLimit()) {
     config_->stats().limited_connections_.inc();
@@ -98,8 +101,15 @@ void Filter::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::RemoteClose ||
       event == Network::ConnectionEvent::LocalClose) {
     resetTimerState();
-    config_->decrementConnection();
-    config_->stats().active_connections_.dec();
+    // Only decrement the accounting if onNewConnection() incremented it. A close event can
+    // arrive without the accounting having been incremented, e.g. when the filter is runtime
+    // disabled (onNewConnection() returns early) or an earlier filter in the chain stopped
+    // iteration so onNewConnection() never ran, and the unsigned counters would underflow.
+    // See https://github.com/envoyproxy/envoy/issues/22127.
+    if (is_incremented_) {
+      config_->decrementConnection();
+      config_->stats().active_connections_.dec();
+    }
   }
 }
 

--- a/source/extensions/filters/network/connection_limit/connection_limit.h
+++ b/source/extensions/filters/network/connection_limit/connection_limit.h
@@ -91,6 +91,7 @@ private:
   Network::ReadFilterCallbacks* read_callbacks_{};
   Event::TimerPtr delay_timer_ = nullptr;
   bool is_rejected_{false};
+  bool is_incremented_{false};
 };
 
 } // namespace ConnectionLimitFilter

--- a/test/extensions/filters/network/connection_limit/connection_limit_test.cc
+++ b/test/extensions/filters/network/connection_limit/connection_limit_test.cc
@@ -174,6 +174,51 @@ runtime_enabled:
                    ->value());
 }
 
+// Verify that a close event without a prior onNewConnection() call (e.g. when an earlier
+// filter in the chain stops iteration before this filter runs) does not underflow the
+// connection accounting. See https://github.com/envoyproxy/envoy/issues/22127.
+TEST_F(ConnectionLimitFilterTest, CloseWithoutOnNewConnection) {
+  initialize(R"EOF(
+stat_prefix: connection_limit_stats
+max_connections: 1
+delay: 0.2s
+)EOF");
+
+  // Close event arrives without onNewConnection() ever running.
+  ActiveFilter active_filter1(config_);
+  active_filter1.filter_.onEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_EQ(0, TestUtility::findGauge(stats_store_,
+                                      "connection_limit.connection_limit_stats.active_connections")
+                   ->value());
+
+  // A subsequent connection must still be admitted, i.e. the internal connection counter must
+  // not underflow.
+  ActiveFilter active_filter2(config_);
+  EXPECT_EQ(Network::FilterStatus::Continue, active_filter2.filter_.onNewConnection());
+}
+
+// Verify that a close event does not decrement the connection accounting when the filter was
+// runtime disabled at connection creation time and therefore never incremented it. See
+// https://github.com/envoyproxy/envoy/issues/22127.
+TEST_F(ConnectionLimitFilterTest, RuntimeDisabledCloseDoesNotDecrement) {
+  initialize(R"EOF(
+stat_prefix: connection_limit_stats
+max_connections: 1
+delay: 0.2s
+runtime_enabled:
+  default_value: true
+  runtime_key: foo_key
+)EOF");
+
+  ActiveFilter active_filter(config_);
+  EXPECT_CALL(runtime_.snapshot_, getBoolean("foo_key", true)).WillOnce(Return(false));
+  EXPECT_EQ(Network::FilterStatus::Continue, active_filter.filter_.onNewConnection());
+  active_filter.filter_.onEvent(Network::ConnectionEvent::RemoteClose);
+  EXPECT_EQ(0, TestUtility::findGauge(stats_store_,
+                                      "connection_limit.connection_limit_stats.active_connections")
+                   ->value());
+}
+
 // Verify increment connection counter CAS edge case.
 TEST_F(ConnectionLimitFilterTest, IncrementCasEdgeCase) {
   initialize(R"EOF(


### PR DESCRIPTION
The connection limit filter decremented its accounting on every close event, even when `onNewConnection()` never incremented it (filter runtime disabled, or an earlier filter stopped iteration). The unsigned counter then underflowed and wrapped to a huge value: debug builds abort at `ASSERT(connections_ > 0)`, and release builds treat the limit as permanently exceeded, wrongly rejecting new connections. The fix tracks a `bool is_incremented_` per connection (mirroring the existing `is_rejected_`) and only decrements when the increment actually happened, making the accounting symmetric across every lifecycle path: accepted, rejected, runtime disabled, chain stopped.

**Commit Message:** connection_limit: only decrement active connections when incremented

**Additional Description:** see above

**Risk Level:** Low. No config or API change; only the previously broken path changes behavior.

**Testing:** Two new regression tests (`CloseWithoutOnNewConnection`, `RuntimeDisabledCloseDoesNotDecrement`) abort on main at `ASSERT(connections_ > 0)` and pass with the fix. The full `connection_limit_test` target (7 tests) passes locally in the CI image (clang); format and spelling checks pass.

**Docs Changes:** N/A

**Release Notes:** `changelogs/current/bug_fixes/connection_limit__only-decrement-active-connections-when-incremented.rst`

**Platform Specific Features:** N/A

Fixes #22127

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
