### PR TITLE
http: add server factory only factory support to dynamic_forward_proxy

### DIFF
--- a/source/extensions/filters/http/dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.cc
@@ -11,14 +11,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace DynamicForwardProxy {
 
-absl::StatusOr<Http::FilterFactoryCb>
-DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> DynamicForwardProxyFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context) {
   Extensions::Common::DynamicForwardProxy::DnsCacheManagerFactoryImpl cache_manager_factory(
-      context);
+      context, context.messageValidationVisitor());
   Extensions::Common::DynamicForwardProxy::DFPClusterStoreFactory cluster_store_factory(
-      context.serverFactoryContext().singletonManager());
+      context.singletonManager());
   Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr cache_manager =
       cache_manager_factory.get();
   auto cache_or_error = cache_manager->getCache(proto_config.dns_cache_config());
@@ -32,6 +31,20 @@ DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<ProxyFilter>(filter_config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+DynamicForwardProxyFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, context);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.h
@@ -25,10 +25,20 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig& config,
       Server::Configuration::ServerFactoryContext&, ProtobufMessage::ValidationVisitor&) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
+      Server::Configuration::ServerFactoryContext& context);
 };
 
 DECLARE_FACTORY(DynamicForwardProxyFilterFactory);

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.cc
@@ -84,12 +84,10 @@ ProxyFilterConfig::ProxyFilterConfig(
     Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr&& cache,
     Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr&& cache_manager,
     Extensions::Common::DynamicForwardProxy::DFPClusterStoreFactory& cluster_store_factory,
-    Server::Configuration::FactoryContext& context)
+    Server::Configuration::ServerFactoryContext& context)
     : cluster_store_(cluster_store_factory.get()), dns_cache_manager_(std::move(cache_manager)),
-      dns_cache_(std::move(cache)),
-      cluster_manager_(context.serverFactoryContext().clusterManager()),
-      main_thread_dispatcher_(context.serverFactoryContext().mainThreadDispatcher()),
-      tls_slot_(context.serverFactoryContext().threadLocal()),
+      dns_cache_(std::move(cache)), cluster_manager_(context.clusterManager()),
+      main_thread_dispatcher_(context.mainThreadDispatcher()), tls_slot_(context.threadLocal()),
       cluster_init_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(proto_config.sub_cluster_config(),
                                                        cluster_init_timeout, 5000)),
       save_upstream_address_(proto_config.save_upstream_address()),

--- a/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/proxy_filter.h
@@ -41,7 +41,7 @@ public:
       Extensions::Common::DynamicForwardProxy::DnsCacheSharedPtr&& cache,
       Extensions::Common::DynamicForwardProxy::DnsCacheManagerSharedPtr&& cache_manager,
       Extensions::Common::DynamicForwardProxy::DFPClusterStoreFactory& cluster_store_factory,
-      Server::Configuration::FactoryContext& context);
+      Server::Configuration::ServerFactoryContext& context);
 
   Extensions::Common::DynamicForwardProxy::DFPClusterStoreSharedPtr clusterStore() {
     return cluster_store_;

--- a/test/extensions/filters/http/dynamic_forward_proxy/BUILD
+++ b/test/extensions/filters/http/dynamic_forward_proxy/BUILD
@@ -20,6 +20,9 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/extensions/filters/http/dynamic_forward_proxy:config",
+        "//source/extensions/network/dns_resolver/cares:config",
+        "//test/mocks/http:http_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "@envoy_api//envoy/extensions/filters/http/dynamic_forward_proxy/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
@@ -4,11 +4,14 @@
 #include "source/extensions/common/dynamic_forward_proxy/dns_cache_impl.h"
 #include "source/extensions/filters/http/dynamic_forward_proxy/config.h"
 
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/server/server_factory_context.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::_;
 using testing::NiceMock;
 
 namespace Envoy {
@@ -16,6 +19,35 @@ namespace Extensions {
 namespace HttpFilters {
 namespace DynamicForwardProxy {
 namespace {
+
+// The downstream HTTP filter path builds the filter factory from a FactoryContext.
+TEST(DynamicForwardProxyFilterFactoryTest, FactoryContext) {
+  DynamicForwardProxyFilterFactory factory;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+
+  envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig proto_config;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
+  cb(filter_callbacks);
+}
+
+// The route/vhost-level HTTP filter path builds the filter factory directly from a
+// ServerFactoryContext.
+TEST(DynamicForwardProxyFilterFactoryTest, ServerFactoryContext) {
+  DynamicForwardProxyFilterFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig proto_config;
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
+  cb(filter_callbacks);
+}
 
 TEST(DynamicForwardProxyFilterFactoryTest, RouteSpecificConfig) {
   DynamicForwardProxyFilterFactory factory;

--- a/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/proxy_filter_test.cc
@@ -70,7 +70,7 @@ public:
     envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig proto_config;
     filter_config_ = std::make_shared<ProxyFilterConfig>(
         proto_config, dns_cache_manager_->getCache(proto_config.dns_cache_config()).value(),
-        this->get(), cluster_store_factory, factory_context_);
+        this->get(), cluster_store_factory, factory_context_.server_factory_context_);
     filter_ = std::make_unique<ProxyFilter>(filter_config_);
 
     filter_->setDecoderFilterCallbacks(callbacks_);
@@ -565,7 +565,7 @@ public:
 
     filter_config_ = std::make_shared<ProxyFilterConfig>(
         proto_config, dns_cache_manager_->getCache(proto_config.dns_cache_config()).value(),
-        this->get(), cluster_store_factory, factory_context_);
+        this->get(), cluster_store_factory, factory_context_.server_factory_context_);
     filter_ = std::make_unique<ProxyFilter>(filter_config_);
 
     filter_->setDecoderFilterCallbacks(callbacks_);
@@ -729,7 +729,7 @@ public:
     envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig proto_config;
     filter_config_ = std::make_shared<ProxyFilterConfig>(
         proto_config, dns_cache_manager_->getCache(proto_config.dns_cache_config()).value(),
-        this->get(), cluster_store_factory, factory_context_);
+        this->get(), cluster_store_factory, factory_context_.server_factory_context_);
     mock_filter_ = std::make_unique<NiceMock<MockProxyFilter>>(filter_config_);
     // Set it up such that the filter has proxy settings enabled.
     ON_CALL(*mock_filter_, isProxying()).WillByDefault(Return(true));
@@ -772,7 +772,7 @@ public:
     proto_config.set_allow_dynamic_host_from_filter_state(true);
     filter_config_ = std::make_shared<ProxyFilterConfig>(
         proto_config, dns_cache_manager_->getCache(proto_config.dns_cache_config()).value(),
-        this->get(), cluster_store_factory, factory_context_);
+        this->get(), cluster_store_factory, factory_context_.server_factory_context_);
     filter_ = std::make_unique<ProxyFilter>(filter_config_);
 
     filter_->setDecoderFilterCallbacks(callbacks_);
@@ -868,7 +868,7 @@ public:
     proto_config.set_allow_dynamic_host_from_filter_state(false);
     filter_config_ = std::make_shared<ProxyFilterConfig>(
         proto_config, dns_cache_manager_->getCache(proto_config.dns_cache_config()).value(),
-        this->get(), cluster_store_factory, factory_context_);
+        this->get(), cluster_store_factory, factory_context_.server_factory_context_);
     filter_ = std::make_unique<ProxyFilter>(filter_config_);
 
     filter_->setDecoderFilterCallbacks(callbacks_);


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to dynamic_forward_proxy
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the dynamic_forward_proxy HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all changes.
Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
