### PR TITLE
vhds: add default resources list for canonical xDS

### DIFF
--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -182,5 +182,8 @@ message Vhds {
   // management server, matching the alias format that VHDS uses for on-demand
   // updates. If this field is empty, no virtual host is subscribed by default and
   // all virtual hosts are fetched on demand.
+  //
+  // The wildcard ``*`` subscribes to all virtual hosts. It cannot be combined with other
+  // entries.
   repeated string default_resources = 2;
 }

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -169,4 +169,18 @@ message Vhds {
 
   // Configuration source specifier for VHDS.
   core.v3.ConfigSource config_source = 1 [(validate.rules).message = {required: true}];
+
+  // The default virtual host resources (domains) that are subscribed by VHDS at
+  // startup, before any on-demand update is requested.
+  //
+  // Each entry is either a single ``*`` to subscribe to all virtual hosts of the
+  // owning route configuration (wildcard), or a specific virtual host domain to
+  // subscribe to.
+  //
+  // Every entry is prefixed with the owning route configuration name (in the form
+  // ``<route_config_name>/<value>``) before the subscription is sent to the
+  // management server, matching the alias format that VHDS uses for on-demand
+  // updates. If this field is empty, no virtual host is subscribed by default and
+  // all virtual hosts are fetched on demand.
+  repeated string default_resources = 2;
 }

--- a/changelogs/current/new_features/vhds__default-resources.rst
+++ b/changelogs/current/new_features/vhds__default-resources.rst
@@ -1,0 +1,6 @@
+Added :ref:`default_resources <envoy_v3_api_field_config.route.v3.Vhds.default_resources>` to the VHDS
+configuration, allowing a route configuration to subscribe to a default set of virtual host resources
+(domains) at startup, before any on-demand update. Each entry is either ``*`` (subscribe to all
+virtual hosts of the owning route configuration) or a specific domain, and is prefixed with the route
+configuration name (``<route_config_name>/<value>``) before being sent to the management server. When
+empty, the existing behavior is preserved and all virtual hosts are fetched on demand.

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -1,5 +1,6 @@
 #include "source/common/router/vhds.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -39,6 +40,17 @@ absl::StatusOr<VhdsSubscriptionPtr> VhdsSubscription::createVhdsSubscription(
   if (!is_ads && !is_delta_grpc) {
     return absl::InvalidArgumentError(
         "vhds: only 'DELTA_GRPC' or 'ADS' (which uses Delta xDS) is supported as a config source.");
+  }
+
+  // A wildcard ('*') default resource subscribes to all virtual hosts, so combining it with other
+  // specific default resources is contradictory. Reject such configuration rather than silently
+  // ignoring the other entries.
+  const auto& default_resources =
+      config_update_info->protobufConfigurationCast().vhds().default_resources();
+  if (default_resources.size() > 1 && std::find(default_resources.begin(), default_resources.end(),
+                                                "*") != default_resources.end()) {
+    return absl::InvalidArgumentError(
+        "vhds: default_resources cannot contain '*' together with other resources.");
   }
 
   // If using ADS, verify the parent ADS stream is in Delta mode

--- a/source/common/router/vhds.cc
+++ b/source/common/router/vhds.cc
@@ -17,6 +17,8 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/router/config_impl.h"
 
+#include "absl/container/flat_hash_set.h"
+
 namespace Envoy {
 namespace Router {
 
@@ -73,8 +75,16 @@ VhdsSubscription::VhdsSubscription(RouteConfigUpdatePtr& config_update_info,
       init_target_(fmt::format("VhdsConfigSubscription {}",
                                config_update_info_->protobufConfigurationCast().name()),
                    [this]() {
-                     subscription_->start(
-                         {config_update_info_->protobufConfigurationCast().name()});
+                     const auto& config = config_update_info_->protobufConfigurationCast();
+                     // Subscribe to the route configuration itself plus any configured default
+                     // virtual host resources. Each default resource is prefixed with the route
+                     // configuration name before being sent to the management server, matching the
+                     // alias format used for on-demand updates.
+                     absl::flat_hash_set<std::string> initial_resources{config.name()};
+                     for (const auto& default_resource : config.vhds().default_resources()) {
+                       initial_resources.insert(domainNameToAlias(config.name(), default_resource));
+                     }
+                     subscription_->start(initial_resources);
                    }),
       resource_type_helper_(factory_context.messageValidationContext().dynamicValidationVisitor(),
                             "name"),

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -276,11 +276,13 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/common/config:utility_lib",
+        "//source/common/init:manager_lib",
         "//source/common/protobuf",
         "//source/common/router:rds_lib",
         "//source/common/router:vhds_lib",
         "//source/server/admin:admin_lib",
         "//test/mocks/config:config_mocks",
+        "//test/mocks/init:init_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:utility_lib",

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -107,9 +107,67 @@ TEST_F(VhdsTest, VhdsInstantiationShouldSucceedWithDELTA_GRPC) {
                   .ok());
 }
 
+// Returns the resource names that VHDS subscribes to at startup for the given config.
+absl::flat_hash_set<std::string> startResourcesForConfig(VhdsTest& test, const std::string& yaml) {
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(yaml);
+  RouteConfigUpdatePtr config_update_info = test.makeRouteConfigUpdate(route_config);
+  auto subscription = VhdsSubscription::createVhdsSubscription(
+                          config_update_info, test.factory_context_, test.context_, test.provider_)
+                          .value();
+
+  absl::flat_hash_set<std::string> started_resources;
+  EXPECT_CALL(*test.factory_context_.cluster_manager_.subscription_factory_.subscription_,
+              start(::testing::_))
+      .WillOnce(::testing::SaveArg<0>(&started_resources));
+
+  Init::ManagerImpl init_manager("vhds_test_init");
+  subscription->registerInitTargetWithInitManager(init_manager);
+  Init::ExpectableWatcherImpl watcher;
+  watcher.expectReady().Times(::testing::AnyNumber());
+  init_manager.initialize(watcher);
+  return started_resources;
+}
+
 // Verify that configured default resources are prefixed with the route configuration name and
 // subscribed at startup alongside the route configuration resource itself.
 TEST_F(VhdsTest, VhdsSubscribesToPrefixedDefaultResourcesOnStart) {
+  const auto started_resources = startResourcesForConfig(*this, R"EOF(
+name: my_route
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  default_resources:
+  - example.com
+  - other.com
+)EOF");
+  EXPECT_THAT(started_resources, ::testing::UnorderedElementsAre("my_route", "my_route/example.com",
+                                                                 "my_route/other.com"));
+}
+
+// Verify that a lone wildcard ('*') default resource subscribes to the wildcard alias.
+TEST_F(VhdsTest, VhdsWildcardDefaultResourceOnly) {
+  const auto started_resources = startResourcesForConfig(*this, R"EOF(
+name: my_route
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  default_resources:
+  - "*"
+)EOF");
+  EXPECT_THAT(started_resources, ::testing::UnorderedElementsAre("my_route", "my_route/*"));
+}
+
+// Verify that configuring '*' together with other default resources is rejected.
+TEST_F(VhdsTest, VhdsWildcardDefaultResourceWithOthersIsRejected) {
   const auto route_config =
       TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
 name: my_route
@@ -121,27 +179,18 @@ vhds:
         envoy_grpc:
           cluster_name: xds_cluster
   default_resources:
-  - "*"
   - example.com
+  - "*"
+  - other.com
 )EOF");
   RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
-  auto subscription = VhdsSubscription::createVhdsSubscription(config_update_info, factory_context_,
+
+  const auto status = VhdsSubscription::createVhdsSubscription(config_update_info, factory_context_,
                                                                context_, provider_)
-                          .value();
-
-  absl::flat_hash_set<std::string> started_resources;
-  EXPECT_CALL(*factory_context_.cluster_manager_.subscription_factory_.subscription_,
-              start(::testing::_))
-      .WillOnce(::testing::SaveArg<0>(&started_resources));
-
-  Init::ManagerImpl init_manager("vhds_test_init");
-  subscription->registerInitTargetWithInitManager(init_manager);
-  Init::ExpectableWatcherImpl watcher;
-  watcher.expectReady().Times(::testing::AnyNumber());
-  init_manager.initialize(watcher);
-
-  EXPECT_THAT(started_resources,
-              ::testing::UnorderedElementsAre("my_route", "my_route/*", "my_route/example.com"));
+                          .status();
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()),
+              ::testing::HasSubstr("default_resources cannot contain '*' together with other"));
 }
 
 // verify that api_type: GRPC fails validation

--- a/test/common/router/vhds_test.cc
+++ b/test/common/router/vhds_test.cc
@@ -8,6 +8,7 @@
 #include "envoy/stats/scope.h"
 
 #include "source/common/config/utility.h"
+#include "source/common/init/manager_impl.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/rds_impl.h"
 #include "source/common/router/route_config_update_receiver_impl.h"
@@ -22,6 +23,7 @@
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -103,6 +105,43 @@ TEST_F(VhdsTest, VhdsInstantiationShouldSucceedWithDELTA_GRPC) {
                                                        context_, provider_)
                   .status()
                   .ok());
+}
+
+// Verify that configured default resources are prefixed with the route configuration name and
+// subscribed at startup alongside the route configuration resource itself.
+TEST_F(VhdsTest, VhdsSubscribesToPrefixedDefaultResourcesOnStart) {
+  const auto route_config =
+      TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(R"EOF(
+name: my_route
+vhds:
+  config_source:
+    api_config_source:
+      api_type: DELTA_GRPC
+      grpc_services:
+        envoy_grpc:
+          cluster_name: xds_cluster
+  default_resources:
+  - "*"
+  - example.com
+)EOF");
+  RouteConfigUpdatePtr config_update_info = makeRouteConfigUpdate(route_config);
+  auto subscription = VhdsSubscription::createVhdsSubscription(config_update_info, factory_context_,
+                                                               context_, provider_)
+                          .value();
+
+  absl::flat_hash_set<std::string> started_resources;
+  EXPECT_CALL(*factory_context_.cluster_manager_.subscription_factory_.subscription_,
+              start(::testing::_))
+      .WillOnce(::testing::SaveArg<0>(&started_resources));
+
+  Init::ManagerImpl init_manager("vhds_test_init");
+  subscription->registerInitTargetWithInitManager(init_manager);
+  Init::ExpectableWatcherImpl watcher;
+  watcher.expectReady().Times(::testing::AnyNumber());
+  init_manager.initialize(watcher);
+
+  EXPECT_THAT(started_resources,
+              ::testing::UnorderedElementsAre("my_route", "my_route/*", "my_route/example.com"));
 }
 
 // verify that api_type: GRPC fails validation


### PR DESCRIPTION
Commit Message: vhds: add default resources list for canonical xDS
Additional Description:

The vhds is designed to support on demand virtual host discovery. **But at some cases, the users may doesn't want the on-demand resource discovery but want the virtual host discovery self.**
For example, for a huge gateway with 20K routes, it's too heavy to update whole route configuration for any route change. With virtual host discovery, we only need to update a virtual host when a route changes. This is a real requirement that I discussed with Envoy based gateway users.

With this PR, we can specific the initial resource list that the vhds subscription subscribes. **And with this, the control plane needn't any change** (may need to support wildcard `*`, but not block point).

This is similar to https://github.com/envoyproxy/envoy/pull/44129, but this PR focus on canonical xds and https://github.com/envoyproxy/envoy/pull/44129 focus on new xdstp.
Although xdstp has lots of advantages for xds fedration support, but the canonical xds is more widely used for now.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
