### PR TITLE
http: add server factory only factory support to decompressor

### DIFF
--- a/envoy/compression/decompressor/config.h
+++ b/envoy/compression/decompressor/config.h
@@ -14,7 +14,7 @@ public:
 
   virtual DecompressorFactoryPtr
   createDecompressorFactoryFromProto(const Protobuf::Message& config,
-                                     Server::Configuration::FactoryContext& context) PURE;
+                                     Server::Configuration::GenericFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.compression.decompressor"; }
 };

--- a/source/extensions/compression/brotli/decompressor/config.cc
+++ b/source/extensions/compression/brotli/decompressor/config.cc
@@ -28,7 +28,7 @@ BrotliDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 BrotliDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::brotli::decompressor::v3::Brotli& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   return std::make_unique<BrotliDecompressorFactory>(proto_config, context.scope());
 }
 

--- a/source/extensions/compression/brotli/decompressor/config.h
+++ b/source/extensions/compression/brotli/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::brotli::decompressor::v3::Brotli& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(BrotliDecompressorLibraryFactory);

--- a/source/extensions/compression/common/decompressor/factory_base.h
+++ b/source/extensions/compression/common/decompressor/factory_base.h
@@ -12,9 +12,9 @@ template <class ConfigProto>
 class DecompressorLibraryFactoryBase
     : public Envoy::Compression::Decompressor::NamedDecompressorLibraryConfigFactory {
 public:
-  Envoy::Compression::Decompressor::DecompressorFactoryPtr
-  createDecompressorFactoryFromProto(const Protobuf::Message& proto_config,
-                                     Server::Configuration::FactoryContext& context) override {
+  Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProto(
+      const Protobuf::Message& proto_config,
+      Server::Configuration::GenericFactoryContext& context) override {
     return createDecompressorFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
@@ -32,8 +32,8 @@ protected:
 
 private:
   virtual Envoy::Compression::Decompressor::DecompressorFactoryPtr
-  createDecompressorFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                          Server::Configuration::FactoryContext& context) PURE;
+  createDecompressorFactoryFromProtoTyped(
+      const ConfigProto& proto_config, Server::Configuration::GenericFactoryContext& context) PURE;
 
   const std::string name_;
 };

--- a/source/extensions/compression/gzip/decompressor/config.cc
+++ b/source/extensions/compression/gzip/decompressor/config.cc
@@ -35,7 +35,7 @@ GzipDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 GzipDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::gzip::decompressor::v3::Gzip& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   return std::make_unique<GzipDecompressorFactory>(proto_config, context.scope());
 }
 

--- a/source/extensions/compression/gzip/decompressor/config.h
+++ b/source/extensions/compression/gzip/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::gzip::decompressor::v3::Gzip& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(GzipDecompressorLibraryFactory);

--- a/source/extensions/compression/zstd/decompressor/config.cc
+++ b/source/extensions/compression/zstd/decompressor/config.cc
@@ -28,7 +28,7 @@ ZstdDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 ZstdDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::zstd::decompressor::v3::Zstd& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   auto& server_context = context.serverFactoryContext();
   return std::make_unique<ZstdDecompressorFactory>(
       proto_config, context.scope(), server_context.mainThreadDispatcher(), server_context.api(),

--- a/source/extensions/compression/zstd/decompressor/config.h
+++ b/source/extensions/compression/zstd/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::zstd::decompressor::v3::Zstd& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(ZstdDecompressorLibraryFactory);

--- a/source/extensions/filters/http/decompressor/BUILD
+++ b/source/extensions/filters/http/decompressor/BUILD
@@ -38,6 +38,7 @@ envoy_cc_extension(
         "//envoy/compression/decompressor:decompressor_config_interface",
         "//source/common/config:utility_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//envoy/extensions/filters/http/decompressor/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/decompressor/config.cc
+++ b/source/extensions/filters/http/decompressor/config.cc
@@ -4,15 +4,16 @@
 
 #include "source/common/config/utility.h"
 #include "source/extensions/filters/http/decompressor/decompressor_filter.h"
+#include "source/server/generic_factory_context.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Decompressor {
 
-absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    const std::string& stats_prefix, Server::Configuration::GenericFactoryContext& context) {
   const std::string decompressor_library_type{TypeUtil::typeUrlToDescriptorFullName(
       proto_config.decompressor_library().typed_config().type_url())};
   Compression::Decompressor::NamedDecompressorLibraryConfigFactory* const
@@ -34,6 +35,20 @@ absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFac
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<DecompressorFilter>(filter_config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context);
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+DecompressorFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
+  return createFilterFactory(proto_config, stats_prefix, generic_context);
 }
 
 /**

--- a/source/extensions/filters/http/decompressor/config.h
+++ b/source/extensions/filters/http/decompressor/config.h
@@ -23,6 +23,17 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::decompressor::v3::Decompressor& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::decompressor::v3::Decompressor& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
+      const std::string& stats_prefix, Server::Configuration::GenericFactoryContext& context);
 };
 
 DECLARE_FACTORY(DecompressorFilterFactory);


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to decompressor
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the decompressor HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI (Claude) was used to assist with this change. The author fully
understands the code.
Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
