### PR TITLE
tcp_tunneling: fix and re-enable flaky EarlyConnectDataRejectedWithOverride test

### DIFF
--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -503,9 +503,6 @@ TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
 }
 
 TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) {
-  // TODO(yanavlasov): fix the test
-  GTEST_SKIP() << "Test is too flaky for CI. "
-                  "https://github.com/envoyproxy/envoy/issues/39856#issuecomment-3637976574";
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {
@@ -525,11 +522,9 @@ TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) 
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   // Send CONNECT request and immediately send some data without waiting for 200
-  // response from Envoy.
-  auto encoder_decoder = codec_client_->startRequest(connect_headers_);
-  request_encoder_ = &encoder_decoder.first;
-  codec_client_->sendData(*request_encoder_, "premature data", false);
-  response_ = std::move(encoder_decoder.second);
+  // response from Envoy. Encode the CONNECT headers and the premature data into a single
+  // socket write so the data cannot race behind the synthesized 200 tunnel response.
+  response_ = codec_client_->makeRequestWithBody(connect_headers_, "premature data", false);
 
   // Envoy will try top open upstream connection before the premature CONNECT data is detected.
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_raw_upstream_connection_));
@@ -568,6 +563,53 @@ TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataAllowedByDefault) {
   response_->waitForHeaders();
   response_->waitForBodyData(strlen("upstream_send_data"));
   EXPECT_EQ("upstream_send_data", response_->body());
+
+  codec_client_->sendData(*request_encoder_, "", true);
+  ASSERT_TRUE(fake_raw_upstream_connection_->waitForHalfClose());
+
+  ASSERT_TRUE(fake_raw_upstream_connection_->close());
+  if (downstream_protocol_ == Http::CodecType::HTTP1) {
+    ASSERT_TRUE(codec_client_->waitForDisconnect());
+  } else {
+    ASSERT_TRUE(response_->waitForEndStream());
+    ASSERT_FALSE(response_->reset());
+  }
+  cleanupUpstreamAndDownstream();
+}
+
+TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataAfterResponseTunneled) {
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        for (auto& filter : *hcm.mutable_http_filters()) {
+          if (filter.name() == "envoy.filters.http.router") {
+            envoy::extensions::filters::http::router::v3::Router router_config;
+            if (filter.has_typed_config()) {
+              std::ignore = filter.typed_config().UnpackTo(&router_config);
+            }
+            router_config.mutable_reject_connect_request_early_data()->set_value(true);
+            std::ignore = filter.mutable_typed_config()->PackFrom(router_config);
+            break;
+          }
+        }
+      });
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  // Send the CONNECT request and wait for the 200 response before sending any data.
+  auto encoder_decoder = codec_client_->startRequest(connect_headers_);
+  request_encoder_ = &encoder_decoder.first;
+  response_ = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_raw_upstream_connection_));
+  response_->waitForHeaders();
+  EXPECT_EQ(response_->headers().getStatusValue(), "200");
+
+  // Data sent after the 200 response has started is legitimate tunnel data, so it is
+  // forwarded upstream rather than rejected as early CONNECT data.
+  codec_client_->sendData(*request_encoder_, "late data", false);
+  ASSERT_TRUE(fake_raw_upstream_connection_->waitForData(
+      FakeRawConnection::waitForInexactMatch("late data")));
 
   codec_client_->sendData(*request_encoder_, "", true);
   ASSERT_TRUE(fake_raw_upstream_connection_->waitForHalfClose());


### PR DESCRIPTION
This fixes and re-enables `ConnectTerminationIntegrationTest.EarlyConnectDataRejectedWithOverride`, which was `GTEST_SKIP`'d as too flaky and left the `reject_connect_request_early_data` security feature without coverage. The test sent the CONNECT headers via `startRequest()` (one socket write) and the premature payload via `sendData()` (a second, separate write). Two writes let Envoy read and dispatch the CONNECT headers, complete the upstream TCP connect on a later event-loop iteration, and synthesize the `200` tunnel-established response (`TcpUpstream::encodeHeaders`, `upstream_request.cc:73-78`) before the data arrived. That forwarded 200 sets `downstream_response_started_` (`router.cc:1801`/`:2014`), so `Filter::isEarlyConnectData()` (`router.cc:1078-1081`) returns false and the data is tunneled instead of taking the 400 reject branch; the test then saw 200 instead of 400 and timed out in `waitForEndStream`. This is the exact failure recorded on #39856.

The fix encodes the CONNECT headers and the premature payload into a single socket write via `makeRequestWithBody(connect_headers_, "premature data", false)`, so the data cannot race behind the synthesized 200. Post-200 payload is legitimate tunnel data by definition, so the enforcement point (before response start) is semantically correct and only the test needs ordering robustness; every historically passing run already had this ordering. A permanent companion test, `EarlyConnectDataAfterResponseTunneled`, pins the other side: with reject enabled, data sent after the 200 has started is tunneled, not rejected.

Primary flake evidence (four CI failures on #39856):
- https://github.com/envoyproxy/envoy/actions/runs/19932640369/job/57148611955#step:20:1338
- https://github.com/envoyproxy/envoy/actions/runs/19939392749/job/57172970688#step:20:1286
- https://github.com/envoyproxy/envoy/actions/runs/19942275183/job/57182893149#step:20:1177
- https://github.com/envoyproxy/envoy/actions/runs/20084391694/job/57618583853#step:21:1864

**Commit Message:** tcp_tunneling: fix and re-enable flaky EarlyConnectDataRejectedWithOverride test

**Additional Description:** The single-write determinism argument is scoped to HTTP/1 downstream (the recorded-failure protocol): the HTTP/1 codec emits the CONNECT headers and payload into one buffer with no Transfer-Encoding or Content-Length injected. For HTTP/2 and HTTP/3, server-side dispatch and QUIC packetization are not statically guaranteed to keep headers and data in one read, so those rest on the empirical multi-run gate below rather than the static argument. A single writev on loopback is in practice, not formally, a single read, so the run gate is the empirical bound offered.

**Risk Level:** Low. Test-only change; no production code, no API, no changelog.

**Testing:** Fixed test passes 50/50 runs per parameter with sharding disabled and no cache (all instantiated downstream HTTP/1, HTTP/2, and HTTP/3 x IP-version parameters), 0 failures, in the CI clang docker image; the new companion test passes on every parameter. The two-write race was reproduced deterministically as a mechanism demonstration on a modified copy of the test (waiting for the 200 before sending data yields status 200 instead of 400 with the payload tunneled, matching the recorded CI signature); that demo is not committed. The sibling `EarlyConnectDataAllowedByDefault` and the full target still pass.

**Docs Changes:** N/A

**Release Notes:** N/A (test-only)

**Platform Specific Features:** N/A

This fixes the EarlyConnectDataRejectedWithOverride flake tracked in #39856 (the issue tracks several distinct flakes, so it is not auto-closed).

**Generative AI disclosure:** Developed with AI assistance (Claude Code); I reviewed and understand every line and take full ownership of the submission.
