### PR TITLE
reverse_tunnel: stamp initiation time once per establishment episode

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -79,7 +79,8 @@ Network::FilterStatus SimpleConnReadFilter::onData(Buffer::Instance& buffer, boo
 
 std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
                                          const std::string& src_cluster_id,
-                                         const std::string& src_node_id) {
+                                         const std::string& src_node_id,
+                                         std::optional<int64_t> initiation_time_ms) {
   // Register connection callbacks.
   ENVOY_LOG(debug, "RCConnectionWrapper: connection: {}, adding connection callbacks",
             connection_->id());
@@ -157,10 +158,15 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
 
   const Http::LowerCaseString& initiation_time_hdr =
       ::Envoy::Extensions::Bootstrap::ReverseConnection::reverseTunnelInitiationTimeHeader();
-  auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    connection_->dispatcher().timeSource().systemTime().time_since_epoch())
-                    .count();
-  headers->addCopy(initiation_time_hdr, absl::StrCat(now_ms));
+  // Prefer the episode initiation time supplied by the caller so that handshake retries during
+  // initial establishment carry the original intent time; fall back to now for direct callers.
+  const int64_t initiation_ms =
+      initiation_time_ms.has_value()
+          ? *initiation_time_ms
+          : std::chrono::duration_cast<std::chrono::milliseconds>(
+                connection_->dispatcher().timeSource().systemTime().time_since_epoch())
+                .count();
+  headers->addCopy(initiation_time_hdr, absl::StrCat(initiation_ms));
 
   using HeaderValueOption = envoy::config::core::v3::HeaderValueOption;
   const auto apply_header = [&headers](const Http::LowerCaseString& key, absl::string_view value,

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -160,10 +160,13 @@ public:
    * @param src_tenant_id the tenant identifier
    * @param src_cluster_id the cluster identifier
    * @param src_node_id the node identifier
+   * @param initiation_time_ms epoch millis to advertise as the tunnel's initiation time; when
+   *        absent, the current system time is used.
    * @return the local address as string
    */
   std::string connect(const std::string& src_tenant_id, const std::string& src_cluster_id,
-                      const std::string& src_node_id);
+                      const std::string& src_node_id,
+                      std::optional<int64_t> initiation_time_ms = std::nullopt);
 
   /**
    * Release ownership of the connection.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -581,6 +581,8 @@ void ReverseConnectionIOHandle::maintainClusterConnections(
       };
     }
 
+    host_to_conn_info_map_[key].target_connection_count = cluster_config.reverse_connection_count;
+
     // Check if we should attempt connection to this host (backoff logic).
     if (!shouldAttemptConnectionToHost(host_address, cluster_name)) {
       ENVOY_LOG(debug, "reverse_tunnel: Skipping connection attempt to host {} due to backoff",
@@ -1052,9 +1054,20 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
   auto wrapper = std::make_unique<RCConnectionWrapper>(*this, std::move(conn_data.connection_),
                                                        conn_data.host_description_, cluster_name);
 
+  // Stamp the episode initiation time on the first dial of an establishment episode, and reuse it
+  // for subsequent handshake retries. It is cleared on handshake success (see onConnectionDone()),
+  // so a redial after a live connection drops begins a fresh episode with a new timestamp.
+  auto& host_info = host_to_conn_info_map_[normalized_host_key];
+  if (!host_info.episode_initiation_time_ms.has_value()) {
+    host_info.episode_initiation_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                               getTimeSource().systemTime().time_since_epoch())
+                                               .count();
+  }
+
   // Send the reverse connection handshake over the TCP connection.
   const std::string connection_key =
-      wrapper->connect(config_.src_tenant_id, config_.src_cluster_id, config_.src_node_id);
+      wrapper->connect(config_.src_tenant_id, config_.src_cluster_id, config_.src_node_id,
+                       host_info.episode_initiation_time_ms);
   ENVOY_LOG(debug, "reverse_tunnel: Initiated reverse connection handshake for host {} with key {}",
             host_address, connection_key);
 
@@ -1236,6 +1249,12 @@ void ReverseConnectionIOHandle::onConnectionDone(
       host_it->second.connection_keys.insert(connection_key);
       ENVOY_LOG(debug, "reverse_tunnel: Added connection key {} for host {}", connection_key,
                 host_address);
+      // End the establishment episode only once all target connections for the host are up, so that
+      // the 2..N handshakes of a multi-connection episode still report the original intent time. A
+      // future redial after a connection drops then begins a fresh episode with a new timestamp.
+      if (host_it->second.connection_keys.size() >= host_it->second.target_connection_count) {
+        host_it->second.episode_initiation_time_ms.reset();
+      }
     }
 
     // Set quiet shutdown since we are duplicating the socket and closing the original socket. When

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -483,6 +483,12 @@ private:
     absl::flat_hash_map<std::string, ReverseConnectionState>
         connection_states;        // State tracking per connection
     uint32_t connecting_count{0}; // Number of pending connections.
+    // Wall-clock epoch millis of the first dial in the current establishment episode. Set on the
+    // first dial made while the host has no live connection, carried unchanged across handshake
+    // retries, and cleared on handshake success. This makes retries during initial establishment
+    // report the original intent time, while a redial after a previously-established connection
+    // drops starts a fresh episode.
+    std::optional<int64_t> episode_initiation_time_ms;
   };
 
   // Map from host address to connection info.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -692,6 +692,60 @@ TEST_F(RCConnectionWrapperTest, ConnectIncludesInitiationTimeHeader) {
   EXPECT_LE(timestamp_ms, after_ms);
 }
 
+// Test that an explicitly supplied initiation time is advertised verbatim rather than the current
+// time. This is the mechanism that lets handshake retries during initial establishment carry the
+// original episode's intent time.
+TEST_F(RCConnectionWrapperTest, ConnectHonorsSuppliedInitiationTime) {
+  auto mock_connection = getDeletableConn(dispatcher_);
+
+  EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, addReadFilter(_));
+  EXPECT_CALL(*mock_connection, connect());
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12345));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+
+  auto mock_address = std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1", 8080);
+  auto mock_local_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 12345);
+
+  EXPECT_CALL(*mock_connection, connectionInfoProvider())
+      .WillRepeatedly(Invoke([mock_address,
+                              mock_local_address]() -> const Network::ConnectionInfoProvider& {
+        static auto mock_provider =
+            std::make_unique<Network::ConnectionInfoSetterImpl>(mock_local_address, mock_address);
+        return *mock_provider;
+      }));
+
+  Buffer::OwnedImpl captured_buffer;
+  EXPECT_CALL(*mock_connection, write(_, _))
+      .WillOnce(Invoke([&captured_buffer](Buffer::Instance& buffer, bool) {
+        captured_buffer.add(buffer);
+        buffer.drain(buffer.length());
+      }));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+
+  // A fixed timestamp well in the past that could never equal "now".
+  const int64_t supplied_ms = 1000;
+  wrapper.connect("test-tenant", "test-cluster", "test-node", supplied_ms);
+
+  const std::string encoded_request = captured_buffer.toString();
+  const std::string header_prefix = "x-envoy-reverse-tunnel-initiation-time: ";
+  auto pos = encoded_request.find(header_prefix);
+  ASSERT_NE(pos, std::string::npos) << "initiation-time header not found in handshake request";
+
+  auto value_start = pos + header_prefix.size();
+  auto value_end = encoded_request.find("\r\n", value_start);
+  ASSERT_NE(value_end, std::string::npos);
+  std::string timestamp_str = encoded_request.substr(value_start, value_end - value_start);
+
+  int64_t timestamp_ms;
+  ASSERT_TRUE(absl::SimpleAtoi(timestamp_str, &timestamp_ms))
+      << "initiation-time header value is not a valid integer: " << timestamp_str;
+  EXPECT_EQ(timestamp_ms, supplied_ms);
+}
+
 // Test RCConnectionWrapper::connect() method with connection write failure.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWriteFailure) {
   // Create a mock connection that fails to write.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -361,6 +361,12 @@ protected:
     io_handle_->conn_wrapper_to_host_map_[wrapper] = host_address;
   }
 
+  // Transfer ownership of a wrapper into the io handle so onConnectionDone() can find and remove
+  // it.
+  void pushConnectionWrapper(std::unique_ptr<RCConnectionWrapper> wrapper) {
+    io_handle_->connection_wrappers_.push_back(std::move(wrapper));
+  }
+
   void cleanup() { io_handle_->cleanup(); }
 
   void removeStaleHostAndCloseConnections(const std::string& host) {
@@ -2382,6 +2388,51 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedTriggersReInit
   auto stat_map = extension_->getCrossWorkerStatMap();
   EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.connecting"], 1);
   EXPECT_EQ(stat_map["test_scope.reverse_connections.cluster.test-cluster.connecting"], 1);
+}
+
+// For a host that needs N>1 connections, the establishment episode timestamp must survive the
+// 2..N-1 handshake completions and only clear once the target connection count is reached.
+TEST_F(ReverseConnectionIOHandleTest, EpisodeInitiationTimeClearedOnlyAtTargetCount) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+  createTriggerPipe();
+
+  // Host wants two connections; simulate the first dial already having stamped the episode time.
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 2);
+  getMutableHostConnectionInfo("192.168.1.1").episode_initiation_time_ms = 1000;
+
+  // Completes one handshake with a distinct local address (so it yields a distinct connection key).
+  auto complete_one_handshake = [&](uint32_t local_port) {
+    auto mock_connection = setupMockConnection();
+    auto local = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", local_port);
+    auto remote = std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1", 8080);
+    auto provider = std::make_shared<Network::ConnectionInfoSetterImpl>(local, remote);
+    EXPECT_CALL(*mock_connection, connectionInfoProvider())
+        .WillRepeatedly(
+            Invoke([provider]() -> const Network::ConnectionInfoProvider& { return *provider; }));
+
+    auto host = createMockHost("192.168.1.1");
+    auto wrapper = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection),
+                                                         host, "test-cluster");
+    RCConnectionWrapper* wrapper_ptr = wrapper.get();
+    addWrapperToHostMap(wrapper_ptr, "192.168.1.1");
+    pushConnectionWrapper(std::move(wrapper));
+    io_handle_->onConnectionDone("reverse connection accepted", wrapper_ptr, false);
+  };
+
+  // First handshake completes: still below target, timestamp must remain.
+  complete_one_handshake(11111);
+  ASSERT_EQ(getHostConnectionInfo("192.168.1.1").connection_keys.size(), 1u);
+  EXPECT_TRUE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(*getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms, 1000);
+
+  // Second handshake reaches the target: timestamp is cleared, ending the episode.
+  complete_one_handshake(22222);
+  ASSERT_EQ(getHostConnectionInfo("192.168.1.1").connection_keys.size(), 2u);
+  EXPECT_FALSE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
 }
 
 TEST_F(ReverseConnectionIOHandleTest, SkipNewConnectionIfAttemptInProgress) {


### PR DESCRIPTION
## Description

Stamp the `x-envoy-reverse-tunnel-initiation-time` handshake header once per establishment *episode* rather than recomputing it on every handshake attempt.

### Problem

The initiation-time header (added in #45582) was set from `system_clock::now()` inside `RCConnectionWrapper::connect()`, which runs on **every** dial. When the initial connection takes several retries (each retry builds a fresh socket + wrapper and calls `connect()` again), the header reflected the last, successful attempt rather than when the tunnel agent first wanted the tunnel up. Any end-to-end propagation-latency measurement therefore excluded the time spent in earlier failed/pending attempts plus backoff.

### Solution

Track a per-host episode initiation time on `HostConnectionInfo`:

- **Set-if-absent** on the first dial made while the host has no live connection (`initiateOneReverseConnection()`), and reuse it for subsequent handshake retries.
- **Cleared on handshake success** (`onConnectionDone()`).

This way, retries during initial establishment all report the original intent time, while a redial after a previously-established connection drops begins a **fresh** episode with a new timestamp (the field was already cleared by the earlier success). The CP side already extracts and reports this header, so no upstream change is required.

### Changes

- **`reverse_connection_io_handle.h`**: Add `std::optional<int64_t> episode_initiation_time_ms` to `HostConnectionInfo`.
- **`reverse_connection_io_handle.cc`**: Set-if-absent before the handshake in `initiateOneReverseConnection()`; clear it on success in `onConnectionDone()`.
- **`rc_connection_wrapper.{h,cc}`**: `connect()` takes an optional `initiation_time_ms`, falling back to the current system time when absent (existing direct callers unchanged).
- **Test**: `ConnectHonorsSuppliedInitiationTime` verifies a supplied timestamp is advertised verbatim.

### Backward Compatibility

No wire-format change — the same header is still sent; only which timestamp it carries changes. Direct callers of `connect()` that don't pass a time keep the previous "now" behavior.

## Risk Level

Low — per-host bookkeeping on an existing handshake path; no change to connection lifecycle, retry, or error handling.

## Testing

`rc_connection_wrapper_test` and `reverse_connection_io_handle_test` pass; added a unit test for the supplied-time path.

Signed-off-by: Krishna Sharma <krishnagpl2001@gmail.com>
