### PR TITLE
http: add server factory only factory support to mcp_router

### DIFF
--- a/source/common/http/muxdemux.cc
+++ b/source/common/http/muxdemux.cc
@@ -114,9 +114,9 @@ MultiStream::~MultiStream() { multicastReset(); }
 absl::Status MultiStream::addStream(const AsyncClient::StreamOptions& options,
                                     absl::string_view cluster_name,
                                     std::weak_ptr<AsyncClient::StreamCallbacks> callbacks,
-                                    Server::Configuration::FactoryContext& factory_context) {
+                                    Server::Configuration::ServerFactoryContext& factory_context) {
   Envoy::Upstream::ThreadLocalCluster* cluster =
-      factory_context.serverFactoryContext().clusterManager().getThreadLocalCluster(cluster_name);
+      factory_context.clusterManager().getThreadLocalCluster(cluster_name);
   if (cluster == nullptr) {
     // Allow missing clusters in case control plane did not converge yet.
     // TODO(yanavlasov): We can possibly fail request here as well.
@@ -146,7 +146,8 @@ void MultiStream::maybeSwitchToIdle() {
   }
 }
 
-MuxDemux::MuxDemux(Server::Configuration::FactoryContext& context) : factory_context_(context) {}
+MuxDemux::MuxDemux(Server::Configuration::ServerFactoryContext& context)
+    : factory_context_(context) {}
 
 MuxDemux::~MuxDemux() = default;
 

--- a/source/common/http/muxdemux.h
+++ b/source/common/http/muxdemux.h
@@ -98,7 +98,7 @@ private:
 
   absl::Status addStream(const AsyncClient::StreamOptions& options, absl::string_view cluster_name,
                          std::weak_ptr<AsyncClient::StreamCallbacks> callbacks,
-                         Server::Configuration::FactoryContext& factory_context);
+                         Server::Configuration::ServerFactoryContext& factory_context);
   void maybeSwitchToIdle();
 
   uint32_t active_streams_{0};
@@ -116,7 +116,7 @@ public:
     std::optional<AsyncClient::StreamOptions> options;
   };
 
-  static std::shared_ptr<MuxDemux> create(Server::Configuration::FactoryContext& context) {
+  static std::shared_ptr<MuxDemux> create(Server::Configuration::ServerFactoryContext& context) {
     return std::shared_ptr<MuxDemux>(new MuxDemux(context));
   }
 
@@ -138,11 +138,11 @@ public:
 
 private:
   friend class MultiStream;
-  MuxDemux(Server::Configuration::FactoryContext& context);
+  MuxDemux(Server::Configuration::ServerFactoryContext& context);
 
   void switchToIdle() { is_idle_ = true; }
 
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& factory_context_;
   bool is_idle_{true};
 };
 

--- a/source/extensions/filters/http/mcp_router/config.cc
+++ b/source/extensions/filters/http/mcp_router/config.cc
@@ -10,17 +10,31 @@ namespace Extensions {
 namespace HttpFilters {
 namespace McpRouter {
 
-absl::StatusOr<Http::FilterFactoryCb>
-McpRouterFilterConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> McpRouterFilterConfigFactory::createFilterFactory(
     const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
+    Stats::Scope& scope) {
 
-  auto config =
-      std::make_shared<McpRouterConfigImpl>(proto_config, stats_prefix, context.scope(), context);
+  auto config = std::make_shared<McpRouterConfigImpl>(proto_config, stats_prefix, scope, context);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<McpRouterFilter>(config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+McpRouterFilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
+                             context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+McpRouterFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context, context.scope());
 }
 
 /**

--- a/source/extensions/filters/http/mcp_router/config.h
+++ b/source/extensions/filters/http/mcp_router/config.h
@@ -28,6 +28,17 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
+      Stats::Scope& scope);
 };
 
 } // namespace McpRouter

--- a/source/extensions/filters/http/mcp_router/filter_config.cc
+++ b/source/extensions/filters/http/mcp_router/filter_config.cc
@@ -76,7 +76,7 @@ template <typename Config> std::vector<McpBackendConfig> parseBackends(const Con
 McpRouterConfigImpl::McpRouterConfigImpl(
     const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
     const std::string& stats_prefix, Stats::Scope& scope,
-    Server::Configuration::FactoryContext& context)
+    Server::Configuration::ServerFactoryContext& context)
     : backends_(parseBackends(proto_config)),
       default_backend_name_(backends_.size() == 1 ? backends_[0].name : ""),
       factory_context_(context), lazy_initialization_(proto_config.lazy_initialization()),

--- a/source/extensions/filters/http/mcp_router/filter_config.h
+++ b/source/extensions/filters/http/mcp_router/filter_config.h
@@ -88,7 +88,7 @@ public:
   virtual const std::vector<McpBackendConfig>& backends() const = 0;
   virtual bool isMultiplexing() const = 0;
   virtual const std::string& defaultBackendName() const = 0;
-  virtual Server::Configuration::FactoryContext& factoryContext() const = 0;
+  virtual Server::Configuration::ServerFactoryContext& factoryContext() const = 0;
   virtual const McpBackendConfig* findBackend(const std::string& name) const = 0;
 
   virtual bool lazyInitialization() const = 0;
@@ -109,12 +109,12 @@ public:
   McpRouterConfigImpl(
       const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
       const std::string& stats_prefix, Stats::Scope& scope,
-      Server::Configuration::FactoryContext& context);
+      Server::Configuration::ServerFactoryContext& context);
 
   const std::vector<McpBackendConfig>& backends() const override { return backends_; }
   bool isMultiplexing() const override { return backends_.size() > 1; }
   const std::string& defaultBackendName() const override { return default_backend_name_; }
-  Server::Configuration::FactoryContext& factoryContext() const override {
+  Server::Configuration::ServerFactoryContext& factoryContext() const override {
     return factory_context_;
   }
   const McpBackendConfig* findBackend(const std::string& name) const override;
@@ -136,7 +136,7 @@ public:
 private:
   std::vector<McpBackendConfig> backends_;
   std::string default_backend_name_;
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::Configuration::ServerFactoryContext& factory_context_;
   bool lazy_initialization_;
   SessionIdentityConfig session_identity_;
   std::string metadata_namespace_;
@@ -156,7 +156,7 @@ public:
   const std::vector<McpBackendConfig>& backends() const override { return backends_; }
   bool isMultiplexing() const override { return backends_.size() > 1; }
   const std::string& defaultBackendName() const override { return default_backend_name_; }
-  Server::Configuration::FactoryContext& factoryContext() const override {
+  Server::Configuration::ServerFactoryContext& factoryContext() const override {
     return base_config_->factoryContext();
   }
   const McpBackendConfig* findBackend(const std::string& name) const override;

--- a/test/common/http/muxdemux_test.cc
+++ b/test/common/http/muxdemux_test.cc
@@ -65,7 +65,7 @@ public:
 };
 
 TEST_F(HttpMuxDemuxTest, MulticastFailsWithoutClusters) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   auto callbacks = makeAsyncClientStreamCallbacks();
   // If no provided clusters exist, multicast call fails.
   EXPECT_THAT(multiplexer->multicast(AsyncClient::StreamOptions(),
@@ -85,7 +85,7 @@ TEST_F(HttpMuxDemuxTest, MulticastFailsWithoutClusters) {
 }
 
 TEST_F(HttpMuxDemuxTest, MulticastFailsWithNoStreamsStarted) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   auto callbacks = makeAsyncClientStreamCallbacks();
   // Add clusters. The fake HttpClient does not create streams by default.
   factory_context_.server_factory_context_.cluster_manager_.initializeThreadLocalClusters(
@@ -107,7 +107,7 @@ TEST_F(HttpMuxDemuxTest, MulticastFailsWithNoStreamsStarted) {
 }
 
 TEST_F(HttpMuxDemuxTest, IdleInvariants) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   // Initial state is idle.
   EXPECT_TRUE(multiplexer->isIdle());
   // If multicast call fails, multiplexer remains idle.
@@ -137,7 +137,7 @@ TEST_F(HttpMuxDemuxTest, IdleInvariants) {
 }
 
 TEST_F(HttpMuxDemuxTest, Multicast) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   initializeThreadLocalClusters({"cluster1", "cluster2"});
   auto callbacks1 = makeAsyncClientStreamCallbacks();
   auto callbacks2 = makeAsyncClientStreamCallbacks();
@@ -204,7 +204,7 @@ TEST_F(HttpMuxDemuxTest, Multicast) {
 }
 
 TEST_F(HttpMuxDemuxTest, DeletingMultistreamResetsActiveStareams) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   initializeThreadLocalClusters({"cluster1", "cluster2"});
   auto callbacks1 = makeAsyncClientStreamCallbacks();
   auto callbacks2 = makeAsyncClientStreamCallbacks();
@@ -240,7 +240,7 @@ TEST_F(HttpMuxDemuxTest, DeletingMultistreamResetsActiveStareams) {
 }
 
 TEST_F(HttpMuxDemuxTest, MulticastWithPerBackendOptions) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
 
   // Track the options passed to start() for each stream
   std::vector<AsyncClient::StreamOptions> captured_options;
@@ -293,7 +293,7 @@ TEST_F(HttpMuxDemuxTest, MulticastWithPerBackendOptions) {
 }
 
 TEST_F(HttpMuxDemuxTest, MulticastDifferentHeaders) {
-  auto multiplexer = MuxDemux::create(factory_context_);
+  auto multiplexer = MuxDemux::create(factory_context_.server_factory_context_);
   initializeThreadLocalClusters({"cluster1", "cluster2"});
   auto callbacks1 = makeAsyncClientStreamCallbacks();
   auto callbacks2 = makeAsyncClientStreamCallbacks();

--- a/test/extensions/filters/http/mcp_router/mcp_router_test.cc
+++ b/test/extensions/filters/http/mcp_router/mcp_router_test.cc
@@ -68,7 +68,8 @@ TEST_F(McpRouterConfigTest, MultipleBackendsEnablesMultiplexing) {
   server2->mutable_mcp_cluster()->set_cluster("calc_cluster");
   server2->mutable_mcp_cluster()->set_path("/mcp/calc");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
 
   EXPECT_EQ(config.backends().size(), 2);
   EXPECT_TRUE(config.isMultiplexing());
@@ -95,7 +96,8 @@ TEST_F(McpRouterConfigTest, SingleBackendSetsDefaultName) {
   server->set_name("tools");
   server->mutable_mcp_cluster()->set_cluster("tools_cluster");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
 
   EXPECT_EQ(config.backends().size(), 1);
   EXPECT_FALSE(config.isMultiplexing());
@@ -110,7 +112,8 @@ TEST_F(McpRouterConfigTest, DefaultPathWhenNotSpecified) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
 
   const McpBackendConfig* backend = config.findBackend("test");
   ASSERT_NE(backend, nullptr);
@@ -125,7 +128,8 @@ TEST_F(McpRouterConfigTest, DefaultMetadataNamespace) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_EQ(config.metadataNamespace(), "envoy.filters.http.mcp");
 }
 
@@ -139,8 +143,8 @@ TEST_F(McpRouterConfigTest, McpRouterClusterConfigImplParsesProto) {
   server->mutable_mcp_cluster()->mutable_timeout()->set_seconds(10);
 
   envoy::extensions::filters::http::mcp_router::v3::McpRouter base_proto;
-  auto base_config = std::make_shared<McpRouterConfigImpl>(base_proto, "test.", *store_.rootScope(),
-                                                           factory_context_);
+  auto base_config = std::make_shared<McpRouterConfigImpl>(
+      base_proto, "test.", *store_.rootScope(), factory_context_.server_factory_context_);
 
   McpRouterClusterConfigImpl cluster_config(proto_config, base_config);
 
@@ -330,7 +334,8 @@ TEST_F(McpRouterConfigTest, SessionIdentityDisabledByDefault) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_FALSE(config.hasSessionIdentity());
   EXPECT_FALSE(config.shouldEnforceValidation());
 }
@@ -345,7 +350,8 @@ TEST_F(McpRouterConfigTest, SessionIdentityWithHeaderSource) {
   auto* identity = proto_config.mutable_session_identity();
   identity->mutable_identity()->mutable_header()->set_name("x-user-id");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(absl::holds_alternative<HeaderSubjectSource>(config.subjectSource()));
   EXPECT_FALSE(config.shouldEnforceValidation()); // DISABLED by default
@@ -364,7 +370,8 @@ TEST_F(McpRouterConfigTest, SessionIdentityWithMetadataSource) {
   metadata_key->add_path()->set_key("payload");
   metadata_key->add_path()->set_key("sub");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(absl::holds_alternative<MetadataSubjectSource>(config.subjectSource()));
 }
@@ -382,7 +389,8 @@ TEST_F(McpRouterConfigTest, MetadataKeyPathParsed) {
   metadata_key->add_path()->set_key("payload");
   metadata_key->add_path()->set_key("sub");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   const auto& source = absl::get<MetadataSubjectSource>(config.subjectSource());
   EXPECT_EQ(source.filter, "jwt");
   ASSERT_EQ(source.path_keys.size(), 2);
@@ -402,7 +410,8 @@ TEST_F(McpRouterConfigTest, ValidationModeEnforce) {
   identity->mutable_validation()->set_mode(
       envoy::extensions::filters::http::mcp_router::v3::ValidationPolicy::ENFORCE);
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_TRUE(config.hasSessionIdentity());
   EXPECT_TRUE(config.shouldEnforceValidation());
   EXPECT_EQ(config.validationMode(), ValidationMode::Enforce);
@@ -420,7 +429,8 @@ protected:
   McpRouterConfigSharedPtr
   createConfig(const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config) {
     return std::make_shared<McpRouterConfigImpl>(proto_config, std::string("test."),
-                                                 *store_.rootScope(), factory_context_);
+                                                 *store_.rootScope(),
+                                                 factory_context_.server_factory_context_);
   }
 
   void setDynamicMetadata(const std::string& filter_name, const std::string& key,
@@ -854,7 +864,8 @@ TEST_F(McpRouterConfigTest, LazyInitializationDefault) {
   server->set_name("test");
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_FALSE(config.lazyInitialization());
 }
 
@@ -865,7 +876,8 @@ TEST_F(McpRouterConfigTest, LazyInitializationEnabled) {
   server->mutable_mcp_cluster()->set_cluster("test_cluster");
   proto_config.set_lazy_initialization(true);
 
-  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(), factory_context_);
+  McpRouterConfigImpl config(proto_config, "test.", *store_.rootScope(),
+                             factory_context_.server_factory_context_);
   EXPECT_TRUE(config.lazyInitialization());
 }
 
@@ -873,8 +885,8 @@ TEST_F(McpRouterConfigTest, LazyInitializationEnabled) {
 TEST_F(McpRouterConfigTest, ClusterConfigDelegatesLazyInit) {
   envoy::extensions::filters::http::mcp_router::v3::McpRouter base_proto;
   base_proto.set_lazy_initialization(true);
-  auto base_config = std::make_shared<McpRouterConfigImpl>(base_proto, "test.", *store_.rootScope(),
-                                                           factory_context_);
+  auto base_config = std::make_shared<McpRouterConfigImpl>(
+      base_proto, "test.", *store_.rootScope(), factory_context_.server_factory_context_);
 
   envoy::extensions::clusters::mcp_multicluster::v3::ClusterConfig cluster_proto;
   auto* server = cluster_proto.add_servers();


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to mcp_router
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the mcp_router HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all changes.
Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
