### PR TITLE
http: add server factory only factory support to tap

### DIFF
--- a/source/extensions/filters/http/tap/BUILD
+++ b/source/extensions/filters/http/tap/BUILD
@@ -60,6 +60,7 @@ envoy_cc_extension(
         ":tap_filter_lib",
         "//envoy/registry",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//envoy/config/tap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/tap/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/tap/config.cc
+++ b/source/extensions/filters/http/tap/config.cc
@@ -7,6 +7,7 @@
 
 #include "source/extensions/filters/http/tap/tap_config_impl.h"
 #include "source/extensions/filters/http/tap/tap_filter.h"
+#include "source/server/generic_factory_context.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -15,8 +16,9 @@ namespace TapFilter {
 
 class HttpTapConfigFactoryImpl : public Extensions::Common::Tap::TapConfigFactory {
 public:
-  HttpTapConfigFactoryImpl(Server::Configuration::FactoryContext& context)
-      : factory_context_(context) {}
+  HttpTapConfigFactoryImpl(Server::Configuration::ServerFactoryContext& context,
+                           ProtobufMessage::ValidationVisitor& validation_visitor)
+      : factory_context_(context, validation_visitor) {}
   // TapConfigFactory
   Extensions::Common::Tap::TapConfigSharedPtr
   createConfigFromProto(const envoy::config::tap::v3::TapConfig& proto_config,
@@ -26,23 +28,37 @@ public:
   }
 
 private:
-  Server::Configuration::FactoryContext& factory_context_;
+  Server::GenericFactoryContextImpl factory_context_;
 };
 
-absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactory(
     const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-
-  FilterConfigSharedPtr filter_config(new FilterConfigImpl(
-      proto_config, stats_prefix, std::make_unique<HttpTapConfigFactoryImpl>(context),
-      context.scope(), server_context.admin(), server_context.singletonManager(),
-      server_context.threadLocal(), server_context.mainThreadDispatcher()));
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,
+    Stats::Scope& scope, ProtobufMessage::ValidationVisitor& validation_visitor) {
+  FilterConfigSharedPtr filter_config(
+      new FilterConfigImpl(proto_config, stats_prefix,
+                           std::make_unique<HttpTapConfigFactoryImpl>(context, validation_visitor),
+                           scope, context.admin(), context.singletonManager(),
+                           context.threadLocal(), context.mainThreadDispatcher()));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<Filter>(filter_config);
     callbacks.addStreamFilter(filter);
     callbacks.addAccessLogHandler(filter);
   };
+}
+
+absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
+    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
+                             context.scope(), context.messageValidationVisitor());
+}
+
+absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
+    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+  return createFilterFactory(proto_config, stats_prefix, context, context.scope(),
+                             context.messageValidationVisitor());
 }
 
 /**

--- a/source/extensions/filters/http/tap/config.h
+++ b/source/extensions/filters/http/tap/config.h
@@ -22,6 +22,18 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
+      const std::string& stats_prefix,
+      Server::Configuration::ServerFactoryContext& context) override;
+
+  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
+  // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactory(const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
+                      const std::string& stats_prefix,
+                      Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope,
+                      ProtobufMessage::ValidationVisitor& validation_visitor);
 };
 
 } // namespace TapFilter

--- a/source/extensions/filters/http/tap/tap_config_impl.cc
+++ b/source/extensions/filters/http/tap/tap_config_impl.cc
@@ -31,7 +31,7 @@ fillHeaderList(Protobuf::RepeatedPtrField<envoy::config::core::v3::HeaderValue>*
 
 HttpTapConfigImpl::HttpTapConfigImpl(const envoy::config::tap::v3::TapConfig& proto_config,
                                      Common::Tap::Sink* admin_streamer,
-                                     Server::Configuration::FactoryContext& context)
+                                     Server::Configuration::GenericFactoryContext& context)
     : TapCommon::TapConfigBaseImpl(std::move(proto_config), admin_streamer, context),
       time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()) {}
 

--- a/source/extensions/filters/http/tap/tap_config_impl.h
+++ b/source/extensions/filters/http/tap/tap_config_impl.h
@@ -21,7 +21,7 @@ class HttpTapConfigImpl : public Extensions::Common::Tap::TapConfigBaseImpl,
 public:
   HttpTapConfigImpl(const envoy::config::tap::v3::TapConfig& proto_config,
                     Extensions::Common::Tap::Sink* admin_streamer,
-                    Server::Configuration::FactoryContext& context);
+                    Server::Configuration::GenericFactoryContext& context);
 
   // TapFilter::HttpTapConfig
   HttpPerRequestTapperPtr


### PR DESCRIPTION
Commit Message: http: add server factory only factory support to tap
Additional Description:
This adds the server-factory-context-only filter factory creation method
(`createHttpFilterFactoryFromProtoTyped` taking only a `ServerFactoryContext`,
introduced in #45989) to the tap HTTP filter(s).

This allows these filters to be created in contexts where only a
`ServerFactoryContext` is available (e.g. route/virtual-host level filter
configuration) rather than requiring the full downstream `FactoryContext`.
The existing downstream `FactoryContext` path is preserved and now delegates
to a shared helper, so behavior for existing use cases is unchanged.

Generative AI was used to assist with this change. I have reviewed all changes.

Risk Level: Low
Testing: Existing/added unit config tests; CI.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
