### PR TITLE
http: add server factory only factory support to gcp_authn

### DIFF
--- a/source/extensions/filters/http/gcp_authn/filter_config.cc
+++ b/source/extensions/filters/http/gcp_authn/filter_config.cc
@@ -16,13 +16,10 @@ namespace GcpAuthn {
 
 using ::envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig;
 
-absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactory(
     const GcpAuthnFilterConfig& config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  std::shared_ptr<TokenCache> token_cache;
-  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.cache_config(), cache_size, 0) > 0) {
-    token_cache = std::make_shared<TokenCache>(config.cache_config(), context);
-  }
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
+
   // config.retry_policy has an invalid case that could not be validated by the
   // proto validation annotation. It has to be validated by the code.
   if (config.has_retry_policy()) {
@@ -30,18 +27,25 @@ absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactory
   }
 
   FilterConfigSharedPtr filter_config =
-      std::make_shared<envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>(
-          config);
-
+      std::make_shared<FilterConfig>(config, context, stats_prefix, scope);
   auto fingerprinter = std::make_shared<CertFingerprinterImpl>();
 
-  return [config, stats_prefix, &context, token_cache = std::move(token_cache),
-          filter_config = std::move(filter_config), fingerprinter = std::move(fingerprinter)](
-             Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<GcpAuthnFilter>(
-        filter_config, context, stats_prefix,
-        (token_cache != nullptr) ? &token_cache->tls.get()->cache() : nullptr, fingerprinter));
+  return [filter_config, fingerprinter](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamDecoderFilter(
+        std::make_shared<GcpAuthnFilter>(filter_config, fingerprinter));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactoryFromProtoTyped(
+    const GcpAuthnFilterConfig& config, const std::string& stats_prefix,
+    Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(config, stats_prefix, context.serverFactoryContext(), context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const GcpAuthnFilterConfig& config, const std::string& stats_prefix,
+    Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, stats_prefix, context, context.scope());
 }
 
 /**

--- a/source/extensions/filters/http/gcp_authn/filter_config.h
+++ b/source/extensions/filters/http/gcp_authn/filter_config.h
@@ -21,6 +21,18 @@ public:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+private:
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
+      Stats::Scope& scope);
 };
 
 } // namespace GcpAuthn

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.cc
@@ -135,8 +135,7 @@ void GcpAuthnClientImpl::makeTokenRequest(
 
   const std::string cluster =
       config_.cluster().empty() ? config_.http_uri().cluster() : config_.cluster();
-  const auto thread_local_cluster =
-      context_.serverFactoryContext().clusterManager().getThreadLocalCluster(cluster);
+  const auto thread_local_cluster = context_.clusterManager().getThreadLocalCluster(cluster);
 
   // Failed to fetch the token if the cluster is not configured.
   if (thread_local_cluster == nullptr) {
@@ -189,8 +188,8 @@ void GcpAuthnClientImpl::onSuccess(const Http::AsyncClient::Request&,
   if (token_type_ == TokenType::Jwt || token_type_ == TokenType::BoundJwt) {
     token_or_error = parseJwtResponse(response_body, audience_, fingerprint_);
   } else {
-    token_or_error = parseAccessTokenResponse(response_body, audience_, fingerprint_,
-                                              context_.serverFactoryContext().timeSource());
+    token_or_error =
+        parseAccessTokenResponse(response_body, audience_, fingerprint_, context_.timeSource());
   }
 
   if (token_or_error.ok()) {

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_client_impl.h
@@ -20,7 +20,7 @@ class GcpAuthnClientImpl : public GcpAuthnClient,
 public:
   GcpAuthnClientImpl(
       const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
-      Server::Configuration::FactoryContext& context)
+      Server::Configuration::ServerFactoryContext& context)
       : config_(config), context_(context) {}
 
   ~GcpAuthnClientImpl() override { cancel(); }
@@ -55,7 +55,7 @@ private:
                         const std::string& final_url, const std::optional<std::string>& fingerprint,
                         GcpAuthnClient::Callbacks& callbacks);
   const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config_;
-  Server::Configuration::FactoryContext& context_;
+  Server::Configuration::ServerFactoryContext& context_;
   Http::AsyncClient::Request* active_request_{};
   GcpAuthnClient::Callbacks* callbacks_{};
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience_;

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.cc
@@ -64,7 +64,16 @@ retrieveAudience(Upstream::ThreadLocalCluster* cluster) {
 
 using ::Envoy::Router::RouteConstSharedPtr;
 using Http::FilterHeadersStatus;
-using JwtVerify::Status;
+
+FilterConfig::FilterConfig(const FilterConfigProto& config,
+                           Server::Configuration::ServerFactoryContext& context,
+                           const std::string& stats_prefix, Stats::Scope& scope)
+    : config_(config), context_(context),
+      stats_{ALL_GCP_AUTHN_FILTER_STATS(POOL_COUNTER_PREFIX(scope, stats_prefix))} {
+  if (PROTOBUF_GET_WRAPPED_OR_DEFAULT(config.cache_config(), cache_size, 0) > 0) {
+    token_cache_ = std::make_shared<TokenCache>(config.cache_config(), context);
+  }
+}
 
 std::optional<std::string>
 GcpAuthnFilter::getClientCertFingerprint(Upstream::ThreadLocalCluster* cluster) {
@@ -91,14 +100,14 @@ GcpAuthnFilter::getClientCertFingerprint(Upstream::ThreadLocalCluster* cluster) 
     return std::nullopt;
   }
 
-  auto fingerprint_or_error = cert_fingerprinter_->getFingerprintFromPem(cert_pem);
+  auto fingerprint_or_error = fingerprinter_->getFingerprintFromPem(cert_pem);
   if (!fingerprint_or_error.ok()) {
     ENVOY_LOG(warn, "Failed to calculate certificate fingerprint: {}",
               fingerprint_or_error.status().message());
     return std::nullopt;
   }
 
-  stats_.client_cert_fingerprint_calculated_.inc();
+  filter_config_->stats().client_cert_fingerprint_calculated_.inc();
   return fingerprint_or_error.value();
 }
 
@@ -114,12 +123,12 @@ Http::FilterHeadersStatus GcpAuthnFilter::decodeHeaders(Http::RequestHeaderMap& 
   initiating_call_ = true;
 
   Envoy::Upstream::ThreadLocalCluster* cluster =
-      context_.serverFactoryContext().clusterManager().getThreadLocalCluster(
+      filter_config_->context().clusterManager().getThreadLocalCluster(
           route->routeEntry()->clusterName());
 
   auto audience_opt = retrieveAudience(cluster);
   if (!audience_opt.has_value()) {
-    stats_.retrieve_audience_failed_.inc();
+    filter_config_->stats().retrieve_audience_failed_.inc();
     state_ = State::Complete;
     return FilterHeadersStatus::Continue;
   }
@@ -146,7 +155,7 @@ Http::FilterHeadersStatus GcpAuthnFilter::decodeHeaders(Http::RequestHeaderMap& 
   if (jwt_token_cache_ != nullptr) {
     auto token = jwt_token_cache_->lookUp(audience_, client_cert_fingerprint_);
     if (token.has_value()) {
-      addTokenToRequest(hdrs, token.value(), filter_config_->token_header());
+      addTokenToRequest(hdrs, token.value(), filter_config_->config().token_header());
       state_ = State::Complete;
       return FilterHeadersStatus::Continue;
     }
@@ -165,7 +174,7 @@ Http::FilterHeadersStatus GcpAuthnFilter::decodeHeaders(Http::RequestHeaderMap& 
     client_->fetchUnboundJwt(audience_, *this);
   } else {
     ENVOY_LOG(warn, "Audience is configured but no token is specified, continuing without token.");
-    stats_.empty_audience_.inc();
+    filter_config_->stats().empty_audience_.inc();
     state_ = State::Complete;
     return FilterHeadersStatus::Continue;
   }
@@ -173,10 +182,6 @@ Http::FilterHeadersStatus GcpAuthnFilter::decodeHeaders(Http::RequestHeaderMap& 
   initiating_call_ = false;
   return state_ == State::Complete ? FilterHeadersStatus::Continue
                                    : Http::FilterHeadersStatus::StopAllIterationAndWatermark;
-}
-
-void GcpAuthnFilter::setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) {
-  decoder_callbacks_ = &callbacks;
 }
 
 void GcpAuthnFilter::onComplete(absl::StatusOr<GcpToken> token) {
@@ -187,7 +192,8 @@ void GcpAuthnFilter::onComplete(absl::StatusOr<GcpToken> token) {
       // `Authorization: Bearer ID_TOKEN` header).
       GcpToken token_val = *token;
       if (request_header_map_ != nullptr) {
-        addTokenToRequest(*request_header_map_, token_val.token, filter_config_->token_header());
+        addTokenToRequest(*request_header_map_, token_val.token,
+                          filter_config_->config().token_header());
       } else {
         ENVOY_LOG(debug, "No request header to be modified.");
       }

--- a/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
+++ b/source/extensions/filters/http/gcp_authn/gcp_authn_filter.h
@@ -35,10 +35,31 @@ struct GcpAuthnFilterStats {
   ALL_GCP_AUTHN_FILTER_STATS(GENERATE_COUNTER_STRUCT)
 };
 
-using FilterConfigSharedPtr =
-    std::shared_ptr<const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>;
+using FilterConfigProto = envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig;
 
-class GcpAuthnFilter : public Http::PassThroughFilter,
+class FilterConfig {
+public:
+  FilterConfig(const FilterConfigProto& config,
+               Server::Configuration::ServerFactoryContext& context,
+               const std::string& stats_prefix, Stats::Scope& scope);
+
+  const FilterConfigProto& config() const { return config_; }
+  GcpAuthnFilterStats& stats() { return stats_; }
+  Server::Configuration::ServerFactoryContext& context() const { return context_; }
+  TokenCacheImpl* tokenCache() const {
+    return token_cache_ ? &token_cache_->tls.get()->cache() : nullptr;
+  }
+
+private:
+  const FilterConfigProto config_;
+  Server::Configuration::ServerFactoryContext& context_;
+  GcpAuthnFilterStats stats_;
+  std::shared_ptr<TokenCache> token_cache_;
+};
+
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
+
+class GcpAuthnFilter : public Http::PassThroughDecoderFilter,
                        public GcpAuthnClient::Callbacks,
                        public Logger::Loggable<Logger::Id::filter> {
 public:
@@ -47,25 +68,23 @@ public:
   // it or has completed.
   enum class State { NotStarted, Calling, Complete };
 
-  GcpAuthnFilter(FilterConfigSharedPtr filter_config,
-                 Server::Configuration::FactoryContext& context, const std::string& stats_prefix,
-                 TokenCacheImpl* token_cache, CertFingerprinterSharedPtr fingerprinter)
-      : filter_config_(std::move(filter_config)), context_(context),
-        client_(std::make_unique<GcpAuthnClientImpl>(*filter_config_, context_)),
-        stats_(generateStats(stats_prefix, context_.scope())),
-        cert_fingerprinter_(std::move(fingerprinter)), jwt_token_cache_(token_cache) {}
+  GcpAuthnFilter(FilterConfigSharedPtr filter_config, CertFingerprinterSharedPtr fingerprinter)
+      : filter_config_(std::move(filter_config)), fingerprinter_(std::move(fingerprinter)),
+        client_(std::make_unique<GcpAuthnClientImpl>(filter_config_->config(),
+                                                     filter_config_->context())),
+        jwt_token_cache_(filter_config_->tokenCache()) {}
 
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
   void onDestroy() override;
   void onComplete(absl::StatusOr<GcpToken> token) override;
-  void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
 
   State state() { return state_; }
-  GcpAuthnFilterStats& stats() { return stats_; }
-  const std::optional<std::string>& fingerprint() const { return client_cert_fingerprint_; }
 
   ~GcpAuthnFilter() override = default;
+
+  // This is for testing only.
+  const std::optional<std::string>& fingerprint() const { return client_cert_fingerprint_; }
 
 private:
   friend class GcpAuthnFilterTest;
@@ -77,19 +96,15 @@ private:
   }
 
   FilterConfigSharedPtr filter_config_;
-  Server::Configuration::FactoryContext& context_;
+  const CertFingerprinterSharedPtr fingerprinter_;
   std::unique_ptr<GcpAuthnClient> client_;
-  Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
   // The pointer to request headers for header manipulation later.
   Envoy::Http::RequestHeaderMap* request_header_map_ = nullptr;
-
-  GcpAuthnFilterStats stats_;
 
   bool initiating_call_{};
   State state_{State::NotStarted};
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience_;
   std::optional<std::string> client_cert_fingerprint_;
-  const CertFingerprinterSharedPtr cert_fingerprinter_;
   // This cache is optional (it will be nullptr if no cache configuration) and not owned by the
   // filter (thread local storage).
   TokenCacheImpl* jwt_token_cache_;

--- a/source/extensions/filters/http/gcp_authn/token_cache.h
+++ b/source/extensions/filters/http/gcp_authn/token_cache.h
@@ -58,8 +58,8 @@ private:
 
 struct TokenCache {
   TokenCache(const envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig& cache_config,
-             Envoy::Server::Configuration::FactoryContext& context)
-      : tls(context.serverFactoryContext().threadLocal()) {
+             Envoy::Server::Configuration::ServerFactoryContext& context)
+      : tls(context.threadLocal()) {
     tls.set([cache_config](Envoy::Event::Dispatcher& dispatcher) {
       return std::make_shared<ThreadLocalCache>(cache_config, dispatcher.timeSource());
     });

--- a/test/extensions/filters/http/gcp_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/gcp_authn/filter_config_test.cc
@@ -38,7 +38,7 @@ TEST(GcpAuthnFilterConfigTest, DEPRECATED_FEATURE_TEST(GcpAuthnFilterWithCorrect
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(filter_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
 }
 
@@ -61,7 +61,7 @@ TEST(GcpAuthnFilterConfigTest, GcpAuthnFilterWithNewProto) {
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(filter_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
-  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);
 }
 

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_client_impl_test.cc
@@ -75,7 +75,9 @@ public:
         }));
   }
 
-  void createClient() { client_ = std::make_unique<GcpAuthnClientImpl>(config_, context_); }
+  void createClient() {
+    client_ = std::make_unique<GcpAuthnClientImpl>(config_, context_.server_factory_context_);
+  }
 
   NiceMock<MockFactoryContext> context_;
   NiceMock<MockThreadLocalCluster> thread_local_cluster_;

--- a/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
+++ b/test/extensions/filters/http/gcp_authn/gcp_authn_filter_test.cc
@@ -93,9 +93,8 @@ public:
   GcpAuthnFilterTest() {
     // Initialize the default configuration.
     TestUtility::loadFromYaml(DefaultConfig, config_);
-    filter_config_ =
-        std::make_shared<envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>(
-            config_);
+    filter_config_ = std::make_shared<FilterConfig>(config_, context_.server_factory_context_,
+                                                    "stats", context_.scope_);
     fingerprinter_ = std::make_shared<NiceMock<MockCertFingerprinter>>();
   }
 
@@ -114,9 +113,8 @@ public:
         }));
   }
 
-  void setupFilterAndCallback(TokenCacheImpl* cache = nullptr) {
-    filter_ =
-        std::make_unique<GcpAuthnFilter>(filter_config_, context_, "stats", cache, fingerprinter_);
+  void setupFilterAndCallback() {
+    filter_ = std::make_unique<GcpAuthnFilter>(filter_config_, fingerprinter_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   }
 
@@ -138,11 +136,9 @@ public:
     ON_CALL(*cluster_info_, metadata()).WillByDefault(testing::ReturnRef(metadata_));
   }
 
-  void overrideConfig(const GcpAuthnFilterConfig& config) {
-    config_ = config;
-    filter_config_ =
-        std::make_shared<envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>(
-            config);
+  void refreshConfig() {
+    filter_config_ = std::make_shared<FilterConfig>(config_, context_.server_factory_context_,
+                                                    "stats", context_.scope_);
   }
 
   void setClient(std::unique_ptr<GcpAuthnClient> client) { filter_->client_ = std::move(client); }
@@ -247,7 +243,7 @@ TEST_F(GcpAuthnFilterTest, NoFilterMetadata) {
   // decodeHeaders() is expected to return `Continue` because no filter metadata is specified
   // in configuration.
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true), Http::FilterHeadersStatus::Continue);
-  EXPECT_EQ(filter_->stats().retrieve_audience_failed_.value(), 1);
+  EXPECT_EQ(filter_config_->stats().retrieve_audience_failed_.value(), 1);
 }
 
 TEST_F(GcpAuthnFilterTest, ResumeFilterChainIteration) {
@@ -399,7 +395,7 @@ TEST_F(GcpAuthnFilterTest, AudienceInvalidType) {
 
   // The filter should fail to unpack, return nullopt, fail open, and return Continue.
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true), Http::FilterHeadersStatus::Continue);
-  EXPECT_EQ(filter_->stats().retrieve_audience_failed_.value(), 1);
+  EXPECT_EQ(filter_config_->stats().retrieve_audience_failed_.value(), 1);
 }
 
 TEST_F(GcpAuthnFilterTest, ClusterNotFound) {
@@ -412,7 +408,7 @@ TEST_F(GcpAuthnFilterTest, ClusterNotFound) {
 
   // decodeHeaders should return Continue directly, increment stats, and fail open.
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true), Http::FilterHeadersStatus::Continue);
-  EXPECT_EQ(filter_->stats().retrieve_audience_failed_.value(), 1);
+  EXPECT_EQ(filter_config_->stats().retrieve_audience_failed_.value(), 1);
 }
 
 TEST_F(GcpAuthnFilterTest, CacheHit) {
@@ -424,7 +420,9 @@ TEST_F(GcpAuthnFilterTest, CacheHit) {
   // Instantiate real TokenCacheImpl.
   envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig cache_config;
   cache_config.mutable_cache_size()->set_value(100);
-  TokenCacheImpl cache(cache_config, context_.serverFactoryContext().timeSource());
+  config_.mutable_cache_config()->CopyFrom(cache_config);
+  refreshConfig();
+  setupFilterAndCallback();
 
   // Populate the cache directly with a valid token.
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
@@ -437,9 +435,7 @@ TEST_F(GcpAuthnFilterTest, CacheHit) {
   token->token = "cached_token";
   token->expires_at = far_future_exp;
   token->audience = audience;
-  cache.insert(std::move(token));
-
-  setupFilterAndCallback(&cache);
+  filter_config_->tokenCache()->insert(std::move(token));
 
   // The filter should inject the cached token and return Continue directly.
   // The async HTTP client should NOT be called (Times(0)).
@@ -456,9 +452,9 @@ TEST_F(GcpAuthnFilterTest, CacheMissAndInsert) {
   // Instantiate real TokenCacheImpl.
   envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig cache_config;
   cache_config.mutable_cache_size()->set_value(100);
-  TokenCacheImpl cache(cache_config, context_.serverFactoryContext().timeSource());
-
-  setupFilterAndCallback(&cache);
+  config_.mutable_cache_config()->CopyFrom(cache_config);
+  refreshConfig();
+  setupFilterAndCallback();
 
   // The filter should fall back to calling the async client because of cache miss.
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true),
@@ -480,7 +476,7 @@ TEST_F(GcpAuthnFilterTest, CacheMissAndInsert) {
   // Verify by performing a lookup in the cache and asserting it is found!
   envoy::extensions::filters::http::gcp_authn::v3::Audience audience;
   audience.set_url("test");
-  auto cached_val = cache.lookUp(audience, std::nullopt);
+  auto cached_val = filter_config_->tokenCache()->lookUp(audience, std::nullopt);
   EXPECT_TRUE(cached_val.has_value());
   EXPECT_EQ(cached_val.value(), std::string(GoodTokenStr));
 }
@@ -526,9 +522,9 @@ TEST_F(GcpAuthnFilterTest, BoundJwtCacheMissAndInsert) {
   // Instantiate real TokenCacheImpl.
   envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig cache_config;
   cache_config.mutable_cache_size()->set_value(100);
-  TokenCacheImpl cache(cache_config, context_.serverFactoryContext().timeSource());
-
-  setupFilterAndCallback(&cache);
+  config_.mutable_cache_config()->CopyFrom(cache_config);
+  refreshConfig();
+  setupFilterAndCallback();
 
   // The filter should fall back to calling the async client because of cache miss.
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true),
@@ -548,7 +544,7 @@ TEST_F(GcpAuthnFilterTest, BoundJwtCacheMissAndInsert) {
 
   // After fetch completes, the token must be automatically inserted into the cache with the
   // fingerprint!
-  auto cached_val = cache.lookUp(audience, expected_fingerprint);
+  auto cached_val = filter_config_->tokenCache()->lookUp(audience, expected_fingerprint);
   EXPECT_TRUE(cached_val.has_value());
   EXPECT_EQ(cached_val.value(), std::string(GoodTokenStr));
 }
@@ -799,15 +795,15 @@ TEST_F(GcpAuthnFilterTest, BoundJwtCacheHit) {
 
   envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig cache_config;
   cache_config.mutable_cache_size()->set_value(100);
-  TokenCacheImpl cache(cache_config, context_.serverFactoryContext().timeSource());
+  config_.mutable_cache_config()->CopyFrom(cache_config);
+  refreshConfig();
+  setupFilterAndCallback();
 
   uint64_t far_future_exp =
       DateUtil::nowToSeconds(context_.serverFactoryContext().timeSource()) + 1000;
   auto token = std::make_unique<GcpToken>("cached_bound_token", far_future_exp, audience,
                                           expected_fingerprint);
-  cache.insert(std::move(token));
-
-  setupFilterAndCallback(&cache);
+  filter_config_->tokenCache()->insert(std::move(token));
 
   EXPECT_CALL(thread_local_cluster_.async_client_, send_(_, _, _)).Times(0);
 
@@ -886,15 +882,15 @@ TEST_F(GcpAuthnFilterTest, BoundAccessTokenCacheHit) {
 
   envoy::extensions::filters::http::gcp_authn::v3::TokenCacheConfig cache_config;
   cache_config.mutable_cache_size()->set_value(100);
-  TokenCacheImpl cache(cache_config, context_.serverFactoryContext().timeSource());
+  config_.mutable_cache_config()->CopyFrom(cache_config);
+  refreshConfig();
+  setupFilterAndCallback();
 
   uint64_t far_future_exp =
       DateUtil::nowToSeconds(context_.serverFactoryContext().timeSource()) + 1000;
   auto token = std::make_unique<GcpToken>("cached_bound_access_token", far_future_exp, audience,
                                           expected_fingerprint);
-  cache.insert(std::move(token));
-
-  setupFilterAndCallback(&cache);
+  filter_config_->tokenCache()->insert(std::move(token));
 
   EXPECT_CALL(thread_local_cluster_.async_client_, send_(_, _, _)).Times(0);
 
@@ -917,7 +913,7 @@ TEST_F(GcpAuthnFilterTest, EmptyAudienceProto) {
 
   EXPECT_EQ(filter_->decodeHeaders(default_headers_, true), Http::FilterHeadersStatus::Continue);
   EXPECT_EQ(filter_->state(), GcpAuthnFilter::State::Complete);
-  EXPECT_EQ(filter_->stats().empty_audience_.value(), 1);
+  EXPECT_EQ(filter_config_->stats().empty_audience_.value(), 1);
 }
 
 TEST_F(GcpAuthnFilterTest, CompleteWithNullRequestHeaderMap) {


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to gcp_authn
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the gcp_authn HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

BTW, in the process, I also refactored the whole gcp_authn to provide better performance and more reasonable configuration loading.

Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
