### PR TITLE
Use status matchers where appropriate (15)

### DIFF
--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -45,6 +45,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules/test_data/c:matcher_no_op_static",
         "//test/mocks/init:init_mocks",
         "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/extensions/dynamic_modules/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/dynamic_modules/bootstrap/BUILD
+++ b/test/extensions/dynamic_modules/bootstrap/BUILD
@@ -41,6 +41,7 @@ envoy_cc_test(
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -71,6 +72,7 @@ envoy_cc_test(
         "//test/mocks/upstream:thread_local_cluster_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -90,6 +92,7 @@ envoy_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/mocks/server:instance_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -19,6 +19,7 @@
 #include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -48,12 +49,12 @@ protected:
 TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -67,12 +68,12 @@ TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
 TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -98,12 +99,12 @@ TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
 TEST_F(BootstrapAbiImplTest, OnScheduledCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -132,12 +133,12 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+    ASSERT_OK(dynamic_module) << dynamic_module.status();
 
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_TRUE(config.ok()) << config.status();
+    ASSERT_OK(config) << config.status();
     // Create a scheduler via the ABI callback.
     auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
         config.value()->thisAsVoidPtr());
@@ -168,12 +169,12 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
 TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
   EXPECT_NE(scheduler_ptr, nullptr);
@@ -191,12 +192,12 @@ TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
 TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Call onScheduled directly - this should call the in-module hook.
   config.value()->onScheduled(789);
 }
@@ -210,7 +211,7 @@ TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
 TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // The init manager should receive an add call during config creation.
   EXPECT_CALL(context_.init_manager_, add(_));
@@ -218,7 +219,7 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // The C no-op module already called signal_init_complete during config creation.
   // Calling it again verifies that duplicate calls are safe.
   envoy_dynamic_module_callback_bootstrap_extension_config_signal_init_complete(
@@ -233,12 +234,12 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -268,12 +269,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Headers missing :method, :path, and host.
   std::vector<envoy_dynamic_module_type_module_http_header> headers = {
       {"x-custom", 8, "value", 5},
@@ -294,12 +295,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -355,12 +356,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -406,12 +407,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -458,12 +459,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -498,12 +499,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -557,12 +558,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -611,12 +612,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutWithBody) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -678,12 +679,12 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -701,12 +702,12 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
 TEST_F(BootstrapAbiImplTest, GetCounterValueNonExistent) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -726,12 +727,12 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -749,12 +750,12 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
 TEST_F(BootstrapAbiImplTest, GetGaugeValueNonExistent) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -776,12 +777,12 @@ TEST_F(BootstrapAbiImplTest, IterateCounters) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -812,12 +813,12 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -848,12 +849,12 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
 TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a counter without labels.
@@ -883,12 +884,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
 TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Try to increment a counter with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1);
@@ -899,12 +900,12 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a gauge without labels.
@@ -939,12 +940,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
 TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Try to set, increment, and decrement a gauge with an invalid ID.
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_set_gauge(
                 config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1),
@@ -961,12 +962,12 @@ TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a histogram without labels.
@@ -992,12 +993,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
 TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Try to record a histogram value with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_record_histogram_value(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 42);
@@ -1008,12 +1009,12 @@ TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define multiple counters.
@@ -1067,12 +1068,12 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
 TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a counter vec with labels.
@@ -1099,12 +1100,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
 TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a counter vec with 2 labels.
@@ -1126,12 +1127,12 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
 TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a gauge vec with labels.
@@ -1165,12 +1166,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
 TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define a histogram vec with labels.
@@ -1197,12 +1198,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
 TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   // Define vec metrics with a single label each.
@@ -1273,13 +1274,13 @@ TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
 TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // The MockDispatcher's createTimer_ returns a NiceMock<MockTimer> by default.
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1304,7 +1305,7 @@ TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
 TEST_F(BootstrapAbiImplTest, TimerFired) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Use MockTimer to capture the timer callback.
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
@@ -1312,7 +1313,7 @@ TEST_F(BootstrapAbiImplTest, TimerFired) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a timer via the ABI callback. This will use the MockTimer we set up.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1353,7 +1354,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+    ASSERT_OK(dynamic_module) << dynamic_module.status();
 
     // Capture the timer callback from createTimer.
     EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(testing::Invoke([&](Event::TimerCb cb) {
@@ -1364,7 +1365,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_TRUE(config.ok()) << config.status();
+    ASSERT_OK(config) << config.status();
     // Create a timer via the ABI callback.
     timer_ptr = envoy_dynamic_module_callback_bootstrap_extension_timer_new(
         config.value()->thisAsVoidPtr());
@@ -1390,7 +1391,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
 TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Set up MockWatcher to be returned by createFilesystemWatcher.
   auto* mock_watcher = new testing::NiceMock<Filesystem::MockWatcher>();
@@ -1400,7 +1401,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Add a watch for a specific path and events.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1412,7 +1413,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
 TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Capture the watcher callback from addWatch.
   Filesystem::Watcher::OnChangedCb captured_cb;
@@ -1428,7 +1429,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Add a watch to capture the callback.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1437,7 +1438,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
 
   // Invoke the captured callback (simulating file change with Modified event).
   ASSERT_NE(captured_cb, nullptr);
-  EXPECT_TRUE(captured_cb(0x2).ok());
+  EXPECT_OK(captured_cb(0x2));
 }
 
 // Test that the watcher callback safely handles a destroyed config via weak_ptr.
@@ -1447,7 +1448,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+    ASSERT_OK(dynamic_module) << dynamic_module.status();
 
     // Capture the watcher callback from addWatch.
     EXPECT_CALL(dispatcher_, createFilesystemWatcher_())
@@ -1465,7 +1466,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_TRUE(config.ok()) << config.status();
+    ASSERT_OK(config) << config.status();
     // Add a watch to capture the callback.
     envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
     bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1478,14 +1479,14 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
   // Execute the captured watcher callback after config is destroyed.
   // This should not crash - the weak_ptr should be expired.
   ASSERT_NE(captured_cb, nullptr);
-  EXPECT_TRUE(captured_cb(0x2).ok());
+  EXPECT_OK(captured_cb(0x2));
 }
 
 // Test that file_watcher_add_watch returns false when addWatch fails.
 TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Set up MockWatcher where addWatch returns an error.
   auto* mock_watcher = new testing::NiceMock<Filesystem::MockWatcher>();
@@ -1496,7 +1497,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Add a watch - should fail and return false.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1512,12 +1513,12 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Expect the admin handler to be registered.
   EXPECT_CALL(context_.admin_, addHandler("/test_prefix", "Test help text", _, true, false, _))
       .WillOnce(testing::Return(true));
@@ -1533,12 +1534,12 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Expect the admin handler registration to fail.
   EXPECT_CALL(context_.admin_, addHandler("/duplicate", "Duplicate handler", _, false, true, _))
       .WillOnce(testing::Return(false));
@@ -1554,7 +1555,7 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
@@ -1562,7 +1563,7 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   envoy_dynamic_module_type_module_buffer help_text = {"No admin", 8};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_register_admin_handler(
@@ -1574,12 +1575,12 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   EXPECT_CALL(context_.admin_, removeHandler("/test_prefix")).WillOnce(testing::Return(true));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/test_prefix", 12};
@@ -1592,12 +1593,12 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   EXPECT_CALL(context_.admin_, removeHandler("/nonexistent")).WillOnce(testing::Return(false));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/nonexistent", 12};
@@ -1610,7 +1611,7 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
@@ -1618,7 +1619,7 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_remove_admin_handler(
       config.value()->thisAsVoidPtr(), path_prefix);
@@ -1629,12 +1630,12 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
 TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Capture the handler callback when addHandler is called.
   Server::Admin::HandlerCb captured_handler;
   EXPECT_CALL(context_.admin_, addHandler("/test_admin", "Test admin handler", _, true, false, _))
@@ -1674,14 +1675,14 @@ TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
 TEST_F(BootstrapAbiImplTest, TimerReEnable) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1703,12 +1704,12 @@ TEST_F(BootstrapAbiImplTest, TimerReEnable) {
 TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -1730,12 +1731,12 @@ TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
 TEST_F(BootstrapAbiImplTest, ClusterAddOrUpdateCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Invoke onClusterAddOrUpdate directly on the config to test the callback forwarding.
   Upstream::ThreadLocalClusterCommand get_cluster = []() -> Upstream::ThreadLocalCluster& {
     PANIC("should not be called");
@@ -1747,12 +1748,12 @@ TEST_F(BootstrapAbiImplTest, ClusterAddOrUpdateCallback) {
 TEST_F(BootstrapAbiImplTest, ClusterRemovalCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Invoke onClusterRemoval directly on the config.
   config.value()->onClusterRemoval("test_cluster");
 }
@@ -1761,12 +1762,12 @@ TEST_F(BootstrapAbiImplTest, ClusterRemovalCallback) {
 TEST_F(BootstrapAbiImplTest, EnableListenerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -1788,12 +1789,12 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycle) {
 TEST_F(BootstrapAbiImplTest, EnableListenerLifecycleBeforeServerInit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Do not set listener manager - simulate calling before server init.
   EXPECT_LOG_CONTAINS("error", "cannot enable listener lifecycle before server is initialized", {
     bool result = envoy_dynamic_module_callback_bootstrap_extension_enable_listener_lifecycle(
@@ -1806,12 +1807,12 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycleBeforeServerInit) {
 TEST_F(BootstrapAbiImplTest, ListenerAddOrUpdateCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Invoke onListenerAddOrUpdate directly on the config to test the callback forwarding.
   NiceMock<Network::MockListenerConfig> mock_listener_config;
   config.value()->onListenerAddOrUpdate("test_listener", mock_listener_config);
@@ -1821,12 +1822,12 @@ TEST_F(BootstrapAbiImplTest, ListenerAddOrUpdateCallback) {
 TEST_F(BootstrapAbiImplTest, ListenerRemovalCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   // Invoke onListenerRemoval directly on the config.
   config.value()->onListenerRemoval("test_listener");
 }
@@ -1835,11 +1836,11 @@ TEST_F(BootstrapAbiImplTest, ListenerRemovalCallback) {
 TEST_F(BootstrapAbiImplTest, MetricsFrozenAfterInit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   EXPECT_TRUE(config.value()->stat_creation_frozen_);
 
   envoy_dynamic_module_type_module_buffer name = {"frozen_counter", 14};
@@ -1864,11 +1865,11 @@ TEST_F(BootstrapAbiImplTest, MetricsFrozenAfterInit) {
 TEST_F(BootstrapAbiImplTest, MetricsConcurrentIncrementCounterVecNoRace) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   unfreezeStatCreation(*config.value());
 
   envoy_dynamic_module_type_module_buffer name = {"race_counter", 12};

--- a/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/abi_impl_test.cc
@@ -49,12 +49,12 @@ protected:
 TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -68,12 +68,12 @@ TEST_F(BootstrapAbiImplTest, SchedulerLifecycle) {
 TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -99,12 +99,12 @@ TEST_F(BootstrapAbiImplTest, SchedulerCommit) {
 TEST_F(BootstrapAbiImplTest, OnScheduledCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a scheduler via the ABI callback.
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
@@ -133,12 +133,12 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status();
+    ASSERT_OK(dynamic_module);
 
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_OK(config) << config.status();
+    ASSERT_OK(config);
     // Create a scheduler via the ABI callback.
     auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
         config.value()->thisAsVoidPtr());
@@ -169,12 +169,12 @@ TEST_F(BootstrapAbiImplTest, OnScheduledAfterConfigDestroyed) {
 TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto* scheduler_ptr = envoy_dynamic_module_callback_bootstrap_extension_config_scheduler_new(
       config.value()->thisAsVoidPtr());
   EXPECT_NE(scheduler_ptr, nullptr);
@@ -192,12 +192,12 @@ TEST_F(BootstrapAbiImplTest, CommitAfterConfigDestroyedDoesNotTouchDispatcher) {
 TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Call onScheduled directly - this should call the in-module hook.
   config.value()->onScheduled(789);
 }
@@ -211,7 +211,7 @@ TEST_F(BootstrapAbiImplTest, OnScheduledDirect) {
 TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // The init manager should receive an add call during config creation.
   EXPECT_CALL(context_.init_manager_, add(_));
@@ -219,7 +219,7 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // The C no-op module already called signal_init_complete during config creation.
   // Calling it again verifies that duplicate calls are safe.
   envoy_dynamic_module_callback_bootstrap_extension_config_signal_init_complete(
@@ -234,12 +234,12 @@ TEST_F(BootstrapAbiImplTest, InitTargetAutoRegisteredAndSignal) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -269,12 +269,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutClusterNotFound) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Headers missing :method, :path, and host.
   std::vector<envoy_dynamic_module_type_module_http_header> headers = {
       {"x-custom", 8, "value", 5},
@@ -295,12 +295,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutMissingHeaders) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -356,12 +356,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccess) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -407,12 +407,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureReset) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -459,12 +459,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureExceedBufferLimit) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -499,12 +499,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutCannotCreateRequest) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -558,12 +558,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutSuccessAfterInModuleConfigCleared) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -612,12 +612,12 @@ TEST_F(BootstrapAbiImplTest, HttpCalloutFailureAfterInModuleConfigCleared) {
 TEST_F(BootstrapAbiImplTest, HttpCalloutWithBody) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -679,12 +679,12 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -702,12 +702,12 @@ TEST_F(BootstrapAbiImplTest, GetCounterValueExisting) {
 TEST_F(BootstrapAbiImplTest, GetCounterValueNonExistent) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -727,12 +727,12 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -750,12 +750,12 @@ TEST_F(BootstrapAbiImplTest, GetGaugeValueExisting) {
 TEST_F(BootstrapAbiImplTest, GetGaugeValueNonExistent) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -777,12 +777,12 @@ TEST_F(BootstrapAbiImplTest, IterateCounters) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -813,12 +813,12 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
 
@@ -849,12 +849,12 @@ TEST_F(BootstrapAbiImplTest, IterateGauges) {
 TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a counter without labels.
@@ -884,12 +884,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounter) {
 TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Try to increment a counter with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_increment_counter(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1);
@@ -900,12 +900,12 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a gauge without labels.
@@ -940,12 +940,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGauge) {
 TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Try to set, increment, and decrement a gauge with an invalid ID.
   EXPECT_EQ(envoy_dynamic_module_callback_bootstrap_extension_config_set_gauge(
                 config.value()->thisAsVoidPtr(), 999, nullptr, 0, 1),
@@ -962,12 +962,12 @@ TEST_F(BootstrapAbiImplTest, GaugeOperationsInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a histogram without labels.
@@ -993,12 +993,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogram) {
 TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Try to record a histogram value with an invalid ID.
   auto result = envoy_dynamic_module_callback_bootstrap_extension_config_record_histogram_value(
       config.value()->thisAsVoidPtr(), 999, nullptr, 0, 42);
@@ -1009,12 +1009,12 @@ TEST_F(BootstrapAbiImplTest, RecordHistogramInvalidId) {
 TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define multiple counters.
@@ -1068,12 +1068,12 @@ TEST_F(BootstrapAbiImplTest, DefineMultipleMetrics) {
 TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a counter vec with labels.
@@ -1100,12 +1100,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndIncrementCounterVec) {
 TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a counter vec with 2 labels.
@@ -1127,12 +1127,12 @@ TEST_F(BootstrapAbiImplTest, IncrementCounterVecInvalidLabels) {
 TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a gauge vec with labels.
@@ -1166,12 +1166,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndManipulateGaugeVec) {
 TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define a histogram vec with labels.
@@ -1198,12 +1198,12 @@ TEST_F(BootstrapAbiImplTest, DefineAndRecordHistogramVec) {
 TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   // Define vec metrics with a single label each.
@@ -1274,13 +1274,13 @@ TEST_F(BootstrapAbiImplTest, VecMetricsInvalidIdAndLabels) {
 TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // The MockDispatcher's createTimer_ returns a NiceMock<MockTimer> by default.
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1305,7 +1305,7 @@ TEST_F(BootstrapAbiImplTest, TimerLifecycle) {
 TEST_F(BootstrapAbiImplTest, TimerFired) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Use MockTimer to capture the timer callback.
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
@@ -1313,7 +1313,7 @@ TEST_F(BootstrapAbiImplTest, TimerFired) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a timer via the ABI callback. This will use the MockTimer we set up.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1354,7 +1354,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status();
+    ASSERT_OK(dynamic_module);
 
     // Capture the timer callback from createTimer.
     EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(testing::Invoke([&](Event::TimerCb cb) {
@@ -1365,7 +1365,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_OK(config) << config.status();
+    ASSERT_OK(config);
     // Create a timer via the ABI callback.
     timer_ptr = envoy_dynamic_module_callback_bootstrap_extension_timer_new(
         config.value()->thisAsVoidPtr());
@@ -1391,7 +1391,7 @@ TEST_F(BootstrapAbiImplTest, TimerFiredAfterConfigDestroyed) {
 TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Set up MockWatcher to be returned by createFilesystemWatcher.
   auto* mock_watcher = new testing::NiceMock<Filesystem::MockWatcher>();
@@ -1401,7 +1401,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Add a watch for a specific path and events.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1413,7 +1413,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatch) {
 TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Capture the watcher callback from addWatch.
   Filesystem::Watcher::OnChangedCb captured_cb;
@@ -1429,7 +1429,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFired) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Add a watch to capture the callback.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1448,7 +1448,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
   {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         testDataDir() + "/libbootstrap_no_op.so", false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status();
+    ASSERT_OK(dynamic_module);
 
     // Capture the watcher callback from addWatch.
     EXPECT_CALL(dispatcher_, createFilesystemWatcher_())
@@ -1466,7 +1466,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
     auto config = newDynamicModuleBootstrapExtensionConfig(
         "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
         context_, context_.store_);
-    ASSERT_OK(config) << config.status();
+    ASSERT_OK(config);
     // Add a watch to capture the callback.
     envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
     bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1486,7 +1486,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherFiredAfterConfigDestroyed) {
 TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Set up MockWatcher where addWatch returns an error.
   auto* mock_watcher = new testing::NiceMock<Filesystem::MockWatcher>();
@@ -1497,7 +1497,7 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Add a watch - should fail and return false.
   envoy_dynamic_module_type_module_buffer path_buf = {"/tmp/test_file", 14};
   bool added = envoy_dynamic_module_callback_bootstrap_extension_file_watcher_add_watch(
@@ -1513,12 +1513,12 @@ TEST_F(BootstrapAbiImplTest, FileWatcherAddWatchFails) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Expect the admin handler to be registered.
   EXPECT_CALL(context_.admin_, addHandler("/test_prefix", "Test help text", _, true, false, _))
       .WillOnce(testing::Return(true));
@@ -1534,12 +1534,12 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandler) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Expect the admin handler registration to fail.
   EXPECT_CALL(context_.admin_, addHandler("/duplicate", "Duplicate handler", _, false, true, _))
       .WillOnce(testing::Return(false));
@@ -1555,7 +1555,7 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerFails) {
 TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
@@ -1563,7 +1563,7 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   envoy_dynamic_module_type_module_buffer help_text = {"No admin", 8};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_register_admin_handler(
@@ -1575,12 +1575,12 @@ TEST_F(BootstrapAbiImplTest, RegisterAdminHandlerNoAdmin) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   EXPECT_CALL(context_.admin_, removeHandler("/test_prefix")).WillOnce(testing::Return(true));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/test_prefix", 12};
@@ -1593,12 +1593,12 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandler) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   EXPECT_CALL(context_.admin_, removeHandler("/nonexistent")).WillOnce(testing::Return(false));
 
   envoy_dynamic_module_type_module_buffer path_prefix = {"/nonexistent", 12};
@@ -1611,7 +1611,7 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNotFound) {
 TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   // Override admin() to return nullopt.
   EXPECT_CALL(context_, admin()).WillRepeatedly(testing::Return(OptRef<Server::Admin>{}));
@@ -1619,7 +1619,7 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   envoy_dynamic_module_type_module_buffer path_prefix = {"/no_admin", 9};
   bool result = envoy_dynamic_module_callback_bootstrap_extension_remove_admin_handler(
       config.value()->thisAsVoidPtr(), path_prefix);
@@ -1630,12 +1630,12 @@ TEST_F(BootstrapAbiImplTest, RemoveAdminHandlerNoAdmin) {
 TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Capture the handler callback when addHandler is called.
   Server::Admin::HandlerCb captured_handler;
   EXPECT_CALL(context_.admin_, addHandler("/test_admin", "Test admin handler", _, true, false, _))
@@ -1675,14 +1675,14 @@ TEST_F(BootstrapAbiImplTest, AdminHandlerCallbackInvokesEventHook) {
 TEST_F(BootstrapAbiImplTest, TimerReEnable) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   Event::MockTimer* mock_timer = new Event::MockTimer(&dispatcher_);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Create a timer via the ABI callback.
   auto* timer_ptr =
       envoy_dynamic_module_callback_bootstrap_extension_timer_new(config.value()->thisAsVoidPtr());
@@ -1704,12 +1704,12 @@ TEST_F(BootstrapAbiImplTest, TimerReEnable) {
 TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -1731,12 +1731,12 @@ TEST_F(BootstrapAbiImplTest, EnableClusterLifecycle) {
 TEST_F(BootstrapAbiImplTest, ClusterAddOrUpdateCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Invoke onClusterAddOrUpdate directly on the config to test the callback forwarding.
   Upstream::ThreadLocalClusterCommand get_cluster = []() -> Upstream::ThreadLocalCluster& {
     PANIC("should not be called");
@@ -1748,12 +1748,12 @@ TEST_F(BootstrapAbiImplTest, ClusterAddOrUpdateCallback) {
 TEST_F(BootstrapAbiImplTest, ClusterRemovalCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Invoke onClusterRemoval directly on the config.
   config.value()->onClusterRemoval("test_cluster");
 }
@@ -1762,12 +1762,12 @@ TEST_F(BootstrapAbiImplTest, ClusterRemovalCallback) {
 TEST_F(BootstrapAbiImplTest, EnableListenerLifecycle) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Simulate server initialization by setting the listener manager.
   testing::NiceMock<Server::MockListenerManager> listener_manager;
   config.value()->setListenerManager(listener_manager);
@@ -1789,12 +1789,12 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycle) {
 TEST_F(BootstrapAbiImplTest, EnableListenerLifecycleBeforeServerInit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Do not set listener manager - simulate calling before server init.
   EXPECT_LOG_CONTAINS("error", "cannot enable listener lifecycle before server is initialized", {
     bool result = envoy_dynamic_module_callback_bootstrap_extension_enable_listener_lifecycle(
@@ -1807,12 +1807,12 @@ TEST_F(BootstrapAbiImplTest, EnableListenerLifecycleBeforeServerInit) {
 TEST_F(BootstrapAbiImplTest, ListenerAddOrUpdateCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Invoke onListenerAddOrUpdate directly on the config to test the callback forwarding.
   NiceMock<Network::MockListenerConfig> mock_listener_config;
   config.value()->onListenerAddOrUpdate("test_listener", mock_listener_config);
@@ -1822,12 +1822,12 @@ TEST_F(BootstrapAbiImplTest, ListenerAddOrUpdateCallback) {
 TEST_F(BootstrapAbiImplTest, ListenerRemovalCallback) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   // Invoke onListenerRemoval directly on the config.
   config.value()->onListenerRemoval("test_listener");
 }
@@ -1836,11 +1836,11 @@ TEST_F(BootstrapAbiImplTest, ListenerRemovalCallback) {
 TEST_F(BootstrapAbiImplTest, MetricsFrozenAfterInit) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   EXPECT_TRUE(config.value()->stat_creation_frozen_);
 
   envoy_dynamic_module_type_module_buffer name = {"frozen_counter", 14};
@@ -1865,11 +1865,11 @@ TEST_F(BootstrapAbiImplTest, MetricsFrozenAfterInit) {
 TEST_F(BootstrapAbiImplTest, MetricsConcurrentIncrementCounterVecNoRace) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   unfreezeStatCreation(*config.value());
 
   envoy_dynamic_module_type_module_buffer name = {"race_counter", 12};

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -29,12 +29,12 @@ protected:
 TEST_F(ExtensionConfigTest, LoadOK) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
   EXPECT_NE(config.value()->in_module_config_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_config_destroy_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_new_, nullptr);
@@ -52,7 +52,7 @@ TEST_F(ExtensionConfigTest, LoadOK) {
 TEST_F(ExtensionConfigTest, ConfigNewFail) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_new.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -63,7 +63,7 @@ TEST_F(ExtensionConfigTest, ConfigNewFail) {
 TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_destroy.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -75,7 +75,7 @@ TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
 TEST_F(ExtensionConfigTest, MissingExtensionNew) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_extension_new.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -87,7 +87,7 @@ TEST_F(ExtensionConfigTest, MissingExtensionNew) {
 TEST_F(ExtensionConfigTest, MissingServerInitialized) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_server_initialized.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -99,7 +99,7 @@ TEST_F(ExtensionConfigTest, MissingServerInitialized) {
 TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_worker_initialized.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -112,7 +112,7 @@ TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
 TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_extension_destroy.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -126,7 +126,7 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
   // symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_constructor.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -138,7 +138,7 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
 TEST_F(ExtensionConfigTest, MissingDrainStarted) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_drain_started.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -150,7 +150,7 @@ TEST_F(ExtensionConfigTest, MissingDrainStarted) {
 TEST_F(ExtensionConfigTest, MissingShutdown) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_shutdown.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -164,7 +164,7 @@ TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
   // envoy_dynamic_module_on_bootstrap_extension_config_scheduled symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_scheduled.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -178,7 +178,7 @@ TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
   // envoy_dynamic_module_on_bootstrap_extension_http_callout_done symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_http_callout_done.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -192,7 +192,7 @@ TEST_F(ExtensionConfigTest, MissingTimerFired) {
   // envoy_dynamic_module_on_bootstrap_extension_timer_fired symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_timer_fired.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -206,7 +206,7 @@ TEST_F(ExtensionConfigTest, MissingFileChanged) {
   // envoy_dynamic_module_on_bootstrap_extension_file_changed symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_file_changed.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -220,7 +220,7 @@ TEST_F(ExtensionConfigTest, MissingAdminRequest) {
   // envoy_dynamic_module_on_bootstrap_extension_admin_request symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_admin_request.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -234,7 +234,7 @@ TEST_F(ExtensionConfigTest, MissingClusterAddOrUpdate) {
   // envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_cluster_add_or_update.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -248,7 +248,7 @@ TEST_F(ExtensionConfigTest, MissingClusterRemoval) {
   // envoy_dynamic_module_on_bootstrap_extension_cluster_removal symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_cluster_removal.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -262,7 +262,7 @@ TEST_F(ExtensionConfigTest, MissingListenerAddOrUpdate) {
   // envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_listener_add_or_update.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -276,7 +276,7 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
   // envoy_dynamic_module_on_bootstrap_extension_listener_removal symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_listener_removal.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
@@ -288,11 +288,11 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
 TEST_F(ExtensionConfigTest, ClusterAccessRequiresServerInitialized) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
   auto config_or = newDynamicModuleBootstrapExtensionConfig(
       "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
       context_, context_.store_);
-  ASSERT_OK(config_or) << config_or.status();
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   // Before the server is initialized the cluster manager is unavailable, so cluster access is

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -15,8 +15,6 @@ namespace Bootstrap {
 namespace DynamicModules {
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
-using ::Envoy::StatusHelpers::IsOk;
-using ::testing::Not;
 
 class ExtensionConfigTest : public testing::Test {
 protected:
@@ -70,9 +68,8 @@ TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_destroy"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_config_destroy")));
 }
 
 TEST_F(ExtensionConfigTest, MissingExtensionNew) {
@@ -83,9 +80,8 @@ TEST_F(ExtensionConfigTest, MissingExtensionNew) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_new"));
+  EXPECT_THAT(config, HasStatusMessage(
+                          testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_new")));
 }
 
 TEST_F(ExtensionConfigTest, MissingServerInitialized) {
@@ -96,9 +92,8 @@ TEST_F(ExtensionConfigTest, MissingServerInitialized) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_server_initialized"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_server_initialized")));
 }
 
 TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
@@ -109,10 +104,9 @@ TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(
-      config.status().message(),
-      testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_worker_thread_initialized"));
+  EXPECT_THAT(config,
+              HasStatusMessage(testing::HasSubstr(
+                  "envoy_dynamic_module_on_bootstrap_extension_worker_thread_initialized")));
 }
 
 TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
@@ -123,9 +117,8 @@ TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_destroy"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_destroy")));
 }
 
 TEST_F(ExtensionConfigTest, MissingConstructor) {
@@ -138,9 +131,8 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_new"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_config_new")));
 }
 
 TEST_F(ExtensionConfigTest, MissingDrainStarted) {
@@ -151,9 +143,8 @@ TEST_F(ExtensionConfigTest, MissingDrainStarted) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_drain_started"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_drain_started")));
 }
 
 TEST_F(ExtensionConfigTest, MissingShutdown) {
@@ -164,9 +155,8 @@ TEST_F(ExtensionConfigTest, MissingShutdown) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_shutdown"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_shutdown")));
 }
 
 TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
@@ -179,9 +169,8 @@ TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_scheduled"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_config_scheduled")));
 }
 
 TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
@@ -194,9 +183,8 @@ TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_http_callout_done"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_http_callout_done")));
 }
 
 TEST_F(ExtensionConfigTest, MissingTimerFired) {
@@ -209,9 +197,8 @@ TEST_F(ExtensionConfigTest, MissingTimerFired) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_timer_fired"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_timer_fired")));
 }
 
 TEST_F(ExtensionConfigTest, MissingFileChanged) {
@@ -224,9 +211,8 @@ TEST_F(ExtensionConfigTest, MissingFileChanged) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_file_changed"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_file_changed")));
 }
 
 TEST_F(ExtensionConfigTest, MissingAdminRequest) {
@@ -239,9 +225,8 @@ TEST_F(ExtensionConfigTest, MissingAdminRequest) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_admin_request"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_admin_request")));
 }
 
 TEST_F(ExtensionConfigTest, MissingClusterAddOrUpdate) {
@@ -254,10 +239,8 @@ TEST_F(ExtensionConfigTest, MissingClusterAddOrUpdate) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(
-      config.status().message(),
-      testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update")));
 }
 
 TEST_F(ExtensionConfigTest, MissingClusterRemoval) {
@@ -270,9 +253,8 @@ TEST_F(ExtensionConfigTest, MissingClusterRemoval) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_cluster_removal"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_cluster_removal")));
 }
 
 TEST_F(ExtensionConfigTest, MissingListenerAddOrUpdate) {
@@ -285,10 +267,8 @@ TEST_F(ExtensionConfigTest, MissingListenerAddOrUpdate) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(
-      config.status().message(),
-      testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update")));
 }
 
 TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
@@ -301,9 +281,8 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_listener_removal"));
+  EXPECT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_bootstrap_extension_listener_removal")));
 }
 
 TEST_F(ExtensionConfigTest, ClusterAccessRequiresServerInitialized) {

--- a/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_config_test.cc
@@ -4,6 +4,7 @@
 #include "test/mocks/server/listener_manager.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -12,6 +13,10 @@ namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
 namespace DynamicModules {
+
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 class ExtensionConfigTest : public testing::Test {
 protected:
@@ -26,12 +31,12 @@ protected:
 TEST_F(ExtensionConfigTest, LoadOK) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
   EXPECT_NE(config.value()->in_module_config_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_config_destroy_, nullptr);
   EXPECT_NE(config.value()->on_bootstrap_extension_new_, nullptr);
@@ -49,24 +54,23 @@ TEST_F(ExtensionConfigTest, LoadOK) {
 TEST_F(ExtensionConfigTest, ConfigNewFail) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_new.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
-  EXPECT_EQ(config.status().message(), "Failed to initialize dynamic module");
+  EXPECT_THAT(config, HasStatusMessage("Failed to initialize dynamic module"));
 }
 
 TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_destroy.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_destroy"));
 }
@@ -74,12 +78,12 @@ TEST_F(ExtensionConfigTest, MissingConfigDestroy) {
 TEST_F(ExtensionConfigTest, MissingExtensionNew) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_extension_new.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_new"));
 }
@@ -87,12 +91,12 @@ TEST_F(ExtensionConfigTest, MissingExtensionNew) {
 TEST_F(ExtensionConfigTest, MissingServerInitialized) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_server_initialized.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_server_initialized"));
 }
@@ -100,12 +104,12 @@ TEST_F(ExtensionConfigTest, MissingServerInitialized) {
 TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_worker_initialized.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(
       config.status().message(),
       testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_worker_thread_initialized"));
@@ -114,12 +118,12 @@ TEST_F(ExtensionConfigTest, MissingWorkerThreadInitialized) {
 TEST_F(ExtensionConfigTest, MissingExtensionDestroy) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_extension_destroy.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_destroy"));
 }
@@ -129,12 +133,12 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
   // symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_constructor.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_new"));
 }
@@ -142,12 +146,12 @@ TEST_F(ExtensionConfigTest, MissingConstructor) {
 TEST_F(ExtensionConfigTest, MissingDrainStarted) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_drain_started.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_drain_started"));
 }
@@ -155,12 +159,12 @@ TEST_F(ExtensionConfigTest, MissingDrainStarted) {
 TEST_F(ExtensionConfigTest, MissingShutdown) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_shutdown.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_shutdown"));
 }
@@ -170,12 +174,12 @@ TEST_F(ExtensionConfigTest, MissingConfigScheduled) {
   // envoy_dynamic_module_on_bootstrap_extension_config_scheduled symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_config_scheduled.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_config_scheduled"));
 }
@@ -185,12 +189,12 @@ TEST_F(ExtensionConfigTest, MissingHttpCalloutDone) {
   // envoy_dynamic_module_on_bootstrap_extension_http_callout_done symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_http_callout_done.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_http_callout_done"));
 }
@@ -200,12 +204,12 @@ TEST_F(ExtensionConfigTest, MissingTimerFired) {
   // envoy_dynamic_module_on_bootstrap_extension_timer_fired symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_timer_fired.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_timer_fired"));
 }
@@ -215,12 +219,12 @@ TEST_F(ExtensionConfigTest, MissingFileChanged) {
   // envoy_dynamic_module_on_bootstrap_extension_file_changed symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_file_changed.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_file_changed"));
 }
@@ -230,12 +234,12 @@ TEST_F(ExtensionConfigTest, MissingAdminRequest) {
   // envoy_dynamic_module_on_bootstrap_extension_admin_request symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_admin_request.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_admin_request"));
 }
@@ -245,12 +249,12 @@ TEST_F(ExtensionConfigTest, MissingClusterAddOrUpdate) {
   // envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_cluster_add_or_update.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(
       config.status().message(),
       testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_cluster_add_or_update"));
@@ -261,12 +265,12 @@ TEST_F(ExtensionConfigTest, MissingClusterRemoval) {
   // envoy_dynamic_module_on_bootstrap_extension_cluster_removal symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_cluster_removal.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_cluster_removal"));
 }
@@ -276,12 +280,12 @@ TEST_F(ExtensionConfigTest, MissingListenerAddOrUpdate) {
   // envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_listener_add_or_update.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(
       config.status().message(),
       testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_listener_add_or_update"));
@@ -292,12 +296,12 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
   // envoy_dynamic_module_on_bootstrap_extension_listener_removal symbol is missing.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_no_listener_removal.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  EXPECT_FALSE(config.ok());
+  EXPECT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_bootstrap_extension_listener_removal"));
 }
@@ -305,11 +309,11 @@ TEST_F(ExtensionConfigTest, MissingListenerRemoval) {
 TEST_F(ExtensionConfigTest, ClusterAccessRequiresServerInitialized) {
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
   auto config_or = newDynamicModuleBootstrapExtensionConfig(
       "test", "config", DefaultMetricsNamespace, std::move(dynamic_module.value()), dispatcher_,
       context_, context_.store_);
-  ASSERT_TRUE(config_or.ok()) << config_or.status();
+  ASSERT_OK(config_or) << config_or.status();
   auto config = config_or.value();
 
   // Before the server is initialized the cluster manager is unavailable, so cluster access is

--- a/test/extensions/dynamic_modules/bootstrap/extension_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_test.cc
@@ -30,12 +30,12 @@ TEST_F(ExtensionTest, NullInModuleExtension) {
   // extension_new returns nullptr).
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_extension_new_null.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
 
@@ -58,12 +58,12 @@ TEST_F(ExtensionTest, IsDestroyedAndGetExtensionConfig) {
   // Test that isDestroyed and getExtensionConfig work correctly.
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -85,12 +85,12 @@ TEST_F(ExtensionTest, LifecycleWithValidExtension) {
   // Test the full lifecycle of a valid extension.
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
 
@@ -127,12 +127,12 @@ TEST_F(ExtensionTest, DrainCallbackInvoked) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -161,12 +161,12 @@ TEST_F(ExtensionTest, ShutdownCallbackWithCompletion) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -195,12 +195,12 @@ TEST_F(ExtensionTest, ShutdownCallbackAfterDestroy) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status();
+  ASSERT_OK(dynamic_module);
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_OK(config) << config.status();
+  ASSERT_OK(config);
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();

--- a/test/extensions/dynamic_modules/bootstrap/extension_test.cc
+++ b/test/extensions/dynamic_modules/bootstrap/extension_test.cc
@@ -4,6 +4,7 @@
 #include "test/mocks/server/instance.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -29,12 +30,12 @@ TEST_F(ExtensionTest, NullInModuleExtension) {
   // extension_new returns nullptr).
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       testDataDir() + "/libbootstrap_extension_new_null.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
 
@@ -57,12 +58,12 @@ TEST_F(ExtensionTest, IsDestroyedAndGetExtensionConfig) {
   // Test that isDestroyed and getExtensionConfig work correctly.
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -84,12 +85,12 @@ TEST_F(ExtensionTest, LifecycleWithValidExtension) {
   // Test the full lifecycle of a valid extension.
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
 
@@ -126,12 +127,12 @@ TEST_F(ExtensionTest, DrainCallbackInvoked) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -141,7 +142,7 @@ TEST_F(ExtensionTest, DrainCallbackInvoked) {
   extension->onServerInitialized(instance);
 
   // Invoke the captured drain callback to exercise the drain notification path.
-  EXPECT_TRUE(captured_drain_cb(std::chrono::milliseconds(0)).ok());
+  EXPECT_OK(captured_drain_cb(std::chrono::milliseconds(0)));
 }
 
 TEST_F(ExtensionTest, ShutdownCallbackWithCompletion) {
@@ -160,12 +161,12 @@ TEST_F(ExtensionTest, ShutdownCallbackWithCompletion) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();
@@ -194,12 +195,12 @@ TEST_F(ExtensionTest, ShutdownCallbackAfterDestroy) {
 
   auto dynamic_module =
       Extensions::DynamicModules::newDynamicModule(testDataDir() + "/libbootstrap_no_op.so", false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status();
+  ASSERT_OK(dynamic_module) << dynamic_module.status();
 
   auto config = newDynamicModuleBootstrapExtensionConfig("test", "config", DefaultMetricsNamespace,
                                                          std::move(dynamic_module.value()),
                                                          dispatcher_, context_, context_.store_);
-  ASSERT_TRUE(config.ok()) << config.status();
+  ASSERT_OK(config) << config.status();
 
   auto extension = std::make_unique<DynamicModuleBootstrapExtension>(config.value());
   extension->initializeInModuleExtension();

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -144,7 +144,7 @@ TEST(CreateDynamicModulesByName, EnvoyDynamicModulesSearchPathSet) {
       1);
 
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
-  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module";
   TestEnvironment::unsetEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH");
 }
 
@@ -153,7 +153,7 @@ TEST(CreateDynamicModulesByName, EnvoyDynamicModulesSearchPathNotSetFallbackToCw
   std::filesystem::path staged_lib = TestEnvironment::substitute("{{ test_rundir }}/libfoo.so");
   std::filesystem::copy(test_lib, staged_lib);
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("foo", false);
-  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module";
   std::filesystem::remove(staged_lib);
 }
 
@@ -165,7 +165,7 @@ TEST(CreateDynamicModulesByName, DlopenDefaultSearchPath) {
       TestEnvironment::substitute("{{ test_rundir }}/libwhatever.so");
   std::filesystem::copy(test_lib, staged_lib);
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("whatever", false);
-  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module";
 
   TestEnvironment::unsetEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH");
   std::filesystem::remove(staged_lib);
@@ -173,7 +173,7 @@ TEST(CreateDynamicModulesByName, DlopenDefaultSearchPath) {
 
 TEST(StaticModule, LoadSuccess) {
   absl::StatusOr<DynamicModulePtr> result = newStaticModule("matcher_no_op_static");
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 }
 
 TEST(StaticModule, SymbolNotFound) {
@@ -188,11 +188,11 @@ TEST(StaticModule, SymbolNotFound) {
 TEST(StaticModule, MultipleLoads) {
   absl::StatusOr<DynamicModulePtr> c_module =
       newDynamicModuleByName("matcher_no_op_static", /*do_not_close=*/false);
-  EXPECT_OK(c_module) << c_module.status().message();
+  EXPECT_OK(c_module);
 
   absl::StatusOr<DynamicModulePtr> c_module_2 =
       newDynamicModuleByName("matcher_no_op_static", /*do_not_close=*/false);
-  EXPECT_OK(c_module_2) << c_module_2.status().message();
+  EXPECT_OK(c_module_2);
 }
 
 TEST(CreateDynamicModulesByName, ModuleNotFound) {
@@ -218,7 +218,7 @@ TEST(NewDynamicModuleFromBytes, Success) {
 
   absl::StatusOr<DynamicModulePtr> module =
       newDynamicModuleFromBytes(module_bytes, sha256, false, false);
-  EXPECT_OK(module) << "Failed to load module from bytes: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module from bytes";
   EXPECT_TRUE(std::filesystem::exists(temp_path));
 
   // Cleanup.
@@ -348,14 +348,14 @@ TEST(NewDynamicModuleFromBytes, RepeatedLoadReusesDlopenHandle) {
   // First load writes and loads the module.
   absl::StatusOr<DynamicModulePtr> module1 =
       newDynamicModuleFromBytes(module_bytes, sha256, true, false);
-  ASSERT_OK(module1) << module1.status().message();
+  ASSERT_OK(module1);
   ASSERT_TRUE(std::filesystem::exists(temp_path));
 
   // Second load with the same sha256 — writes again but the RTLD_NOLOAD check in
   // newDynamicModule returns the existing handle, so the init function is not called twice.
   absl::StatusOr<DynamicModulePtr> module2 =
       newDynamicModuleFromBytes(module_bytes, sha256, true, false);
-  ASSERT_OK(module2) << module2.status().message();
+  ASSERT_OK(module2);
 
   // Cleanup.
   module1->reset();
@@ -421,7 +421,7 @@ TEST_F(NewDynamicModuleByConfigTest, ByNameSuccess) {
   ProtoDynamicModuleConfig config;
   config.set_name("no_op");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 }
@@ -439,7 +439,7 @@ TEST_F(NewDynamicModuleByConfigTest, LocalFileSuccess) {
   ProtoDynamicModuleConfig config;
   config.mutable_module()->mutable_local()->set_filename(testSharedObjectPath("no_op", "c"));
   auto result = newDynamicModuleByConfig(config, "test_module");
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 }
@@ -478,7 +478,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteCacheHitLoads) {
                              std::filesystem::copy_options::overwrite_existing);
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 
@@ -569,7 +569,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteAsyncReturnsAsyncState) {
   auto result =
       newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_, init_manager,
                                [&on_loaded_called](DynamicModulePtr) { on_loaded_called = true; });
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_EQ(result->loaded, nullptr);
   ASSERT_NE(result->async, nullptr);
   EXPECT_NE(result->async->remote_provider, nullptr);

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -12,6 +12,7 @@
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/init/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/ascii.h"
@@ -22,10 +23,14 @@ namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 
+using ::Envoy::StatusHelpers::HasStatusCode;
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
+
 TEST(DynamicModuleTestGeneral, InvalidPath) {
   absl::StatusOr<DynamicModulePtr> result = newDynamicModule("invalid_name", false);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
 }
 
 INSTANTIATE_TEST_SUITE_P(LanguageTests, DynamicModuleTestLanguages, testing::Values("c", "rust"),
@@ -36,10 +41,10 @@ TEST_P(DynamicModuleTestLanguages, DoNotClose) {
   using GetSomeVariableFuncType = int (*)(void);
   absl::StatusOr<DynamicModulePtr> module =
       newDynamicModule(testSharedObjectPath("no_op", language), false);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
   const auto getSomeVariable =
       module->get()->getFunctionPointer<GetSomeVariableFuncType>("getSomeVariable");
-  EXPECT_TRUE(getSomeVariable.ok());
+  EXPECT_OK(getSomeVariable);
   EXPECT_EQ(getSomeVariable.value()(), 1);
   EXPECT_EQ(getSomeVariable.value()(), 2);
   EXPECT_EQ(getSomeVariable.value()(), 3);
@@ -47,12 +52,12 @@ TEST_P(DynamicModuleTestLanguages, DoNotClose) {
   // Release the module, and reload it.
   module->reset();
   module = newDynamicModule(testSharedObjectPath("no_op", language), true);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
 
   // This module must be reloaded and the variable must be reset.
   const auto getSomeVariable2 =
       (module->get()->getFunctionPointer<GetSomeVariableFuncType>("getSomeVariable"));
-  EXPECT_TRUE(getSomeVariable2.ok());
+  EXPECT_OK(getSomeVariable2);
   EXPECT_EQ(getSomeVariable2.value()(), 1); // Start from 1 again.
   EXPECT_EQ(getSomeVariable2.value()(), 2);
   EXPECT_EQ(getSomeVariable2.value()(), 3);
@@ -60,50 +65,50 @@ TEST_P(DynamicModuleTestLanguages, DoNotClose) {
   // Release the module, and reload it.
   module->reset();
   module = newDynamicModule(testSharedObjectPath("no_op", language), false);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
 
   // This module must be the already loaded one, and the variable must be kept.
   const auto getSomeVariable3 =
       module->get()->getFunctionPointer<GetSomeVariableFuncType>("getSomeVariable");
-  EXPECT_TRUE(getSomeVariable3.ok());
+  EXPECT_OK(getSomeVariable3);
   EXPECT_EQ(getSomeVariable3.value()(), 4); // Start from 4.
 }
 
 TEST(DynamicModuleTestLanguages, InitFunctionOnlyCalledOnce) {
   const auto path = testSharedObjectPath("program_init_assert", "c");
   absl::StatusOr<DynamicModulePtr> m1 = newDynamicModule(path, false);
-  EXPECT_TRUE(m1.ok());
+  EXPECT_OK(m1);
   // At this point, m1 is alive, so the init function should have been called.
   // When creating a new module with the same path, the init function should not be called again.
   absl::StatusOr<DynamicModulePtr> m2 = newDynamicModule(path, false);
-  EXPECT_TRUE(m2.ok());
+  EXPECT_OK(m2);
   m1->reset();
   m2->reset();
 
   // Even with the do_not_close=true, init function should only be called once.
   m1 = newDynamicModule(path, true);
-  EXPECT_TRUE(m1.ok());
+  EXPECT_OK(m1);
   m1->reset(); // Closing the module, but the module is still alive in the process.
   // This m2 should point to the same module as m1 whose handle is already freed, but
   // the init function should not be called again.
   m2 = newDynamicModule(path, true);
-  EXPECT_TRUE(m2.ok());
+  EXPECT_OK(m2);
 }
 
 TEST(DynamicModuleTestLanguages, LoadLibGlobally) {
   const auto path = testSharedObjectPath("program_global", "c");
   absl::StatusOr<DynamicModulePtr> module = newDynamicModule(path, false, true);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
 
   // The child module should be able to access the symbol from the global module.
   const auto child_path = testSharedObjectPath("program_child", "c");
   absl::StatusOr<DynamicModulePtr> child_module = newDynamicModule(child_path, false, false);
-  EXPECT_TRUE(child_module.ok());
+  EXPECT_OK(child_module);
 
   using GetSomeVariableFuncType = int (*)(void);
   const auto getSomeVariable =
       child_module->get()->getFunctionPointer<GetSomeVariableFuncType>("getSomeVariable");
-  EXPECT_TRUE(getSomeVariable.ok());
+  EXPECT_OK(getSomeVariable);
   EXPECT_EQ(getSomeVariable.value()(), 42);
 }
 
@@ -111,8 +116,7 @@ TEST_P(DynamicModuleTestLanguages, NoProgramInit) {
   std::string language = GetParam();
   absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("no_program_init", language), false);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to resolve symbol envoy_dynamic_module_on_program_init"));
 }
@@ -121,8 +125,7 @@ TEST_P(DynamicModuleTestLanguages, ProgramInitFail) {
   std::string language = GetParam();
   absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("program_init_fail", language), false);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to initialize dynamic module:"));
 }
@@ -132,7 +135,7 @@ TEST_P(DynamicModuleTestLanguages, ABIVersionMismatch) {
   std::string language = GetParam();
   absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("abi_version_mismatch", language), false);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
 }
 
 TEST(CreateDynamicModulesByName, EnvoyDynamicModulesSearchPathSet) {
@@ -143,7 +146,7 @@ TEST(CreateDynamicModulesByName, EnvoyDynamicModulesSearchPathSet) {
       1);
 
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
-  EXPECT_TRUE(module.ok()) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
   TestEnvironment::unsetEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH");
 }
 
@@ -152,7 +155,7 @@ TEST(CreateDynamicModulesByName, EnvoyDynamicModulesSearchPathNotSetFallbackToCw
   std::filesystem::path staged_lib = TestEnvironment::substitute("{{ test_rundir }}/libfoo.so");
   std::filesystem::copy(test_lib, staged_lib);
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("foo", false);
-  EXPECT_TRUE(module.ok()) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
   std::filesystem::remove(staged_lib);
 }
 
@@ -164,7 +167,7 @@ TEST(CreateDynamicModulesByName, DlopenDefaultSearchPath) {
       TestEnvironment::substitute("{{ test_rundir }}/libwhatever.so");
   std::filesystem::copy(test_lib, staged_lib);
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("whatever", false);
-  EXPECT_TRUE(module.ok()) << "Failed to load module: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module: " << module.status().message();
 
   TestEnvironment::unsetEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH");
   std::filesystem::remove(staged_lib);
@@ -172,14 +175,13 @@ TEST(CreateDynamicModulesByName, DlopenDefaultSearchPath) {
 
 TEST(StaticModule, LoadSuccess) {
   absl::StatusOr<DynamicModulePtr> result = newStaticModule("matcher_no_op_static");
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 }
 
 TEST(StaticModule, SymbolNotFound) {
   // "nonexistent_module" has no prefixed symbols in the binary.
   absl::StatusOr<DynamicModulePtr> result = newStaticModule("nonexistent_module");
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to resolve symbol "
                                  "envoy_dynamic_module_on_program_init"));
@@ -188,17 +190,16 @@ TEST(StaticModule, SymbolNotFound) {
 TEST(StaticModule, MultipleLoads) {
   absl::StatusOr<DynamicModulePtr> c_module =
       newDynamicModuleByName("matcher_no_op_static", /*do_not_close=*/false);
-  EXPECT_TRUE(c_module.ok()) << c_module.status().message();
+  EXPECT_OK(c_module) << c_module.status().message();
 
   absl::StatusOr<DynamicModulePtr> c_module_2 =
       newDynamicModuleByName("matcher_no_op_static", /*do_not_close=*/false);
-  EXPECT_TRUE(c_module_2.ok()) << c_module_2.status().message();
+  EXPECT_OK(c_module_2) << c_module_2.status().message();
 }
 
 TEST(CreateDynamicModulesByName, ModuleNotFound) {
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
-  EXPECT_FALSE(module.ok());
-  EXPECT_EQ(module.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(module, HasStatusCode(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(module.status().message(),
               testing::HasSubstr(
                   "Failed to load dynamic module: libno_op.so not found in any search path"));
@@ -219,7 +220,7 @@ TEST(NewDynamicModuleFromBytes, Success) {
 
   absl::StatusOr<DynamicModulePtr> module =
       newDynamicModuleFromBytes(module_bytes, sha256, false, false);
-  EXPECT_TRUE(module.ok()) << "Failed to load module from bytes: " << module.status().message();
+  EXPECT_OK(module) << "Failed to load module from bytes: " << module.status().message();
   EXPECT_TRUE(std::filesystem::exists(temp_path));
 
   // Cleanup.
@@ -236,8 +237,7 @@ TEST(NewDynamicModuleFromBytes, InvalidBytes) {
 
   absl::StatusOr<DynamicModulePtr> module =
       newDynamicModuleFromBytes(garbage, sha256, false, false);
-  EXPECT_FALSE(module.ok());
-  EXPECT_EQ(module.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(module, HasStatusCode(absl::StatusCode::kInvalidArgument));
 
   // The invalid file should have been cleaned up.
   EXPECT_FALSE(std::filesystem::exists(temp_path));
@@ -254,7 +254,7 @@ TEST(VerifyFileSha256, RoundTripWithComputedDigest) {
   Buffer::OwnedImpl hash_buffer(contents);
   const std::string expected_hex =
       Hex::encode(::Envoy::Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
-  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  EXPECT_OK(verifyFileSha256(tmp, expected_hex));
   std::filesystem::remove(tmp);
 }
 
@@ -267,8 +267,7 @@ TEST(VerifyFileSha256, MismatchReturnsFailedPrecondition) {
   }
   const std::string wrong_sha = "0000000000000000000000000000000000000000000000000000000000000000";
   auto status = verifyFileSha256(tmp, wrong_sha);
-  EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kFailedPrecondition));
   EXPECT_THAT(std::string(status.message()), testing::HasSubstr("SHA256 mismatch"));
   EXPECT_THAT(std::string(status.message()), testing::HasSubstr(wrong_sha));
   std::filesystem::remove(tmp);
@@ -281,8 +280,7 @@ TEST(VerifyFileSha256, MissingFileReturnsInternal) {
   ASSERT_FALSE(std::filesystem::exists(missing));
   auto status =
       verifyFileSha256(missing, "0000000000000000000000000000000000000000000000000000000000000000");
-  EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.code(), absl::StatusCode::kInternal);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
   EXPECT_THAT(std::string(status.message()),
               testing::HasSubstr("Failed to open file for SHA256 verification"));
 }
@@ -293,7 +291,7 @@ TEST(VerifyFileSha256, EmptyFileMatchesEmptyDigest) {
   { std::ofstream out(tmp, std::ios::binary); }
   // SHA256 of the empty input.
   const std::string empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-  EXPECT_TRUE(verifyFileSha256(tmp, empty_sha).ok());
+  EXPECT_OK(verifyFileSha256(tmp, empty_sha));
   std::filesystem::remove(tmp);
 }
 
@@ -313,7 +311,7 @@ TEST(VerifyFileSha256, LargeFileExceedingChunkSize) {
   Buffer::OwnedImpl hash_buffer(contents);
   const std::string expected_hex =
       Hex::encode(::Envoy::Common::Crypto::UtilitySingleton::get().getSha256Digest(hash_buffer));
-  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  EXPECT_OK(verifyFileSha256(tmp, expected_hex));
   std::filesystem::remove(tmp);
 }
 
@@ -333,7 +331,7 @@ TEST(VerifyFileSha256, MixedCaseExpectedHexNormalised) {
   for (char& c : expected_hex) {
     c = absl::ascii_toupper(c);
   }
-  EXPECT_TRUE(verifyFileSha256(tmp, expected_hex).ok());
+  EXPECT_OK(verifyFileSha256(tmp, expected_hex));
   std::filesystem::remove(tmp);
 }
 
@@ -352,14 +350,14 @@ TEST(NewDynamicModuleFromBytes, RepeatedLoadReusesDlopenHandle) {
   // First load writes and loads the module.
   absl::StatusOr<DynamicModulePtr> module1 =
       newDynamicModuleFromBytes(module_bytes, sha256, true, false);
-  ASSERT_TRUE(module1.ok()) << module1.status().message();
+  ASSERT_OK(module1) << module1.status().message();
   ASSERT_TRUE(std::filesystem::exists(temp_path));
 
   // Second load with the same sha256 — writes again but the RTLD_NOLOAD check in
   // newDynamicModule returns the existing handle, so the init function is not called twice.
   absl::StatusOr<DynamicModulePtr> module2 =
       newDynamicModuleFromBytes(module_bytes, sha256, true, false);
-  ASSERT_TRUE(module2.ok()) << module2.status().message();
+  ASSERT_OK(module2) << module2.status().message();
 
   // Cleanup.
   module1->reset();
@@ -416,7 +414,7 @@ protected:
 TEST_F(NewDynamicModuleByConfigTest, NoModuleNorName) {
   ProtoDynamicModuleConfig config;
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Either 'name' or 'module' must be specified"));
 }
@@ -426,7 +424,7 @@ TEST_F(NewDynamicModuleByConfigTest, ByNameSuccess) {
   ProtoDynamicModuleConfig config;
   config.set_name("no_op");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 }
@@ -436,8 +434,7 @@ TEST_F(NewDynamicModuleByConfigTest, ByNameFailure) {
   ProtoDynamicModuleConfig config;
   config.set_name("nonexistent_module");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 }
 
 // Local-file loading succeeds synchronously and requires no context (the context-less caller path).
@@ -445,7 +442,7 @@ TEST_F(NewDynamicModuleByConfigTest, LocalFileSuccess) {
   ProtoDynamicModuleConfig config;
   config.mutable_module()->mutable_local()->set_filename(testSharedObjectPath("no_op", "c"));
   auto result = newDynamicModuleByConfig(config, "test_module");
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 }
@@ -455,8 +452,7 @@ TEST_F(NewDynamicModuleByConfigTest, LocalFileFailure) {
   ProtoDynamicModuleConfig config;
   config.mutable_module()->mutable_local()->set_filename("/nonexistent/path/to/module.so");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 }
 
 // A module data source that is neither a local file path nor a remote source is rejected.
@@ -464,7 +460,7 @@ TEST_F(NewDynamicModuleByConfigTest, ModuleWithoutLocalFileOrRemoteRejected) {
   ProtoDynamicModuleConfig config;
   config.mutable_module()->mutable_local()->set_inline_bytes("AAAA");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Only local file path or remote HTTP source is supported"));
 }
@@ -472,7 +468,7 @@ TEST_F(NewDynamicModuleByConfigTest, ModuleWithoutLocalFileOrRemoteRejected) {
 // A remote source without a factory context is rejected (the context-less caller cannot fetch).
 TEST_F(NewDynamicModuleByConfigTest, RemoteWithoutContextRejected) {
   auto result = newDynamicModuleByConfig(makeRemoteConfig("abc123"), "test_module");
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Remote module sources require a factory context"));
 }
@@ -487,7 +483,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteCacheHitLoads) {
                              std::filesystem::copy_options::overwrite_existing);
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(result->loaded, nullptr);
   EXPECT_EQ(result->async, nullptr);
 
@@ -507,7 +503,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteCacheHitTamperedRemoved) {
   ASSERT_TRUE(std::filesystem::exists(cached));
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(expected_sha), "test_module", context_);
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Remote module sources require an init manager"));
   // The tampered cache entry must have been removed.
@@ -527,8 +523,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteCacheHitValidShaButLoadFails) {
   }
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Cached remote module failed to load"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Cached remote module failed to load")));
 
   std::filesystem::remove(cached);
 }
@@ -543,8 +538,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteNackOnCacheMiss) {
   // The cluster is not initialized in the mock, so the background fetch fails fast; the config is
   // still rejected as a cache miss.
   auto result = newDynamicModuleByConfig(config, "test_module", context_);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("not cached")));
 }
 
 // A remote source with a context but no init manager is rejected.
@@ -553,7 +547,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteNoCacheNoInitManager) {
   std::filesystem::remove(moduleTempPath(sha));
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_);
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Remote module sources require an init manager"));
 }
@@ -567,7 +561,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteNoOnLoadedCallbackRejected) {
   auto result =
       newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_, init_manager,
                                /*on_loaded=*/nullptr);
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Remote module sources require an on_loaded callback"));
 }
@@ -583,7 +577,7 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteAsyncReturnsAsyncState) {
   auto result =
       newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_, init_manager,
                                [&on_loaded_called](DynamicModulePtr) { on_loaded_called = true; });
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_EQ(result->loaded, nullptr);
   ASSERT_NE(result->async, nullptr);
   EXPECT_NE(result->async->remote_provider, nullptr);

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -23,6 +23,7 @@ namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 
+using ::Envoy::StatusHelpers::HasStatus;
 using ::Envoy::StatusHelpers::HasStatusCode;
 using ::Envoy::StatusHelpers::HasStatusMessage;
 
@@ -114,18 +115,18 @@ TEST_P(DynamicModuleTestLanguages, NoProgramInit) {
   std::string language = GetParam();
   absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("no_program_init", language), false);
-  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to resolve symbol envoy_dynamic_module_on_program_init"));
+  EXPECT_THAT(result,
+              HasStatus(absl::StatusCode::kInvalidArgument,
+                        testing::HasSubstr(
+                            "Failed to resolve symbol envoy_dynamic_module_on_program_init")));
 }
 
 TEST_P(DynamicModuleTestLanguages, ProgramInitFail) {
   std::string language = GetParam();
   absl::StatusOr<DynamicModulePtr> result =
       newDynamicModule(testSharedObjectPath("program_init_fail", language), false);
-  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to initialize dynamic module:"));
+  EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
+                                testing::HasSubstr("Failed to initialize dynamic module:")));
 }
 
 TEST_P(DynamicModuleTestLanguages, ABIVersionMismatch) {
@@ -179,10 +180,9 @@ TEST(StaticModule, LoadSuccess) {
 TEST(StaticModule, SymbolNotFound) {
   // "nonexistent_module" has no prefixed symbols in the binary.
   absl::StatusOr<DynamicModulePtr> result = newStaticModule("nonexistent_module");
-  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to resolve symbol "
-                                 "envoy_dynamic_module_on_program_init"));
+  EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
+                                testing::HasSubstr("Failed to resolve symbol "
+                                                   "envoy_dynamic_module_on_program_init")));
 }
 
 TEST(StaticModule, MultipleLoads) {
@@ -197,10 +197,11 @@ TEST(StaticModule, MultipleLoads) {
 
 TEST(CreateDynamicModulesByName, ModuleNotFound) {
   absl::StatusOr<DynamicModulePtr> module = newDynamicModuleByName("no_op", false);
-  EXPECT_THAT(module, HasStatusCode(absl::StatusCode::kInvalidArgument));
-  EXPECT_THAT(module.status().message(),
-              testing::HasSubstr(
-                  "Failed to load dynamic module: libno_op.so not found in any search path"));
+  EXPECT_THAT(
+      module,
+      HasStatus(absl::StatusCode::kInvalidArgument,
+                testing::HasSubstr(
+                    "Failed to load dynamic module: libno_op.so not found in any search path")));
 }
 
 TEST(NewDynamicModuleFromBytes, Success) {
@@ -265,8 +266,8 @@ TEST(VerifyFileSha256, MismatchReturnsFailedPrecondition) {
   }
   const std::string wrong_sha = "0000000000000000000000000000000000000000000000000000000000000000";
   auto status = verifyFileSha256(tmp, wrong_sha);
-  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kFailedPrecondition));
-  EXPECT_THAT(std::string(status.message()), testing::HasSubstr("SHA256 mismatch"));
+  EXPECT_THAT(status, HasStatus(absl::StatusCode::kFailedPrecondition,
+                                testing::HasSubstr("SHA256 mismatch")));
   EXPECT_THAT(std::string(status.message()), testing::HasSubstr(wrong_sha));
   std::filesystem::remove(tmp);
 }
@@ -278,9 +279,8 @@ TEST(VerifyFileSha256, MissingFileReturnsInternal) {
   ASSERT_FALSE(std::filesystem::exists(missing));
   auto status =
       verifyFileSha256(missing, "0000000000000000000000000000000000000000000000000000000000000000");
-  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
-  EXPECT_THAT(std::string(status.message()),
-              testing::HasSubstr("Failed to open file for SHA256 verification"));
+  EXPECT_THAT(status, HasStatus(absl::StatusCode::kInternal,
+                                testing::HasSubstr("Failed to open file for SHA256 verification")));
 }
 
 TEST(VerifyFileSha256, EmptyFileMatchesEmptyDigest) {

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -25,8 +25,6 @@ namespace DynamicModules {
 
 using ::Envoy::StatusHelpers::HasStatusCode;
 using ::Envoy::StatusHelpers::HasStatusMessage;
-using ::Envoy::StatusHelpers::IsOk;
-using ::testing::Not;
 
 TEST(DynamicModuleTestGeneral, InvalidPath) {
   absl::StatusOr<DynamicModulePtr> result = newDynamicModule("invalid_name", false);
@@ -414,9 +412,8 @@ protected:
 TEST_F(NewDynamicModuleByConfigTest, NoModuleNorName) {
   ProtoDynamicModuleConfig config;
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Either 'name' or 'module' must be specified"));
+  EXPECT_THAT(result,
+              HasStatusMessage(testing::HasSubstr("Either 'name' or 'module' must be specified")));
 }
 
 // By-name loading succeeds synchronously and requires no context (the context-less caller path).
@@ -460,17 +457,15 @@ TEST_F(NewDynamicModuleByConfigTest, ModuleWithoutLocalFileOrRemoteRejected) {
   ProtoDynamicModuleConfig config;
   config.mutable_module()->mutable_local()->set_inline_bytes("AAAA");
   auto result = newDynamicModuleByConfig(config, "test_module");
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Only local file path or remote HTTP source is supported"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr(
+                          "Only local file path or remote HTTP source is supported")));
 }
 
 // A remote source without a factory context is rejected (the context-less caller cannot fetch).
 TEST_F(NewDynamicModuleByConfigTest, RemoteWithoutContextRejected) {
   auto result = newDynamicModuleByConfig(makeRemoteConfig("abc123"), "test_module");
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Remote module sources require a factory context"));
+  EXPECT_THAT(result, HasStatusMessage(
+                          testing::HasSubstr("Remote module sources require a factory context")));
 }
 
 // A cached file whose contents match the expected SHA256 is loaded directly (cache hit).
@@ -503,9 +498,8 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteCacheHitTamperedRemoved) {
   ASSERT_TRUE(std::filesystem::exists(cached));
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(expected_sha), "test_module", context_);
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Remote module sources require an init manager"));
+  EXPECT_THAT(result, HasStatusMessage(
+                          testing::HasSubstr("Remote module sources require an init manager")));
   // The tampered cache entry must have been removed.
   EXPECT_FALSE(std::filesystem::exists(cached));
 }
@@ -547,9 +541,8 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteNoCacheNoInitManager) {
   std::filesystem::remove(moduleTempPath(sha));
 
   auto result = newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_);
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Remote module sources require an init manager"));
+  EXPECT_THAT(result, HasStatusMessage(
+                          testing::HasSubstr("Remote module sources require an init manager")));
 }
 
 // A remote source with a context and init manager but no on_loaded callback is rejected.
@@ -561,9 +554,8 @@ TEST_F(NewDynamicModuleByConfigTest, RemoteNoOnLoadedCallbackRejected) {
   auto result =
       newDynamicModuleByConfig(makeRemoteConfig(sha), "test_module", context_, init_manager,
                                /*on_loaded=*/nullptr);
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Remote module sources require an on_loaded callback"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr(
+                          "Remote module sources require an on_loaded callback")));
 }
 
 // A remote source with a context, init manager, and on_loaded callback starts an asynchronous

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -63,6 +63,7 @@ envoy_cc_test(
         "//source/extensions/filters/http/dynamic_modules:factory_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/extensions/filters/http/dynamic_modules/v3:pkg_cc_proto",
     ],
 )
@@ -100,6 +101,7 @@ envoy_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 
@@ -129,6 +131,7 @@ envoy_cc_test(
         "//test/mocks/upstream:host_set_mocks",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -25,6 +25,7 @@
 #include "test/mocks/upstream/host_set.h"
 #include "test/mocks/upstream/priority_set.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -3530,12 +3531,12 @@ public:
 
     // Create a real dynamic module and filter config.
     auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_scope_, context_);
-    ASSERT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
     filter_ = std::make_unique<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);
@@ -3705,11 +3706,11 @@ class DynamicModuleHttpFilterLifecycleTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_scope_, context_);
-    ASSERT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
   }
 
@@ -4210,12 +4211,12 @@ public:
 
     auto dynamic_module = Envoy::Extensions::DynamicModules::newDynamicModule(
         testSharedObjectPath("no_op", "c"), false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_store_.rootScope(), context_);
-    ASSERT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
 
     filter_ = std::make_shared<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -3531,12 +3531,12 @@ public:
 
     // Create a real dynamic module and filter config.
     auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_scope_, context_);
-    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
 
     filter_ = std::make_unique<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);
@@ -3706,11 +3706,11 @@ class DynamicModuleHttpFilterLifecycleTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module);
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_scope_, context_);
-    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
   }
 
@@ -4211,12 +4211,12 @@ public:
 
     auto dynamic_module = Envoy::Extensions::DynamicModules::newDynamicModule(
         testSharedObjectPath("no_op", "c"), false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
         *stats_store_.rootScope(), context_);
-    ASSERT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    ASSERT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
 
     filter_ = std::make_shared<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -25,7 +25,6 @@
 #include "gtest/gtest.h"
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
-using ::Envoy::StatusHelpers::IsOk;
 using testing::Invoke;
 using ::testing::Not;
 using testing::ReturnRef;
@@ -110,9 +109,8 @@ TEST_F(DynamicModuleFilterConfigTest, InlineBytesRejected) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_THAT(cb_or_error, Not(IsOk()));
-  EXPECT_THAT(cb_or_error.status().message(),
-              testing::HasSubstr("Only local file path or remote HTTP source is supported"));
+  EXPECT_THAT(cb_or_error, HasStatusMessage(testing::HasSubstr(
+                               "Only local file path or remote HTTP source is supported")));
 }
 
 TEST_F(DynamicModuleFilterConfigTest, NoModuleOrName) {
@@ -127,9 +125,8 @@ TEST_F(DynamicModuleFilterConfigTest, NoModuleOrName) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_THAT(cb_or_error, Not(IsOk()));
-  EXPECT_THAT(cb_or_error.status().message(),
-              testing::HasSubstr("Either 'name' or 'module' must be specified"));
+  EXPECT_THAT(cb_or_error,
+              HasStatusMessage(testing::HasSubstr("Either 'name' or 'module' must be specified")));
 }
 
 TEST_F(DynamicModuleFilterConfigTest, RemoteSourceWithoutInitManagerReturnsError) {
@@ -857,9 +854,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchBadModule) {
   // Next config push finds the cached file, tries to load it, and gets a load error.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_THAT(result2, Not(IsOk()));
-  EXPECT_THAT(result2.status().message(),
-              testing::HasSubstr("Cached remote module failed to load"));
+  EXPECT_THAT(result2, HasStatusMessage(testing::HasSubstr("Cached remote module failed to load")));
 
   std::filesystem::remove(cached_path);
 }
@@ -927,9 +922,8 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheInvalidationOnMissingFile) {
   auto result2 =
       factory.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
                                   /*init_manager=*/std::nullopt);
-  EXPECT_THAT(result2, Not(IsOk()));
-  EXPECT_THAT(result2.status().message(),
-              testing::HasSubstr("Remote module sources require an init manager"));
+  EXPECT_THAT(result2, HasStatusMessage(
+                           testing::HasSubstr("Remote module sources require an init manager")));
 }
 
 TEST_F(DynamicModuleFilterConfigTest, InvalidLocalFile) {

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -24,7 +24,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
 using testing::Invoke;
+using ::testing::Not;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -85,7 +88,7 @@ TEST_F(DynamicModuleFilterConfigTest, LocalFileLoading) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -107,7 +110,7 @@ TEST_F(DynamicModuleFilterConfigTest, InlineBytesRejected) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_FALSE(cb_or_error.ok());
+  EXPECT_THAT(cb_or_error, Not(IsOk()));
   EXPECT_THAT(cb_or_error.status().message(),
               testing::HasSubstr("Only local file path or remote HTTP source is supported"));
 }
@@ -124,7 +127,7 @@ TEST_F(DynamicModuleFilterConfigTest, NoModuleOrName) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_FALSE(cb_or_error.ok());
+  EXPECT_THAT(cb_or_error, Not(IsOk()));
   EXPECT_THAT(cb_or_error.status().message(),
               testing::HasSubstr("Either 'name' or 'module' must be specified"));
 }
@@ -173,7 +176,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceRegistersInitTarget) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   // The init manager should not be initialized yet — the remote fetch is pending.
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Uninitialized);
@@ -200,7 +203,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchFailureFailOpen) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   // Initialize the init manager to trigger the fetch. Cluster "cluster_1" is not set up
   // in the mock, so the fetch fails immediately. With num_retries=0 and allow_empty=true,
@@ -267,7 +270,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccess) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   // Initialize → triggers fetch → HTTP success → module loaded from bytes.
   EXPECT_CALL(init_watcher_, ready());
@@ -330,7 +333,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccessInvalidModule) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -395,7 +398,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccessMissingFilterSymbo
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -465,7 +468,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheHitAfterFetch) {
   // First call: remote fetch writes the module to disk.
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -477,7 +480,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheHitAfterFetch) {
   auto result2 =
       factory2.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
                                    /*init_manager=*/std::nullopt);
-  EXPECT_TRUE(result2.ok()) << result2.status().message();
+  EXPECT_OK(result2) << result2.status().message();
 
   // Verify the cache-loaded factory callback installs the filter.
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
@@ -529,7 +532,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeCacheHit) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 
   // Clean up.
   std::filesystem::remove(cached_path);
@@ -581,8 +584,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeCacheHitTamperedFileIsRejected) {
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
   // The verification step removes the tampered file and the code falls through to the fetch
   // path; in NACK mode the fetch path reports "not cached".
-  EXPECT_FALSE(cb_or_error.ok());
-  EXPECT_THAT(cb_or_error.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(cb_or_error, HasStatusMessage(testing::HasSubstr("not cached")));
 
   // The tampered cache entry must have been removed by the factory so a subsequent legitimate
   // fetch can repopulate it.
@@ -610,8 +612,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeCacheMissReturnsError) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_FALSE(cb_or_error.ok());
-  EXPECT_THAT(cb_or_error.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(cb_or_error, HasStatusMessage(testing::HasSubstr("not cached")));
 
   // A NACK-mode cache miss rejects the config; it bumps remote_fetch_error.
   EXPECT_EQ(1U, failureCounter(context_.server_factory_context_.scope(), "remote_fetch_error",
@@ -670,8 +671,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchPopulatesCache) {
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result1.ok());
-  EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result1, HasStatusMessage(testing::HasSubstr("not cached")));
 
   auto cached_path = Extensions::DynamicModules::moduleTempPath(sha256);
   EXPECT_TRUE(std::filesystem::exists(cached_path));
@@ -679,7 +679,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchPopulatesCache) {
   // Second call finds the cached file and succeeds.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_TRUE(result2.ok()) << result2.status().message();
+  EXPECT_OK(result2) << result2.status().message();
 
   // Clean up.
   std::filesystem::remove(cached_path);
@@ -709,8 +709,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchFailure) {
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result1.ok());
-  EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result1, HasStatusMessage(testing::HasSubstr("not cached")));
 
   auto cached_path = Extensions::DynamicModules::moduleTempPath(
       "deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678");
@@ -719,8 +718,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchFailure) {
   // Second call cleans up the completed (failed) entry and starts a new fetch.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result2.ok());
-  EXPECT_THAT(result2.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result2, HasStatusMessage(testing::HasSubstr("not cached")));
 }
 
 // NACK mode works without an init manager (ECDS / per-route path).
@@ -745,8 +743,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeWithoutInitManager) {
   DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                             stats_scope_, /*init_manager=*/std::nullopt);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("not cached")));
   EXPECT_THAT(result.status().message(), testing::Not(testing::HasSubstr("init manager")));
 }
 
@@ -788,16 +785,14 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeInFlightDedup) {
   // First call: starts a background fetch.
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result1.ok());
-  EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result1, HasStatusMessage(testing::HasSubstr("not cached")));
   EXPECT_NE(captured_cb, nullptr);
 
   // Second call while the fetch is still in-flight: no new send_ expected (WillOnce above
   // would fail if a second call happened).
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result2.ok());
-  EXPECT_THAT(result2.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result2, HasStatusMessage(testing::HasSubstr("not cached")));
 
   // Clean up: erase the in-flight entry from the singleton so the fetcher is destroyed
   // while the mock request is still alive. This triggers cancel() on the mock.
@@ -853,8 +848,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchBadModule) {
   DynamicModuleConfigFactory factory;
   auto result1 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result1.ok());
-  EXPECT_THAT(result1.status().message(), testing::HasSubstr("not cached"));
+  EXPECT_THAT(result1, HasStatusMessage(testing::HasSubstr("not cached")));
 
   // The background fetch only writes bytes to disk (no dlopen), so the file persists.
   auto cached_path = Extensions::DynamicModules::moduleTempPath(sha256);
@@ -863,7 +857,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchBadModule) {
   // Next config push finds the cached file, tries to load it, and gets a load error.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_FALSE(result2.ok());
+  EXPECT_THAT(result2, Not(IsOk()));
   EXPECT_THAT(result2.status().message(),
               testing::HasSubstr("Cached remote module failed to load"));
 
@@ -919,7 +913,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheInvalidationOnMissingFile) {
   // First call: remote fetch writes the module to disk.
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok());
+  EXPECT_OK(cb_or_error);
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -933,7 +927,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheInvalidationOnMissingFile) {
   auto result2 =
       factory.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
                                   /*init_manager=*/std::nullopt);
-  EXPECT_FALSE(result2.ok());
+  EXPECT_THAT(result2, Not(IsOk()));
   EXPECT_THAT(result2.status().message(),
               testing::HasSubstr("Remote module sources require an init manager"));
 }
@@ -953,8 +947,7 @@ TEST_F(DynamicModuleFilterConfigTest, InvalidLocalFile) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_FALSE(cb_or_error.ok());
-  EXPECT_THAT(cb_or_error.status().message(), testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(cb_or_error, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 }
 
 // Verify that when both name and module are set, module takes precedence.
@@ -979,7 +972,7 @@ TEST_F(DynamicModuleFilterConfigTest, ModulePrecedenceOverName) {
   // If name were used, this would fail because "nonexistent_module_should_be_ignored" doesn't
   // exist. Since module takes precedence, it should succeed with the local file.
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_TRUE(cb_or_error.ok()) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
 }
 
 } // namespace Configuration

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -87,7 +87,7 @@ TEST_F(DynamicModuleFilterConfigTest, LocalFileLoading) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -173,7 +173,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceRegistersInitTarget) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   // The init manager should not be initialized yet — the remote fetch is pending.
   EXPECT_EQ(context_.initManager().state(), Init::Manager::State::Uninitialized);
@@ -200,7 +200,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchFailureFailOpen) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   // Initialize the init manager to trigger the fetch. Cluster "cluster_1" is not set up
   // in the mock, so the fetch fails immediately. With num_retries=0 and allow_empty=true,
@@ -267,7 +267,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccess) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   // Initialize → triggers fetch → HTTP success → module loaded from bytes.
   EXPECT_CALL(init_watcher_, ready());
@@ -330,7 +330,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccessInvalidModule) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -395,7 +395,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceFetchSuccessMissingFilterSymbo
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -465,7 +465,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheHitAfterFetch) {
   // First call: remote fetch writes the module to disk.
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   EXPECT_CALL(init_watcher_, ready());
   context_.initManager().initialize(init_watcher_);
@@ -477,7 +477,7 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteCacheHitAfterFetch) {
   auto result2 =
       factory2.createFilterFactory(proto_config, "", context_.server_factory_context_, stats_scope_,
                                    /*init_manager=*/std::nullopt);
-  EXPECT_OK(result2) << result2.status().message();
+  EXPECT_OK(result2);
 
   // Verify the cache-loaded factory callback installs the filter.
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
@@ -529,7 +529,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeCacheHit) {
 
   DynamicModuleConfigFactory factory;
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 
   // Clean up.
   std::filesystem::remove(cached_path);
@@ -676,7 +676,7 @@ TEST_F(DynamicModuleFilterConfigTest, NackModeBackgroundFetchPopulatesCache) {
   // Second call finds the cached file and succeeds.
   auto result2 = factory.createFilterFactory(proto_config, "", context_.server_factory_context_,
                                              stats_scope_, init_manager_);
-  EXPECT_OK(result2) << result2.status().message();
+  EXPECT_OK(result2);
 
   // Clean up.
   std::filesystem::remove(cached_path);
@@ -966,7 +966,7 @@ TEST_F(DynamicModuleFilterConfigTest, ModulePrecedenceOverName) {
   // If name were used, this would fail because "nonexistent_module_should_be_ignored" doesn't
   // exist. Since module takes precedence, it should succeed with the local file.
   auto cb_or_error = factory.createFilterFactoryFromProto(proto_config, "stats", context_);
-  EXPECT_OK(cb_or_error) << cb_or_error.status().message();
+  EXPECT_OK(cb_or_error);
 }
 
 } // namespace Configuration

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -13,6 +13,7 @@ namespace DynamicModules {
 namespace HttpFilters {
 
 using ::Envoy::StatusHelpers::HasStatusCode;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::Not;
 
@@ -130,9 +131,8 @@ filter_config:
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createRouteSpecificFilterConfig(
       proto_config, context.server_factory_context_, context.messageValidationVisitor());
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_http_filter_per_route_config_new"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr(
+                          "envoy_dynamic_module_on_http_filter_per_route_config_new")));
 }
 
 TEST(DynamicModuleConfigFactory, LoadOKPerRouteWithStruct) {
@@ -487,9 +487,8 @@ filter_config:
     TestUtility::loadFromYamlAndValidate(yaml, proto_config);
 
     auto result = factory.createFilterFactoryFromProto(proto_config, "", init_fail_context);
-    EXPECT_THAT(result, Not(IsOk()));
-    EXPECT_THAT(result.status().message(),
-                testing::HasSubstr("Failed to initialize dynamic module"));
+    EXPECT_THAT(result,
+                HasStatusMessage(testing::HasSubstr("Failed to initialize dynamic module")));
     auto& server_scope = init_fail_context.server_factory_context_.scope();
     EXPECT_EQ(1U, failureCounter(server_scope, "config_init_error", "foo"));
     EXPECT_EQ(0U, failureCounter(server_scope, "module_load_error", "foo"));

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -12,7 +12,7 @@ namespace Extensions {
 namespace DynamicModules {
 namespace HttpFilters {
 
-using ::Envoy::StatusHelpers::HasStatusCode;
+using ::Envoy::StatusHelpers::HasStatus;
 using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::Not;
@@ -416,8 +416,8 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module:"));
+  EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
+                                testing::HasSubstr("Failed to load dynamic module:")));
 
   // A module that cannot be loaded at all bumps the module_load_error counter, tagged with the
   // filter name. The counter is on the server scope, which outlives the rejected listener config.
@@ -456,10 +456,9 @@ filter_config:
     TestUtility::loadFromYamlAndValidate(yaml, proto_config);
 
     auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-    EXPECT_THAT(
-        result.status().message(),
-        testing::HasSubstr(fmt::format("Failed to resolve symbol {}", missing_symbol_name)));
+    EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
+                                  testing::HasSubstr(fmt::format("Failed to resolve symbol {}",
+                                                                 missing_symbol_name))));
   }
 
   // The module loads fine in each of these cases (dlopen + program_init succeed); the failure is in
@@ -514,8 +513,8 @@ filter_config:
 
     auto result = factory.createRouteSpecificFilterConfig(
         proto_config, context, ProtobufMessage::getNullValidationVisitor());
-    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-    EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module:"));
+    EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
+                                  testing::HasSubstr("Failed to load dynamic module:")));
     EXPECT_EQ(1U, failureCounter(context.scope(), "per_route_config_error", "foo"));
   }
 
@@ -547,8 +546,8 @@ filter_config:
 
     auto result = factory.createRouteSpecificFilterConfig(
         proto_config, context, ProtobufMessage::getNullValidationVisitor());
-    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
-    EXPECT_THAT(result.status().message(), testing::HasSubstr(expected_error));
+    EXPECT_THAT(result,
+                HasStatus(absl::StatusCode::kInvalidArgument, testing::HasSubstr(expected_error)));
     // A fresh context is used per iteration, so the per-route failure counter is exactly one.
     EXPECT_EQ(1U, failureCounter(context.scope(), "per_route_config_error", "foo"));
   }

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -4,12 +4,17 @@
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 namespace HttpFilters {
+
+using ::Envoy::StatusHelpers::HasStatusCode;
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 TEST(DynamicModuleConfigFactory, Overrides) {
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
@@ -46,7 +51,7 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
   auto factory_cb = result.value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
@@ -125,7 +130,7 @@ filter_config:
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createRouteSpecificFilterConfig(
       proto_config, context.server_factory_context_, context.messageValidationVisitor());
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_http_filter_per_route_config_new"));
 }
@@ -223,7 +228,7 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
   auto factory_cb = result.value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
@@ -298,7 +303,7 @@ filter_name: foo
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
   auto factory_cb = result.value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
@@ -337,7 +342,7 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
   auto factory_cb = result.value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
@@ -377,7 +382,7 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_TRUE(result.ok());
+  EXPECT_OK(result);
   auto factory_cb = result.value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
@@ -411,8 +416,7 @@ filter_config:
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
   auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-  EXPECT_FALSE(result.ok());
-  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module:"));
 
   // A module that cannot be loaded at all bumps the module_load_error counter, tagged with the
@@ -452,8 +456,7 @@ filter_config:
     TestUtility::loadFromYamlAndValidate(yaml, proto_config);
 
     auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-    EXPECT_FALSE(result.ok());
-    EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
     EXPECT_THAT(
         result.status().message(),
         testing::HasSubstr(fmt::format("Failed to resolve symbol {}", missing_symbol_name)));
@@ -484,7 +487,7 @@ filter_config:
     TestUtility::loadFromYamlAndValidate(yaml, proto_config);
 
     auto result = factory.createFilterFactoryFromProto(proto_config, "", init_fail_context);
-    EXPECT_FALSE(result.ok());
+    EXPECT_THAT(result, Not(IsOk()));
     EXPECT_THAT(result.status().message(),
                 testing::HasSubstr("Failed to initialize dynamic module"));
     auto& server_scope = init_fail_context.server_factory_context_.scope();
@@ -512,8 +515,7 @@ filter_config:
 
     auto result = factory.createRouteSpecificFilterConfig(
         proto_config, context, ProtobufMessage::getNullValidationVisitor());
-    EXPECT_FALSE(result.ok());
-    EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
     EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module:"));
     EXPECT_EQ(1U, failureCounter(context.scope(), "per_route_config_error", "foo"));
   }
@@ -546,8 +548,7 @@ filter_config:
 
     auto result = factory.createRouteSpecificFilterConfig(
         proto_config, context, ProtobufMessage::getNullValidationVisitor());
-    EXPECT_FALSE(result.ok());
-    EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+    EXPECT_THAT(result, HasStatusCode(absl::StatusCode::kInvalidArgument));
     EXPECT_THAT(result.status().message(), testing::HasSubstr(expected_error));
     // A fresh context is used per iteration, so the per-route failure counter is exactly one.
     EXPECT_EQ(1U, failureCounter(context.scope(), "per_route_config_error", "foo"));
@@ -581,7 +582,7 @@ TEST(DynamicModuleConfigFactory, MalformedFilterConfig) {
     set_malformed(proto_config);
 
     auto result = factory.createFilterFactoryFromProto(proto_config, "", context);
-    EXPECT_FALSE(result.ok());
+    EXPECT_THAT(result, Not(IsOk()));
     auto& server_scope = context.server_factory_context_.scope();
     EXPECT_EQ(1U, failureCounter(server_scope, "config_init_error", "foo"));
     EXPECT_EQ(0U, failureCounter(server_scope, "module_load_error", "foo"));
@@ -595,7 +596,7 @@ TEST(DynamicModuleConfigFactory, MalformedFilterConfig) {
 
     auto result = factory.createRouteSpecificFilterConfig(
         proto_config, context, ProtobufMessage::getNullValidationVisitor());
-    EXPECT_FALSE(result.ok());
+    EXPECT_THAT(result, Not(IsOk()));
     EXPECT_EQ(1U, failureCounter(context.scope(), "per_route_config_error", "foo"));
   }
 }

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -26,8 +26,7 @@ namespace HttpFilters {
 
 namespace {
 
-using ::Envoy::StatusHelpers::IsOk;
-using ::testing::Not;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 
 // Test ObjectFactory used by the Rust SDK typed filter state test. Creates a StringAccessorImpl
 // from the provided bytes.
@@ -116,9 +115,8 @@ TEST_P(DynamicModuleHttpLanguageTests, ConfigInitializationFailure) {
   auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
       "config_init_failure", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
       *stats_store.createScope(""), context);
-  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
-  EXPECT_THAT(filter_config_or_status.status().message(),
-              testing::HasSubstr("Failed to initialize dynamic module"));
+  EXPECT_THAT(filter_config_or_status,
+              HasStatusMessage(testing::HasSubstr("Failed to initialize dynamic module")));
 }
 
 TEST_P(DynamicModuleHttpLanguageTests, StatsCallbacks) {

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -14,6 +14,7 @@
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -24,6 +25,9 @@ namespace DynamicModules {
 namespace HttpFilters {
 
 namespace {
+
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 // Test ObjectFactory used by the Rust SDK typed filter state test. Creates a StringAccessorImpl
 // from the provided bytes.
@@ -49,7 +53,7 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
 
   const auto language = GetParam();
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", language), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -58,7 +62,7 @@ TEST_P(DynamicModuleTestLanguages, Nop) {
           filter_name, filter_config,
           Envoy::Extensions::DynamicModules::HttpFilters::DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -106,13 +110,13 @@ INSTANTIATE_TEST_SUITE_P(HttpLanguageTests, DynamicModuleHttpLanguageTests,
 
 TEST_P(DynamicModuleHttpLanguageTests, ConfigInitializationFailure) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
       "config_init_failure", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
       *stats_store.createScope(""), context);
-  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize dynamic module"));
 }
@@ -125,7 +129,7 @@ TEST_P(DynamicModuleHttpLanguageTests, StatsCallbacks) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::TestUtil::TestStore stats_store;
@@ -134,7 +138,7 @@ TEST_P(DynamicModuleHttpLanguageTests, StatsCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope.symbolTable(), 0);
@@ -246,7 +250,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HeaderCallbacks) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -254,7 +258,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HeaderCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -311,7 +315,7 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -320,7 +324,7 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -439,7 +443,7 @@ TEST_P(DynamicModuleHttpLanguageTests, FilterStateCallbacks) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -448,7 +452,7 @@ TEST_P(DynamicModuleHttpLanguageTests, FilterStateCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -518,7 +522,7 @@ TEST_P(DynamicModuleHttpLanguageTests, LocalReplyCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -526,7 +530,7 @@ TEST_P(DynamicModuleHttpLanguageTests, LocalReplyCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -544,7 +548,7 @@ TEST_P(DynamicModuleHttpLanguageTests, ResetStream) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -552,7 +556,7 @@ TEST_P(DynamicModuleHttpLanguageTests, ResetStream) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -573,7 +577,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SendGoAwayAndClose) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -581,7 +585,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SendGoAwayAndClose) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -602,7 +606,7 @@ TEST_P(DynamicModuleHttpLanguageTests, RecreateStream) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -610,7 +614,7 @@ TEST_P(DynamicModuleHttpLanguageTests, RecreateStream) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -638,7 +642,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SocketOptionCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -646,7 +650,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SocketOptionCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -669,7 +673,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -677,7 +681,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -731,14 +735,14 @@ TEST_P(DynamicModuleHttpLanguageTests, ClusterCallbacks) {
   mock_host_set->degraded_hosts_.resize(1);
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   Stats::IsolatedStoreImpl stats_store;
   auto filter_config_or_status =
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  ASSERT_TRUE(filter_config_or_status.ok());
+  ASSERT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -769,7 +773,7 @@ TEST_P(DynamicModuleTestLanguages, WillNotMoveDataAutomatically) {
 
   const auto language = GetParam();
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", language), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -778,7 +782,7 @@ TEST_P(DynamicModuleTestLanguages, WillNotMoveDataAutomatically) {
           filter_name, filter_config,
           Envoy::Extensions::DynamicModules::HttpFilters::DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_store.createScope(""), context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_store.symbolTable(), 0);
@@ -828,7 +832,7 @@ TEST_P(DynamicModuleHttpLanguageTests, BodyCallbacks) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -837,7 +841,7 @@ TEST_P(DynamicModuleHttpLanguageTests, BodyCallbacks) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -899,7 +903,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_non_existing_cluste
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
   Upstream::MockClusterManager cluster_manager;
@@ -915,7 +919,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_non_existing_cluste
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -943,7 +947,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_immediate_failing_c
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -958,7 +962,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_immediate_failing_c
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
       std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
@@ -1002,7 +1006,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_success) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -1017,7 +1021,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_success) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
       std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
@@ -1077,7 +1081,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_resetting) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -1092,7 +1096,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterHttpCallout_resetting) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   std::shared_ptr<Upstream::MockThreadLocalCluster> cluster =
       std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
@@ -1135,7 +1139,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpCallout_success) {
 
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("http_integration_test", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -1172,7 +1176,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpCallout_success) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   EXPECT_TRUE(config_callbacks_captured);
 
   // Simulate the config callout response. This calls on_http_filter_config_http_callout_done.
@@ -1206,7 +1210,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpCallout_failing) {
 
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("http_integration_test", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -1236,7 +1240,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpCallout_failing) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   EXPECT_TRUE(config_callbacks_captured);
 
   // Simulate a callout failure.
@@ -1266,7 +1270,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpStream_success) {
 
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("http_integration_test", GetParam()), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -1298,7 +1302,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterConfigHttpStream_success) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   EXPECT_TRUE(stream_callbacks_captured);
 
   // Deliver response headers then complete the stream.
@@ -1343,7 +1347,7 @@ TEST(DynamicModuleHttpFilterConfigCalloutTest, SendHttpCalloutClusterNotFound) {
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t id = 0;
@@ -1378,7 +1382,7 @@ TEST(DynamicModuleHttpFilterConfigCalloutTest, SendHttpCalloutCannotCreateReques
           }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t id = 0;
@@ -1411,7 +1415,7 @@ TEST(DynamicModuleHttpFilterConfigCalloutTest, CancelPendingCallout) {
           }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t id = 0;
@@ -1452,7 +1456,7 @@ TEST(DynamicModuleHttpFilterConfigCalloutTest, HttpCalloutCallbackOnSuccessNoCal
           }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t id = 0;
@@ -1496,7 +1500,7 @@ TEST(DynamicModuleHttpFilterConfigCalloutTest, HttpCalloutCallbackOnFailureReset
           }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t id = 0;
@@ -1523,7 +1527,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamClusterNotFound) {
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1547,7 +1551,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamMissingRequiredHead
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   // Message missing :path header.
@@ -1578,7 +1582,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamCannotCreateRequest
       }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1617,7 +1621,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamWithBody) {
   EXPECT_CALL(stream, sendData(_, true));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1661,7 +1665,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamInlineResetOnHeader
   }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1703,7 +1707,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamInlineResetOnData) 
   }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1751,7 +1755,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StartHttpStreamInlineComplete) {
   }));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1774,7 +1778,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, ResetHttpStreamNonExistent) {
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   // Resetting a non-existent stream should be a no-op and not crash.
   config_or.value()->resetHttpStream(99999);
 }
@@ -1803,7 +1807,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, ResetHttpStreamExisting) {
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1846,7 +1850,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, CancelPendingStreamCallout) {
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1873,7 +1877,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, SendStreamDataNonExistent) {
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   Buffer::OwnedImpl data("test");
   EXPECT_FALSE(config_or.value()->sendStreamData(99999, data, false));
 }
@@ -1900,7 +1904,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, SendStreamDataValid) {
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1926,7 +1930,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, SendStreamTrailersNonExistent) {
   EXPECT_CALL(context, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto trailers = Http::RequestTrailerMapImpl::create();
   EXPECT_FALSE(config_or.value()->sendStreamTrailers(99999, std::move(trailers)));
 }
@@ -1953,7 +1957,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, SendStreamTrailersValid) {
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -1993,7 +1997,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StreamCallbackOnHeadersNoCallback)
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -2035,7 +2039,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StreamCallbackOnDataNoCallbackAndE
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -2081,7 +2085,7 @@ TEST(DynamicModuleHttpFilterConfigStreamTest, StreamCallbackOnTrailersNoCallback
   EXPECT_CALL(context, mainThreadDispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));
 
   auto config_or = makeNoOpConfig(context, *stats_scope);
-  ASSERT_TRUE(config_or.ok());
+  ASSERT_OK(config_or);
   auto config = config_or.value();
 
   uint64_t sid = 0;
@@ -2113,7 +2117,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterPerRouteConfigLifetimes) {
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2128,14 +2132,14 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterPerRouteConfigLifetimes) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           filter_name, filter_config, DefaultMetricsNamespace, false,
           std::move(dynamic_module.value()), *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto dynamic_module_for_route =
       newDynamicModule(testSharedObjectPath("http_integration_test", GetParam()), false);
   if (!dynamic_module.ok()) {
     ENVOY_LOG_MISC(debug, "Failed to load dynamic module: {}", dynamic_module.status().message());
   }
-  EXPECT_TRUE(dynamic_module_for_route.ok());
+  EXPECT_OK(dynamic_module_for_route);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2156,7 +2160,7 @@ TEST_P(DynamicModuleHttpLanguageTests, HttpFilterPerRouteConfigLifetimes) {
     auto route_filter_config_or_status =
         Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpPerRouteConfig(
             filter_name, route_filter_config_str, std::move(dynamic_module_for_route.value()));
-    EXPECT_TRUE(route_filter_config_or_status.ok());
+    EXPECT_OK(route_filter_config_or_status);
     auto route_filter_config = std::move(route_filter_config_or_status.value());
 
     const Router::RouteSpecificFilterConfig* router_config_ptr = route_filter_config.get();
@@ -2266,7 +2270,7 @@ TEST(HttpFilter, SendStreamTrailersOnInvalidStream) {
 
 TEST(DynamicModuleHttpCalloutTest, CancelPendingRequest) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2283,7 +2287,7 @@ TEST(DynamicModuleHttpCalloutTest, CancelPendingRequest) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2318,7 +2322,7 @@ TEST(DynamicModuleHttpCalloutTest, CancelPendingRequest) {
 
 TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnComplete) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2335,7 +2339,7 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnComplete) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2371,7 +2375,7 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnComplete) {
 
 TEST(DynamicModuleHttpStreamTest, StartHttpStreamDoesNotSetContentLength) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2388,7 +2392,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamDoesNotSetContentLength) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2439,7 +2443,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamDoesNotSetContentLength) {
 
 TEST(DynamicModuleHttpStreamTest, StartHttpStreamAndNoCluster) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2453,7 +2457,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamAndNoCluster) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2475,7 +2479,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamAndNoCluster) {
 
 TEST(DynamicModuleHttpStreamTest, StartHttpStreamMissingRequiredHeaders) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2492,7 +2496,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamMissingRequiredHeaders) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2514,7 +2518,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamMissingRequiredHeaders) {
 
 TEST(DynamicModuleHttpStreamTest, StartHttpStreamHandlesInlineResetDuringHeaders) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2531,7 +2535,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamHandlesInlineResetDuringHeaders
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2570,7 +2574,7 @@ TEST(DynamicModuleHttpStreamTest, StartHttpStreamHandlesInlineResetDuringHeaders
 
 TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnReset) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2587,7 +2591,7 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnReset) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2621,7 +2625,7 @@ TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnReset) {
 
 TEST(DynamicModulesTest, HttpFilterResetHttpStream) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2638,7 +2642,7 @@ TEST(DynamicModulesTest, HttpFilterResetHttpStream) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2686,7 +2690,7 @@ TEST(DynamicModulesTest, HttpFilterResetHttpStream) {
 
 TEST(DynamicModulesTest, HttpFilterStartHttpStreamNoBodyEndStream) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2703,7 +2707,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamNoBodyEndStream) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2741,7 +2745,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamNoBodyEndStream) {
 
 TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnHeaders) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2758,7 +2762,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnHeaders) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2801,7 +2805,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnHeaders) {
 
 TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnData) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2818,7 +2822,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnData) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2865,7 +2869,7 @@ TEST(DynamicModulesTest, HttpFilterStartHttpStreamInlineResetOnData) {
 // Test that startHttpStream returns CannotCreateRequest when async_client.start() returns nullptr.
 TEST(DynamicModulesTest, StartHttpStreamCannotCreateRequest) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2882,7 +2886,7 @@ TEST(DynamicModulesTest, StartHttpStreamCannotCreateRequest) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   NiceMock<Event::MockDispatcher> dispatcher;
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
@@ -2919,7 +2923,7 @@ TEST(DynamicModulesTest, StartHttpStreamCannotCreateRequest) {
 // still be resumed via continueEncoding(). A single shared flag used to suppress this resume.
 TEST(DynamicModulesTest, PerDirectionContinueDecodeDoesNotBlockEncode) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2927,7 +2931,7 @@ TEST(DynamicModulesTest, PerDirectionContinueDecodeDoesNotBlockEncode) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);
@@ -2955,7 +2959,7 @@ TEST(DynamicModulesTest, PerDirectionContinueDecodeDoesNotBlockEncode) {
 // continued, so a paused decode phase can still be resumed via continueDecoding().
 TEST(DynamicModulesTest, PerDirectionContinueEncodeDoesNotBlockDecode) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok());
+  EXPECT_OK(dynamic_module);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
   auto stats_scope = stats_store.createScope("");
@@ -2963,7 +2967,7 @@ TEST(DynamicModulesTest, PerDirectionContinueEncodeDoesNotBlockDecode) {
       Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
           "filter", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
           *stats_scope, context);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
                                                           stats_scope->symbolTable(), 0);

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -109,7 +109,7 @@ INSTANTIATE_TEST_SUITE_P(HttpLanguageTests, DynamicModuleHttpLanguageTests,
 
 TEST_P(DynamicModuleHttpLanguageTests, ConfigInitializationFailure) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
@@ -520,7 +520,7 @@ TEST_P(DynamicModuleHttpLanguageTests, LocalReplyCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -546,7 +546,7 @@ TEST_P(DynamicModuleHttpLanguageTests, ResetStream) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -575,7 +575,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SendGoAwayAndClose) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -604,7 +604,7 @@ TEST_P(DynamicModuleHttpLanguageTests, RecreateStream) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -640,7 +640,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SocketOptionCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -671,7 +671,7 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
   const std::string filter_config = "";
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Stats::IsolatedStoreImpl stats_store;
@@ -733,7 +733,7 @@ TEST_P(DynamicModuleHttpLanguageTests, ClusterCallbacks) {
   mock_host_set->degraded_hosts_.resize(1);
 
   auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats_store;
   auto filter_config_or_status =

--- a/test/extensions/dynamic_modules/listener/BUILD
+++ b/test/extensions/dynamic_modules/listener/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/network:network_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 
@@ -70,6 +71,7 @@ envoy_cc_test(
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -19,6 +19,7 @@
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/host.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 
@@ -66,12 +67,12 @@ class DynamicModuleListenerFilterAbiCallbackTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -2438,12 +2439,12 @@ class DynamicModuleListenerFilterHttpCalloutTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -67,12 +67,12 @@ class DynamicModuleListenerFilterAbiCallbackTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -2439,12 +2439,12 @@ class DynamicModuleListenerFilterHttpCalloutTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -16,6 +16,7 @@ namespace Extensions {
 namespace DynamicModules {
 namespace ListenerFilters {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::Not;
 
@@ -255,9 +256,8 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
-  EXPECT_THAT(filter_config_or_status.status().message(),
-              testing::HasSubstr("Failed to initialize"));
+  EXPECT_THAT(filter_config_or_status,
+              HasStatusMessage(testing::HasSubstr("Failed to initialize")));
 }
 
 TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -8,12 +8,16 @@
 #include "test/mocks/network/io_handle.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 namespace ListenerFilters {
+
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 // A simple mock implementation of ListenerFilterBuffer for testing.
 class TestListenerFilterBuffer : public Network::ListenerFilterBuffer {
@@ -44,12 +48,12 @@ class DynamicModuleListenerFilterTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -119,12 +123,12 @@ TEST_F(DynamicModuleListenerFilterTest, FilterWithNullInModuleFilterOnClose) {
 TEST_F(DynamicModuleListenerFilterTest, OnAcceptWithNullInModuleFilterClosesSocket) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_filter_new_fail", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-  EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+  EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
   auto filter_config = filter_config_or_status.value();
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(filter_config);
@@ -207,12 +211,12 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitialization) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "some_config", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto config = filter_config_or_status.value();
   EXPECT_NE(nullptr, config->in_module_config_);
@@ -231,12 +235,12 @@ TEST(DynamicModuleListenerFilterConfigTest, MissingSymbols) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   // Use the HTTP filter no_op module which lacks listener filter symbols.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
 }
 
 TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
@@ -246,12 +250,12 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
   // Use a module that returns nullptr from config_new.
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_config_new_fail", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
 }
@@ -262,12 +266,12 @@ TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   auto config = filter_config_or_status.value();
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(config);
@@ -289,12 +293,12 @@ TEST(DynamicModuleListenerFilterConfigTest, OnDataStopIterationStatus) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   auto config = filter_config_or_status.value();
 
   NiceMock<Network::MockListenerFilterCallbacks> callbacks;

--- a/test/extensions/dynamic_modules/listener/filter_test.cc
+++ b/test/extensions/dynamic_modules/listener/filter_test.cc
@@ -49,12 +49,12 @@ class DynamicModuleListenerFilterTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -124,12 +124,12 @@ TEST_F(DynamicModuleListenerFilterTest, FilterWithNullInModuleFilterOnClose) {
 TEST_F(DynamicModuleListenerFilterTest, OnAcceptWithNullInModuleFilterClosesSocket) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_filter_new_fail", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-  EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+  EXPECT_OK(filter_config_or_status);
   auto filter_config = filter_config_or_status.value();
 
   auto filter = std::make_unique<DynamicModuleListenerFilter>(filter_config);
@@ -212,7 +212,7 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitialization) {
   NiceMock<Upstream::MockClusterManager> cluster_manager;
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module = newDynamicModule(testSharedObjectPath("listener_no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "some_config", DefaultMetricsNamespace, std::move(dynamic_module.value()),
@@ -236,7 +236,7 @@ TEST(DynamicModuleListenerFilterConfigTest, MissingSymbols) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   // Use the HTTP filter no_op module which lacks listener filter symbols.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
@@ -251,7 +251,7 @@ TEST(DynamicModuleListenerFilterConfigTest, ConfigInitializationFailure) {
   // Use a module that returns nullptr from config_new.
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_config_new_fail", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
@@ -266,7 +266,7 @@ TEST(DynamicModuleListenerFilterConfigTest, StopIterationStatus) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
@@ -293,7 +293,7 @@ TEST(DynamicModuleListenerFilterConfigTest, OnDataStopIterationStatus) {
   NiceMock<Event::MockDispatcher> main_thread_dispatcher;
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("listener_stop_iteration", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleListenerFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),

--- a/test/extensions/dynamic_modules/network/BUILD
+++ b/test/extensions/dynamic_modules/network/BUILD
@@ -27,6 +27,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 
@@ -45,6 +46,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/network/dynamic_modules/v3:pkg_cc_proto",
     ],
@@ -68,6 +70,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -89,12 +89,12 @@ class DynamicModuleNetworkFilterAbiCallbackTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -1672,12 +1672,12 @@ class DynamicModuleNetworkFilterHttpCalloutTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -19,6 +19,7 @@
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/host.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 
@@ -88,12 +89,12 @@ class DynamicModuleNetworkFilterAbiCallbackTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -1671,12 +1672,12 @@ class DynamicModuleNetworkFilterHttpCalloutTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;

--- a/test/extensions/dynamic_modules/network/factory_test.cc
+++ b/test/extensions/dynamic_modules/network/factory_test.cc
@@ -7,11 +7,16 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 
 namespace Envoy {
 namespace Server {
 namespace Configuration {
+
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 class DynamicModuleNetworkFilterFactoryTest : public testing::Test {
 public:
@@ -35,7 +40,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfig) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 
   // The happy path emits no load-failure counters.
   auto& server_scope = context_.server_factory_context_.serverScope();
@@ -51,7 +56,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithLocalFile) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 }
 
 // Remote module sources are not supported for network filters (no init manager is wired up).
@@ -65,7 +70,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, RemoteSourceRejected) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
 }
 
 TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithFilterConfig) {
@@ -76,7 +81,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithFilterConfig) {
       config.mutable_filter_config()->PackFrom(ValueUtil::stringValue("test_config_value"));
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 }
 
 TEST_F(DynamicModuleNetworkFilterFactoryTest, InvalidModuleName) {
@@ -85,8 +90,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, InvalidModuleName) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 
   EXPECT_EQ(1U, failureCounter(context_.server_factory_context_.serverScope(), "module_load_error",
                                "test_filter"));
@@ -99,8 +103,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, MissingNetworkFilterSymbols) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to create filter config"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to create filter config")));
 
   // The module loads fine but lacks the network filter ABI symbols, so the failure is counted as
   // config_init_error, not module_load_error.
@@ -116,8 +119,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ConfigInitializationFailure) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to create filter config"));
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to create filter config")));
 
   EXPECT_EQ(1U, failureCounter(context_.server_factory_context_.serverScope(), "config_init_error",
                                "test_filter"));
@@ -135,7 +137,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, MalformedFilterConfig) {
   any->set_value("invalid_binary_data_that_cannot_be_unpacked_as_string_value");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
 
   auto& server_scope = context_.server_factory_context_.serverScope();
   EXPECT_EQ(1U, failureCounter(server_scope, "config_init_error", "test_filter"));
@@ -170,7 +172,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithTerminalFilter) {
 
   // Terminal filter configuration should be accepted and create filter factory successfully.
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 
   // Verify the filter can still be added to filter manager.
   NiceMock<Network::MockFilterManager> filter_manager;
@@ -184,7 +186,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, FilterFactoryCallbackAddsFilter) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   // Test that the filter factory callback correctly adds a filter.
   NiceMock<Network::MockFilterManager> filter_manager;
@@ -199,7 +201,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, DoNotCloseOption) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 }
 
 TEST_F(DynamicModuleNetworkFilterFactoryTest, LoadGloballyOption) {
@@ -209,7 +211,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, LoadGloballyOption) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 }
 
 // Test that the legacy behavior registers the custom stat namespace when the runtime guard is
@@ -230,7 +232,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, LegacyBehaviorWithRuntimeGuard) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_TRUE(result.ok()) << result.status().message();
+  EXPECT_OK(result) << result.status().message();
 
   // Verify the custom namespace was registered.
   EXPECT_TRUE(custom_stat_namespaces.registered("custom_namespace"));

--- a/test/extensions/dynamic_modules/network/factory_test.cc
+++ b/test/extensions/dynamic_modules/network/factory_test.cc
@@ -40,7 +40,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfig) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 
   // The happy path emits no load-failure counters.
   auto& server_scope = context_.server_factory_context_.serverScope();
@@ -56,7 +56,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithLocalFile) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 }
 
 // Remote module sources are not supported for network filters (no init manager is wired up).
@@ -81,7 +81,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithFilterConfig) {
       config.mutable_filter_config()->PackFrom(ValueUtil::stringValue("test_config_value"));
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 }
 
 TEST_F(DynamicModuleNetworkFilterFactoryTest, InvalidModuleName) {
@@ -172,7 +172,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, ValidConfigWithTerminalFilter) {
 
   // Terminal filter configuration should be accepted and create filter factory successfully.
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 
   // Verify the filter can still be added to filter manager.
   NiceMock<Network::MockFilterManager> filter_manager;
@@ -186,7 +186,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, FilterFactoryCallbackAddsFilter) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   // Test that the filter factory callback correctly adds a filter.
   NiceMock<Network::MockFilterManager> filter_manager;
@@ -201,7 +201,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, DoNotCloseOption) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 }
 
 TEST_F(DynamicModuleNetworkFilterFactoryTest, LoadGloballyOption) {
@@ -211,7 +211,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, LoadGloballyOption) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 }
 
 // Test that the legacy behavior registers the custom stat namespace when the runtime guard is
@@ -232,7 +232,7 @@ TEST_F(DynamicModuleNetworkFilterFactoryTest, LegacyBehaviorWithRuntimeGuard) {
   config.set_filter_name("test_filter");
 
   auto result = factory_.createFilterFactoryFromProto(config, context_);
-  EXPECT_OK(result) << result.status().message();
+  EXPECT_OK(result);
 
   // Verify the custom namespace was registered.
   EXPECT_TRUE(custom_stat_namespaces.registered("custom_namespace"));

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -6,6 +6,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -15,16 +16,19 @@ namespace Extensions {
 namespace DynamicModules {
 namespace NetworkFilters {
 
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
+
 class DynamicModuleNetworkFilterTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -112,12 +116,12 @@ TEST_F(DynamicModuleNetworkFilterTest, FilterDestroyWithoutInitialization) {
 TEST_F(DynamicModuleNetworkFilterTest, FilterWithoutInModuleFilter) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_filter_new_fail", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-  EXPECT_TRUE(filter_config_or_status.ok()) << filter_config_or_status.status().message();
+  EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
   auto filter_config = filter_config_or_status.value();
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config);
   filter->initializeReadFilterCallbacks(read_callbacks_);
@@ -226,7 +230,7 @@ TEST_F(DynamicModuleNetworkFilterTest, CallbackAccessors) {
 
 TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -234,7 +238,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "some_config", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
 
   auto config = filter_config_or_status.value();
   EXPECT_NE(nullptr, config->in_module_config_);
@@ -250,7 +254,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
 TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
   // Use the HTTP-only no_op module which lacks network filter symbols.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -258,14 +262,14 @@ TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
 }
 
 TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
   // Use a module that returns nullptr from config_new.
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_config_new_fail", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -273,7 +277,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_FALSE(filter_config_or_status.ok());
+  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
   EXPECT_THAT(filter_config_or_status.status().message(),
               testing::HasSubstr("Failed to initialize"));
 }
@@ -281,7 +285,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
 TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_stop_iteration", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -289,7 +293,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_TRUE(filter_config_or_status.ok());
+  EXPECT_OK(filter_config_or_status);
   auto config = filter_config_or_status.value();
 
   NiceMock<Event::MockDispatcher> worker_thread_dispatcher{"worker_0"};

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -16,6 +16,7 @@ namespace Extensions {
 namespace DynamicModules {
 namespace NetworkFilters {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::Not;
 
@@ -277,9 +278,8 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager, *stats.rootScope(), main_thread_dispatcher);
-  EXPECT_THAT(filter_config_or_status, Not(IsOk()));
-  EXPECT_THAT(filter_config_or_status.status().message(),
-              testing::HasSubstr("Failed to initialize"));
+  EXPECT_THAT(filter_config_or_status,
+              HasStatusMessage(testing::HasSubstr("Failed to initialize")));
 }
 
 TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -24,12 +24,12 @@ class DynamicModuleNetworkFilterTest : public testing::Test {
 public:
   void SetUp() override {
     auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
         "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
         cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-    EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+    EXPECT_OK(filter_config_or_status);
     filter_config_ = filter_config_or_status.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     filter_config_->stat_creation_frozen_ = false;
@@ -117,12 +117,12 @@ TEST_F(DynamicModuleNetworkFilterTest, FilterDestroyWithoutInitialization) {
 TEST_F(DynamicModuleNetworkFilterTest, FilterWithoutInModuleFilter) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_filter_new_fail", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   auto filter_config_or_status = newDynamicModuleNetworkFilterConfig(
       "test_filter", "", DefaultMetricsNamespace, std::move(dynamic_module.value()),
       cluster_manager_, *stats_.rootScope(), main_thread_dispatcher_);
-  EXPECT_OK(filter_config_or_status) << filter_config_or_status.status().message();
+  EXPECT_OK(filter_config_or_status);
   auto filter_config = filter_config_or_status.value();
   auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config);
   filter->initializeReadFilterCallbacks(read_callbacks_);
@@ -231,7 +231,7 @@ TEST_F(DynamicModuleNetworkFilterTest, CallbackAccessors) {
 
 TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
   auto dynamic_module = newDynamicModule(testSharedObjectPath("network_no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -255,7 +255,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitialization) {
 TEST(DynamicModuleNetworkFilterConfigTest, MissingSymbols) {
   // Use the HTTP-only no_op module which lacks network filter symbols.
   auto dynamic_module = newDynamicModule(testSharedObjectPath("no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -270,7 +270,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
   // Use a module that returns nullptr from config_new.
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_config_new_fail", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;
@@ -285,7 +285,7 @@ TEST(DynamicModuleNetworkFilterConfigTest, ConfigInitializationFailure) {
 TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
   auto dynamic_module =
       newDynamicModule(testSharedObjectPath("network_stop_iteration", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   Stats::IsolatedStoreImpl stats;
   NiceMock<Upstream::MockClusterManager> cluster_manager;

--- a/test/extensions/dynamic_modules/stat_sink/BUILD
+++ b/test/extensions/dynamic_modules/stat_sink/BUILD
@@ -31,6 +31,7 @@ envoy_cc_test(
         "//source/extensions/stat_sinks/dynamic_modules:config",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/stat_sinks/dynamic_modules/v3:pkg_cc_proto",
     ],
@@ -52,6 +53,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -19,6 +19,7 @@ namespace {
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::IsOkAndHolds;
 using testing::NiceMock;
 using ::testing::Not;
 
@@ -82,7 +83,7 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
       << sink_or_error.status().message();
 
   // The happy path emits no load-failure counters.
@@ -99,7 +100,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, ValidConfigLocalFile) {
   proto_config.set_sink_name("test_sink");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
       << sink_or_error.status().message();
 }
 
@@ -130,7 +131,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
       << sink_or_error.status().message();
 }
 

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -153,7 +153,7 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
+  ASSERT_OK(sink_or_error);
 }
 
 // A sink_config Any that claims to be a StringValue but carries truncated wire bytes makes

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -6,6 +6,7 @@
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -16,7 +17,9 @@ namespace StatSinks {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::IsOk;
 using testing::NiceMock;
+using ::testing::Not;
 
 class DynamicModuleStatsSinkFactoryTest : public testing::Test {
 public:
@@ -78,7 +81,7 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_TRUE(sink_or_error.ok()) << sink_or_error.status().message();
+  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
   EXPECT_NE(nullptr, sink_or_error.value());
 
   // The happy path emits no load-failure counters.
@@ -95,7 +98,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, ValidConfigLocalFile) {
   proto_config.set_sink_name("test_sink");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_TRUE(sink_or_error.ok()) << sink_or_error.status().message();
+  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
   EXPECT_NE(nullptr, sink_or_error.value());
 }
 
@@ -110,7 +113,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, RemoteSourceRejected) {
   proto_config.set_sink_name("test_sink");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
 }
 
 // An empty sink_config is allowed and the module receives zero bytes.
@@ -126,7 +129,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_TRUE(sink_or_error.ok()) << sink_or_error.status().message();
+  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
   EXPECT_NE(nullptr, sink_or_error.value());
 }
 
@@ -148,7 +151,7 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_TRUE(sink_or_error.ok()) << sink_or_error.status().message();
+  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
 }
 
 // A sink_config Any that claims to be a StringValue but carries truncated wire bytes makes
@@ -164,7 +167,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, MalformedSinkConfig) {
   any->set_value("\x0a");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()),
               testing::HasSubstr("Failed to parse sink config"));
 
@@ -184,7 +187,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()),
               testing::HasSubstr("Failed to load dynamic module"));
 
@@ -204,7 +207,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()),
               testing::HasSubstr("Failed to initialize dynamic module stats sink config"));
 
@@ -227,7 +230,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()), testing::ContainsRegex("config_new"));
 }
 
@@ -243,7 +246,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()),
               testing::ContainsRegex("config_destroy"));
 }
@@ -260,7 +263,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()), testing::ContainsRegex("flush"));
 }
 
@@ -276,7 +279,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_FALSE(sink_or_error.ok());
+  EXPECT_THAT(sink_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(sink_or_error.status().message()),
               testing::ContainsRegex("histogram_complete"));
 }

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -83,8 +83,7 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
-      << sink_or_error.status().message();
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()));
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(context_.serverScope(), "module_load_error", "test_sink"));
@@ -100,8 +99,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, ValidConfigLocalFile) {
   proto_config.set_sink_name("test_sink");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
-      << sink_or_error.status().message();
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()));
 }
 
 // Remote module sources are not supported for stats sinks (no init manager is wired up).
@@ -131,8 +129,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()))
-      << sink_or_error.status().message();
+  ASSERT_THAT(sink_or_error, IsOkAndHolds(::testing::NotNull()));
 }
 
 // A Struct config is JSON-serialized before being handed to the module.

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -82,8 +82,8 @@ sink_config:
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
-  EXPECT_NE(nullptr, sink_or_error.value());
+  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << sink_or_error.status().message();
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(context_.serverScope(), "module_load_error", "test_sink"));
@@ -99,8 +99,8 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, ValidConfigLocalFile) {
   proto_config.set_sink_name("test_sink");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
-  EXPECT_NE(nullptr, sink_or_error.value());
+  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << sink_or_error.status().message();
 }
 
 // Remote module sources are not supported for stats sinks (no init manager is wired up).
@@ -130,8 +130,8 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  ASSERT_OK(sink_or_error) << sink_or_error.status().message();
-  EXPECT_NE(nullptr, sink_or_error.value());
+  ASSERT_THAT(sink_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << sink_or_error.status().message();
 }
 
 // A Struct config is JSON-serialized before being handed to the module.

--- a/test/extensions/dynamic_modules/stat_sink/config_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/config_test.cc
@@ -17,6 +17,7 @@ namespace StatSinks {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using testing::NiceMock;
 using ::testing::Not;
@@ -167,9 +168,7 @@ TEST_F(DynamicModuleStatsSinkFactoryTest, MalformedSinkConfig) {
   any->set_value("\x0a");
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()),
-              testing::HasSubstr("Failed to parse sink config"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::HasSubstr("Failed to parse sink config")));
 
   EXPECT_EQ(1U, failureCounter(context_.serverScope(), "config_init_error", "test_sink"));
   EXPECT_EQ(0U, failureCounter(context_.serverScope(), "module_load_error", "test_sink"));
@@ -187,9 +186,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()),
-              testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 
   EXPECT_EQ(1U, failureCounter(context_.serverScope(), "module_load_error", "test_sink"));
 }
@@ -207,9 +204,8 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()),
-              testing::HasSubstr("Failed to initialize dynamic module stats sink config"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::HasSubstr(
+                                 "Failed to initialize dynamic module stats sink config")));
 
   // The module loads fine but its config creation fails, so this is counted as config_init_error.
   EXPECT_EQ(1U, failureCounter(context_.serverScope(), "config_init_error", "test_sink"));
@@ -230,8 +226,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()), testing::ContainsRegex("config_new"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::ContainsRegex("config_new")));
 }
 
 TEST_F(DynamicModuleStatsSinkFactoryTest, MissingConfigDestroy) {
@@ -246,9 +241,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()),
-              testing::ContainsRegex("config_destroy"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::ContainsRegex("config_destroy")));
 }
 
 TEST_F(DynamicModuleStatsSinkFactoryTest, MissingFlush) {
@@ -263,8 +256,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()), testing::ContainsRegex("flush"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::ContainsRegex("flush")));
 }
 
 TEST_F(DynamicModuleStatsSinkFactoryTest, MissingHistogramComplete) {
@@ -279,9 +271,7 @@ sink_name: test_sink
   TestUtility::loadFromYaml(yaml, proto_config);
 
   auto sink_or_error = factory_.createStatsSink(proto_config, context_);
-  EXPECT_THAT(sink_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(sink_or_error.status().message()),
-              testing::ContainsRegex("histogram_complete"));
+  EXPECT_THAT(sink_or_error, HasStatusMessage(testing::ContainsRegex("histogram_complete")));
 }
 
 } // namespace

--- a/test/extensions/dynamic_modules/stat_sink/sink_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/sink_test.cc
@@ -9,6 +9,7 @@
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/stats/mocks.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -19,9 +20,11 @@ namespace StatSinks {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::IsOk;
 using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
+using ::testing::Not;
 using testing::ReturnRef;
 
 // Tracks what the module was asked to do so individual tests can verify the
@@ -45,11 +48,11 @@ public:
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("stat_sink_no_op", "c"),
         /*do_not_close=*/false);
-    ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
 
     auto config = newDynamicModuleStatsSinkConfig("test_sink", "test_config",
                                                   std::move(dynamic_module.value()), context_);
-    ASSERT_TRUE(config.ok()) << config.status().message();
+    ASSERT_OK(config) << config.status().message();
     config_ = std::move(config.value());
   }
 
@@ -245,10 +248,10 @@ TEST_F(DynamicModuleStatsSinkGaugeTest, DefineGaugeAfterFrozenIsRejected) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_no_op", "c"),
       /*do_not_close=*/false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
   auto config = newDynamicModuleStatsSinkConfig("test_sink", "test_config",
                                                 std::move(dynamic_module.value()), context_);
-  ASSERT_TRUE(config.ok()) << config.status().message();
+  ASSERT_OK(config) << config.status().message();
 
   size_t id = 0;
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
@@ -417,12 +420,12 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionMissingSymbol) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_missing_config_new", "c"),
       /*do_not_close=*/false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(
       "test_sink", "test_config", std::move(dynamic_module.value()), context);
-  EXPECT_FALSE(config_or_error.ok());
+  EXPECT_THAT(config_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(config_or_error.status().message()),
               testing::ContainsRegex("config_new"));
 }
@@ -433,12 +436,12 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionModuleReturnsNull) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_config_new_fail", "c"),
       /*do_not_close=*/false);
-  ASSERT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(
       "test_sink", "test_config", std::move(dynamic_module.value()), context);
-  EXPECT_FALSE(config_or_error.ok());
+  EXPECT_THAT(config_or_error, Not(IsOk()));
   EXPECT_THAT(std::string(config_or_error.status().message()),
               testing::HasSubstr("Failed to initialize dynamic module stats sink config"));
 }

--- a/test/extensions/dynamic_modules/stat_sink/sink_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/sink_test.cc
@@ -47,11 +47,11 @@ public:
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("stat_sink_no_op", "c"),
         /*do_not_close=*/false);
-    ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+    ASSERT_OK(dynamic_module);
 
     auto config = newDynamicModuleStatsSinkConfig("test_sink", "test_config",
                                                   std::move(dynamic_module.value()), context_);
-    ASSERT_OK(config) << config.status().message();
+    ASSERT_OK(config);
     config_ = std::move(config.value());
   }
 
@@ -247,10 +247,10 @@ TEST_F(DynamicModuleStatsSinkGaugeTest, DefineGaugeAfterFrozenIsRejected) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_no_op", "c"),
       /*do_not_close=*/false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module);
   auto config = newDynamicModuleStatsSinkConfig("test_sink", "test_config",
                                                 std::move(dynamic_module.value()), context_);
-  ASSERT_OK(config) << config.status().message();
+  ASSERT_OK(config);
 
   size_t id = 0;
   EXPECT_EQ(envoy_dynamic_module_type_metrics_result_Frozen,
@@ -419,7 +419,7 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionMissingSymbol) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_missing_config_new", "c"),
       /*do_not_close=*/false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(
@@ -433,7 +433,7 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionModuleReturnsNull) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("stat_sink_config_new_fail", "c"),
       /*do_not_close=*/false);
-  ASSERT_OK(dynamic_module) << dynamic_module.status().message();
+  ASSERT_OK(dynamic_module);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(

--- a/test/extensions/dynamic_modules/stat_sink/sink_test.cc
+++ b/test/extensions/dynamic_modules/stat_sink/sink_test.cc
@@ -20,11 +20,10 @@ namespace StatSinks {
 namespace DynamicModules {
 namespace {
 
-using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
-using ::testing::Not;
 using testing::ReturnRef;
 
 // Tracks what the module was asked to do so individual tests can verify the
@@ -425,9 +424,7 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionMissingSymbol) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(
       "test_sink", "test_config", std::move(dynamic_module.value()), context);
-  EXPECT_THAT(config_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(config_or_error.status().message()),
-              testing::ContainsRegex("config_new"));
+  EXPECT_THAT(config_or_error, HasStatusMessage(testing::ContainsRegex("config_new")));
 }
 
 // When on_stat_sink_config_new returns null, newDynamicModuleStatsSinkConfig
@@ -441,9 +438,8 @@ TEST(DynamicModuleStatsSinkConfigTest, FactoryFunctionModuleReturnsNull) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   auto config_or_error = newDynamicModuleStatsSinkConfig(
       "test_sink", "test_config", std::move(dynamic_module.value()), context);
-  EXPECT_THAT(config_or_error, Not(IsOk()));
-  EXPECT_THAT(std::string(config_or_error.status().message()),
-              testing::HasSubstr("Failed to initialize dynamic module stats sink config"));
+  EXPECT_THAT(config_or_error, HasStatusMessage(testing::HasSubstr(
+                                   "Failed to initialize dynamic module stats sink config")));
 }
 
 } // namespace

--- a/test/extensions/dynamic_modules/udp/BUILD
+++ b/test/extensions/dynamic_modules/udp/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
         "//source/extensions/filters/udp/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -41,6 +42,7 @@ envoy_cc_test(
         "//source/extensions/filters/udp/dynamic_modules:filter_lib",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/network:network_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/dynamic_modules/udp/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/udp/abi_impl_test.cc
@@ -8,6 +8,7 @@
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/status_utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -19,7 +20,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;

--- a/test/extensions/dynamic_modules/udp/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/udp/abi_impl_test.cc
@@ -20,7 +20,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -17,7 +17,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;
@@ -63,7 +63,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, ConfigMissingSymbols) {
   // Use the no_op module which lacks UDP symbols.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test_filter");
@@ -82,7 +82,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, NullInModuleFilter) {
   // Create a separate config that returns null from on_filter_new.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test_filter");
@@ -147,7 +147,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, MultipleReceiveErrors) {
 TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithEmptyName) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("");
@@ -161,7 +161,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithEmptyName) {
 TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithNoConfig) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -217,7 +217,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_stop_iteration", "c"), false);
-    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module);
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;
@@ -248,7 +248,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingConfigDestroy) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_config_destroy", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -267,7 +267,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterNew) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_filter_new", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -285,7 +285,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingOnData) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_on_data", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -303,7 +303,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterDestroy) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_filter_destroy", "c"), false);
-  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module);
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/network/mocks.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
@@ -16,7 +17,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;
@@ -62,7 +63,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, ConfigMissingSymbols) {
   // Use the no_op module which lacks UDP symbols.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test_filter");
@@ -81,7 +82,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, NullInModuleFilter) {
   // Create a separate config that returns null from on_filter_new.
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test_filter");
@@ -146,7 +147,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, MultipleReceiveErrors) {
 TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithEmptyName) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("");
@@ -160,7 +161,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithEmptyName) {
 TEST_F(DynamicModuleUdpListenerFilterTest, FilterConfigWithNoConfig) {
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_op", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -216,7 +217,7 @@ public:
   void SetUp() override {
     auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
         Extensions::DynamicModules::testSharedObjectPath("udp_stop_iteration", "c"), false);
-    EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+    EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
     envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter
         proto_config;
@@ -247,7 +248,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingConfigDestroy) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_config_destroy", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -266,7 +267,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterNew) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_filter_new", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -284,7 +285,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingOnData) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_on_data", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");
@@ -302,7 +303,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterDestroy) {
   Stats::IsolatedStoreImpl stats;
   auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
       Extensions::DynamicModules::testSharedObjectPath("udp_no_filter_destroy", "c"), false);
-  EXPECT_TRUE(dynamic_module.ok()) << dynamic_module.status().message();
+  EXPECT_OK(dynamic_module) << dynamic_module.status().message();
 
   envoy::extensions::filters::udp::dynamic_modules::v3::DynamicModuleUdpListenerFilter proto_config;
   proto_config.set_filter_name("test");


### PR DESCRIPTION
Commit Message: Use status matchers where appropriate (15)
Additional Description: Part of a wide cleanup of status-related expectations - EXPECT_TRUE and EXPECT_FALSE have unhelpful output on test failure compared to the actual status matchers, and in some cases are less readable. A cleanup of this pattern will tend to also improve future code.
Risk Level: test-only

Note: AI (Codex 5.6) was used to generate this set of PRs; I have reviewed each PR manually before marking it ready for review.