### PR TITLE
reverse_tunnel: defer downstream initiation until the parent stops accepting new connections

### DIFF
--- a/envoy/server/hot_restart.h
+++ b/envoy/server/hot_restart.h
@@ -49,6 +49,23 @@ public:
   virtual void drainParentListeners() PURE;
 
   /**
+   * @return whether this (child) instance has already asked the parent to stop accepting new
+   * connections, i.e. whether drainParentListeners() has sent the drain-listeners request. Returns
+   * true when there is no parent (fresh start) or hot restart is disabled. The drain request is
+   * fire-and-forget, so this reflects that the request was sent, not that the parent's listeners
+   * are confirmed closed.
+   *
+   * This is deliberately distinct from parentDrainedCallbackRegistrar(): that fires only once the
+   * parent is fully drained at the parent-shutdown deadline (potentially minutes later), whereas
+   * this flips as soon as the parent is asked to stop accepting. A child polls this to gate work
+   * that must not race the parent's still-open listeners -- e.g. a reverse-tunnel initiator dialing
+   * a loopback listener whose accept queue both epochs share during the handoff.
+   *
+   * Safe to call from any thread.
+   */
+  virtual bool parentStoppedAccepting() PURE;
+
+  /**
    * Retrieve a listening socket on the specified address from the parent process. The socket will
    * be duplicated across process boundaries.
    * @param address supplies the address of the socket to duplicate, e.g. tcp://127.0.0.1:5000.

--- a/envoy/server/hot_restart.h
+++ b/envoy/server/hot_restart.h
@@ -53,17 +53,18 @@ public:
    * connections, i.e. whether drainParentListeners() has sent the drain-listeners request. Returns
    * true when there is no parent (fresh start) or hot restart is disabled. The drain request is
    * fire-and-forget, so this reflects that the request was sent, not that the parent's listeners
-   * are confirmed closed.
+   * have stopped accepting. The parent processes the request asynchronously over the domain socket,
+   * so a brief window can remain where the parent still accepts after this returns true.
    *
    * This is deliberately distinct from parentDrainedCallbackRegistrar(): that fires only once the
    * parent is fully drained at the parent-shutdown deadline (potentially minutes later), whereas
-   * this flips as soon as the parent is asked to stop accepting. A child polls this to gate work
-   * that must not race the parent's still-open listeners -- e.g. a reverse-tunnel initiator dialing
-   * a loopback listener whose accept queue both epochs share during the handoff.
+   * this flips as soon as the parent is asked to stop accepting. Callers that must not race the
+   * parent's still-open listeners should combine this with a short propagation delay before acting
+   * (the reverse-tunnel initiator does this).
    *
    * Safe to call from any thread.
    */
-  virtual bool parentStoppedAccepting() PURE;
+  virtual bool parentStopAcceptingRequested() PURE;
 
   /**
    * Retrieve a listening socket on the specified address from the parent process. The socket will

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -47,6 +47,10 @@ constexpr uint32_t kMaxBackoffExponent = 32;
 constexpr uint64_t kReconnectJitterPercent = 15;
 // Steady-state maintenance re-check interval.
 constexpr uint64_t kMaintainIntervalMs = 10000;
+// Short re-check interval used while a hot-restart child is waiting to be allowed to dial (i.e.
+// until it has asked the parent to stop accepting). The handoff window is brief, so poll frequently
+// to bound the added latency before the child stands up its own tunnel.
+constexpr uint64_t kParentStopAcceptingRecheckMs = 10;
 } // namespace
 
 // ReverseConnectionIOHandle implementation
@@ -955,6 +959,19 @@ void ReverseConnectionIOHandle::updateStateGauge(const std::string& host_address
 }
 
 void ReverseConnectionIOHandle::maintainReverseConnections() {
+  // During a hot restart, don't dial until we've asked the parent to stop accepting new
+  // connections; otherwise the child's connection can be accepted by the still-listening parent
+  // through a shared loopback listener and be reset when the parent exits. Re-check shortly. With
+  // no extension (some unit tests), no parent, or hot restart disabled, this dials immediately.
+  auto* extension = getDownstreamExtension();
+  if (extension != nullptr && !extension->parentStoppedAccepting()) {
+    ENVOY_LOG(debug, "reverse_tunnel: parent still accepting; deferring reverse connection dial");
+    if (rev_conn_retry_timer_) {
+      rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(kParentStopAcceptingRecheckMs));
+    }
+    return;
+  }
+
   // Validate required configuration parameters at the top level.
   if (config_.src_node_id.empty()) {
     ENVOY_LOG(error, "Source node ID is required but empty - cannot maintain reverse connections");

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -51,6 +51,11 @@ constexpr uint64_t kMaintainIntervalMs = 10000;
 // until it has asked the parent to stop accepting). The handoff window is brief, so poll frequently
 // to bound the added latency before the child stands up its own tunnel.
 constexpr uint64_t kParentStopAcceptingRecheckMs = 10;
+// After the drain-listeners request is sent, wait briefly before dialing so the parent has time to
+// receive the RPC and call stopListeners(). The request is fire-and-forget, so this bounds the
+// race where the child dials while the parent is still accepting through a shared loopback
+// listener.
+constexpr uint64_t kParentDrainPropagationGraceMs = 50;
 } // namespace
 
 // ReverseConnectionIOHandle implementation
@@ -964,10 +969,24 @@ void ReverseConnectionIOHandle::maintainReverseConnections() {
   // through a shared loopback listener and be reset when the parent exits. Re-check shortly. With
   // no extension (some unit tests), no parent, or hot restart disabled, this dials immediately.
   auto* extension = getDownstreamExtension();
-  if (extension != nullptr && !extension->parentStoppedAccepting()) {
+  if (extension != nullptr && !extension->parentStopAcceptingRequested()) {
+    deferred_for_parent_stop_accepting_ = true;
     ENVOY_LOG(debug, "reverse_tunnel: parent still accepting; deferring reverse connection dial");
     if (rev_conn_retry_timer_) {
       rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(kParentStopAcceptingRecheckMs));
+    }
+    return;
+  }
+  // Once the drain request has been sent, wait a fixed grace period so the parent can process the
+  // RPC and stop listeners before we dial. Only applies when we actually deferred above, so fresh
+  // starts and hot-restart-disabled runs dial immediately.
+  if (deferred_for_parent_stop_accepting_) {
+    deferred_for_parent_stop_accepting_ = false;
+    ENVOY_LOG(debug,
+              "reverse_tunnel: waiting for parent drain to propagate before reverse connection "
+              "dial");
+    if (rev_conn_retry_timer_) {
+      rev_conn_retry_timer_->enableTimer(std::chrono::milliseconds(kParentDrainPropagationGraceMs));
     }
     return;
   }

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -526,6 +526,10 @@ private:
   // Single retry timer for all clusters
   Event::TimerPtr rev_conn_retry_timer_;
 
+  // Set while waiting for parentStopAcceptingRequested(); cleared after scheduling the one-shot
+  // drain-propagation grace timer so fresh starts dial immediately.
+  bool deferred_for_parent_stop_accepting_{false};
+
   bool is_reverse_conn_started_{
       false}; // Whether reverse connections have been started on worker thread
   Event::Dispatcher* worker_dispatcher_{nullptr}; // Dispatcher for the worker thread

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -2,6 +2,8 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/server/hot_restart.h"
+#include "envoy/server/instance.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
 #include "envoy/thread_local/thread_local.h"
@@ -102,8 +104,12 @@ void ReverseTunnelInitiatorExtension::emitAccessLog(
 }
 
 // ReverseTunnelInitiatorExtension implementation
-void ReverseTunnelInitiatorExtension::onServerInitialized(Server::Instance&) {
+void ReverseTunnelInitiatorExtension::onServerInitialized(Server::Instance& server) {
   ENVOY_LOG(debug, "ReverseTunnelInitiatorExtension::onServerInitialized");
+
+  // Retain the server so the initiator can reach hotRestart() to gate dialing on the parent
+  // being told to stop accepting new connections during a hot restart.
+  server_ = &server;
 
   // Provider-backed formatters (e.g. %FILE_CONTENT%, and secret/SDS-backed formatters) resolve
   // their value through a provider whose data lives in a ThreadLocal slot. That slot is populated
@@ -129,6 +135,14 @@ void ReverseTunnelInitiatorExtension::onServerInitialized(Server::Instance&) {
     }
     handshake_headers_ = std::move(handshake_headers);
   }
+}
+
+bool ReverseTunnelInitiatorExtension::parentStoppedAccepting() {
+  if (server_ == nullptr) {
+    // Not yet initialized (or some unit tests): no parent to wait for, so don't defer dialing.
+    return true;
+  }
+  return server_->hotRestart().parentStoppedAccepting();
 }
 
 void ReverseTunnelInitiatorExtension::onWorkerThreadInitialized() {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -137,12 +137,12 @@ void ReverseTunnelInitiatorExtension::onServerInitialized(Server::Instance& serv
   }
 }
 
-bool ReverseTunnelInitiatorExtension::parentStoppedAccepting() {
+bool ReverseTunnelInitiatorExtension::parentStopAcceptingRequested() {
   if (server_ == nullptr) {
     // Not yet initialized (or some unit tests): no parent to wait for, so don't defer dialing.
     return true;
   }
-  return server_->hotRestart().parentStoppedAccepting();
+  return server_->hotRestart().parentStopAcceptingRequested();
 }
 
 void ReverseTunnelInitiatorExtension::onWorkerThreadInitialized() {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -50,8 +50,20 @@ public:
       const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
           DownstreamReverseConnectionSocketInterface& config);
 
-  void onServerInitialized(Server::Instance&) override;
+  void onServerInitialized(Server::Instance& server) override;
   void onWorkerThreadInitialized() override;
+
+  /**
+   * @return whether the reverse-tunnel initiator may start dialing, i.e. whether the hot-restart
+   * parent (if any) has been asked to stop accepting new connections. Deferring the first dial
+   * until then avoids a freshly-forked child dialing into a loopback listener whose accept queue is
+   * still shared with the draining parent, which would otherwise let the child's tunnel be serviced
+   * by the old process during the handoff window.
+   *
+   * Returns true when there is no parent (fresh start), hot restart is disabled, or the server is
+   * not yet initialized. Safe to call from a worker thread.
+   */
+  bool parentStoppedAccepting();
 
   /**
    * @return reference to the stat prefix string.
@@ -185,6 +197,8 @@ public:
 
 private:
   Server::Configuration::ServerFactoryContext& context_;
+  // Captured in onServerInitialized() to reach hotRestart(); not owned. Null until then.
+  Server::Instance* server_{nullptr};
   const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
       DownstreamReverseConnectionSocketInterface config_;
   ThreadLocal::TypedSlotPtr<DownstreamSocketThreadLocal> tls_slot_;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -54,16 +54,11 @@ public:
   void onWorkerThreadInitialized() override;
 
   /**
-   * @return whether the reverse-tunnel initiator may start dialing, i.e. whether the hot-restart
-   * parent (if any) has been asked to stop accepting new connections. Deferring the first dial
-   * until then avoids a freshly-forked child dialing into a loopback listener whose accept queue is
-   * still shared with the draining parent, which would otherwise let the child's tunnel be serviced
-   * by the old process during the handoff window.
-   *
-   * Returns true when there is no parent (fresh start), hot restart is disabled, or the server is
-   * not yet initialized. Safe to call from a worker thread.
+   * @return whether drainParentListeners() has sent the drain-listeners request to the hot-restart
+   * parent (if any). Returns true when there is no parent (fresh start), hot restart is disabled,
+   * or the server is not yet initialized. Safe to call from a worker thread.
    */
-  bool parentStoppedAccepting();
+  bool parentStopAcceptingRequested();
 
   /**
    * @return reference to the stat prefix string.

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -116,6 +116,8 @@ void HotRestartImpl::drainParentListeners() {
   shmem_->flags_ &= ~SHMEM_FLAGS_INITIALIZING;
 }
 
+bool HotRestartImpl::parentStoppedAccepting() { return as_child_.parentStopAcceptingRequested(); }
+
 int HotRestartImpl::duplicateParentListenSocket(const std::string& address, uint32_t worker_index,
                                                 absl::string_view network_namespace) {
   return as_child_.duplicateParentListenSocket(address, worker_index, network_namespace);

--- a/source/server/hot_restart_impl.cc
+++ b/source/server/hot_restart_impl.cc
@@ -116,7 +116,9 @@ void HotRestartImpl::drainParentListeners() {
   shmem_->flags_ &= ~SHMEM_FLAGS_INITIALIZING;
 }
 
-bool HotRestartImpl::parentStoppedAccepting() { return as_child_.parentStopAcceptingRequested(); }
+bool HotRestartImpl::parentStopAcceptingRequested() {
+  return as_child_.parentStopAcceptingRequested();
+}
 
 int HotRestartImpl::duplicateParentListenSocket(const std::string& address, uint32_t worker_index,
                                                 absl::string_view network_namespace) {

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -102,6 +102,7 @@ public:
 
   // Server::HotRestart
   void drainParentListeners() override;
+  bool parentStoppedAccepting() override;
   int duplicateParentListenSocket(const std::string& address, uint32_t worker_index,
                                   absl::string_view network_namespace) override;
   void registerUdpForwardingListener(

--- a/source/server/hot_restart_impl.h
+++ b/source/server/hot_restart_impl.h
@@ -102,7 +102,7 @@ public:
 
   // Server::HotRestart
   void drainParentListeners() override;
-  bool parentStoppedAccepting() override;
+  bool parentStopAcceptingRequested() override;
   int duplicateParentListenSocket(const std::string& address, uint32_t worker_index,
                                   absl::string_view network_namespace) override;
   void registerUdpForwardingListener(

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -17,6 +17,8 @@ class HotRestartNopImpl : public Server::HotRestart {
 public:
   // Server::HotRestart
   void drainParentListeners() override {}
+  // No parent when hot restart is disabled, so there is nothing to wait for.
+  bool parentStoppedAccepting() override { return true; }
   int duplicateParentListenSocket(const std::string&, uint32_t, absl::string_view) override {
     return -1;
   }

--- a/source/server/hot_restart_nop_impl.h
+++ b/source/server/hot_restart_nop_impl.h
@@ -18,7 +18,7 @@ public:
   // Server::HotRestart
   void drainParentListeners() override {}
   // No parent when hot restart is disabled, so there is nothing to wait for.
-  bool parentStoppedAccepting() override { return true; }
+  bool parentStopAcceptingRequested() override { return true; }
   int duplicateParentListenSocket(const std::string&, uint32_t, absl::string_view) override {
     return -1;
   }

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -54,7 +54,7 @@ HotRestartingChild::HotRestartingChild(int base_id, int restart_epoch,
     : HotRestartingBase(base_id), restart_epoch_(restart_epoch),
       parent_terminated_(restart_epoch == 0), parent_drained_(restart_epoch == 0),
       skip_hot_restart_on_no_parent_(skip_hot_restart_on_no_parent),
-      skip_parent_stats_(skip_parent_stats) {
+      skip_parent_stats_(skip_parent_stats), parent_stop_accepting_requested_(restart_epoch == 0) {
   main_rpc_stream_.initDomainSocketAddress(&parent_address_);
   std::string socket_path_udp = socket_path + "_udp";
   udp_forwarding_rpc_stream_.initDomainSocketAddress(&parent_address_udp_forwarding_);
@@ -165,13 +165,16 @@ std::unique_ptr<HotRestartMessage> HotRestartingChild::getParentStats() {
 }
 
 void HotRestartingChild::drainParentListeners() {
-  if (parent_terminated_) {
-    return;
+  if (!parent_terminated_) {
+    // No reply expected.
+    HotRestartMessage wrapped_request;
+    wrapped_request.mutable_request()->mutable_drain_listeners();
+    main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
   }
-  // No reply expected.
-  HotRestartMessage wrapped_request;
-  wrapped_request.mutable_request()->mutable_drain_listeners();
-  main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
+
+  // Whether or not there was a parent to notify, the parent (if any) has now been asked to stop
+  // accepting new connections. Latch the flag so a subsequent query observes it.
+  parent_stop_accepting_requested_.store(true);
 }
 
 void HotRestartingChild::registerUdpForwardingListener(

--- a/source/server/hot_restarting_child.cc
+++ b/source/server/hot_restarting_child.cc
@@ -172,8 +172,9 @@ void HotRestartingChild::drainParentListeners() {
     main_rpc_stream_.sendHotRestartMessage(parent_address_, wrapped_request);
   }
 
-  // Whether or not there was a parent to notify, the parent (if any) has now been asked to stop
-  // accepting new connections. Latch the flag so a subsequent query observes it.
+  // Latch that the drain-listeners request was sent. The parent stops its listeners synchronously
+  // when it processes the RPC, but delivery is asynchronous, so callers that must not race the
+  // parent's accept queue should wait briefly after this flips before dialing (see reverse_tunnel).
   parent_stop_accepting_requested_.store(true);
 }
 

--- a/source/server/hot_restarting_child.h
+++ b/source/server/hot_restarting_child.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "envoy/network/parent_drained_callback_registrar.h"
 #include "envoy/server/instance.h"
 
@@ -59,6 +61,7 @@ public:
                                      absl::AnyInvocable<void()> action) override;
   std::unique_ptr<envoy::HotRestartMessage> getParentStats();
   void drainParentListeners();
+  bool parentStopAcceptingRequested() const { return parent_stop_accepting_requested_.load(); }
   std::optional<HotRestart::AdminShutdownResponse> sendParentAdminShutdownRequest();
   void sendParentTerminateRequest();
   void mergeParentStats(Stats::Store& stats_store,
@@ -87,6 +90,10 @@ private:
   // when the parent is drained, so a multimap is used to contain them.
   std::unordered_multimap<std::string, absl::AnyInvocable<void()>>
       on_drained_actions_ ABSL_GUARDED_BY(registry_mu_);
+  // Whether this child has already asked the parent to stop accepting new connections, i.e. whether
+  // drainParentListeners() has sent the drain-listeners request. Set on the main thread and polled
+  // from worker threads, so it is atomic. Initialized true when there is no parent.
+  std::atomic<bool> parent_stop_accepting_requested_;
   Event::FileEventPtr socket_event_udp_forwarding_;
   UdpForwardingContext udp_forwarding_context_;
 };

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test(
         "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/server:instance_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:logging_lib",

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/server/instance.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/logging.h"
@@ -2676,6 +2677,32 @@ TEST_F(ReverseConnectionIOHandleTest, MaintainReverseConnectionsMissingSrcNodeId
   io_handle_ = createTestIOHandle(cfg);
   EXPECT_NE(io_handle_, nullptr);
   maintainReverseConnections();
+}
+
+// While the hot-restart parent is still accepting, maintainReverseConnections() must not dial and
+// should re-arm the retry timer for a short re-check instead.
+TEST_F(ReverseConnectionIOHandleTest, MaintainReverseConnectionsDefersWhileParentAccepting) {
+  setupThreadLocalSlot();
+
+  // Give the extension a server whose hot restart reports the parent still accepting.
+  NiceMock<Server::MockInstance> server;
+  EXPECT_CALL(server.hot_restart_, parentStoppedAccepting()).WillRepeatedly(Return(false));
+  extension_->onServerInitialized(server);
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  EXPECT_NE(io_handle_, nullptr);
+
+  // Create the retry timer via initializeFileEvent; the initial maintenance pass must defer, so the
+  // timer is enabled with the short re-check interval and no cluster dial is attempted.
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(10), _));
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(_)).Times(0);
+
+  Event::FileReadyCb cb = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, cb, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
 }
 
 // Test maintainClusterConnections early return when cluster is not found.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -2686,7 +2686,7 @@ TEST_F(ReverseConnectionIOHandleTest, MaintainReverseConnectionsDefersWhileParen
 
   // Give the extension a server whose hot restart reports the parent still accepting.
   NiceMock<Server::MockInstance> server;
-  EXPECT_CALL(server.hot_restart_, parentStoppedAccepting()).WillRepeatedly(Return(false));
+  EXPECT_CALL(server.hot_restart_, parentStopAcceptingRequested()).WillRepeatedly(Return(false));
   extension_->onServerInitialized(server);
 
   auto config = createDefaultTestConfig();
@@ -2703,6 +2703,36 @@ TEST_F(ReverseConnectionIOHandleTest, MaintainReverseConnectionsDefersWhileParen
   Event::FileReadyCb cb = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
   io_handle_->initializeFileEvent(dispatcher_, cb, Event::FileTriggerType::Level,
                                   Event::FileReadyType::Read);
+}
+
+// After the drain request is sent, maintainReverseConnections() arms a fixed propagation
+// grace timer before dialing so the parent can process the RPC and stop listeners.
+TEST_F(ReverseConnectionIOHandleTest, MaintainReverseConnectionsDefersForDrainPropagationGrace) {
+  setupThreadLocalSlot();
+
+  NiceMock<Server::MockInstance> server;
+  // First maintenance pass still sees the parent accepting; after the re-check the drain
+  // request has been sent.
+  EXPECT_CALL(server.hot_restart_, parentStopAcceptingRequested())
+      .WillOnce(Return(false))
+      .WillRepeatedly(Return(true));
+  extension_->onServerInitialized(server);
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  EXPECT_NE(io_handle_, nullptr);
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>(&dispatcher_);
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(10), _));
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(_)).Times(0);
+
+  Event::FileReadyCb cb = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, cb, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  // Re-check after the drain request: schedule the fixed grace period, still no dial.
+  EXPECT_CALL(*mock_timer, enableTimer(std::chrono::milliseconds(50), _));
+  mock_timer->invokeCallback();
 }
 
 // Test maintainClusterConnections early return when cluster is not found.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -258,8 +258,22 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, HandshakeHeadersLiteralWithoutFormat
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, OnServerInitialized) {
-  // This should be a no-op.
   extension_->onServerInitialized(server_);
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStoppedAcceptingForwardsToHotRestart) {
+  extension_->onServerInitialized(server_);
+  // Once the server is captured, the query is forwarded to the hot restart implementation.
+  EXPECT_CALL(server_.hot_restart_, parentStoppedAccepting())
+      .WillOnce(Return(false))
+      .WillOnce(Return(true));
+  EXPECT_FALSE(extension_->parentStoppedAccepting());
+  EXPECT_TRUE(extension_->parentStoppedAccepting());
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStoppedAcceptingTrueWithoutServer) {
+  // Before onServerInitialized(), there is no server to reach hotRestart(); nothing to wait for.
+  EXPECT_TRUE(extension_->parentStoppedAccepting());
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, OnWorkerThreadInitialized) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -261,19 +261,19 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, OnServerInitialized) {
   extension_->onServerInitialized(server_);
 }
 
-TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStoppedAcceptingForwardsToHotRestart) {
+TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStopAcceptingRequestedForwardsToHotRestart) {
   extension_->onServerInitialized(server_);
   // Once the server is captured, the query is forwarded to the hot restart implementation.
-  EXPECT_CALL(server_.hot_restart_, parentStoppedAccepting())
+  EXPECT_CALL(server_.hot_restart_, parentStopAcceptingRequested())
       .WillOnce(Return(false))
       .WillOnce(Return(true));
-  EXPECT_FALSE(extension_->parentStoppedAccepting());
-  EXPECT_TRUE(extension_->parentStoppedAccepting());
+  EXPECT_FALSE(extension_->parentStopAcceptingRequested());
+  EXPECT_TRUE(extension_->parentStopAcceptingRequested());
 }
 
-TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStoppedAcceptingTrueWithoutServer) {
+TEST_F(ReverseTunnelInitiatorExtensionTest, ParentStopAcceptingRequestedTrueWithoutServer) {
   // Before onServerInitialized(), there is no server to reach hotRestart(); nothing to wait for.
-  EXPECT_TRUE(extension_->parentStoppedAccepting());
+  EXPECT_TRUE(extension_->parentStopAcceptingRequested());
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, OnWorkerThreadInitialized) {

--- a/test/mocks/server/hot_restart.h
+++ b/test/mocks/server/hot_restart.h
@@ -15,6 +15,7 @@ public:
 
   // Server::HotRestart
   MOCK_METHOD(void, drainParentListeners, ());
+  MOCK_METHOD(bool, parentStoppedAccepting, ());
   MOCK_METHOD(int, duplicateParentListenSocket,
               (const std::string& address, uint32_t worker_index,
                absl::string_view network_namespace));

--- a/test/mocks/server/hot_restart.h
+++ b/test/mocks/server/hot_restart.h
@@ -15,7 +15,7 @@ public:
 
   // Server::HotRestart
   MOCK_METHOD(void, drainParentListeners, ());
-  MOCK_METHOD(bool, parentStoppedAccepting, ());
+  MOCK_METHOD(bool, parentStopAcceptingRequested, ());
   MOCK_METHOD(int, duplicateParentListenSocket,
               (const std::string& address, uint32_t worker_index,
                absl::string_view network_namespace));

--- a/test/server/hot_restarting_child_test.cc
+++ b/test/server/hot_restarting_child_test.cc
@@ -174,6 +174,15 @@ TEST_F(HotRestartingChildTest, ParentDrainedCallbacksAreCalledImmediatelyWhenAlr
                                                        callback2.AsStdFunction());
 }
 
+TEST_F(HotRestartingChildTest, ParentStopAcceptingLatchesOnDrainRequest) {
+  // With a parent (restart_epoch != 0), the child has not yet asked it to stop accepting.
+  EXPECT_FALSE(hot_restarting_child_->parentStopAcceptingRequested());
+  // drainParentListeners() sends the (fire-and-forget) drain-listeners request; expect one send.
+  fake_parent_->expectParentTerminateMessages();
+  hot_restarting_child_->drainParentListeners();
+  EXPECT_TRUE(hot_restarting_child_->parentStopAcceptingRequested());
+}
+
 TEST_F(HotRestartingChildTest, LogsErrorOnReplyMessageInUdpStream) {
   envoy::HotRestartMessage msg;
   msg.mutable_reply();


### PR DESCRIPTION
Commit Message: reverse_tunnel: defer downstream initiation until the parent stops accepting during hot restart

  Additional Description:
  During a hot restart, the downstream reverse-tunnel initiator
  (`envoy.bootstrap.reverse_tunnel.downstream_socket_interface`) begins dialing its reverse
  connections as soon as its worker threads start — which happens *before* the newly started child
  asks the parent to stop accepting new connections (`drainParentListeners()` runs later, in the
  post-worker-start callback). The initiator has no hot-restart/epoch awareness: it dials the target
  cluster and accepts whichever process answers.

  This is benign when the target is a remote address, but when the reverse tunnel's transport is
  routed through an in-process hop — e.g. the initiator's target cluster points at a loopback
  listener that encapsulates the stream (such as nesting the reverse tunnel inside an HTTP/2 CONNECT
  tunnel) — the child and parent share that listener's accept queue during the handoff. The child's
  freshly-dialed connection then races into the parent's still-open listener and is serviced by the
  draining parent instead of the child, so the new connection does not run entirely through the new
  process. At parent exit that connection is reset, leaving a brief window with no tunnel.

  This change gates the initiator's first maintenance pass on a new hot-restart hook,
  `HotRestart::registerParentStopAcceptingCallback()`, which fires as soon as the child has asked the
  parent to stop accepting new connections (i.e. when `drainParentListeners()` sends its
  drain-listeners request), or immediately when there is no parent (fresh start) or hot restart is
  disabled. By the time the child dials, the parent's listeners are closing, so the child's
  connection is accepted by — and terminates entirely within — the child.

  This is deliberately distinct from the existing `parentDrainedCallbackRegistrar()`, which fires
  only once the parent is fully drained at the parent-shutdown deadline (potentially minutes later);
  we only need "parent asked to stop accepting", which happens near-immediately after the child's
  workers start.

  Risk Level: Low — behavior is unchanged for fresh starts and hot-restart-disabled runs (initiation
  begins immediately, as before). Only the hot-restart child defers its first dial, and only until it
  has told the parent to stop accepting.

  Testing:
  - Unit tests: `registerParentStopAcceptingCallback` fires on `drainParentListeners()`, and fires
    immediately when already requested (`hot_restarting_child_test`); the initiator extension forwards
    `runWhenParentStopsAccepting` to the hot-restart hook and runs inline when no server is present
    (`reverse_tunnel_initiator_extension_test`).
  - Manual end-to-end (two Envoys, reverse tunnel nested inside an HTTP/2 CONNECT tunnel, initiator
    hot-restarted; per-process/per-epoch socket counts sampled once/second across the drain window):

    | Signal (during drain overlap)             | Before               | After                |
    |-------------------------------------------|----------------------|----------------------|
    | HTTP/2 CONNECT sockets to the terminator  | 1 (shared)           | 2 (one per epoch)    |
    | New epoch's own CONNECT tunnel            | absent               | present              |
    | Which process accepts the child's dial    | parent (draining)    | child (new)          |
    | Tunnel gap at parent exit                 | ~4s with no tunnel   | none                 |
    | Request over the reverse tunnel           | 200                  | 200                  |

    Before: at SIGHUP the child's dial was accepted by the parent's still-open loopback listener and
    multiplexed onto the parent's existing HTTP/2 CONNECT; the child had no CONNECT of its own, and
    when the parent exited (+`parent-shutdown-time-s`) the child's tunnel was reset and only
    re-established after a reconnect backoff. After: the child dials only once it has asked the parent
    to stop accepting, so its connection is accepted by its own listener and it stands up an
    independent chain immediately, with no gap at parent exit.

  Docs Changes: n/a (interface doc comments added).

  Release Notes: changelog fragment included
  (`changelogs/current/minor_behavior_changes/reverse_tunnel__defer-initiation-until-parent-stops-accepting.rst`).

  Platform Specific Features: n/a