### PR TITLE
listener: reject udp listeners with bind_to_port false

### DIFF
--- a/changelogs/current/bug_fixes/udp__fixed-crash-with-bind-to-port-false.rst
+++ b/changelogs/current/bug_fixes/udp__fixed-crash-with-bind-to-port-false.rst
@@ -1,0 +1,4 @@
+Fixed a crash when a UDP or QUIC listener was configured with ``bind_to_port`` set to ``false``.
+Such a listener has no bound socket, so applying the listen socket options dereferenced a null I/O
+handle while the listener was being created. This configuration is now rejected with a
+configuration error, as a UDP listener must be bound to a port to receive datagrams.

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -693,6 +693,11 @@ ListenerImpl::buildUdpListenerFactory(const envoy::config::listener::v3::Listene
   if (socket_type_ != Network::Socket::Type::Datagram) {
     return absl::OkStatus();
   }
+  if (!bind_to_port_) {
+    return absl::InvalidArgumentError(
+        "UDP listeners do not support bind_to_port set to false; a UDP socket must be bound to "
+        "receive datagrams.");
+  }
   if (!reuse_port_ && concurrency > 1) {
     return absl::InvalidArgumentError(
         "Listening on UDP when concurrency is > 1 without the SO_REUSEPORT "

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -6620,6 +6620,22 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, ReusePortListenerDisabled) {
   EXPECT_EQ(0, manager_->listeners().size());
 }
 
+// A UDP listener with bind_to_port set to false has no bound socket, so applying socket options to
+// it used to dereference a null io handle and crash Envoy. Verify the config is rejected instead.
+TEST_P(ListenerManagerImplWithRealFiltersTest, UdpListenerWithBindToPortFalse) {
+  auto listener = createIPv4Listener("UdpListener");
+  listener.mutable_address()->mutable_socket_address()->set_protocol(
+      envoy::config::core::v3::SocketAddress::UDP);
+  // Connection-less (non-QUIC) UDP listeners must not specify filter chains.
+  listener.clear_filter_chains();
+  listener.mutable_bind_to_port()->set_value(false);
+
+  EXPECT_THROW_WITH_MESSAGE(addOrUpdateListener(listener), EnvoyException,
+                            "UDP listeners do not support bind_to_port set to false; a UDP socket "
+                            "must be bound to receive datagrams.");
+  EXPECT_EQ(0, manager_->listeners().size());
+}
+
 // Envoy throws exceptions for UDP listener with dynamic filter config.
 TEST_P(ListenerManagerImplWithRealFiltersTest, UdpListenerWithDynamicFilterConfig) {
   auto listener = createIPv4Listener("UdpListener");


### PR DESCRIPTION
A UDP or QUIC listener configured with bind_to_port set to false has no bound socket, so applying the listen socket options dereferenced a null I/O handle and crashed Envoy on startup. This now returns a configuration error instead, since a UDP listener has to be bound to actually receive datagrams.

Fixes #46231