### PR TITLE
Add proxy-wasm-cpp-host PR#553 endianness fix for s390x

### DIFF
--- a/bazel/proxy_wasm_cpp_host-s390x.patch
+++ b/bazel/proxy_wasm_cpp_host-s390x.patch
@@ -1,0 +1,12 @@
+--- a/include/proxy-wasm/wasm.h
++++ b/include/proxy-wasm/wasm.h
+@@ -444,7 +444,8 @@
+ }
+
+ template <typename T> inline bool WasmBase::setDatatype(uint64_t ptr, const T &t) {
+-  return wasm_vm_->setMemory(ptr, sizeof(T), &t);
++  T value = htowasm(t, wasm_vm_->usesWasmByteOrder());
++  return wasm_vm_->setMemory(ptr, sizeof(T), &value);
+ }
+
+ } // namespace proxy_wasm

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -905,6 +905,7 @@ def _proxy_wasm_cpp_host():
         patch_args = ["-p1"],
         patches = [
             "@envoy//bazel:proxy_wasm_cpp_host.patch",
+            "@envoy//bazel:proxy_wasm_cpp_host-s390x.patch",
         ],
         repo_mapping = {"@com_google_absl": "@abseil-cpp"},
     )


### PR DESCRIPTION
This PR backports the proxy-wasm-cpp-host PR https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/553 portion of the changes from Envoy PR https://github.com/envoyproxy/envoy/pull/45756 to the Envoy 1.38 branch.

On s390x writing the native host representation into Wasm memory results in incorrect byte ordering. Converting the value using htowasm() before calling setMemory() ensures the value is stored in the correct byte order expected by the Wasm runtime. This change affects only the proxy-wasm-cpp-host dependency.

The original PR contains additional updates related to Wasmtime version changes. Those changes are intentionally not included here, since they are not required for Envoy 1.38. This PR only carries the proxy-wasm-cpp-host fix needed for s390x. The patch is verified successfully on s390x machine.