### PR TITLE
thrift_proxy: use 64-bit arithmetic in lax binary readMessageBegin length check

### DIFF
--- a/changelogs/current/bug_fixes/thrift_proxy__lax-binary-message-length-overflow.rst
+++ b/changelogs/current/bug_fixes/thrift_proxy__lax-binary-message-length-overflow.rst
@@ -1,0 +1,5 @@
+Fixed a 32-bit integer overflow in the ``thrift_proxy`` lax (non-strict) binary protocol decoder.
+A message name length of 0xFFFFFFF7 or greater wrapped the insufficient-data check in
+``readMessageBegin`` and raised a spurious decode error that closed the downstream connection. The
+check is now performed in 64-bit arithmetic and the decoder waits for more data instead, matching
+the strict binary protocol.

--- a/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
+++ b/source/extensions/filters/network/thrift_proxy/binary_protocol_impl.cc
@@ -389,7 +389,7 @@ bool LaxBinaryProtocolImpl::readMessageBegin(Buffer::Instance& buffer, MessageMe
 
   uint32_t name_len = buffer.peekBEInt<uint32_t>();
 
-  if (buffer.length() < 9 + name_len) {
+  if (buffer.length() < static_cast<uint64_t>(name_len) + 9) {
     return false;
   }
 

--- a/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
+++ b/test/extensions/filters/network/thrift_proxy/binary_protocol_impl_test.cc
@@ -962,6 +962,36 @@ TEST_F(LaxBinaryProtocolTest, ReadMessageBegin) {
     EXPECT_EQ(buffer.length(), 9);
   }
 
+  // Name length that wraps 32-bit arithmetic in the insufficient-data check
+  {
+    Buffer::OwnedImpl buffer;
+    resetMetadata();
+
+    buffer.writeBEInt<uint32_t>(0xFFFFFFF7); // name length
+    addRepeated(buffer, 5, 'x');
+
+    bool result = true;
+    EXPECT_NO_THROW(result = proto.readMessageBegin(buffer, metadata_));
+    EXPECT_FALSE(result);
+    expectDefaultMetadata();
+    EXPECT_EQ(buffer.length(), 9);
+  }
+
+  // Name length whose wrapped peek offset lands inside the length field itself
+  {
+    Buffer::OwnedImpl buffer;
+    resetMetadata();
+
+    buffer.writeBEInt<uint32_t>(0xFFFFFFFF); // name length
+    addRepeated(buffer, 5, 'x');
+
+    bool result = true;
+    EXPECT_NO_THROW(result = proto.readMessageBegin(buffer, metadata_));
+    EXPECT_FALSE(result);
+    expectDefaultMetadata();
+    EXPECT_EQ(buffer.length(), 9);
+  }
+
   // Named message
   {
     Buffer::OwnedImpl buffer;


### PR DESCRIPTION
`LaxBinaryProtocolImpl::readMessageBegin` reads a 32-bit big-endian method-name length from the wire and then guards its insufficient-data check with `if (buffer.length() < 9 + name_len)`. Because `name_len` is a `uint32_t` and `9` is an `int`, the addition is performed in 32-bit unsigned arithmetic and wraps for `name_len` in `[0xFFFFFFF7, 0xFFFFFFFF]`, so the needs-more-data check is bypassed on a buffer as small as 9 bytes. Execution then falls through and throws `EnvoyException` ("buffer underflow" for the lower part of that range, or "invalid (lax) binary protocol message type -1" for the top), which the connection manager treats as a decode error: it increments the `request_decoding_error_` stat and closes the downstream connection, resetting any other in-flight RPCs multiplexed on it. The correct behavior for an out-of-range length is to return false and wait for more data.

The fix performs the comparison as `buffer.length() < static_cast<uint64_t>(name_len) + 9` so the addition is 64-bit and cannot wrap, mirroring the strict binary protocol's already-correct check (`binary_protocol_impl.cc:41`, where the minimum length is a `constexpr uint64_t`). This is not a crash: the throw always fires before the `linearize` release assert on this path.

**Commit Message:** thrift_proxy: use 64-bit arithmetic in lax binary readMessageBegin length check

**Additional Description:** see above

**Risk Level:** Low. Strictly narrowing decoder fix; only name lengths of 0xFFFFFFF7 and above change behavior, from a thrown exception (decode-error stat plus connection close) to a clean needs-more-data return, and no valid Thrift message declares a roughly 4 GB method name.

**Testing:** Two regression sub-cases added inside `LaxBinaryProtocolTest.ReadMessageBegin` (name_len 0xFFFFFFF7 and 0xFFFFFFFF on exact 9-byte buffers, asserting no throw, a false return, unchanged buffer length, and default metadata). Red before the fix (both throw `EnvoyException`: "buffer underflow" and "invalid (lax) binary protocol message type -1"), green after. `//test/extensions/filters/network/thrift_proxy:binary_protocol_impl_test` passes filtered and whole-file in the CI clang docker image; check_format passes.

**Docs Changes:** N/A

**Release Notes:** changelogs/current/bug_fixes/thrift_proxy__lax-binary-message-length-overflow.rst

**Platform Specific Features:** N/A

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
