### PR TITLE
api: mark rate limit quota (RLQS) API as stable

### DIFF
--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/BUILD
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/BUILD
@@ -9,7 +9,6 @@ api_proto_package(
         "//envoy/config/core/v3:pkg",
         "//envoy/type/v3:pkg",
         "@xds//udpa/annotations:pkg",
-        "@xds//xds/annotations/v3:pkg",
         "@xds//xds/type/matcher/v3:pkg",
     ],
 )

--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -12,7 +12,6 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "google/rpc/status.proto";
 
-import "xds/annotations/v3/status.proto";
 import "xds/type/matcher/v3/matcher.proto";
 
 import "udpa/annotations/status.proto";
@@ -23,7 +22,6 @@ option java_outer_classname = "RateLimitQuotaProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rate_limit_quota/v3;rate_limit_quotav3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: Rate Limit Quota]
 // Rate Limit Quota :ref:`configuration overview <config_http_filters_rate_limit_quota>`.

--- a/api/envoy/service/rate_limit_quota/v3/BUILD
+++ b/api/envoy/service/rate_limit_quota/v3/BUILD
@@ -9,6 +9,5 @@ api_proto_package(
     deps = [
         "//envoy/type/v3:pkg",
         "@xds//udpa/annotations:pkg",
-        "@xds//xds/annotations/v3:pkg",
     ],
 )

--- a/api/envoy/service/rate_limit_quota/v3/rlqs.proto
+++ b/api/envoy/service/rate_limit_quota/v3/rlqs.proto
@@ -6,8 +6,6 @@ import "envoy/type/v3/ratelimit_strategy.proto";
 
 import "google/protobuf/duration.proto";
 
-import "xds/annotations/v3/status.proto";
-
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -16,7 +14,6 @@ option java_outer_classname = "RlqsProto";
 option java_multiple_files = true;
 option go_package = "github.com/envoyproxy/go-control-plane/envoy/service/rate_limit_quota/v3;rate_limit_quotav3";
 option (udpa.annotations.file_status).package_version_status = ACTIVE;
-option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // [#protodoc-title: Rate Limit Quota Service (RLQS)]
 

--- a/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
+++ b/docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst
@@ -1,12 +1,7 @@
 .. _config_http_filters_rate_limit_quota:
 
-Rate Limit Quota (Work-In-Progress)
-===================================
-
-.. attention::
-
-  The Rate Limit Quota filter is currently under active development and is not ready for use yet.
-  Capabilities and the configuration structures could be changed.
+Rate Limit Quota
+================
 
 * Global rate limiting :ref:`architecture overview <arch_overview_global_rate_limit>`
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig>`

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -739,7 +739,7 @@ envoy.filters.http.rate_limit_quota:
   categories:
   - envoy.filters.http
   security_posture: unknown
-  status: wip
+  status: stable
   type_urls:
   - envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig
   - envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaOverride


### PR DESCRIPTION
as discussed in [Envoy community meeting](https://docs.google.com/document/d/1Yc4zkV-A_cC_R3C0u6D15WQAsRSxADs8p2l8UMMa4P4/edit?tab=t.0#heading=h.vgkvn1hr5uor) on July 14, 2026 ([comment thread](https://docs.google.com/document/d/1Yc4zkV-A_cC_R3C0u6D15WQAsRSxADs8p2l8UMMa4P4/edit?disco=AAACDBLfZlE)).

Remove the "work-in-progress" warnings from the Rate Limit Quota (RLQS) API docs:

- `api/envoy/service/rate_limit_quota/v3/rlqs.proto` — remove `option (xds.annotations.v3.file_status).work_in_progress = true;` (and the now-unused `xds/annotations/v3/status.proto` import). This drops the `.. warning:: This API feature is currently work-in-progress ...` banner that `protodoc` emits on the [RLQS proto reference page](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/rate_limit_quota/v3/rlqs.proto).
- `api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto` — same annotation/import removal.
- `docs/root/configuration/http/http_filters/rate_limit_quota_filter.rst` — drop `(Work-In-Progress)` from the page title and remove the `.. attention::` "under active development / not ready for use yet" note on the [HTTP filter config page](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rate_limit_quota_filter).