### PR TITLE
reverse_tunnels:  strip RPING keepalives on the TLS readv() path

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/common/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/common/BUILD
@@ -33,5 +33,6 @@ envoy_cc_library(
     deps = [
         ":reverse_connection_utility_lib",
         "//source/common/network:default_socket_interface_lib",
+        "//source/common/network:io_socket_error_lib",
     ],
 )

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.cc
@@ -1,5 +1,8 @@
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
@@ -27,6 +30,18 @@ bool ReverseConnectionUtility::isPingMessage(absl::string_view data) {
     return false;
   }
   return ::memcmp(data.data(), PING_MESSAGE.data(), PING_MESSAGE.size()) == 0;
+}
+
+ReverseConnectionUtility::RpingPrefixMatch
+ReverseConnectionUtility::classifyRpingPrefix(absl::string_view data) {
+  const size_t len = std::min(data.size(), PING_MESSAGE.size());
+  const absl::string_view peek = data.substr(0, len);
+  if (len == PING_MESSAGE.size()) {
+    return isPingMessage(peek) ? RpingPrefixMatch::Complete : RpingPrefixMatch::NotRping;
+  }
+  // Fewer than a full keepalive: a viable prefix if it matches RPING so far.
+  return peek == PING_MESSAGE.substr(0, len) ? RpingPrefixMatch::PartialPrefix
+                                             : RpingPrefixMatch::NotRping;
 }
 
 Buffer::InstancePtr ReverseConnectionUtility::createPingResponse() {

--- a/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h
@@ -40,6 +40,20 @@ public:
 
   static bool isPingMessage(absl::string_view data);
 
+  // Classification of the front bytes of a read against the RPING keepalive marker.
+  enum class RpingPrefixMatch {
+    // The first PING_MESSAGE.size() bytes are a complete RPING keepalive.
+    Complete,
+    // Fewer than PING_MESSAGE.size() bytes, all matching the RPING prefix so far.
+    PartialPrefix,
+    // Neither a complete RPING nor a viable prefix of one.
+    NotRping,
+  };
+
+  // Classifies `data` against RPING. Only the first PING_MESSAGE.size() bytes are considered;
+  // trailing application bytes are ignored. Empty input is a (trivial) PartialPrefix.
+  static RpingPrefixMatch classifyRpingPrefix(absl::string_view data);
+
   static Buffer::InstancePtr createPingResponse();
 
   static bool sendPingResponse(Network::Connection& connection);

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -2,10 +2,11 @@
 
 #include <cstring>
 #include <string>
-#include <vector>
 
 #include "source/common/network/io_socket_error_impl.h"
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
+
+#include "absl/container/fixed_array.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -118,10 +119,13 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
   // right behind it. If we swallowed the RPING and returned, that trailing data would sit unread
   // with no further wakeup coming. To avoid that, once we consume an RPING we keep reading until
   // the socket is actually empty (a short read or EAGAIN).
+  //
+  // Scratch buffer for one read, reused across loop iterations. Sized to full capacity so it fits
+  // every iteration; each read uses only `room` of it.
+  absl::FixedArray<char> tmp(capacity);
   while (true) {
     // Size the read so partial_ping_ + fresh never exceeds caller capacity.
     const uint64_t room = capacity - partial_ping_.size();
-    std::vector<char> tmp(room);
     Buffer::RawSlice tmp_slice;
     tmp_slice.mem_ = tmp.data();
     tmp_slice.len_ = room;

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -90,16 +90,20 @@ uint64_t RpingInterceptor::scatterToSlices(absl::string_view src, Buffer::RawSli
 
 Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::RawSlice* slices,
                                                 uint64_t num_slice) {
-  // Passthrough when there is nothing to strip: inside read()'s dispatch, or once echo has
-  // latched off with no partial keepalive staged.
-  if (processing_read_ || (!ping_echo_active_ && staged_.empty())) {
+  // Read straight through without inspecting for RPING in two cases:
+  //   - processing_read_: the raw read() path is driving this readv() and already strips RPING
+  //     itself, so doing it here too would double-process.
+  //   - ping keepalives have stopped (!ping_echo_active_) and no partial ping is held over from a
+  //     previous read (partial_ping_ empty), so there is nothing left to strip.
+  if (processing_read_ || (!ping_echo_active_ && partial_ping_.empty())) {
     return IoSocketHandleImpl::readv(max_length, slices, num_slice);
   }
 
   const uint64_t expected = ReverseConnectionUtility::PING_MESSAGE.size();
 
-  // staged_ is non-empty only while nothing has been delivered, so the caller is still reading a
-  // fresh record header: capacity >= expected then, which the loop below relies on to progress.
+  // Total space the caller offered; the most we can deliver. A partial ping is only ever held
+  // before real data flows, so capacity here is always >= a full ping (5 bytes), keeping
+  // room (capacity - partial_ping_) positive so the loop below makes progress.
   uint64_t capacity = 0;
   for (uint64_t i = 0; i < num_slice; i++) {
     capacity += slices[i].len_;
@@ -109,12 +113,14 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
     return IoSocketHandleImpl::readv(max_length, slices, num_slice);
   }
 
-  // Under edge-triggered epoll, keep reading past a consumed RPING until the kernel is drained
-  // (short read or EAGAIN); otherwise data coalesced behind it (e.g. a ClientHello) is stranded
-  // with no further read event.
+  // epoll wakes us only when new data *arrives*, not while unread data is already sitting in the
+  // socket. So a single read can return an RPING with real data (e.g. a TLS ClientHello) packed
+  // right behind it. If we swallowed the RPING and returned, that trailing data would sit unread
+  // with no further wakeup coming. To avoid that, once we consume an RPING we keep reading until
+  // the socket is actually empty (a short read or EAGAIN).
   while (true) {
-    // Size the read so staged_ + fresh never exceeds caller capacity.
-    const uint64_t room = capacity - staged_.size();
+    // Size the read so partial_ping_ + fresh never exceeds caller capacity.
+    const uint64_t room = capacity - partial_ping_.size();
     std::vector<char> tmp(room);
     Buffer::RawSlice tmp_slice;
     tmp_slice.mem_ = tmp.data();
@@ -123,25 +129,25 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
     Api::IoCallUint64Result fresh = IoSocketHandleImpl::readv(room, &tmp_slice, 1);
 
     if (fresh.err_ != nullptr) {
-      // Would-block/error: staged_ is preserved for the next call.
+      // Would-block/error: partial_ping_ is preserved for the next call.
       return fresh;
     }
     if (fresh.return_value_ == 0) {
-      // EOF. A staged partial keepalive can never complete; drop it and report shutdown.
-      staged_.clear();
+      // EOF. A held partial keepalive can never complete; drop it and report shutdown.
+      partial_ping_.clear();
       return Api::IoCallUint64Result{0, Api::IoError::none()};
     }
 
     std::string assembled;
-    assembled.reserve(staged_.size() + fresh.return_value_);
-    assembled.append(staged_.data(), staged_.size());
+    assembled.reserve(partial_ping_.size() + fresh.return_value_);
+    assembled.append(partial_ping_.data(), partial_ping_.size());
     assembled.append(tmp.data(), static_cast<size_t>(fresh.return_value_));
 
     switch (ReverseConnectionUtility::classifyRpingPrefix(assembled)) {
     case ReverseConnectionUtility::RpingPrefixMatch::Complete: {
       // Complete RPING at the front: echo it and drop it.
       onPingMessage();
-      staged_.clear();
+      partial_ping_.clear();
 
       absl::string_view remainder{assembled.data() + expected, assembled.size() - expected};
       if (remainder.empty()) {
@@ -153,14 +159,14 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
       return Api::IoCallUint64Result{written, Api::IoError::none()};
     }
     case ReverseConnectionUtility::RpingPrefixMatch::PartialPrefix:
-      // Proper RPING prefix: the short read means the kernel is drained. Stage it and return
+      // Proper RPING prefix: the short read means the kernel is drained. Hold it and return
       // EAGAIN; the rest arrives as a fresh readable event.
-      staged_.assign(assembled.begin(), assembled.end());
+      partial_ping_.assign(assembled.begin(), assembled.end());
       return Api::IoCallUint64Result{0, Network::IoSocketError::getIoSocketEagainError()};
     case ReverseConnectionUtility::RpingPrefixMatch::NotRping: {
       // Not RPING: echo latches off and all bytes pass through in order.
       ping_echo_active_ = false;
-      staged_.clear();
+      partial_ping_.clear();
       const uint64_t written = scatterToSlices(assembled, slices, num_slice);
       return Api::IoCallUint64Result{written, Api::IoError::none()};
     }

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -1,5 +1,10 @@
 #include "source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h"
 
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "source/common/network/io_socket_error_impl.h"
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 
 namespace Envoy {
@@ -9,10 +14,18 @@ namespace ReverseConnection {
 
 Api::IoCallUint64Result RpingInterceptor::read(Buffer::Instance& buffer,
                                                std::optional<uint64_t> max_length) {
-  // Perform the actual read first.
+  // Guard the inner readv() dispatch to a passthrough so RPING is detected once, here.
+  processing_read_ = true;
   Api::IoCallUint64Result result = IoSocketHandleImpl::read(buffer, max_length);
-  ENVOY_LOG(trace, "RpingInterceptor: read result: {}", result.return_value_);
+  processing_read_ = false;
+  ENVOY_LOG(trace, "RpingInterceptor: read FD: {} returned {} bytes (buffer path)", fd_,
+            result.return_value_);
 
+  return applyRpingToBuffer(buffer, std::move(result));
+}
+
+Api::IoCallUint64Result RpingInterceptor::applyRpingToBuffer(Buffer::Instance& buffer,
+                                                             Api::IoCallUint64Result result) {
   // If RPING keepalives are still active, check whether the incoming data is a RPING message.
   if (ping_echo_active_ && result.err_ == nullptr && result.return_value_ > 0) {
     const uint64_t expected = ReverseConnectionUtility::PING_MESSAGE.size();
@@ -68,6 +81,136 @@ Api::IoCallUint64Result RpingInterceptor::read(Buffer::Instance& buffer,
   }
 
   return result;
+}
+
+uint64_t RpingInterceptor::scatterToSlices(absl::string_view src, Buffer::RawSlice* slices,
+                                           uint64_t num_slice) {
+  uint64_t written = 0;
+  for (uint64_t i = 0; i < num_slice && written < src.size(); i++) {
+    const uint64_t n = std::min<uint64_t>(slices[i].len_, src.size() - written);
+    memcpy(slices[i].mem_, src.data() + written, n);
+    written += n;
+  }
+  ASSERT(written == src.size());
+  return written;
+}
+
+Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::RawSlice* slices,
+                                                uint64_t num_slice) {
+  // Passthrough when there is nothing to strip: inside read()'s dispatch, or once echo has
+  // latched off with no partial keepalive staged.
+  if (processing_read_ || (!ping_echo_active_ && staged_.empty())) {
+    ENVOY_LOG(trace,
+              "RpingInterceptor: readv passthrough FD: {} (processing_read={}, ping_echo_active={}, "
+              "staged={})",
+              fd_, processing_read_, ping_echo_active_, staged_.size());
+    return IoSocketHandleImpl::readv(max_length, slices, num_slice);
+  }
+
+  const uint64_t expected = ReverseConnectionUtility::PING_MESSAGE.size();
+
+  // staged_ is non-empty only while nothing has been delivered, so the caller is still reading a
+  // fresh record header: capacity >= expected then, which the loop below relies on to progress.
+  uint64_t capacity = 0;
+  for (uint64_t i = 0; i < num_slice; i++) {
+    capacity += slices[i].len_;
+  }
+  capacity = std::min<uint64_t>(capacity, max_length);
+  if (capacity == 0) {
+    return IoSocketHandleImpl::readv(max_length, slices, num_slice);
+  }
+
+  ENVOY_LOG(trace,
+            "RpingInterceptor: readv enter FD: {} capacity: {} max_length: {} staged: {} bytes",
+            fd_, capacity, max_length, staged_.size());
+
+  // Under edge-triggered epoll, keep reading past a consumed RPING until the kernel is drained
+  // (short read or EAGAIN); otherwise data coalesced behind it (e.g. a ClientHello) is stranded
+  // with no further read event.
+  while (true) {
+    // Size the read so staged_ + fresh never exceeds caller capacity.
+    const uint64_t room = capacity - staged_.size();
+    std::vector<char> tmp(room);
+    Buffer::RawSlice tmp_slice;
+    tmp_slice.mem_ = tmp.data();
+    tmp_slice.len_ = room;
+
+    Api::IoCallUint64Result fresh = IoSocketHandleImpl::readv(room, &tmp_slice, 1);
+
+    if (fresh.err_ != nullptr) {
+      // Would-block/error: staged_ is preserved for the next call.
+      ENVOY_LOG(trace,
+                "RpingInterceptor: readv FD: {} underlying read not ok (would_block={}), keeping {} "
+                "staged bytes",
+                fd_, fresh.wouldBlock(), staged_.size());
+      return fresh;
+    }
+    if (fresh.return_value_ == 0) {
+      // EOF. A staged partial keepalive can never complete; drop it and report shutdown.
+      ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} EOF, discarding {} staged bytes", fd_,
+                staged_.size());
+      staged_.clear();
+      return Api::IoCallUint64Result{0, Api::IoError::none()};
+    }
+
+    std::string assembled;
+    assembled.reserve(staged_.size() + fresh.return_value_);
+    assembled.append(staged_.data(), staged_.size());
+    assembled.append(tmp.data(), static_cast<size_t>(fresh.return_value_));
+    ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} read {} fresh bytes, {} assembled with staged",
+              fd_, fresh.return_value_, assembled.size());
+
+    const uint64_t len = std::min<uint64_t>(assembled.size(), expected);
+    absl::string_view peek_sv{assembled.data(), static_cast<size_t>(len)};
+
+    // Complete RPING at the front: echo it and drop it.
+    if (len == expected && ReverseConnectionUtility::isPingMessage(peek_sv)) {
+      ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} stripped complete RPING keepalive", fd_);
+      onPingMessage();
+      staged_.clear();
+
+      absl::string_view remainder{assembled.data() + expected, assembled.size() - expected};
+      if (remainder.empty()) {
+        // Loop to drain any data coalesced behind the RPING before returning EAGAIN.
+        ENVOY_LOG(trace,
+                  "RpingInterceptor: readv FD: {} RPING alone, looping to drain any coalesced data",
+                  fd_);
+        continue;
+      }
+      ENVOY_LOG(trace,
+                "RpingInterceptor: readv FD: {} delivering {} application bytes after RPING, "
+                "disabling echo",
+                fd_, remainder.size());
+      ping_echo_active_ = false;
+      const uint64_t written = scatterToSlices(remainder, slices, num_slice);
+      return Api::IoCallUint64Result{written, Api::IoError::none()};
+    }
+
+    // Proper RPING prefix: the short read means the kernel is drained. Stage it and return EAGAIN;
+    // the rest arrives as a fresh readable event.
+    if (len < expected) {
+      const absl::string_view rping_prefix =
+          ReverseConnectionUtility::PING_MESSAGE.substr(0, static_cast<size_t>(len));
+      if (peek_sv == rping_prefix) {
+        ENVOY_LOG(trace,
+                  "RpingInterceptor: readv FD: {} partial RPING prefix ({} bytes), staging and "
+                  "returning would-block",
+                  fd_, len);
+        staged_.assign(assembled.begin(), assembled.end());
+        return Api::IoCallUint64Result{0, Network::IoSocketError::getIoSocketEagainError()};
+      }
+    }
+
+    // Not RPING: echo latches off and all bytes pass through in order.
+    ENVOY_LOG(trace,
+              "RpingInterceptor: readv FD: {} non-RPING data ({} bytes), disabling echo and "
+              "passing through",
+              fd_, assembled.size());
+    ping_echo_active_ = false;
+    staged_.clear();
+    const uint64_t written = scatterToSlices(assembled, slices, num_slice);
+    return Api::IoCallUint64Result{written, Api::IoError::none()};
+  }
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -30,13 +30,13 @@ Api::IoCallUint64Result RpingInterceptor::applyRpingToBuffer(Buffer::Instance& b
   if (ping_echo_active_ && result.err_ == nullptr && result.return_value_ > 0) {
     const uint64_t expected = ReverseConnectionUtility::PING_MESSAGE.size();
 
-    // Compare up to the expected size using a zero-copy view.
+    // Classify the front of the buffer using a zero-copy view of up to the expected size.
     const uint64_t len = std::min<uint64_t>(buffer.length(), expected);
     const char* data = static_cast<const char*>(buffer.linearize(len));
     absl::string_view peek_sv{data, static_cast<size_t>(len)};
 
-    // Check if we have a complete RPING message.
-    if (len == expected && ReverseConnectionUtility::isPingMessage(peek_sv)) {
+    switch (ReverseConnectionUtility::classifyRpingPrefix(peek_sv)) {
+    case ReverseConnectionUtility::RpingPrefixMatch::Complete: {
       // Found a complete RPING. Echo and drain it from the buffer.
       buffer.drain(expected);
       onPingMessage();
@@ -58,26 +58,19 @@ Api::IoCallUint64Result RpingInterceptor::applyRpingToBuffer(Buffer::Instance& b
           (result.return_value_ >= expected) ? (result.return_value_ - expected) : 0;
       return Api::IoCallUint64Result{adjusted, Api::IoError::none()};
     }
-
-    // If partial data could be the start of RPING (only when fewer than expected bytes).
-    if (len < expected) {
-      const absl::string_view rping_prefix =
-          ReverseConnectionUtility::PING_MESSAGE.substr(0, static_cast<size_t>(len));
-      if (peek_sv == rping_prefix) {
-        ENVOY_LOG(trace,
-                  "RpingInterceptor: partial RPING received ({} bytes), waiting "
-                  "for more.",
-                  len);
-        return result; // Wait for more data.
-      }
+    case ReverseConnectionUtility::RpingPrefixMatch::PartialPrefix:
+      ENVOY_LOG(trace, "RpingInterceptor: partial RPING received ({} bytes), waiting for more.",
+                len);
+      return result; // Wait for more data.
+    case ReverseConnectionUtility::RpingPrefixMatch::NotRping:
+      // Data is not RPING (complete or partial). Disable echo permanently.
+      ENVOY_LOG(trace,
+                "RpingInterceptor: received application data ({} bytes), "
+                "disabling RPING echo for FD: {}",
+                len, fd_);
+      ping_echo_active_ = false;
+      break;
     }
-
-    // Data is not RPING (complete or partial). Disable echo permanently.
-    ENVOY_LOG(trace,
-              "RpingInterceptor: received application data ({} bytes), "
-              "disabling RPING echo for FD: {}",
-              len, fd_);
-    ping_echo_active_ = false;
   }
 
   return result;
@@ -100,10 +93,6 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
   // Passthrough when there is nothing to strip: inside read()'s dispatch, or once echo has
   // latched off with no partial keepalive staged.
   if (processing_read_ || (!ping_echo_active_ && staged_.empty())) {
-    ENVOY_LOG(trace,
-              "RpingInterceptor: readv passthrough FD: {} (processing_read={}, ping_echo_active={}, "
-              "staged={})",
-              fd_, processing_read_, ping_echo_active_, staged_.size());
     return IoSocketHandleImpl::readv(max_length, slices, num_slice);
   }
 
@@ -120,10 +109,6 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
     return IoSocketHandleImpl::readv(max_length, slices, num_slice);
   }
 
-  ENVOY_LOG(trace,
-            "RpingInterceptor: readv enter FD: {} capacity: {} max_length: {} staged: {} bytes",
-            fd_, capacity, max_length, staged_.size());
-
   // Under edge-triggered epoll, keep reading past a consumed RPING until the kernel is drained
   // (short read or EAGAIN); otherwise data coalesced behind it (e.g. a ClientHello) is stranded
   // with no further read event.
@@ -139,16 +124,10 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
 
     if (fresh.err_ != nullptr) {
       // Would-block/error: staged_ is preserved for the next call.
-      ENVOY_LOG(trace,
-                "RpingInterceptor: readv FD: {} underlying read not ok (would_block={}), keeping {} "
-                "staged bytes",
-                fd_, fresh.wouldBlock(), staged_.size());
       return fresh;
     }
     if (fresh.return_value_ == 0) {
       // EOF. A staged partial keepalive can never complete; drop it and report shutdown.
-      ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} EOF, discarding {} staged bytes", fd_,
-                staged_.size());
       staged_.clear();
       return Api::IoCallUint64Result{0, Api::IoError::none()};
     }
@@ -157,59 +136,37 @@ Api::IoCallUint64Result RpingInterceptor::readv(uint64_t max_length, Buffer::Raw
     assembled.reserve(staged_.size() + fresh.return_value_);
     assembled.append(staged_.data(), staged_.size());
     assembled.append(tmp.data(), static_cast<size_t>(fresh.return_value_));
-    ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} read {} fresh bytes, {} assembled with staged",
-              fd_, fresh.return_value_, assembled.size());
 
-    const uint64_t len = std::min<uint64_t>(assembled.size(), expected);
-    absl::string_view peek_sv{assembled.data(), static_cast<size_t>(len)};
-
-    // Complete RPING at the front: echo it and drop it.
-    if (len == expected && ReverseConnectionUtility::isPingMessage(peek_sv)) {
-      ENVOY_LOG(trace, "RpingInterceptor: readv FD: {} stripped complete RPING keepalive", fd_);
+    switch (ReverseConnectionUtility::classifyRpingPrefix(assembled)) {
+    case ReverseConnectionUtility::RpingPrefixMatch::Complete: {
+      // Complete RPING at the front: echo it and drop it.
       onPingMessage();
       staged_.clear();
 
       absl::string_view remainder{assembled.data() + expected, assembled.size() - expected};
       if (remainder.empty()) {
         // Loop to drain any data coalesced behind the RPING before returning EAGAIN.
-        ENVOY_LOG(trace,
-                  "RpingInterceptor: readv FD: {} RPING alone, looping to drain any coalesced data",
-                  fd_);
         continue;
       }
-      ENVOY_LOG(trace,
-                "RpingInterceptor: readv FD: {} delivering {} application bytes after RPING, "
-                "disabling echo",
-                fd_, remainder.size());
       ping_echo_active_ = false;
       const uint64_t written = scatterToSlices(remainder, slices, num_slice);
       return Api::IoCallUint64Result{written, Api::IoError::none()};
     }
-
-    // Proper RPING prefix: the short read means the kernel is drained. Stage it and return EAGAIN;
-    // the rest arrives as a fresh readable event.
-    if (len < expected) {
-      const absl::string_view rping_prefix =
-          ReverseConnectionUtility::PING_MESSAGE.substr(0, static_cast<size_t>(len));
-      if (peek_sv == rping_prefix) {
-        ENVOY_LOG(trace,
-                  "RpingInterceptor: readv FD: {} partial RPING prefix ({} bytes), staging and "
-                  "returning would-block",
-                  fd_, len);
-        staged_.assign(assembled.begin(), assembled.end());
-        return Api::IoCallUint64Result{0, Network::IoSocketError::getIoSocketEagainError()};
-      }
+    case ReverseConnectionUtility::RpingPrefixMatch::PartialPrefix:
+      // Proper RPING prefix: the short read means the kernel is drained. Stage it and return
+      // EAGAIN; the rest arrives as a fresh readable event.
+      staged_.assign(assembled.begin(), assembled.end());
+      return Api::IoCallUint64Result{0, Network::IoSocketError::getIoSocketEagainError()};
+    case ReverseConnectionUtility::RpingPrefixMatch::NotRping: {
+      // Not RPING: echo latches off and all bytes pass through in order.
+      ping_echo_active_ = false;
+      staged_.clear();
+      const uint64_t written = scatterToSlices(assembled, slices, num_slice);
+      return Api::IoCallUint64Result{written, Api::IoError::none()};
     }
-
-    // Not RPING: echo latches off and all bytes pass through in order.
-    ENVOY_LOG(trace,
-              "RpingInterceptor: readv FD: {} non-RPING data ({} bytes), disabling echo and "
-              "passing through",
-              fd_, assembled.size());
-    ping_echo_active_ = false;
-    staged_.clear();
-    const uint64_t written = scatterToSlices(assembled, slices, num_slice);
-    return Api::IoCallUint64Result{written, Api::IoError::none()};
+    }
+    // Unreachable: every classification case above returns or continues.
+    PANIC("unexpected RPING classification");
   }
 }
 

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.cc
@@ -81,7 +81,7 @@ uint64_t RpingInterceptor::scatterToSlices(absl::string_view src, Buffer::RawSli
   uint64_t written = 0;
   for (uint64_t i = 0; i < num_slice && written < src.size(); i++) {
     const uint64_t n = std::min<uint64_t>(slices[i].len_, src.size() - written);
-    memcpy(slices[i].mem_, src.data() + written, n);
+    memcpy(slices[i].mem_, src.data() + written, n); // NOLINT(safe-memcpy)
     written += n;
   }
   ASSERT(written == src.size());

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
@@ -40,7 +40,7 @@ private:
   bool processing_read_{false};
 
   // Partial RPING prefix carried across readv() calls until the keepalive completes; <=4 bytes.
-  absl::InlinedVector<char, 5> staged_;
+  absl::InlinedVector<char, 5> partial_ping_;
 };
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
+++ b/source/extensions/bootstrap/reverse_tunnel/common/rping_interceptor.h
@@ -2,6 +2,9 @@
 
 #include "source/common/network/io_socket_handle_impl.h"
 
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/string_view.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Bootstrap {
@@ -9,9 +12,13 @@ namespace ReverseConnection {
 
 class RpingInterceptor : public virtual Network::IoSocketHandleImpl {
 public:
-  // Intercept reads to handle reverse connection keep-alive pings.
+  // Strip RPING keepalives off the socket. The raw transport reads via read(); the TLS transport
+  // reads via readv() (the BoringSSL BIO). read() dispatches through the virtual readv(), so the
+  // processing_read_ guard keeps the two paths mutually exclusive and each RPING processed once.
   Api::IoCallUint64Result read(Buffer::Instance& buffer,
                                std::optional<uint64_t> max_length) override;
+  Api::IoCallUint64Result readv(uint64_t max_length, Buffer::RawSlice* slices,
+                                uint64_t num_slice) override;
 
   virtual void onPingMessage() PURE;
 
@@ -19,6 +26,21 @@ protected:
   // Whether to actively echo RPING messages while the connection is idle.
   // Disabled permanently after the first non-RPING application byte is observed.
   bool ping_echo_active_{true};
+
+private:
+  // Drains a complete RPING from `buffer` (echoing via onPingMessage()) and returns the result
+  // with the RPING hidden from the caller. Backs the read() path.
+  Api::IoCallUint64Result applyRpingToBuffer(Buffer::Instance& buffer,
+                                             Api::IoCallUint64Result result);
+
+  // Copies `src` across `slices`, returning bytes written. Caller guarantees src fits.
+  uint64_t scatterToSlices(absl::string_view src, Buffer::RawSlice* slices, uint64_t num_slice);
+
+  // Set while read() drives the base read()->readv() dispatch; makes readv() a pure passthrough.
+  bool processing_read_{false};
+
+  // Partial RPING prefix carried across readv() calls until the keepalive completes; <=4 bytes.
+  absl::InlinedVector<char, 5> staged_;
 };
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility_test.cc
@@ -50,6 +50,35 @@ TEST_F(ReverseConnectionUtilityTest, IsPingMessageInvalidData) {
   EXPECT_FALSE(ReverseConnectionUtility::isPingMessage("Hello World"));
 }
 
+// Test RPING prefix classification.
+using RpingPrefixMatch = ReverseConnectionUtility::RpingPrefixMatch;
+
+TEST_F(ReverseConnectionUtilityTest, ClassifyRpingPrefixComplete) {
+  // Exactly RPING, or RPING followed by trailing application bytes: both are Complete since only
+  // the first PING_MESSAGE.size() bytes are considered.
+  EXPECT_EQ(RpingPrefixMatch::Complete, ReverseConnectionUtility::classifyRpingPrefix("RPING"));
+  EXPECT_EQ(RpingPrefixMatch::Complete,
+            ReverseConnectionUtility::classifyRpingPrefix("RPINGhello"));
+}
+
+TEST_F(ReverseConnectionUtilityTest, ClassifyRpingPrefixPartial) {
+  // Empty input and every proper prefix of RPING are viable partials.
+  EXPECT_EQ(RpingPrefixMatch::PartialPrefix, ReverseConnectionUtility::classifyRpingPrefix(""));
+  EXPECT_EQ(RpingPrefixMatch::PartialPrefix, ReverseConnectionUtility::classifyRpingPrefix("R"));
+  EXPECT_EQ(RpingPrefixMatch::PartialPrefix, ReverseConnectionUtility::classifyRpingPrefix("RP"));
+  EXPECT_EQ(RpingPrefixMatch::PartialPrefix, ReverseConnectionUtility::classifyRpingPrefix("RPI"));
+  EXPECT_EQ(RpingPrefixMatch::PartialPrefix, ReverseConnectionUtility::classifyRpingPrefix("RPIN"));
+}
+
+TEST_F(ReverseConnectionUtilityTest, ClassifyRpingPrefixNotRping) {
+  // A short non-prefix, and a full-length non-match, are both classified as not-RPING.
+  EXPECT_EQ(RpingPrefixMatch::NotRping, ReverseConnectionUtility::classifyRpingPrefix("X"));
+  EXPECT_EQ(RpingPrefixMatch::NotRping, ReverseConnectionUtility::classifyRpingPrefix("RPX"));
+  EXPECT_EQ(RpingPrefixMatch::NotRping, ReverseConnectionUtility::classifyRpingPrefix("PING"));
+  EXPECT_EQ(RpingPrefixMatch::NotRping,
+            ReverseConnectionUtility::classifyRpingPrefix("Hello World"));
+}
+
 // Test createPingResponse functionality
 TEST_F(ReverseConnectionUtilityTest, CreatePingResponse) {
   auto ping_buffer = ReverseConnectionUtility::createPingResponse();

--- a/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -30,6 +31,22 @@ class RpingInterceptorTest : public testing::Test {
 protected:
   std::unique_ptr<TestRpingInterceptor> makeInterceptor(int fd) {
     return std::make_unique<TestRpingInterceptor>(fd);
+  }
+
+  // The readv() drain loop re-reads after consuming a keepalive, so the read end must be
+  // non-blocking (as production sockets are) for the loop to terminate on EAGAIN.
+  void setNonBlocking(int fd) {
+    const int flags = fcntl(fd, F_GETFL, 0);
+    ASSERT_EQ(fcntl(fd, F_SETFL, flags | O_NONBLOCK), 0);
+  }
+
+  // Reads through the interceptor's readv() into a caller buffer, mirroring the TLS BIO's
+  // single-slice call.
+  Api::IoCallUint64Result readvInto(TestRpingInterceptor& interceptor, char* buf, uint64_t cap) {
+    Buffer::RawSlice slice;
+    slice.mem_ = buf;
+    slice.len_ = cap;
+    return interceptor.readv(cap, &slice, 1);
   }
 };
 
@@ -153,6 +170,175 @@ TEST_F(RpingInterceptorTest, NonRpingFirstDisablesPingModeThenRpingPassesThrough
   EXPECT_EQ(second.return_value_, rping.size());
   EXPECT_EQ(second_read_buffer.toString(), rping);
   EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  close(fds[1]);
+}
+
+// A full RPING read via readv() is consumed and echoed; the caller sees would-block.
+TEST_F(RpingInterceptorTest, FullRpingConsumedViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  char buf[64];
+  const auto result = readvInto(*interceptor, buf, sizeof(buf));
+
+  EXPECT_TRUE(result.wouldBlock());
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+// A RPING split across two readv() calls completes and is echoed once.
+TEST_F(RpingInterceptorTest, ChoppedRpingViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string prefix = rping.substr(0, 3);
+  const std::string suffix = rping.substr(3);
+
+  char buf[64];
+  ASSERT_EQ(write(fds[1], prefix.data(), prefix.size()), static_cast<ssize_t>(prefix.size()));
+  const auto first = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_TRUE(first.wouldBlock());
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  ASSERT_EQ(write(fds[1], suffix.data(), suffix.size()), static_cast<ssize_t>(suffix.size()));
+  const auto second = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_TRUE(second.wouldBlock());
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+// RPING immediately followed by application data: the RPING is stripped, the data passes through.
+TEST_F(RpingInterceptorTest, PingPlusDataViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string payload = " value";
+  const std::string combined = rping + payload;
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()),
+            static_cast<ssize_t>(combined.size()));
+
+  char buf[64];
+  const auto result = readvInto(*interceptor, buf, sizeof(buf));
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, payload.size());
+  EXPECT_EQ(absl::string_view(buf, result.return_value_), payload);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+// Application data after a consumed RPING passes through unchanged.
+TEST_F(RpingInterceptorTest, DataAfterPingViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string data = "GET /";
+
+  char buf[64];
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+  const auto first = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_TRUE(first.wouldBlock());
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  ASSERT_EQ(write(fds[1], data.data(), data.size()), static_cast<ssize_t>(data.size()));
+  const auto second = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, data.size());
+  EXPECT_EQ(absl::string_view(buf, second.return_value_), data);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+// A non-RPING first read latches echo off; a later RPING then passes through verbatim.
+TEST_F(RpingInterceptorTest, NonRpingFirstThenPassthroughViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string first_data = "HELLO";
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+
+  char buf[64];
+  ASSERT_EQ(write(fds[1], first_data.data(), first_data.size()),
+            static_cast<ssize_t>(first_data.size()));
+  const auto first = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_EQ(first.err_, nullptr);
+  EXPECT_EQ(first.return_value_, first_data.size());
+  EXPECT_EQ(absl::string_view(buf, first.return_value_), first_data);
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+  const auto second = readvInto(*interceptor, buf, sizeof(buf));
+  EXPECT_EQ(second.err_, nullptr);
+  EXPECT_EQ(second.return_value_, rping.size());
+  EXPECT_EQ(absl::string_view(buf, second.return_value_), rping);
+  EXPECT_EQ(interceptor->pingMessages(), 0);
+
+  close(fds[1]);
+}
+
+// The processing_read_ guard keeps read() from double-processing via the inner readv() dispatch.
+TEST_F(RpingInterceptorTest, NoDoubleProcessing) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  ASSERT_EQ(write(fds[1], rping.data(), rping.size()), static_cast<ssize_t>(rping.size()));
+
+  Buffer::OwnedImpl buffer;
+  const auto result = interceptor->read(buffer, std::nullopt);
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, rping.size());
+  EXPECT_EQ(buffer.length(), 0);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
+
+  close(fds[1]);
+}
+
+// A RPING coalesced with trailing data in one segment must not strand the data behind a
+// would-block; the drain loop reads past the consumed RPING and delivers the data.
+TEST_F(RpingInterceptorTest, CoalescedRpingPlusDataDrainsViaReadv) {
+  int fds[2];
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+  setNonBlocking(fds[0]);
+
+  auto interceptor = makeInterceptor(fds[0]);
+  const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
+  const std::string data = "HELLO";
+  const std::string combined = rping + data;
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()),
+            static_cast<ssize_t>(combined.size()));
+
+  // Mirror the TLS BIO reading one record-header's worth at a time.
+  char buf[5];
+  const auto result = readvInto(*interceptor, buf, sizeof(buf));
+
+  EXPECT_EQ(result.err_, nullptr);
+  EXPECT_EQ(result.return_value_, data.size());
+  EXPECT_EQ(absl::string_view(buf, result.return_value_), data);
+  EXPECT_EQ(interceptor->pingMessages(), 1);
 
   close(fds[1]);
 }

--- a/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/common/rping_interceptor_test.cc
@@ -228,8 +228,7 @@ TEST_F(RpingInterceptorTest, PingPlusDataViaReadv) {
   const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
   const std::string payload = " value";
   const std::string combined = rping + payload;
-  ASSERT_EQ(write(fds[1], combined.data(), combined.size()),
-            static_cast<ssize_t>(combined.size()));
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()), static_cast<ssize_t>(combined.size()));
 
   char buf[64];
   const auto result = readvInto(*interceptor, buf, sizeof(buf));
@@ -328,8 +327,7 @@ TEST_F(RpingInterceptorTest, CoalescedRpingPlusDataDrainsViaReadv) {
   const std::string rping = std::string(ReverseConnectionUtility::PING_MESSAGE);
   const std::string data = "HELLO";
   const std::string combined = rping + data;
-  ASSERT_EQ(write(fds[1], combined.data(), combined.size()),
-            static_cast<ssize_t>(combined.size()));
+  ASSERT_EQ(write(fds[1], combined.data(), combined.size()), static_cast<ssize_t>(combined.size()));
 
   // Mirror the TLS BIO reading one record-header's worth at a time.
   char buf[5];

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
@@ -682,10 +682,7 @@ TEST_P(ReverseConnectionClusterIntegrationTest, EndToEndReverseTunnelTestWithMut
                                std::chrono::milliseconds(5000));
 }
 
-// Drives mTLS tunnel traffic across several RPING keepalive ticks. RPING keepalives are plaintext
-// and must be stripped beneath the TLS transport (via RpingInterceptor::readv on the BIO path); if
-// they leak into the TLS record parser the handshake/records corrupt. A short ping_interval and
-// repeated requests spanning multiple ticks exercise pings arriving on a live TLS session.
+// Runs an application mTLS session over a reverse tunnel across several RPING keepalive cycles.
 TEST_P(ReverseConnectionClusterIntegrationTest, MutualTLSSurvivesRpingKeepalive) {
   DISABLE_IF_ADMIN_DISABLED;
 
@@ -733,55 +730,85 @@ TEST_P(ReverseConnectionClusterIntegrationTest, MutualTLSSurvivesRpingKeepalive)
     };
 
     // 1s is the smallest usable ping_interval: the filter and socket manager both hold it as
-    // whole seconds, so sub-second values truncate to zero.
+    // whole seconds, so sub-second values truncate to zero. auto_close_connections is left at its
+    // default (false via configureReverseTunnelSetup) so the idle tunnel is not torn down.
     configureReverseTunnelSetup(bootstrap, loopback_addr, tunnel_listener_port, "test-node-id",
                                 "test-cluster-id", "test-tenant-id", tunnel_cluster_modifier,
                                 tunnel_listener_modifier, /*add_lua_host_id_filter=*/true,
                                 /*ping_interval_seconds=*/1);
+
+    // Layer a fresh application TLS session *through* the established tunnel. The tunnel socket is
+    // reused as a raw fd after handoff, so this TLS runs on top of the RPING interceptor: the
+    // reverse_connection_cluster (client) and reverse_conn_listener (server) handshake over the
+    // reused socket. This drives the interceptor's readv() on the BIO path, where a plaintext
+    // RPING keepalive collides with the TLS record stream.
+    for (int i = 0; i < bootstrap.mutable_static_resources()->clusters_size(); i++) {
+      auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(i);
+      if (cluster->name() == "reverse_connection_cluster") {
+        auto* transport_socket = cluster->mutable_transport_socket();
+        transport_socket->set_name("envoy.transport_sockets.tls");
+        envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext ctx;
+        ctx.mutable_common_tls_context()
+            ->mutable_validation_context()
+            ->mutable_trusted_ca()
+            ->set_filename(rundir + "/test/config/integration/certs/cacert.pem");
+        ctx.mutable_common_tls_context()->add_alpn_protocols("h2");
+        std::ignore = transport_socket->mutable_typed_config()->PackFrom(ctx);
+      }
+    }
+    for (int i = 0; i < bootstrap.mutable_static_resources()->listeners_size(); i++) {
+      auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(i);
+      if (listener->name() == "reverse_conn_listener") {
+        auto* transport_socket = listener->mutable_filter_chains(0)->mutable_transport_socket();
+        transport_socket->set_name("envoy.transport_sockets.tls");
+        envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext ctx;
+        auto* cert = ctx.mutable_common_tls_context()->add_tls_certificates();
+        cert->mutable_certificate_chain()->set_filename(
+            rundir + "/test/config/integration/certs/servercert.pem");
+        cert->mutable_private_key()->set_filename(rundir +
+                                                  "/test/config/integration/certs/serverkey.pem");
+        ctx.mutable_common_tls_context()->add_alpn_protocols("h2");
+        std::ignore = transport_socket->mutable_typed_config()->PackFrom(ctx);
+      }
+    }
   });
 
   initialize();
   registerTestServerPorts({"tunnel_listener", "egress_listener"});
 
-  // Wait for the mTLS reverse tunnel to establish.
+  // Wait for the mTLS reverse tunnel to establish and register in the idle pool.
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1),
                                std::chrono::milliseconds(5000));
   test_server_->waitForGauge("reverse_tunnel_acceptor.nodes.test-node-id", Ge(1));
 
-  // Drive several requests spaced across ping ticks (ping_interval is 1s). With the fix, every
-  // request completes and no RPING corrupts a TLS record; without it, a keepalive that lands on a
-  // live TLS session breaks the handshake/records and a request fails.
-  constexpr int kNumRequests = 4;
-  for (int i = 0; i < kNumRequests; i++) {
-    ENVOY_LOG_MISC(info, "MutualTLSSurvivesRpingKeepalive: sending request {}", i);
-    codec_client_ = makeHttpConnection(lookupPort("egress_listener"));
-    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
-
-    ASSERT_TRUE(
-        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-    ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-    ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
-    upstream_request_->encodeHeaders(default_response_headers_, true);
-
-    ASSERT_TRUE(response->waitForEndStream());
-    EXPECT_TRUE(response->complete());
-    EXPECT_EQ("200", response->headers().getStatusValue());
-
-    // No RPING ever corrupted a TLS handshake on the acceptor.
-    EXPECT_EQ(test_server_->counter("reverse_tunnel.handshake.parse_error")->value(), 0);
-
-    cleanupUpstreamAndDownstream();
-    fake_upstream_connection_.reset();
-
-    // Sleep just over a ping tick so the next request overlaps a fresh keepalive.
-    timeSystem().advanceTimeWait(std::chrono::milliseconds(1200));
+  // Hold the tunnel idle across several ping ticks (ping_interval is 1s). Keepalives fire on the
+  // idle pooled socket and traverse the live TLS session; the initiator's readv must strip each
+  // one. If any leaked into the TLS parser the session would break and the gauge would drop.
+  const std::string connected_gauge = "reverse_tunnel_acceptor.nodes.test-node-id";
+  for (int tick = 0; tick < 5; tick++) {
+    timeSystem().advanceTimeWait(std::chrono::milliseconds(1100));
+    // The node is still connected: no RPING corrupted the session into a disconnect.
+    EXPECT_GE(test_server_->gauge(connected_gauge)->value(), 1);
   }
 
-  test_server_->waitForCounter("cluster.reverse_connection_cluster.upstream_rq_completed",
-                               Ge(kNumRequests));
-  EXPECT_EQ(
-      test_server_->counter("cluster.reverse_connection_cluster.upstream_cx_connect_fail")->value(),
-      0);
+  // The tunnel survived the keepalives; a request over the still-live TLS session must succeed.
+  codec_client_ = makeHttpConnection(lookupPort("egress_listener"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  // No RPING ever corrupted a TLS handshake, and the request completed over the tunnel.
+  EXPECT_EQ(test_server_->counter("reverse_tunnel.handshake.parse_error")->value(), 0);
+  test_server_->waitForCounter("cluster.reverse_connection_cluster.upstream_rq_completed", Ge(1));
+
+  cleanupUpstreamAndDownstream();
 
   BufferingStreamDecoderPtr drain_response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "POST", "/drain_listeners", "", Http::CodecType::HTTP1, GetParam());

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_integration_test.cc
@@ -119,7 +119,8 @@ protected:
                                    const std::string& tenant_id = "test-tenant-id",
                                    TunnelClusterModifier tunnel_cluster_modifier = nullptr,
                                    TunnelListenerModifier tunnel_listener_modifier = nullptr,
-                                   bool add_lua_host_id_filter = true) {
+                                   bool add_lua_host_id_filter = true,
+                                   uint32_t ping_interval_seconds = 60) {
 
     // Clear existing listeners, but keep cluster_0 which will be auto-populated with
     // fake_upstreams_[0].
@@ -152,7 +153,7 @@ protected:
 
     // Configure the reverse tunnel filter.
     envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel rt_config;
-    rt_config.mutable_ping_interval()->set_seconds(60);
+    rt_config.mutable_ping_interval()->set_seconds(ping_interval_seconds);
     rt_config.set_auto_close_connections(true);
     rt_config.set_request_path("/reverse_connections/request");
     rt_config.set_request_method(envoy::config::core::v3::GET);
@@ -679,6 +680,113 @@ TEST_P(ReverseConnectionClusterIntegrationTest, EndToEndReverseTunnelTestWithMut
   // Wait for listeners to be fully stopped before test cleanup.
   test_server_->waitForCounter("listener_manager.listener_stopped", Eq(3),
                                std::chrono::milliseconds(5000));
+}
+
+// Drives mTLS tunnel traffic across several RPING keepalive ticks. RPING keepalives are plaintext
+// and must be stripped beneath the TLS transport (via RpingInterceptor::readv on the BIO path); if
+// they leak into the TLS record parser the handshake/records corrupt. A short ping_interval and
+// repeated requests spanning multiple ticks exercise pings arriving on a live TLS session.
+TEST_P(ReverseConnectionClusterIntegrationTest, MutualTLSSurvivesRpingKeepalive) {
+  DISABLE_IF_ADMIN_DISABLED;
+
+  const uint32_t tunnel_listener_port = tunnelListenerPort();
+  const std::string loopback_addr = loopbackAddress();
+  const std::string rundir = TestEnvironment::runfilesDirectory();
+
+  config_helper_.addConfigModifier([this, tunnel_listener_port, loopback_addr,
+                                    rundir](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto tunnel_listener_modifier = [&rundir](envoy::config::listener::v3::FilterChain* chain) {
+      auto* transport_socket = chain->mutable_transport_socket();
+      transport_socket->set_name("envoy.transport_sockets.tls");
+
+      envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+      auto* tls_cert = tls_context.mutable_common_tls_context()->add_tls_certificates();
+      tls_cert->mutable_certificate_chain()->set_filename(
+          rundir + "/test/config/integration/certs/servercert.pem");
+      tls_cert->mutable_private_key()->set_filename(rundir +
+                                                    "/test/config/integration/certs/serverkey.pem");
+      tls_context.mutable_require_client_certificate()->set_value(true);
+      tls_context.mutable_common_tls_context()
+          ->mutable_validation_context()
+          ->mutable_trusted_ca()
+          ->set_filename(rundir + "/test/config/integration/certs/cacert.pem");
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
+      std::ignore = transport_socket->mutable_typed_config()->PackFrom(tls_context);
+    };
+
+    auto tunnel_cluster_modifier = [&rundir](envoy::config::cluster::v3::Cluster* cluster) {
+      auto* transport_socket = cluster->mutable_transport_socket();
+      transport_socket->set_name("envoy.transport_sockets.tls");
+
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+      auto* tls_cert = tls_context.mutable_common_tls_context()->add_tls_certificates();
+      tls_cert->mutable_certificate_chain()->set_filename(
+          rundir + "/test/config/integration/certs/clientcert.pem");
+      tls_cert->mutable_private_key()->set_filename(rundir +
+                                                    "/test/config/integration/certs/clientkey.pem");
+      tls_context.mutable_common_tls_context()
+          ->mutable_validation_context()
+          ->mutable_trusted_ca()
+          ->set_filename(rundir + "/test/config/integration/certs/cacert.pem");
+      tls_context.mutable_common_tls_context()->add_alpn_protocols("h2");
+      std::ignore = transport_socket->mutable_typed_config()->PackFrom(tls_context);
+    };
+
+    // 1s is the smallest usable ping_interval: the filter and socket manager both hold it as
+    // whole seconds, so sub-second values truncate to zero.
+    configureReverseTunnelSetup(bootstrap, loopback_addr, tunnel_listener_port, "test-node-id",
+                                "test-cluster-id", "test-tenant-id", tunnel_cluster_modifier,
+                                tunnel_listener_modifier, /*add_lua_host_id_filter=*/true,
+                                /*ping_interval_seconds=*/1);
+  });
+
+  initialize();
+  registerTestServerPorts({"tunnel_listener", "egress_listener"});
+
+  // Wait for the mTLS reverse tunnel to establish.
+  test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1),
+                               std::chrono::milliseconds(5000));
+  test_server_->waitForGauge("reverse_tunnel_acceptor.nodes.test-node-id", Ge(1));
+
+  // Drive several requests spaced across ping ticks (ping_interval is 1s). With the fix, every
+  // request completes and no RPING corrupts a TLS record; without it, a keepalive that lands on a
+  // live TLS session breaks the handshake/records and a request fails.
+  constexpr int kNumRequests = 4;
+  for (int i = 0; i < kNumRequests; i++) {
+    ENVOY_LOG_MISC(info, "MutualTLSSurvivesRpingKeepalive: sending request {}", i);
+    codec_client_ = makeHttpConnection(lookupPort("egress_listener"));
+    auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+    ASSERT_TRUE(
+        fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+    ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().getStatusValue());
+
+    // No RPING ever corrupted a TLS handshake on the acceptor.
+    EXPECT_EQ(test_server_->counter("reverse_tunnel.handshake.parse_error")->value(), 0);
+
+    cleanupUpstreamAndDownstream();
+    fake_upstream_connection_.reset();
+
+    // Sleep just over a ping tick so the next request overlaps a fresh keepalive.
+    timeSystem().advanceTimeWait(std::chrono::milliseconds(1200));
+  }
+
+  test_server_->waitForCounter("cluster.reverse_connection_cluster.upstream_rq_completed",
+                               Ge(kNumRequests));
+  EXPECT_EQ(
+      test_server_->counter("cluster.reverse_connection_cluster.upstream_cx_connect_fail")->value(),
+      0);
+
+  BufferingStreamDecoderPtr drain_response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/drain_listeners", "", Http::CodecType::HTTP1, GetParam());
+  EXPECT_TRUE(drain_response->complete());
+  EXPECT_EQ("200", drain_response->headers().getStatusValue());
 }
 
 // Test resilience when an initiator node goes down and comes back up.


### PR DESCRIPTION
**Commit Message:**  strip RPING keepalives on the TLS readv() path
**Additional Description:**

**_Motivation:_**
Reverse-tunnel keepalives are 5-byte plaintext "RPING" markers written straight onto the socket. The RpingInterceptor strips them so upper layers never see them; but it only did so on the raw read() path. Over TLS, BoringSSL reads via readv(), which was not intercepted, so RPING bytes leaked into the TLS record parser and corrupted the session.  As a result, whenever the upstream reverse-connection cluster has a TLS transport socket configured, a keepalive could reach the TLS parser as a bogus record and tear the tunnel down.

**_Fix:_** Override readv() to strip RPING on the BIO path too. read() dispatches through readv() internally, so a guard keeps them mutually exclusive and each ping is processed once. readv() handles two extra cases:

- Partial ping: hold the fragment (partial_ping_) and return EAGAIN; the next read reassembles it.
- Coalesced data: epoll is edge-triggered, so real data (e.g. a ClientHello) can arrive packed behind an RPING. After consuming a lone RPING we keep reading until the socket drains.

Risk Level: Low
Testing: Integration Test Added
Docs Changes:  N.A
Release Notes:  N.A
Platform Specific Features:  N.A
