### PR TITLE
http: add server factory only factory support to header_to_metadata, json_to_metadata, sse_to_metadata and mcp_json_rest_bridge

### DIFF
--- a/source/extensions/filters/http/header_to_metadata/config.cc
+++ b/source/extensions/filters/http/header_to_metadata/config.cc
@@ -14,11 +14,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace HeaderToMetadataFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactory(
     const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  absl::StatusOr<ConfigSharedPtr> filter_config_or = Config::create(
-      proto_config, context.serverFactoryContext().regexEngine(), context.scope(), false);
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
+  absl::StatusOr<ConfigSharedPtr> filter_config_or =
+      Config::create(proto_config, context.regexEngine(), scope, false);
   RETURN_IF_ERROR(filter_config_or.status());
 
   return [filter_config = std::move(filter_config_or.value())](
@@ -26,6 +26,18 @@ absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactor
     callbacks.addStreamFilter(
         Http::StreamFilterSharedPtr{new HeaderToMetadataFilter(filter_config)});
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/header_to_metadata/config.h
+++ b/source/extensions/filters/http/header_to_metadata/config.h
@@ -23,6 +23,17 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
+      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& config,

--- a/source/extensions/filters/http/json_to_metadata/config.cc
+++ b/source/extensions/filters/http/json_to_metadata/config.cc
@@ -11,17 +11,29 @@ namespace Extensions {
 namespace HttpFilters {
 namespace JsonToMetadata {
 
-absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactory(
     const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  absl::StatusOr<std::shared_ptr<FilterConfig>> filter_config_or = FilterConfig::create(
-      proto_config, context.scope(), context.serverFactoryContext().regexEngine(), false);
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
+  absl::StatusOr<std::shared_ptr<FilterConfig>> filter_config_or =
+      FilterConfig::create(proto_config, scope, context.regexEngine(), false);
   RETURN_IF_ERROR(filter_config_or.status());
 
   return [filter_config = std::move(filter_config_or.value())](
              Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/json_to_metadata/config.h
+++ b/source/extensions/filters/http/json_to_metadata/config.h
@@ -22,6 +22,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
       const std::string&, Server::Configuration::FactoryContext&) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
+      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
+      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& config,

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
@@ -14,7 +14,17 @@ absl::StatusOr<Http::FilterFactoryCb>
 McpJsonRestBridgeFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
         proto_config,
-    const std::string&, Server::Configuration::FactoryContext&) {
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  // This filter does not use the factory context, so delegate to the server-context variant.
+  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
+                                               context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+McpJsonRestBridgeFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
+        proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext&) {
 
   if (proto_config.tool_config().has_tool_list_http_rule()) {
     const auto& rule = proto_config.tool_config().tool_list_http_rule();

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.h
@@ -27,6 +27,11 @@ private:
           proto_config,
       const std::string&, Server::Configuration::FactoryContext&) override;
 
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
+          proto_config,
+      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute&

--- a/source/extensions/filters/http/sse_to_metadata/config.cc
+++ b/source/extensions/filters/http/sse_to_metadata/config.cc
@@ -11,11 +11,19 @@ namespace SseToMetadata {
 
 absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  // This filter only uses the server factory context, so delegate to the server-context variant.
+  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
+                                               context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
 
   // Create shared config (which instantiates the parser from TypedExtensionConfig)
   // Note: content_parser is validated as required by proto validation rules
-  auto config = std::make_shared<FilterConfig>(proto_config, context.serverFactoryContext());
+  auto config = std::make_shared<FilterConfig>(proto_config, context);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamEncoderFilter(std::make_shared<Filter>(config));

--- a/source/extensions/filters/http/sse_to_metadata/config.h
+++ b/source/extensions/filters/http/sse_to_metadata/config.h
@@ -25,6 +25,11 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace SseToMetadata

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -119,6 +119,35 @@ request_rules:
   cb(filter_callbacks);
 }
 
+// Tests that a valid config is properly consumed via a server factory context.
+TEST(HeaderToMetadataFilterConfigTest, CreateFilterWithServerContext) {
+  const std::string yaml = R"EOF(
+request_rules:
+  - header: x-version
+    on_header_present:
+      metadata_namespace: envoy.lb
+      key: version
+      type: STRING
+    on_header_missing:
+      metadata_namespace: envoy.lb
+      key: default
+      value: 'true'
+      type: STRING
+  )EOF";
+
+  HeaderToMetadataProtoConfig proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  HeaderToMetadataConfig factory;
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  cb(filter_callbacks);
+}
+
 // Tests that per route config properly overrides the global config.
 TEST(HeaderToMetadataFilterConfigTest, PerRouteConfig) {
   const std::string yaml = R"EOF(

--- a/test/extensions/filters/http/json_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/config_test.cc
@@ -69,6 +69,35 @@ response_rules:
   callback(filter_callback);
 }
 
+TEST(Factory, CreateFilterWithServerContext) {
+  const std::string yaml_request = R"(
+request_rules:
+  rules:
+  - selectors:
+    - key: version
+    on_present:
+      metadata_namespace: envoy.lb
+      key: version
+    on_missing:
+      metadata_namespace: envoy.lb
+      key: version
+      value: 'unknown'
+      preserve_existing_metadata_value: true
+  )";
+
+  JsonToMetadataConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
+  TestUtility::loadFromYaml(yaml_request, *proto_config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  auto callback =
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  callback(filter_callback);
+}
+
 TEST(Factory, NoOnPresentOnMissing) {
   const std::string yaml_request = R"(
 request_rules:

--- a/test/extensions/filters/http/mcp_json_rest_bridge/config_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/config_test.cc
@@ -36,6 +36,19 @@ TEST(McpJsonRestBridgeFilterConfigFactoryTest, RegisterAndCreateFilterWithEmptyC
   (*cb)(filter_callbacks);
 }
 
+TEST(McpJsonRestBridgeFilterConfigFactoryTest, CreateFilterWithServerContext) {
+  envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  McpJsonRestBridgeFilterConfigFactory factory;
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter);
+  cb(filter_callbacks);
+}
+
 TEST(McpJsonRestBridgeFilterConfigTest, InvalidToolListHttpRuleThrowsException) {
   envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge proto_config;
   TestUtility::loadFromYaml(R"EOF(

--- a/test/extensions/filters/http/sse_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/sse_to_metadata/config_test.cc
@@ -46,6 +46,38 @@ TEST(SseToMetadataConfigTest, ValidConfig) {
   cb_or.value()(filter_callback);
 }
 
+TEST(SseToMetadataConfigTest, CreateFilterWithServerContext) {
+  const std::string yaml = R"EOF(
+  response_rules:
+    content_parser:
+      name: envoy.content_parsers.json
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.content_parsers.json.v3.JsonContentParser
+        rules:
+          - rule:
+              selectors:
+                - key: "usage"
+                - key: "total_tokens"
+              on_present:
+                metadata_namespace: "envoy.lb"
+                key: "tokens"
+                type: NUMBER
+  )EOF";
+
+  envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata proto_config;
+  TestUtility::loadFromYamlAndValidate(yaml, proto_config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  SseToMetadataConfig factory;
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamEncoderFilter(_));
+  cb(filter_callback);
+}
+
 TEST(SseToMetadataConfigTest, MultipleMetadataDescriptors) {
   const std::string yaml = R"EOF(
   response_rules:


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to header_to_metadata, json_to_metadata, sse_to_metadata and mcp_json_rest_bridge
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the header_to_metadata, json_to_metadata, sse_to_metadata and mcp_json_rest_bridge HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all code changes.

Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
