### PR TITLE
test: fix null async tcp client dereference in tcp_async_client_integration_test

### DIFF
--- a/test/integration/filters/test_network_async_tcp_filter.cc
+++ b/test/integration/filters/test_network_async_tcp_filter.cc
@@ -51,6 +51,15 @@ public:
   }
 
   Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override {
+    if (client_ == nullptr) {
+      // The client has been destroyed by the kill_after_on_data_ path. With half close
+      // enabled the downstream payload and FIN can arrive in two separate read dispatches,
+      // so ignore any dispatch after the client is gone. See
+      // https://github.com/envoyproxy/envoy/issues/43233.
+      stats_.on_data_.inc();
+      return Network::FilterStatus::StopIteration;
+    }
+
     if (require_reconnect_ && !client_->connect()) {
       ENVOY_LOG_MISC(debug, "Unable to reconnect to cluster");
       return Network::FilterStatus::StopIteration;
@@ -102,6 +111,11 @@ private:
 
       ENVOY_LOG_MISC(debug, "tcp client test filter downstream detected close type: {}.",
                      static_cast<int>(parent_.read_callbacks_->connection().detectedCloseType()));
+
+      if (parent_.client_ == nullptr) {
+        // The client has been destroyed by the kill_after_on_data_ path.
+        return;
+      }
 
       if (parent_.read_callbacks_->connection().detectedCloseType() ==
           StreamInfo::DetectedCloseType::RemoteReset) {

--- a/test/integration/tcp_async_client_integration_test.cc
+++ b/test/integration/tcp_async_client_integration_test.cc
@@ -193,6 +193,27 @@ TEST_P(TcpAsyncClientIntegrationTest, ClientTearDown) {
   tcp_client->close();
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/43233. With half close
+// enabled, the downstream payload and FIN can be delivered to the filter in two separate
+// read dispatches. The first dispatch destroys the async client (kill_after_on_data), and
+// the second dispatch used to dereference the destroyed client and segfault.
+TEST_P(TcpAsyncClientIntegrationTest, ClientTearDownSplitFin) {
+  init(true);
+
+  std::string request("request");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write(request, false));
+  // Once the counter is visible the first onData() call has run and the async client is
+  // being destroyed within the same dispatch; any later read event sees a null client.
+  test_server_->waitForCounter("test_network_async_tcp_filter.on_data", Ge(1));
+  // Deliver the FIN as a separate read event.
+  ASSERT_TRUE(tcp_client->write("", true));
+  test_server_->waitForCounter("test_network_async_tcp_filter.on_data", Ge(2));
+
+  tcp_client->close();
+}
+
 #if ENVOY_PLATFORM_ENABLE_SEND_RST
 // Test if RST close can be detected from downstream and upstream is closed by RST.
 TEST_P(TcpAsyncClientIntegrationTest, TestClientCloseRST) {


### PR DESCRIPTION
`test_network_async_tcp_filter` destroys its `AsyncTcpClient` in the first `onData()` when `kill_after_on_data` is set. With half close enabled, the payload and FIN can arrive as two separate read dispatches, and the second dispatch dereferenced the destroyed client (segfault, the CI flake in #43233). The coalescing is nondeterministic, which is why the flake was hard to reproduce. This guards the filter `onData()` and downstream `onEvent()` paths against a null client and adds a `ClientTearDownSplitFin` regression test that always delivers the FIN as a separate read event.

**Commit Message:** test: fix null async tcp client dereference in tcp_async_client_integration_test

**Additional Description:** see above

**Risk Level:** Low. Test only, no production code change.

**Testing:**
- `ClientTearDownSplitFin` fails 20 out of 20 runs on main (segfault, faulting address 0x0 in the downstream read dispatch, matching the issue) and passes with the guards.
- Full `//test/integration:tcp_async_client_integration_test` target: 200 out of 200 runs pass (`--runs_per_test=200`) in the CI clang image.
- `check_format` passes.

**Docs Changes:** N/A

**Release Notes:** N/A (test only)

**Platform Specific Features:** N/A

Fixes #43233

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
