### PR TITLE
network: migrate ratelimit, rbac, ext_authz filters to exception free

### DIFF
--- a/source/extensions/filters/network/ext_authz/config.cc
+++ b/source/extensions/filters/network/ext_authz/config.cc
@@ -20,14 +20,14 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace ExtAuthz {
 
-Network::FilterFactoryCb ExtAuthzConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Network::FilterFactoryCb> ExtAuthzConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::ext_authz::v3::ExtAuthz& proto_config,
     Server::Configuration::FactoryContext& context) {
   ConfigSharedPtr ext_authz_config =
       std::make_shared<Config>(proto_config, context.scope(), context.serverFactoryContext());
   const uint32_t timeout_ms = PROTOBUF_GET_MS_OR_DEFAULT(proto_config.grpc_service(), timeout, 200);
 
-  THROW_IF_NOT_OK(Envoy::Config::Utility::checkTransportVersion(proto_config));
+  RETURN_IF_NOT_OK(Envoy::Config::Utility::checkTransportVersion(proto_config));
   return [grpc_service = proto_config.grpc_service(), &context, ext_authz_config,
           timeout_ms](Network::FilterManager& filter_manager) -> void {
     auto factory_or_error = context.serverFactoryContext()

--- a/source/extensions/filters/network/ext_authz/config.h
+++ b/source/extensions/filters/network/ext_authz/config.h
@@ -14,13 +14,13 @@ namespace ExtAuthz {
 /**
  * Config registration for the external authorization filter. @see NamedNetworkFilterConfigFactory.
  */
-class ExtAuthzConfigFactory
-    : public Common::FactoryBase<envoy::extensions::filters::network::ext_authz::v3::ExtAuthz> {
+class ExtAuthzConfigFactory : public Common::ExceptionFreeFactoryBase<
+                                  envoy::extensions::filters::network::ext_authz::v3::ExtAuthz> {
 public:
-  ExtAuthzConfigFactory() : FactoryBase(NetworkFilterNames::get().ExtAuthorization) {}
+  ExtAuthzConfigFactory() : ExceptionFreeFactoryBase(NetworkFilterNames::get().ExtAuthorization) {}
 
 private:
-  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Network::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::network::ext_authz::v3::ExtAuthz& proto_config,
       Server::Configuration::FactoryContext& context) override;
 };

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -17,7 +17,7 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RateLimitFilter {
 
-Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Network::FilterFactoryCb> RateLimitConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::ratelimit::v3::RateLimit& proto_config,
     Server::Configuration::FactoryContext& context) {
 
@@ -30,7 +30,8 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
   const std::chrono::milliseconds timeout =
       std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(proto_config, timeout, 20));
 
-  THROW_IF_NOT_OK(Envoy::Config::Utility::checkTransportVersion(proto_config.rate_limit_service()));
+  RETURN_IF_NOT_OK(
+      Envoy::Config::Utility::checkTransportVersion(proto_config.rate_limit_service()));
   Grpc::GrpcServiceConfigWithHashKey config_with_hash_key =
       Grpc::GrpcServiceConfigWithHashKey(proto_config.rate_limit_service().grpc_service());
   return [config_with_hash_key, &context, timeout,

--- a/source/extensions/filters/network/ratelimit/config.h
+++ b/source/extensions/filters/network/ratelimit/config.h
@@ -15,13 +15,13 @@ namespace RateLimitFilter {
 /**
  * Config registration for the rate limit filter. @see NamedNetworkFilterConfigFactory.
  */
-class RateLimitConfigFactory
-    : public Common::FactoryBase<envoy::extensions::filters::network::ratelimit::v3::RateLimit> {
+class RateLimitConfigFactory : public Common::ExceptionFreeFactoryBase<
+                                   envoy::extensions::filters::network::ratelimit::v3::RateLimit> {
 public:
-  RateLimitConfigFactory() : FactoryBase(NetworkFilterNames::get().RateLimit) {}
+  RateLimitConfigFactory() : ExceptionFreeFactoryBase(NetworkFilterNames::get().RateLimit) {}
 
 private:
-  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Network::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::network::ratelimit::v3::RateLimit& proto_config,
       Server::Configuration::FactoryContext& context) override;
 };

--- a/source/extensions/filters/network/rbac/config.cc
+++ b/source/extensions/filters/network/rbac/config.cc
@@ -16,73 +16,76 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RBACFilter {
 
-static void validateFail(const std::string& header) {
-  throw EnvoyException(fmt::format("Found header({}) rule,"
-                                   "not supported by RBAC network filter",
-                                   header));
+static absl::Status validateFail(const std::string& header) {
+  return absl::InvalidArgumentError(fmt::format("Found header({}) rule,"
+                                                "not supported by RBAC network filter",
+                                                header));
 }
 
-static void validatePermission(const envoy::config::rbac::v3::Permission& permission) {
+static absl::Status validatePermission(const envoy::config::rbac::v3::Permission& permission) {
   if (permission.has_header()) {
-    validateFail(permission.header().DebugString());
+    return validateFail(permission.header().DebugString());
   }
   if (permission.has_and_rules()) {
     for (const auto& r : permission.and_rules().rules()) {
-      validatePermission(r);
+      RETURN_IF_NOT_OK(validatePermission(r));
     }
   }
   if (permission.has_or_rules()) {
     for (const auto& r : permission.or_rules().rules()) {
-      validatePermission(r);
+      RETURN_IF_NOT_OK(validatePermission(r));
     }
   }
   if (permission.has_not_rule()) {
-    validatePermission(permission.not_rule());
+    RETURN_IF_NOT_OK(validatePermission(permission.not_rule()));
   }
+  return absl::OkStatus();
 }
 
-static void validatePrincipal(const envoy::config::rbac::v3::Principal& principal) {
+static absl::Status validatePrincipal(const envoy::config::rbac::v3::Principal& principal) {
   if (principal.has_header()) {
-    validateFail(principal.header().DebugString());
+    return validateFail(principal.header().DebugString());
   }
   if (principal.has_and_ids()) {
     for (const auto& r : principal.and_ids().ids()) {
-      validatePrincipal(r);
+      RETURN_IF_NOT_OK(validatePrincipal(r));
     }
   }
   if (principal.has_or_ids()) {
     for (const auto& r : principal.or_ids().ids()) {
-      validatePrincipal(r);
+      RETURN_IF_NOT_OK(validatePrincipal(r));
     }
   }
   if (principal.has_not_id()) {
-    validatePrincipal(principal.not_id());
+    RETURN_IF_NOT_OK(validatePrincipal(principal.not_id()));
   }
+  return absl::OkStatus();
 }
 
 /**
  * Validate the RBAC rules doesn't include any header or metadata rule.
  */
-static void validateRbacRules(const envoy::config::rbac::v3::RBAC& rules) {
+static absl::Status validateRbacRules(const envoy::config::rbac::v3::RBAC& rules) {
   for (const auto& policy : rules.policies()) {
     for (const auto& permission : policy.second.permissions()) {
-      validatePermission(permission);
+      RETURN_IF_NOT_OK(validatePermission(permission));
     }
     for (const auto& principal : policy.second.principals()) {
-      validatePrincipal(principal);
+      RETURN_IF_NOT_OK(validatePrincipal(principal));
     }
   }
+  return absl::OkStatus();
 }
 
-Network::FilterFactoryCb
+absl::StatusOr<Network::FilterFactoryCb>
 RoleBasedAccessControlNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::rbac::v3::RBAC& proto_config,
     Server::Configuration::FactoryContext& context) {
   if (proto_config.has_rules()) {
-    validateRbacRules(proto_config.rules());
+    RETURN_IF_NOT_OK(validateRbacRules(proto_config.rules()));
   }
   if (proto_config.has_shadow_rules()) {
-    validateRbacRules(proto_config.shadow_rules());
+    RETURN_IF_NOT_OK(validateRbacRules(proto_config.shadow_rules()));
   }
   RoleBasedAccessControlFilterConfigSharedPtr config(
       std::make_shared<RoleBasedAccessControlFilterConfig>(proto_config, context.scope(),

--- a/source/extensions/filters/network/rbac/config.h
+++ b/source/extensions/filters/network/rbac/config.h
@@ -15,14 +15,14 @@ namespace RBACFilter {
  * Config registration for the RBAC network filter. @see NamedNetworkFilterConfigFactory.
  */
 class RoleBasedAccessControlNetworkFilterConfigFactory
-    : public Common::FactoryBase<envoy::extensions::filters::network::rbac::v3::RBAC> {
+    : public Common::ExceptionFreeFactoryBase<envoy::extensions::filters::network::rbac::v3::RBAC> {
 
 public:
   RoleBasedAccessControlNetworkFilterConfigFactory()
-      : FactoryBase(NetworkFilterNames::get().Rbac) {}
+      : ExceptionFreeFactoryBase(NetworkFilterNames::get().Rbac) {}
 
 private:
-  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Network::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::network::rbac::v3::RBAC& proto_config,
       Server::Configuration::FactoryContext& context) override;
 };

--- a/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
+++ b/test/extensions/filters/network/common/fuzz/uber_readfilter.cc
@@ -111,7 +111,9 @@ void UberFilterFuzzer::fuzz(
     // Make sure no invalid system calls are executed in fuzzer.
     checkInvalidInputForFuzzer(filter_name, message.get());
     ENVOY_LOG_MISC(info, "Config content after decoded: {}", message->DebugString());
-    cb_ = factory.createFilterFactoryFromProto(*message, factory_context_).value();
+    auto cb_or = factory.createFilterFactoryFromProto(*message, factory_context_);
+    THROW_IF_NOT_OK_REF(cb_or.status());
+    cb_ = cb_or.value();
   } catch (const EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled exception in filter setup {}", e.what());
     return;

--- a/test/extensions/filters/network/ext_authz/BUILD
+++ b/test/extensions/filters/network/ext_authz/BUILD
@@ -42,6 +42,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/network/ext_authz:config",
+        "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/server:factory_context_mocks",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/ext_authz/v3:pkg_cc_proto",

--- a/test/extensions/filters/network/ext_authz/config_test.cc
+++ b/test/extensions/filters/network/ext_authz/config_test.cc
@@ -5,6 +5,7 @@
 
 #include "source/extensions/filters/network/ext_authz/config.h"
 
+#include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/utility.h"
 
@@ -12,7 +13,10 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::HasSubstr;
 using testing::Invoke;
+using testing::NiceMock;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -57,6 +61,31 @@ TEST(ExtAuthzFilterConfigTest, ValidateFail) {
 }
 
 TEST(ExtAuthzFilterConfigTest, ExtAuthzCorrectProto) { expectCorrectProto(); }
+
+TEST(ExtAuthzFilterConfigTest, DeprecatedV2TransportApiVersion) {
+  std::string yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_authz_server
+      stat_prefix: google
+  failure_mode_allow: false
+  stat_prefix: name
+  transport_api_version: V2
+)EOF";
+
+  ExtAuthzConfigFactory factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+  ON_CALL(context, messageValidationVisitor()).WillByDefault(ReturnRef(validation_visitor));
+
+  auto result = factory.createFilterFactoryFromProto(*proto_config, context);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("V2 xDS transport protocol version is deprecated"));
+}
 
 TEST(ExtAuthzFilterConfigTest, ExtAuthzWithMetadataContextNamespaces) {
   std::string yaml = R"EOF(

--- a/test/extensions/filters/network/ratelimit/BUILD
+++ b/test/extensions/filters/network/ratelimit/BUILD
@@ -45,6 +45,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/network/ratelimit:config",
+        "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/extensions/filters/network/ratelimit/config_test.cc
+++ b/test/extensions/filters/network/ratelimit/config_test.cc
@@ -4,6 +4,7 @@
 
 #include "source/extensions/filters/network/ratelimit/config.h"
 
+#include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/utility.h"
 
@@ -11,6 +12,9 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::HasSubstr;
+using testing::NiceMock;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Extensions {
@@ -71,6 +75,35 @@ TEST(RateLimitFilterConfigTest, EmptyProto) {
           factory.createEmptyConfigProto().get());
   EXPECT_THROW(factory.createFilterFactoryFromProto(empty_proto_config, context).IgnoreError(),
                EnvoyException);
+}
+
+TEST(RateLimitFilterConfigTest, DeprecatedV2TransportApiVersion) {
+  const std::string yaml = R"EOF(
+  stat_prefix: my_stat_prefix
+  domain: fake_domain
+  descriptors:
+    entries:
+       key: my_key
+       value: my_value
+  rate_limit_service:
+    transport_api_version: V2
+    grpc_service:
+      envoy_grpc:
+        cluster_name: ratelimit_cluster
+  )EOF";
+
+  envoy::extensions::filters::network::ratelimit::v3::RateLimit proto_config{};
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+  ON_CALL(context, messageValidationVisitor()).WillByDefault(ReturnRef(validation_visitor));
+
+  RateLimitConfigFactory factory;
+  auto result = factory.createFilterFactoryFromProto(proto_config, context);
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(),
+              HasSubstr("V2 xDS transport protocol version is deprecated"));
 }
 
 TEST(RateLimitFilterConfigTest, IncorrectProto) {

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -13,6 +13,7 @@
 #include "xds/type/matcher/v3/matcher.pb.h"
 
 using testing::_;
+using testing::HasSubstr;
 using testing::NiceMock;
 
 namespace Envoy {
@@ -22,7 +23,7 @@ namespace RBACFilter {
 namespace {
 
 const std::string header = R"EOF(
-{ "header": {"name": "key", "exact_match": "value"} }
+{ "header": {"name": "key", "string_match": { "exact": "value" }} }
 )EOF";
 
 constexpr absl::string_view header_key = "key";
@@ -49,13 +50,15 @@ private:
 
     NiceMock<Server::Configuration::MockFactoryContext> context;
     RoleBasedAccessControlNetworkFilterConfigFactory factory;
-    EXPECT_THROW(factory.createFilterFactoryFromProto(config, context).IgnoreError(),
-                 Envoy::EnvoyException);
+    auto rules_result = factory.createFilterFactoryFromProto(config, context);
+    EXPECT_FALSE(rules_result.ok());
+    EXPECT_THAT(rules_result.status().message(), HasSubstr("Found header"));
 
     config.clear_rules();
     (*config.mutable_shadow_rules()->mutable_policies())["foo"] = policy_proto;
-    EXPECT_THROW(factory.createFilterFactoryFromProto(config, context).IgnoreError(),
-                 Envoy::EnvoyException);
+    auto shadow_rules_result = factory.createFilterFactoryFromProto(config, context);
+    EXPECT_FALSE(shadow_rules_result.ok());
+    EXPECT_THAT(shadow_rules_result.status().message(), HasSubstr("Found header"));
   }
 
   void checkMatcher(const std::string& matcher_yaml) {

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -207,7 +207,6 @@ paths:
     - source/extensions/filters/http/oauth2
     - source/extensions/filters/http/wasm
     - source/extensions/filters/network/dubbo_proxy
-    - source/extensions/filters/network/rbac
     - source/extensions/filters/network/common
     - source/extensions/filters/network/redis_proxy
     - source/extensions/filters/network/zookeeper_proxy


### PR DESCRIPTION
Migrate the ratelimit, rbac, and ext_authz network filter config factories from the throwing `Common::FactoryBase` to `Common::ExceptionFreeFactoryBase`, so config validation returns `absl::StatusOr` instead of throwing. This mirrors the already merged HTTP twins (#38629, #46035) and continues the exception free migration tracked in #27412. Error messages and failure semantics are unchanged (`EnvoyException` becomes `absl::InvalidArgumentError` with identical text).

rbac's factory validation was the only throw in its directory, so its entry is removed from the `tools/code_format/config.yaml` exception allowlist, locking the directory throw free via `check_format`. ratelimit and ext_authz keep their entries: both retain throws outside the config validation surface (descriptor formatter, per connection client creation), left for a follow-up.

The network read filter fuzz harness relied on factories throwing for invalid configs (`.value()` inside a `catch (EnvoyException)`). It now checks the returned status first, mirroring the HTTP fuzz harness, so error statuses keep exiting setup early instead of escaping as `BadStatusOrAccess` (caught by the `ext_authz_2` corpus entry, a V2 config).

**Commit Message:** network: migrate ratelimit, rbac, ext_authz filters to exception free

**Additional Description:** see above

**Risk Level:** Low. Behavior preserving refactor, no user visible change.

**Testing:** The three `config_test` targets and `//test/extensions/filters/network/common/fuzz:network_readfilter_fuzz_test` (which exercises the migrated error path via the `ext_authz_2` corpus) pass in the CI clang image. Added `DeprecatedV2TransportApiVersion` negative tests for ratelimit and ext_authz; rbac's `checkRule` expectations converted from `EXPECT_THROW` to status assertions. `check_format` passes with the rbac allowlist entry removed.

**Docs Changes:** N/A

**Release Notes:** N/A (internal refactor)

**Platform Specific Features:** N/A

Part of #27412

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
