### PR TITLE
reverse_tunnel: propagate initiator worker and connection ids

### DIFF
--- a/changelogs/current/new_features/reverse_tunnel__handshake-worker-connection-id.rst
+++ b/changelogs/current/new_features/reverse_tunnel__handshake-worker-connection-id.rst
@@ -1,0 +1,14 @@
+The downstream reverse-tunnel initiator
+(``envoy.bootstrap.reverse_tunnel.downstream_socket_interface``) now includes two additional
+identifiers in the HTTP handshake it sends to the acceptor: ``x-envoy-reverse-tunnel-worker-id``
+(the initiator worker dispatcher name, e.g. ``worker_2``) and ``x-envoy-reverse-tunnel-connection-id``
+(the initiator's per-connection id). Both are surfaced in the initiator access log via the new
+``worker_id`` and ``connection_id`` fields of the ``envoy.reverse_tunnel.initiator`` dynamic metadata
+namespace. The upstream acceptor
+(``envoy.bootstrap.reverse_tunnel.upstream_socket_interface``) now parses these headers and exposes
+them on every reverse-tunnel lifecycle event as the ``initiator_worker_id`` and
+``initiator_connection_id`` fields of the ``envoy.reverse_tunnel.lifecycle`` dynamic metadata
+namespace and as the ``envoy.reverse_tunnel.initiator_worker_id`` /
+``envoy.reverse_tunnel.initiator_connection_id`` connection filter-state keys. Together these let
+tunnels originating from different workers/connections of the same initiator be told apart and
+correlated across both ends.

--- a/docs/root/_configs/reverse_connection/initiator-envoy.yaml
+++ b/docs/root/_configs/reverse_connection/initiator-envoy.yaml
@@ -25,6 +25,8 @@ bootstrap_extensions:
               tenant=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:tenant_id)%
               upstream_cluster=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:upstream_cluster)%
               host=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:host_address)%
+              worker=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:worker_id)%
+              connection_id=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:connection_id)%
               error=%DYNAMIC_METADATA(envoy.reverse_tunnel.initiator:error)%
 
 static_resources:

--- a/docs/root/configuration/other_features/reverse_tunnel.rst
+++ b/docs/root/configuration/other_features/reverse_tunnel.rst
@@ -262,8 +262,11 @@ The lifecycle logger emits the following event names:
 * ``idle_ping_timeout`` – the idle connection is being closed because the peer failed to respond to ``RPING`` probes.
 
 The dynamic metadata namespace is ``envoy.reverse_tunnel.lifecycle``. The emitted fields are
-``event``, ``node_id``, ``cluster_id``, ``tenant_id``, ``worker``, ``fd``, ``socket_state``,
-and, when relevant, ``handoff_kind`` or ``close_reason``.
+``event``, ``node_id``, ``cluster_id``, ``tenant_id``, ``worker``, ``initiator_worker_id``,
+``initiator_connection_id``, ``fd``, ``socket_state``, and, when relevant, ``handoff_kind`` or
+``close_reason``. ``worker`` is the acceptor's own worker thread, while ``initiator_worker_id`` and
+``initiator_connection_id`` are the worker and connection identifiers advertised by the initiator in
+the handshake (empty when the initiator does not advertise them).
 
 **Socket state values** (the ``socket_state`` field):
 
@@ -291,6 +294,8 @@ The same identifiers are also copied into connection filter state under these ke
 * ``envoy.reverse_tunnel.cluster_id``
 * ``envoy.reverse_tunnel.tenant_id``
 * ``envoy.reverse_tunnel.worker``
+* ``envoy.reverse_tunnel.initiator_worker_id`` (only when advertised by the initiator)
+* ``envoy.reverse_tunnel.initiator_connection_id`` (only when advertised by the initiator)
 * ``envoy.reverse_tunnel.fd``
 
 .. _config_reverse_tunnel_network_filter:
@@ -571,6 +576,14 @@ metadata namespace and can be referenced using the ``%DYNAMIC_METADATA(envoy.rev
      - string
      - A unique identifier for this specific reverse tunnel connection instance. Useful for
        correlating handshake and close events for the same connection.
+   * - ``worker_id``
+     - string
+     - The initiator worker thread that opened this connection, as the worker dispatcher name
+       (e.g. ``worker_2``). Distinguishes tunnels originating from different workers.
+   * - ``connection_id``
+     - string
+     - The initiator's per-connection identifier for this connection. Combined with ``worker_id``,
+       distinguishes individual tunnels from the same initiator instance.
    * - ``error``
      - string
      - The error message describing the failure reason. Empty string on non-failure events.

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
@@ -112,6 +112,23 @@ inline const Http::LowerCaseString& reverseTunnelInitiationTimeHeader() {
   return kHeader;
 }
 
+// Identifies the initiator worker thread that opened the tunnel (the worker dispatcher name, e.g.
+// "worker_2"). Distinguishes tunnels originating from different workers of the same initiator.
+inline const Http::LowerCaseString& reverseTunnelWorkerIdHeader() {
+  static const Http::LowerCaseString kHeader{
+      absl::StrCat(Http::Headers::get().prefix(), "-reverse-tunnel-worker-id")};
+  return kHeader;
+}
+
+// The initiator's per-connection identifier (Envoy's monotonic connection id) for the outbound
+// handshake connection. Combined with the worker id, distinguishes individual tunnels from the
+// same initiator instance.
+inline const Http::LowerCaseString& reverseTunnelConnectionIdHeader() {
+  static const Http::LowerCaseString kHeader{
+      absl::StrCat(Http::Headers::get().prefix(), "-reverse-tunnel-connection-id")};
+  return kHeader;
+}
+
 class ReverseConnectionMessageHandlerFactory {
 public:
   static std::shared_ptr<class PingMessageHandler> createPingHandler();

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -13,9 +13,9 @@ namespace ReverseConnection {
 // DownstreamReverseConnectionIOHandle constructor implementation
 DownstreamReverseConnectionIOHandle::DownstreamReverseConnectionIOHandle(
     Network::ConnectionSocketPtr socket, ReverseConnectionIOHandle* parent,
-    const std::string& connection_key)
+    const std::string& connection_key, uint64_t connection_id)
     : IoSocketHandleImpl(socket->ioHandle().fdDoNotUse()), owned_socket_(std::move(socket)),
-      parent_(parent), connection_key_(connection_key) {
+      parent_(parent), connection_key_(connection_key), connection_id_(connection_id) {
   ENVOY_LOG(debug,
             "DownstreamReverseConnectionIOHandle: taking ownership of socket with FD: {} for "
             "connection key: {}",
@@ -67,7 +67,7 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
   // Notify the parent that this downstream connection has been closed.
   // This can trigger re-initiation of the reverse connection if needed.
   if (parent_) {
-    parent_->onDownstreamConnectionClosed(connection_key_);
+    parent_->onDownstreamConnectionClosed(connection_key_, connection_id_);
     ENVOY_LOG(
         debug,
         "DownstreamReverseConnectionIOHandle: notified parent of connection closure for key: {}",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h
@@ -26,11 +26,13 @@ class ReverseConnectionIOHandle;
 class DownstreamReverseConnectionIOHandle : public RpingInterceptor {
 public:
   /**
-   * Constructor that takes ownership of the socket and stores parent pointer and connection key.
+   * Constructor that takes ownership of the socket and stores parent pointer, connection key, and
+   * the initiator's per-connection identifier (retained so it can be reported at close time, when
+   * the originating connection object is already gone).
    */
   DownstreamReverseConnectionIOHandle(Network::ConnectionSocketPtr socket,
                                       ReverseConnectionIOHandle* parent,
-                                      const std::string& connection_key);
+                                      const std::string& connection_key, uint64_t connection_id);
 
   ~DownstreamReverseConnectionIOHandle() override;
 
@@ -74,6 +76,8 @@ private:
   ReverseConnectionIOHandle* parent_;
   // Connection key for tracking this specific connection.
   std::string connection_key_;
+  // The initiator's per-connection identifier, reported to the parent on close.
+  uint64_t connection_id_;
 };
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -168,6 +168,15 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
                 .count();
   headers->addCopy(initiation_time_hdr, absl::StrCat(initiation_ms));
 
+  // Advertise which initiator worker and connection opened this tunnel so the two ends can be
+  // correlated and tunnels from different workers/connections told apart.
+  const Http::LowerCaseString& worker_id_hdr =
+      ::Envoy::Extensions::Bootstrap::ReverseConnection::reverseTunnelWorkerIdHeader();
+  const Http::LowerCaseString& connection_id_hdr =
+      ::Envoy::Extensions::Bootstrap::ReverseConnection::reverseTunnelConnectionIdHeader();
+  headers->addCopy(worker_id_hdr, connection_->dispatcher().name());
+  headers->addCopy(connection_id_hdr, absl::StrCat(connection_->id()));
+
   using HeaderValueOption = envoy::config::core::v3::HeaderValueOption;
   const auto apply_header = [&headers](const Http::LowerCaseString& key, absl::string_view value,
                                        HeaderValueOption::HeaderAppendAction action) {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -25,6 +25,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
 
+#include "absl/strings/str_cat.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -70,13 +71,22 @@ void ReverseConnectionIOHandle::emitAccessLog(const std::string& event,
                                               const std::string& host_address,
                                               const std::string& cluster_name,
                                               const std::string& connection_key,
+                                              std::optional<uint64_t> connection_id,
                                               const std::string& error_message) {
   if (!extension_) {
     return;
   }
+  // The worker id is the worker dispatcher name (e.g. "worker_2"), the same identity sent in the
+  // handshake worker-id header and used across reverse-tunnel stats.
+  const std::string worker_id =
+      worker_dispatcher_ != nullptr ? worker_dispatcher_->name() : std::string{};
+  // Render an absent connection id as an empty string; 0 is a valid id, so a sentinel would be
+  // ambiguous.
+  const std::string connection_id_str =
+      connection_id.has_value() ? absl::StrCat(*connection_id) : std::string{};
   extension_->emitAccessLog(getTimeSource(), event, config_.src_node_id, config_.src_cluster_id,
                             config_.src_tenant_id, cluster_name, host_address, connection_key,
-                            error_message);
+                            worker_id, connection_id_str, error_message);
 }
 
 void ReverseConnectionIOHandle::cleanup() {
@@ -260,6 +270,9 @@ Envoy::Network::IoHandlePtr ReverseConnectionIOHandle::accept(struct sockaddr* a
 
         const std::string connection_key =
             connection->connectionInfoProvider().localAddress()->asString();
+        // Capture the connection id now so the tunnel handle can report it on close, after the
+        // originating connection object is gone.
+        const uint64_t connection_id = connection->id();
         ENVOY_LOG(debug, "reverse_tunnel: got connection key: {}", connection_key);
 
         // Instead of moving the socket, duplicate the file descriptor.
@@ -291,10 +304,10 @@ Envoy::Network::IoHandlePtr ReverseConnectionIOHandle::accept(struct sockaddr* a
         // Reset file events on the duplicated socket to clear any inherited events.
         duplicated_socket->ioHandle().resetFileEvents();
 
-        // Create RAII-based IoHandle with duplicated socket, passing parent pointer and connection
-        // key.
+        // Create RAII-based IoHandle with duplicated socket, passing parent pointer, connection
+        // key, and connection id.
         auto io_handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-            std::move(duplicated_socket), this, connection_key);
+            std::move(duplicated_socket), this, connection_key, connection_id);
 
         ENVOY_LOG(info,
                   "reverse_tunnel: RAII IoHandle created with duplicated socket for node_id: {}"
@@ -850,7 +863,8 @@ ReverseConnectionIOHandle::dropTunnelFromTracking(const std::string& connection_
   return {host_address, cluster_name};
 }
 
-void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key) {
+void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& connection_key,
+                                                             uint64_t connection_id) {
   ENVOY_LOG(debug, "reverse_tunnel: Downstream connection closed: {}", connection_key);
 
   auto [host_address, cluster_name] = dropTunnelFromTracking(connection_key);
@@ -864,7 +878,7 @@ void ReverseConnectionIOHandle::onDownstreamConnectionClosed(const std::string& 
     return;
   }
 
-  emitAccessLog("connection_closed", host_address, cluster_name, connection_key, "");
+  emitAccessLog("connection_closed", host_address, cluster_name, connection_key, connection_id, "");
 
   // The next call to maintainClusterConnections() will detect the missing connection
   // and re-initiate it automatically.
@@ -1212,7 +1226,8 @@ void ReverseConnectionIOHandle::onConnectionDone(
 
     trackConnectionFailure(host_address, cluster_name, retry_after);
 
-    emitAccessLog("handshake_failure", host_address, cluster_name, connection_key, error);
+    emitAccessLog("handshake_failure", host_address, cluster_name, connection_key,
+                  connection ? std::make_optional(connection->id()) : std::nullopt, error);
 
   } else {
     // Handle connection success.
@@ -1224,7 +1239,8 @@ void ReverseConnectionIOHandle::onConnectionDone(
     updateConnectionState(host_address, cluster_name, connection_key,
                           ReverseConnectionState::Connected);
 
-    emitAccessLog("handshake_success", host_address, cluster_name, connection_key, "");
+    emitAccessLog("handshake_success", host_address, cluster_name, connection_key,
+                  connection ? std::make_optional(connection->id()) : std::nullopt, "");
 
     ENVOY_LOG(info, "reverse_tunnel: Transferring tunnel socket for "
                     "reverse_conn_listener consumption");

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -299,8 +299,9 @@ public:
    * Handle downstream connection closure and update internal maps so that the next
    * maintenance cycle re-initiates the connection.
    * @param connection_key the unique key identifying the closed connection.
+   * @param connection_id the initiator's per-connection identifier for the closed connection.
    */
-  void onDownstreamConnectionClosed(const std::string& connection_key);
+  void onDownstreamConnectionClosed(const std::string& connection_key, uint64_t connection_id);
 
   /**
    * Drop a tunnel from tracking because it has begun draining (the downstream HCM sent a
@@ -428,11 +429,14 @@ private:
    * @param host_address the address of the remote host
    * @param cluster_name the name of the upstream cluster
    * @param connection_key the unique key identifying the connection
+   * @param connection_id the initiator's per-connection identifier, or nullopt if the connection is
+   *        no longer available (e.g. after it has been released or closed); logged as an empty
+   *        string rather than a sentinel value so it is unambiguously distinct from a real id.
    * @param error_message the error message (empty on success)
    */
   void emitAccessLog(const std::string& event, const std::string& host_address,
                      const std::string& cluster_name, const std::string& connection_key,
-                     const std::string& error_message);
+                     std::optional<uint64_t> connection_id, const std::string& error_message);
 
   /**
    * Clean up all reverse connection resources.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -69,7 +69,8 @@ void ReverseTunnelInitiatorExtension::emitAccessLog(
     TimeSource& time_source, const std::string& event, const std::string& node_id,
     const std::string& cluster_id, const std::string& tenant_id,
     const std::string& upstream_cluster, const std::string& host_address,
-    const std::string& connection_key, const std::string& error_message) {
+    const std::string& connection_key, const std::string& worker_id,
+    const std::string& connection_id, const std::string& error_message) {
   if (access_logs_.empty()) {
     return;
   }
@@ -88,6 +89,8 @@ void ReverseTunnelInitiatorExtension::emitAccessLog(
   fields["upstream_cluster"].set_string_value(upstream_cluster);
   fields["host_address"].set_string_value(host_address);
   fields["connection_key"].set_string_value(connection_key);
+  fields["worker_id"].set_string_value(worker_id);
+  fields["connection_id"].set_string_value(connection_id);
   fields["error"].set_string_value(error_message);
   stream_info.setDynamicMetadata("envoy.reverse_tunnel.initiator", metadata);
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -152,12 +152,15 @@ public:
    * @param upstream_cluster the name of the upstream cluster
    * @param host_address the address of the remote host
    * @param connection_key the unique key identifying the connection
+   * @param worker_id the initiator worker (dispatcher name) that opened the connection
+   * @param connection_id the initiator's per-connection identifier
    * @param error_message the error message (empty on success)
    */
   void emitAccessLog(TimeSource& time_source, const std::string& event, const std::string& node_id,
                      const std::string& cluster_id, const std::string& tenant_id,
                      const std::string& upstream_cluster, const std::string& host_address,
-                     const std::string& connection_key, const std::string& error_message);
+                     const std::string& connection_key, const std::string& worker_id,
+                     const std::string& connection_id, const std::string& error_message);
 
   /**
    * Increment handshake stats for reverse tunnel connections (per-worker only).

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension.cc
@@ -200,6 +200,10 @@ void ReverseTunnelAcceptorExtension::populateLifecycleStreamInfo(
     maybeSetStringFilterState(*filter_state, kFilterStateClusterId, lifecycle.cluster_id);
     maybeSetStringFilterState(*filter_state, kFilterStateTenantId, lifecycle.tenant_id);
     maybeSetStringFilterState(*filter_state, kFilterStateWorker, lifecycle.worker);
+    maybeSetStringFilterState(*filter_state, kFilterStateInitiatorWorkerId,
+                              lifecycle.initiator_worker_id);
+    maybeSetStringFilterState(*filter_state, kFilterStateInitiatorConnectionId,
+                              lifecycle.initiator_connection_id);
     if (lifecycle.fd >= 0) {
       maybeSetUint64FilterState(*filter_state, kFilterStateFd, lifecycle.fd);
     }
@@ -211,6 +215,8 @@ void ReverseTunnelAcceptorExtension::populateLifecycleStreamInfo(
   setStringMetadataField(metadata, "cluster_id", lifecycle.cluster_id);
   setStringMetadataField(metadata, "tenant_id", lifecycle.tenant_id);
   setStringMetadataField(metadata, "worker", lifecycle.worker);
+  setStringMetadataField(metadata, "initiator_worker_id", lifecycle.initiator_worker_id);
+  setStringMetadataField(metadata, "initiator_connection_id", lifecycle.initiator_connection_id);
   setStringMetadataField(metadata, "socket_state", socketStateForEvent(event, lifecycle));
   if (!handoff_kind.empty()) {
     setStringMetadataField(metadata, "handoff_kind", handoff_kind);

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_lifecycle_info.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_lifecycle_info.h
@@ -21,13 +21,18 @@ struct ReverseTunnelLifecycleInfo {
   std::string tenant_id;
   Network::Address::InstanceConstSharedPtr local_address;
   Network::Address::InstanceConstSharedPtr remote_address;
+  // The acceptor's own worker (dispatcher name) that owns this socket.
   std::string worker;
+  // The initiator's worker and connection identifiers, extracted from the handshake. Empty when the
+  // initiator did not advertise them. Distinct from ``worker`` above, which is the acceptor's.
+  std::string initiator_worker_id;
+  std::string initiator_connection_id;
   int fd{-1};
   bool handed_off_to_upstream{false};
   bool upstream_lifecycle_filter_attached{false};
   bool socket_dead_notified{false};
   bool close_log_emitted{false};
-  std::string close_reason;
+  std::string close_reason{};
 };
 
 inline constexpr absl::string_view kAccessLogMetadataNamespace = "envoy.reverse_tunnel.lifecycle";
@@ -37,6 +42,10 @@ inline constexpr absl::string_view kFilterStateClusterId = "envoy.reverse_tunnel
 inline constexpr absl::string_view kFilterStateTenantId = "envoy.reverse_tunnel.tenant_id";
 inline constexpr absl::string_view kFilterStateWorker = "envoy.reverse_tunnel.worker";
 inline constexpr absl::string_view kFilterStateFd = "envoy.reverse_tunnel.fd";
+inline constexpr absl::string_view kFilterStateInitiatorWorkerId =
+    "envoy.reverse_tunnel.initiator_worker_id";
+inline constexpr absl::string_view kFilterStateInitiatorConnectionId =
+    "envoy.reverse_tunnel.initiator_connection_id";
 
 inline constexpr absl::string_view kLifecycleEventTunnelSetup = "tunnel_setup";
 inline constexpr absl::string_view kLifecycleEventIdlePingSent = "idle_ping_sent";

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_upstream_lifecycle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_upstream_lifecycle.cc
@@ -99,6 +99,10 @@ Network::FilterStatus ReverseTunnelUpstreamLifecycleFilter::onNewConnection() {
     maybeSetStringFilterState(*filter_state, kFilterStateClusterId, lifecycle_->cluster_id);
     maybeSetStringFilterState(*filter_state, kFilterStateTenantId, lifecycle_->tenant_id);
     maybeSetStringFilterState(*filter_state, kFilterStateWorker, lifecycle_->worker);
+    maybeSetStringFilterState(*filter_state, kFilterStateInitiatorWorkerId,
+                              lifecycle_->initiator_worker_id);
+    maybeSetStringFilterState(*filter_state, kFilterStateInitiatorConnectionId,
+                              lifecycle_->initiator_connection_id);
     if (lifecycle_->fd >= 0) {
       maybeSetUint64FilterState(*filter_state, kFilterStateFd, lifecycle_->fd);
     }

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -100,23 +100,24 @@ UpstreamSocketManager::pickLeastLoadedSocketManager(const std::string& node_id,
   return *target_socket_manager;
 }
 
-void UpstreamSocketManager::handoffSocketToWorker(const std::string& node_id,
-                                                  const std::string& cluster_id,
-                                                  Network::ConnectionSocketPtr socket,
-                                                  const std::chrono::seconds& ping_interval,
-                                                  absl::string_view tenant_id) {
+void UpstreamSocketManager::handoffSocketToWorker(
+    const std::string& node_id, const std::string& cluster_id, Network::ConnectionSocketPtr socket,
+    const std::chrono::seconds& ping_interval, absl::string_view tenant_id,
+    absl::string_view initiator_worker_id, absl::string_view initiator_connection_id) {
   dispatcher_.post([this, node_id, cluster_id, ping_interval, tenant_id = std::string(tenant_id),
+                    initiator_worker_id = std::string(initiator_worker_id),
+                    initiator_connection_id = std::string(initiator_connection_id),
                     socket = std::move(socket)]() mutable -> void {
     this->addConnectionSocket(node_id, cluster_id, std::move(socket), ping_interval,
-                              true /* rebalanced */, tenant_id);
+                              true /* rebalanced */, tenant_id, initiator_worker_id,
+                              initiator_connection_id);
   });
 }
 
-void UpstreamSocketManager::addConnectionSocket(const std::string& node_id,
-                                                const std::string& cluster_id,
-                                                Network::ConnectionSocketPtr socket,
-                                                const std::chrono::seconds& ping_interval,
-                                                bool rebalanced, absl::string_view tenant_id) {
+void UpstreamSocketManager::addConnectionSocket(
+    const std::string& node_id, const std::string& cluster_id, Network::ConnectionSocketPtr socket,
+    const std::chrono::seconds& ping_interval, bool rebalanced, absl::string_view tenant_id,
+    absl::string_view initiator_worker_id, absl::string_view initiator_connection_id) {
   const std::string scoped_node_id =
       maybeBuildTenantScopedIdentifier(tenant_isolation_enabled_, tenant_id, node_id);
   const std::string scoped_cluster_id =
@@ -132,7 +133,7 @@ void UpstreamSocketManager::addConnectionSocket(const std::string& node_id,
                 "{} cluster: {}",
                 node_id, cluster_id);
       target_manager.handoffSocketToWorker(node_id, cluster_id, std::move(socket), ping_interval,
-                                           tenant_id);
+                                           tenant_id, initiator_worker_id, initiator_connection_id);
       return;
     }
   }
@@ -165,18 +166,15 @@ void UpstreamSocketManager::addConnectionSocket(const std::string& node_id,
   fd_to_node_map_[fd] = scoped_node_id;
   fd_to_cluster_map_[fd] = scoped_cluster_id;
   fd_to_lifecycle_info_[fd] =
-      ReverseTunnelLifecycleInfo{node_id,
-                                 cluster_id,
-                                 std::string(tenant_id),
-                                 socket->connectionInfoProvider().localAddress(),
-                                 socket->connectionInfoProvider().remoteAddress(),
-                                 dispatcher_.name(),
-                                 fd,
-                                 false,
-                                 false,
-                                 false,
-                                 false,
-                                 ""};
+      ReverseTunnelLifecycleInfo{.node_id = node_id,
+                                 .cluster_id = cluster_id,
+                                 .tenant_id = std::string(tenant_id),
+                                 .local_address = socket->connectionInfoProvider().localAddress(),
+                                 .remote_address = socket->connectionInfoProvider().remoteAddress(),
+                                 .worker = dispatcher_.name(),
+                                 .initiator_worker_id = std::string(initiator_worker_id),
+                                 .initiator_connection_id = std::string(initiator_connection_id),
+                                 .fd = fd};
   node_to_active_fd_count_[scoped_node_id]++;
 
   // Create per-connection timeout timer for ping responses.

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.h
@@ -49,11 +49,16 @@ public:
    * @param socket the socket to be added.
    * @param ping_interval the interval at which ping keepalives are sent.
    * @param rebalanced true if adding socket after rebalancing.
+   * @param tenant_id tenant identifier supplied by the peer.
+   * @param initiator_worker_id the initiator worker (dispatcher name) that opened the tunnel.
+   * @param initiator_connection_id the initiator's per-connection identifier.
    */
   void addConnectionSocket(const std::string& node_id, const std::string& cluster_id,
                            Network::ConnectionSocketPtr socket,
                            const std::chrono::seconds& ping_interval, bool rebalanced = true,
-                           absl::string_view tenant_id = {});
+                           absl::string_view tenant_id = {},
+                           absl::string_view initiator_worker_id = {},
+                           absl::string_view initiator_connection_id = {});
 
   /**
    * Returns true if a new reverse connection can be accepted for the given node, scoped by tenant
@@ -71,11 +76,16 @@ public:
    * @param cluster_id cluster_id of receiving cluster.
    * @param socket the socket to be added.
    * @param ping_interval the interval at which ping keepalives are sent.
+   * @param tenant_id tenant identifier supplied by the peer.
+   * @param initiator_worker_id the initiator worker (dispatcher name) that opened the tunnel.
+   * @param initiator_connection_id the initiator's per-connection identifier.
    */
   void handoffSocketToWorker(const std::string& node_id, const std::string& cluster_id,
                              Network::ConnectionSocketPtr socket,
                              const std::chrono::seconds& ping_interval,
-                             absl::string_view tenant_id = {});
+                             absl::string_view tenant_id = {},
+                             absl::string_view initiator_worker_id = {},
+                             absl::string_view initiator_connection_id = {});
 
   /**
    * Get an available reverse connection socket.

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -538,7 +538,21 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
     }
   }
 
-  parent_.processAcceptedConnection(node_id, cluster_id, tenant_id, initiation_time_ms);
+  // Extract the initiator's worker and connection identifiers if present. Both are optional so
+  // older initiators that do not advertise them are handled gracefully (empty values).
+  const auto initiator_worker_vals =
+      headers_->get(Bootstrap::ReverseConnection::reverseTunnelWorkerIdHeader());
+  const absl::string_view initiator_worker_id =
+      initiator_worker_vals.empty() ? absl::string_view{}
+                                    : initiator_worker_vals[0]->value().getStringView();
+  const auto initiator_connection_vals =
+      headers_->get(Bootstrap::ReverseConnection::reverseTunnelConnectionIdHeader());
+  const absl::string_view initiator_connection_id =
+      initiator_connection_vals.empty() ? absl::string_view{}
+                                        : initiator_connection_vals[0]->value().getStringView();
+
+  parent_.processAcceptedConnection(node_id, cluster_id, tenant_id, initiation_time_ms,
+                                    initiator_worker_id, initiator_connection_id);
   parent_.stats_.accepted_.inc();
 
   // Close the listener-side connection so tunnel bytes go to the duped fd, not back into
@@ -553,7 +567,9 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
 void ReverseTunnelFilter::processAcceptedConnection(absl::string_view node_id,
                                                     absl::string_view cluster_id,
                                                     absl::string_view tenant_id,
-                                                    int64_t initiation_time_ms) {
+                                                    int64_t initiation_time_ms,
+                                                    absl::string_view initiator_worker_id,
+                                                    absl::string_view initiator_connection_id) {
   ENVOY_CONN_LOG(debug,
                  "reverse_tunnel: connection accepted for node '{}' in cluster '{}' (tenant: '{}')",
                  read_callbacks_->connection(), node_id, cluster_id, tenant_id);
@@ -617,7 +633,8 @@ void ReverseTunnelFilter::processAcceptedConnection(absl::string_view node_id,
   ENVOY_CONN_LOG(trace, "reverse_tunnel: registering wrapped socket for reuse", connection);
   socket_manager->addConnectionSocket(std::string(node_id), std::string(cluster_id),
                                       std::move(wrapped_socket), ping_seconds,
-                                      /* rebalanced= */ config_->skipRebalancing(), tenant_id);
+                                      /* rebalanced= */ config_->skipRebalancing(), tenant_id,
+                                      initiator_worker_id, initiator_connection_id);
   ENVOY_CONN_LOG(debug, "reverse_tunnel: successfully registered wrapped socket for reuse",
                  connection);
 

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -158,7 +158,9 @@ private:
 
   // Process reverse tunnel connection.
   void processAcceptedConnection(absl::string_view node_id, absl::string_view cluster_id,
-                                 absl::string_view tenant_id, int64_t initiation_time_ms);
+                                 absl::string_view tenant_id, int64_t initiation_time_ms,
+                                 absl::string_view initiator_worker_id,
+                                 absl::string_view initiator_connection_id);
 
   ReverseTunnelFilterConfigSharedPtr config_;
   Network::ReadFilterCallbacks* read_callbacks_{nullptr};

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -149,7 +149,8 @@ protected:
   // Helper to create a DownstreamReverseConnectionIOHandle.
   std::unique_ptr<DownstreamReverseConnectionIOHandle>
   createHandle(ReverseConnectionIOHandle* parent = nullptr,
-               const std::string& connection_key = "test_connection_key") {
+               const std::string& connection_key = "test_connection_key",
+               uint64_t connection_id = 0) {
     // Create a new mock socket for each handle to avoid releasing the shared one.
     auto new_mock_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
     auto new_mock_io_handle = std::make_unique<NiceMock<Network::MockIoHandle>>();
@@ -163,7 +164,7 @@ protected:
 
     auto socket_ptr = std::unique_ptr<Network::ConnectionSocket>(new_mock_socket.release());
     return std::make_unique<DownstreamReverseConnectionIOHandle>(std::move(socket_ptr), parent,
-                                                                 connection_key);
+                                                                 connection_key, connection_id);
   }
 
   // Test fixtures.
@@ -250,7 +251,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, OnPingMessageWritesRpingToSocket
 
   auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
   auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-      std::move(socket_ptr), io_handle_.get(), "test_ping_key");
+      std::move(socket_ptr), io_handle_.get(), "test_ping_key", /*connection_id=*/1);
 
   handle->onPingMessage();
 
@@ -285,7 +286,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadRpingEchoScenarios) {
     // Create handle with the socket.
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key");
+        std::move(socket_ptr), io_handle_.get(), "test_key", /*connection_id=*/1);
 
     // Write RPING to the other end of the socket pair.
     ssize_t written = write(fds[1], rping_msg.data(), rping_msg.size());
@@ -324,7 +325,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadRpingEchoScenarios) {
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key2");
+        std::move(socket_ptr), io_handle_.get(), "test_key2", /*connection_id=*/2);
 
     const std::string app_data = "GET /path HTTP/1.1\r\n";
     const std::string combined = rping_msg + app_data;
@@ -364,7 +365,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadRpingEchoScenarios) {
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key3");
+        std::move(socket_ptr), io_handle_.get(), "test_key3", /*connection_id=*/3);
 
     const std::string http_data = "GET /path HTTP/1.1\r\n";
 
@@ -411,7 +412,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadPartialDataAndStateTransitio
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key");
+        std::move(socket_ptr), io_handle_.get(), "test_key", /*connection_id=*/1);
 
     // Write partial RPING (first 3 bytes).
     const std::string partial_rping = rping_msg.substr(0, 3);
@@ -443,7 +444,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadPartialDataAndStateTransitio
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key2");
+        std::move(socket_ptr), io_handle_.get(), "test_key2", /*connection_id=*/2);
 
     const std::string http_data = "GET /path";
 
@@ -489,7 +490,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadEchoDisabledAndErrorHandling
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key");
+        std::move(socket_ptr), io_handle_.get(), "test_key", /*connection_id=*/1);
 
     // First, disable echo by sending HTTP data.
     const std::string http_data = "HTTP/1.1";
@@ -536,7 +537,7 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ReadEchoDisabledAndErrorHandling
 
     auto socket_ptr = Network::ConnectionSocketPtr(mock_socket.release());
     auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-        std::move(socket_ptr), io_handle_.get(), "test_key2");
+        std::move(socket_ptr), io_handle_.get(), "test_key2", /*connection_id=*/2);
 
     // Close write end to simulate EOF.
     close(fds[1]);
@@ -565,7 +566,8 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, CloseAndDestructorNoDoubleClose)
   EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
 
   auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose",
+      /*connection_id=*/7);
   handle->close();
   handle.reset();
 
@@ -587,7 +589,8 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleCloseCallNoDoubleClose) {
   EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
 
   auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose",
+      /*connection_id=*/7);
   handle->close();
   handle->close();
   handle.reset();
@@ -610,7 +613,8 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, DoubleShutdownCallNoDoubleClose)
   EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(ReturnRef(*mock_socket->io_handle_));
 
   auto handle = std::make_unique<DownstreamReverseConnectionIOHandle>(
-      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose");
+      std::move(mock_socket), io_handle_.get(), "CloseAndDestructorNoDoubleClose",
+      /*connection_id=*/7);
   handle->shutdown(0);
   handle->shutdown(0);
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -746,6 +746,50 @@ TEST_F(RCConnectionWrapperTest, ConnectHonorsSuppliedInitiationTime) {
   EXPECT_EQ(timestamp_ms, supplied_ms);
 }
 
+// Test that connect() includes the worker-id and connection-id handshake headers, sourced from the
+// connection's dispatcher name and connection id respectively.
+TEST_F(RCConnectionWrapperTest, ConnectIncludesWorkerAndConnectionIdHeaders) {
+  auto mock_connection = getDeletableConn(dispatcher_);
+
+  EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, addReadFilter(_));
+  EXPECT_CALL(*mock_connection, connect());
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(98765));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+
+  auto mock_address = std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1", 8080);
+  auto mock_local_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 12345);
+
+  EXPECT_CALL(*mock_connection, connectionInfoProvider())
+      .WillRepeatedly(Invoke([mock_address,
+                              mock_local_address]() -> const Network::ConnectionInfoProvider& {
+        static auto mock_provider =
+            std::make_unique<Network::ConnectionInfoSetterImpl>(mock_local_address, mock_address);
+        return *mock_provider;
+      }));
+
+  Buffer::OwnedImpl captured_buffer;
+  EXPECT_CALL(*mock_connection, write(_, _))
+      .WillOnce(Invoke([&captured_buffer](Buffer::Instance& buffer, bool) {
+        captured_buffer.add(buffer);
+        buffer.drain(buffer.length());
+      }));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+
+  RCConnectionWrapper wrapper(*io_handle_, std::move(mock_connection), mock_host, "test-cluster");
+  wrapper.connect("test-tenant", "test-cluster", "test-node");
+
+  const std::string encoded_request = captured_buffer.toString();
+
+  // The worker id is the connection's dispatcher name ("worker_0" in this fixture).
+  EXPECT_NE(encoded_request.find("x-envoy-reverse-tunnel-worker-id: worker_0"), std::string::npos)
+      << "worker-id header not found in handshake request: " << encoded_request;
+  // The connection id is the mocked connection id.
+  EXPECT_NE(encoded_request.find("x-envoy-reverse-tunnel-connection-id: 98765"), std::string::npos)
+      << "connection-id header not found in handshake request: " << encoded_request;
+}
+
 // Test RCConnectionWrapper::connect() method with connection write failure.
 TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeWriteFailure) {
   // Create a mock connection that fails to write.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -2348,7 +2348,7 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedTriggersReInit
   }
 
   // Step 4: Simulate downstream connection closure.
-  io_handle_->onDownstreamConnectionClosed(connection_key);
+  io_handle_->onDownstreamConnectionClosed(connection_key, /*connection_id=*/12345);
 
   // Verify connection key is removed from host tracking.
   host_it = getHostToConnInfoMap().find("192.168.1.1");
@@ -3426,7 +3426,7 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedUnknownKeyIsNo
   io_handle_ = createTestIOHandle(config);
   ASSERT_NE(io_handle_, nullptr);
 
-  io_handle_->onDownstreamConnectionClosed("203.0.113.9:9999");
+  io_handle_->onDownstreamConnectionClosed("203.0.113.9:9999", /*connection_id=*/0);
   EXPECT_TRUE(getHostToConnInfoMap().empty());
 }
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -786,7 +786,7 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogNoOpsWhenEmpty) {
   // emitAccessLog should be a no-op when no access logs are configured.
   Event::SimulatedTimeSystem time_system;
   extension_->emitAccessLog(time_system, "handshake_success", "node1", "cluster1", "tenant1",
-                            "upstream_cluster", "10.0.0.1:443", "conn-key-1", "");
+                            "upstream_cluster", "10.0.0.1:443", "conn-key-1", "worker_0", "42", "");
   // No crash, no side effects — just verifying the early return.
 }
 
@@ -810,11 +810,13 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogCallsLoggers) {
         EXPECT_EQ(metadata.fields().at("upstream_cluster").string_value(), "my_upstream");
         EXPECT_EQ(metadata.fields().at("host_address").string_value(), "10.0.0.1:443");
         EXPECT_EQ(metadata.fields().at("connection_key").string_value(), "conn-123");
+        EXPECT_EQ(metadata.fields().at("worker_id").string_value(), "worker_1");
+        EXPECT_EQ(metadata.fields().at("connection_id").string_value(), "555");
         EXPECT_EQ(metadata.fields().at("error").string_value(), "");
       }));
 
   extension_->emitAccessLog(time_system, "handshake_success", "node1", "cluster1", "tenant1",
-                            "my_upstream", "10.0.0.1:443", "conn-123", "");
+                            "my_upstream", "10.0.0.1:443", "conn-123", "worker_1", "555", "");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogWithError) {
@@ -834,7 +836,8 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogWithError) {
       }));
 
   extension_->emitAccessLog(time_system, "handshake_failure", "node1", "cluster1", "tenant1",
-                            "my_upstream", "10.0.0.1:443", "conn-456", "connection refused");
+                            "my_upstream", "10.0.0.1:443", "conn-456", "worker_1", "456",
+                            "connection refused");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogMultipleLoggers) {
@@ -851,7 +854,7 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogMultipleLoggers) {
   EXPECT_CALL(*mock_log2, log(_, _));
 
   extension_->emitAccessLog(time_system, "connection_closed", "node1", "cluster1", "tenant1",
-                            "my_upstream", "10.0.0.1:443", "conn-789", "");
+                            "my_upstream", "10.0.0.1:443", "conn-789", "worker_1", "789", "");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogConnectionClosedFullMetadata) {
@@ -871,12 +874,14 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogConnectionClosedFullMet
         EXPECT_EQ(metadata.fields().at("upstream_cluster").string_value(), "us-west-cluster");
         EXPECT_EQ(metadata.fields().at("host_address").string_value(), "192.168.1.100:8443");
         EXPECT_EQ(metadata.fields().at("connection_key").string_value(), "conn-close-001");
+        EXPECT_EQ(metadata.fields().at("worker_id").string_value(), "worker_3");
+        EXPECT_EQ(metadata.fields().at("connection_id").string_value(), "1001");
         EXPECT_EQ(metadata.fields().at("error").string_value(), "");
       }));
 
   extension_->emitAccessLog(time_system, "connection_closed", "node-abc", "cluster-xyz",
                             "tenant-123", "us-west-cluster", "192.168.1.100:8443", "conn-close-001",
-                            "");
+                            "worker_3", "1001", "");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogWithEmptyOptionalFields) {
@@ -891,12 +896,14 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogWithEmptyOptionalFields
             stream_info.dynamicMetadata().filter_metadata().at("envoy.reverse_tunnel.initiator");
         EXPECT_EQ(metadata.fields().at("event").string_value(), "handshake_success");
         EXPECT_EQ(metadata.fields().at("tenant_id").string_value(), "");
+        EXPECT_EQ(metadata.fields().at("worker_id").string_value(), "");
+        EXPECT_EQ(metadata.fields().at("connection_id").string_value(), "");
         EXPECT_EQ(metadata.fields().at("error").string_value(), "");
-        EXPECT_EQ(metadata.fields().size(), 8);
+        EXPECT_EQ(metadata.fields().size(), 10);
       }));
 
   extension_->emitAccessLog(time_system, "handshake_success", "node1", "cluster1", "",
-                            "my_upstream", "10.0.0.1:443", "conn-empty", "");
+                            "my_upstream", "10.0.0.1:443", "conn-empty", "", "", "");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogVerifiesMetadataNamespace) {
@@ -912,7 +919,8 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogVerifiesMetadataNamespa
         EXPECT_TRUE(filter_metadata.contains("envoy.reverse_tunnel.initiator"));
       }));
 
-  extension_->emitAccessLog(time_system, "handshake_success", "n", "c", "t", "u", "h", "k", "");
+  extension_->emitAccessLog(time_system, "handshake_success", "n", "c", "t", "u", "h", "k", "w",
+                            "1", "");
 }
 
 TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogErrorFieldAlwaysPresent) {
@@ -930,7 +938,7 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogErrorFieldAlwaysPresent
       }));
 
   extension_->emitAccessLog(time_system, "handshake_success", "node1", "cluster1", "tenant1",
-                            "upstream", "10.0.0.1:443", "conn-1", "");
+                            "upstream", "10.0.0.1:443", "conn-1", "worker_0", "1", "");
 }
 
 // Verifies that a provider-backed handshake formatter (%FILE_CONTENT%) resolves to the file

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_upstream_lifecycle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_upstream_lifecycle_test.cc
@@ -140,7 +140,9 @@ TEST_F(ReverseTunnelUpstreamLifecycleFilterTest,
   const int fd = 321;
   auto socket = createMockSocket(fd);
   socket_manager_->addConnectionSocket("node-c", "cluster-c", std::move(socket),
-                                       std::chrono::seconds(30), false, "tenant-c");
+                                       std::chrono::seconds(30), false, "tenant-c",
+                                       /*initiator_worker_id=*/"worker_5",
+                                       /*initiator_connection_id=*/"42");
   handed_off_socket_ = socket_manager_->getConnectionSocket("node-c");
   ASSERT_NE(handed_off_socket_, nullptr);
 
@@ -154,6 +156,8 @@ TEST_F(ReverseTunnelUpstreamLifecycleFilterTest,
   EXPECT_EQ(filterStateString(kFilterStateNodeId), "node-c");
   EXPECT_EQ(filterStateString(kFilterStateClusterId), "cluster-c");
   EXPECT_EQ(filterStateString(kFilterStateTenantId), "tenant-c");
+  EXPECT_EQ(filterStateString(kFilterStateInitiatorWorkerId), "worker_5");
+  EXPECT_EQ(filterStateString(kFilterStateInitiatorConnectionId), "42");
   EXPECT_EQ(filterStateUint64(kFilterStateFd), fd);
 
   auto access_log = std::make_shared<NiceMock<AccessLog::MockInstance>>();

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
@@ -351,6 +351,32 @@ TEST_F(TestUpstreamSocketManager, SetupLogPreservesOriginalIdentifiersWithTenant
   extension_->setTestOnlyAccessLogs({});
 }
 
+TEST_F(TestUpstreamSocketManager, SetupLogSurfacesInitiatorWorkerAndConnectionIds) {
+  auto access_log = std::make_shared<NiceMock<AccessLog::MockInstance>>();
+  extension_->setTestOnlyAccessLogs({access_log});
+
+  const int fd = 124;
+  auto socket = createMockSocket(fd, "10.0.0.1:8080", "10.0.0.2:9090");
+
+  EXPECT_CALL(*access_log, log(_, _))
+      .WillOnce(Invoke([&](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        const auto& metadata = lifecycleMetadata(stream_info);
+        EXPECT_EQ(metadata.fields().at("initiator_worker_id").string_value(), "worker_7");
+        EXPECT_EQ(metadata.fields().at("initiator_connection_id").string_value(), "9001");
+        EXPECT_EQ(filterStateString(stream_info, kFilterStateInitiatorWorkerId), "worker_7");
+        EXPECT_EQ(filterStateString(stream_info, kFilterStateInitiatorConnectionId), "9001");
+      }))
+      .RetiresOnSaturation();
+
+  socket_manager_->addConnectionSocket("node-a", "cluster-a", std::move(socket),
+                                       std::chrono::seconds(30), false, "tenant-a",
+                                       /*initiator_worker_id=*/"worker_7",
+                                       /*initiator_connection_id=*/"9001");
+
+  testing::Mock::VerifyAndClearExpectations(access_log.get());
+  extension_->setTestOnlyAccessLogs({});
+}
+
 TEST_F(TestUpstreamSocketManager, SyntheticLifecycleLogDoesNotSetConnectionId) {
   auto access_log = std::make_shared<NiceMock<AccessLog::MockInstance>>();
   extension_->setTestOnlyAccessLogs({access_log});

--- a/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/drain_aware_hcm/drain_aware_config_test.cc
@@ -280,7 +280,7 @@ TEST_F(DrainAwareConfigTest, CreateCodecDrainEnabledReverseTunnelWiresRedial) {
   auto tunnel_handle =
       std::make_unique<Bootstrap::ReverseConnection::DownstreamReverseConnectionIOHandle>(
           std::make_unique<NiceMock<Network::MockConnectionSocket>>(), parent.get(),
-          "10.0.0.1:5000");
+          "10.0.0.1:5000", /*connection_id=*/0);
   auto outer_mock = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
   ON_CALL(*outer_mock, ioHandle()).WillByDefault(ReturnRef(*tunnel_handle));
   ON_CALL(testing::Const(*outer_mock), ioHandle()).WillByDefault(ReturnRef(*tunnel_handle));

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -187,6 +187,22 @@ public:
     return headers;
   }
 
+  // Helper to craft an HTTP request that also carries the initiator worker-id and connection-id
+  // handshake headers.
+  std::string makeHttpRequestWithInitiatorIds(const std::string& method, const std::string& path,
+                                              const std::string& node, const std::string& cluster,
+                                              const std::string& tenant,
+                                              const std::string& initiator_worker_id,
+                                              const std::string& initiator_connection_id) {
+    std::string req = fmt::format("{} {} HTTP/1.1\r\n", method, path);
+    req += "Host: localhost\r\n";
+    req += makeRtHeaders(node, cluster, tenant);
+    req += "x-envoy-reverse-tunnel-worker-id: " + initiator_worker_id + "\r\n";
+    req += "x-envoy-reverse-tunnel-connection-id: " + initiator_connection_id + "\r\n";
+    req += "Content-Length: 0\r\n\r\n";
+    return req;
+  }
+
   // Helper to craft HTTP request with initiation time header.
   std::string makeHttpRequestWithInitiationTime(const std::string& method, const std::string& path,
                                                 const std::string& node, const std::string& cluster,
@@ -1646,6 +1662,48 @@ TEST_F(ReverseTunnelFilterWithUpstreamTest,
   Buffer::OwnedImpl request(makeHttpRequestWithInitiationTime(
       "GET", "/reverse_connections/request", node_id, cluster_id, tenant_id, initiation_time_ms));
   EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+}
+
+// The initiator worker-id and connection-id headers are parsed and threaded into the accepted
+// socket's lifecycle info, so lifecycle access logs can surface them.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ProcessAcceptedConnectionPropagatesInitiatorIds) {
+  const std::string node_id = "node-ids";
+  const std::string cluster_id = "cluster";
+  const std::string tenant_id = "tenant";
+  const int duped_fd = 100;
+
+  setupUpstreamExtension();
+  setupUpstreamThreadLocalSlot();
+
+  auto mock_socket = std::make_unique<Network::MockConnectionSocket>();
+  auto mock_io_handle = std::make_unique<Network::MockIoHandle>();
+  auto dup_io_handle = std::make_unique<Network::MockIoHandle>();
+
+  EXPECT_CALL(*dup_io_handle, resetFileEvents());
+  EXPECT_CALL(*dup_io_handle, fdDoNotUse()).WillRepeatedly(testing::Return(duped_fd));
+  EXPECT_CALL(*dup_io_handle, isOpen()).WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(*mock_io_handle, duplicate())
+      .WillOnce(testing::Return(testing::ByMove(std::move(dup_io_handle))));
+  EXPECT_CALL(*mock_socket, ioHandle()).WillRepeatedly(testing::ReturnRef(*mock_io_handle));
+  EXPECT_CALL(*mock_socket, isOpen()).WillRepeatedly(testing::Return(true));
+
+  static Network::ConnectionSocketPtr stored_mock_socket_ids;
+  static std::unique_ptr<Network::MockIoHandle> stored_io_handle_ids;
+  stored_io_handle_ids = std::move(mock_io_handle);
+  stored_mock_socket_ids = std::move(mock_socket);
+
+  EXPECT_CALL(callbacks_.connection_, getSocket())
+      .WillRepeatedly(testing::ReturnRef(stored_mock_socket_ids));
+
+  Buffer::OwnedImpl request(makeHttpRequestWithInitiatorIds(
+      "GET", "/reverse_connections/request", node_id, cluster_id, tenant_id, "worker_9", "314159"));
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(request, false));
+
+  const auto* lifecycle =
+      upstream_thread_local_registry_->socketManager()->getLifecycleInfo(duped_fd);
+  ASSERT_NE(lifecycle, nullptr);
+  EXPECT_EQ(lifecycle->initiator_worker_id, "worker_9");
+  EXPECT_EQ(lifecycle->initiator_connection_id, "314159");
 }
 
 TEST_F(ReverseTunnelFilterWithUpstreamTest,


### PR DESCRIPTION
Commit Message: reverse_tunnel: propagate initiator worker and connection ids

Additional Description:
The reverse-tunnel handshake carried no way to distinguish tunnels opened by different worker threads or connections of the same initiator. This adds two optional handshake headers and surfaces them on both ends so operators can tell tunnels apart and correlate a tunnel across the initiator and acceptor.

**Downstream (initiator).** `RCConnectionWrapper::connect()` now sends `x-envoy-reverse-tunnel-worker-id` (the initiator worker dispatcher name, e.g. `worker_2`) and `x-envoy-reverse-tunnel-connection-id` (the initiator's per-connection id). Both are exposed in the initiator access log via the new `worker_id` and `connection_id` fields of the `envoy.reverse_tunnel.initiator` dynamic metadata namespace. The connection id is captured at socket handoff so it is still available for the `connection_closed` event after the connection object is gone.

**Upstream (acceptor).** The `envoy.filters.network.reverse_tunnel` filter parses the two headers (best-effort; empty for older initiators) and threads them through `addConnectionSocket` into `ReverseTunnelLifecycleInfo`. They are emitted on every reverse-tunnel lifecycle event as the `initiator_worker_id` and `initiator_connection_id` fields of the `envoy.reverse_tunnel.lifecycle` dynamic metadata namespace, and as the `envoy.reverse_tunnel.initiator_worker_id` / `envoy.reverse_tunnel.initiator_connection_id` connection filter-state keys. These are distinct from the acceptor's own `worker` field.

Both directions are additive and backward compatible: an initiator that does not send the headers yields empty values, and no configuration changes are required.

Risk Level: Low
Testing: Unit tests added/updated across the downstream initiator, the acceptor socket manager, the lifecycle filter, and the network filter parse path. Full `//test/extensions/bootstrap/reverse_tunnel/...`, `//test/extensions/filters/network/reverse_tunnel/...`, and `//test/extensions/clusters/reverse_connection/...` suites pass.
Docs Changes: Updated `docs/root/configuration/other_features/reverse_tunnel.rst` (lifecycle metadata fields + filter-state keys, initiator access-log field table) and the initiator example config.
Release Notes: Added a `new_features` changelog entry.
