### PR TITLE
Delflake //test/integration:circuit_breakers_integration_test

### DIFF
--- a/test/integration/circuit_breakers_integration_test.cc
+++ b/test/integration/circuit_breakers_integration_test.cc
@@ -264,6 +264,9 @@ TEST_P(OutlierDetectionIntegrationTest, NoClusterOverwrite) {
     EXPECT_EQ("500", response->headers().getStatusValue());
   }
 
+  // Wait for the main thread to eject the host
+  test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
+                               Eq(1));
   // Send another request. It should not reach upstream and should be handled by envoy.
   // The only existing endpoint in the cluster has been marked as unhealthy.
   IntegrationStreamDecoderPtr response =
@@ -355,6 +358,9 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteNon5xxAsErrors) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("200", response->headers().getStatusValue());
 
+  // Wait for the main thread to eject the host
+  test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
+                               Eq(1));
   // Now send a request. It will be captured by Envoy and 503 will be returned as the only upstream
   // is unhealthy now..
   response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -428,6 +434,9 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteGatewayErrors) {
     EXPECT_EQ("502", response->headers().getStatusValue());
   }
 
+  // Wait for the main thread to eject the host
+  test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
+                               Eq(1));
   // Now send a request. It will be captured by Envoy and 503 will be returned as the only upstream
   // is unhealthy now..
   IntegrationStreamDecoderPtr response =


### PR DESCRIPTION
The test needed to wait for main thread to complete the ejection task before sending the next request.

Risk Level: none
Testing: unit test
Docs Changes: no
Release Notes: no
Platform Specific Features: no
