### PR TITLE
http: add server factory only factory support to ratelimit

### DIFF
--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.cc
@@ -154,16 +154,14 @@ void GrpcClientImpl::onFailure(Grpc::Status::GrpcStatus status, const std::strin
   call_backs->complete(LimitStatus::Error, nullptr, nullptr, nullptr, EMPTY_STRING, nullptr);
 }
 
-ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
+ClientPtr rateLimitClient(Server::Configuration::ServerFactoryContext& context,
                           const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
                           const std::optional<std::chrono::milliseconds>& timeout) {
   // TODO(ramaraochavali): register client to singleton when GrpcClientImpl supports concurrent
   // requests.
   auto client_or_error =
-      context.serverFactoryContext()
-          .clusterManager()
-          .grpcAsyncClientManager()
-          .getOrCreateRawAsyncClientWithHashKey(config_with_hash_key, context.scope(), true);
+      context.clusterManager().grpcAsyncClientManager().getOrCreateRawAsyncClientWithHashKey(
+          config_with_hash_key, context.scope(), true);
   THROW_IF_NOT_OK_REF(client_or_error.status());
   return std::make_unique<Filters::Common::RateLimit::GrpcClientImpl>(client_or_error.value(),
                                                                       timeout);

--- a/source/extensions/filters/common/ratelimit/ratelimit_impl.h
+++ b/source/extensions/filters/common/ratelimit/ratelimit_impl.h
@@ -82,7 +82,7 @@ private:
  * Builds the rate limit client.
  * @param timeout the timeout for the gRPC request. If nullopt, no timeout is applied (infinite).
  */
-ClientPtr rateLimitClient(Server::Configuration::FactoryContext& context,
+ClientPtr rateLimitClient(Server::Configuration::ServerFactoryContext& context,
                           const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
                           const std::optional<std::chrono::milliseconds>& timeout);
 

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -17,16 +17,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace RateLimitFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactory(
     const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-
+    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
   ASSERT(!proto_config.domain().empty());
   absl::Status status = absl::OkStatus();
-  FilterConfigSharedPtr filter_config(new FilterConfig(proto_config, server_context.localInfo(),
-                                                       context.scope(), server_context.runtime(),
-                                                       server_context, status));
+  FilterConfigSharedPtr filter_config(new FilterConfig(proto_config, context.localInfo(), scope,
+                                                       context.runtime(), context, status));
   RETURN_IF_NOT_OK_REF(status);
   // A timeout of 0 means infinite (no timeout). Convert to nullopt in that case.
   const uint64_t timeout_ms = PROTOBUF_GET_MS_OR_DEFAULT(proto_config, timeout, 20);
@@ -44,6 +41,18 @@ absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactory
         filter_config,
         Filters::Common::RateLimit::rateLimitClient(context, config_with_hash_key, timeout)));
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
+    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -25,6 +25,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
+      const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
+      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/network/ratelimit/config.cc
+++ b/source/extensions/filters/network/ratelimit/config.cc
@@ -36,8 +36,8 @@ Network::FilterFactoryCb RateLimitConfigFactory::createFilterFactoryFromProtoTyp
   return [config_with_hash_key, &context, timeout,
           filter_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addReadFilter(std::make_shared<Filter>(
-        filter_config,
-        Filters::Common::RateLimit::rateLimitClient(context, config_with_hash_key, timeout)));
+        filter_config, Filters::Common::RateLimit::rateLimitClient(context.serverFactoryContext(),
+                                                                   config_with_hash_key, timeout)));
   };
 }
 

--- a/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.cc
+++ b/source/extensions/filters/network/thrift_proxy/filters/ratelimit/config.cc
@@ -38,8 +38,8 @@ RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
   return [config_with_hash_key, &context, timeout,
           config](ThriftProxy::ThriftFilters::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addDecoderFilter(std::make_shared<Filter>(
-        config,
-        Filters::Common::RateLimit::rateLimitClient(context, config_with_hash_key, timeout)));
+        config, Filters::Common::RateLimit::rateLimitClient(context.serverFactoryContext(),
+                                                            config_with_hash_key, timeout)));
   };
 }
 


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to ratelimit
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the ratelimit HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI (Claude) was used to assist with this change. The author fully
understands the code.
Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
