### PR TITLE
grpc: migrates TypedAsyncClient to ArenaWrappedProto

### DIFF
--- a/contrib/sip_proxy/filters/network/source/conn_manager.h
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.h
@@ -364,7 +364,6 @@ private:
   Network::ReadFilterCallbacks* read_callbacks_{};
 
   DecoderPtr decoder_;
-  absl::flat_hash_map<std::string, ActiveTransPtr> transactions_;
   Buffer::OwnedImpl request_buffer_;
   Random::RandomGenerator& random_generator_;
   TimeSource& time_source_;
@@ -375,6 +374,7 @@ private:
   // This is used in Router, put here to pass to Router
   std::shared_ptr<Router::TransactionInfos> transaction_infos_;
   PendingList pending_list_;
+  absl::flat_hash_map<std::string, ActiveTransPtr> transactions_;
 };
 
 } // namespace SipProxy

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.cc
@@ -161,11 +161,7 @@ void GrpcClientImpl::sendRequest(
   // Already invoke `onFailure` asynchronously, no need to call it explicitly here.
 }
 
-void GrpcClientImpl::onSuccess(
-    std::unique_ptr<
-        envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-        response,
-    Tracing::Span& span) {
+void GrpcClientImpl::onSuccess(TraServiceResponsePtr&& response, Tracing::Span& span) {
 
   UNREFERENCED_PARAMETER(span);
   if (response->has_create_response()) {
@@ -189,10 +185,7 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::strin
   // callbacks_ = nullptr;
 }
 
-void GrpcClientImpl::onReceiveMessage(
-    std::unique_ptr<
-        envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-        message) {
+void GrpcClientImpl::onReceiveMessage(TraServiceResponsePtr&& message) {
   callbacks_->complete(ResponseType::SubscribeResp, message->type(), message->subscribe_response());
   // callbacks_ = nullptr;
 }

--- a/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
+++ b/contrib/sip_proxy/filters/network/source/tra/tra_impl.h
@@ -30,6 +30,8 @@ using TrafficRoutingAssistantAsyncRequestCallbacks = Grpc::AsyncRequestCallbacks
     envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>;
 using TrafficRoutingAssistantAsyncStreamCallbacks = Grpc::AsyncStreamCallbacks<
     envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>;
+using TraServiceResponsePtr = Grpc::ResponsePtr<
+    envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>;
 
 // TODO: We should have only one client per thread, but today we create one per filter stack.
 // This will require support for more than one outstanding request per client.
@@ -67,19 +69,12 @@ public:
 
   // Grpc::AsyncRequestCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-  void
-  onSuccess(std::unique_ptr<
-                envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-                response,
-            Tracing::Span& span) override;
+  void onSuccess(TraServiceResponsePtr&& response, Tracing::Span& span) override;
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                  Tracing::Span& span) override;
 
   // Grpc::AsyncStreamCallbacks
-  void onReceiveMessage(
-      std::unique_ptr<
-          envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-          message) override;
+  void onReceiveMessage(TraServiceResponsePtr&& message) override;
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&& metadata) override {
     UNREFERENCED_PARAMETER(metadata);
   }
@@ -110,11 +105,7 @@ private:
     void onCreateInitialMetadata(Http::RequestHeaderMap& data) override {
       return parent_.onCreateInitialMetadata(data);
     }
-    void onSuccess(
-        std::unique_ptr<
-            envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-            response,
-        Tracing::Span& span) override {
+    void onSuccess(TraServiceResponsePtr&& response, Tracing::Span& span) override {
       parent_.onSuccess(std::move(response), span);
       cleanup();
     }
@@ -148,10 +139,7 @@ private:
     void onCreateInitialMetadata(Http::RequestHeaderMap& data) override {
       return parent_.onCreateInitialMetadata(data);
     }
-    void onReceiveMessage(
-        std::unique_ptr<
-            envoy::extensions::filters::network::sip_proxy::tra::v3alpha::TraServiceResponse>&&
-            message) override {
+    void onReceiveMessage(TraServiceResponsePtr&& message) override {
       parent_.onReceiveMessage(std::move(message));
     }
     void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&& metadata) override {

--- a/envoy/config/BUILD
+++ b/envoy/config/BUILD
@@ -70,8 +70,8 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//envoy/upstream:load_stats_reporter_interface",
         "//source/common/common:cleanup_lib",
-        "//source/common/protobuf:arena_wrapped_proto_lib",
         "//source/common/protobuf",
+        "//source/common/protobuf:arena_wrapped_proto_lib",
     ],
 )
 

--- a/envoy/config/BUILD
+++ b/envoy/config/BUILD
@@ -70,6 +70,7 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//envoy/upstream:load_stats_reporter_interface",
         "//source/common/common:cleanup_lib",
+        "//source/common/protobuf:arena_wrapped_proto_lib",
         "//source/common/protobuf",
     ],
 )

--- a/envoy/config/grpc_mux.h
+++ b/envoy/config/grpc_mux.h
@@ -13,6 +13,7 @@
 #include "envoy/upstream/load_stats_reporter.h"
 
 #include "source/common/common/cleanup.h"
+#include "source/common/protobuf/arena_wrapped_proto.h"
 #include "source/common/protobuf/protobuf.h"
 
 namespace Envoy {
@@ -145,7 +146,7 @@ public:
 using GrpcMuxPtr = std::unique_ptr<GrpcMux>;
 using GrpcMuxSharedPtr = std::shared_ptr<GrpcMux>;
 
-template <class ResponseProto> using ResponseProtoPtr = std::unique_ptr<ResponseProto>;
+template <class ResponseProto> using ResponseProtoPtr = ArenaWrappedProto<ResponseProto>;
 /**
  * A grouping of callbacks that a GrpcMux should provide to its GrpcStream.
  */

--- a/source/common/config/null_grpc_mux_impl.h
+++ b/source/common/config/null_grpc_mux_impl.h
@@ -42,7 +42,7 @@ public:
   void onWriteable() override {}
   void onStreamEstablished() override {}
   void onEstablishmentFailure(bool) override {}
-  void onDiscoveryResponse(std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&&,
+  void onDiscoveryResponse(ResponseProtoPtr<envoy::service::discovery::v3::DiscoveryResponse>&&,
                            ControlPlaneStats&) override {}
 };
 

--- a/source/common/grpc/BUILD
+++ b/source/common/grpc/BUILD
@@ -25,6 +25,7 @@ envoy_cc_library(
         "//envoy/stream_info:stream_info_interface",
         "//source/common/buffer:zero_copy_input_stream_lib",
         "//source/common/http:async_client_lib",
+        "//source/common/protobuf:arena_wrapped_proto_lib",
     ],
 )
 

--- a/source/common/grpc/typed_async_client.cc
+++ b/source/common/grpc/typed_async_client.cc
@@ -15,16 +15,13 @@ void sendMessageUntyped(RawAsyncStream* stream, const Protobuf::Message& request
   stream->sendMessageRaw(Common::serializeMessage(request), end_stream);
 }
 
-ProtobufTypes::MessagePtr parseMessageUntyped(ProtobufTypes::MessagePtr&& message,
-                                              Buffer::InstancePtr&& response) {
+bool parseMessageUntyped(Protobuf::Message& message, Buffer::InstancePtr&& response) {
   // TODO(htuch): Need to add support for compressed responses as well here.
   if (response->length() > 0) {
     Buffer::ZeroCopyInputStreamImpl stream(std::move(response));
-    if (!message->ParseFromZeroCopyStream(&stream)) {
-      return nullptr;
-    }
+    return message.ParseFromZeroCopyStream(&stream);
   }
-  return std::move(message);
+  return true;
 }
 
 RawAsyncStream* startUntyped(RawAsyncClient* client,

--- a/source/common/grpc/typed_async_client.h
+++ b/source/common/grpc/typed_async_client.h
@@ -6,6 +6,7 @@
 #include "envoy/grpc/async_client.h"
 
 #include "source/common/common/empty_string.h"
+#include "source/common/protobuf/arena_wrapped_proto.h"
 
 namespace Envoy {
 namespace Grpc {
@@ -15,8 +16,7 @@ namespace Internal {
  * Forward declarations for helper functions.
  */
 void sendMessageUntyped(RawAsyncStream* stream, const Protobuf::Message& request, bool end_stream);
-ProtobufTypes::MessagePtr parseMessageUntyped(ProtobufTypes::MessagePtr&& message,
-                                              Buffer::InstancePtr&& response);
+bool parseMessageUntyped(Protobuf::Message& message, Buffer::InstancePtr&& response);
 RawAsyncStream* startUntyped(RawAsyncClient* client,
                              const Protobuf::MethodDescriptor& service_method,
                              RawAsyncStreamCallbacks& callbacks,
@@ -65,7 +65,7 @@ private:
   RawAsyncStream* stream_{};
 };
 
-template <typename Response> using ResponsePtr = std::unique_ptr<Response>;
+template <typename Response> using ResponsePtr = ArenaWrappedProto<Response>;
 
 /**
  * Convenience subclasses for AsyncRequestCallbacks.
@@ -77,10 +77,8 @@ public:
 
 private:
   void onSuccessRaw(Buffer::InstancePtr&& response, Tracing::Span& span) override {
-    auto message = ResponsePtr<Response>(Envoy::Protobuf::DynamicCastMessage<Response>(
-        Internal::parseMessageUntyped(std::make_unique<Response>(), std::move(response))
-            .release()));
-    if (!message) {
+    ResponsePtr<Response> message;
+    if (!Internal::parseMessageUntyped(*message, std::move(response))) {
       onFailure(Status::WellKnownGrpcStatus::Internal, "", span);
       return;
     }
@@ -98,10 +96,8 @@ public:
 
 private:
   bool onReceiveMessageRaw(Buffer::InstancePtr&& response) override {
-    auto message = ResponsePtr<Response>(Envoy::Protobuf::DynamicCastMessage<Response>(
-        Internal::parseMessageUntyped(std::make_unique<Response>(), std::move(response))
-            .release()));
-    if (!message) {
+    ResponsePtr<Response> message;
+    if (!Internal::parseMessageUntyped(*message, std::move(response))) {
       return false;
     }
     onReceiveMessage(std::move(message));

--- a/source/common/protobuf/arena_wrapped_proto.h
+++ b/source/common/protobuf/arena_wrapped_proto.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+#include <memory>
 #include <utility>
 
 #include "envoy/common/optref.h"
@@ -44,6 +46,29 @@ public:
   }
 
   ~ArenaWrappedProto() = default; // Destructor of arena_ frees proto_ automatically.
+
+  // Allow construction from nullptr.
+  ArenaWrappedProto(std::nullptr_t) : arena_(nullptr), proto_(nullptr) {}
+
+  // Conversion constructor from std::unique_ptr.
+  // This is implicit to facilitate migration from std::unique_ptr to ArenaWrappedProto.
+  ArenaWrappedProto(std::unique_ptr<ProtoT>&& heap_proto) {
+    if (heap_proto) {
+      arena_ = std::make_unique<google::protobuf::Arena>();
+      proto_ = google::protobuf::Arena::Create<ProtoT>(arena_.get());
+      proto_->Swap(heap_proto.get());
+    } else {
+      arena_ = nullptr;
+      proto_ = nullptr;
+    }
+  }
+
+  // Boolean conversion (e.g., if (wrapper))
+  explicit operator bool() const { return proto_ != nullptr; }
+
+  // Comparison with nullptr.
+  bool operator==(std::nullptr_t) const { return proto_ == nullptr; }
+  bool operator!=(std::nullptr_t) const { return proto_ != nullptr; }
 
   // --- Transparent Accessors ---
 

--- a/source/common/upstream/health_discovery_service.cc
+++ b/source/common/upstream/health_discovery_service.cc
@@ -232,7 +232,7 @@ HdsDelegate::createHdsCluster(const envoy::config::cluster::v3::Cluster& cluster
 }
 
 absl::Status HdsDelegate::processMessage(
-    std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier>&& message) {
+    Grpc::ResponsePtr<envoy::service::health::v3::HealthCheckSpecifier>&& message) {
   ENVOY_LOG(debug, "New health check response message {} ", message->DebugString());
   ASSERT(message);
   std::vector<HdsClusterPtr> hds_clusters;
@@ -292,7 +292,7 @@ absl::Status HdsDelegate::processMessage(
 }
 
 void HdsDelegate::onReceiveMessage(
-    std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier>&& message) {
+    Grpc::ResponsePtr<envoy::service::health::v3::HealthCheckSpecifier>&& message) {
   stats_.requests_.inc();
   ENVOY_LOG(debug, "New health check response message {} ", message->DebugString());
 

--- a/source/common/upstream/health_discovery_service.h
+++ b/source/common/upstream/health_discovery_service.h
@@ -17,6 +17,7 @@
 #include "source/common/common/macros.h"
 #include "source/common/config/utility.h"
 #include "source/common/grpc/async_client_impl.h"
+#include "source/common/grpc/typed_async_client.h"
 #include "source/common/network/resolver_impl.h"
 #include "source/common/upstream/health_checker_impl.h"
 #include "source/common/upstream/locality_endpoint.h"
@@ -144,7 +145,7 @@ public:
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&& metadata) override;
   void onReceiveMessage(
-      std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier>&& message) override;
+      Grpc::ResponsePtr<envoy::service::health::v3::HealthCheckSpecifier>&& message) override;
   void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&& metadata) override;
   void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
   envoy::service::health::v3::HealthCheckRequestOrEndpointHealthResponse sendResponse();
@@ -160,7 +161,7 @@ private:
   // Establishes a connection with the management server
   void establishNewStream();
   absl::Status
-  processMessage(std::unique_ptr<envoy::service::health::v3::HealthCheckSpecifier>&& message);
+  processMessage(Grpc::ResponsePtr<envoy::service::health::v3::HealthCheckSpecifier>&& message);
   envoy::config::cluster::v3::Cluster
   createClusterConfig(const envoy::service::health::v3::ClusterHealthCheck& cluster_health_check);
   absl::Status updateHdsCluster(HdsClusterPtr cluster,

--- a/source/common/upstream/load_stats_reporter_impl.cc
+++ b/source/common/upstream/load_stats_reporter_impl.cc
@@ -263,7 +263,7 @@ void LoadStatsReporterImpl::onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&
 }
 
 void LoadStatsReporterImpl::onReceiveMessage(
-    std::unique_ptr<envoy::service::load_stats::v3::LoadStatsResponse>&& message) {
+    Grpc::ResponsePtr<envoy::service::load_stats::v3::LoadStatsResponse>&& message) {
   ENVOY_LOG(debug, "New load report epoch: {}", message->DebugString());
   message_ = std::move(message);
   startLoadReportPeriod();

--- a/source/common/upstream/load_stats_reporter_impl.h
+++ b/source/common/upstream/load_stats_reporter_impl.h
@@ -53,7 +53,7 @@ public:
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&& metadata) override;
   void onReceiveMessage(
-      std::unique_ptr<envoy::service::load_stats::v3::LoadStatsResponse>&& message) override;
+      Grpc::ResponsePtr<envoy::service::load_stats::v3::LoadStatsResponse>&& message) override;
   void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&& metadata) override;
   void onRemoteClose(Grpc::Status::GrpcStatus status, const std::string& message) override;
 
@@ -80,7 +80,7 @@ private:
   Event::TimerPtr retry_timer_;
   Event::TimerPtr response_timer_;
   const envoy::service::load_stats::v3::LoadStatsRequest request_template_;
-  std::unique_ptr<envoy::service::load_stats::v3::LoadStatsResponse> message_;
+  Grpc::ResponsePtr<envoy::service::load_stats::v3::LoadStatsResponse> message_{nullptr};
   // Map from cluster name to start of measurement interval.
   absl::node_hash_map<std::string, std::chrono::steady_clock::duration> clusters_;
   TimeSource& time_source_;

--- a/source/extensions/access_loggers/common/grpc_access_logger_clients.h
+++ b/source/extensions/access_loggers/common/grpc_access_logger_clients.h
@@ -99,7 +99,7 @@ public:
     // Grpc::AsyncStreamCallbacks
     void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
     void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-    void onReceiveMessage(std::unique_ptr<LogResponse>&&) override {}
+    void onReceiveMessage(Grpc::ResponsePtr<LogResponse>&&) override {}
     void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
     void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {
       ASSERT(parent_.stream_ != nullptr);

--- a/source/extensions/config_subscription/grpc/grpc_mux_failover.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_failover.h
@@ -395,7 +395,7 @@ private:
   // the class will no longer need to extend the interface, and these can be removed.
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override { PANIC("not implemented"); }
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override { PANIC("not implemented"); }
-  void onReceiveMessage(std::unique_ptr<ResponseType>&&) override { PANIC("not implemented"); }
+  void onReceiveMessage(Grpc::ResponsePtr<ResponseType>&&) override { PANIC("not implemented"); }
   void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {
     PANIC("not implemented");
   }

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
@@ -361,7 +361,7 @@ ScopedResume GrpcMuxImpl::pause(const std::vector<std::string> type_urls) {
 }
 
 void GrpcMuxImpl::onDiscoveryResponse(
-    std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
+    ResponseProtoPtr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
     ControlPlaneStats& control_plane_stats) {
   const std::string type_url = message->type_url();
   ENVOY_LOG(debug, "Received gRPC message for {} at version {}", type_url, message->version_info());

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.h
@@ -83,14 +83,11 @@ public:
   Upstream::LoadStatsReporter* maybeCreateLoadStatsReporter() override;
   Upstream::LoadStatsReporter* loadStatsReporter() const override;
 
-  void handleDiscoveryResponse(
-      std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&& message);
-
   // Config::GrpcStreamCallbacks
   void onStreamEstablished() override;
   void onEstablishmentFailure(bool) override;
   void
-  onDiscoveryResponse(std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
+  onDiscoveryResponse(ResponseProtoPtr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
                       ControlPlaneStats& control_plane_stats) override;
   void onWriteable() override;
 

--- a/source/extensions/config_subscription/grpc/grpc_stream.h
+++ b/source/extensions/config_subscription/grpc/grpc_stream.h
@@ -17,7 +17,7 @@
 namespace Envoy {
 namespace Config {
 
-template <class ResponseProto> using ResponseProtoPtr = std::unique_ptr<ResponseProto>;
+template <class ResponseProto> using ResponseProtoPtr = Grpc::ResponsePtr<ResponseProto>;
 
 // Oversees communication for gRPC xDS implementations (parent to both regular xDS and delta
 // xDS variants). Reestablishes the gRPC channel when necessary, and provides rate limiting of

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.cc
@@ -155,7 +155,7 @@ ScopedResume NewGrpcMuxImpl::pause(const std::vector<std::string> type_urls) {
 }
 
 void NewGrpcMuxImpl::onDiscoveryResponse(
-    std::unique_ptr<envoy::service::discovery::v3::DeltaDiscoveryResponse>&& message,
+    ResponseProtoPtr<envoy::service::discovery::v3::DeltaDiscoveryResponse>&& message,
     ControlPlaneStats& control_plane_stats) {
   ENVOY_LOG(debug, "Received DeltaDiscoveryResponse for {} at version {}", message->type_url(),
             message->system_version_info());

--- a/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/new_grpc_mux_impl.h
@@ -64,7 +64,7 @@ public:
   ScopedResume pause(const std::vector<std::string> type_urls) override;
 
   void onDiscoveryResponse(
-      std::unique_ptr<envoy::service::discovery::v3::DeltaDiscoveryResponse>&& message,
+      ResponseProtoPtr<envoy::service::discovery::v3::DeltaDiscoveryResponse>&& message,
       ControlPlaneStats& control_plane_stats) override;
 
   void onStreamEstablished() override;

--- a/source/extensions/config_subscription/grpc/xds_mux/grpc_mux_impl.h
+++ b/source/extensions/config_subscription/grpc/xds_mux/grpc_mux_impl.h
@@ -99,7 +99,7 @@ public:
     handleStreamEstablishmentFailure(next_attempt_may_send_initial_resource_version);
   }
   void onWriteable() override { trySendDiscoveryRequests(); }
-  void onDiscoveryResponse(std::unique_ptr<RS>&& message,
+  void onDiscoveryResponse(ResponseProtoPtr<RS>&& message,
                            ControlPlaneStats& control_plane_stats) override {
     genericHandleResponse(message->type_url(), *message, control_plane_stats);
   }

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -105,8 +105,8 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
   request_ = async_client_->send(service_method_, request, *this, parent_span, options);
 }
 
-void GrpcClientImpl::onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckResponse>&& response,
-                               Tracing::Span& span) {
+void GrpcClientImpl::onSuccess(
+    Grpc::ResponsePtr<envoy::service::auth::v3::CheckResponse>&& response, Tracing::Span& span) {
   ENVOY_LOG(trace, "Received CheckResponse: {}", response->DebugString());
   ResponsePtr authz_response = std::make_unique<Response>(Response{});
   authz_response->grpc_status = response->status().code();

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
@@ -57,7 +57,7 @@ public:
 
   // Grpc::AsyncRequestCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-  void onSuccess(std::unique_ptr<envoy::service::auth::v3::CheckResponse>&& response,
+  void onSuccess(Grpc::ResponsePtr<envoy::service::auth::v3::CheckResponse>&& response,
                  Tracing::Span& span) override;
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                  Tracing::Span& span) override;

--- a/source/extensions/filters/common/ext_proc/grpc_client.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "source/common/grpc/typed_async_client.h"
 #include "source/common/http/sidestream_watermark.h"
 #include "source/extensions/filters/common/ext_proc/client_base.h"
 
@@ -17,7 +18,7 @@ namespace ExternalProcessing {
 template <typename ResponseType> class ProcessorCallbacks : public RequestCallbacks<ResponseType> {
 public:
   ~ProcessorCallbacks() override = default;
-  virtual void onReceiveMessage(std::unique_ptr<ResponseType>&& response) PURE;
+  virtual void onReceiveMessage(Grpc::ResponsePtr<ResponseType>&& response) PURE;
   virtual void onGrpcError(Grpc::Status::GrpcStatus error, const std::string& message) PURE;
   virtual void onGrpcClose() PURE;
   virtual void logStreamInfo() PURE;

--- a/source/extensions/filters/common/ext_proc/grpc_client_impl.h
+++ b/source/extensions/filters/common/ext_proc/grpc_client_impl.h
@@ -56,7 +56,7 @@ public:
   }
 
   // AsyncStreamCallbacks
-  void onReceiveMessage(std::unique_ptr<ResponseType>&& message) override;
+  void onReceiveMessage(Grpc::ResponsePtr<ResponseType>&& message) override;
 
   // RawAsyncStreamCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
@@ -165,7 +165,7 @@ bool ProcessorStreamImpl<RequestType, ResponseType>::halfCloseAndDeleteOnRemoteC
 
 template <typename RequestType, typename ResponseType>
 void ProcessorStreamImpl<RequestType, ResponseType>::onReceiveMessage(
-    std::unique_ptr<ResponseType>&& response) {
+    Grpc::ResponsePtr<ResponseType>&& response) {
   if (!callbacks_.has_value()) {
     ENVOY_LOG(debug, "Underlying filter object has been destroyed.");
     return;

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -98,7 +98,7 @@ void GrpcClientImpl::limit(RequestCallbacks& callbacks, const std::string& domai
 }
 
 void GrpcClientImpl::onSuccess(
-    std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse>&& response,
+    Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>&& response,
     Tracing::Span& span) {
   LimitStatus status = LimitStatus::OK;
   ASSERT(response->overall_code() != envoy::service::ratelimit::v3::RateLimitResponse::UNKNOWN);

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.h
@@ -63,7 +63,7 @@ public:
 
   // Grpc::AsyncRequestCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
-  void onSuccess(std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse>&& response,
+  void onSuccess(Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>&& response,
                  Tracing::Span& span) override;
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                  Tracing::Span& span) override;

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -716,7 +716,7 @@ void Filter::sendRequest(const ProcessorState& state, ProcessingRequest&& req, b
 
 void Filter::onComplete(ProcessingResponse& response) {
   ENVOY_STREAM_LOG(debug, "Received successful response from server", *decoder_callbacks_);
-  auto resp_ptr = std::make_unique<ProcessingResponse>(response);
+  auto resp_ptr = Grpc::ResponsePtr<ProcessingResponse>(response);
   onReceiveMessage(std::move(resp_ptr));
 }
 
@@ -1788,7 +1788,7 @@ void Filter::closeGrpcStreamIfLastRespReceived(const ProcessingResponse& respons
   }
 }
 
-void Filter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& r) {
+void Filter::onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& r) {
 
   if (config_->observabilityMode()) {
     ENVOY_STREAM_LOG(trace, "Ignoring received message when observability mode is enabled",

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -560,7 +560,7 @@ public:
   // ExternalProcessorCallbacks
   void handleErrorResponse(absl::Status processing_status);
   void onReceiveMessage(
-      std::unique_ptr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) override;
+      Grpc::ResponsePtr<envoy::service::ext_proc::v3::ProcessingResponse>&& response) override;
   void onGrpcError(Grpc::Status::GrpcStatus error, const std::string& message) override;
   void onGrpcClose() override;
   void onGrpcCloseWithStatus(Grpc::Status::GrpcStatus status);

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
@@ -271,7 +271,7 @@ createTokenBucketFromAction(const RateLimitStrategy& strategy, TimeSource& time_
 }
 
 void GlobalRateLimitClientImpl::onReceiveMessage(RateLimitQuotaResponsePtr&& response) {
-  if (response == nullptr) {
+  if (!response) {
     return;
   }
   main_dispatcher_.post(

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -37,7 +37,7 @@ using GrpcAsyncClient =
     Grpc::AsyncClient<envoy::service::rate_limit_quota::v3::RateLimitQuotaUsageReports,
                       envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse>;
 using RateLimitQuotaResponsePtr =
-    std::unique_ptr<envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse>;
+    Grpc::ResponsePtr<envoy::service::rate_limit_quota::v3::RateLimitQuotaResponse>;
 
 // Callbacks to trigger when the main thread finishes executing a queued
 // operation. Primarily used for testing.

--- a/source/extensions/filters/network/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/network/ext_proc/ext_proc.cc
@@ -342,7 +342,7 @@ void NetworkExtProcFilter::sendRequest(Buffer::Instance& data, bool end_stream, 
   data.drain(data.length());
 }
 
-void NetworkExtProcFilter::onReceiveMessage(std::unique_ptr<ProcessingResponse>&& res) {
+void NetworkExtProcFilter::onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& res) {
   if (processing_complete_) {
     ENVOY_CONN_LOG(debug, "Ignoring response message: processing already completed",
                    read_callbacks_->connection());

--- a/source/extensions/filters/network/ext_proc/ext_proc.h
+++ b/source/extensions/filters/network/ext_proc/ext_proc.h
@@ -12,6 +12,7 @@
 #include "envoy/network/filter.h"
 #include "envoy/service/network_ext_proc/v3/network_external_processor.pb.h"
 
+#include "source/common/grpc/typed_async_client.h"
 #include "source/extensions/filters/network/ext_proc/client_impl.h"
 
 #include "absl/container/flat_hash_set.h"
@@ -223,7 +224,7 @@ public:
   void updateCloseCallbackStatus(bool enable, bool is_read);
 
   // ExternalProcessorCallbacks
-  void onReceiveMessage(std::unique_ptr<ProcessingResponse>&& res) override;
+  void onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& res) override;
   void onGrpcClose() override;
   void onGrpcError(Grpc::Status::GrpcStatus error, const std::string& message) override;
   void logStreamInfo() override {};

--- a/source/extensions/filters/network/redis_proxy/external_auth.cc
+++ b/source/extensions/filters/network/redis_proxy/external_auth.cc
@@ -68,7 +68,7 @@ void GrpcExternalAuthClient::authenticateExternal(AuthenticateCallback& callback
 
 // Callback method called when the request is successful.
 void GrpcExternalAuthClient::onSuccess(
-    std::unique_ptr<envoy::service::redis_auth::v3::RedisProxyExternalAuthResponse>&& response,
+    Grpc::ResponsePtr<envoy::service::redis_auth::v3::RedisProxyExternalAuthResponse>&& response,
     Tracing::Span& span) {
   ENVOY_LOG(trace, "Received response for external Redis authentication. Status: {}",
             response->status().code());

--- a/source/extensions/filters/network/redis_proxy/external_auth.h
+++ b/source/extensions/filters/network/redis_proxy/external_auth.h
@@ -121,7 +121,7 @@ public:
   // Grpc::AsyncRequestCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
   void onSuccess(
-      std::unique_ptr<envoy::service::redis_auth::v3::RedisProxyExternalAuthResponse>&& response,
+      Grpc::ResponsePtr<envoy::service::redis_auth::v3::RedisProxyExternalAuthResponse>&& response,
       Tracing::Span& span) override;
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                  Tracing::Span& span) override;

--- a/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
+++ b/source/extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h
@@ -45,7 +45,7 @@ public:
   // Grpc::AsyncStreamCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap&) override {}
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-  void onReceiveMessage(std::unique_ptr<ResponseProto>&&) override {}
+  void onReceiveMessage(Grpc::ResponsePtr<ResponseProto>&&) override {}
   void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
   void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override {};
 

--- a/source/extensions/tracers/skywalking/trace_segment_reporter.h
+++ b/source/extensions/tracers/skywalking/trace_segment_reporter.h
@@ -30,7 +30,7 @@ public:
   // Grpc::AsyncStreamCallbacks
   void onCreateInitialMetadata(Http::RequestHeaderMap& metadata) override;
   void onReceiveInitialMetadata(Http::ResponseHeaderMapPtr&&) override {}
-  void onReceiveMessage(std::unique_ptr<skywalking::v3::Commands>&&) override {}
+  void onReceiveMessage(Grpc::ResponsePtr<skywalking::v3::Commands>&&) override {}
   void onReceiveTrailingMetadata(Http::ResponseTrailerMapPtr&&) override {}
   void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override;
 

--- a/test/common/upstream/hds_test.cc
+++ b/test/common/upstream/hds_test.cc
@@ -1261,7 +1261,8 @@ TEST_F(HdsTest, TestCustomHealthCheckPortWhenUpdate) {
 
   // Process message
   EXPECT_CALL(*test_factory_, createClusterInfo(_)).WillOnce(Return(cluster_info_));
-  hds_delegate_friend_.processPrivateMessage(*hds_delegate_, std::move(message));
+  auto message_copy = std::make_unique<envoy::service::health::v3::HealthCheckSpecifier>(*message);
+  hds_delegate_friend_.processPrivateMessage(*hds_delegate_, std::move(message_copy));
 
   for (int i = 0; i < 3; i++) {
     auto& host =

--- a/test/extensions/config_subscription/grpc/grpc_stream_test.cc
+++ b/test/extensions/config_subscription/grpc/grpc_stream_test.cc
@@ -248,7 +248,7 @@ TEST_F(GrpcStreamTest, ReceiveMessage) {
   envoy::service::discovery::v3::DiscoveryResponse received_message;
   EXPECT_CALL(callbacks_, onDiscoveryResponse(_, _))
       .WillOnce([&received_message](
-                    std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
+                    ResponseProtoPtr<envoy::service::discovery::v3::DiscoveryResponse>&& message,
                     ControlPlaneStats&) { received_message = *message; });
   grpc_stream_->onReceiveMessage(std::move(response));
   EXPECT_TRUE(TestUtility::protoEqual(response_copy, received_message));

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -66,7 +66,7 @@ public:
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationOk) {
   initialize();
 
-  auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  auto check_response = CheckResponsePtr();
   auto status = check_response->mutable_status();
 
   Protobuf::Struct expected_dynamic_metadata;
@@ -177,7 +177,7 @@ TEST_F(ExtAuthzGrpcClientTest, IndifferentToInvalidHeaders) {
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationDenied) {
   initialize();
 
-  auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  auto check_response = CheckResponsePtr();
   auto status = check_response->mutable_status();
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::PermissionDenied;
   status->set_code(grpc_status);
@@ -203,7 +203,7 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationDenied) {
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationDeniedGrpcUnknownStatus) {
   initialize();
 
-  auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  auto check_response = CheckResponsePtr();
   auto status = check_response->mutable_status();
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Unknown;
   status->set_code(grpc_status);
@@ -446,7 +446,7 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationErrorNoAttributes) {
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithDynamicMetadata) {
   initialize();
 
-  auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  auto check_response = CheckResponsePtr();
   auto status = check_response->mutable_status();
 
   Protobuf::Struct expected_dynamic_metadata;
@@ -487,7 +487,7 @@ TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithDynamicMetadata) {
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkWithQueryParameters) {
   initialize();
 
-  auto check_response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  auto check_response = CheckResponsePtr();
   auto status = check_response->mutable_status();
 
   const auto grpc_status = Grpc::Status::WellKnownGrpcStatus::Ok;
@@ -582,8 +582,7 @@ ok_response:
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
                                       AuthzOkResponse(expected_authz_response))));
-  client_->onSuccess(std::make_unique<envoy::service::auth::v3::CheckResponse>(check_response),
-                     span_);
+  client_->onSuccess(CheckResponsePtr(std::move(check_response)), span_);
 }
 
 TEST_F(ExtAuthzGrpcClientTest, AuthorizationOkUpstreamHeaderMutations) {
@@ -631,8 +630,7 @@ ok_response:
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
                                       AuthzOkResponse(expected_authz_response))));
-  client_->onSuccess(std::make_unique<envoy::service::auth::v3::CheckResponse>(check_response),
-                     span_);
+  client_->onSuccess(CheckResponsePtr(std::move(check_response)), span_);
 }
 
 // TODO(https://github.com/envoyproxy/envoy/issues/45003)
@@ -674,8 +672,7 @@ ok_response:
   EXPECT_CALL(span_, setTag(Eq("ext_authz_status"), Eq("ext_authz_ok")));
   EXPECT_CALL(request_callbacks_, onComplete_(WhenDynamicCastTo<ResponsePtr&>(
                                       AuthzOkResponse(expected_authz_response))));
-  client_->onSuccess(std::make_unique<envoy::service::auth::v3::CheckResponse>(check_response),
-                     span_);
+  client_->onSuccess(CheckResponsePtr(std::move(check_response)), span_);
 }
 
 } // namespace ExtAuthz

--- a/test/extensions/filters/common/ext_authz/test_common.cc
+++ b/test/extensions/filters/common/ext_authz/test_common.cc
@@ -45,7 +45,7 @@ CheckResponsePtr TestCommon::makeCheckResponse(Grpc::Status::GrpcStatus response
                                                const std::string& body,
                                                const HeaderValueOptionVector& headers,
                                                const HeaderValueOptionVector& downstream_headers) {
-  auto response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  CheckResponsePtr response;
   auto status = response->mutable_status();
   status->set_code(response_status);
 
@@ -89,7 +89,7 @@ CheckResponsePtr TestCommon::makeErrorCheckResponse(Grpc::Status::GrpcStatus res
                                                     envoy::type::v3::StatusCode http_status_code,
                                                     const std::string& body,
                                                     const HeaderValueOptionVector& headers) {
-  auto response = std::make_unique<envoy::service::auth::v3::CheckResponse>();
+  CheckResponsePtr response;
   auto status = response->mutable_status();
   status->set_code(response_status);
 

--- a/test/extensions/filters/common/ext_authz/test_common.h
+++ b/test/extensions/filters/common/ext_authz/test_common.h
@@ -30,7 +30,7 @@ struct KeyValueOption {
 
 using KeyValueOptionVector = std::vector<KeyValueOption>;
 using HeaderValueOptionVector = std::vector<envoy::config::core::v3::HeaderValueOption>;
-using CheckResponsePtr = std::unique_ptr<envoy::service::auth::v3::CheckResponse>;
+using CheckResponsePtr = Grpc::ResponsePtr<envoy::service::auth::v3::CheckResponse>;
 
 class TestCommon {
 public:

--- a/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
+++ b/test/extensions/filters/common/ratelimit/ratelimit_impl_test.cc
@@ -66,7 +66,7 @@ public:
 };
 
 TEST_F(RateLimitGrpcClientTest, Basic) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
 
   {
     envoy::service::ratelimit::v3::RateLimitRequest request;
@@ -89,7 +89,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
     client_.onCreateInitialMetadata(headers);
     EXPECT_EQ(nullptr, headers.RequestId());
 
-    response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+    response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("over_limit")));
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _, _, _, _, _));
@@ -108,7 +108,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
 
     client_.onCreateInitialMetadata(headers);
 
-    response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+    response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OK);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("ok")));
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _, _, _, _));
@@ -127,7 +127,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
                   {{{{"foo", "bar"}, {"bar", "baz"}}}, {{{"foo2", "bar2"}, {"bar2", "baz2"}}}},
                   Tracing::NullSpan::instance(), stream_info_);
 
-    response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+    response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::Error, _, _, _, _, _));
     client_.onFailure(Grpc::Status::Unknown, "", span_);
   }
@@ -148,7 +148,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
 
     client_.onCreateInitialMetadata(headers);
 
-    response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+    response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OK);
     EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("ok")));
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _, _, _, _));
@@ -157,7 +157,7 @@ TEST_F(RateLimitGrpcClientTest, Basic) {
 }
 
 TEST_F(RateLimitGrpcClientTest, Cancel) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
 
   EXPECT_CALL(*async_client_, sendRaw(_, _, _, _, _, _)).WillOnce(Return(&async_request_));
 
@@ -170,7 +170,7 @@ TEST_F(RateLimitGrpcClientTest, Cancel) {
 
 // Makes request with hits_addend > 0.
 TEST_F(RateLimitGrpcClientTest, RequestWithHitsAddend) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
   envoy::service::ratelimit::v3::RateLimitRequest request;
   Http::TestRequestHeaderMapImpl headers;
   uint32_t hits_addend = 5;
@@ -192,7 +192,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithHitsAddend) {
   client_.onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
 
-  response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+  response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
   response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT);
   EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("over_limit")));
   EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _, _, _, _, _));
@@ -201,7 +201,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithHitsAddend) {
 
 // Makes request with per descriptor hits_addend.
 TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorHitsAddend) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
   envoy::service::ratelimit::v3::RateLimitRequest request;
   Http::TestRequestHeaderMapImpl headers;
   GrpcClientImpl::createRequest(request, "foo", {{{{"foo", "bar"}}, {}, 1234}}, 0);
@@ -224,7 +224,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorHitsAddend) {
   client_.onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
 
-  response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+  response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
   response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT);
   EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("over_limit")));
   EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OverLimit, _, _, _, _, _));
@@ -233,7 +233,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorHitsAddend) {
 
 // Makes request with per descriptor is_negative_hits set.
 TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorIsNegativeHits) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
   envoy::service::ratelimit::v3::RateLimitRequest request;
   Http::TestRequestHeaderMapImpl headers;
   Envoy::RateLimit::Descriptor desc;
@@ -262,7 +262,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorIsNegativeHits) {
   client_.onCreateInitialMetadata(headers);
   EXPECT_EQ(nullptr, headers.RequestId());
 
-  response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+  response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
   response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OK);
   EXPECT_CALL(span_, setTag(Eq("ratelimit_status"), Eq("ok")));
   EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _, _, _, _));
@@ -270,7 +270,7 @@ TEST_F(RateLimitGrpcClientTest, RequestWithPerDescriptorIsNegativeHits) {
 }
 
 TEST_F(RateLimitGrpcClientTest, SendRequestAndDetach) {
-  std::unique_ptr<envoy::service::ratelimit::v3::RateLimitResponse> response;
+  Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse> response;
 
   {
     envoy::service::ratelimit::v3::RateLimitRequest request;
@@ -292,7 +292,7 @@ TEST_F(RateLimitGrpcClientTest, SendRequestAndDetach) {
                   stream_info_, 0);
     client_.detach();
 
-    response = std::make_unique<envoy::service::ratelimit::v3::RateLimitResponse>();
+    response = Grpc::ResponsePtr<envoy::service::ratelimit::v3::RateLimitResponse>();
     response->set_overall_code(envoy::service::ratelimit::v3::RateLimitResponse::OK);
     EXPECT_CALL(request_callbacks_, complete_(LimitStatus::OK, _, _, _, _, _));
     client_.onSuccess(std::move(response), span_);

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -91,7 +91,7 @@ protected:
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse&) override {}
   void onError() override {}
 
-  Grpc::ResponsePtr<ProcessingResponse> last_response_;
+  Grpc::ResponsePtr<ProcessingResponse> last_response_{nullptr};
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;
   std::string grpc_error_message_;
   bool grpc_closed_ = false;

--- a/test/extensions/filters/http/ext_proc/client_test.cc
+++ b/test/extensions/filters/http/ext_proc/client_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/config/core/v3/grpc_service.pb.h"
 
 #include "source/common/grpc/common.h"
+#include "source/common/grpc/typed_async_client.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/extensions/filters/http/ext_proc/client_impl.h"
 
@@ -76,7 +77,7 @@ protected:
   }
 
   // ExternalProcessorCallbacks
-  void onReceiveMessage(std::unique_ptr<ProcessingResponse>&& response) override {
+  void onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& response) override {
     last_response_ = std::move(response);
   }
 
@@ -90,7 +91,7 @@ protected:
   void onComplete(envoy::service::ext_proc::v3::ProcessingResponse&) override {}
   void onError() override {}
 
-  std::unique_ptr<ProcessingResponse> last_response_;
+  Grpc::ResponsePtr<ProcessingResponse> last_response_;
   Grpc::Status::GrpcStatus grpc_status_ = Grpc::Status::WellKnownGrpcStatus::Ok;
   std::string grpc_error_message_;
   bool grpc_closed_ = false;

--- a/test/extensions/filters/http/ext_proc/ext_proc_benchmark_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_benchmark_test.cc
@@ -13,6 +13,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/strings/numbers.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 
@@ -246,6 +247,48 @@ TEST_F(BenchmarkTest, ProcessBufferedResponseBody) {
       });
   initialize();
   measureHttpGets("buffered-response-body", 2000);
+}
+
+TEST_F(BenchmarkTest, ProcessComplexResponse) {
+  proto_config_.mutable_processing_mode()->set_response_body_mode(ProcessingMode::BUFFERED);
+
+  auto add_many_headers = [](envoy::service::ext_proc::v3::CommonResponse* response) {
+    auto* mutation = response->mutable_header_mutation();
+    for (int i = 0; i < 50; i++) {
+      auto* new_hdr = mutation->add_set_headers();
+      new_hdr->mutable_append()->set_value(false);
+      new_hdr->mutable_header()->set_key(absl::StrCat("x-envoy-benchmark-", i));
+      new_hdr->mutable_header()->set_raw_value(
+          "some-long-value-to-force-allocation-uniqueness-and-size");
+    }
+  };
+
+  test_processor_.start(
+      ipVersion(),
+      [add_many_headers](grpc::ServerReaderWriter<ProcessingResponse, ProcessingRequest>* stream) {
+        ProcessingRequest request_in;
+        ASSERT_TRUE(stream->Read(&request_in));
+        ASSERT_TRUE(request_in.has_request_headers());
+        ProcessingResponse request_out;
+        add_many_headers(request_out.mutable_request_headers()->mutable_response());
+        stream->Write(request_out);
+
+        ProcessingRequest response_in;
+        ASSERT_TRUE(stream->Read(&response_in));
+        ASSERT_TRUE(response_in.has_response_headers());
+        ProcessingResponse response_out;
+        add_many_headers(response_out.mutable_response_headers()->mutable_response());
+        stream->Write(response_out);
+
+        ProcessingRequest body_in;
+        ASSERT_TRUE(stream->Read(&body_in));
+        ASSERT_TRUE(body_in.has_response_body());
+        ProcessingResponse body_out;
+        add_many_headers(body_out.mutable_response_body()->mutable_response());
+        stream->Write(body_out);
+      });
+  initialize();
+  measureHttpGets("complex-response", 2000);
 }
 
 } // namespace

--- a/test/extensions/filters/http/rate_limit_quota/client_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/client_test.cc
@@ -622,7 +622,7 @@ TEST_F(GlobalClientTest, TestBasicResponseProcessing) {
   int max_tokens = 300;
   auto token_bucket_action =
       buildTokenBucketAction(sample_bucket_id3, max_tokens, 60, std::chrono::seconds(12));
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(deny_action);
   response->add_bucket_action()->CopyFrom(allow_action);
   response->add_bucket_action()->CopyFrom(token_bucket_action);
@@ -650,7 +650,7 @@ TEST_F(GlobalClientTest, TestBasicResponseProcessing) {
   EXPECT_EQ(cached_tb->consume(max_tokens, false), max_tokens);
 
   // Resend the same token bucket action.
-  response = std::make_unique<RateLimitQuotaResponse>();
+  response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(token_bucket_action);
   // Send the response across the stream.
   global_client_->onReceiveMessage(std::move(response));
@@ -700,7 +700,7 @@ TEST_F(GlobalClientTest, TestDuplicateTokenBucket) {
   int max_tokens = 300;
   auto token_bucket_action =
       buildTokenBucketAction(sample_bucket_id_, max_tokens, 60, std::chrono::seconds(12));
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(token_bucket_action);
 
   // Send the response across the stream.
@@ -721,7 +721,7 @@ TEST_F(GlobalClientTest, TestDuplicateTokenBucket) {
   EXPECT_EQ(cached_tb->consume(max_tokens, false), max_tokens);
 
   // Resend the same token bucket action.
-  response = std::make_unique<RateLimitQuotaResponse>();
+  response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(token_bucket_action);
   // Send the response across the stream.
   global_client_->onReceiveMessage(std::move(response));
@@ -785,7 +785,7 @@ TEST_F(GlobalClientTest, TestResponseProcessingForNonExistentBucket) {
 
   auto deny_action = buildBlanketAction(sample_bucket_id_, true);
   auto allow_action = buildBlanketAction(sample_bucket_id2, false);
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(deny_action);
   response->add_bucket_action()->CopyFrom(allow_action);
 
@@ -860,8 +860,7 @@ TEST_F(GlobalClientTest, TestResponseEdgeCases) {
 
   // Check handling of empty responses & null responses from the RLQS server to
   // make sure the external server cannot cause the envoy to crash.
-  std::unique_ptr<RateLimitQuotaResponse> empty_response =
-      std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr empty_response = RateLimitQuotaResponsePtr();
   global_client_->onReceiveMessage(std::move(empty_response));
   waitForNotification(cb_ptr_->response_processed);
   global_client_->onReceiveMessage(nullptr);
@@ -875,7 +874,7 @@ TEST_F(GlobalClientTest, TestResponseEdgeCases) {
   *invalid_unset_action.mutable_quota_assignment_action()->mutable_rate_limit_strategy() =
       RateLimitStrategy();
 
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(requests_per_time_action);
   response->add_bucket_action()->CopyFrom(invalid_unset_action);
 
@@ -982,7 +981,7 @@ TEST_F(GlobalClientTest, TestExpirationAndFallback) {
   // Bucket3: allow-all assignment -> fallback-deny -> default-allow.
   BucketAction allow_action = buildBlanketAction(sample_bucket_id3, false);
 
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(deny_action);
   response->add_bucket_action()->CopyFrom(token_bucket_action);
   response->add_bucket_action()->CopyFrom(allow_action);
@@ -1090,8 +1089,7 @@ TEST_F(GlobalClientTest, TestExpirationAndFallback) {
 
   // Send a new assignment for the third bucket. Expect fallback & expiration
   // timers to reset.
-  std::unique_ptr<RateLimitQuotaResponse> replacement_response =
-      std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr replacement_response = RateLimitQuotaResponsePtr();
   replacement_response->add_bucket_action()->CopyFrom(allow_action);
 
   // Mimic sending the response across the stream.
@@ -1170,7 +1168,7 @@ TEST_F(GlobalClientTest, TestFallbackToDuplicateTokenBucket) {
   BucketAction token_bucket_action =
       buildTokenBucketAction(sample_bucket_id_, max_tokens, 60, std::chrono::seconds(12));
 
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(token_bucket_action);
 
   // Mimic sending the response across the stream.
@@ -1247,7 +1245,7 @@ TEST_F(GlobalClientTest, TestAbandonAction) {
 
   // Test abandon-action response handling.
   auto abandon_action = buildAbandonAction(sample_bucket_id_);
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(abandon_action);
 
   // Mimic sending the response across the stream.
@@ -1294,7 +1292,7 @@ TEST_F(GlobalClientTest, TestResponseBucketMissingId) {
   // buckets.
   auto empty_id_allow_action = buildBlanketAction(BucketId(), false);
   auto deny_action = buildBlanketAction(sample_bucket_id_, true);
-  std::unique_ptr<RateLimitQuotaResponse> response = std::make_unique<RateLimitQuotaResponse>();
+  RateLimitQuotaResponsePtr response = RateLimitQuotaResponsePtr();
   response->add_bucket_action()->CopyFrom(empty_id_allow_action);
   response->add_bucket_action()->CopyFrom(deny_action);
 

--- a/test/extensions/filters/network/ext_proc/ext_proc_test.cc
+++ b/test/extensions/filters/network/ext_proc/ext_proc_test.cc
@@ -166,7 +166,7 @@ TEST_F(NetworkExtProcFilterTest, ReceiveMessageAfterProcessingComplete) {
   filter_->onGrpcError(Grpc::Status::Internal, "test error");
 
   // Create a message to send - the filter should ignore it
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   auto* read_data = response->mutable_read_data();
   read_data->set_data("data");
   read_data->set_end_of_stream(false);
@@ -201,7 +201,7 @@ TEST_F(NetworkExtProcFilterTest, ReceiveEmptyMessage) {
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.stream_msgs_sent"));
 
   // Create a message with neither read_data nor write_data
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
 
   // Ensure no data is injected into either filter chain
   EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, _)).Times(0);
@@ -403,8 +403,7 @@ TEST_F(NetworkExtProcFilterTest, NormalProcessingReadData) {
   // Expect data to be injected to the filter chain
   EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Check data counters
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.read_data_injected"));
@@ -444,8 +443,7 @@ TEST_F(NetworkExtProcFilterTest, NormalProcessingWriteData) {
   // Expect data to be injected to the filter chain
   EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Check data counters
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.write_data_injected"));
@@ -544,8 +542,7 @@ TEST_F(NetworkExtProcFilterTest, UpdateCloseCallbackStatusEdgeCases) {
   EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, false));
   EXPECT_CALL(read_callbacks_, disableClose(false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Test write callbacks with multiple enable/disable
   EXPECT_CALL(*stream_ptr, send(_, false));
@@ -561,8 +558,7 @@ TEST_F(NetworkExtProcFilterTest, UpdateCloseCallbackStatusEdgeCases) {
   EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false));
   EXPECT_CALL(write_callbacks_, disableClose(false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 }
 
 // Test downstream connection close event
@@ -1045,8 +1041,7 @@ TEST_F(NetworkExtProcFilterTest, TimerStopsOnResponse) {
   EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, false));
   EXPECT_CALL(read_callbacks_, disableClose(false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // No timeout should occur
   EXPECT_EQ(0, getCounterValue("network_ext_proc.test_ext_proc.message_timeouts"));
@@ -1099,8 +1094,7 @@ TEST_F(NetworkExtProcFilterTest, WriteTimerStopsOnWriteResponse) {
   EXPECT_CALL(write_callbacks_, injectWriteDataToFilterChain(_, false));
   EXPECT_CALL(write_callbacks_, disableClose(false));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   EXPECT_EQ(0, getCounterValue("network_ext_proc.test_ext_proc.message_timeouts"));
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.write_data_injected"));
@@ -1267,23 +1261,21 @@ TEST_F(NetworkExtProcFilterTest, LoggingInfoLatencyTracking) {
   // Start processing
   Buffer::OwnedImpl data("test");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   response->mutable_read_data()->set_data("modified");
   connection_.dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(100));
   filter_->onReceiveMessage(std::move(response));
 
   Buffer::OwnedImpl data_second("test_second");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data_second, false));
-  auto response_second =
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response_second = Grpc::ResponsePtr<ProcessingResponse>();
   response_second->mutable_read_data()->set_data("modified");
   connection_.dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(200));
   filter_->onReceiveMessage(std::move(response_second));
 
   Buffer::OwnedImpl write_data("write");
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onWrite(write_data, false));
-  auto write_response =
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto write_response = Grpc::ResponsePtr<ProcessingResponse>();
   write_response->mutable_write_data()->set_data("write");
   connection_.dispatcher_.globalTimeSystem().advanceTimeWait(std::chrono::milliseconds(50));
   filter_->onReceiveMessage(std::move(write_response));
@@ -1345,7 +1337,7 @@ TEST_F(NetworkExtProcFilterTest, HandleConnectionStatusClose) {
   Buffer::OwnedImpl data("test");
   filter_->onData(data, false);
 
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   response->set_connection_status(envoy::service::network_ext_proc::v3::ProcessingResponse::CLOSE);
 
   EXPECT_CALL(connection_,
@@ -1364,7 +1356,7 @@ TEST_F(NetworkExtProcFilterTest, HandleConnectionStatusCloseRst) {
   Buffer::OwnedImpl data("test");
   filter_->onData(data, false);
 
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   response->set_connection_status(
       envoy::service::network_ext_proc::v3::ProcessingResponse::CLOSE_RST);
 
@@ -1384,7 +1376,7 @@ TEST_F(NetworkExtProcFilterTest, HandleConnectionStatusUnknown) {
   Buffer::OwnedImpl data("test");
   filter_->onData(data, false);
 
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   response->set_connection_status(
       static_cast<envoy::service::network_ext_proc::v3::ProcessingResponse_ConnectionStatus>(999));
 
@@ -1396,7 +1388,7 @@ TEST_F(NetworkExtProcFilterTest, HandleConnectionStatusUnknown) {
 TEST_F(NetworkExtProcFilterTest, RecordCallCompletionNullStartTime) {
   // Directly calling onReceiveMessage without a pending call should trigger recordCallCompletion
   // with nullopt start time
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   response->mutable_read_data()->set_data("test");
 
   filter_->onReceiveMessage(std::move(response));
@@ -1509,8 +1501,7 @@ TEST_F(NetworkExtProcFilterTest, CloseSidestream) {
   // Expect the stream to be gracefully closed
   EXPECT_CALL(*stream_ptr, close()).WillOnce(Return(true));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Verify stream closed counter
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.streams_closed"));
@@ -1550,8 +1541,7 @@ TEST_F(NetworkExtProcFilterTest, CloseSidestreamBalancedCallbacks) {
   EXPECT_CALL(read_callbacks_, disableClose(false));
   EXPECT_CALL(*stream_ptr, close()).WillOnce(Return(true));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Verify stream closed counter
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.streams_closed"));
@@ -1589,8 +1579,7 @@ TEST_F(NetworkExtProcFilterTest, CloseSidestreamMultipleOutstandingBalancedCallb
   EXPECT_CALL(read_callbacks_, disableClose(false));
   EXPECT_CALL(*stream_ptr, close()).WillOnce(Return(true));
 
-  filter_->onReceiveMessage(
-      std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>(response));
+  filter_->onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>(response));
 
   // Verify stream closed counter
   EXPECT_EQ(1, getCounterValue("network_ext_proc.test_ext_proc.streams_closed"));
@@ -1612,7 +1601,7 @@ TEST_F(NetworkExtProcFilterTest, ReceiveDynamicMetadataAllowed) {
   filter_->initializeReadFilterCallbacks(read_callbacks_);
   filter_->initializeWriteFilterCallbacks(write_callbacks_);
 
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   auto* dynamic_metadata = response->mutable_dynamic_metadata();
   Protobuf::Struct struct_obj;
   auto& fields = *struct_obj.mutable_fields();
@@ -1640,7 +1629,7 @@ TEST_F(NetworkExtProcFilterTest, ReceiveDynamicMetadataNotAllowed) {
   filter_->initializeReadFilterCallbacks(read_callbacks_);
   filter_->initializeWriteFilterCallbacks(write_callbacks_);
 
-  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  auto response = Grpc::ResponsePtr<ProcessingResponse>();
   auto* dynamic_metadata = response->mutable_dynamic_metadata();
   Protobuf::Struct struct_obj;
   auto& fields = *struct_obj.mutable_fields();

--- a/test/extensions/stats_sinks/open_telemetry/open_telemetry_impl_test.cc
+++ b/test/extensions/stats_sinks/open_telemetry/open_telemetry_impl_test.cc
@@ -196,7 +196,7 @@ TEST_F(OpenTelemetryGrpcMetricsExporterImplTest, SendExportRequest) {
 }
 
 TEST_F(OpenTelemetryGrpcMetricsExporterImplTest, PartialSuccess) {
-  auto response = std::make_unique<MetricsExportResponse>();
+  auto response = Grpc::ResponsePtr<MetricsExportResponse>();
   response->mutable_partial_success()->set_rejected_data_points(1);
   exporter_->onSuccess(std::move(response), Tracing::NullSpan::instance());
 }

--- a/test/integration/filters/server_factory_context_filter.cc
+++ b/test/integration/filters/server_factory_context_filter.cc
@@ -15,7 +15,7 @@
 
 namespace Envoy {
 
-using ResponsePtr = std::unique_ptr<helloworld::HelloReply>;
+using ResponsePtr = Grpc::ResponsePtr<helloworld::HelloReply>;
 using FilterConfigSharedPtr =
     std::shared_ptr<const test::integration::filters::ServerFactoryContextFilterConfig>;
 

--- a/test/mocks/config/mocks.h
+++ b/test/mocks/config/mocks.h
@@ -202,7 +202,7 @@ public:
   MOCK_METHOD(void, onStreamEstablished, ());
   MOCK_METHOD(void, onEstablishmentFailure, (bool));
   MOCK_METHOD(void, onDiscoveryResponse,
-              (std::unique_ptr<envoy::service::discovery::v3::DiscoveryResponse> && message,
+              (ResponseProtoPtr<envoy::service::discovery::v3::DiscoveryResponse> && message,
                ControlPlaneStats& control_plane_stats));
   MOCK_METHOD(void, onWriteable, ());
 };

--- a/test/mocks/grpc/mocks.h
+++ b/test/mocks/grpc/mocks.h
@@ -48,12 +48,10 @@ public:
   MOCK_METHOD(void, removeWatermarkCallbacks, ());
 };
 
-template <class ResponseType> using ResponseTypePtr = std::unique_ptr<ResponseType>;
-
 template <class ResponseType>
 class MockAsyncRequestCallbacks : public AsyncRequestCallbacks<ResponseType> {
 public:
-  void onSuccess(ResponseTypePtr<ResponseType>&& response, Tracing::Span& span) override {
+  void onSuccess(ResponsePtr<ResponseType>&& response, Tracing::Span& span) override {
     onSuccess_(*response, span);
   }
 
@@ -70,7 +68,7 @@ public:
     onReceiveInitialMetadata_(*metadata);
   }
 
-  void onReceiveMessage(ResponseTypePtr<ResponseType>&& message) override {
+  void onReceiveMessage(ResponsePtr<ResponseType>&& message) override {
     onReceiveMessage_(*message);
   }
 


### PR DESCRIPTION
Migrates `TypedAsyncClient` and its callbacks to use `ArenaWrappedProto` (aliased as `ResponsePtr`) instead of `std::unique_ptr` for response messages. This allows allocating received messages on a protobuf Arena, improving memory allocation efficiency and reducing fragmentation for complex configurations.

Changes:
- Updated `AsyncStreamCallbacks` and `AsyncRequestCallbacks` in `typed_async_client.h` to use `ResponsePtr`.
- Updated `ArenaWrappedProto` to support implicit conversion from `std::unique_ptr` (via `Swap`) to ease migration of test mocks and existing callers.
- Migrated `GrpcMux`, `NewGrpcMuxImpl`, `GrpcMuxImpl`, `GrpcMuxFailover`, and `XdsMux::GrpcMuxImpl` to use `ResponseProtoPtr` (aliased to `ArenaWrappedProto`) for `onDiscoveryResponse` and `onReceiveMessage`.
- Resolved a dependency cycle by using `ArenaWrappedProto` directly in `envoy/config/grpc_mux.h` and adding the `arena_wrapped_proto_lib` dependency, instead of including `typed_async_client.h`.
- Migrated HDS, LRS, Metrics Service, Access Loggers, and various filters (ratelimit, ext_authz, open_telemetry, rate_limit_quota, ext_proc) to use the new ResponsePtr signatures.
- Fixed test failures in hds_test and load_stats_reporter_test caused by the migration.

This change was entirely generated by the Gemini AI model. I have read the code and
understand how it operates.

I ran an ExtProc benchmark to evaluate the change, at Gemini's suggestion. We added a test case with more complex protocol buffer messages to more clearly shw the impact. Here are the results:

Before:
```
Duration(us)  # Calls  Mean(ns)   StdDev(ns)  Min(ns)   Max(ns)  Category      Description                      
     5249431     1000   5249431  2.17487e+06  2262412  41138615  benchmark     complex-response
```

After:
```
Duration(us)  # Calls  Mean(ns)  StdDev(ns)  Min(ns)  Max(ns)  Category      Description                      
     3491074     1000   3491074      849543  2038786  7966704  benchmark     complex-response
```

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
