### PR TITLE
Update QUICHE from 02cb2a7d5 to 7a02e7746

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -321,7 +321,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-07-09"
+  release_date: "2026-07-15"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -569,8 +569,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "02cb2a7d57669ee66cffaefb5f57a2410b755205",
-        sha256 = "f694414b20cabbc495b61c797e44f276226f9a9da9955fd1c07c7aff9d159f68",
+        version = "7a02e774630152a6f67f12458f9545ae3dabfc9b",
+        sha256 = "529c4b61254429e2953a8944ff6fd7583aacafe07a5e7e5b19f74fb17cf26394",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/02cb2a7d5..7a02e7746

```
$ git log 02cb2a7d5..7a02e7746 --date=short --no-merges --format="%ad %al %s"

2026-07-15 dschinazi OHTTP key config: maintain ordering
2026-07-14 vasilvv Turn `buffered_reset_stream_at_` into a heap-allocated object, since it's used infrequently.
2026-07-14 dschinazi masque_tcp_server: add post-quantum support
2026-07-14 dschinazi OHTTP key config: use first supported key config
2026-07-14 dschinazi masque_tcp_server: create one gateway per request
2026-07-13 quiche-dev Enabling rolled out flags.
2026-07-13 rch Avoid Use-After-Free in QuicSession::OnFinalByteOffsetReceived. Fixes crbug.com/519347100 based on patch from vmiura@google.com.
2026-07-13 asedeno Fis OSS QUICHE build.
2026-07-13 apaseltiner Simplify operator== for Structured Headers types
2026-07-13 dschinazi masque_tcp_server: some more no-op refactor
2026-07-10 dschinazi OHTTP: add ability to get ObliviousHttpHeaderKeyConfig from ObliviousHttpKeyConfigs
2026-07-10 dschinazi OHTTP key config: expose underlying objects
2026-07-10 dschinazi masque_tcp_server: no-op cleanup of OHTTP code
2026-07-10 dschinazi OHTTP key config: add support for media types
2026-07-09 vasilvv Make `busy_counter_` only present in debug builds.
2026-07-09 dschinazi OHTTP key config: add support for more crypto algorithms
2026-07-09 dschinazi OHTTP key config: add ability to write length prefix
2026-07-09 dschinazi OHTTP key config: allow parsing RFC 9458 length prefixes
```

Risk Level: low
Testing: CI
