### PR TITLE
http: add server factory only factory support to cache_v2

### DIFF
--- a/source/extensions/filters/http/cache_v2/cache_sessions.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.h
@@ -90,7 +90,7 @@ public:
   // This is implemented in CacheSessionsImpl so that tests which only use a mock don't
   // need to build the real thing, but declared here so that the actual use-site can
   // create an instance without including the larger header.
-  static std::shared_ptr<CacheSessions> create(Server::Configuration::FactoryContext& context,
+  static std::shared_ptr<CacheSessions> create(Server::Configuration::ServerFactoryContext& context,
                                                std::unique_ptr<HttpCache> cache);
 
   virtual void lookup(ActiveLookupRequestPtr request, ActiveLookupResultCallback&& cb) PURE;

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -128,8 +128,9 @@ void ActiveLookupContext::getTrailers(GetTrailersCallback&& cb) {
   entry_->wantTrailers(dispatcher(), std::move(cb));
 }
 
-std::shared_ptr<CacheSessions> CacheSessions::create(Server::Configuration::FactoryContext& context,
-                                                     std::unique_ptr<HttpCache> cache) {
+std::shared_ptr<CacheSessions>
+CacheSessions::create(Server::Configuration::ServerFactoryContext& context,
+                      std::unique_ptr<HttpCache> cache) {
   return std::make_shared<CacheSessionsImpl>(context, std::move(cache));
 }
 

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -272,10 +272,10 @@ private:
 class CacheSessionsImpl : public CacheSessions,
                           public std::enable_shared_from_this<CacheSessionsImpl> {
 public:
-  CacheSessionsImpl(Server::Configuration::FactoryContext& context,
+  CacheSessionsImpl(Server::Configuration::ServerFactoryContext& context,
                     std::unique_ptr<HttpCache> cache)
-      : time_source_(context.serverFactoryContext().timeSource()), cache_(std::move(cache)),
-        stats_(generateStats(context.serverFactoryContext().scope(), cache_->cacheInfo().name_)) {}
+      : time_source_(context.timeSource()), cache_(std::move(cache)),
+        stats_(generateStats(context.scope(), cache_->cacheInfo().name_)) {}
 
   void lookup(ActiveLookupRequestPtr request, ActiveLookupResultCallback&& cb) override;
   CacheFilterStats& stats() const override { return *stats_; }

--- a/source/extensions/filters/http/cache_v2/config.cc
+++ b/source/extensions/filters/http/cache_v2/config.cc
@@ -9,9 +9,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CacheV2 {
 
-absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context) {
   std::shared_ptr<CacheSessions> cache;
   if (!config.disabled().value()) {
     if (!config.has_typed_config()) {
@@ -33,11 +33,22 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFro
     }
     cache = *std::move(status_or_cache);
   }
-  return
-      [config = std::make_shared<CacheFilterConfig>(config, cache, context.serverFactoryContext())](
-          Http::FilterChainFactoryCallbacks& callbacks) -> void {
-        callbacks.addStreamFilter(std::make_shared<CacheFilter>(config));
-      };
+  return [config = std::make_shared<CacheFilterConfig>(config, cache, context)](
+             Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<CacheFilter>(config));
+  };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
+    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(config, context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
+    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, context);
 }
 
 REGISTER_FACTORY(CacheFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/cache_v2/config.h
+++ b/source/extensions/filters/http/cache_v2/config.h
@@ -19,6 +19,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  static absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
+                      Server::Configuration::ServerFactoryContext& context);
 };
 
 } // namespace CacheV2

--- a/source/extensions/filters/http/cache_v2/http_cache.h
+++ b/source/extensions/filters/http/cache_v2/http_cache.h
@@ -147,11 +147,11 @@ public:
   // Returns a CacheSessions initialized with an HttpCache that will remain
   // valid indefinitely (at least as long as the calling CacheFilter).
   //
-  // Pass factory context to allow HttpCache to use async client, stats scope
+  // Pass the server factory context to allow HttpCache to use async client, stats scope
   // etc.
   virtual absl::StatusOr<std::shared_ptr<CacheSessions>>
   getCache(const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-           Server::Configuration::FactoryContext& context) PURE;
+           Server::Configuration::ServerFactoryContext& context) PURE;
 
 private:
   const std::string name_;

--- a/source/extensions/http/cache_v2/file_system_http_cache/config.cc
+++ b/source/extensions/http/cache_v2/file_system_http_cache/config.cc
@@ -50,7 +50,7 @@ public:
 
   absl::StatusOr<std::shared_ptr<CacheSessions>>
   get(std::shared_ptr<CacheSingleton> singleton, const ConfigProto& non_normalized_config,
-      Server::Configuration::FactoryContext& context) {
+      Server::Configuration::ServerFactoryContext& context) {
     std::shared_ptr<CacheSessions> cache;
     ConfigProto config = normalizeConfig(non_normalized_config);
     auto key = config.cache_path();
@@ -64,7 +64,7 @@ public:
           async_file_manager_factory_->getAsyncFileManager(config.manager_config());
       std::unique_ptr<FileSystemHttpCache> fs_cache = std::make_unique<FileSystemHttpCache>(
           singleton, cache_eviction_thread_, std::move(config), std::move(async_file_manager),
-          context.serverFactoryContext().scope());
+          context.scope());
       cache = CacheSessions::create(context, std::move(fs_cache));
       caches_[key] = cache;
     } else {
@@ -104,17 +104,15 @@ public:
   // From HttpCacheFactory
   absl::StatusOr<std::shared_ptr<CacheSessions>>
   getCache(const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& filter_config,
-           Server::Configuration::FactoryContext& context) override {
+           Server::Configuration::ServerFactoryContext& context) override {
     ConfigProto config;
     RETURN_IF_NOT_OK(MessageUtil::unpackTo(filter_config.typed_config(), config));
-    std::shared_ptr<CacheSingleton> caches =
-        context.serverFactoryContext().singletonManager().getTyped<CacheSingleton>(
-            SINGLETON_MANAGER_REGISTERED_NAME(file_system_http_cache_v2_singleton), [&context] {
-              return std::make_shared<CacheSingleton>(
-                  Common::AsyncFiles::AsyncFileManagerFactory::singleton(
-                      &context.serverFactoryContext().singletonManager()),
-                  context.serverFactoryContext().api().threadFactory());
-            });
+    std::shared_ptr<CacheSingleton> caches = context.singletonManager().getTyped<CacheSingleton>(
+        SINGLETON_MANAGER_REGISTERED_NAME(file_system_http_cache_v2_singleton), [&context] {
+          return std::make_shared<CacheSingleton>(
+              Common::AsyncFiles::AsyncFileManagerFactory::singleton(&context.singletonManager()),
+              context.api().threadFactory());
+        });
     return caches->get(caches, config, context);
   }
 };

--- a/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
+++ b/source/extensions/http/cache_v2/simple_http_cache/simple_http_cache.cc
@@ -230,8 +230,8 @@ public:
   // From HttpCacheFactory
   absl::StatusOr<std::shared_ptr<CacheSessions>>
   getCache(const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config&,
-           Server::Configuration::FactoryContext& context) override {
-    return context.serverFactoryContext().singletonManager().getTyped<CacheSessions>(
+           Server::Configuration::ServerFactoryContext& context) override {
+    return context.singletonManager().getTyped<CacheSessions>(
         SINGLETON_MANAGER_REGISTERED_NAME(simple_http_cache_v2_singleton), [&context]() {
           return CacheSessions::create(context, std::make_unique<SimpleHttpCache>());
         });

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -69,7 +69,8 @@ protected:
         .WillRepeatedly(Return(true));
     auto mock_http_cache = std::make_unique<MockHttpCache>();
     mock_http_cache_ = mock_http_cache.get();
-    cache_sessions_ = CacheSessions::create(mock_factory_context_, std::move(mock_http_cache));
+    cache_sessions_ = CacheSessions::create(mock_factory_context_.server_factory_context_,
+                                            std::move(mock_http_cache));
     ON_CALL(*mock_http_cache_, lookup)
         .WillByDefault([this](LookupRequest&&, HttpCache::LookupCallback&& cb) {
           captured_lookup_callbacks_.push_back(std::move(cb));

--- a/test/extensions/filters/http/cache_v2/config_test.cc
+++ b/test/extensions/filters/http/cache_v2/config_test.cc
@@ -26,6 +26,19 @@ protected:
   Http::MockFilterChainFactoryCallbacks filter_callback_;
 };
 
+TEST_F(CacheFilterFactoryTest, BasicWithServerFactoryContext) {
+  std::ignore = config_.mutable_typed_config()->PackFrom(
+      envoy::extensions::http::cache_v2::simple_http_cache::v3::SimpleHttpCacheV2Config());
+  Http::FilterFactoryCb cb =
+      factory_.createHttpFilterFactoryFromProto(config_, "stats", context_.serverFactoryContext())
+          .value();
+  Http::StreamFilterSharedPtr filter;
+  EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
+  cb(filter_callback_);
+  ASSERT(filter);
+  ASSERT(dynamic_cast<CacheFilter*>(filter.get()));
+}
+
 TEST_F(CacheFilterFactoryTest, Basic) {
   std::ignore = config_.mutable_typed_config()->PackFrom(
       envoy::extensions::http::cache_v2::simple_http_cache::v3::SimpleHttpCacheV2Config());
@@ -72,7 +85,7 @@ public:
   ProtobufTypes::MessagePtr createEmptyConfigProto() override { return std::make_unique<Key>(); }
   absl::StatusOr<std::shared_ptr<CacheSessions>>
   getCache(const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config&,
-           Server::Configuration::FactoryContext&) override {
+           Server::Configuration::ServerFactoryContext&) override {
     return absl::InvalidArgumentError("intentional fail");
   }
 };

--- a/test/extensions/filters/http/cache_v2/mocks.h
+++ b/test/extensions/filters/http/cache_v2/mocks.h
@@ -121,7 +121,7 @@ class MockHttpCacheFactory : public HttpCacheFactory {
 public:
   MOCK_METHOD(absl::StatusOr<std::shared_ptr<CacheSessions>>, getCache,
               (const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-               Server::Configuration::FactoryContext& context));
+               Server::Configuration::ServerFactoryContext& context));
 };
 
 class MockUpstreamRequest : public UpstreamRequest {

--- a/test/extensions/http/cache_v2/file_system_http_cache/file_system_http_cache_test.cc
+++ b/test/extensions/http/cache_v2/file_system_http_cache/file_system_http_cache_test.cc
@@ -75,7 +75,10 @@ public:
         .WillByDefault([]() -> Thread::ThreadFactory& { return Thread::threadFactoryForTest(); });
   }
 
-  void initCache() { cache_ = *http_cache_factory_->getCache(cacheConfig(testConfig()), context_); }
+  void initCache() {
+    cache_ =
+        *http_cache_factory_->getCache(cacheConfig(testConfig()), context_.server_factory_context_);
+  }
 
   void waitForEvictionThreadIdle() { cache()->cache_eviction_thread_.waitForIdle(); }
 
@@ -124,7 +127,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, InitialStatsAreSetCorrectly) {
   cfg.mutable_max_cache_size_bytes()->set_value(max_size);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-a"), file_1_contents, true);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-b"), file_2_contents, true);
-  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache()->stats().size_limit_bytes_.value(), max_size);
   EXPECT_EQ(cache()->stats().size_limit_count_.value(), max_count);
@@ -142,7 +145,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderCou
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-b"), file_contents, true);
   // TODO(#24994): replace this with backdating the files when that's possible.
   sleep(1); // NO_CHECK_FORMAT(real_time)
-  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache()->stats().eviction_runs_.value(), 0);
   EXPECT_EQ(cache()->stats().size_bytes_.value(), file_contents.size() * 2);
@@ -174,7 +177,7 @@ TEST_F(FileSystemHttpCacheTestWithNoDefaultCache, EvictsOldestFilesUntilUnderSiz
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-b"), file_contents, true);
   // TODO(#24994): replace this with backdating the files when that's possible.
   sleep(1); // NO_CHECK_FORMAT(real_time)
-  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  cache_ = *http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   waitForEvictionThreadIdle();
   EXPECT_EQ(cache()->stats().eviction_runs_.value(), 0);
   env_.writeStringToFileForTest(absl::StrCat(cache_path_, "cache-c"), large_file_contents, true);
@@ -234,20 +237,22 @@ TEST_F(FileSystemHttpCacheTest,
        InvalidArgumentOnTryingToCreateCachesWithDistinctConfigsOnSamePath) {
   ConfigProto cfg = testConfig();
   cfg.mutable_manager_config()->mutable_thread_pool()->set_thread_count(2);
-  EXPECT_THAT(http_cache_factory_->getCache(cacheConfig(cfg), context_),
+  EXPECT_THAT(http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_),
               HasStatusCode(absl::StatusCode::kInvalidArgument));
 }
 
 TEST_F(FileSystemHttpCacheTest, IdenticalCacheConfigReturnsSameCacheInstance) {
   ConfigProto cfg = testConfig();
-  auto second_cache = http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  auto second_cache =
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   EXPECT_EQ(cache_, *second_cache);
 }
 
 TEST_F(FileSystemHttpCacheTest, CacheConfigsWithDifferentPathsReturnDistinctCacheInstances) {
   ConfigProto cfg = testConfig();
   cfg.set_cache_path("/tmp");
-  auto second_cache = http_cache_factory_->getCache(cacheConfig(cfg), context_);
+  auto second_cache =
+      http_cache_factory_->getCache(cacheConfig(cfg), context_.server_factory_context_);
   EXPECT_NE(cache_, *second_cache);
 }
 
@@ -911,7 +916,7 @@ TEST(Registration, GetCacheFromFactory) {
   ON_CALL(factory_context.server_factory_context_.api_, threadFactory())
       .WillByDefault([]() -> Thread::ThreadFactory& { return Thread::threadFactoryForTest(); });
   TestUtility::loadFromYaml(std::string(yaml_config), cache_config);
-  auto status_or_cache = factory->getCache(cache_config, factory_context);
+  auto status_or_cache = factory->getCache(cache_config, factory_context.server_factory_context_);
   ASSERT_OK(status_or_cache);
   EXPECT_EQ((*status_or_cache)->cacheInfo().name_,
             "envoy.extensions.http.cache_v2.file_system_http_cache");

--- a/test/extensions/http/cache_v2/simple_http_cache/simple_http_cache_test.cc
+++ b/test/extensions/http/cache_v2/simple_http_cache/simple_http_cache_test.cc
@@ -41,7 +41,7 @@ TEST(Registration, GetFactory) {
   envoy::extensions::filters::http::cache_v2::v3::CacheV2Config config;
   testing::NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   std::ignore = config.mutable_typed_config()->PackFrom(*factory->createEmptyConfigProto());
-  auto cache = factory->getCache(config, factory_context);
+  auto cache = factory->getCache(config, factory_context.server_factory_context_);
   ASSERT_OK(cache);
   EXPECT_EQ((*cache)->cacheInfo().name_, "envoy.extensions.http.cache_v2.simple");
 }


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to cache_v2
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the cache_v2 HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all changes also.


Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
