### PR TITLE
credential_injector: strip trailing CR/LF from generic secret credential

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -52,6 +52,8 @@ areas:
     title: circuit_breaker
   composite:
     title: composite
+  credential_injector:
+    title: credential_injector
   dns_resolver:
     title: dns_resolver
   dynamic_modules:

--- a/changelogs/current/bug_fixes/credential_injector__strip-trailing-newline.rst
+++ b/changelogs/current/bug_fixes/credential_injector__strip-trailing-newline.rst
@@ -1,0 +1,5 @@
+Fixed a bug where a credential loaded from a file-based generic secret was injected into the
+request header verbatim, including any trailing newline commonly present in secret files. Since
+HTTP header values cannot contain CR/LF, this produced an invalid header and the request failed.
+Trailing CR/LF characters are now stripped from the credential before injection, and a credential
+consisting only of CR/LF characters is treated as missing.

--- a/docs/root/configuration/http/http_filters/credential_injector_filter.rst
+++ b/docs/root/configuration/http/http_filters/credential_injector_filter.rst
@@ -81,6 +81,12 @@ For example, if your secret file contains just the token ``xyz123`` and you conf
 
 The resulting header will be: ``Authorization: Bearer xyz123``
 
+.. note::
+  Trailing newline and carriage return characters are stripped from the credential before it is
+  injected, since HTTP header values cannot contain them. This is particularly relevant for
+  file-based secrets, which commonly end with a trailing newline. A credential consisting only
+  of such characters is treated as missing.
+
 OAuth2 credential injector (client credential grant)
 ----------------------------------------------------
 * This extension should be configured with the type URL ``type.googleapis.com/envoy.extensions.http.injected_credentials.oauth2.v3.OAuth2``.

--- a/source/extensions/http/injected_credentials/generic/generic_impl.cc
+++ b/source/extensions/http/injected_credentials/generic/generic_impl.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/http/injected_credentials/generic/generic_impl.h"
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -14,12 +15,18 @@ absl::Status GenericCredentialInjector::inject(Envoy::Http::RequestHeaderMap& he
     return absl::AlreadyExistsError("Credential already exists in the header");
   }
 
-  if (secret_reader_->credential().empty()) {
+  // Secret files commonly end with a trailing newline, which is not allowed in HTTP header
+  // values. Strip trailing CR/LF so the injected header is valid.
+  absl::string_view credential = secret_reader_->credential();
+  while (!credential.empty() && (credential.back() == '\n' || credential.back() == '\r')) {
+    credential.remove_suffix(1);
+  }
+
+  if (credential.empty()) {
     return absl::NotFoundError("Failed to get credential from secret");
   }
 
-  const std::string header_value = absl::StrCat(header_value_prefix_, secret_reader_->credential());
-  headers.setCopy(header_, header_value);
+  headers.setCopy(header_, absl::StrCat(header_value_prefix_, credential));
   return absl::OkStatus();
 }
 

--- a/test/extensions/filters/http/credential_injector/filter_test.cc
+++ b/test/extensions/filters/http/credential_injector/filter_test.cc
@@ -230,6 +230,111 @@ TEST_F(GenericCredentialInjectorPrefixTest, InjectCredentialWithCustomPrefix) {
   filter->onDestroy();
 }
 
+// Tests for stripping of trailing CR/LF from the credential, which commonly ends up in
+// file-based secrets and is not allowed in HTTP header values.
+class GenericCredentialInjectorTrimTest : public testing::Test {
+protected:
+  void setup(const std::string& secret, const std::string& header_value_prefix = "") {
+    secret_reader_ = std::make_shared<MockSecretReader>(secret);
+    auto extension =
+        std::make_shared<Http::InjectedCredentials::Generic::GenericCredentialInjector>(
+            "Authorization", header_value_prefix, secret_reader_);
+    config_ = std::make_shared<FilterConfig>(extension, false, false, "stats", *stats_.rootScope());
+  }
+
+  std::shared_ptr<MockSecretReader> secret_reader_;
+  std::shared_ptr<FilterConfig> config_;
+  NiceMock<Stats::IsolatedStoreImpl> stats_;
+  NiceMock<Envoy::Http::MockStreamDecoderFilterCallbacks> decoder_filter_callbacks_;
+};
+
+TEST_F(GenericCredentialInjectorTrimTest, StripTrailingNewline) {
+  setup("myToken123\n");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ("myToken123", request_headers.get_("Authorization"));
+  filter->onDestroy();
+}
+
+TEST_F(GenericCredentialInjectorTrimTest, StripTrailingCrLf) {
+  setup("myToken123\r\n");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ("myToken123", request_headers.get_("Authorization"));
+  filter->onDestroy();
+}
+
+TEST_F(GenericCredentialInjectorTrimTest, StripMultipleTrailingNewlines) {
+  setup("myToken123\n\n");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ("myToken123", request_headers.get_("Authorization"));
+  filter->onDestroy();
+}
+
+TEST_F(GenericCredentialInjectorTrimTest, StripTrailingNewlineWithPrefix) {
+  setup("myToken123\n", "Bearer ");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ("Bearer myToken123", request_headers.get_("Authorization"));
+  filter->onDestroy();
+}
+
+// Only trailing CR/LF is stripped; other whitespace is preserved.
+TEST_F(GenericCredentialInjectorTrimTest, TrailingSpacePreserved) {
+  setup("myToken123 \n");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
+            filter->decodeHeaders(request_headers, true));
+  EXPECT_EQ("myToken123 ", request_headers.get_("Authorization"));
+  filter->onDestroy();
+}
+
+// A secret consisting only of CR/LF is treated as a missing credential.
+TEST_F(GenericCredentialInjectorTrimTest, NewlineOnlySecretTreatedAsMissing) {
+  setup("\n");
+  std::shared_ptr<CredentialInjectorFilter> filter =
+      std::make_shared<CredentialInjectorFilter>(config_);
+  filter->setDecoderFilterCallbacks(decoder_filter_callbacks_);
+
+  Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_CALL(decoder_filter_callbacks_, sendLocalReply(_, _, _, _, _))
+      .WillOnce(Invoke([&](Envoy::Http::Code code, absl::string_view body,
+                           std::function<void(Envoy::Http::ResponseHeaderMap & headers)>,
+                           const std::optional<Grpc::Status::GrpcStatus> grpc_status,
+                           absl::string_view details) {
+        EXPECT_EQ(Envoy::Http::Code::Unauthorized, code);
+        EXPECT_EQ("Failed to inject credential.", body);
+        EXPECT_EQ(grpc_status, std::nullopt);
+        EXPECT_EQ(details, "failed_to_inject_credential");
+      }));
+  filter->decodeHeaders(request_headers, true);
+}
+
 } // namespace
 } // namespace CredentialInjector
 } // namespace HttpFilters

--- a/test/extensions/http/credential_injector/generic/credential_injector_integration_test.cc
+++ b/test/extensions/http/credential_injector/generic/credential_injector_integration_test.cc
@@ -297,6 +297,56 @@ typed_config:
   EXPECT_EQ(1UL, test_server_->counter("http.config_test.credential_injector.injected")->value());
 }
 
+// A trailing newline in the secret (common in file-based secrets) is stripped before the
+// credential is injected, so the resulting header is valid.
+TEST_P(CredentialInjectorIntegrationTestAllProtocols, InjectCredentialStripsTrailingNewline) {
+  TestEnvironment::writeStringToFileForTest("credential_newline.yaml", R"EOF(
+resources:
+  - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+    name: credential_newline
+    generic_secret:
+      secret:
+        inline_string: "dXNlcjpwYXNz\n")EOF",
+                                            false);
+  const std::string filter_config =
+      R"EOF(
+name: envoy.filters.http.credential_injector
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+  overwrite: false
+  credential:
+    name: basic_auth
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.generic.v3.Generic
+      header: Authorization
+      header_value_prefix: "Basic "
+      credential:
+        name: credential_newline
+        sds_config:
+          path_config_source:
+            path: "{{ test_tmpdir }}/credential_newline.yaml"
+)EOF";
+  config_helper_.prependFilter(TestEnvironment::substitute(filter_config));
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  waitForNextUpstreamRequest();
+
+  EXPECT_EQ("Basic dXNlcjpwYXNz", upstream_request_->headers()
+                                      .get(Http::LowerCaseString("Authorization"))[0]
+                                      ->value()
+                                      .getStringView());
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  EXPECT_EQ(1UL, test_server_->counter("http.config_test.credential_injector.injected")->value());
+}
+
 } // namespace
 } // namespace CredentialInjector
 } // namespace HttpFilters


### PR DESCRIPTION
File-based generic secrets commonly end with a trailing newline. The generic credential injector was copying the secret into the HTTP header verbatim, producing an invalid header value and a failed request. Strip trailing CR/LF from the credential before injection, and treat a credential consisting only of CR/LF as missing.

---

Commit Message: credential_injector: strip trailing CR/LF from generic secret credential
Risk Level: low
Testing: unit, integration
AI Assisted: yes
Docs Changes: yes
Release Notes: yes

