### PR TITLE
tracing: add set_instrumentation_scope option to opentelemetry tracer

### DIFF
--- a/api/envoy/config/trace/v3/opentelemetry.proto
+++ b/api/envoy/config/trace/v3/opentelemetry.proto
@@ -21,7 +21,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 // Configuration for the OpenTelemetry tracer.
 //  [#extension: envoy.tracers.opentelemetry]
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message OpenTelemetryConfig {
   // The upstream gRPC cluster that will receive OTLP traces.
   // Note that the tracer drops traces if the server does not read data fast enough.
@@ -76,4 +76,8 @@ message OpenTelemetryConfig {
   // Specifies whether to set the ``service.name`` resource attribute.
   // If not specified, the default is to set this attribute.
   google.protobuf.BoolValue set_service_name_resource_attribute = 8;
+
+  // Specifies whether to set the instrumentation scope name ("envoy") and version on emitted traces.
+  // If not specified, the default is to set the instrumentation scope name and version.
+  google.protobuf.BoolValue set_instrumentation_scope = 9;
 }

--- a/changelogs/current/new_features/tracing__opentelemetry_set_instrumentation_scope.rst
+++ b/changelogs/current/new_features/tracing__opentelemetry_set_instrumentation_scope.rst
@@ -1,0 +1,1 @@
+tracing: added :ref:`set_instrumentation_scope <envoy_v3_api_field_config.trace.v3.OpenTelemetryConfig.set_instrumentation_scope>` option to the OpenTelemetry tracer to allow controlling the emission of the instrumentation scope name and version in traces.

--- a/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
+++ b/source/extensions/tracers/opentelemetry/opentelemetry_tracer_impl.cc
@@ -127,10 +127,12 @@ Driver::Driver(const envoy::config::trace::v3::OpenTelemetryConfig& opentelemetr
     // Get the max cache size from config
     uint64_t max_cache_size = PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config, max_cache_size,
                                                               DEFAULT_MAX_CACHE_SIZE);
-    TracerPtr tracer =
-        std::make_unique<Tracer>(std::move(exporter), factory_context.timeSource(),
-                                 factory_context.api().randomGenerator(), factory_context.runtime(),
-                                 dispatcher, tracing_stats_, resource_ptr, sampler, max_cache_size);
+    bool set_instrumentation_scope =
+        PROTOBUF_GET_WRAPPED_OR_DEFAULT(opentelemetry_config, set_instrumentation_scope, true);
+    TracerPtr tracer = std::make_unique<Tracer>(
+        std::move(exporter), factory_context.timeSource(), factory_context.api().randomGenerator(),
+        factory_context.runtime(), dispatcher, tracing_stats_, resource_ptr, sampler,
+        max_cache_size, set_instrumentation_scope);
     return std::make_shared<TlsTracer>(std::move(tracer));
   });
 }

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -209,10 +209,10 @@ Tracer::Tracer(OpenTelemetryTraceExporterPtr exporter, Envoy::TimeSource& time_s
                Random::RandomGenerator& random, Runtime::Loader& runtime,
                Event::Dispatcher& dispatcher, OpenTelemetryTracerStats tracing_stats,
                const ResourceConstSharedPtr resource, SamplerSharedPtr sampler,
-               uint64_t max_cache_size)
+               uint64_t max_cache_size, bool set_instrumentation_scope)
     : exporter_(std::move(exporter)), time_source_(time_source), random_(random), runtime_(runtime),
       tracing_stats_(tracing_stats), resource_(resource), sampler_(sampler),
-      max_cache_size_(max_cache_size) {
+      max_cache_size_(max_cache_size), set_instrumentation_scope_(set_instrumentation_scope) {
   flush_timer_ = dispatcher.createTimer([this]() -> void {
     tracing_stats_.timer_flushed_.inc();
     flushSpans();
@@ -251,9 +251,11 @@ void Tracer::flushSpans() {
 
   ::opentelemetry::proto::trace::v1::ScopeSpans* scope_span = resource_span->add_scope_spans();
 
-  // set the instrumentation scope name and version
-  *scope_span->mutable_scope()->mutable_name() = "envoy";
-  *scope_span->mutable_scope()->mutable_version() = Envoy::VersionInfo::version();
+  if (set_instrumentation_scope_) {
+    // set the instrumentation scope name and version
+    *scope_span->mutable_scope()->mutable_name() = "envoy";
+    *scope_span->mutable_scope()->mutable_version() = Envoy::VersionInfo::version();
+  }
 
   for (const auto& pending_span : span_buffer_) {
     (*scope_span->add_spans()) = pending_span;

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -40,7 +40,7 @@ public:
   Tracer(OpenTelemetryTraceExporterPtr exporter, Envoy::TimeSource& time_source,
          Random::RandomGenerator& random, Runtime::Loader& runtime, Event::Dispatcher& dispatcher,
          OpenTelemetryTracerStats tracing_stats, const ResourceConstSharedPtr resource,
-         SamplerSharedPtr sampler, uint64_t max_cache_size);
+         SamplerSharedPtr sampler, uint64_t max_cache_size, bool set_instrumentation_scope = true);
 
   void sendSpan(::opentelemetry::proto::trace::v1::Span& span);
 
@@ -76,6 +76,7 @@ private:
   const ResourceConstSharedPtr resource_;
   SamplerSharedPtr sampler_;
   uint64_t max_cache_size_;
+  const bool set_instrumentation_scope_{true};
 };
 
 /**

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -271,6 +271,66 @@ TEST_F(OpenTelemetryDriverTest, PassSetServiceNameResourceAttributeDefaultTrue) 
   driver_ = std::make_unique<Driver>(opentelemetry_config, context_, mock_resource_provider);
 }
 
+// Verifies that set_instrumentation_scope=false omits scope name and version
+TEST_F(OpenTelemetryDriverTest, SetInstrumentationScopeFalse) {
+  const std::string yaml_string = R"EOF(
+    grpc_service:
+      envoy_grpc:
+        cluster_name: fake-cluster
+      timeout: 0.250s
+    set_instrumentation_scope: false
+    )EOF";
+  envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
+  TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
+
+  setup(opentelemetry_config);
+
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+
+  Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                             "test", {Tracing::Reason::Sampling, true});
+  EXPECT_NE(span, nullptr);
+
+  constexpr absl::string_view request_yaml = R"(
+resource_spans:
+  resource:
+    attributes:
+      key: "service.name"
+      value:
+        string_value: "unknown_service:envoy"
+      key: "key1"
+      value:
+        string_value: "val1"
+  scope_spans:
+    scope: {{}}
+    spans:
+      name: "test"
+      kind: SPAN_KIND_SERVER
+      start_time_unix_nano: {}
+      end_time_unix_nano: {}
+  )";
+  opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
+  SystemTime timestamp = time_system_.systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(Return(timestamp));
+
+  int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();
+
+  TestUtility::loadFromYaml(fmt::format(request_yaml, timestamp_ns, timestamp_ns), request_proto);
+  auto* expected_span =
+      request_proto.mutable_resource_spans(0)->mutable_scope_spans(0)->mutable_spans(0);
+  expected_span->set_trace_id(absl::HexStringToBytes(span->getTraceId()));
+  expected_span->set_span_id(absl::HexStringToBytes(span->getSpanId()));
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger("tracing.opentelemetry.min_flush_spans", 5U))
+      .WillRepeatedly(Return(1));
+  EXPECT_CALL(
+      *mock_client_,
+      sendRaw(_, _, Grpc::ProtoBufferEqIgnoreRepeatedFieldOrdering(request_proto), _, _, _));
+  span->finishSpan();
+  EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
+}
+
 // Verifies that the tracer cannot be configured with two exporters at the same time
 TEST_F(OpenTelemetryDriverTest, BothGrpcAndHttpExportersConfigured) {
   const std::string yaml_string = R"EOF(


### PR DESCRIPTION
Commit Message: otel: add option to disable instrumentation scope name and version

Additional Description:
Currently, the OpenTelemetry tracer always populates instrumentation scope metadata (`scope.name` = "envoy", `scope.version` = Envoy version).

We have a customer-facing user interface for viewing traces and we don't want to leak internal Envoy details of our product.

This PR introduces a new configuration option `set_instrumentation_scope` (default true) in `OpenTelemetryConfig` to allow opting-out of populating these scope metadata fields. When set to false, the scope name and version will be omitted from the scope spans.

The new behavior (omitting attributes) is default off to preserve backward compatibility.

Risk Level: Low
Testing:
- Unit tests in `test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc` have been added to verify that scope name and version are omitted when disabled.

Docs Changes: None.
Release Notes: Added a configuration option to disable populating instrumentation scope name and version in the OpenTelemetry tracer.
Platform Specific Features: None.
Runtime guard: None.

[Disclosed usage of generative AI: Yes, used to assist in code modifications.]