### PR TITLE
fix: quic stream buffer underflow on HTTP/3 Request

### DIFF
--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -502,7 +502,6 @@ void EnvoyQuicClientStream::OnClose() {
   clearWatermarkBuffer();
 }
 
-
 void EnvoyQuicClientStream::OnCanWrite() {
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
   quic::QuicSpdyClientStream::OnCanWrite();

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -502,13 +502,6 @@ void EnvoyQuicClientStream::OnClose() {
   clearWatermarkBuffer();
 }
 
-void EnvoyQuicClientStream::clearWatermarkBuffer() {
-  if (BufferedDataBytes() > 0) {
-    // If the stream is closed without sending out all buffered data, regard
-    // them as sent now and adjust connection buffer book keeping.
-    updateBytesBuffered(BufferedDataBytes(), 0);
-  }
-}
 
 void EnvoyQuicClientStream::OnCanWrite() {
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);

--- a/source/common/quic/envoy_quic_client_stream.h
+++ b/source/common/quic/envoy_quic_client_stream.h
@@ -78,8 +78,6 @@ public:
   void OnConnectionClosed(const quic::QuicConnectionCloseFrame& frame,
                           quic::ConnectionCloseSource source) override;
 
-  void clearWatermarkBuffer();
-
   // quic::QuicSpdyStream::MetadataVisitor
   void OnMetadataComplete(size_t frame_len, const quic::QuicHeaderList& header_list) override;
 

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -487,13 +487,6 @@ void EnvoyQuicServerStream::OnClose() {
   stats_gatherer_ = nullptr;
 }
 
-void EnvoyQuicServerStream::clearWatermarkBuffer() {
-  if (BufferedDataBytes() > 0) {
-    // If the stream is closed without sending out all buffered data, regard
-    // them as sent now and adjust connection buffer book keeping.
-    updateBytesBuffered(BufferedDataBytes(), 0);
-  }
-}
 
 void EnvoyQuicServerStream::OnCanWrite() {
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -487,7 +487,6 @@ void EnvoyQuicServerStream::OnClose() {
   stats_gatherer_ = nullptr;
 }
 
-
 void EnvoyQuicServerStream::OnCanWrite() {
   SendBufferMonitor::ScopedWatermarkBufferUpdater updater(this, this);
   quic::QuicSpdyServerStreamBase::OnCanWrite();

--- a/source/common/quic/envoy_quic_server_stream.h
+++ b/source/common/quic/envoy_quic_server_stream.h
@@ -92,8 +92,6 @@ public:
                           quic::ConnectionCloseSource source) override;
   void CloseWriteSide() override;
 
-  void clearWatermarkBuffer();
-
   // EnvoyQuicStream
   Http::HeaderUtility::HeaderValidationResult
   validateHeader(absl::string_view header_name, absl::string_view header_value) override;

--- a/source/common/quic/envoy_quic_stream.h
+++ b/source/common/quic/envoy_quic_stream.h
@@ -205,6 +205,13 @@ protected:
   onStreamError(std::optional<bool> should_close_connection,
                 quic::QuicRstStreamErrorCode rst = quic::QUIC_BAD_APPLICATION_PAYLOAD) PURE;
 
+  // Drain the stream's contribution to the connection-level bytes_to_send_ counter on close.
+  void clearWatermarkBuffer() {
+    if (reported_buffered_bytes_ > 0) {
+      updateBytesBuffered(reported_buffered_bytes_, 0);
+    }
+  }
+
   // TODO(danzh) remove this once QUICHE enforces content-length consistency.
   void updateReceivedContentBytes(size_t payload_length, bool end_stream) {
     received_content_bytes_ += payload_length;

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -1184,5 +1184,32 @@ TEST_F(EnvoyQuicServerStreamTest, InconsistentContentLengthHeadersOnlyDisabled) 
   quic_stream_->encodeHeaders(response_headers_, /*end_stream=*/true);
 }
 
+TEST_F(EnvoyQuicServerStreamTest, OnCloseDoesNotUnderflowBytesToSendWithUnreportedBufferedBytes) {
+  // make WritevData consume nothing so bytes stay buffered in the QUIC send buffer.
+  EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
+      .WillRepeatedly(
+          Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
+                    quic::StreamSendingState, bool, std::optional<quic::EncryptionLevel>) {
+            return quic::QuicConsumedData{0, false};
+          }));
+
+  // simulate QUICHE writing bytes directly to the stream send buffer without going through
+  // ScopedWatermarkBufferUpdater.
+  std::string fake_settings_payload(41, '\0');
+  quic_stream_->WriteOrBufferData(fake_settings_payload, false, nullptr);
+  EXPECT_EQ(41u, quic_stream_->BufferedDataBytes());
+  EXPECT_EQ(0u, quic_session_.bytesToSend());
+
+  // deliver a request with FIN so that OnClose() is triggered on encodeHeaders end_stream=true.
+  receiveRequest(request_body_, true, request_body_.size() * 2);
+
+  EXPECT_LOG_NOT_CONTAINS("error", "Underflowed",
+                          quic_stream_->encodeHeaders(response_headers_, true));
+
+  // confirm no underflow: headers buffered bytes_to_send_ is positive not wrapped to near UINT64_MAX.
+  EXPECT_GT(quic_session_.bytesToSend(), 0u);
+  EXPECT_LT(quic_session_.bytesToSend(), 1000u);
+}
+
 } // namespace Quic
 } // namespace Envoy

--- a/test/common/quic/envoy_quic_server_stream_test.cc
+++ b/test/common/quic/envoy_quic_server_stream_test.cc
@@ -1187,11 +1187,9 @@ TEST_F(EnvoyQuicServerStreamTest, InconsistentContentLengthHeadersOnlyDisabled) 
 TEST_F(EnvoyQuicServerStreamTest, OnCloseDoesNotUnderflowBytesToSendWithUnreportedBufferedBytes) {
   // make WritevData consume nothing so bytes stay buffered in the QUIC send buffer.
   EXPECT_CALL(quic_session_, WritevData(_, _, _, _, _, _))
-      .WillRepeatedly(
-          Invoke([](quic::QuicStreamId, size_t, quic::QuicStreamOffset,
-                    quic::StreamSendingState, bool, std::optional<quic::EncryptionLevel>) {
-            return quic::QuicConsumedData{0, false};
-          }));
+      .WillRepeatedly(Invoke(
+          [](quic::QuicStreamId, size_t, quic::QuicStreamOffset, quic::StreamSendingState, bool,
+             std::optional<quic::EncryptionLevel>) { return quic::QuicConsumedData{0, false}; }));
 
   // simulate QUICHE writing bytes directly to the stream send buffer without going through
   // ScopedWatermarkBufferUpdater.
@@ -1206,7 +1204,8 @@ TEST_F(EnvoyQuicServerStreamTest, OnCloseDoesNotUnderflowBytesToSendWithUnreport
   EXPECT_LOG_NOT_CONTAINS("error", "Underflowed",
                           quic_stream_->encodeHeaders(response_headers_, true));
 
-  // confirm no underflow: headers buffered bytes_to_send_ is positive not wrapped to near UINT64_MAX.
+  // confirm no underflow: headers buffered bytes_to_send_ is positive not wrapped to near
+  // UINT64_MAX.
   EXPECT_GT(quic_session_.bytesToSend(), 0u);
   EXPECT_LT(quic_session_.bytesToSend(), 1000u);
 }

--- a/test/integration/quic_http_integration_test.cc
+++ b/test/integration/quic_http_integration_test.cc
@@ -2355,5 +2355,30 @@ TEST_P(QuicHttpIntegrationTest, InconsistentContentLengthHeadersOnlyDisabled) {
   codec_client_->close();
 }
 
+TEST_P(QuicHttpIntegrationTest, FirstRequestSucceedsWithoutEnvoyBugOnNewConnection) {
+  initialize();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  // first request on the new connection.
+  auto response1 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_TRUE(response1->complete());
+  EXPECT_EQ("200", response1->headers().getStatusValue());
+
+  // second request on the same connection.
+  auto response2 = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response2->waitForEndStream());
+  EXPECT_TRUE(response2->complete());
+  EXPECT_EQ("200", response2->headers().getStatusValue());
+
+  test_server_->waitForCounter("server.envoy_bug_failures", testing::Eq(0));
+
+  codec_client_->close();
+}
+
 } // namespace Quic
 } // namespace Envoy


### PR DESCRIPTION
_Commit Message:_
quiche's WriteOrBufferData on any stream never goes through ScopedWatermarkBufferUpdater, so reported_buffered_bytes_ can lag behind BufferedDataBytes() whenever quiche writes directly.

_Additional Description:_
the fix move clearWatermarkBuffer() from both subclasses into the base class EnvoyQuicStream which owns the private member reported_buffered_bytes_, and change the drain argument from BufferedDataBytes() to reported_buffered_bytes_.

the reported_buffered_bytes_ tracks exactly what this stream has contributed to bytes_to_send_. it is incremented and decremented exclusively through updateBytesBuffered, which is only called from ScopedWatermarkBufferUpdater. the quiche internal writes bypass ScopedWatermarkBufferUpdater, so they are never counted in reported_buffered_bytes_.

_Risk Level:_
Low

Fixes #46087