### PR TITLE
http: add server factory only factory support to oauth2, original_src, custom_response and ip_tagging

### DIFF
--- a/source/extensions/filters/http/custom_response/factory.cc
+++ b/source/extensions/filters/http/custom_response/factory.cc
@@ -7,16 +7,28 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CustomResponse {
 
+absl::StatusOr<::Envoy::Http::FilterFactoryCb> CustomResponseFilterFactory::createFilterFactory(
+    const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
+    const std::string& stats_prefix, Envoy::Server::Configuration::ServerFactoryContext& context) {
+  Stats::StatNameManagedStorage prefix(stats_prefix, context.scope().symbolTable());
+  auto config_ptr = std::make_shared<FilterConfig>(config, context, prefix.statName());
+  return [config_ptr](::Envoy::Http::FilterChainFactoryCallbacks& callbacks) mutable -> void {
+    callbacks.addStreamFilter(std::make_shared<CustomResponseFilter>(config_ptr));
+  };
+}
+
 absl::StatusOr<::Envoy::Http::FilterFactoryCb>
 CustomResponseFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
     const std::string& stats_prefix, Envoy::Server::Configuration::FactoryContext& context) {
-  Stats::StatNameManagedStorage prefix(stats_prefix, context.scope().symbolTable());
-  auto config_ptr =
-      std::make_shared<FilterConfig>(config, context.serverFactoryContext(), prefix.statName());
-  return [config_ptr](::Envoy::Http::FilterChainFactoryCallbacks& callbacks) mutable -> void {
-    callbacks.addStreamFilter(std::make_shared<CustomResponseFilter>(config_ptr));
-  };
+  return createFilterFactory(config, stats_prefix, context.serverFactoryContext());
+}
+
+absl::StatusOr<::Envoy::Http::FilterFactoryCb>
+CustomResponseFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
+    const std::string& stats_prefix, Envoy::Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(config, stats_prefix, context);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/custom_response/factory.h
+++ b/source/extensions/filters/http/custom_response/factory.h
@@ -22,12 +22,23 @@ public:
   absl::StatusOr<::Envoy::Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<::Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       ProtobufMessage::ValidationVisitor& validator) override;
+
+private:
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths.
+  static absl::StatusOr<::Envoy::Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
+      const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context);
 };
 
 } // namespace CustomResponse

--- a/source/extensions/filters/http/ip_tagging/config.cc
+++ b/source/extensions/filters/http/ip_tagging/config.cc
@@ -29,6 +29,21 @@ absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createFilterFactor
       };
 }
 
+absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
+    const std::string& stat_prefix, Server::Configuration::ServerFactoryContext& context) {
+
+  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config = IpTaggingFilterConfig::create(
+      proto_config, stat_prefix, context.singletonManager(), context.scope(), context.runtime(),
+      context.api(), context.threadLocal(), context.mainThreadDispatcher(),
+      context.messageValidationVisitor());
+  RETURN_IF_NOT_OK_REF(config.status());
+  return
+      [config = std::move(config.value())](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+        callbacks.addStreamDecoderFilter(std::make_shared<IpTaggingFilter>(config));
+      };
+}
+
 /**
  * Static registration for the ip tagging filter. @see RegisterFactory.
  */

--- a/source/extensions/filters/http/ip_tagging/config.h
+++ b/source/extensions/filters/http/ip_tagging/config.h
@@ -22,6 +22,11 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace IpTagging

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -132,15 +132,16 @@ createFilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Con
 }
 } // namespace
 
-absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-  auto& cluster_manager = context.serverFactoryContext().clusterManager();
+absl::StatusOr<Http::FilterFactoryCb>
+OAuth2Config::createFilterFactory(const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
+                                  const std::string& stats_prefix,
+                                  Server::Configuration::ServerFactoryContext& context,
+                                  Stats::Scope& scope, OptRef<Init::Manager> init_manager) {
+  auto& cluster_manager = context.clusterManager();
   FilterConfigSharedPtr config = nullptr;
   if (proto.has_config()) {
-    auto config_or_error = createFilterConfig(proto.config(), server_context, context.initManager(),
-                                              context.scope(), stats_prefix);
+    auto config_or_error =
+        createFilterConfig(proto.config(), context, init_manager, scope, stats_prefix);
     if (!config_or_error.ok()) {
       return config_or_error.status();
     }
@@ -161,9 +162,21 @@ absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createFilterFactoryFromProto
               return std::make_shared<OAuth2CookieValidator>(
                   time_source, active_config.cookieNames(), active_config.cookieDomain());
             },
-            context.serverFactoryContext().timeSource(),
-            context.serverFactoryContext().api().randomGenerator()));
+            context.timeSource(), context.api().randomGenerator()));
       };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto, stats_prefix, context.serverFactoryContext(), context.scope(),
+                             context.initManager());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto, stats_prefix, context, context.scope(), {});
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/oauth2/config.h
+++ b/source/extensions/filters/http/oauth2/config.h
@@ -23,6 +23,17 @@ public:
                                     const std::string&,
                                     Server::Configuration::FactoryContext&) override;
 
+  absl::StatusOr<Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProtoTyped(const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
+                                        const std::string&,
+                                        Server::Configuration::ServerFactoryContext&) override;
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const envoy::extensions::filters::http::oauth2::v3::OAuth2& config,
+                      const std::string& stats_prefix,
+                      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
+                      OptRef<Init::Manager> init_manager);
+
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::oauth2::v3::OAuth2PerRoute&,

--- a/source/extensions/filters/http/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.cc
@@ -14,7 +14,16 @@ namespace OriginalSrc {
 
 absl::StatusOr<Http::FilterFactoryCb> OriginalSrcConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
-    const std::string&, Server::Configuration::FactoryContext&) {
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  // This filter does not use the factory context, so delegate to the server-context variant.
+  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
+                                               context.serverFactoryContext());
+}
+
+absl::StatusOr<Http::FilterFactoryCb>
+OriginalSrcConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext&) {
   Config config(proto_config);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<OriginalSrcFilter>(config));

--- a/source/extensions/filters/http/original_src/original_src_config_factory.h
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.h
@@ -21,6 +21,11 @@ public:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
       const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
+      const std::string& stat_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
 
 } // namespace OriginalSrc

--- a/test/extensions/filters/http/ip_tagging/BUILD
+++ b/test/extensions/filters/http/ip_tagging/BUILD
@@ -31,6 +31,7 @@ envoy_extension_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/protobuf:protobuf_mocks",
         "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/server:factory_context_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -6,12 +6,14 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/network/utility.h"
 #include "source/common/singleton/manager_impl.h"
+#include "source/extensions/filters/http/ip_tagging/config.h"
 #include "source/extensions/filters/http/ip_tagging/ip_tagging_filter.h"
 
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/runtime/mocks.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/test_common/environment.h"
@@ -20,6 +22,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using testing::_;
+using testing::NiceMock;
 using testing::Return;
 
 namespace Envoy {
@@ -1225,6 +1229,29 @@ ip_tags:
   unlink(TestEnvironment::temporaryPath("ip_tagging_test/watcher_old_target.yaml").c_str());
   unlink(TestEnvironment::temporaryPath("ip_tagging_test/watcher_new_target.yaml").c_str());
   dispatcher_->exit();
+}
+
+// Test creating filter with server factory context (route/vhost level support).
+TEST_F(IpTaggingFilterTest, CreateFilterWithServerContext) {
+  const std::string config_yaml = R"EOF(
+request_type: internal
+ip_tags:
+  - ip_tag_name: internal_request
+    ip_list:
+      - {address_prefix: 1.2.3.5, prefix_len: 32}
+)EOF";
+  envoy::extensions::filters::http::ip_tagging::v3::IPTagging proto_config;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(config_yaml), proto_config);
+
+  IpTaggingFilterFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(proto_config, "prefix.", server_context).value();
+
+  NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
+  cb(filter_callbacks);
 }
 
 } // namespace

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -150,6 +150,48 @@ config:
   cb(filter_callback);
 }
 
+TEST(ConfigTest, CreateFilterWithServerContext) {
+  const std::string yaml = R"EOF(
+config:
+  token_endpoint:
+    cluster: foo
+    uri: oauth.com/token
+    timeout: 3s
+  credentials:
+    client_id: "secret"
+    token_secret:
+      name: token
+    hmac_secret:
+      name: hmac
+  authorization_endpoint: https://oauth.com/oauth/authorize/
+  redirect_uri: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/callback"
+  redirect_path_matcher:
+    path:
+      exact: /callback
+  signout_path:
+    path:
+      exact: /signout
+    )EOF";
+
+  OAuth2Config factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  server_context.cluster_manager_.initializeClusters({"foo"}, {});
+
+  NiceMock<Secret::MockSecretManager> secret_manager;
+  ON_CALL(server_context, secretManager()).WillByDefault(ReturnRef(secret_manager));
+  ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
+      .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
+          envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
 TEST(ConfigTest, CreateFilterTlsClientAuthWithoutTokenSecret) {
   const std::string yaml = R"EOF(
 config:

--- a/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
@@ -46,6 +46,33 @@ TEST(OriginalSrcHttpConfigFactoryTest, TestCreateFactory) {
   EXPECT_NE(dynamic_cast<OriginalSrcFilter*>(added_filter.get()), nullptr);
 }
 
+TEST(OriginalSrcHttpConfigFactoryTest, CreateFilterWithServerContext) {
+  const std::string yaml = R"EOF(
+    mark: 5
+)EOF";
+
+  OriginalSrcConfigFactory factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+
+  Http::FilterFactoryCb cb =
+      factory.createHttpFilterFactoryFromProto(*proto_config, "", server_context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  Http::StreamDecoderFilterSharedPtr added_filter;
+  EXPECT_CALL(filter_callback, addStreamDecoderFilter(_))
+      .WillOnce(Invoke([&added_filter](Http::StreamDecoderFilterSharedPtr filter) {
+        added_filter = std::move(filter);
+      }));
+
+  cb(filter_callback);
+
+  // Make sure we actually create the correct type!
+  EXPECT_NE(dynamic_cast<OriginalSrcFilter*>(added_filter.get()), nullptr);
+}
+
 } // namespace
 } // namespace OriginalSrc
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to oauth2, original_src, custom_response and ip_tagging
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the oauth2, original_src, custom_response and ip_tagging HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all the changes and fixed something.

Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
