### PR TITLE
oauth2: add RequestId tag to filter application logs

### DIFF
--- a/changelogs/current/new_features/oauth2__request-id-log-tag.rst
+++ b/changelogs/current/new_features/oauth2__request-id-log-tag.rst
@@ -1,0 +1,3 @@
+The OAuth2 filter now includes a ``RequestId`` tag in its application log lines, matching the
+access log ``%STREAM_ID%`` / ``x-request-id`` value, so operators can correlate OAuth2
+application logs with access logs on a per-request basis.

--- a/source/extensions/filters/http/oauth2/BUILD
+++ b/source/extensions/filters/http/oauth2/BUILD
@@ -16,6 +16,10 @@ envoy_extension_package()
 envoy_cc_library(
     name = "oauth_callback_interface",
     hdrs = ["oauth.h"],
+    deps = [
+        "//envoy/http:filter_interface",
+        "//envoy/stream_info:stream_info_interface",
+    ],
 )
 
 envoy_proto_library(

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -884,10 +884,6 @@ void OAuth2Filter::resolveAndSetActiveConfig() {
   oauth_client_->setDecoderFilterCallbacks(*decoder_callbacks_);
 }
 
-std::map<std::string, std::string> OAuth2Filter::getLogTags() const {
-  return oauthLogTags(*decoder_callbacks_);
-}
-
 /**
  * primary cases:
  * 1) pass through header is matching
@@ -1024,7 +1020,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     // Check if we can update the access token via a refresh token.
     if (config_->useRefreshToken() && validator_->canUpdateTokenByRefreshToken()) {
 
-      ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
+      ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                               "Trying to update the access token using the refresh token");
 
       // try to update access token by refresh token
@@ -1056,7 +1052,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
           "Unauthorized, and redirecting to OAuth server is not allowed: {}", path_str));
       return Http::FilterHeadersStatus::StopIteration;
     } else {
-      ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
+      ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                               "redirecting to OAuth server: {}", path_str);
       redirectToOAuthServer(headers);
       return Http::FilterHeadersStatus::StopIteration;
@@ -1153,11 +1149,12 @@ bool OAuth2Filter::canSkipOAuth(Http::RequestHeaderMap& headers) const {
     if (config_->forwardIdToken() && !validator_->idToken().empty()) {
       forwardIdToken(headers, validator_->idToken());
     }
-    ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                             "skipping oauth flow due to valid hmac cookie");
     return true;
   }
-  ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_, "can not skip oauth flow");
+  ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                          "can not skip oauth flow");
   return false;
 }
 
@@ -1231,7 +1228,7 @@ std::string OAuth2Filter::decryptToken(const std::string& encrypted_token) const
                               !Http::HeaderUtility::headerValueIsValid(decrypt_result.plaintext);
 
   if (decrypt_failed) {
-    ENVOY_TAGGED_STREAM_LOG(error, getLogTags(), *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(error, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                             "failed to decrypt token: {}, error: {}", encrypted_token,
                             decrypt_result.error.value_or("plaintext is not a valid header value"));
     // There are two cases:
@@ -1511,13 +1508,13 @@ OAuth2Filter::getExpiresTimeForRefreshToken(const std::string& refresh_token,
         return std::to_string(expiration_epoch.count());
       } else {
         ENVOY_TAGGED_STREAM_LOG(
-            debug, getLogTags(), *decoder_callbacks_,
+            debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
             "The expiration time in the refresh token is less than the current time");
         return "0";
       }
     }
     ENVOY_TAGGED_STREAM_LOG(
-        debug, getLogTags(), *decoder_callbacks_,
+        debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
         "The refresh token is not a JWT or exp claim is omitted. The lifetime of the "
         "refresh token will be taken from filter configuration");
     const std::chrono::seconds default_refresh_token_expires_in =
@@ -1546,12 +1543,12 @@ std::string OAuth2Filter::getExpiresTimeForIdToken(const std::string& id_token,
         return std::to_string(expiration_epoch.count());
       } else {
         ENVOY_TAGGED_STREAM_LOG(
-            debug, getLogTags(), *decoder_callbacks_,
+            debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
             "The expiration time in the id token is less than the current time");
         return "0";
       }
     }
-    ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                             "The id token is not a JWT or exp claim is omitted, even though it is "
                             "required by the OpenID Connect 1.0 specification. "
                             "The lifetime of the id token will be aligned with the access token");
@@ -1770,7 +1767,7 @@ void OAuth2Filter::addFlowCookieDeletionHeaders(Http::ResponseHeaderMap& headers
 }
 
 void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
-  ENVOY_TAGGED_STREAM_LOG(warn, getLogTags(), *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(warn, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                           "Responding with 401 Unauthorized. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(
@@ -1787,7 +1784,7 @@ void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
 }
 
 void OAuth2Filter::sendSecretsNotReadyResponse(const std::string& details) {
-  ENVOY_TAGGED_STREAM_LOG(warn, getLogTags(), *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(warn, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                           "Responding with 503 Service Unavailable. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, ServiceUnavailableBodyMessage,
@@ -1821,7 +1818,7 @@ void OAuth2Filter::continueWithFailedOAuth(const std::string& reason,
   config_->stats().oauth_allow_failed_passthrough_.inc();
   const std::string log_details =
       extra_details.empty() ? reason : absl::StrCat(reason, ": ", extra_details);
-  ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                           "allow_failed_matcher matched, continuing as unauthorized: {}",
                           log_details);
 }

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -884,6 +884,20 @@ void OAuth2Filter::resolveAndSetActiveConfig() {
   oauth_client_->setDecoderFilterCallbacks(*decoder_callbacks_);
 }
 
+std::map<std::string, std::string> OAuth2Filter::getLogTags() const {
+  // Attach the request id (matching access-log %STREAM_ID% / x-request-id) so OAuth2 application
+  // logs can be correlated with access logs on a per-request basis.
+  std::map<std::string, std::string> log_tags;
+  const auto provider = decoder_callbacks_->streamInfo().getStreamIdProvider();
+  if (provider.has_value()) {
+    const auto request_id = provider->toStringView();
+    if (request_id.has_value()) {
+      log_tags.emplace("RequestId", std::string(request_id.value()));
+    }
+  }
+  return log_tags;
+}
+
 /**
  * primary cases:
  * 1) pass through header is matching
@@ -893,17 +907,6 @@ void OAuth2Filter::resolveAndSetActiveConfig() {
  * 5) user is unauthorized
  */
 Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
-  // Capture the request id (matching access-log %STREAM_ID% / x-request-id) once per request so it
-  // can be attached as a RequestId tag to the filter's application logs, allowing operators to
-  // correlate OAuth2 application logs with access logs on a per-request basis.
-  const auto provider = decoder_callbacks_->streamInfo().getStreamIdProvider();
-  if (provider.has_value()) {
-    const auto request_id = provider->toStringView();
-    if (request_id.has_value()) {
-      log_tags_.emplace("RequestId", std::string(request_id.value()));
-    }
-  }
-
   // Sanitize OAuth status headers unconditionally at the start of the filter to prevent clients
   // from spoofing them. These headers are only supposed to be set by the OAuth2 filter itself.
   headers.remove(OAuth2Headers::get().OAuthStatus);
@@ -1031,7 +1034,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     // Check if we can update the access token via a refresh token.
     if (config_->useRefreshToken() && validator_->canUpdateTokenByRefreshToken()) {
 
-      ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+      ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
                               "Trying to update the access token using the refresh token");
 
       // try to update access token by refresh token
@@ -1063,7 +1066,7 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
           "Unauthorized, and redirecting to OAuth server is not allowed: {}", path_str));
       return Http::FilterHeadersStatus::StopIteration;
     } else {
-      ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+      ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
                               "redirecting to OAuth server: {}", path_str);
       redirectToOAuthServer(headers);
       return Http::FilterHeadersStatus::StopIteration;
@@ -1160,11 +1163,11 @@ bool OAuth2Filter::canSkipOAuth(Http::RequestHeaderMap& headers) const {
     if (config_->forwardIdToken() && !validator_->idToken().empty()) {
       forwardIdToken(headers, validator_->idToken());
     }
-    ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
                             "skipping oauth flow due to valid hmac cookie");
     return true;
   }
-  ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_, "can not skip oauth flow");
+  ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_, "can not skip oauth flow");
   return false;
 }
 
@@ -1238,7 +1241,7 @@ std::string OAuth2Filter::decryptToken(const std::string& encrypted_token) const
                               !Http::HeaderUtility::headerValueIsValid(decrypt_result.plaintext);
 
   if (decrypt_failed) {
-    ENVOY_TAGGED_STREAM_LOG(error, log_tags_, *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(error, getLogTags(), *decoder_callbacks_,
                             "failed to decrypt token: {}, error: {}", encrypted_token,
                             decrypt_result.error.value_or("plaintext is not a valid header value"));
     // There are two cases:
@@ -1518,13 +1521,13 @@ OAuth2Filter::getExpiresTimeForRefreshToken(const std::string& refresh_token,
         return std::to_string(expiration_epoch.count());
       } else {
         ENVOY_TAGGED_STREAM_LOG(
-            debug, log_tags_, *decoder_callbacks_,
+            debug, getLogTags(), *decoder_callbacks_,
             "The expiration time in the refresh token is less than the current time");
         return "0";
       }
     }
     ENVOY_TAGGED_STREAM_LOG(
-        debug, log_tags_, *decoder_callbacks_,
+        debug, getLogTags(), *decoder_callbacks_,
         "The refresh token is not a JWT or exp claim is omitted. The lifetime of the "
         "refresh token will be taken from filter configuration");
     const std::chrono::seconds default_refresh_token_expires_in =
@@ -1553,12 +1556,12 @@ std::string OAuth2Filter::getExpiresTimeForIdToken(const std::string& id_token,
         return std::to_string(expiration_epoch.count());
       } else {
         ENVOY_TAGGED_STREAM_LOG(
-            debug, log_tags_, *decoder_callbacks_,
+            debug, getLogTags(), *decoder_callbacks_,
             "The expiration time in the id token is less than the current time");
         return "0";
       }
     }
-    ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+    ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
                             "The id token is not a JWT or exp claim is omitted, even though it is "
                             "required by the OpenID Connect 1.0 specification. "
                             "The lifetime of the id token will be aligned with the access token");
@@ -1777,7 +1780,7 @@ void OAuth2Filter::addFlowCookieDeletionHeaders(Http::ResponseHeaderMap& headers
 }
 
 void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
-  ENVOY_TAGGED_STREAM_LOG(warn, log_tags_, *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(warn, getLogTags(), *decoder_callbacks_,
                           "Responding with 401 Unauthorized. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(
@@ -1794,7 +1797,7 @@ void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
 }
 
 void OAuth2Filter::sendSecretsNotReadyResponse(const std::string& details) {
-  ENVOY_TAGGED_STREAM_LOG(warn, log_tags_, *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(warn, getLogTags(), *decoder_callbacks_,
                           "Responding with 503 Service Unavailable. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, ServiceUnavailableBodyMessage,
@@ -1828,7 +1831,7 @@ void OAuth2Filter::continueWithFailedOAuth(const std::string& reason,
   config_->stats().oauth_allow_failed_passthrough_.inc();
   const std::string log_details =
       extra_details.empty() ? reason : absl::StrCat(reason, ": ", extra_details);
-  ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+  ENVOY_TAGGED_STREAM_LOG(debug, getLogTags(), *decoder_callbacks_,
                           "allow_failed_matcher matched, continuing as unauthorized: {}",
                           log_details);
 }

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -893,6 +893,17 @@ void OAuth2Filter::resolveAndSetActiveConfig() {
  * 5) user is unauthorized
  */
 Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
+  // Capture the request id (matching access-log %STREAM_ID% / x-request-id) once per request so it
+  // can be attached as a RequestId tag to the filter's application logs, allowing operators to
+  // correlate OAuth2 application logs with access logs on a per-request basis.
+  const auto provider = decoder_callbacks_->streamInfo().getStreamIdProvider();
+  if (provider.has_value()) {
+    const auto request_id = provider->toStringView();
+    if (request_id.has_value()) {
+      log_tags_.emplace("RequestId", std::string(request_id.value()));
+    }
+  }
+
   // Sanitize OAuth status headers unconditionally at the start of the filter to prevent clients
   // from spoofing them. These headers are only supposed to be set by the OAuth2 filter itself.
   headers.remove(OAuth2Headers::get().OAuthStatus);
@@ -1020,8 +1031,8 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     // Check if we can update the access token via a refresh token.
     if (config_->useRefreshToken() && validator_->canUpdateTokenByRefreshToken()) {
 
-      ENVOY_STREAM_LOG(debug, "Trying to update the access token using the refresh token",
-                       *decoder_callbacks_);
+      ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+                              "Trying to update the access token using the refresh token");
 
       // try to update access token by refresh token
       auto client_credential = getClientCredential();
@@ -1052,7 +1063,8 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
           "Unauthorized, and redirecting to OAuth server is not allowed: {}", path_str));
       return Http::FilterHeadersStatus::StopIteration;
     } else {
-      ENVOY_STREAM_LOG(debug, "redirecting to OAuth server: {}", *decoder_callbacks_, path_str);
+      ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+                              "redirecting to OAuth server: {}", path_str);
       redirectToOAuthServer(headers);
       return Http::FilterHeadersStatus::StopIteration;
     }
@@ -1148,10 +1160,11 @@ bool OAuth2Filter::canSkipOAuth(Http::RequestHeaderMap& headers) const {
     if (config_->forwardIdToken() && !validator_->idToken().empty()) {
       forwardIdToken(headers, validator_->idToken());
     }
-    ENVOY_STREAM_LOG(debug, "skipping oauth flow due to valid hmac cookie", *decoder_callbacks_);
+    ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+                            "skipping oauth flow due to valid hmac cookie");
     return true;
   }
-  ENVOY_STREAM_LOG(debug, "can not skip oauth flow", *decoder_callbacks_);
+  ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_, "can not skip oauth flow");
   return false;
 }
 
@@ -1225,9 +1238,9 @@ std::string OAuth2Filter::decryptToken(const std::string& encrypted_token) const
                               !Http::HeaderUtility::headerValueIsValid(decrypt_result.plaintext);
 
   if (decrypt_failed) {
-    ENVOY_STREAM_LOG(error, "failed to decrypt token: {}, error: {}", *decoder_callbacks_,
-                     encrypted_token,
-                     decrypt_result.error.value_or("plaintext is not a valid header value"));
+    ENVOY_TAGGED_STREAM_LOG(error, log_tags_, *decoder_callbacks_,
+                            "failed to decrypt token: {}, error: {}", encrypted_token,
+                            decrypt_result.error.value_or("plaintext is not a valid header value"));
     // There are two cases:
     // 1. The token is a legacy unencrypted token.
     // In this case, we return the token as-is to allow the request to proceed.
@@ -1504,16 +1517,16 @@ OAuth2Filter::getExpiresTimeForRefreshToken(const std::string& refresh_token,
         const auto expiration_epoch = expiration_from_jwt - now;
         return std::to_string(expiration_epoch.count());
       } else {
-        ENVOY_STREAM_LOG(debug,
-                         "The expiration time in the refresh token is less than the current time",
-                         *decoder_callbacks_);
+        ENVOY_TAGGED_STREAM_LOG(
+            debug, log_tags_, *decoder_callbacks_,
+            "The expiration time in the refresh token is less than the current time");
         return "0";
       }
     }
-    ENVOY_STREAM_LOG(debug,
-                     "The refresh token is not a JWT or exp claim is omitted. The lifetime of the "
-                     "refresh token will be taken from filter configuration",
-                     *decoder_callbacks_);
+    ENVOY_TAGGED_STREAM_LOG(
+        debug, log_tags_, *decoder_callbacks_,
+        "The refresh token is not a JWT or exp claim is omitted. The lifetime of the "
+        "refresh token will be taken from filter configuration");
     const std::chrono::seconds default_refresh_token_expires_in =
         config_->defaultRefreshTokenExpiresIn();
     return std::to_string(default_refresh_token_expires_in.count());
@@ -1539,16 +1552,16 @@ std::string OAuth2Filter::getExpiresTimeForIdToken(const std::string& id_token,
         const auto expiration_epoch = expiration_from_jwt - now;
         return std::to_string(expiration_epoch.count());
       } else {
-        ENVOY_STREAM_LOG(debug, "The expiration time in the id token is less than the current time",
-                         *decoder_callbacks_);
+        ENVOY_TAGGED_STREAM_LOG(
+            debug, log_tags_, *decoder_callbacks_,
+            "The expiration time in the id token is less than the current time");
         return "0";
       }
     }
-    ENVOY_STREAM_LOG(debug,
-                     "The id token is not a JWT or exp claim is omitted, even though it is "
-                     "required by the OpenID Connect 1.0 specification. "
-                     "The lifetime of the id token will be aligned with the access token",
-                     *decoder_callbacks_);
+    ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+                            "The id token is not a JWT or exp claim is omitted, even though it is "
+                            "required by the OpenID Connect 1.0 specification. "
+                            "The lifetime of the id token will be aligned with the access token");
     return std::to_string(expires_in.count());
   }
   return std::to_string(expires_in.count());
@@ -1764,8 +1777,8 @@ void OAuth2Filter::addFlowCookieDeletionHeaders(Http::ResponseHeaderMap& headers
 }
 
 void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
-  ENVOY_STREAM_LOG(warn, "Responding with 401 Unauthorized. Cause: {}", *decoder_callbacks_,
-                   details);
+  ENVOY_TAGGED_STREAM_LOG(warn, log_tags_, *decoder_callbacks_,
+                          "Responding with 401 Unauthorized. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(
       Http::Code::Unauthorized, UnauthorizedBodyMessage,
@@ -1781,8 +1794,8 @@ void OAuth2Filter::sendUnauthorizedResponse(const std::string& details) {
 }
 
 void OAuth2Filter::sendSecretsNotReadyResponse(const std::string& details) {
-  ENVOY_STREAM_LOG(warn, "Responding with 503 Service Unavailable. Cause: {}", *decoder_callbacks_,
-                   details);
+  ENVOY_TAGGED_STREAM_LOG(warn, log_tags_, *decoder_callbacks_,
+                          "Responding with 503 Service Unavailable. Cause: {}", details);
   config_->stats().oauth_failure_.inc();
   decoder_callbacks_->sendLocalReply(Http::Code::ServiceUnavailable, ServiceUnavailableBodyMessage,
                                      nullptr, std::nullopt, details);
@@ -1815,8 +1828,9 @@ void OAuth2Filter::continueWithFailedOAuth(const std::string& reason,
   config_->stats().oauth_allow_failed_passthrough_.inc();
   const std::string log_details =
       extra_details.empty() ? reason : absl::StrCat(reason, ": ", extra_details);
-  ENVOY_STREAM_LOG(debug, "allow_failed_matcher matched, continuing as unauthorized: {}",
-                   *decoder_callbacks_, log_details);
+  ENVOY_TAGGED_STREAM_LOG(debug, log_tags_, *decoder_callbacks_,
+                          "allow_failed_matcher matched, continuing as unauthorized: {}",
+                          log_details);
 }
 
 Http::FilterHeadersStatus OAuth2Filter::handleOAuthFailure(const std::string& reason,

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -885,17 +885,7 @@ void OAuth2Filter::resolveAndSetActiveConfig() {
 }
 
 std::map<std::string, std::string> OAuth2Filter::getLogTags() const {
-  // Attach the request id (matching access-log %STREAM_ID% / x-request-id) so OAuth2 application
-  // logs can be correlated with access logs on a per-request basis.
-  std::map<std::string, std::string> log_tags;
-  const auto provider = decoder_callbacks_->streamInfo().getStreamIdProvider();
-  if (provider.has_value()) {
-    const auto request_id = provider->toStringView();
-    if (request_id.has_value()) {
-      log_tags.emplace("RequestId", std::string(request_id.value()));
-    }
-  }
-  return log_tags;
+  return oauthLogTags(*decoder_callbacks_);
 }
 
 /**

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -448,11 +448,6 @@ private:
   Http::RequestHeaderMap* request_headers_{nullptr};
   bool was_refresh_token_flow_{false};
 
-  // Log tags (RequestId) added to OAuth2 application log lines so they can be correlated with the
-  // access log; populated once per request in decodeHeaders. RequestId matches access-log
-  // %STREAM_ID% / x-request-id.
-  std::map<std::string, std::string> log_tags_;
-
   std::shared_ptr<OAuth2Client> oauth_client_;
   FilterConfigSharedPtr default_config_;
   const FilterConfig* config_{nullptr};
@@ -462,6 +457,10 @@ private:
   Random::RandomGenerator& random_;
 
   void resolveAndSetActiveConfig();
+
+  // Returns the log tags (RequestId, matching access-log %STREAM_ID% / x-request-id) attached to
+  // the filter's application logs so they can be correlated with the access log.
+  std::map<std::string, std::string> getLogTags() const;
 
   // Determines whether or not the current request can skip the entire OAuth flow (HMAC is valid,
   // connection is mTLS, etc.)

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -459,7 +459,8 @@ private:
   void resolveAndSetActiveConfig();
 
   // Returns the log tags (RequestId, matching access-log %STREAM_ID% / x-request-id) attached to
-  // the filter's application logs so they can be correlated with the access log.
+  // the filter's application logs so they can be correlated with the access log. Shared with
+  // OAuth2ClientImpl via oauthLogTags() so all OAuth2 log lines for a request carry the same tag.
   std::map<std::string, std::string> getLogTags() const;
 
   // Determines whether or not the current request can skip the entire OAuth flow (HMAC is valid,

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -446,6 +447,11 @@ private:
   std::string flow_id_;
   Http::RequestHeaderMap* request_headers_{nullptr};
   bool was_refresh_token_flow_{false};
+
+  // Log tags (RequestId) added to OAuth2 application log lines so they can be correlated with the
+  // access log; populated once per request in decodeHeaders. RequestId matches access-log
+  // %STREAM_ID% / x-request-id.
+  std::map<std::string, std::string> log_tags_;
 
   std::shared_ptr<OAuth2Client> oauth_client_;
   FilterConfigSharedPtr default_config_;

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -457,11 +456,6 @@ private:
   Random::RandomGenerator& random_;
 
   void resolveAndSetActiveConfig();
-
-  // Returns the log tags (RequestId, matching access-log %STREAM_ID% / x-request-id) attached to
-  // the filter's application logs so they can be correlated with the access log. Shared with
-  // OAuth2ClientImpl via oauthLogTags() so all OAuth2 log lines for a request carry the same tag.
-  std::map<std::string, std::string> getLogTags() const;
 
   // Determines whether or not the current request can skip the entire OAuth flow (HMAC is valid,
   // connection is mTLS, etc.)

--- a/source/extensions/filters/http/oauth2/oauth.h
+++ b/source/extensions/filters/http/oauth2/oauth.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <chrono>
+#include <map>
 #include <string>
 #include <vector>
 
 #include "envoy/common/pure.h"
 #include "envoy/http/filter.h"
+#include "envoy/stream_info/stream_info.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -39,6 +41,27 @@ public:
  * Describes the authentication type used by the client when communicating with the auth server.
  */
 enum class AuthType { UrlEncodedBody, BasicAuth, TlsClientAuth, PrivateKeyJwt };
+
+/**
+ * Returns the log tags attached to the OAuth2 application logs so that they can be correlated with
+ * the access log on a per-request basis. RequestId matches the access log %STREAM_ID% /
+ * x-request-id value.
+ *
+ * The tagged log macros only evaluate their tags argument when a log line is actually emitted, so
+ * this is not called on every request.
+ */
+inline std::map<std::string, std::string>
+oauthLogTags(Http::StreamDecoderFilterCallbacks& decoder_callbacks) {
+  std::map<std::string, std::string> log_tags;
+  const auto provider = decoder_callbacks.streamInfo().getStreamIdProvider();
+  if (provider.has_value()) {
+    const auto request_id = provider->toStringView();
+    if (request_id.has_value()) {
+      log_tags.emplace("RequestId", std::string(request_id.value()));
+    }
+  }
+  return log_tags;
+}
 
 } // namespace Oauth2
 } // namespace HttpFilters

--- a/source/extensions/filters/http/oauth2/oauth_client.cc
+++ b/source/extensions/filters/http/oauth2/oauth_client.cc
@@ -107,7 +107,8 @@ void OAuth2ClientImpl::asyncGetAccessToken(const std::string& auth_code,
 
   request->body().add(body);
   request->headers().setContentLength(body.length());
-  ENVOY_STREAM_LOG(debug, "Dispatching OAuth request for access token.", *decoder_callbacks_);
+  ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                          "Dispatching OAuth request for access token.");
   dispatchRequest(std::move(request));
 }
 
@@ -158,8 +159,8 @@ void OAuth2ClientImpl::asyncRefreshAccessToken(const std::string& refresh_token,
 
   request->body().add(body);
   request->headers().setContentLength(body.length());
-  ENVOY_STREAM_LOG(debug, "Dispatching OAuth request for update access token by refresh token.",
-                   *decoder_callbacks_);
+  ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                          "Dispatching OAuth request for update access token by refresh token.");
   dispatchRequest(std::move(request));
 }
 
@@ -238,9 +239,10 @@ void OAuth2ClientImpl::onSuccess(const Http::AsyncClient::Request&,
   const auto response_code = message->headers().Status()->value().getStringView();
 
   if (response_code != "200") {
-    ENVOY_STREAM_LOG(debug, "Oauth response code: {}", *decoder_callbacks_, response_code);
-    ENVOY_STREAM_LOG(debug, "Oauth response body: {}", *decoder_callbacks_,
-                     message->bodyAsString());
+    ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                            "Oauth response code: {}", response_code);
+    ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                            "Oauth response body: {}", message->bodyAsString());
     switch (oldState) {
     case OAuthState::PendingAccessToken:
       handleOAuthFailure(is_request_dispatched, "Failed to get access token",
@@ -317,7 +319,8 @@ void OAuth2ClientImpl::onFailure(const Http::AsyncClient::Request&,
     return;
   }
 
-  ENVOY_STREAM_LOG(debug, "OAuth request failed.", *decoder_callbacks_);
+  ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
+                          "OAuth request failed.");
   const OAuthState oldState = state_;
   state_ = OAuthState::Idle;
 

--- a/test/extensions/filters/http/oauth2/BUILD
+++ b/test/extensions/filters/http/oauth2/BUILD
@@ -75,6 +75,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/common/secret:secret_manager_impl_lib",
+        "//source/common/stream_info:stream_id_provider_lib",
         "//source/extensions/filters/http/oauth2:config",
         "//source/extensions/filters/http/oauth2:oauth_callback_interface",
         "//source/extensions/filters/http/oauth2:oauth_client",

--- a/test/extensions/filters/http/oauth2/BUILD
+++ b/test/extensions/filters/http/oauth2/BUILD
@@ -99,10 +99,12 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.oauth2"],
     rbe_pool = "6gig",
     deps = [
+        "//source/common/stream_info:stream_id_provider_lib",
         "//source/extensions/filters/http/oauth2:oauth_client",
         "//test/integration:http_integration_lib",
         "//test/mocks/server:server_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:logging_lib",
         # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
         # so it needs the built-in HTTP command parsers registered.
         "//source/common/formatter:http_speicific_formatter_extension_lib",

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -12,6 +12,7 @@
 #include "source/common/protobuf/utility.h"
 #include "source/common/runtime/runtime_protos.h"
 #include "source/common/secret/secret_manager_impl.h"
+#include "source/common/stream_info/stream_id_provider_impl.h"
 #include "source/extensions/filters/http/oauth2/filter.h"
 
 #include "test/mocks/http/mocks.h"
@@ -1451,6 +1452,59 @@ TEST_F(OAuth2Test, OAuthOkPass) {
 
   EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_failure").value(), 0);
   EXPECT_EQ(scope_.counterFromString("test.my_prefix.oauth_success").value(), 1);
+}
+
+/**
+ * Scenario: a request carrying a stream request id is processed by the filter.
+ *
+ * Expected behavior: the OAuth2 filter's application log lines include a RequestId tag whose value
+ * matches the stream's request id (the same value as the access log %STREAM_ID% / x-request-id), so
+ * application logs can be correlated with access logs on a per-request basis.
+ */
+TEST_F(OAuth2Test, LogsRequestIdTag) {
+  const std::string request_id = "a765d063-2c3d-4b19-92d4-4486a16e7f50";
+  StreamInfo::StreamIdProviderImpl id_provider{std::string(request_id)};
+  EXPECT_CALL(decoder_callbacks_.stream_info_, getStreamIdProvider())
+      .WillRepeatedly(Return(makeOptRef<const StreamInfo::StreamIdProvider>(id_provider)));
+
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  // Take the valid-HMAC-cookie path, which emits "skipping oauth flow due to valid hmac cookie".
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+  std::string legit_token{"legit_token"};
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
+
+  EXPECT_LOG_CONTAINS("debug", absl::StrCat("\"RequestId\":\"", request_id, "\""),
+                      { filter_->decodeHeaders(mock_request_headers, false); });
+}
+
+/**
+ * Scenario: the filter processes a request whose stream has no request id provider.
+ *
+ * Expected behavior: the OAuth2 filter still logs, but the log line carries no RequestId tag.
+ */
+TEST_F(OAuth2Test, NoRequestIdTagWhenProviderAbsent) {
+  // The default MockStreamInfo returns an empty StreamIdProvider, so no RequestId is emitted.
+  Http::TestRequestHeaderMapImpl mock_request_headers{
+      {Http::Headers::get().Path.get(), "/anypath"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(true));
+  std::string legit_token{"legit_token"};
+  EXPECT_CALL(*validator_, token()).WillRepeatedly(ReturnRef(legit_token));
+
+  EXPECT_LOG_NOT_CONTAINS("debug", "RequestId",
+                          { filter_->decodeHeaders(mock_request_headers, false); });
 }
 
 /**

--- a/test/extensions/filters/http/oauth2/oauth_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_test.cc
@@ -4,14 +4,17 @@
 
 #include "source/common/http/message_impl.h"
 #include "source/common/protobuf/utility.h"
+#include "source/common/stream_info/stream_id_provider_impl.h"
 #include "source/extensions/filters/http/oauth2/oauth.h"
 #include "source/extensions/filters/http/oauth2/oauth_client.h"
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -834,6 +837,137 @@ TEST_F(OAuth2ClientTest, CancelSuppressesLateOnSuccess) {
   Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
   ASSERT_TRUE(popPendingCallback(
       [&](auto* callback) { callback->onSuccess(request, std::move(mock_response)); }));
+}
+
+// Test fixture that wires decoder filter callbacks carrying a stream request id, so the OAuth
+// client's application log lines can be checked for the RequestId tag.
+class OAuth2ClientLogTagsTest : public OAuth2ClientTest {
+public:
+  static constexpr absl::string_view RequestId = "a765d063-2c3d-4b19-92d4-4486a16e7f50";
+
+  OAuth2ClientLogTagsTest() : id_provider_(std::string(RequestId)) {
+    client_->setDecoderFilterCallbacks(decoder_callbacks_);
+    client_->setCallbacks(*mock_callbacks_);
+  }
+
+  // Makes the stream report the request id above. Not called by the tests covering the case where
+  // the stream has no request id provider.
+  void setStreamRequestId() {
+    EXPECT_CALL(decoder_callbacks_.stream_info_, getStreamIdProvider())
+        .WillRepeatedly(Return(makeOptRef<const StreamInfo::StreamIdProvider>(id_provider_)));
+  }
+
+  // Queues the async client callback rather than completing the request inline.
+  void expectQueuedRequest() {
+    EXPECT_CALL(request_, cancel()).Times(testing::AnyNumber());
+    EXPECT_CALL(cm_.thread_local_cluster_.async_client_, send_(_, _, _))
+        .WillRepeatedly(
+            Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
+                       const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+              callbacks_.push_back(&cb);
+              return &request_;
+            }));
+  }
+
+  static std::string expectedTag() { return absl::StrCat("\"RequestId\":\"", RequestId, "\""); }
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
+  StreamInfo::StreamIdProviderImpl id_provider_;
+};
+
+/**
+ * Scenario: the client dispatches a token exchange request for an authorization code.
+ *
+ * Expected behavior: the dispatch log line carries a RequestId tag matching the stream's request
+ * id, so it can be correlated with the access log and with the OAuth2 filter's own log lines.
+ */
+TEST_F(OAuth2ClientLogTagsTest, LogsRequestIdTagOnAccessTokenDispatch) {
+  setStreamRequestId();
+  expectQueuedRequest();
+
+  EXPECT_LOG_CONTAINS("debug", expectedTag(),
+                      { client_->asyncGetAccessToken("a", "b", "c", "d", "e"); });
+}
+
+/**
+ * Scenario: the client dispatches a token exchange request using a refresh token.
+ *
+ * Expected behavior: the dispatch log line carries the RequestId tag.
+ */
+TEST_F(OAuth2ClientLogTagsTest, LogsRequestIdTagOnRefreshTokenDispatch) {
+  setStreamRequestId();
+  expectQueuedRequest();
+
+  EXPECT_LOG_CONTAINS("debug", expectedTag(), { client_->asyncRefreshAccessToken("a", "b", "c"); });
+}
+
+/**
+ * Scenario: the authorization server rejects the token exchange with a non-200 response.
+ *
+ * Expected behavior: the response code and response body log lines carry the RequestId tag.
+ */
+TEST_F(OAuth2ClientLogTagsTest, LogsRequestIdTagOnNonSuccessResponse) {
+  setStreamRequestId();
+  expectQueuedRequest();
+
+  client_->asyncGetAccessToken("a", "b", "c", "d", "e");
+  EXPECT_EQ(1, callbacks_.size());
+
+  Http::ResponseHeaderMapPtr mock_response_headers{
+      new Http::TestResponseHeaderMapImpl{{Http::Headers::get().Status.get(), "403"}}};
+  Http::ResponseMessagePtr mock_response(
+      new Http::ResponseMessageImpl(std::move(mock_response_headers)));
+  mock_response->body().add("invalid_grant");
+
+  EXPECT_CALL(*mock_callbacks_, handleOAuthFailure(_, _))
+      .WillOnce(Return(Http::FilterHeadersStatus::StopIteration));
+
+  Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
+  // The tags are serialized in map order (ConnectionId, RequestId, StreamId) ahead of the message,
+  // so assert the tag and the tagged messages separately rather than as one substring.
+  const ExpectedLogMessages expected{{"debug", expectedTag()},
+                                     {"debug", "] Oauth response code: 403"},
+                                     {"debug", "] Oauth response body: invalid_grant"}};
+  EXPECT_LOG_CONTAINS_ALL_OF(expected, {
+    ASSERT_TRUE(popPendingCallback(
+        [&](auto* callback) { callback->onSuccess(request, std::move(mock_response)); }));
+  });
+}
+
+/**
+ * Scenario: the token exchange request fails at the transport level.
+ *
+ * Expected behavior: the failure log line carries the RequestId tag.
+ */
+TEST_F(OAuth2ClientLogTagsTest, LogsRequestIdTagOnRequestFailure) {
+  setStreamRequestId();
+  expectQueuedRequest();
+
+  client_->asyncGetAccessToken("a", "b", "c", "d", "e");
+  EXPECT_EQ(1, callbacks_.size());
+
+  EXPECT_CALL(*mock_callbacks_, handleOAuthFailure(_, _))
+      .WillOnce(Return(Http::FilterHeadersStatus::StopIteration));
+
+  Http::MockAsyncClientRequest request(&cm_.thread_local_cluster_.async_client_);
+  EXPECT_LOG_CONTAINS("debug", expectedTag(), {
+    ASSERT_TRUE(popPendingCallback([&](auto* callback) {
+      callback->onFailure(request, Http::AsyncClient::FailureReason::Reset);
+    }));
+  });
+}
+
+/**
+ * Scenario: the stream has no request id provider.
+ *
+ * Expected behavior: the client still logs, but the log line carries no RequestId tag.
+ */
+TEST_F(OAuth2ClientLogTagsTest, NoRequestIdTagWhenProviderAbsent) {
+  // The default MockStreamInfo returns an empty StreamIdProvider, so no RequestId is emitted.
+  expectQueuedRequest();
+
+  EXPECT_LOG_NOT_CONTAINS("debug", "RequestId",
+                          { client_->asyncGetAccessToken("a", "b", "c", "d", "e"); });
 }
 
 } // namespace Oauth2


### PR DESCRIPTION
**Commit Message:**
oauth2: add RequestId tag to filter application logs

**Additional Description:**
Adds a `RequestId` tag to the OAuth2 filter's application log lines, sourced from the stream's request id provider (`StreamInfo::getStreamIdProvider()->toStringView()`) so it matches the access log `%STREAM_ID%` / `x-request-id` value. This lets operators correlate OAuth2 application logs with access logs on a per-request basis.

Today the filter logs via `ENVOY_STREAM_LOG`, which emits only `ConnectionId` and `StreamId` (a numeric, in-process stream id). That numeric `StreamId` differs from the access-log `%STREAM_ID%` UUID, so the two logs could not be reliably correlated per request — only by `ConnectionId`, which is insufficient when multiple HTTP/2 or HTTP/3 streams share a connection.

**Risk Level:** Low (additive log tag; no API/config/proto change)
**Testing:** Added unit tests.
**Docs Changes:** N/A
**Release Notes:** Added (`changelogs/current/new_features/oauth2__request-id-log-tag.rst`)
**Fixes:** #46164