### PR TITLE
Use status matchers where appropriate (16)

### DIFF
--- a/test/extensions/filters/http/a2a/BUILD
+++ b/test/extensions/filters/http/a2a/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     srcs = ["a2a_json_parser_test.cc"],
     deps = [
         "//source/extensions/filters/http/a2a:a2a_json_parser_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -34,6 +35,7 @@ envoy_cc_test(
     deps = [
         "//source/extensions/filters/http/a2a:config",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/a2a/a2a_json_parser_test.cc
+++ b/test/extensions/filters/http/a2a/a2a_json_parser_test.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/filters/http/a2a/a2a_json_parser.h"
 
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -9,6 +10,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace A2a {
 namespace {
+
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 class A2aJsonParserTest : public ::testing::Test {
 protected:
@@ -41,8 +45,8 @@ TEST_F(A2aJsonParserTest, ParseSimpleMessageSend) {
   })";
 
   // Parse the JSON string.
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
 
   // Verify overall validity and method.
   EXPECT_TRUE(parser_.isValidA2aRequest());
@@ -202,8 +206,8 @@ TEST_F(A2aJsonParserTest, ParseMessageSend) {
   })";
 
   // Parse the JSON string.
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
 
   // Verify overall validity and method.
   EXPECT_TRUE(parser_.isValidA2aRequest());
@@ -433,9 +437,9 @@ TEST_F(A2aJsonParserTest, ParseMessageSendMultiChunks) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(part1).ok());
-  ASSERT_TRUE(parser_.parse(part2).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(part1));
+  ASSERT_OK(parser_.parse(part2));
+  ASSERT_OK(parser_.finishParse());
 
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "message/send");
@@ -476,8 +480,8 @@ TEST_F(A2aJsonParserTest, ParseTasksGet) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/get");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "124");
@@ -525,8 +529,8 @@ TEST_F(A2aJsonParserTest, ParseTasksList) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/list");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "125");
@@ -606,8 +610,8 @@ TEST_F(A2aJsonParserTest, ParseTasksPushNotificationConfigSet) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/pushNotificationConfig/set");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "126");
@@ -692,8 +696,8 @@ TEST_F(A2aJsonParserTest, ParseUnrecognizedMethod) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "unknown/method");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "123");
@@ -712,8 +716,8 @@ TEST_F(A2aJsonParserTest, InvalidJson) {
 
   // The parse call itself will succeed since it is streaming and waiting for more data,
   // but finishParse should definitely fail.
-  ASSERT_TRUE(parser_.parse(json).ok());
-  EXPECT_FALSE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  EXPECT_THAT(parser_.finishParse(), Not(IsOk()));
 }
 
 TEST_F(A2aJsonParserTest, MissingJsonRpc) {
@@ -723,8 +727,8 @@ TEST_F(A2aJsonParserTest, MissingJsonRpc) {
     "params": {}
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   // Should return false because 'jsonrpc' field is missing from extracted metadata
   EXPECT_FALSE(parser_.isValidA2aRequest());
 }
@@ -744,8 +748,8 @@ TEST_F(A2aJsonParserTest, ParseTasksListMissingOptionalFields) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/list");
   EXPECT_EQ(
@@ -770,8 +774,8 @@ TEST_F(A2aJsonParserTest, GetTaskRequest) {
     }
   }
 })";
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/get");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 102);
@@ -811,8 +815,8 @@ TEST_F(A2aJsonParserTest, CancelTaskRequest) {
     }
   }
 })";
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/cancel");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 103);
@@ -845,8 +849,8 @@ TEST_F(A2aJsonParserTest, ResubscribeTaskRequest) {
     }
   }
 })";
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/resubscribe");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 106);
@@ -886,8 +890,8 @@ TEST_F(A2aJsonParserTest, ParseTasksPushNotificationConfigGet) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/pushNotificationConfig/get");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 130);
@@ -927,8 +931,8 @@ TEST_F(A2aJsonParserTest, ParseTasksPushNotificationConfigList) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/pushNotificationConfig/list");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 131);
@@ -967,8 +971,8 @@ TEST_F(A2aJsonParserTest, ParseTasksPushNotificationConfigDelete) {
     }
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/pushNotificationConfig/delete");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 132);
@@ -993,8 +997,8 @@ TEST_F(A2aJsonParserTest, ParseAgentGetAuthenticatedExtendedCard) {
     "params": {}
   })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "agent/getAuthenticatedExtendedCard");
   EXPECT_EQ(parser_.metadata().fields().at("id").number_value(), 133);
@@ -1016,8 +1020,8 @@ TEST_F(A2aJsonParserTest, GetNestedValue) {
       }
     }
   })";
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
 
   // Valid paths
@@ -1038,8 +1042,8 @@ TEST_F(A2aJsonParserTest, Reset) {
   const std::string json2 =
       R"({"jsonrpc": "2.0", "method": "tasks/cancel", "id": "2", "params": {"id": "task2"}})";
 
-  ASSERT_TRUE(parser_.parse(json1).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json1));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/get");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "1");
@@ -1048,8 +1052,8 @@ TEST_F(A2aJsonParserTest, Reset) {
   EXPECT_FALSE(parser_.isValidA2aRequest());
   EXPECT_TRUE(parser_.metadata().fields().empty());
 
-  ASSERT_TRUE(parser_.parse(json2).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json2));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_EQ(parser_.getMethod(), "tasks/cancel");
   EXPECT_EQ(parser_.metadata().fields().at("id").string_value(), "2");
@@ -1081,8 +1085,8 @@ TEST_F(A2aJsonParserTest, ParseResponseWithResult) {
   }
 })";
 
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_TRUE(parser_.metadata().fields().contains("jsonrpc"));
   EXPECT_EQ(parser_.metadata().fields().at("jsonrpc").string_value(), "2.0");
@@ -1123,8 +1127,8 @@ TEST_F(A2aJsonParserTest, GetTaskErrorResponse) {
         "data": null
     }
     })";
-  ASSERT_TRUE(parser_.parse(json).ok());
-  ASSERT_TRUE(parser_.finishParse().ok());
+  ASSERT_OK(parser_.parse(json));
+  ASSERT_OK(parser_.finishParse());
   EXPECT_TRUE(parser_.isValidA2aRequest());
   EXPECT_TRUE(parser_.metadata().fields().contains("jsonrpc"));
   EXPECT_EQ(parser_.metadata().fields().at("jsonrpc").string_value(), "2.0");

--- a/test/extensions/filters/http/a2a/config_test.cc
+++ b/test/extensions/filters/http/a2a/config_test.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/http/a2a/config.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -26,7 +27,7 @@ TEST_F(A2aFilterConfigFactoryTest, CreateFilterFactory) {
 
   // Envoy OSS uses absl::StatusOr, so we check .ok() or .status().ok()
   auto cb = factory_.createFilterFactoryFromProto(config, "stats", context);
-  EXPECT_TRUE(cb.status().ok());
+  EXPECT_OK(cb.status());
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));

--- a/test/extensions/filters/http/compressor/BUILD
+++ b/test/extensions/filters/http/compressor/BUILD
@@ -78,6 +78,7 @@ envoy_extension_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/compressor/config_test.cc
+++ b/test/extensions/filters/http/compressor/config_test.cc
@@ -8,6 +8,7 @@
 #include "test/extensions/filters/http/compressor/mock_compressor_library.pb.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -94,7 +95,7 @@ TEST(CompressorFilterFactoryTests, RegisteredCompressorLibraryConfig) {
       Envoy::Compression::Compressor::NamedCompressorLibraryConfigFactory>
       reg(factory_impl);
   auto cb_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
-  EXPECT_TRUE(cb_or.status().ok());
+  EXPECT_OK(cb_or.status());
 }
 
 // Factory that accesses GenericFactoryContext methods.
@@ -144,7 +145,7 @@ TEST(CompressorFilterFactoryTests, PerRouteWithGenericFactoryContext) {
 
   auto cfg_or = factory.createRouteSpecificFilterConfig(per_route, context,
                                                         context.messageValidationVisitor());
-  EXPECT_TRUE(cfg_or.status().ok());
+  EXPECT_OK(cfg_or.status());
 }
 
 TEST(CompressorFilterFactoryTests, EmptyPerRouteConfig) {
@@ -166,7 +167,7 @@ TEST(CompressorFilterFactoryTests, PerRouteWithGenericContextBuilds) {
   CompressorFilterFactory factory;
   auto cfg_or = factory.createRouteSpecificFilterConfig(per_route, context,
                                                         context.messageValidationVisitor());
-  EXPECT_TRUE(cfg_or.status().ok());
+  EXPECT_OK(cfg_or.status());
   // No further assertions; this exercises the GenericFactoryContext path.
 }
 

--- a/test/extensions/filters/http/geoip/BUILD
+++ b/test/extensions/filters/http/geoip/BUILD
@@ -24,6 +24,7 @@ envoy_extension_cc_test(
         "//test/mocks/geoip:geoip_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/geoip/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -14,9 +14,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::testing::AllOf;
-using ::testing::Not;
 
 namespace Envoy {
 namespace Extensions {
@@ -199,10 +198,10 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigMutualExclusionXffAndIpAddressHeade
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GeoipFilterFactory factory;
   auto status_or = factory.createFilterFactoryFromProtoTyped(filter_config, "geoip", context);
-  EXPECT_THAT(status_or, Not(IsOk()));
-  EXPECT_EQ(status_or.status().message(),
-            "Only one of xff_config or custom_header_config can be set in the geoip filter "
-            "configuration");
+  EXPECT_THAT(status_or,
+              HasStatusMessage(
+                  "Only one of xff_config or custom_header_config can be set in the geoip filter "
+                  "configuration"));
 }
 
 } // namespace

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -8,12 +8,15 @@
 #include "test/mocks/geoip/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::IsOk;
 using ::testing::AllOf;
+using ::testing::Not;
 
 namespace Envoy {
 namespace Extensions {
@@ -196,7 +199,7 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigMutualExclusionXffAndIpAddressHeade
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GeoipFilterFactory factory;
   auto status_or = factory.createFilterFactoryFromProtoTyped(filter_config, "geoip", context);
-  EXPECT_FALSE(status_or.ok());
+  EXPECT_THAT(status_or, Not(IsOk()));
   EXPECT_EQ(status_or.status().message(),
             "Only one of xff_config or custom_header_config can be set in the geoip filter "
             "configuration");

--- a/test/extensions/geoip_providers/maxmind/BUILD
+++ b/test/extensions/geoip_providers/maxmind/BUILD
@@ -54,6 +54,7 @@ envoy_extension_cc_test(
         "//source/extensions/geoip_providers/maxmind:provider_impl",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:logging_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/geoip_providers/maxmind/v3:pkg_cc_proto",
     ],

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -9,6 +9,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
@@ -712,7 +713,7 @@ TEST_F(GeoipProviderTest, DbReloadedOnMmdbFileUpdate) {
   cb_added_opt.value().waitReady();
   {
     absl::ReaderMutexLock guard(mutex_);
-    EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
+    EXPECT_OK(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo));
   }
   expectReloadStats("city_db", 1, 0);
   captured_lookup_response_.clear();
@@ -754,7 +755,7 @@ TEST_F(GeoipProviderTest, DbEpochGaugeUpdatesWhenReloadedOnMmdbFileUpdate) {
   cb_added_opt.value().waitReady();
   {
     absl::ReaderMutexLock guard(mutex_);
-    EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
+    EXPECT_OK(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo));
   }
   expectReloadStats("city_db", 1, 0);
   expectStats("city_db", 0, 0, 0, 1753263760);
@@ -1057,7 +1058,7 @@ TEST_P(MmdbReloadImplTest, MmdbReloaded) {
   cb_added_opt.value().waitReady();
   {
     absl::ReaderMutexLock guard(mutex_);
-    EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
+    EXPECT_OK(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo));
   }
   expectReloadStats(test_case.db_type_, 1, 0);
   captured_lookup_response_.clear();
@@ -1113,7 +1114,7 @@ TEST_P(MmdbReloadImplTest, MmdbReloadedInFlightReadsNotAffected) {
   cb_added_opt.value().waitReady();
   {
     absl::ReaderMutexLock guard(mutex_);
-    EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
+    EXPECT_OK(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo));
   }
   GeoipProviderPeer::synchronizer(provider_).signal(lookup_sync_point_name);
   t0.join();
@@ -1189,7 +1190,7 @@ TEST_P(MmdbReloadErrorImplTest, MmdbReloadErrorUsesPreviousDb) {
   cb_added_opt.value().waitReady();
   {
     absl::ReaderMutexLock guard(mutex_);
-    EXPECT_TRUE(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo).ok());
+    EXPECT_OK(on_changed_cbs_[0](Filesystem::Watcher::Events::MovedTo));
   }
   // On reload error the old db instance should be used for subsequent lookup requests.
   expectReloadStats(test_case.db_type_, 0, 1);

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -78,7 +78,7 @@ public:
     envoy::extensions::filters::http::cache::v3::CacheConfig cache_config;
     TestUtility::loadFromYaml(std::string(yaml_config), cache_config);
     ConfigProto cfg;
-    EXPECT_TRUE(MessageUtil::unpackTo(cache_config.typed_config(), cfg).ok());
+    EXPECT_OK(MessageUtil::unpackTo(cache_config.typed_config(), cfg));
     cfg.set_cache_path(cache_path_);
     return cfg;
   }

--- a/test/extensions/load_balancing_policies/maglev/BUILD
+++ b/test/extensions/load_balancing_policies/maglev/BUILD
@@ -29,6 +29,7 @@ envoy_extension_cc_test(
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
@@ -52,6 +53,7 @@ envoy_extension_cc_test(
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
@@ -67,6 +69,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/mocks/upstream:priority_set_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/load_balancing_policies/maglev/v3:pkg_cc_proto",
     ],
@@ -94,6 +97,7 @@ envoy_cc_benchmark_binary(
     deps = [
         "//source/extensions/load_balancing_policies/maglev:maglev_lb_lib",
         "//test/extensions/load_balancing_policies/common:benchmark_base_tester_lib",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/load_balancing_policies/maglev/config_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/config_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/priority_set.h"
+#include "test/test_common/status_utility.h"
 
 #include "gtest/gtest.h"
 
@@ -36,7 +37,7 @@ TEST(MaglevConfigTest, Validate) {
                        context.api_.random_, context.time_system_);
     EXPECT_NE(nullptr, thread_aware_lb);
 
-    ASSERT_TRUE(thread_aware_lb->initialize().ok());
+    ASSERT_OK(thread_aware_lb->initialize());
 
     auto thread_local_lb_factory = thread_aware_lb->factory();
     EXPECT_NE(nullptr, thread_local_lb_factory);

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_benchmark.cc
@@ -2,6 +2,7 @@
 
 #include "test/benchmark/main.h"
 #include "test/extensions/load_balancing_policies/common/benchmark_base_tester.h"
+#include "test/test_common/status_utility.h"
 
 namespace Envoy {
 namespace Upstream {
@@ -27,7 +28,7 @@ void benchmarkMaglevLoadBalancerChooseHost(::benchmark::State& state) {
     const uint64_t num_hosts = state.range(0);
     const uint64_t keys_to_simulate = state.range(1);
     MaglevTester tester(num_hosts);
-    ASSERT_TRUE(tester.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester.maglev_lb_->initialize());
     LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.lb_params_);
     absl::node_hash_map<std::string, uint64_t> hit_counter;
     TestLoadBalancerContext context;
@@ -63,7 +64,7 @@ void benchmarkMaglevLoadBalancerBuildTable(::benchmark::State& state) {
 
     // We are only interested in timing the initial table build.
     state.ResumeTiming();
-    ASSERT_TRUE(tester.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester.maglev_lb_->initialize());
     state.PauseTiming();
     const size_t end_mem = Memory::Stats::totalCurrentlyAllocated();
     state.counters["memory"] = end_mem - start_mem;
@@ -85,7 +86,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(2);
 
     MaglevTester tester(num_hosts);
-    ASSERT_TRUE(tester.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester.maglev_lb_->initialize());
     LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.lb_params_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
@@ -95,7 +96,7 @@ void benchmarkMaglevLoadBalancerHostLoss(::benchmark::State& state) {
     }
 
     MaglevTester tester2(num_hosts - hosts_to_lose);
-    ASSERT_TRUE(tester2.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester2.maglev_lb_->initialize());
     lb = tester2.maglev_lb_->factory()->create(tester2.lb_params_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {
@@ -132,7 +133,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
     const uint64_t keys_to_simulate = state.range(4);
 
     MaglevTester tester(num_hosts, weighted_subset_percent, before_weight);
-    ASSERT_TRUE(tester.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester.maglev_lb_->initialize());
     LoadBalancerPtr lb = tester.maglev_lb_->factory()->create(tester.lb_params_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
@@ -142,7 +143,7 @@ void benchmarkMaglevLoadBalancerWeighted(::benchmark::State& state) {
     }
 
     MaglevTester tester2(num_hosts, weighted_subset_percent, after_weight);
-    ASSERT_TRUE(tester2.maglev_lb_->initialize().ok());
+    ASSERT_OK(tester2.maglev_lb_->initialize());
     lb = tester2.maglev_lb_->factory()->create(tester2.lb_params_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {

--- a/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
+++ b/test/extensions/load_balancing_policies/maglev/maglev_lb_test.cc
@@ -14,6 +14,7 @@
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 
 namespace Envoy {
@@ -95,7 +96,7 @@ public:
     }
 
     createLb();
-    EXPECT_TRUE(lb_->initialize().ok());
+    EXPECT_OK(lb_->initialize());
   }
 
   NiceMock<MockPrioritySet> priority_set_;

--- a/test/extensions/load_balancing_policies/ring_hash/BUILD
+++ b/test/extensions/load_balancing_policies/ring_hash/BUILD
@@ -33,6 +33,7 @@ envoy_extension_cc_test(
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
@@ -48,6 +49,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/mocks/upstream:priority_set_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/load_balancing_policies/ring_hash/v3:pkg_cc_proto",
     ],
@@ -75,6 +77,7 @@ envoy_cc_benchmark_binary(
     deps = [
         "//source/extensions/load_balancing_policies/ring_hash:ring_hash_lb_lib",
         "//test/extensions/load_balancing_policies/common:benchmark_base_tester_lib",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/load_balancing_policies/ring_hash/config_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/config_test.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/priority_set.h"
+#include "test/test_common/status_utility.h"
 
 #include "gtest/gtest.h"
 
@@ -37,7 +38,7 @@ TEST(RingHashConfigTest, Validate) {
                        context.api_.random_, context.time_system_);
     EXPECT_NE(nullptr, thread_aware_lb);
 
-    ASSERT_TRUE(thread_aware_lb->initialize().ok());
+    ASSERT_OK(thread_aware_lb->initialize());
 
     auto thread_local_lb_factory = thread_aware_lb->factory();
     EXPECT_NE(nullptr, thread_local_lb_factory);

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_benchmark.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_benchmark.cc
@@ -2,6 +2,7 @@
 
 #include "test/benchmark/main.h"
 #include "test/extensions/load_balancing_policies/common/benchmark_base_tester.h"
+#include "test/test_common/status_utility.h"
 
 namespace Envoy {
 namespace Upstream {
@@ -31,7 +32,7 @@ void benchmarkRingHashLoadBalancerBuildRing(::benchmark::State& state) {
 
     // We are only interested in timing the initial ring build.
     state.ResumeTiming();
-    ASSERT_TRUE(tester.ring_hash_lb_->initialize().ok());
+    ASSERT_OK(tester.ring_hash_lb_->initialize());
     state.PauseTiming();
     const size_t end_mem = Memory::Stats::totalCurrentlyAllocated();
     state.counters["memory"] = end_mem - start_mem;
@@ -56,7 +57,7 @@ void benchmarkRingHashLoadBalancerChooseHost(::benchmark::State& state) {
     const uint64_t min_ring_size = state.range(1);
     const uint64_t keys_to_simulate = state.range(2);
     RingHashTester tester(num_hosts, min_ring_size);
-    ASSERT_TRUE(tester.ring_hash_lb_->initialize().ok());
+    ASSERT_OK(tester.ring_hash_lb_->initialize());
     LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create(tester.lb_params_);
     absl::node_hash_map<std::string, uint64_t> hit_counter;
     TestLoadBalancerContext context;
@@ -100,7 +101,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
 
   for (auto _ : state) { // NOLINT: Silences warning about dead store
     RingHashTester tester(num_hosts, min_ring_size);
-    ASSERT_TRUE(tester.ring_hash_lb_->initialize().ok());
+    ASSERT_OK(tester.ring_hash_lb_->initialize());
     LoadBalancerPtr lb = tester.ring_hash_lb_->factory()->create(tester.lb_params_);
     std::vector<HostConstSharedPtr> hosts;
     TestLoadBalancerContext context;
@@ -110,7 +111,7 @@ void benchmarkRingHashLoadBalancerHostLoss(::benchmark::State& state) {
     }
 
     RingHashTester tester2(num_hosts - hosts_to_lose, min_ring_size);
-    ASSERT_TRUE(tester2.ring_hash_lb_->initialize().ok());
+    ASSERT_OK(tester2.ring_hash_lb_->initialize());
     lb = tester2.ring_hash_lb_->factory()->create(tester2.lb_params_);
     std::vector<HostConstSharedPtr> hosts2;
     for (uint64_t i = 0; i < keys_to_simulate; i++) {

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -20,6 +20,7 @@
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 
 #include "absl/container/node_hash_map.h"
@@ -74,7 +75,7 @@ public:
     lb_ = std::make_unique<RingHashLoadBalancer>(
         priority_set_, stats_, *stats_store_.rootScope(), context_.runtime_loader_,
         context_.api_.random_, 50, typed_config.lb_config_, typed_config.hash_policy_);
-    EXPECT_TRUE(lb_->initialize().ok());
+    EXPECT_OK(lb_->initialize());
   }
 
   // Run all tests against both priority 0 and priority 1 host sets, to ensure
@@ -1167,12 +1168,12 @@ TEST(RingHashCoalesceDisabledTest, FallbackPathExercised) {
   envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash config;
   absl::Status creation_status;
   TypedRingHashLbConfig typed_config(config, context.regex_engine_, creation_status);
-  ASSERT_TRUE(creation_status.ok());
+  ASSERT_OK(creation_status);
 
   auto lb = std::make_unique<RingHashLoadBalancer>(
       priority_set, stats, *stats_store.rootScope(), context.runtime_loader_, context.api_.random_,
       50, typed_config.lb_config_, typed_config.hash_policy_);
-  EXPECT_TRUE(lb->initialize().ok());
+  EXPECT_OK(lb->initialize());
 
   MockHostSet& host_set = *priority_set.getMockHostSet(0);
   host_set.hosts_ = {makeTestHost(info, "tcp://127.0.0.1:80")};
@@ -1213,7 +1214,7 @@ public:
                           hosts_per_locality_p1),
         {}, *hosts_p1, {}, std::nullopt, std::nullopt);
 
-    EXPECT_TRUE(lb_.initialize().ok());
+    EXPECT_OK(lb_.initialize());
   }
 
   std::shared_ptr<MockClusterInfo> info_;
@@ -1237,7 +1238,7 @@ TEST(RingHashMidBatchInitializeCrashTest, NoOobOnNewPriority) {
   envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash config;
   absl::Status creation_status;
   TypedRingHashLbConfig typed_config(config, context.regex_engine_, creation_status);
-  ASSERT_TRUE(creation_status.ok());
+  ASSERT_OK(creation_status);
 
   RingHashLoadBalancer lb(priority_set, stats, *stats_store.rootScope(), context.runtime_loader_,
                           context.api_.random_, 50, typed_config.lb_config_,
@@ -1271,9 +1272,9 @@ TEST_P(RingHashLoadBalancerTest, ValidateEndpointsSkipsNullPriorityEntries) {
 
   absl::Status creation_status;
   TypedRingHashLbConfig typed_config(config_, context_.regex_engine_, creation_status);
-  ASSERT_TRUE(creation_status.ok());
+  ASSERT_OK(creation_status);
 
-  EXPECT_TRUE(typed_config.validateEndpoints(priorities).ok());
+  EXPECT_OK(typed_config.validateEndpoints(priorities));
 }
 
 } // namespace

--- a/test/extensions/load_balancing_policies/subset/BUILD
+++ b/test/extensions/load_balancing_policies/subset/BUILD
@@ -24,6 +24,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/mocks/upstream:priority_set_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/load_balancing_policies/subset/v3:pkg_cc_proto",
     ],

--- a/test/extensions/load_balancing_policies/subset/config_test.cc
+++ b/test/extensions/load_balancing_policies/subset/config_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/server/factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/priority_set.h"
+#include "test/test_common/status_utility.h"
 
 #include "gtest/gtest.h"
 
@@ -57,7 +58,7 @@ TEST(SubsetConfigTest, SubsetConfigTest) {
                      context.api_.random_, context.time_system_);
   EXPECT_NE(nullptr, thread_aware_lb);
 
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   auto thread_local_lb_factory = thread_aware_lb->factory();
   EXPECT_NE(nullptr, thread_local_lb_factory);

--- a/test/extensions/quic/connection_id_generator/quic_lb/BUILD
+++ b/test/extensions/quic/connection_id_generator/quic_lb/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.quic.connection_id_generator.quic_lb"],
     rbe_pool = "6gig",
     deps = envoy_select_enable_http3([
+        "//test/test_common:status_utility_lib",
         "//source/extensions/quic/connection_id_generator/quic_lb:quic_lb_lib",
         "//test/mocks/secret:secret_mocks",
         "//test/mocks/server:factory_context_mocks",

--- a/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
+++ b/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
@@ -4,6 +4,7 @@
 #include "test/mocks/secret/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/network_utility.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -173,7 +174,7 @@ TEST(QuicLbTest, InvalidConfig) {
   encryption_parameters.mutable_generic_secret();
   auto status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(), "Missing 'encryption_key'");
 
@@ -185,7 +186,7 @@ TEST(QuicLbTest, InvalidConfig) {
   factory_context.server_factory_context_.resetSecretManager();
   status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
             "'encryption_key' length was 3, but it must be length 16");
@@ -196,7 +197,7 @@ TEST(QuicLbTest, InvalidConfig) {
   factory_context.server_factory_context_.resetSecretManager();
   status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(), "Missing 'configuration_version'");
 
@@ -209,7 +210,7 @@ TEST(QuicLbTest, InvalidConfig) {
   factory_context.server_factory_context_.resetSecretManager();
   status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
             "'configuration_version' length was 2, but it must be length 1 byte");
@@ -222,7 +223,7 @@ TEST(QuicLbTest, InvalidConfig) {
   factory_context.server_factory_context_.resetSecretManager();
   status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
   EXPECT_EQ(factory_or_status.status().message(),
             "'configuration_version' was 7, but must be less than 7");
@@ -234,9 +235,9 @@ TEST(QuicLbTest, InvalidConfig) {
   factory_context.server_factory_context_.resetSecretManager();
   status = factory_context.server_factory_context_.secretManager().addStaticSecret(
       encryption_parameters);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   factory_or_status = Factory::create(cfg, factory_context);
-  EXPECT_TRUE(factory_or_status.ok());
+  EXPECT_OK(factory_or_status);
 
   // Server ID length mismatch
   cfg.set_expected_server_id_length(3);
@@ -247,7 +248,7 @@ TEST(QuicLbTest, InvalidConfig) {
   // Valid config with expected length set.
   cfg.set_expected_server_id_length(6);
   factory_or_status = Factory::create(cfg, factory_context);
-  EXPECT_TRUE(factory_or_status.ok());
+  EXPECT_OK(factory_or_status);
 
   // Invalid concurrency.
   EXPECT_CALL(factory_context.server_factory_context_.options_, concurrency())
@@ -464,7 +465,7 @@ TEST(QuicLbTest, EmptySecretCallback) {
 
   absl::StatusOr<std::unique_ptr<Factory>> factory_or_status =
       Factory::create(cfg, factory_context);
-  EXPECT_TRUE(factory_or_status.ok());
+  EXPECT_OK(factory_or_status);
 
   auto status = update_callback();
   EXPECT_EQ(status.message(), "secret update callback called with empty secret");


### PR DESCRIPTION
Commit Message: Use status matchers where appropriate (16)
Additional Description: Part of a wide cleanup of status-related expectations - EXPECT_TRUE and EXPECT_FALSE have unhelpful output on test failure compared to the actual status matchers, and in some cases are less readable. A cleanup of this pattern will tend to also improve future code.
Risk Level: test-only

Note: AI (Codex 5.6) was used to generate this set of PRs; I have reviewed each PR manually before marking it ready for review.
