### PR TITLE
Fix formatting in aws_regions.rst for clarity

### DIFF
--- a/docs/root/configuration/http/http_filters/_include/aws_regions.rst
+++ b/docs/root/configuration/http/http_filters/_include/aws_regions.rst
@@ -15,7 +15,7 @@ If :ref:`signing_algorithm <envoy_v3_api_field_extensions.filters.http.aws_reque
    are respected if they are set, else the file ``~/.aws/credentials`` and profile ``default`` are used. The field ``region`` defined
    for the profile in the credentials file is used.
 
-4. The AWS config file. The environment variables ``AWS_CONFIG_FILE``, ``AWS_PROFILE``and ``DEFAULT_AWS_PROFILE`` are
+4. The AWS config file. The environment variables ``AWS_CONFIG_FILE``, ``AWS_PROFILE`` and ``DEFAULT_AWS_PROFILE`` are
    respected if they are set, else the file ``~/.aws/config`` and profile ``default`` are used. The field ``region`` defined for the
    profile in the config file is used.
 
@@ -30,6 +30,6 @@ If :ref:`signing_algorithm <envoy_v3_api_field_extensions.filters.http.aws_reque
    are respected if they are set, else the file ``~/.aws/credentials`` and profile ``default`` are used. The field
    ``sigv4a_signing_region_set`` defined for the profile in the credentials file is used.
 
-4. The AWS config file. The environment variables ``AWS_CONFIG_FILE``, ``AWS_PROFILE``and ``DEFAULT_AWS_PROFILE`` are
+4. The AWS config file. The environment variables ``AWS_CONFIG_FILE``, ``AWS_PROFILE`` and ``DEFAULT_AWS_PROFILE`` are
    respected if they are set, else the file ``~/.aws/config`` and profile ``default`` are used. The field ``sigv4a_signing_region_set``
    defined for the profile in the config file is used.


### PR DESCRIPTION
When reading the docs I found some variable references were not properly formatted. This commit just adds 2 spaces.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Fixed rendering in <https://www.envoyproxy.io/docs/envoy/v1.38.3/configuration/http/http_filters/_include/aws_regions.html>
Additional Description: Missing spaces after closing code block quotes
Risk Level: Zero, zilch, minimal
Testing: Rendered in GitHub properly. Formatting matches the other fields which did not have issues.
Docs Changes:
Release Notes: Added missing spaces to doc about AWS regions
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

## This is what is being fixed

<img width="2281" height="1337" alt="image" src="https://github.com/user-attachments/assets/026d9277-9577-4f35-8555-135c6c481583" />

