### PR TITLE
http: add server factory only factory support to cache

### DIFF
--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -7,9 +7,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
-absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context) {
   std::shared_ptr<HttpCache> cache;
   if (!config.disabled().value()) {
     if (!config.has_typed_config()) {
@@ -26,10 +26,22 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFro
     cache = http_cache_factory->getCache(config, context);
   }
 
-  return [config = std::make_shared<CacheFilterConfig>(config, context.serverFactoryContext()),
+  return [config = std::make_shared<CacheFilterConfig>(config, context),
           cache](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CacheFilter>(config, cache));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(config, context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, context);
 }
 
 REGISTER_FACTORY(CacheFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/cache/config.h
+++ b/source/extensions/filters/http/cache/config.h
@@ -19,6 +19,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  static absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
+                      Server::Configuration::ServerFactoryContext& context);
 };
 
 } // namespace Cache

--- a/source/extensions/filters/http/cache/http_cache.h
+++ b/source/extensions/filters/http/cache/http_cache.h
@@ -316,11 +316,11 @@ public:
   // Returns an HttpCache that will remain valid indefinitely (at least as long
   // as the calling CacheFilter).
   //
-  // Pass factory context to allow HttpCache to use async client, stats scope
+  // Pass the server factory context to allow HttpCache to use async client, stats scope
   // etc.
   virtual std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-           Server::Configuration::FactoryContext& context) PURE;
+           Server::Configuration::ServerFactoryContext& context) PURE;
 
 private:
   const std::string name_;

--- a/source/extensions/http/cache/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache/file_system_http_cache/config.cc
@@ -97,17 +97,15 @@ public:
   // From HttpCacheFactory
   std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig& filter_config,
-           Server::Configuration::FactoryContext& context) override {
+           Server::Configuration::ServerFactoryContext& context) override {
     ConfigProto config;
     THROW_IF_NOT_OK(MessageUtil::unpackTo(filter_config.typed_config(), config));
-    std::shared_ptr<CacheSingleton> caches =
-        context.serverFactoryContext().singletonManager().getTyped<CacheSingleton>(
-            SINGLETON_MANAGER_REGISTERED_NAME(file_system_http_cache_singleton), [&context] {
-              return std::make_shared<CacheSingleton>(
-                  Common::AsyncFiles::AsyncFileManagerFactory::singleton(
-                      &context.serverFactoryContext().singletonManager()),
-                  context.serverFactoryContext().api().threadFactory());
-            });
+    std::shared_ptr<CacheSingleton> caches = context.singletonManager().getTyped<CacheSingleton>(
+        SINGLETON_MANAGER_REGISTERED_NAME(file_system_http_cache_singleton), [&context] {
+          return std::make_shared<CacheSingleton>(
+              Common::AsyncFiles::AsyncFileManagerFactory::singleton(&context.singletonManager()),
+              context.api().threadFactory());
+        });
     return caches->get(caches, config, context.scope());
   }
 };

--- a/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache/simple_http_cache/simple_http_cache.cc
@@ -341,8 +341,8 @@ public:
   // From HttpCacheFactory
   std::shared_ptr<HttpCache>
   getCache(const envoy::extensions::filters::http::cache::v3::CacheConfig&,
-           Server::Configuration::FactoryContext& context) override {
-    return context.serverFactoryContext().singletonManager().getTyped<SimpleHttpCache>(
+           Server::Configuration::ServerFactoryContext& context) override {
+    return context.singletonManager().getTyped<SimpleHttpCache>(
         SINGLETON_MANAGER_REGISTERED_NAME(simple_http_cache_singleton), &createCache);
   }
 

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -23,9 +23,8 @@ protected:
   Http::MockFilterChainFactoryCallbacks filter_callback_;
 };
 
-TEST_F(CacheFilterFactoryTest, Basic) {
-  std::ignore = config_.mutable_typed_config()->PackFrom(
-      envoy::extensions::http::cache::simple_http_cache::v3::SimpleHttpCacheConfig());
+TEST_F(CacheFilterFactoryTest, Disabled) {
+  config_.mutable_disabled()->set_value(true);
   Http::FilterFactoryCb cb =
       factory_.createFilterFactoryFromProto(config_, "stats", context_).value();
   Http::StreamFilterSharedPtr filter;
@@ -35,10 +34,11 @@ TEST_F(CacheFilterFactoryTest, Basic) {
   ASSERT(dynamic_cast<CacheFilter*>(filter.get()));
 }
 
-TEST_F(CacheFilterFactoryTest, Disabled) {
+TEST_F(CacheFilterFactoryTest, DisabledWithServerFactoryContext) {
   config_.mutable_disabled()->set_value(true);
   Http::FilterFactoryCb cb =
-      factory_.createFilterFactoryFromProto(config_, "stats", context_).value();
+      factory_.createHttpFilterFactoryFromProto(config_, "stats", context_.server_factory_context_)
+          .value();
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
   cb(filter_callback_);

--- a/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache/file_system_http_cache/file_system_http_cache_test.cc
@@ -69,7 +69,7 @@ public:
 
   void initCache() {
     cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
-        http_cache_factory_->getCache(cacheConfig(testConfig()), context_));
+        http_cache_factory_->getCache(cacheConfig(testConfig()), context_.server_factory_context_));
   }
 
   void waitForEvictionThreadIdle() { cache_->cache_eviction_thread_.waitForIdle(); }
@@ -119,7 +119,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, InitialStatsAreSetCorrectly) {
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-a"), file_1_contents, true);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-b"), file_2_contents, true);
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
-      http_cache_factory_->getCache(cacheConfig(cfg), context_));
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_));
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache_->stats().size_limit_bytes_.value(), max_size);
   EXPECT_EQ(cache_->stats().size_limit_count_.value(), max_count);
@@ -138,7 +138,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderCou
   // TODO(#24994): replace this with backdating the files when that's possible.
   sleep(1); // NO_CHECK_FORMAT(real_time)
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
-      http_cache_factory_->getCache(cacheConfig(cfg), context_));
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_));
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
   EXPECT_EQ(cache_->stats().size_bytes_.value(), file_contents.size() * 2);
@@ -171,7 +171,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderSiz
   // TODO(#24994): replace this with backdating the files when that's possible.
   sleep(1); // NO_CHECK_FORMAT(real_time)
   cache_ = std::dynamic_pointer_cast<FileSystemHttpCache>(
-      http_cache_factory_->getCache(cacheConfig(cfg), context_));
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_));
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache_->stats().eviction_runs_.value(), 0);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-c"), large_file_contents, true);
@@ -238,19 +238,22 @@ TEST_F(FileSystemHttpCacheTest, TrackFileRemovedClampsAtZero) {
 TEST_F(FileSystemHttpCacheTest, ExceptionOnTryingToCreateCachesWithDistinctConfigsOnSamePath) {
   ConfigProto cfg = testConfig();
   cfg.mutable_manager_config()->mutable_thread_pool()->set_thread_count(2);
-  EXPECT_ANY_THROW(http_cache_factory_->getCache(cacheConfig(cfg), context_));
+  EXPECT_ANY_THROW(
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_));
 }
 
 TEST_F(FileSystemHttpCacheTest, IdenticalCacheConfigReturnsSameCacheInstance) {
   ConfigProto cfg = testConfig();
-  auto second_cache = http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  auto second_cache =
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   EXPECT_EQ(cache_, second_cache);
 }
 
 TEST_F(FileSystemHttpCacheTest, CacheConfigsWithDifferentPathsReturnDistinctCacheInstances) {
   ConfigProto cfg = testConfig();
   cfg.set_cache_path("/tmp");
-  auto second_cache = http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  auto second_cache =
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   EXPECT_NE(cache_, second_cache);
 }
 
@@ -1396,11 +1399,12 @@ TEST(Registration, GetCacheFromFactory) {
   ON_CALL(factory_context.server_factory_context_.api_, threadFactory())
       .WillByDefault([]() -> Thread::ThreadFactory& { return Thread::threadFactoryForTest(); });
   TestUtility::loadFromYaml(std::string(yaml_config), cache_config);
-  EXPECT_EQ(factory->getCache(cache_config, factory_context)->cacheInfo().name_,
-            "envoy.extensions.http.cache.file_system_http_cache");
+  EXPECT_EQ(
+      factory->getCache(cache_config, factory_context.server_factory_context_)->cacheInfo().name_,
+      "envoy.extensions.http.cache.file_system_http_cache");
   // Verify that the config path got a / suffixed onto it.
   EXPECT_EQ(std::dynamic_pointer_cast<FileSystemHttpCache>(
-                factory->getCache(cache_config, factory_context))
+                factory->getCache(cache_config, factory_context.server_factory_context_))
                 ->config()
                 .cache_path(),
             "/tmp/");

--- a/test/extensions/http/cache/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/http/cache/simple_http_cache/simple_http_cache_test.cc
@@ -40,7 +40,7 @@ TEST(Registration, GetFactory) {
   envoy::extensions::filters::http::cache::v3::CacheConfig config;
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   std::ignore = config.mutable_typed_config()->PackFrom(*factory->createEmptyConfigProto());
-  EXPECT_EQ(factory->getCache(config, factory_context)->cacheInfo().name_,
+  EXPECT_EQ(factory->getCache(config, factory_context.server_factory_context_)->cacheInfo().name_,
             "envoy.extensions.http.cache.simple");
 }
 


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to cache
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the cache HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all changes.
Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
