### PR TITLE
Reuse old SDS provider config when fetch timeout has changed

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -148,6 +148,7 @@ RUNTIME_GUARD(envoy_restart_features_raise_file_limits);
 RUNTIME_GUARD(envoy_restart_features_shared_cares_dns_resolver);
 RUNTIME_GUARD(envoy_restart_features_validate_http3_pseudo_headers);
 RUNTIME_GUARD(envoy_restart_features_worker_threads_watchdog_fix);
+RUNTIME_GUARD(envoy_reloadable_features_normalize_sds_config);
 // Begin false flags. Most of them should come with a TODO to flip true.
 
 // Sentinel and test flag.

--- a/source/common/secret/BUILD
+++ b/source/common/secret/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/ssl/tls_certificate_config.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/common/secret/sds_api.h"
 
 #include "absl/container/node_hash_map.h"
@@ -85,8 +86,22 @@ private:
                  const std::string& config_name,
                  Server::Configuration::ServerFactoryContext& server_context,
                  OptRef<Init::Manager> init_manager, bool warm) {
-      const std::string map_key =
-          absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
+      std::string map_key;
+      if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.normalize_sds_config")) {
+        // Normalize the config source before calculating the hash. initial_fetch_timeout does not
+        // affect selection of the secret provider. It is cleared and restored after
+        // calculating the hash.
+        // Since sds_config_source is passed as const, the constness must be casted away before
+        // modifying it.
+        auto* orig_initial_timeout =
+            const_cast<envoy::config::core::v3::ConfigSource&>(sds_config_source)
+                .release_initial_fetch_timeout();
+        map_key = absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
+        const_cast<envoy::config::core::v3::ConfigSource&>(sds_config_source)
+            .set_allocated_initial_fetch_timeout(orig_initial_timeout);
+      } else {
+        map_key = absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
+      }
 
       std::shared_ptr<SecretType> secret_provider = dynamic_secret_providers_[map_key].lock();
       if (!secret_provider) {

--- a/test/common/secret/BUILD
+++ b/test/common/secret/BUILD
@@ -23,6 +23,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         ":private_key_provider_proto_cc_proto",
+        "//source/common/runtime:runtime_features_lib",
         "//source/common/secret:sds_api_lib",
         "//source/common/secret:secret_manager_impl_lib",
         "//source/common/ssl:certificate_validation_context_config_impl_lib",

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -9,6 +9,7 @@
 #include "source/common/common/base64.h"
 #include "source/common/common/logger.h"
 #include "source/common/config/api_version.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/common/secret/sds_api.h"
 #include "source/common/secret/secret_manager_impl.h"
 #include "source/common/ssl/certificate_validation_context_config_impl.h"
@@ -1178,6 +1179,50 @@ TEST_F(SecretManagerImplTest, DeprecatedSanMatcher) {
   EXPECT_EQ("example.foo", cvc_config->subjectAltNameMatchers()[3].matcher().exact());
   EXPECT_EQ(envoy::extensions::transport_sockets::tls::v3::SubjectAltNameMatcher::IP_ADDRESS,
             cvc_config->subjectAltNameMatchers()[3].san_type());
+}
+
+// Verify the secret_provider does not change after changing the initial fetch timeout
+TEST_F(SecretManagerImplTest, NormalizeDynamicTlsCertificateSecretProviderConfig) {
+  for (const bool normalize_config : {true, false}) {
+    Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.normalize_sds_config",
+                                  normalize_config);
+
+    SecretManagerPtr secret_manager(new SecretManagerImpl(config_tracker_));
+
+    NiceMock<Server::Configuration::MockTransportSocketFactoryContext> secret_context;
+    NiceMock<LocalInfo::MockLocalInfo> local_info;
+    NiceMock<Event::MockDispatcher> dispatcher;
+    NiceMock<Init::MockManager> init_manager;
+    Init::TargetHandlePtr init_target_handle;
+    EXPECT_CALL(init_manager, add(_))
+        .WillRepeatedly(Invoke([&init_target_handle](const Init::Target& target) {
+          init_target_handle = target.createHandle("test");
+        }));
+    EXPECT_CALL(secret_context.server_context_, mainThreadDispatcher())
+        .WillRepeatedly(ReturnRef(dispatcher));
+    EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
+
+    envoy::config::core::v3::ConfigSource config_source;
+    TestUtility::loadFromYaml(R"(
+ads: {}
+initial_fetch_timeout: 5s
+    )", config_source);
+    auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
+        config_source, "abc.com", secret_context.server_context_, init_manager, true);
+
+    // Change only initial_fetch_timeout, which does not affect the identity of the SDS
+    // subscription.
+    config_source.mutable_initial_fetch_timeout()->set_seconds(
+        config_source.initial_fetch_timeout().seconds() + 1);
+    auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
+        config_source, "abc.com", secret_context.server_context_, init_manager, true);
+
+    if (normalize_config) {
+      EXPECT_EQ(secret_provider1, secret_provider2);
+    } else {
+      EXPECT_NE(secret_provider1, secret_provider2);
+    }
+  }
 }
 
 } // namespace


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: 
Reuse old SDS provider config when fetch timeout has changed.
Additional Description: 
If the initial fetch config is changed for SDS config provider, the listener will fail to warm and cause connection failures until Envoy is restarted.

Risk Level:
low 
Testing:
Added unit test
[Runtime guard: envoy_reloadable_features_normalize_sds_config]
[Fixes #Issue: #46155]
