### PR TITLE
http: add server factory only factory support to a2a, api_key_auth, bandwidth_limit and cdn_loop

### DIFF
--- a/source/extensions/filters/http/a2a/config.cc
+++ b/source/extensions/filters/http/a2a/config.cc
@@ -12,10 +12,17 @@ namespace A2a {
 absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  // This filter only uses the server factory context, so delegate to the server-context variant.
+  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
+                                               context.serverFactoryContext());
+}
 
-  // Use the server_factory_context to access the root scope for stats
-  auto config = std::make_shared<A2aFilterConfig>(proto_config, stats_prefix,
-                                                  context.serverFactoryContext().scope());
+absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+
+  // Use the server factory context to access the root scope for stats.
+  auto config = std::make_shared<A2aFilterConfig>(proto_config, stats_prefix, context.scope());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<A2aFilter>(config));

--- a/source/extensions/filters/http/a2a/config.h
+++ b/source/extensions/filters/http/a2a/config.h
@@ -19,6 +19,11 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace A2a

--- a/source/extensions/filters/http/api_key_auth/config.cc
+++ b/source/extensions/filters/http/api_key_auth/config.cc
@@ -8,18 +8,30 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ApiKeyAuth {
 
-absl::StatusOr<Http::FilterFactoryCb> ApiKeyAuthFilterFactory::createFilterFactoryFromProtoTyped(
-    const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-
+absl::StatusOr<Http::FilterFactoryCb>
+ApiKeyAuthFilterFactory::createFilterFactory(const ApiKeyAuthProto& proto_config,
+                                             const std::string& stats_prefix, Stats::Scope& scope) {
   absl::Status status = absl::OkStatus();
   FilterConfigSharedPtr config =
-      std::make_shared<FilterConfig>(proto_config, context.scope(), stats_prefix, status);
+      std::make_shared<FilterConfig>(proto_config, scope, stats_prefix, status);
   RETURN_IF_NOT_OK_REF(status);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<ApiKeyAuthFilter>(config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> ApiKeyAuthFilterFactory::createFilterFactoryFromProtoTyped(
+    const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
+    Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+ApiKeyAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
+    Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/api_key_auth/config.h
+++ b/source/extensions/filters/http/api_key_auth/config.h
@@ -20,6 +20,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProtoTyped(const ApiKeyAuthProto& config, const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const ApiKeyAuthProto& config, const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  static absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
+                      Stats::Scope& scope);
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const ApiKeyAuthPerRouteProto& proto_config,
                                        Server::Configuration::ServerFactoryContext&,

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -12,17 +12,28 @@ namespace Extensions {
 namespace HttpFilters {
 namespace BandwidthLimitFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFactory(
     const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-
-  absl::StatusOr<FilterConfigSharedPtr> filter_config = FilterConfig::create(
-      proto_config, context.scope(), server_context.runtime(), server_context.timeSource());
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
+  absl::StatusOr<FilterConfigSharedPtr> filter_config =
+      FilterConfig::create(proto_config, scope, context.runtime(), context.timeSource());
   RETURN_IF_NOT_OK_REF(filter_config.status());
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<BandwidthLimiter>(*filter_config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+BandwidthLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/bandwidth_limit/config.h
+++ b/source/extensions/filters/http/bandwidth_limit/config.h
@@ -24,6 +24,17 @@ private:
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
+      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,

--- a/source/extensions/filters/http/cdn_loop/config.cc
+++ b/source/extensions/filters/http/cdn_loop/config.cc
@@ -23,7 +23,15 @@ using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::ParsedCdnId;
 
 absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& /*context*/) {
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  // This filter does not use the factory context, so delegate to the server-context variant.
+  return createHttpFilterFactoryFromProtoTyped(config, stats_prefix,
+                                               context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
+    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& /*context*/) {
   StatusOr<ParsedCdnId> context = parseCdnId(ParseContext(config.cdn_id()));
   if (!context.ok() || !context->context().atEnd()) {
     return absl::InvalidArgumentError(

--- a/source/extensions/filters/http/cdn_loop/config.h
+++ b/source/extensions/filters/http/cdn_loop/config.h
@@ -23,6 +23,11 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace CdnLoop

--- a/test/extensions/filters/http/a2a/config_test.cc
+++ b/test/extensions/filters/http/a2a/config_test.cc
@@ -33,6 +33,18 @@ TEST_F(A2aFilterConfigFactoryTest, CreateFilterFactory) {
   cb.value()(filter_callback);
 }
 
+TEST_F(A2aFilterConfigFactoryTest, CreateFilterWithServerContext) {
+  envoy::extensions::filters::http::a2a::v3::A2a config;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  Http::FilterFactoryCb cb =
+      factory_.createHttpFilterFactoryFromProto(config, "stats", server_context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace A2a
 } // namespace HttpFilters

--- a/test/extensions/filters/http/api_key_auth/config_test.cc
+++ b/test/extensions/filters/http/api_key_auth/config_test.cc
@@ -102,6 +102,31 @@ TEST(ApiKeyAuthFilterFactoryTest, NormalFactory) {
   EXPECT_TRUE(route_config != nullptr);
 }
 
+TEST(ApiKeyAuthFilterFactoryTest, CreateFilterWithServerContext) {
+  const std::string yaml = R"(
+  credentials:
+  - key: key1
+    client: user1
+  - key: key2
+    client: user2
+  key_sources:
+  - header: "Authorization"
+  )";
+
+  ApiKeyAuthProto proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  ApiKeyAuthFilterFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
+  cb(filter_callback);
+}
+
 } // namespace
 } // namespace ApiKeyAuth
 } // namespace HttpFilters

--- a/test/extensions/filters/http/bandwidth_limit/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/config_test.cc
@@ -31,6 +31,24 @@ TEST(Factory, GlobalEmptyConfig) {
   callback(filter_callback);
 }
 
+TEST(Factory, CreateFilterWithServerContext) {
+  const std::string yaml = R"(
+  stat_prefix: test
+  )";
+
+  BandwidthLimitFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  auto callback =
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  callback(filter_callback);
+}
+
 TEST(Factory, RouteSpecificFilterConfig) {
   const std::string config_yaml = R"(
   stat_prefix: test

--- a/test/extensions/filters/http/cdn_loop/config_test.cc
+++ b/test/extensions/filters/http/cdn_loop/config_test.cc
@@ -33,6 +33,23 @@ TEST(CdnLoopFilterFactoryTest, ValidValuesWork) {
   EXPECT_NE(dynamic_cast<CdnLoopFilter*>(filter.get()), nullptr);
 }
 
+TEST(CdnLoopFilterFactoryTest, CreateFilterWithServerContext) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Http::StreamDecoderFilterSharedPtr filter;
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
+
+  envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig config;
+  config.set_cdn_id("cdn");
+  CdnLoopFilterFactory factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(config, "stats", server_context).value();
+  cb(filter_callbacks);
+  EXPECT_NE(filter.get(), nullptr);
+  EXPECT_NE(dynamic_cast<CdnLoopFilter*>(filter.get()), nullptr);
+}
+
 TEST(CdnLoopFilterFactoryTest, BlankCdnIdThrows) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to a2a, api_key_auth, bandwidth_limit and cdn_loop
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the a2a, api_key_auth, bandwidth_limit and cdn_loop HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all the changes in this PR and understand the code.

Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
