### PR TITLE
dynamic_modules: expose current log level getter for HttpFilterConfigHandle in GO SDK

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-log-level-getter-go-sdk.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-log-level-getter-go-sdk.rst
@@ -1,0 +1,2 @@
+Expose ``envoy_dynamic_module_callback_get_log_level`` in the Go HTTP filter and filter config handles as
+``GetLogLevel`` and ``envoy_dynamic_module_callback_log_enabled`` as ``IsLogLevelEnabled``.

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -1653,6 +1653,16 @@ func (h *dymConfigHandle) Log(level shared.LogLevel, format string, args ...any)
 	hostLog(level, format, args)
 }
 
+func (h *dymConfigHandle) GetLogLevel() shared.LogLevel {
+	return shared.LogLevel(C.envoy_dynamic_module_callback_get_log_level())
+}
+
+func (h *dymConfigHandle) IsLogLevelEnabled(level shared.LogLevel) bool {
+	return bool(C.envoy_dynamic_module_callback_log_enabled(
+		(C.envoy_dynamic_module_type_log_level)(uint32(level)),
+	))
+}
+
 func (h *dymConfigHandle) DefineHistogram(name string,
 	tagKeys ...string) (shared.MetricID, shared.MetricsResult) {
 	// Prepare tag keys.

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -1633,6 +1633,16 @@ func (h *dymConfigHandle) Log(level shared.LogLevel, format string, args ...any)
 	hostLog(level, format, args)
 }
 
+func (h *dymConfigHandle) GetLogLevel() shared.LogLevel {
+	return shared.LogLevel(C.envoy_dynamic_module_callback_get_log_level())
+}
+
+func (h *dymConfigHandle) IsLogLevelEnabled(level shared.LogLevel) bool {
+	return bool(C.envoy_dynamic_module_callback_log_enabled(
+		(C.envoy_dynamic_module_type_log_level)(uint32(level)),
+	))
+}
+
 func (h *dymConfigHandle) DefineHistogram(name string,
 	tagKeys ...string) (shared.MetricID, shared.MetricsResult) {
 	// Prepare tag keys.

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -533,6 +533,16 @@ type HttpFilterConfigHandle interface {
 	// Log will log the given message via the host environment's logging mechanism.
 	Log(level LogLevel, format string, args ...any)
 
+	// GetLogLevel returns the current effective log level of the host environment's logging
+	// mechanism. The returned level reflects runtime changes, for example those applied via the
+	// admin API.
+	GetLogLevel() LogLevel
+
+	// IsLogLevelEnabled reports whether the given log level is enabled by the host environment's
+	// logging mechanism. It can be used to skip expensive work that is only needed when a message
+	// at the given level would actually be logged.
+	IsLogLevelEnabled(level LogLevel) bool
+
 	// DefineHistogram creates a histogram metric with the given name, and tag keys.
 	// Returns histogram metric id. This metric can never be used after the plugin
 	// config is unloaded.

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -546,6 +546,16 @@ type HttpFilterConfigHandle interface {
 	// Log will log the given message via the host environment's logging mechanism.
 	Log(level LogLevel, format string, args ...any)
 
+	// GetLogLevel returns the current effective log level of the host environment's logging
+	// mechanism. The returned level reflects runtime changes, for example those applied via the
+	// admin API.
+	GetLogLevel() LogLevel
+
+	// IsLogLevelEnabled reports whether the given log level is enabled by the host environment's
+	// logging mechanism. It can be used to skip expensive work that is only needed when a message
+	// at the given level would actually be logged.
+	IsLogLevelEnabled(level LogLevel) bool
+
 	// DefineHistogram creates a histogram metric with the given name, and tag keys.
 	// Returns histogram metric id. This metric can never be used after the plugin
 	// config is unloaded.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
@@ -1739,6 +1739,20 @@ func (mr *MockHttpFilterConfigHandleMockRecorder) GetGenericSecret(id any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenericSecret", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).GetGenericSecret), id)
 }
 
+// GetLogLevel mocks base method.
+func (m *MockHttpFilterConfigHandle) GetLogLevel() shared.LogLevel {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogLevel")
+	ret0, _ := ret[0].(shared.LogLevel)
+	return ret0
+}
+
+// GetLogLevel indicates an expected call of GetLogLevel.
+func (mr *MockHttpFilterConfigHandleMockRecorder) GetLogLevel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogLevel", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).GetLogLevel))
+}
+
 // GetScheduler mocks base method.
 func (m *MockHttpFilterConfigHandle) GetScheduler() shared.Scheduler {
 	m.ctrl.T.Helper()
@@ -1804,6 +1818,20 @@ func (mr *MockHttpFilterConfigHandleMockRecorder) IncrementGaugeValue(id, value 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{id, value}, tagsValues...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementGaugeValue", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).IncrementGaugeValue), varargs...)
+}
+
+// IsLogLevelEnabled mocks base method.
+func (m *MockHttpFilterConfigHandle) IsLogLevelEnabled(level shared.LogLevel) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLogLevelEnabled", level)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLogLevelEnabled indicates an expected call of IsLogLevelEnabled.
+func (mr *MockHttpFilterConfigHandleMockRecorder) IsLogLevelEnabled(level any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLogLevelEnabled", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).IsLogLevelEnabled), level)
 }
 
 // Log mocks base method.

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
@@ -1715,6 +1715,20 @@ func (mr *MockHttpFilterConfigHandleMockRecorder) GetGenericSecret(id any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenericSecret", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).GetGenericSecret), id)
 }
 
+// GetLogLevel mocks base method.
+func (m *MockHttpFilterConfigHandle) GetLogLevel() shared.LogLevel {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogLevel")
+	ret0, _ := ret[0].(shared.LogLevel)
+	return ret0
+}
+
+// GetLogLevel indicates an expected call of GetLogLevel.
+func (mr *MockHttpFilterConfigHandleMockRecorder) GetLogLevel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogLevel", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).GetLogLevel))
+}
+
 // GetScheduler mocks base method.
 func (m *MockHttpFilterConfigHandle) GetScheduler() shared.Scheduler {
 	m.ctrl.T.Helper()
@@ -1780,6 +1794,20 @@ func (mr *MockHttpFilterConfigHandleMockRecorder) IncrementGaugeValue(id, value 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{id, value}, tagsValues...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrementGaugeValue", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).IncrementGaugeValue), varargs...)
+}
+
+// IsLogLevelEnabled mocks base method.
+func (m *MockHttpFilterConfigHandle) IsLogLevelEnabled(level shared.LogLevel) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLogLevelEnabled", level)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLogLevelEnabled indicates an expected call of IsLogLevelEnabled.
+func (mr *MockHttpFilterConfigHandleMockRecorder) IsLogLevelEnabled(level any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLogLevelEnabled", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).IsLogLevelEnabled), level)
 }
 
 // Log mocks base method.

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -1490,27 +1490,47 @@ type LogLevelConfigFactory struct {
 
 func (f *LogLevelConfigFactory) Create(handle shared.HttpFilterConfigHandle,
 	config []byte) (shared.HttpFilterFactory, error) {
-	return &LogLevelFilterFactory{}, nil
+	return &LogLevelFilterFactory{
+		configLogLevel:     handle.GetLogLevel(),
+		configInfoEnabled:  handle.IsLogLevelEnabled(shared.LogLevelInfo),
+		configErrorEnabled: handle.IsLogLevelEnabled(shared.LogLevelError),
+	}, nil
 }
 
 type LogLevelFilterFactory struct {
 	shared.EmptyHttpFilterFactory
+	configLogLevel     shared.LogLevel
+	configInfoEnabled  bool
+	configErrorEnabled bool
 }
 
 func (f *LogLevelFilterFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
-	return &LogLevelFilter{handle: handle}
+	return &LogLevelFilter{
+		handle:             handle,
+		configLogLevel:     f.configLogLevel,
+		configInfoEnabled:  f.configInfoEnabled,
+		configErrorEnabled: f.configErrorEnabled,
+	}
 }
 
 type LogLevelFilter struct {
 	shared.EmptyHttpFilter
-	handle shared.HttpFilterHandle
+	handle             shared.HttpFilterHandle
+	configLogLevel     shared.LogLevel
+	configInfoEnabled  bool
+	configErrorEnabled bool
 }
 
 func (p *LogLevelFilter) OnResponseHeaders(headers shared.HeaderMap,
 	endOfStream bool) shared.HeadersStatus {
+	// tests http filter handle
 	headers.Set("x-log-level", strconv.FormatUint(uint64(p.handle.GetLogLevel()), 10))
 	headers.Set("x-log-info-enabled", strconv.FormatBool(p.handle.IsLogLevelEnabled(shared.LogLevelInfo)))
 	headers.Set("x-log-error-enabled", strconv.FormatBool(p.handle.IsLogLevelEnabled(shared.LogLevelError)))
+	// tests filter config handle
+	headers.Set("x-config-log-level", strconv.FormatUint(uint64(p.configLogLevel), 10))
+	headers.Set("x-config-log-info-enabled", strconv.FormatBool(p.configInfoEnabled))
+	headers.Set("x-config-log-error-enabled", strconv.FormatBool(p.configErrorEnabled))
 	return shared.HeadersStatusContinue
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -176,7 +176,11 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "list_metadata_callbacks" => Some(Box::new(ListMetadataCallbacksFilterConfig {})),
     "filter_state_object_recreate" => Some(Box::new(FilterStateObjectRecreateFilterConfig {})),
     "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig {})),
-    "log_level" => Some(Box::new(LogLevelFilterConfig {})),
+    "log_level" => Some(Box::new(LogLevelFilterConfig {
+      config_log_level: get_log_level() as u32,
+      config_info_enabled: is_log_enabled(envoy_dynamic_module_type_log_level::Info),
+      config_error_enabled: is_log_enabled(envoy_dynamic_module_type_log_level::Error),
+    })),
     _ => panic!("Unknown filter name: {name}"),
   }
 }
@@ -460,15 +464,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamConnectionIdFilter {
   }
 }
 
-struct LogLevelFilterConfig {}
+struct LogLevelFilterConfig {
+  config_log_level: u32,
+  config_info_enabled: bool,
+  config_error_enabled: bool,
+}
 
 impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for LogLevelFilterConfig {
   fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(LogLevelFilter {})
+    Box::new(LogLevelFilter {
+      config_log_level: self.config_log_level,
+      config_info_enabled: self.config_info_enabled,
+      config_error_enabled: self.config_error_enabled,
+    })
   }
 }
 
-struct LogLevelFilter {}
+struct LogLevelFilter {
+  config_log_level: u32,
+  config_info_enabled: bool,
+  config_error_enabled: bool,
+}
 
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for LogLevelFilter {
   fn on_response_headers(
@@ -476,12 +492,20 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for LogLevelFilter {
     envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    // tests http filter handle
     let level = (get_log_level() as u32).to_string();
     envoy_filter.set_response_header("x-log-level", level.as_bytes());
     let info_enabled = is_log_enabled(envoy_dynamic_module_type_log_level::Info).to_string();
     envoy_filter.set_response_header("x-log-info-enabled", info_enabled.as_bytes());
     let error_enabled = is_log_enabled(envoy_dynamic_module_type_log_level::Error).to_string();
     envoy_filter.set_response_header("x-log-error-enabled", error_enabled.as_bytes());
+    // tests filter config handle
+    let config_level = self.config_log_level.to_string();
+    envoy_filter.set_response_header("x-config-log-level", config_level.as_bytes());
+    let config_info_enabled = self.config_info_enabled.to_string();
+    envoy_filter.set_response_header("x-config-log-info-enabled", config_info_enabled.as_bytes());
+    let config_error_enabled = self.config_error_enabled.to_string();
+    envoy_filter.set_response_header("x-config-log-error-enabled", config_error_enabled.as_bytes());
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -180,7 +180,11 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
       dropped_filters: Arc::new(AtomicUsize::new(0)),
     })),
     "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig {})),
-    "log_level" => Some(Box::new(LogLevelFilterConfig {})),
+    "log_level" => Some(Box::new(LogLevelFilterConfig {
+      config_log_level: get_log_level() as u32,
+      config_info_enabled: is_log_enabled(envoy_dynamic_module_type_log_level::Info),
+      config_error_enabled: is_log_enabled(envoy_dynamic_module_type_log_level::Error),
+    })),
     _ => panic!("Unknown filter name: {name}"),
   }
 }
@@ -532,15 +536,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UpstreamConnectionIdFilter {
   }
 }
 
-struct LogLevelFilterConfig {}
+struct LogLevelFilterConfig {
+  config_log_level: u32,
+  config_info_enabled: bool,
+  config_error_enabled: bool,
+}
 
 impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for LogLevelFilterConfig {
   fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-    Box::new(LogLevelFilter {})
+    Box::new(LogLevelFilter {
+      config_log_level: self.config_log_level,
+      config_info_enabled: self.config_info_enabled,
+      config_error_enabled: self.config_error_enabled,
+    })
   }
 }
 
-struct LogLevelFilter {}
+struct LogLevelFilter {
+  config_log_level: u32,
+  config_info_enabled: bool,
+  config_error_enabled: bool,
+}
 
 impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for LogLevelFilter {
   fn on_response_headers(
@@ -548,12 +564,20 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for LogLevelFilter {
     envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    // tests http filter handle
     let level = (get_log_level() as u32).to_string();
     envoy_filter.set_response_header("x-log-level", level.as_bytes());
     let info_enabled = is_log_enabled(envoy_dynamic_module_type_log_level::Info).to_string();
     envoy_filter.set_response_header("x-log-info-enabled", info_enabled.as_bytes());
     let error_enabled = is_log_enabled(envoy_dynamic_module_type_log_level::Error).to_string();
     envoy_filter.set_response_header("x-log-error-enabled", error_enabled.as_bytes());
+    // tests filter config handle
+    let config_level = self.config_log_level.to_string();
+    envoy_filter.set_response_header("x-config-log-level", config_level.as_bytes());
+    let config_info_enabled = self.config_info_enabled.to_string();
+    envoy_filter.set_response_header("x-config-log-info-enabled", config_info_enabled.as_bytes());
+    let config_error_enabled = self.config_error_enabled.to_string();
+    envoy_filter.set_response_header("x-config-log-error-enabled", config_error_enabled.as_bytes());
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -577,7 +577,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for LogLevelFilter {
     let config_info_enabled = self.config_info_enabled.to_string();
     envoy_filter.set_response_header("x-config-log-info-enabled", config_info_enabled.as_bytes());
     let config_error_enabled = self.config_error_enabled.to_string();
-    envoy_filter.set_response_header("x-config-log-error-enabled", config_error_enabled.as_bytes());
+    envoy_filter.set_response_header(
+      "x-config-log-error-enabled",
+      config_error_enabled.as_bytes(),
+    );
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }
 }


### PR DESCRIPTION
*This is my first PR to envoy proxy and I have used AI (Claude Code) to navigate across the code base and understand some things*

This is a follow up PR for https://github.com/envoyproxy/envoy/issues/45032 to also expose the methods for filter config handles. The changes should be pretty straightforward and very similiar to what was done in the previous [PR](https://github.com/envoyproxy/envoy/pull/46052).

**Commit Message**: dynamic_modules: expose current log level getter for HttpFilterConfigHandle in GO SDK
**Risk Level**: LOW 
**Testing**: Added Tests (also added some tests for Rust SDK even though there the crate already exposes the method)
**Release Notes**: Added