### PR TITLE
zookeeper_proxy: migrate config validation to exception free

### DIFF
--- a/source/extensions/filters/network/zookeeper_proxy/config.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/config.cc
@@ -18,7 +18,7 @@ namespace ZooKeeperProxy {
 /**
  * Config registration for the ZooKeeper proxy filter. @see NamedNetworkFilterConfigFactory.
  */
-Network::FilterFactoryCb ZooKeeperConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Network::FilterFactoryCb> ZooKeeperConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::network::zookeeper_proxy::v3::ZooKeeperProxy& proto_config,
     Server::Configuration::FactoryContext& context) {
 
@@ -44,16 +44,21 @@ Network::FilterFactoryCb ZooKeeperConfigFactory::createFilterFactoryFromProtoTyp
   for (const auto& threshold_override : latency_threshold_overrides) {
     auto insertion = opcodes.insert(threshold_override.opcode());
     if (!insertion.second) {
-      throw EnvoyException(fmt::format("Duplicated opcode find in config: {}",
-                                       static_cast<uint32_t>(threshold_override.opcode())));
+      return absl::InvalidArgumentError(
+          fmt::format("Duplicated opcode find in config: {}",
+                      static_cast<uint32_t>(threshold_override.opcode())));
     }
   }
+
+  absl::StatusOr<LatencyThresholdOverrideMap> latency_threshold_override_map =
+      ZooKeeperFilterConfig::parseLatencyThresholdOverrides(latency_threshold_overrides);
+  RETURN_IF_NOT_OK_REF(latency_threshold_override_map.status());
 
   ZooKeeperFilterConfigSharedPtr filter_config(std::make_shared<ZooKeeperFilterConfig>(
       stat_prefix, max_packet_bytes, enable_per_opcode_request_bytes_metrics,
       enable_per_opcode_response_bytes_metrics, enable_per_opcode_decoder_error_metrics,
-      enable_latency_threshold_metrics, default_latency_threshold, latency_threshold_overrides,
-      context.scope()));
+      enable_latency_threshold_metrics, default_latency_threshold,
+      latency_threshold_override_map.value(), context.scope()));
   auto& time_source = context.serverFactoryContext().mainThreadDispatcher().timeSource();
 
   return [filter_config, &time_source](Network::FilterManager& filter_manager) -> void {

--- a/source/extensions/filters/network/zookeeper_proxy/config.h
+++ b/source/extensions/filters/network/zookeeper_proxy/config.h
@@ -16,13 +16,13 @@ namespace ZooKeeperProxy {
  * Config registration for the ZooKeeper proxy filter.
  */
 class ZooKeeperConfigFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::network::zookeeper_proxy::v3::ZooKeeperProxy> {
 public:
-  ZooKeeperConfigFactory() : FactoryBase(NetworkFilterNames::get().ZooKeeperProxy) {}
+  ZooKeeperConfigFactory() : ExceptionFreeFactoryBase(NetworkFilterNames::get().ZooKeeperProxy) {}
 
 private:
-  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Network::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::network::zookeeper_proxy::v3::ZooKeeperProxy& proto_config,
       Server::Configuration::FactoryContext& context) override;
 };

--- a/source/extensions/filters/network/zookeeper_proxy/filter.cc
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.cc
@@ -26,7 +26,7 @@ ZooKeeperFilterConfig::ZooKeeperFilterConfig(
     const bool enable_per_opcode_response_bytes_metrics,
     const bool enable_per_opcode_decoder_error_metrics, const bool enable_latency_threshold_metrics,
     const std::chrono::milliseconds default_latency_threshold,
-    const LatencyThresholdOverrideList& latency_threshold_overrides, Stats::Scope& scope)
+    const LatencyThresholdOverrideMap& latency_threshold_override_map, Stats::Scope& scope)
     : scope_(scope), max_packet_bytes_(max_packet_bytes), stats_(generateStats(stat_prefix, scope)),
       stat_name_set_(scope.symbolTable().makeSet("Zookeeper")),
       stat_prefix_(stat_name_set_->add(stat_prefix)), auth_(stat_name_set_->add("auth")),
@@ -38,7 +38,7 @@ ZooKeeperFilterConfig::ZooKeeperFilterConfig(
       enable_per_opcode_decoder_error_metrics_(enable_per_opcode_decoder_error_metrics),
       enable_latency_threshold_metrics_(enable_latency_threshold_metrics),
       default_latency_threshold_(default_latency_threshold),
-      latency_threshold_override_map_(parseLatencyThresholdOverrides(latency_threshold_overrides)) {
+      latency_threshold_override_map_(latency_threshold_override_map) {
   // https://zookeeper.apache.org/doc/r3.5.4-beta/zookeeperProgrammers.html#sc_BuiltinACLSchemes
   // lists commons schemes: "world", "auth", "digest", "host", "x509", and
   // "ip". These are used in filter.cc by appending "_rq".
@@ -171,20 +171,24 @@ void ZooKeeperFilterConfig::initOpCode(OpCodes opcode, Stats::Counter& resp_coun
   opcode_info.latency_name_ = stat_name_set_->add(absl::StrCat(name, "_latency"));
 }
 
-int32_t ZooKeeperFilterConfig::getOpCodeIndex(LatencyThresholdOverride_Opcode opcode) {
+absl::StatusOr<int32_t>
+ZooKeeperFilterConfig::getOpCodeIndex(LatencyThresholdOverride_Opcode opcode) {
   const OpcodeMap& opcode_map = opcodeMap();
   auto it = opcode_map.find(opcode);
   if (it != opcode_map.end()) {
     return it->second;
   }
-  throw EnvoyException(fmt::format("Unknown opcode from config: {}", static_cast<int32_t>(opcode)));
+  return absl::InvalidArgumentError(
+      fmt::format("Unknown opcode from config: {}", static_cast<int32_t>(opcode)));
 }
 
-LatencyThresholdOverrideMap ZooKeeperFilterConfig::parseLatencyThresholdOverrides(
+absl::StatusOr<LatencyThresholdOverrideMap> ZooKeeperFilterConfig::parseLatencyThresholdOverrides(
     const LatencyThresholdOverrideList& latency_threshold_overrides) {
   LatencyThresholdOverrideMap latency_threshold_override_map;
   for (const auto& threshold_override : latency_threshold_overrides) {
-    latency_threshold_override_map[getOpCodeIndex(threshold_override.opcode())] =
+    absl::StatusOr<int32_t> opcode_index = getOpCodeIndex(threshold_override.opcode());
+    RETURN_IF_NOT_OK_REF(opcode_index.status());
+    latency_threshold_override_map[opcode_index.value()] =
         std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(threshold_override, threshold));
   }
   return latency_threshold_override_map;

--- a/source/extensions/filters/network/zookeeper_proxy/filter.h
+++ b/source/extensions/filters/network/zookeeper_proxy/filter.h
@@ -256,8 +256,13 @@ public:
                         const bool enable_per_opcode_decoder_error_metrics,
                         const bool enable_latency_threshold_metrics,
                         const std::chrono::milliseconds default_latency_threshold,
-                        const LatencyThresholdOverrideList& latency_threshold_overrides,
+                        const LatencyThresholdOverrideMap& latency_threshold_override_map,
                         Stats::Scope& scope);
+
+  // Parses the latency threshold overrides from the config into a map keyed by the opcode enum
+  // value defined in decoder.h. Returns an error status if an unknown opcode is present.
+  static absl::StatusOr<LatencyThresholdOverrideMap>
+  parseLatencyThresholdOverrides(const LatencyThresholdOverrideList& latency_threshold_overrides);
 
   const ZooKeeperProxyStats& stats() { return stats_; }
   uint32_t maxPacketBytes() const { return max_packet_bytes_; }
@@ -338,9 +343,7 @@ private:
                                        {LatencyThresholdOverride::AddWatch, 106}});
   }
 
-  int32_t getOpCodeIndex(LatencyThresholdOverride_Opcode opcode);
-  LatencyThresholdOverrideMap
-  parseLatencyThresholdOverrides(const LatencyThresholdOverrideList& latency_threshold_overrides);
+  static absl::StatusOr<int32_t> getOpCodeIndex(LatencyThresholdOverride_Opcode opcode);
 
   const bool enable_latency_threshold_metrics_;
   const std::chrono::milliseconds default_latency_threshold_;

--- a/test/extensions/filters/network/zookeeper_proxy/BUILD
+++ b/test/extensions/filters/network/zookeeper_proxy/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/network/zookeeper_proxy:config",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/network/zookeeper_proxy/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/network/zookeeper_proxy/config_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/config_test.cc
@@ -5,6 +5,7 @@
 #include "source/extensions/filters/network/zookeeper_proxy/filter.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -14,6 +15,9 @@ namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace ZooKeeperProxy {
+
+using StatusHelpers::HasStatus;
+using testing::HasSubstr;
 
 using ZooKeeperProxyProtoConfig =
     envoy::extensions::filters::network::zookeeper_proxy::v3::ZooKeeperProxy;
@@ -167,9 +171,23 @@ latency_threshold_overrides:
   )EOF";
 
   TestUtility::loadFromYamlAndValidate(yaml, proto_config_);
-  EXPECT_THROW_WITH_REGEX(
-      ZooKeeperConfigFactory().createFilterFactoryFromProto(proto_config_, context_).IgnoreError(),
-      EnvoyException, "Duplicated opcode find in config");
+  EXPECT_THAT(
+      ZooKeeperConfigFactory().createFilterFactoryFromProto(proto_config_, context_),
+      HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr("Duplicated opcode find in config")));
+}
+
+// The unknown opcode error path is unreachable through a validated proto config (the opcode
+// enum is validated as defined_only and every defined value is mapped), so call the parse
+// helper directly with an out-of-range opcode.
+TEST_F(ZookeeperFilterConfigTest, UnknownOpcodeInLatencyThresholdOverrides) {
+  LatencyThresholdOverrideList latency_threshold_overrides;
+  LatencyThresholdOverride* threshold_override = latency_threshold_overrides.Add();
+  threshold_override->set_opcode(static_cast<LatencyThresholdOverride_Opcode>(999));
+  threshold_override->mutable_threshold()->set_nanos(150000000);
+
+  EXPECT_THAT(
+      ZooKeeperFilterConfig::parseLatencyThresholdOverrides(latency_threshold_overrides),
+      HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr("Unknown opcode from config: 999")));
 }
 
 TEST_F(ZookeeperFilterConfigTest, SimpleConfig) {

--- a/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
+++ b/test/extensions/filters/network/zookeeper_proxy/filter_test.cc
@@ -39,7 +39,8 @@ public:
     config_ = std::make_shared<ZooKeeperFilterConfig>(
         stat_prefix_, 1048576, enable_per_opcode_request_bytes_metrics,
         enable_per_opcode_response_bytes_metrics, enable_per_opcode_decoder_error_metrics,
-        enable_latency_threshold_metrics, default_latency_threshold, latency_threshold_overrides,
+        enable_latency_threshold_metrics, default_latency_threshold,
+        ZooKeeperFilterConfig::parseLatencyThresholdOverrides(latency_threshold_overrides).value(),
         scope_);
     filter_ = std::make_unique<ZooKeeperFilter>(config_, time_system_);
     filter_->initializeReadFilterCallbacks(filter_callbacks_);

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -210,7 +210,6 @@ paths:
     - source/extensions/filters/network/dubbo_proxy
     - source/extensions/filters/network/common
     - source/extensions/filters/network/redis_proxy
-    - source/extensions/filters/network/zookeeper_proxy
     - source/extensions/filters/network/ext_authz
     - source/extensions/filters/network/ext_proc
     - source/extensions/filters/network/mongo_proxy


### PR DESCRIPTION
The zookeeper_proxy network filter was one of the few remaining network filters whose config factory still threw `EnvoyException` instead of returning `absl::StatusOr`, which kept its whole directory on the `tools/code_format/config.yaml` exception allowlist and outside the no-throw check. This change switches `ZooKeeperConfigFactory` from `Common::FactoryBase` to `Common::ExceptionFreeFactoryBase` so `createFilterFactoryFromProtoTyped` returns `absl::StatusOr<Network::FilterFactoryCb>`, converts the two config-time throws (the duplicated-opcode check and the unknown-opcode lookup) to `absl::InvalidArgumentError` with byte-identical message text, and removes the zookeeper_proxy entry from the exception allowlist so check_format now enforces no-throw for the entire directory. The ZooKeeper filter's data plane was already made exception free in #31485; these two config-time throws were all that remained, so this finishes zookeeper_proxy specifically. It continues the exception-free migration tracked in #27412, following the same pattern as recently merged network-filter (#46111) and HTTP-filter (#46042) work.

**Commit Message:** zookeeper_proxy: migrate config validation to exception free

**Additional Description:** `parseLatencyThresholdOverrides` becomes a public static helper returning `absl::StatusOr<LatencyThresholdOverrideMap>`; the factory parses before constructing `ZooKeeperFilterConfig`, whose constructor now takes the parsed map and can no longer fail.

**Risk Level:** Low. Config-load-time only refactor with no data plane change; error messages and failure semantics are unchanged (`EnvoyException` becomes `absl::InvalidArgumentError` with identical text, surfaced through the same config rejection path).

**Testing:**
- `//test/extensions/filters/network/zookeeper_proxy:config_test` and `:filter_test` pass in the CI clang docker image. The duplicated-opcode case was converted from `EXPECT_THROW_WITH_REGEX` to a status matcher with the identical message substring; a new `UnknownOpcodeInLatencyThresholdOverrides` test calls the now-public static helper directly with an out-of-range opcode and asserts `InvalidArgumentError` with the identical text, covering the error branch so per-directory coverage does not regress. filter_test's existing tests run unchanged through the updated `initialize()` helper.
- Countable metric: throw sites in the directory go from 2 to 0 (`grep -rE 'throw|THROW'`), and the allowlist entry is removed. Mutation proof: with the allowlist entry removed, injecting a `throw` into filter.cc makes `check_format` fail with "Don't introduce throws into exception-free files"; at the parent commit the same injected throw passes, confirming the directory is now enforced.

**Docs Changes:** N/A

**Release Notes:** N/A (internal refactor, no behavior change; matches the no-changelog precedent of #46111 and #46042)

**Platform Specific Features:** N/A

Part of #27412

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
