### PR TITLE
Use status matchers where appropriate (12)

### DIFF
--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -39,6 +39,7 @@ envoy_cc_test(
         "//test/mocks/upstream:priority_set_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:thread_factory_for_test_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -34,6 +34,7 @@ namespace Extensions {
 namespace Clusters {
 namespace DynamicModules {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::Not;
 
@@ -221,15 +222,13 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("CLUSTER_PROVIDED"));
+  ASSERT_THAT(result, HasStatusMessage(testing::HasSubstr("CLUSTER_PROVIDED")));
 }
 
 // Test that a missing module fails gracefully.
 TEST_F(DynamicModuleClusterTest, MissingModule) {
   auto result = createCluster(makeYamlConfig("nonexistent_module"));
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module"));
+  ASSERT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
 
   EXPECT_EQ(1U, failureCounter(server_context_.serverScope(), "module_load_error", "test"));
 }
@@ -237,9 +236,8 @@ TEST_F(DynamicModuleClusterTest, MissingModule) {
 // Test that on_cluster_config_new returning nullptr fails.
 TEST_F(DynamicModuleClusterTest, ConfigNewFail) {
   auto result = createCluster(makeYamlConfig("cluster_config_new_fail"));
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to create in-module cluster configuration"));
+  ASSERT_THAT(result, HasStatusMessage(
+                          testing::HasSubstr("Failed to create in-module cluster configuration")));
 
   // The module loads fine but its config creation fails, counted as config_init_error.
   EXPECT_EQ(1U, failureCounter(server_context_.serverScope(), "config_init_error", "test"));
@@ -249,9 +247,8 @@ TEST_F(DynamicModuleClusterTest, ConfigNewFail) {
 // Test that on_cluster_new returning nullptr fails.
 TEST_F(DynamicModuleClusterTest, ClusterNewFail) {
   auto result = createCluster(makeYamlConfig("cluster_new_fail"));
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to create in-module cluster instance"));
+  ASSERT_THAT(result,
+              HasStatusMessage(testing::HasSubstr("Failed to create in-module cluster instance")));
 }
 
 // The cluster_config Any cannot be unpacked. This is parsed before the module is loaded, so it is
@@ -1057,9 +1054,8 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
 TEST_F(DynamicModuleClusterTest, MissingClusterSymbol) {
   // The "no_op" module exports on_program_init but not cluster symbols.
   auto result = createCluster(makeYamlConfig("no_op"));
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_cluster_config_new"));
+  ASSERT_THAT(result,
+              HasStatusMessage(testing::HasSubstr("envoy_dynamic_module_on_cluster_config_new")));
 }
 
 // Test that creating a cluster with BytesValue config type works.

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -22,6 +22,7 @@
 #include "test/mocks/upstream/priority_set.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/thread_factory_for_test.h"
 #include "test/test_common/utility.h"
 
@@ -32,6 +33,9 @@ namespace Envoy {
 namespace Extensions {
 namespace Clusters {
 namespace DynamicModules {
+
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 // Test peer class to access private members of DynamicModuleCluster.
 // This must be outside the anonymous namespace to match the friend declaration.
@@ -159,7 +163,7 @@ using ::Envoy::Extensions::DynamicModules::failureCounter;
 
 TEST_F(DynamicModuleClusterTest, BasicCreation) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 
@@ -187,7 +191,7 @@ cluster_type:
 )EOF",
                   Extensions::DynamicModules::testSharedObjectPath("cluster_no_op", "c"));
   auto result = createCluster(yaml);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 }
@@ -196,7 +200,7 @@ cluster_type:
 TEST_F(DynamicModuleClusterTest, CreationWithClusterConfig) {
   auto result =
       createCluster(makeYamlConfigWithClusterConfig("cluster_no_op", "test", "some_config"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 }
@@ -217,14 +221,14 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(), testing::HasSubstr("CLUSTER_PROVIDED"));
 }
 
 // Test that a missing module fails gracefully.
 TEST_F(DynamicModuleClusterTest, MissingModule) {
   auto result = createCluster(makeYamlConfig("nonexistent_module"));
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(), testing::HasSubstr("Failed to load dynamic module"));
 
   EXPECT_EQ(1U, failureCounter(server_context_.serverScope(), "module_load_error", "test"));
@@ -233,7 +237,7 @@ TEST_F(DynamicModuleClusterTest, MissingModule) {
 // Test that on_cluster_config_new returning nullptr fails.
 TEST_F(DynamicModuleClusterTest, ConfigNewFail) {
   auto result = createCluster(makeYamlConfig("cluster_config_new_fail"));
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to create in-module cluster configuration"));
 
@@ -245,7 +249,7 @@ TEST_F(DynamicModuleClusterTest, ConfigNewFail) {
 // Test that on_cluster_new returning nullptr fails.
 TEST_F(DynamicModuleClusterTest, ClusterNewFail) {
   auto result = createCluster(makeYamlConfig("cluster_new_fail"));
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to create in-module cluster instance"));
 }
@@ -265,7 +269,7 @@ TEST_F(DynamicModuleClusterTest, MalformedClusterConfig) {
   Upstream::ClusterFactoryContextImpl factory_context(server_context_, nullptr, nullptr, false);
   DynamicModuleClusterFactory factory;
   auto result = factory.create(cluster, factory_context);
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
 
   EXPECT_EQ(1U, failureCounter(server_context_.serverScope(), "config_init_error", "test"));
   EXPECT_EQ(0U, failureCounter(server_context_.serverScope(), "module_load_error", "test"));
@@ -274,7 +278,7 @@ TEST_F(DynamicModuleClusterTest, MalformedClusterConfig) {
 // Test batch host addition and removal via the public API.
 TEST_F(DynamicModuleClusterTest, HostManagement) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -313,7 +317,7 @@ TEST_F(DynamicModuleClusterTest, HostManagement) {
 // Test batch addition with a single host.
 TEST_F(DynamicModuleClusterTest, HostManagementSingleHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -332,7 +336,7 @@ TEST_F(DynamicModuleClusterTest, HostManagementSingleHost) {
 // Test that batch remove of multiple hosts works correctly.
 TEST_F(DynamicModuleClusterTest, BatchRemoveMultipleHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -351,7 +355,7 @@ TEST_F(DynamicModuleClusterTest, BatchRemoveMultipleHosts) {
 // Test that addresses already present in the host set are skipped on a subsequent batch.
 TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -398,7 +402,7 @@ TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
 // Test that invalid addresses cause the entire batch to fail.
 TEST_F(DynamicModuleClusterTest, InvalidAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -417,7 +421,7 @@ TEST_F(DynamicModuleClusterTest, InvalidAddress) {
 // Test that invalid weights cause the entire batch to fail.
 TEST_F(DynamicModuleClusterTest, InvalidWeight) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -435,14 +439,14 @@ TEST_F(DynamicModuleClusterTest, InvalidWeight) {
 // Test the load balancer lifecycle.
 TEST_F(DynamicModuleClusterTest, LoadBalancerLifecycle) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
   auto& talb = result->second;
   ASSERT_NE(nullptr, talb);
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
 
   auto lb_factory = talb->factory();
   ASSERT_NE(nullptr, lb_factory);
@@ -476,7 +480,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerLifecycle) {
 // Test the load balancer with hosts and the priority set access.
 TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -489,7 +493,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
   // Create the LB.
   auto& talb = result->second;
   ASSERT_NE(nullptr, talb);
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
 
   auto lb_factory = talb->factory();
   ASSERT_NE(nullptr, lb_factory);
@@ -507,7 +511,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
 // prioritySet() answers host queries from the worker local set supplied at construction.
 TEST_F(DynamicModuleClusterTest, PrioritySetUsesWorkerLocalSet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   NiceMock<Upstream::MockPrioritySet> worker_ps;
@@ -521,7 +525,7 @@ TEST_F(DynamicModuleClusterTest, PrioritySetUsesWorkerLocalSet) {
 // Test that the cluster initializes with the Primary phase.
 TEST_F(DynamicModuleClusterTest, InitializePhase) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -531,7 +535,7 @@ TEST_F(DynamicModuleClusterTest, InitializePhase) {
 // Test that the cluster can be initialized and the in-module cluster is set.
 TEST_F(DynamicModuleClusterTest, InModuleClusterIsSet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -543,7 +547,7 @@ TEST_F(DynamicModuleClusterTest, InModuleClusterIsSet) {
 // Test the ABI callback implementations for batch host management directly.
 TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -590,7 +594,7 @@ TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
 // Test the LB ABI callback implementations directly.
 TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -602,7 +606,7 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
 
   // Create the LB.
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -628,7 +632,7 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
 // Test the LB host information ABI callbacks.
 TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -641,7 +645,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
 
   // Create the LB.
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -829,7 +833,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
 // and with empty locality.
 TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -883,7 +887,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
 
   // Create the LB.
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -1053,7 +1057,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
 TEST_F(DynamicModuleClusterTest, MissingClusterSymbol) {
   // The "no_op" module exports on_program_init but not cluster symbols.
   auto result = createCluster(makeYamlConfig("no_op"));
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_cluster_config_new"));
 }
@@ -1077,7 +1081,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1102,7 +1106,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1127,7 +1131,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1135,7 +1139,7 @@ cluster_type:
 // preInitComplete triggers onPreInitComplete which invokes the completion callback.
 TEST_F(DynamicModuleClusterTest, PreInitFlow) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1160,7 +1164,7 @@ TEST_F(DynamicModuleClusterTest, PreInitFlow) {
 // Test that the scheduler can be created and deleted via ABI callbacks.
 TEST_F(DynamicModuleClusterTest, SchedulerLifecycle) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1176,7 +1180,7 @@ TEST_F(DynamicModuleClusterTest, SchedulerLifecycle) {
 // Test that the scheduler commit posts to the dispatcher.
 TEST_F(DynamicModuleClusterTest, SchedulerCommit) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1214,7 +1218,7 @@ TEST_F(DynamicModuleClusterTest, SchedulerCommit) {
 // Test that onScheduled is called when the posted callback executes.
 TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1250,7 +1254,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
 // Worker timer creation returns null before any chooseHost has captured a worker dispatcher.
 TEST_F(DynamicModuleClusterTest, WorkerTimerNewReturnsNullWithoutDispatcher) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1278,7 +1282,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
 
   {
     auto result = createCluster(makeYamlConfig("cluster_no_op"));
-    ASSERT_TRUE(result.ok()) << result.status().message();
+    ASSERT_OK(result) << result.status().message();
 
     auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
     ASSERT_NE(nullptr, cluster);
@@ -1318,7 +1322,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
 // `commit` must not touch the dispatcher once the owning cluster has been destroyed.
 TEST_F(DynamicModuleClusterTest, CommitAfterClusterDestroyedDoesNotTouchDispatcher) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1338,7 +1342,7 @@ TEST_F(DynamicModuleClusterTest, CommitAfterClusterDestroyedDoesNotTouchDispatch
 // Test calling onScheduled directly.
 TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1351,7 +1355,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
 // lazily.
 TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsSafeOnUnpopulatedSlot) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1365,18 +1369,18 @@ TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsSafeOnUnpopulatedSlot) {
 // Test worker_slot_set / worker_slot_get round-trip and destroy on overwrite and teardown.
 TEST_F(DynamicModuleClusterTest, WorkerSlotSetGetAndDestroy) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
   auto module_handle = Envoy::Extensions::DynamicModules::newDynamicModule(
       Envoy::Extensions::DynamicModules::testSharedObjectPath("cluster_run_on_all_workers", "c"),
       /*do_not_close=*/true);
-  ASSERT_TRUE(module_handle.ok()) << module_handle.status().message();
+  ASSERT_OK(module_handle) << module_handle.status().message();
   using GetCountFn = size_t (*)();
   auto get_destroy_count = module_handle.value()->getFunctionPointer<GetCountFn>(
       "cluster_run_on_all_workers_test_get_destroy_count");
-  ASSERT_TRUE(get_destroy_count.ok()) << get_destroy_count.status().message();
+  ASSERT_OK(get_destroy_count) << get_destroy_count.status().message();
 
   // Publish payload1; the module's destroy hook will free() it.
   uint64_t* payload1 = static_cast<uint64_t*>(std::malloc(sizeof(uint64_t)));
@@ -1410,7 +1414,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotSetGetAndDestroy) {
 // slot or scheduling any work.
 TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsNoOpWithoutWorkerEventHook) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1424,7 +1428,7 @@ TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsNoOpWithoutWorkerEventHook) {
 // worker_slot_set or run_on_all_workers call).
 TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrBeforeAllocation) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1435,7 +1439,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrBeforeAllocation) {
 // but no payload has been published via worker_slot_set.
 TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrWhenSlotAllocatedButEmpty) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1448,7 +1452,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrWhenSlotAllocatedBut
 // Test cluster_get_name returns the cluster's CDS name from the cluster-side context.
 TEST_F(DynamicModuleClusterTest, ClusterGetNameReturnsCdsName) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1460,7 +1464,7 @@ TEST_F(DynamicModuleClusterTest, ClusterGetNameReturnsCdsName) {
 // Test the DynamicModuleClusterHandle destructor dispatches to main thread.
 TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1475,7 +1479,7 @@ TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
 // Covers that a worker-thread handle destruction posts the full teardown to the main dispatcher.
 TEST_F(DynamicModuleClusterTest, HandleDestructorFromWorkerThreadDefersAllTeardownToMainThread) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1512,7 +1516,7 @@ TEST_F(DynamicModuleClusterTest, ServerInitializedCallback) {
       .WillOnce(testing::DoAll(testing::SaveArg<1>(&captured_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   // Invoke the captured callback to exercise the server initialized path.
   captured_cb();
@@ -1526,10 +1530,10 @@ TEST_F(DynamicModuleClusterTest, DrainStartedCallback) {
       .WillOnce(testing::DoAll(testing::SaveArg<1>(&captured_drain_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   // Invoke the captured drain callback to exercise the drain notification path.
-  EXPECT_TRUE(captured_drain_cb(std::chrono::milliseconds(0)).ok());
+  EXPECT_OK(captured_drain_cb(std::chrono::milliseconds(0)));
 }
 
 // Test that the shutdown lifecycle callback is invoked with completion.
@@ -1544,7 +1548,7 @@ TEST_F(DynamicModuleClusterTest, ShutdownCallbackWithCompletion) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   // Invoke the captured shutdown callback with a completion callback.
   bool completion_called = false;
@@ -1564,7 +1568,7 @@ TEST_F(DynamicModuleClusterTest, ShutdownCallbackAfterClusterDestroy) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1600,11 +1604,11 @@ TEST_F(DynamicModuleClusterTest, AllLifecycleCallbacksRegistered) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   // Invoke all lifecycle callbacks to verify the full lifecycle flow.
   captured_init_cb();
-  EXPECT_TRUE(captured_drain_cb(std::chrono::milliseconds(0)).ok());
+  EXPECT_OK(captured_drain_cb(std::chrono::milliseconds(0)));
   bool completion_called = false;
   captured_shutdown_cb([&completion_called]() { completion_called = true; });
   EXPECT_TRUE(completion_called);
@@ -1617,7 +1621,7 @@ TEST_F(DynamicModuleClusterTest, AllLifecycleCallbacksRegistered) {
 // Test defining and incrementing a scalar counter via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndIncrementCounter) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1641,7 +1645,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndIncrementCounter) {
 // Test defining and using a scalar gauge via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndUseGauge) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1671,7 +1675,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndUseGauge) {
 // Test defining and recording a scalar histogram via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndRecordHistogram) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1695,7 +1699,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndRecordHistogram) {
 // Test metric not found errors for invalid IDs.
 TEST_F(DynamicModuleClusterTest, MetricsNotFoundForInvalidId) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1729,7 +1733,7 @@ TEST_F(DynamicModuleClusterTest, MetricsNotFoundForInvalidId) {
 // Test defining and using a counter vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsCounterVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1774,7 +1778,7 @@ TEST_F(DynamicModuleClusterTest, MetricsCounterVecWithLabels) {
 // Test defining and using a gauge vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsGaugeVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1810,7 +1814,7 @@ TEST_F(DynamicModuleClusterTest, MetricsGaugeVecWithLabels) {
 // Test defining and using a histogram vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsHistogramVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1842,7 +1846,7 @@ TEST_F(DynamicModuleClusterTest, MetricsHistogramVecWithLabels) {
 // Test that using a vec metric ID with zero labels returns InvalidLabels.
 TEST_F(DynamicModuleClusterTest, MetricsVecScalarIdConflictErrors) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1897,7 +1901,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecScalarIdConflictErrors) {
 // Test that providing wrong number of label values returns InvalidLabels.
 TEST_F(DynamicModuleClusterTest, MetricsVecWrongLabelCount) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1942,7 +1946,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecWrongLabelCount) {
 // Test that using non-existent vec IDs with labels returns MetricNotFound.
 TEST_F(DynamicModuleClusterTest, MetricsVecNotFoundWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -2175,7 +2179,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetHostSelectionRetryCountNullContext)
 // Test should_select_another_host.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2184,7 +2188,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001", "127.0.0.1:10002"}, {1, 2}, hosts));
 
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -2201,7 +2205,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
 // Test should_select_another_host returns false.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2210,7 +2214,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001"}, {1}, hosts));
 
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -2227,7 +2231,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
 // Test should_select_another_host with invalid priority and index.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2236,7 +2240,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
   ASSERT_TRUE(addSimpleHosts(*cluster, {"127.0.0.1:10001"}, {1}, hosts));
 
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   auto lb = lb_factory->create({cluster->prioritySet()});
   auto* dm_lb = dynamic_cast<DynamicModuleLoadBalancer*>(lb.get());
@@ -2256,10 +2260,10 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
 // Test should_select_another_host with nullptr context.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostNullContext) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto& talb = result->second;
-  EXPECT_TRUE(talb->initialize().ok());
+  EXPECT_OK(talb->initialize());
   auto lb_factory = talb->factory();
   NiceMock<Upstream::MockPrioritySet> mock_ps;
   auto lb = lb_factory->create({mock_ps});
@@ -2579,7 +2583,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetHostStatNullPointers) {
 // Test that the index-based `get_host_stat` maps each stat enum to the matching `HostStats` field.
 TEST_F(DynamicModuleClusterTest, LbGetHostStatReadsValues) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   std::vector<Upstream::HostSharedPtr> hosts;
@@ -2742,7 +2746,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionHandleCancelNullFn) {
 // Test async host selection complete callback with a valid host.
 TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteWithHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto& [cluster, lb] = result.value();
 
   auto& module_cluster = dynamic_cast<DynamicModuleCluster&>(*cluster);
@@ -2775,7 +2779,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteWithHost) {
 // Test async host selection complete callback with null host.
 TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteNullHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto& [cluster, lb] = result.value();
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
@@ -2799,7 +2803,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteNullHost) {
 // Test async host selection complete callback with empty details.
 TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto& [cluster, lb] = result.value();
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
@@ -2824,7 +2828,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
 // already been destroyed.
 TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteAfterLbDestroyedDropsEvent) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto& [cluster, lb] = result.value();
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(
@@ -2845,7 +2849,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteAfterLbDestroyedDrops
 // still be found by the registry.
 TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteRegistersFreshInstancePerLb) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto& [cluster, lb] = result.value();
 
   auto handle = std::make_shared<DynamicModuleClusterHandle>(
@@ -2867,7 +2871,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteRegistersFreshInstanc
 // Test HTTP callout with cluster not found.
 TEST_F(DynamicModuleClusterTest, HttpCalloutClusterNotFound) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -2894,7 +2898,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutClusterNotFound) {
 // Test HTTP callout with missing required headers.
 TEST_F(DynamicModuleClusterTest, HttpCalloutMissingHeaders) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -2917,7 +2921,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutMissingHeaders) {
 // Test HTTP callout success with response headers and body.
 TEST_F(DynamicModuleClusterTest, HttpCalloutSuccess) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -2962,7 +2966,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutSuccess) {
 // Test HTTP callout failure with reset.
 TEST_F(DynamicModuleClusterTest, HttpCalloutFailureReset) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3002,7 +3006,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutFailureReset) {
 // Test HTTP callout failure with exceed response buffer limit.
 TEST_F(DynamicModuleClusterTest, HttpCalloutFailureExceedBufferLimit) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3043,7 +3047,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutFailureExceedBufferLimit) {
 // Test HTTP callout when async client cannot create request.
 TEST_F(DynamicModuleClusterTest, HttpCalloutCannotCreateRequest) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3073,7 +3077,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutCannotCreateRequest) {
 // Test HTTP callout with request body.
 TEST_F(DynamicModuleClusterTest, HttpCalloutWithBody) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3118,7 +3122,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutWithBody) {
 // Test HTTP callout success after in-module cluster is cleared.
 TEST_F(DynamicModuleClusterTest, HttpCalloutSuccessAfterInModuleClusterCleared) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3164,7 +3168,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutSuccessAfterInModuleClusterCleared) 
 // Test HTTP callout failure after in-module cluster is cleared.
 TEST_F(DynamicModuleClusterTest, HttpCalloutFailureAfterInModuleClusterCleared) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(cluster, nullptr);
 
@@ -3208,7 +3212,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutFailureAfterInModuleClusterCleared) 
 // Test adding hosts with locality information.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3240,7 +3244,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocality) {
 // Test adding hosts with locality and metadata.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadata) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3269,7 +3273,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadata) {
 // Test adding hosts with locality via the ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3306,7 +3310,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityABI) {
 // Test adding hosts with locality and metadata via the ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadataABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3345,7 +3349,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadataABI) {
 // Test updating host health status.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealth) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3376,7 +3380,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealth) {
 // Test update_host_health via the ABI callback.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3411,7 +3415,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthABI) {
 // Test finding a host by address.
 TEST_F(DynamicModuleClusterTest, FindHostByAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3436,7 +3440,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddress) {
 // Test find_host_by_address via the ABI callback.
 TEST_F(DynamicModuleClusterTest, FindHostByAddressABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3463,7 +3467,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddressABI) {
 // Test that the cluster LB on_host_membership_update callback fires and provides host addresses.
 TEST_F(DynamicModuleClusterTest, LbHostMembershipUpdate) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3488,7 +3492,7 @@ TEST_F(DynamicModuleClusterTest, LbHostMembershipUpdate) {
 // Test get_member_update_host_address callback returns correct addresses during update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3512,7 +3516,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
 // Test get_member_update_host returns the host pointers borrowed during a membership update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPointer) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3561,7 +3565,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPointer) {
 // Test get_member_update_host_packed_address returns the packed IP/port during a membership update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPackedAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3631,7 +3635,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPackedAddress) {
 // Test hosts-per-locality is correctly maintained with locality-aware hosts.
 TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3665,7 +3669,7 @@ TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
 // Test that update_host_health affects the healthy host list.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthAffectsHealthyHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3693,7 +3697,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAffectsHealthyHosts) {
 // Test find_host_by_address on the cluster LB (worker thread).
 TEST_F(DynamicModuleClusterTest, LbFindHostByAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3730,7 +3734,7 @@ TEST_F(DynamicModuleClusterTest, LbFindHostByAddress) {
 // Test get_host returns a host pointer by index from all hosts regardless of health.
 TEST_F(DynamicModuleClusterTest, LbGetHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3763,7 +3767,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHost) {
 // Test get_host returns unhealthy hosts that get_healthy_host does not.
 TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3791,7 +3795,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
 // Test that add_hosts supports adding hosts at a specific priority level.
 TEST_F(DynamicModuleClusterTest, AddHostsToPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3819,7 +3823,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsToPriority) {
 // Test add_hosts with priority via ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithPriorityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3860,7 +3864,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithPriorityABI) {
 // Test add_hosts with locality and priority via ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndPriorityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3896,7 +3900,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndPriorityABI) {
 // Test that update_host_health works correctly for hosts at non-zero priority levels.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3938,7 +3942,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
 // subscription target and would fail if the registration moved back to the cluster main set.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateCbRegistersOnWorkerLocalPrioritySet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
 
@@ -3953,7 +3957,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateCbRegistersOnWorkerLocalPriorityS
 // subscribe and unsubscribe paths under sanitizer builds.
 TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   Upstream::PrioritySetImpl worker_priority_set;
@@ -3987,7 +3991,7 @@ TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
 // Verifies that `cluster_add_hosts` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4011,7 +4015,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
 // Verifies that `cluster_remove_hosts` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, RemoveHostsOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4032,7 +4036,7 @@ TEST_F(DynamicModuleClusterTest, RemoveHostsOffMainThreadFailsClosed) {
 // Verifies that `cluster_update_host_health` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4053,7 +4057,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthOffMainThreadFailsClosed) {
 // Verifies that `cluster_pre_init_complete` is a safe no-op when called off the main thread.
 TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4071,7 +4075,7 @@ TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
 // Verifies that `cluster_find_host_by_address` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, FindHostByAddressOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4093,7 +4097,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddressOffMainThreadFailsClosed) {
 // Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
 TEST_F(DynamicModuleClusterTest, MetricsFrozenAfterInit) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -4120,7 +4124,7 @@ TEST_F(DynamicModuleClusterTest, MetricsFrozenAfterInit) {
 // shared `stat_name_pool_`. Run under `--config=tsan` to verify.
 TEST_F(DynamicModuleClusterTest, MetricsConcurrentIncrementCounterVecNoRace) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
   unfreezeStatCreation(*config);
@@ -4177,7 +4181,7 @@ TEST_F(DynamicModuleClusterTest, MetricsConcurrentIncrementCounterVecNoRace) {
 // setHostData / getHostData return false when the priority is out of range.
 TEST_F(DynamicModuleClusterTest, SetGetHostDataPriorityOutOfRange) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4196,7 +4200,7 @@ TEST_F(DynamicModuleClusterTest, SetGetHostDataPriorityOutOfRange) {
 // updateHostHealth returns false when the supplied host is not present in any priority set.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthHostNotInAnyPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4211,7 +4215,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthHostNotInAnyPriority) {
 // on_cluster_http_callout_done, since there is no path for the response to be delivered.
 TEST_F(DynamicModuleClusterTest, HttpCalloutRequestedWithoutDoneHook) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4238,7 +4242,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutRequestedWithoutDoneHook) {
 // module's on_cluster_lb_new returned null and in_module_lb_ remains unset).
 TEST_F(DynamicModuleClusterTest, ChooseHostShortCircuitsWhenInModuleLbIsNull) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4262,7 +4266,7 @@ TEST_F(DynamicModuleClusterTest, HandleDestructorIsNoOpWhenClusterIsNull) {
 // The cluster destructor cancels any pending HTTP callouts before clearing them.
 TEST_F(DynamicModuleClusterTest, DestructorCancelsPendingHttpCallouts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -164,7 +164,7 @@ using ::Envoy::Extensions::DynamicModules::failureCounter;
 
 TEST_F(DynamicModuleClusterTest, BasicCreation) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 
@@ -192,7 +192,7 @@ cluster_type:
 )EOF",
                   Extensions::DynamicModules::testSharedObjectPath("cluster_no_op", "c"));
   auto result = createCluster(yaml);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 }
@@ -201,7 +201,7 @@ cluster_type:
 TEST_F(DynamicModuleClusterTest, CreationWithClusterConfig) {
   auto result =
       createCluster(makeYamlConfigWithClusterConfig("cluster_no_op", "test", "some_config"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
   EXPECT_NE(nullptr, result->second);
 }
@@ -275,7 +275,7 @@ TEST_F(DynamicModuleClusterTest, MalformedClusterConfig) {
 // Test batch host addition and removal via the public API.
 TEST_F(DynamicModuleClusterTest, HostManagement) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -314,7 +314,7 @@ TEST_F(DynamicModuleClusterTest, HostManagement) {
 // Test batch addition with a single host.
 TEST_F(DynamicModuleClusterTest, HostManagementSingleHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -333,7 +333,7 @@ TEST_F(DynamicModuleClusterTest, HostManagementSingleHost) {
 // Test that batch remove of multiple hosts works correctly.
 TEST_F(DynamicModuleClusterTest, BatchRemoveMultipleHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -352,7 +352,7 @@ TEST_F(DynamicModuleClusterTest, BatchRemoveMultipleHosts) {
 // Test that addresses already present in the host set are skipped on a subsequent batch.
 TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -399,7 +399,7 @@ TEST_F(DynamicModuleClusterTest, DuplicateHostDetection) {
 // Test that invalid addresses cause the entire batch to fail.
 TEST_F(DynamicModuleClusterTest, InvalidAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -418,7 +418,7 @@ TEST_F(DynamicModuleClusterTest, InvalidAddress) {
 // Test that invalid weights cause the entire batch to fail.
 TEST_F(DynamicModuleClusterTest, InvalidWeight) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -436,7 +436,7 @@ TEST_F(DynamicModuleClusterTest, InvalidWeight) {
 // Test the load balancer lifecycle.
 TEST_F(DynamicModuleClusterTest, LoadBalancerLifecycle) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -477,7 +477,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerLifecycle) {
 // Test the load balancer with hosts and the priority set access.
 TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -508,7 +508,7 @@ TEST_F(DynamicModuleClusterTest, LoadBalancerWithHosts) {
 // prioritySet() answers host queries from the worker local set supplied at construction.
 TEST_F(DynamicModuleClusterTest, PrioritySetUsesWorkerLocalSet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   NiceMock<Upstream::MockPrioritySet> worker_ps;
@@ -522,7 +522,7 @@ TEST_F(DynamicModuleClusterTest, PrioritySetUsesWorkerLocalSet) {
 // Test that the cluster initializes with the Primary phase.
 TEST_F(DynamicModuleClusterTest, InitializePhase) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -532,7 +532,7 @@ TEST_F(DynamicModuleClusterTest, InitializePhase) {
 // Test that the cluster can be initialized and the in-module cluster is set.
 TEST_F(DynamicModuleClusterTest, InModuleClusterIsSet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -544,7 +544,7 @@ TEST_F(DynamicModuleClusterTest, InModuleClusterIsSet) {
 // Test the ABI callback implementations for batch host management directly.
 TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -591,7 +591,7 @@ TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
 // Test the LB ABI callback implementations directly.
 TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -629,7 +629,7 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
 // Test the LB host information ABI callbacks.
 TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -830,7 +830,7 @@ TEST_F(DynamicModuleClusterTest, LbHostInformationCallbacks) {
 // and with empty locality.
 TEST_F(DynamicModuleClusterTest, LbHostInformationWithMetadataAndLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1077,7 +1077,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1102,7 +1102,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1127,7 +1127,7 @@ cluster_type:
 )EOF";
 
   auto result = createCluster(yaml);
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   EXPECT_NE(nullptr, result->first);
 }
 
@@ -1135,7 +1135,7 @@ cluster_type:
 // preInitComplete triggers onPreInitComplete which invokes the completion callback.
 TEST_F(DynamicModuleClusterTest, PreInitFlow) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1160,7 +1160,7 @@ TEST_F(DynamicModuleClusterTest, PreInitFlow) {
 // Test that the scheduler can be created and deleted via ABI callbacks.
 TEST_F(DynamicModuleClusterTest, SchedulerLifecycle) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1176,7 +1176,7 @@ TEST_F(DynamicModuleClusterTest, SchedulerLifecycle) {
 // Test that the scheduler commit posts to the dispatcher.
 TEST_F(DynamicModuleClusterTest, SchedulerCommit) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1214,7 +1214,7 @@ TEST_F(DynamicModuleClusterTest, SchedulerCommit) {
 // Test that onScheduled is called when the posted callback executes.
 TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1250,7 +1250,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledCallback) {
 // Worker timer creation returns null before any chooseHost has captured a worker dispatcher.
 TEST_F(DynamicModuleClusterTest, WorkerTimerNewReturnsNullWithoutDispatcher) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1278,7 +1278,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
 
   {
     auto result = createCluster(makeYamlConfig("cluster_no_op"));
-    ASSERT_OK(result) << result.status().message();
+    ASSERT_OK(result);
 
     auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
     ASSERT_NE(nullptr, cluster);
@@ -1318,7 +1318,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledAfterClusterDestroyed) {
 // `commit` must not touch the dispatcher once the owning cluster has been destroyed.
 TEST_F(DynamicModuleClusterTest, CommitAfterClusterDestroyedDoesNotTouchDispatcher) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1338,7 +1338,7 @@ TEST_F(DynamicModuleClusterTest, CommitAfterClusterDestroyedDoesNotTouchDispatch
 // Test calling onScheduled directly.
 TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1351,7 +1351,7 @@ TEST_F(DynamicModuleClusterTest, OnScheduledDirect) {
 // lazily.
 TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsSafeOnUnpopulatedSlot) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1365,18 +1365,18 @@ TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsSafeOnUnpopulatedSlot) {
 // Test worker_slot_set / worker_slot_get round-trip and destroy on overwrite and teardown.
 TEST_F(DynamicModuleClusterTest, WorkerSlotSetGetAndDestroy) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
   auto module_handle = Envoy::Extensions::DynamicModules::newDynamicModule(
       Envoy::Extensions::DynamicModules::testSharedObjectPath("cluster_run_on_all_workers", "c"),
       /*do_not_close=*/true);
-  ASSERT_OK(module_handle) << module_handle.status().message();
+  ASSERT_OK(module_handle);
   using GetCountFn = size_t (*)();
   auto get_destroy_count = module_handle.value()->getFunctionPointer<GetCountFn>(
       "cluster_run_on_all_workers_test_get_destroy_count");
-  ASSERT_OK(get_destroy_count) << get_destroy_count.status().message();
+  ASSERT_OK(get_destroy_count);
 
   // Publish payload1; the module's destroy hook will free() it.
   uint64_t* payload1 = static_cast<uint64_t*>(std::malloc(sizeof(uint64_t)));
@@ -1410,7 +1410,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotSetGetAndDestroy) {
 // slot or scheduling any work.
 TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsNoOpWithoutWorkerEventHook) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1424,7 +1424,7 @@ TEST_F(DynamicModuleClusterTest, RunOnAllWorkersIsNoOpWithoutWorkerEventHook) {
 // worker_slot_set or run_on_all_workers call).
 TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrBeforeAllocation) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1435,7 +1435,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrBeforeAllocation) {
 // but no payload has been published via worker_slot_set.
 TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrWhenSlotAllocatedButEmpty) {
   auto result = createCluster(makeYamlConfig("cluster_run_on_all_workers"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1448,7 +1448,7 @@ TEST_F(DynamicModuleClusterTest, WorkerSlotGetReturnsNullptrWhenSlotAllocatedBut
 // Test cluster_get_name returns the cluster's CDS name from the cluster-side context.
 TEST_F(DynamicModuleClusterTest, ClusterGetNameReturnsCdsName) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1460,7 +1460,7 @@ TEST_F(DynamicModuleClusterTest, ClusterGetNameReturnsCdsName) {
 // Test the DynamicModuleClusterHandle destructor dispatches to main thread.
 TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1475,7 +1475,7 @@ TEST_F(DynamicModuleClusterTest, HandleDestructorDispatchesToMainThread) {
 // Covers that a worker-thread handle destruction posts the full teardown to the main dispatcher.
 TEST_F(DynamicModuleClusterTest, HandleDestructorFromWorkerThreadDefersAllTeardownToMainThread) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -1512,7 +1512,7 @@ TEST_F(DynamicModuleClusterTest, ServerInitializedCallback) {
       .WillOnce(testing::DoAll(testing::SaveArg<1>(&captured_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   // Invoke the captured callback to exercise the server initialized path.
   captured_cb();
@@ -1526,7 +1526,7 @@ TEST_F(DynamicModuleClusterTest, DrainStartedCallback) {
       .WillOnce(testing::DoAll(testing::SaveArg<1>(&captured_drain_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   // Invoke the captured drain callback to exercise the drain notification path.
   EXPECT_OK(captured_drain_cb(std::chrono::milliseconds(0)));
@@ -1544,7 +1544,7 @@ TEST_F(DynamicModuleClusterTest, ShutdownCallbackWithCompletion) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   // Invoke the captured shutdown callback with a completion callback.
   bool completion_called = false;
@@ -1564,7 +1564,7 @@ TEST_F(DynamicModuleClusterTest, ShutdownCallbackAfterClusterDestroy) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -1600,7 +1600,7 @@ TEST_F(DynamicModuleClusterTest, AllLifecycleCallbacksRegistered) {
           testing::DoAll(testing::SaveArg<1>(&captured_shutdown_cb), testing::Return(nullptr)));
 
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   // Invoke all lifecycle callbacks to verify the full lifecycle flow.
   captured_init_cb();
@@ -1617,7 +1617,7 @@ TEST_F(DynamicModuleClusterTest, AllLifecycleCallbacksRegistered) {
 // Test defining and incrementing a scalar counter via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndIncrementCounter) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1641,7 +1641,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndIncrementCounter) {
 // Test defining and using a scalar gauge via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndUseGauge) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1671,7 +1671,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndUseGauge) {
 // Test defining and recording a scalar histogram via the ABI callbacks.
 TEST_F(DynamicModuleClusterTest, MetricsDefineAndRecordHistogram) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1695,7 +1695,7 @@ TEST_F(DynamicModuleClusterTest, MetricsDefineAndRecordHistogram) {
 // Test metric not found errors for invalid IDs.
 TEST_F(DynamicModuleClusterTest, MetricsNotFoundForInvalidId) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1729,7 +1729,7 @@ TEST_F(DynamicModuleClusterTest, MetricsNotFoundForInvalidId) {
 // Test defining and using a counter vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsCounterVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1774,7 +1774,7 @@ TEST_F(DynamicModuleClusterTest, MetricsCounterVecWithLabels) {
 // Test defining and using a gauge vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsGaugeVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1810,7 +1810,7 @@ TEST_F(DynamicModuleClusterTest, MetricsGaugeVecWithLabels) {
 // Test defining and using a histogram vec with labels.
 TEST_F(DynamicModuleClusterTest, MetricsHistogramVecWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1842,7 +1842,7 @@ TEST_F(DynamicModuleClusterTest, MetricsHistogramVecWithLabels) {
 // Test that using a vec metric ID with zero labels returns InvalidLabels.
 TEST_F(DynamicModuleClusterTest, MetricsVecScalarIdConflictErrors) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1897,7 +1897,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecScalarIdConflictErrors) {
 // Test that providing wrong number of label values returns InvalidLabels.
 TEST_F(DynamicModuleClusterTest, MetricsVecWrongLabelCount) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -1942,7 +1942,7 @@ TEST_F(DynamicModuleClusterTest, MetricsVecWrongLabelCount) {
 // Test that using non-existent vec IDs with labels returns MetricNotFound.
 TEST_F(DynamicModuleClusterTest, MetricsVecNotFoundWithLabels) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -2175,7 +2175,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetHostSelectionRetryCountNullContext)
 // Test should_select_another_host.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2201,7 +2201,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHost) {
 // Test should_select_another_host returns false.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2227,7 +2227,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostReturnsFalse) {
 // Test should_select_another_host with invalid priority and index.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -2256,7 +2256,7 @@ TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostInvalidArgs) {
 // Test should_select_another_host with nullptr context.
 TEST_F(DynamicModuleClusterTest, LbContextShouldSelectAnotherHostNullContext) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto& talb = result->second;
   EXPECT_OK(talb->initialize());
@@ -2579,7 +2579,7 @@ TEST_F(DynamicModuleClusterTest, LbContextGetHostStatNullPointers) {
 // Test that the index-based `get_host_stat` maps each stat enum to the matching `HostStats` field.
 TEST_F(DynamicModuleClusterTest, LbGetHostStatReadsValues) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   std::vector<Upstream::HostSharedPtr> hosts;
@@ -3208,7 +3208,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutFailureAfterInModuleClusterCleared) 
 // Test adding hosts with locality information.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3240,7 +3240,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocality) {
 // Test adding hosts with locality and metadata.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadata) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3269,7 +3269,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadata) {
 // Test adding hosts with locality via the ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
@@ -3306,7 +3306,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityABI) {
 // Test adding hosts with locality and metadata via the ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadataABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3345,7 +3345,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndMetadataABI) {
 // Test updating host health status.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealth) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3376,7 +3376,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealth) {
 // Test update_host_health via the ABI callback.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3411,7 +3411,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthABI) {
 // Test finding a host by address.
 TEST_F(DynamicModuleClusterTest, FindHostByAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3436,7 +3436,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddress) {
 // Test find_host_by_address via the ABI callback.
 TEST_F(DynamicModuleClusterTest, FindHostByAddressABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3463,7 +3463,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddressABI) {
 // Test that the cluster LB on_host_membership_update callback fires and provides host addresses.
 TEST_F(DynamicModuleClusterTest, LbHostMembershipUpdate) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3488,7 +3488,7 @@ TEST_F(DynamicModuleClusterTest, LbHostMembershipUpdate) {
 // Test get_member_update_host_address callback returns correct addresses during update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3512,7 +3512,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostAddress) {
 // Test get_member_update_host returns the host pointers borrowed during a membership update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPointer) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3561,7 +3561,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPointer) {
 // Test get_member_update_host_packed_address returns the packed IP/port during a membership update.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPackedAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
@@ -3631,7 +3631,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateHostPackedAddress) {
 // Test hosts-per-locality is correctly maintained with locality-aware hosts.
 TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3665,7 +3665,7 @@ TEST_F(DynamicModuleClusterTest, HostsPerLocalityWithLocality) {
 // Test that update_host_health affects the healthy host list.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthAffectsHealthyHosts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3693,7 +3693,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAffectsHealthyHosts) {
 // Test find_host_by_address on the cluster LB (worker thread).
 TEST_F(DynamicModuleClusterTest, LbFindHostByAddress) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3730,7 +3730,7 @@ TEST_F(DynamicModuleClusterTest, LbFindHostByAddress) {
 // Test get_host returns a host pointer by index from all hosts regardless of health.
 TEST_F(DynamicModuleClusterTest, LbGetHost) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3763,7 +3763,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHost) {
 // Test get_host returns unhealthy hosts that get_healthy_host does not.
 TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3791,7 +3791,7 @@ TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
 // Test that add_hosts supports adding hosts at a specific priority level.
 TEST_F(DynamicModuleClusterTest, AddHostsToPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3819,7 +3819,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsToPriority) {
 // Test add_hosts with priority via ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithPriorityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3860,7 +3860,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithPriorityABI) {
 // Test add_hosts with locality and priority via ABI callback.
 TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndPriorityABI) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* cluster_ptr = static_cast<void*>(cluster.get());
@@ -3896,7 +3896,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithLocalityAndPriorityABI) {
 // Test that update_host_health works correctly for hosts at non-zero priority levels.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
@@ -3938,7 +3938,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthAtNonZeroPriority) {
 // subscription target and would fail if the registration moved back to the cluster main set.
 TEST_F(DynamicModuleClusterTest, LbMemberUpdateCbRegistersOnWorkerLocalPrioritySet) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto handle = std::make_shared<DynamicModuleClusterHandle>(cluster);
 
@@ -3953,7 +3953,7 @@ TEST_F(DynamicModuleClusterTest, LbMemberUpdateCbRegistersOnWorkerLocalPriorityS
 // subscribe and unsubscribe paths under sanitizer builds.
 TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
 
   Upstream::PrioritySetImpl worker_priority_set;
@@ -3987,7 +3987,7 @@ TEST_F(DynamicModuleClusterTest, LbRepeatedConstructTeardownWithUpdates) {
 // Verifies that `cluster_add_hosts` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4011,7 +4011,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
 // Verifies that `cluster_remove_hosts` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, RemoveHostsOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4032,7 +4032,7 @@ TEST_F(DynamicModuleClusterTest, RemoveHostsOffMainThreadFailsClosed) {
 // Verifies that `cluster_update_host_health` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4053,7 +4053,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthOffMainThreadFailsClosed) {
 // Verifies that `cluster_pre_init_complete` is a safe no-op when called off the main thread.
 TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4071,7 +4071,7 @@ TEST_F(DynamicModuleClusterTest, PreInitCompleteOffMainThreadFailsClosed) {
 // Verifies that `cluster_find_host_by_address` is fail-closed when called off the main thread.
 TEST_F(DynamicModuleClusterTest, FindHostByAddressOffMainThreadFailsClosed) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4093,7 +4093,7 @@ TEST_F(DynamicModuleClusterTest, FindHostByAddressOffMainThreadFailsClosed) {
 // Verifies the factory auto-freezes stat creation so `define_*` returns `Frozen` after init.
 TEST_F(DynamicModuleClusterTest, MetricsFrozenAfterInit) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
 
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
@@ -4120,7 +4120,7 @@ TEST_F(DynamicModuleClusterTest, MetricsFrozenAfterInit) {
 // shared `stat_name_pool_`. Run under `--config=tsan` to verify.
 TEST_F(DynamicModuleClusterTest, MetricsConcurrentIncrementCounterVecNoRace) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   auto* config = cluster->config().get();
   unfreezeStatCreation(*config);
@@ -4177,7 +4177,7 @@ TEST_F(DynamicModuleClusterTest, MetricsConcurrentIncrementCounterVecNoRace) {
 // setHostData / getHostData return false when the priority is out of range.
 TEST_F(DynamicModuleClusterTest, SetGetHostDataPriorityOutOfRange) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4196,7 +4196,7 @@ TEST_F(DynamicModuleClusterTest, SetGetHostDataPriorityOutOfRange) {
 // updateHostHealth returns false when the supplied host is not present in any priority set.
 TEST_F(DynamicModuleClusterTest, UpdateHostHealthHostNotInAnyPriority) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4211,7 +4211,7 @@ TEST_F(DynamicModuleClusterTest, UpdateHostHealthHostNotInAnyPriority) {
 // on_cluster_http_callout_done, since there is no path for the response to be delivered.
 TEST_F(DynamicModuleClusterTest, HttpCalloutRequestedWithoutDoneHook) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4238,7 +4238,7 @@ TEST_F(DynamicModuleClusterTest, HttpCalloutRequestedWithoutDoneHook) {
 // module's on_cluster_lb_new returned null and in_module_lb_ remains unset).
 TEST_F(DynamicModuleClusterTest, ChooseHostShortCircuitsWhenInModuleLbIsNull) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 
@@ -4262,7 +4262,7 @@ TEST_F(DynamicModuleClusterTest, HandleDestructorIsNoOpWhenClusterIsNull) {
 // The cluster destructor cancels any pending HTTP callouts before clearing them.
 TEST_F(DynamicModuleClusterTest, DestructorCancelsPendingHttpCallouts) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
-  ASSERT_OK(result) << result.status().message();
+  ASSERT_OK(result);
   auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
   ASSERT_NE(nullptr, cluster);
 

--- a/test/extensions/filters/http/api_key_auth/BUILD
+++ b/test/extensions/filters/http/api_key_auth/BUILD
@@ -33,6 +33,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/api_key_auth:config",
         "//test/mocks/server:server_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/extensions/filters/http/api_key_auth/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/filters/http/api_key_auth/config_test.cc
+++ b/test/extensions/filters/http/api_key_auth/config_test.cc
@@ -15,8 +15,7 @@ namespace HttpFilters {
 namespace ApiKeyAuth {
 namespace {
 
-using ::Envoy::StatusHelpers::IsOk;
-using ::testing::Not;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 
 TEST(ApiKeyAuthFilterFactoryTest, DuplicateApiKey) {
   const std::string yaml = R"(
@@ -37,8 +36,7 @@ TEST(ApiKeyAuthFilterFactoryTest, DuplicateApiKey) {
 
   auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
 
-  EXPECT_THAT(status_or, Not(IsOk()));
-  EXPECT_EQ("Duplicated credential key: 'key1'", status_or.status().message());
+  EXPECT_THAT(status_or, HasStatusMessage("Duplicated credential key: 'key1'"));
 }
 
 TEST(ApiKeyAuthFilterFactoryTest, EmptyKeySource) {
@@ -60,8 +58,7 @@ TEST(ApiKeyAuthFilterFactoryTest, EmptyKeySource) {
 
   auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
 
-  EXPECT_THAT(status_or, Not(IsOk()));
-  EXPECT_EQ("One of 'header'/'query'/'cookie' must be set.", status_or.status().message());
+  EXPECT_THAT(status_or, HasStatusMessage("One of 'header'/'query'/'cookie' must be set."));
 }
 
 TEST(ApiKeyAuthFilterFactoryTest, NormalFactory) {

--- a/test/extensions/filters/http/api_key_auth/config_test.cc
+++ b/test/extensions/filters/http/api_key_auth/config_test.cc
@@ -4,6 +4,7 @@
 #include "source/extensions/filters/http/api_key_auth/config.h"
 
 #include "test/mocks/server/mocks.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -13,6 +14,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ApiKeyAuth {
 namespace {
+
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 
 TEST(ApiKeyAuthFilterFactoryTest, DuplicateApiKey) {
   const std::string yaml = R"(
@@ -33,7 +37,7 @@ TEST(ApiKeyAuthFilterFactoryTest, DuplicateApiKey) {
 
   auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
 
-  EXPECT_FALSE(status_or.ok());
+  EXPECT_THAT(status_or, Not(IsOk()));
   EXPECT_EQ("Duplicated credential key: 'key1'", status_or.status().message());
 }
 
@@ -56,7 +60,7 @@ TEST(ApiKeyAuthFilterFactoryTest, EmptyKeySource) {
 
   auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
 
-  EXPECT_FALSE(status_or.ok());
+  EXPECT_THAT(status_or, Not(IsOk()));
   EXPECT_EQ("One of 'header'/'query'/'cookie' must be set.", status_or.status().message());
 }
 
@@ -88,7 +92,7 @@ TEST(ApiKeyAuthFilterFactoryTest, NormalFactory) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
 
   auto status_or = factory.createFilterFactoryFromProto(proto_config, "stats", context);
-  EXPECT_TRUE(status_or.ok());
+  EXPECT_OK(status_or);
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));

--- a/test/extensions/filters/http/custom_response/BUILD
+++ b/test/extensions/filters/http/custom_response/BUILD
@@ -53,6 +53,7 @@ envoy_extension_cc_test(
         "//source/extensions/http/custom_response/local_response_policy:local_response_policy_lib",
         "//source/extensions/http/custom_response/redirect_policy:redirect_policy_lib",
         "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/custom_response/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/custom_response/config_test.cc
+++ b/test/extensions/filters/http/custom_response/config_test.cc
@@ -5,6 +5,7 @@
 #include "source/extensions/filters/http/custom_response/factory.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -67,7 +68,7 @@ TEST(CustomResponseFilterConfigTest, NoHostAndPathRedirect) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
-  EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok());
+  EXPECT_OK(factory.createFilterFactoryFromProto(filter_config, "stats", context));
 }
 
 TEST(CustomResponseFilterConfigTest, PrefixRewrite) {
@@ -90,7 +91,7 @@ TEST(CustomResponseFilterConfigTest, PrefixRewrite) {
   EXPECT_CALL(context, messageValidationVisitor());
   CustomResponseFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      EXPECT_TRUE(factory.createFilterFactoryFromProto(filter_config, "stats", context).ok()),
+      EXPECT_OK(factory.createFilterFactoryFromProto(filter_config, "stats", context)),
       EnvoyException, "prefix_rewrite is not supported for Custom Response");
 }
 

--- a/test/extensions/filters/network/tcp_proxy/BUILD
+++ b/test/extensions/filters/network/tcp_proxy/BUILD
@@ -21,6 +21,7 @@ envoy_extension_cc_test(
         "//test/common/formatter:command_extension_lib",
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/network/tcp_proxy/config_test.cc
+++ b/test/extensions/filters/network/tcp_proxy/config_test.cc
@@ -8,6 +8,7 @@
 #include "test/common/formatter/command_extension.h"
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -88,7 +89,7 @@ TEST(ConfigTest, ConfigWithDrainCloseCheck) {
   config.set_cluster("cluster");
   config.mutable_check_drain_close()->set_value(true);
 
-  EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
+  EXPECT_OK(factory.createFilterFactoryFromProto(config, context));
 }
 
 TEST(ConfigTest, TunnelingConfigWithFormatters) {
@@ -115,7 +116,7 @@ TEST(ConfigTest, TunnelingConfigWithFormatters) {
   formatter->set_name("envoy.formatter.TestFormatter");
   std::ignore = formatter->mutable_typed_config()->PackFrom(Protobuf::StringValue());
 
-  EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
+  EXPECT_OK(factory.createFilterFactoryFromProto(config, context));
 }
 
 TEST(ConfigTest, TunnelingConfigWithUnknownFormatter) {

--- a/test/extensions/load_balancing_policies/dynamic_modules/BUILD
+++ b/test/extensions/load_balancing_policies/dynamic_modules/BUILD
@@ -33,6 +33,7 @@ envoy_cc_test(
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/load_balancing_policies/dynamic_modules/v3:pkg_cc_proto",
     ],

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -27,6 +27,7 @@ namespace LoadBalancingPolicies {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::NiceMock;
 using ::testing::Not;
@@ -109,9 +110,8 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleNotFound) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
-  EXPECT_THAT(lb_config_or_error.status().message(),
-              testing::HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(lb_config_or_error,
+              HasStatusMessage(testing::HasSubstr("Failed to load dynamic module")));
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "module_load_error", "test_lb"));
 }
 
@@ -123,9 +123,8 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleConfigNewFails) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
-  EXPECT_THAT(lb_config_or_error.status().message(),
-              testing::HasSubstr("failed to create load balancer config"));
+  EXPECT_THAT(lb_config_or_error,
+              HasStatusMessage(testing::HasSubstr("failed to create load balancer config")));
 
   // The module loads fine but its config creation fails, so this is counted as config_init_error.
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "config_init_error", "test_lb"));
@@ -160,9 +159,8 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleMissingSymbol) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
-  EXPECT_THAT(lb_config_or_error.status().message(),
-              testing::HasSubstr("envoy_dynamic_module_on_lb_choose_host"));
+  EXPECT_THAT(lb_config_or_error,
+              HasStatusMessage(testing::HasSubstr("envoy_dynamic_module_on_lb_choose_host")));
 }
 
 TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithStringValueConfig) {

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -81,8 +81,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccessWithLocalFile) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, IsOkAndHolds(::testing::NotNull()))
-      << lb_config_or_error.status().message();
+  EXPECT_THAT(lb_config_or_error, IsOkAndHolds(::testing::NotNull()));
 }
 
 // Remote module sources are not supported for load balancing policies (no init manager is wired

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -15,6 +15,7 @@
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -26,7 +27,9 @@ namespace LoadBalancingPolicies {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::IsOk;
 using ::testing::NiceMock;
+using ::testing::Not;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -59,7 +62,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_TRUE(lb_config_or_error.ok());
+  EXPECT_OK(lb_config_or_error);
   EXPECT_NE(lb_config_or_error.value(), nullptr);
 
   // The happy path emits no load-failure counters.
@@ -77,7 +80,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccessWithLocalFile) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_TRUE(lb_config_or_error.ok()) << lb_config_or_error.status().message();
+  EXPECT_OK(lb_config_or_error) << lb_config_or_error.status().message();
   EXPECT_NE(lb_config_or_error.value(), nullptr);
 }
 
@@ -95,7 +98,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigRemoteSourceRejected) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_FALSE(lb_config_or_error.ok());
+  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
 }
 
 TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleNotFound) {
@@ -106,7 +109,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleNotFound) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_FALSE(lb_config_or_error.ok());
+  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
   EXPECT_THAT(lb_config_or_error.status().message(),
               testing::HasSubstr("Failed to load dynamic module"));
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "module_load_error", "test_lb"));
@@ -120,7 +123,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleConfigNewFails) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_FALSE(lb_config_or_error.ok());
+  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
   EXPECT_THAT(lb_config_or_error.status().message(),
               testing::HasSubstr("failed to create load balancer config"));
 
@@ -142,7 +145,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigMalformedLbPolicyConfig) 
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_FALSE(lb_config_or_error.ok());
+  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
 
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "config_init_error", "test_lb"));
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test_lb"));
@@ -157,7 +160,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigModuleMissingSymbol) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_FALSE(lb_config_or_error.ok());
+  EXPECT_THAT(lb_config_or_error, Not(IsOk()));
   EXPECT_THAT(lb_config_or_error.status().message(),
               testing::HasSubstr("envoy_dynamic_module_on_lb_choose_host"));
 }
@@ -175,7 +178,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithStringValueConfig) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_TRUE(lb_config_or_error.ok());
+  EXPECT_OK(lb_config_or_error);
 }
 
 TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithBytesValueConfig) {
@@ -191,7 +194,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithBytesValueConfig) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_TRUE(lb_config_or_error.ok());
+  EXPECT_OK(lb_config_or_error);
 }
 
 TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithStructConfig) {
@@ -207,7 +210,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigWithStructConfig) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_TRUE(lb_config_or_error.ok());
+  EXPECT_OK(lb_config_or_error);
 }
 
 // =============================================================================
@@ -222,7 +225,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, CreateThreadAwareLoadBalancer) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
@@ -230,7 +233,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, CreateThreadAwareLoadBalancer) {
   EXPECT_NE(thread_aware_lb, nullptr);
 
   // Initialize and get the factory.
-  EXPECT_TRUE(thread_aware_lb->initialize().ok());
+  EXPECT_OK(thread_aware_lb->initialize());
   auto lb_factory = thread_aware_lb->factory();
   EXPECT_NE(lb_factory, nullptr);
 }
@@ -311,13 +314,13 @@ TEST_F(DynamicModulesLoadBalancerTest, RoundRobinHostSelection) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   // Create a worker LB.
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
@@ -343,13 +346,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ChooseHostWithContext) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -378,13 +381,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ChooseHostNoHealthyHosts) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -407,13 +410,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ChooseHostEmptyHostSets) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -432,13 +435,13 @@ TEST_F(DynamicModulesLoadBalancerTest, LbNewFails) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -458,13 +461,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ChooseHostInvalidIndex) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -485,13 +488,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ChooseHostInvalidPriority) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -511,13 +514,13 @@ TEST_F(DynamicModulesLoadBalancerTest, PeekAnotherHost) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -535,13 +538,13 @@ TEST_F(DynamicModulesLoadBalancerTest, LifetimeCallbacks) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -559,13 +562,13 @@ TEST_F(DynamicModulesLoadBalancerTest, SelectExistingConnection) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -640,13 +643,13 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidPriority) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -686,13 +689,13 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksWithInvalidHostIndex) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -727,13 +730,13 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksSuccessfulCases) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -828,13 +831,13 @@ TEST_F(DynamicModulesLoadBalancerTest, AbiCallbacksHostStatsAndLocality) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -914,13 +917,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostHealthByAddressSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -958,13 +961,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostHealthByAddressNullInputs) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1000,13 +1003,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ContextCallbacksSuccessfulCases) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1145,13 +1148,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostAccepted) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1176,13 +1179,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostRejected) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1207,13 +1210,13 @@ TEST_F(DynamicModulesLoadBalancerTest, ShouldSelectAnotherHostInvalidPriority) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1316,13 +1319,13 @@ TEST_F(DynamicModulesLoadBalancerTest, PerHostDataSetAndGet) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1383,13 +1386,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostMetadataTypedAccessSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1444,13 +1447,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostMetadataNotFound) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1524,13 +1527,13 @@ TEST_F(DynamicModulesLoadBalancerTest, LocalityCallbacksSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1569,13 +1572,13 @@ TEST_F(DynamicModulesLoadBalancerTest, LocalityCallbacksEdgeCases) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1641,13 +1644,13 @@ TEST_F(DynamicModulesLoadBalancerTest, CallbacksTestModuleExercisesNewCallbacks)
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1675,13 +1678,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateNotifiesModule) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1710,13 +1713,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateEmptyVectors) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1740,13 +1743,13 @@ TEST_F(DynamicModulesLoadBalancerTest, HostMembershipUpdateCallbackAddress) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1779,13 +1782,13 @@ TEST_F(DynamicModulesLoadBalancerTest, LbNewFailDoesNotRegisterCallback) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto thread_aware_lb =
       factory.create(OptRef<const Upstream::LoadBalancerConfig>(*lb_config_or_error.value()),
                      cluster_info_, priority_set_, runtime_, random_, time_source_);
   ASSERT_NE(thread_aware_lb, nullptr);
-  ASSERT_TRUE(thread_aware_lb->initialize().ok());
+  ASSERT_OK(thread_aware_lb->initialize());
 
   Upstream::LoadBalancerParams params{priority_set_, nullptr};
   auto lb = thread_aware_lb->factory()->create(params);
@@ -1813,7 +1816,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsCounterDefineAndIncrement) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -1856,7 +1859,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsGaugeDefineAndManipulate) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -1901,7 +1904,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsHistogramDefineAndRecord) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -1931,7 +1934,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsInvalidId) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -1985,7 +1988,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsMultipleCounters) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2028,7 +2031,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsCounterVecWithLabels) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2075,7 +2078,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsGaugeVecWithLabels) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2118,7 +2121,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsHistogramVecWithLabels) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2162,7 +2165,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecScalarIdConflictErrors) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2223,7 +2226,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecWrongLabelCount) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2261,7 +2264,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsVecNotFoundWithLabels) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2288,7 +2291,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsFrozenAfterInit) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());
@@ -2330,7 +2333,7 @@ TEST_F(DynamicModulesLoadBalancerTest, MetricsConcurrentIncrementCounterVecNoRac
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  ASSERT_TRUE(lb_config_or_error.ok());
+  ASSERT_OK(lb_config_or_error);
 
   auto* typed_config =
       dynamic_cast<const TypedDynamicModuleLbConfig*>(lb_config_or_error.value().get());

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::IsOkAndHolds;
 using ::testing::NiceMock;
 using ::testing::Not;
 using ::testing::Return;
@@ -63,7 +64,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
+  EXPECT_THAT(lb_config_or_error, IsOkAndHolds(::testing::NotNull()));
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test_lb"));
@@ -80,7 +81,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccessWithLocalFile) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_THAT(lb_config_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+  EXPECT_THAT(lb_config_or_error, IsOkAndHolds(::testing::NotNull()))
       << lb_config_or_error.status().message();
 }
 

--- a/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
+++ b/test/extensions/load_balancing_policies/dynamic_modules/config_test.cc
@@ -63,8 +63,7 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccess) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_OK(lb_config_or_error);
-  EXPECT_NE(lb_config_or_error.value(), nullptr);
+  EXPECT_THAT(lb_config_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test_lb"));
@@ -81,8 +80,8 @@ TEST_F(DynamicModulesLoadBalancerConfigTest, LoadConfigSuccessWithLocalFile) {
 
   Factory factory;
   auto lb_config_or_error = factory.loadConfig(factory_context_, config);
-  EXPECT_OK(lb_config_or_error) << lb_config_or_error.status().message();
-  EXPECT_NE(lb_config_or_error.value(), nullptr);
+  EXPECT_THAT(lb_config_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << lb_config_or_error.status().message();
 }
 
 // Remote module sources are not supported for load balancing policies (no init manager is wired

--- a/test/extensions/matching/input_matchers/dynamic_modules/BUILD
+++ b/test/extensions/matching/input_matchers/dynamic_modules/BUILD
@@ -38,6 +38,7 @@ envoy_cc_test(
     deps = [
         "//source/extensions/matching/input_matchers/dynamic_modules:matcher_lib",
         "//test/extensions/dynamic_modules:util",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/matching/input_matchers/dynamic_modules/matcher_test.cc
+++ b/test/extensions/matching/input_matchers/dynamic_modules/matcher_test.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/matching/input_matchers/dynamic_modules/matcher.h"
 
 #include "test/extensions/dynamic_modules/util.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -29,22 +30,22 @@ public:
 TEST_F(DynamicModuleMatcherTest, AlwaysMatchModule) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_no_op", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));
 
   auto on_config_new = module->getFunctionPointer<OnMatcherConfigNewType>(
       "envoy_dynamic_module_on_matcher_config_new");
-  ASSERT_TRUE(on_config_new.ok());
+  ASSERT_OK(on_config_new);
 
   auto on_config_destroy = module->getFunctionPointer<OnMatcherConfigDestroyType>(
       "envoy_dynamic_module_on_matcher_config_destroy");
-  ASSERT_TRUE(on_config_destroy.ok());
+  ASSERT_OK(on_config_destroy);
 
   auto on_match =
       module->getFunctionPointer<OnMatcherMatchType>("envoy_dynamic_module_on_matcher_match");
-  ASSERT_TRUE(on_match.ok());
+  ASSERT_OK(on_match);
 
   envoy_dynamic_module_type_envoy_buffer name_buf = {"test", 4};
   envoy_dynamic_module_type_envoy_buffer config_buf = {"", 0};
@@ -68,22 +69,22 @@ TEST_F(DynamicModuleMatcherTest, AlwaysMatchModule) {
 TEST_F(DynamicModuleMatcherTest, HeaderCheckModule) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_check_headers", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));
 
   auto on_config_new = module->getFunctionPointer<OnMatcherConfigNewType>(
       "envoy_dynamic_module_on_matcher_config_new");
-  ASSERT_TRUE(on_config_new.ok());
+  ASSERT_OK(on_config_new);
 
   auto on_config_destroy = module->getFunctionPointer<OnMatcherConfigDestroyType>(
       "envoy_dynamic_module_on_matcher_config_destroy");
-  ASSERT_TRUE(on_config_destroy.ok());
+  ASSERT_OK(on_config_destroy);
 
   auto on_match =
       module->getFunctionPointer<OnMatcherMatchType>("envoy_dynamic_module_on_matcher_match");
-  ASSERT_TRUE(on_match.ok());
+  ASSERT_OK(on_match);
 
   // Configure the module to look for "x-test-header".
   envoy_dynamic_module_type_envoy_buffer name_buf = {"header_check", 12};
@@ -131,7 +132,7 @@ TEST_F(DynamicModuleMatcherTest, HeaderCheckModule) {
 TEST_F(DynamicModuleMatcherTest, SupportedDataInputTypes) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_no_op", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));
@@ -160,7 +161,7 @@ class OtherCustomMatchData : public ::Envoy::Matcher::CustomMatchData {};
 TEST_F(DynamicModuleMatcherTest, NonDynamicModuleCustomMatchDataReturnsFalse) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_no_op", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));
@@ -189,7 +190,7 @@ TEST_F(DynamicModuleMatcherTest, NonDynamicModuleCustomMatchDataReturnsFalse) {
 TEST_F(DynamicModuleMatcherTest, NonCustomMatchDataReturnsFalse) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_no_op", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));
@@ -216,7 +217,7 @@ TEST_F(DynamicModuleMatcherTest, NonCustomMatchDataReturnsFalse) {
 TEST_F(DynamicModuleMatcherTest, NullRequestHeaders) {
   auto module_or_error =
       Extensions::DynamicModules::newDynamicModuleByName("matcher_check_headers", true, false);
-  ASSERT_TRUE(module_or_error.ok());
+  ASSERT_OK(module_or_error);
 
   auto module = std::shared_ptr<Extensions::DynamicModules::DynamicModule>(
       std::move(module_or_error.value()));

--- a/test/extensions/resource_monitors/cpu_utilization/BUILD
+++ b/test/extensions/resource_monitors/cpu_utilization/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
         "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:options_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
     ],
 )
 

--- a/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
+++ b/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
@@ -10,6 +10,7 @@
 #include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/options.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -20,6 +21,8 @@ namespace ResourceMonitors {
 namespace CpuUtilizationMonitor {
 namespace {
 
+using ::Envoy::StatusHelpers::IsOk;
+using ::testing::Not;
 using testing::Return;
 
 // =============================================================================
@@ -169,7 +172,7 @@ TEST_F(LinuxContainerCpuStatsReaderTest, CannotReadFileCpuAllocated) {
 
   // Test that getUtilization also handles the error
   auto result = container_stats_reader.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
 }
 
@@ -244,13 +247,13 @@ TEST_F(LinuxContainerCpuStatsReaderTest, V1GetUtilizationFirstCallReturnsZero) {
                                                 cpuAllocatedPath(), cpuTimesPath());
   auto result = container_stats_reader.getUtilization();
 
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_DOUBLE_EQ(result.value(), 0.0);
 
   // Also test negative work_over_period error scenario (cpu_times decreased)
   setCpuTimes("500\n");
   result = container_stats_reader.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
 }
 
@@ -397,7 +400,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, InvalidCpuEffectiveFormats) {
   CgroupV2CpuStatsReader reader(api->fileSystem(), test_time_source, v2CpuStatPath(),
                                 v2CpuMaxPath(), v2CpuEffectivePath());
   auto result = reader.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
 }
 
@@ -415,7 +418,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, InvalidCpuMaxFormats) {
   CpuTimesV2 envoy_container_stats = container_stats_reader1.getCpuTimes();
   EXPECT_FALSE(envoy_container_stats.is_valid);
   auto result = container_stats_reader1.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
 
   // Test 2: Failed to parse - non-numeric quota
@@ -450,7 +453,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, CannotReadCpuStatFile) {
 
   // Test that getUtilization also handles the error
   auto result = container_stats_reader.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
 }
 
@@ -495,13 +498,13 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, V2GetUtilizationFirstCallReturnsZero)
       api->fileSystem(), test_time_source, v2CpuStatPath(), v2CpuMaxPath(), v2CpuEffectivePath());
   auto result = container_stats_reader.getUtilization();
 
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_DOUBLE_EQ(result.value(), 0.0);
 
   // Also test negative work_over_period error scenario (usage decreased)
   setV2CpuStat("usage_usec 400000\n");
   result = container_stats_reader.getUtilization();
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
 }
 
@@ -594,7 +597,7 @@ TEST(LinuxCpuStatsReaderUtilizationTest, FirstCallReturnsZero) {
   LinuxCpuStatsReader cpu_stats_reader(temp_path);
   auto result = cpu_stats_reader.getUtilization();
 
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_DOUBLE_EQ(result.value(), 0.0);
 }
 
@@ -606,13 +609,13 @@ TEST(LinuxCpuStatsReaderUtilizationTest, CalculatesUtilizationCorrectly) {
   file_updater.update("cpu  1000 100 200 700 0 0 0 0 0 0\n");
   LinuxCpuStatsReader cpu_stats_reader(temp_path);
   auto result1 = cpu_stats_reader.getUtilization();
-  ASSERT_TRUE(result1.ok());
+  ASSERT_OK(result1);
   EXPECT_DOUBLE_EQ(result1.value(), 0.0); // First call returns 0
 
   // Second reading: work increased by 600, total increased by 1000
   file_updater.update("cpu  1600 100 200 1100 0 0 0 0 0 0\n");
   auto result2 = cpu_stats_reader.getUtilization();
-  ASSERT_TRUE(result2.ok());
+  ASSERT_OK(result2);
   EXPECT_DOUBLE_EQ(result2.value(), 0.6); // 600/1000
 }
 
@@ -621,7 +624,7 @@ TEST(LinuxCpuStatsReaderUtilizationTest, InvalidFileReturnsError) {
   LinuxCpuStatsReader cpu_stats_reader(temp_path);
   auto result = cpu_stats_reader.getUtilization();
 
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
 }
 
@@ -637,14 +640,14 @@ TEST(LinuxCpuStatsReaderUtilizationTest, NegativeWorkDeltaReturnsError) {
   file_updater.update("cpu  500 100 200 1100 0 0 0 0 0 0\n");
   auto result = cpu_stats_reader.getUtilization();
 
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
 
   // Also test zero total_over_period by keeping stats unchanged
   file_updater.update("cpu  500 100 200 1100 0 0 0 0 0 0\n");
   result = cpu_stats_reader.getUtilization();
 
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
   EXPECT_NE(result.status().message().find("total_over_period"), std::string::npos);
 }
 

--- a/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
+++ b/test/extensions/resource_monitors/cpu_utilization/linux_cpu_stats_reader_test.cc
@@ -21,8 +21,7 @@ namespace ResourceMonitors {
 namespace CpuUtilizationMonitor {
 namespace {
 
-using ::Envoy::StatusHelpers::IsOk;
-using ::testing::Not;
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using testing::Return;
 
 // =============================================================================
@@ -172,8 +171,7 @@ TEST_F(LinuxContainerCpuStatsReaderTest, CannotReadFileCpuAllocated) {
 
   // Test that getUtilization also handles the error
   auto result = container_stats_reader.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to read CPU times")));
 }
 
 TEST_F(LinuxContainerCpuStatsReaderTest, CannotReadFileCpuTimes) {
@@ -253,8 +251,7 @@ TEST_F(LinuxContainerCpuStatsReaderTest, V1GetUtilizationFirstCallReturnsZero) {
   // Also test negative work_over_period error scenario (cpu_times decreased)
   setCpuTimes("500\n");
   result = container_stats_reader.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Work_over_period")));
 }
 
 // =============================================================================
@@ -400,8 +397,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, InvalidCpuEffectiveFormats) {
   CgroupV2CpuStatsReader reader(api->fileSystem(), test_time_source, v2CpuStatPath(),
                                 v2CpuMaxPath(), v2CpuEffectivePath());
   auto result = reader.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to read CPU times")));
 }
 
 // Error: Invalid cpu.max file formats
@@ -418,8 +414,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, InvalidCpuMaxFormats) {
   CpuTimesV2 envoy_container_stats = container_stats_reader1.getCpuTimes();
   EXPECT_FALSE(envoy_container_stats.is_valid);
   auto result = container_stats_reader1.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to read CPU times")));
 
   // Test 2: Failed to parse - non-numeric quota
   setV2CpuMax("notanumber 100000\n");
@@ -453,8 +448,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, CannotReadCpuStatFile) {
 
   // Test that getUtilization also handles the error
   auto result = container_stats_reader.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to read CPU times")));
 }
 
 TEST_F(LinuxContainerCpuStatsReaderV2Test, CannotReadEffectiveCpusFile) {
@@ -504,8 +498,7 @@ TEST_F(LinuxContainerCpuStatsReaderV2Test, V2GetUtilizationFirstCallReturnsZero)
   // Also test negative work_over_period error scenario (usage decreased)
   setV2CpuStat("usage_usec 400000\n");
   result = container_stats_reader.getUtilization();
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Work_over_period")));
 }
 
 // =============================================================================
@@ -624,8 +617,7 @@ TEST(LinuxCpuStatsReaderUtilizationTest, InvalidFileReturnsError) {
   LinuxCpuStatsReader cpu_stats_reader(temp_path);
   auto result = cpu_stats_reader.getUtilization();
 
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Failed to read CPU times"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Failed to read CPU times")));
 }
 
 TEST(LinuxCpuStatsReaderUtilizationTest, NegativeWorkDeltaReturnsError) {
@@ -640,15 +632,13 @@ TEST(LinuxCpuStatsReaderUtilizationTest, NegativeWorkDeltaReturnsError) {
   file_updater.update("cpu  500 100 200 1100 0 0 0 0 0 0\n");
   auto result = cpu_stats_reader.getUtilization();
 
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("Work_over_period"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("Work_over_period")));
 
   // Also test zero total_over_period by keeping stats unchanged
   file_updater.update("cpu  500 100 200 1100 0 0 0 0 0 0\n");
   result = cpu_stats_reader.getUtilization();
 
-  EXPECT_THAT(result, Not(IsOk()));
-  EXPECT_NE(result.status().message().find("total_over_period"), std::string::npos);
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr("total_over_period")));
 }
 
 } // namespace

--- a/test/extensions/tracers/dynamic_modules/BUILD
+++ b/test/extensions/tracers/dynamic_modules/BUILD
@@ -42,6 +42,7 @@ envoy_cc_test(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )
@@ -58,6 +59,7 @@ envoy_cc_test(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/tracing:tracing_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/tracers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/tracers/dynamic_modules/abi_impl_test.cc
@@ -7,6 +7,7 @@
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -34,10 +35,10 @@ public:
     setTestModulesSearchPath();
     auto module =
         Envoy::Extensions::DynamicModules::newDynamicModuleByName("tracer_no_op", false, false);
-    EXPECT_TRUE(module.ok());
+    EXPECT_OK(module);
     auto config_or = newDynamicModuleTracerConfig("test_tracer", "", "test_ns",
                                                   std::move(module.value()), *store_.rootScope());
-    EXPECT_TRUE(config_or.ok());
+    EXPECT_OK(config_or);
     config_ = config_or.value();
     // Re-open stat creation so tests can call `define_*` from the test thread.
     config_->stat_creation_frozen_ = false;

--- a/test/extensions/tracers/dynamic_modules/tracer_test.cc
+++ b/test/extensions/tracers/dynamic_modules/tracer_test.cc
@@ -10,6 +10,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using testing::NiceMock;
 using ::testing::Not;
@@ -77,8 +78,7 @@ TEST_F(TracerConfigTest, CreateFailConfigInitReturnsNull) {
   Stats::IsolatedStoreImpl store;
   auto config = newDynamicModuleTracerConfig("test_tracer", "", "test_ns",
                                              std::move(module.value()), *store.rootScope());
-  ASSERT_THAT(config, Not(IsOk()));
-  EXPECT_EQ(config.status().message(), "Failed to initialize dynamic module tracer config");
+  ASSERT_THAT(config, HasStatusMessage("Failed to initialize dynamic module tracer config"));
 }
 
 // =============================================================================

--- a/test/extensions/tracers/dynamic_modules/tracer_test.cc
+++ b/test/extensions/tracers/dynamic_modules/tracer_test.cc
@@ -4,12 +4,15 @@
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::IsOk;
 using testing::NiceMock;
+using ::testing::Not;
 
 namespace Envoy {
 namespace Extensions {
@@ -28,10 +31,10 @@ DynamicModuleTracerConfigSharedPtr createTracerConfig(const std::string& module_
                                                       Stats::Scope& scope) {
   auto module =
       Envoy::Extensions::DynamicModules::newDynamicModuleByName(module_name, false, false);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
   auto config_or =
       newDynamicModuleTracerConfig("test_tracer", "", "test_ns", std::move(module.value()), scope);
-  EXPECT_TRUE(config_or.ok());
+  EXPECT_OK(config_or);
   return config_or.value();
 }
 
@@ -47,34 +50,34 @@ public:
 TEST_F(TracerConfigTest, CreateSuccess) {
   auto module =
       Envoy::Extensions::DynamicModules::newDynamicModuleByName("tracer_no_op", false, false);
-  ASSERT_TRUE(module.ok());
+  ASSERT_OK(module);
 
   Stats::IsolatedStoreImpl store;
   auto config = newDynamicModuleTracerConfig("test_tracer", "test_config", "test_ns",
                                              std::move(module.value()), *store.rootScope());
-  ASSERT_TRUE(config.ok());
+  ASSERT_OK(config);
   EXPECT_NE(config.value()->in_module_config_, nullptr);
 }
 
 TEST_F(TracerConfigTest, CreateFailMissingSymbol) {
   auto module = Envoy::Extensions::DynamicModules::newDynamicModuleByName("no_op", false, false);
-  ASSERT_TRUE(module.ok());
+  ASSERT_OK(module);
 
   Stats::IsolatedStoreImpl store;
   auto config = newDynamicModuleTracerConfig("test_tracer", "", "test_ns",
                                              std::move(module.value()), *store.rootScope());
-  ASSERT_FALSE(config.ok());
+  ASSERT_THAT(config, Not(IsOk()));
 }
 
 TEST_F(TracerConfigTest, CreateFailConfigInitReturnsNull) {
   auto module =
       Envoy::Extensions::DynamicModules::newDynamicModuleByName("tracer_config_fail", false, false);
-  ASSERT_TRUE(module.ok());
+  ASSERT_OK(module);
 
   Stats::IsolatedStoreImpl store;
   auto config = newDynamicModuleTracerConfig("test_tracer", "", "test_ns",
                                              std::move(module.value()), *store.rootScope());
-  ASSERT_FALSE(config.ok());
+  ASSERT_THAT(config, Not(IsOk()));
   EXPECT_EQ(config.status().message(), "Failed to initialize dynamic module tracer config");
 }
 

--- a/test/extensions/transport_sockets/dynamic_modules/BUILD
+++ b/test/extensions/transport_sockets/dynamic_modules/BUILD
@@ -35,6 +35,7 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:environment_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/transport_sockets/dynamic_modules/v3:pkg_cc_proto",
     ],

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -123,8 +123,8 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ValidConfigWithLocalFile) {
   config.set_transport_socket_name("passthrough");
 
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
-  EXPECT_NE(nullptr, factory_or_error.value());
+  ASSERT_THAT(factory_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << factory_or_error.status().message();
 }
 
 TEST_F(DynamicModuleTransportSocketConfigTest, ImplementsSecureTransport) {

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -93,7 +93,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, CreateEmptyConfigProto) {
 TEST_F(DynamicModuleTransportSocketConfigTest, DownstreamValidConfig) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = downstream_factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error);
   auto factory = std::move(factory_or_error.value());
   EXPECT_FALSE(factory->implementsSecureTransport());
   EXPECT_NE(nullptr, factory->createDownstreamTransportSocket());
@@ -102,7 +102,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, DownstreamValidConfig) {
 TEST_F(DynamicModuleTransportSocketConfigTest, UpstreamValidConfig) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error);
   auto factory = std::move(factory_or_error.value());
   EXPECT_FALSE(factory->implementsSecureTransport());
   EXPECT_EQ("", factory->defaultServerNameIndication());
@@ -132,7 +132,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ImplementsSecureTransport) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   config.set_implements_secure_transport(true);
   auto factory_or_error = downstream_factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error);
   EXPECT_TRUE(factory_or_error.value()->implementsSecureTransport());
 }
 
@@ -141,7 +141,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, WithTransportSocketConfig) {
   std::ignore =
       config.mutable_transport_socket_config()->PackFrom(ValueUtil::stringValue("config_bytes"));
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_OK(factory_or_error) << factory_or_error.status().message();
+  EXPECT_OK(factory_or_error);
 }
 
 TEST_F(DynamicModuleTransportSocketConfigTest, InvalidModuleName) {
@@ -202,7 +202,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, DoNotCloseAndLoadGloballyOptions)
   config.mutable_dynamic_module_config()->set_do_not_close(true);
   config.mutable_dynamic_module_config()->set_load_globally(true);
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_OK(factory_or_error) << factory_or_error.status().message();
+  EXPECT_OK(factory_or_error);
 }
 
 // Tests that exercise a transport socket instance against a mocked I/O handle.
@@ -223,7 +223,7 @@ public:
       std::ignore = config.mutable_transport_socket_config()->PackFrom(bytes_value);
     }
     auto factory_or_error = factory_.createTransportSocketFactory(config, context_, {});
-    EXPECT_OK(factory_or_error) << factory_or_error.status().message();
+    EXPECT_OK(factory_or_error);
     factory_ptr_ = std::move(factory_or_error.value());
     auto socket = factory_ptr_->createDownstreamTransportSocket();
     socket->setTransportSocketCallbacks(callbacks_);
@@ -480,7 +480,7 @@ TEST_F(DynamicModuleTransportSocketTest, NullInModuleSocketDegradesSafely) {
 TEST_F(DynamicModuleTransportSocketTest, ConnectionCallbacksWithoutCallbacksAreSafe) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error);
   factory_ptr_ = std::move(factory_or_error.value());
   auto socket = factory_ptr_->createDownstreamTransportSocket();
   // setTransportSocketCallbacks is intentionally not called, so the callbacks pointer is null.

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -172,9 +172,9 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ConfigInitializationFailure) {
   // The reference module returns null for an unknown socket name.
   auto config = buildProtoConfig(kReferenceModule, "unknown_socket");
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_THAT(factory_or_error, Not(IsOk()));
-  EXPECT_THAT(factory_or_error.status().message(),
-              HasSubstr("Failed to initialize dynamic module transport socket config"));
+  EXPECT_THAT(
+      factory_or_error,
+      HasStatusMessage(HasSubstr("Failed to initialize dynamic module transport socket config")));
 
   EXPECT_EQ(1U, failureCounter(context_.server_context_.serverScope(), "config_init_error",
                                "unknown_socket"));

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -13,14 +13,18 @@
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::NiceMock;
+using ::testing::Not;
 using testing::ReturnRef;
 
 namespace Envoy {
@@ -88,7 +92,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, CreateEmptyConfigProto) {
 TEST_F(DynamicModuleTransportSocketConfigTest, DownstreamValidConfig) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = downstream_factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
   auto factory = std::move(factory_or_error.value());
   EXPECT_FALSE(factory->implementsSecureTransport());
   EXPECT_NE(nullptr, factory->createDownstreamTransportSocket());
@@ -97,7 +101,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, DownstreamValidConfig) {
 TEST_F(DynamicModuleTransportSocketConfigTest, UpstreamValidConfig) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
   auto factory = std::move(factory_or_error.value());
   EXPECT_FALSE(factory->implementsSecureTransport());
   EXPECT_EQ("", factory->defaultServerNameIndication());
@@ -119,7 +123,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ValidConfigWithLocalFile) {
   config.set_transport_socket_name("passthrough");
 
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
   EXPECT_NE(nullptr, factory_or_error.value());
 }
 
@@ -127,7 +131,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ImplementsSecureTransport) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   config.set_implements_secure_transport(true);
   auto factory_or_error = downstream_factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
   EXPECT_TRUE(factory_or_error.value()->implementsSecureTransport());
 }
 
@@ -136,14 +140,13 @@ TEST_F(DynamicModuleTransportSocketConfigTest, WithTransportSocketConfig) {
   std::ignore =
       config.mutable_transport_socket_config()->PackFrom(ValueUtil::stringValue("config_bytes"));
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  EXPECT_OK(factory_or_error) << factory_or_error.status().message();
 }
 
 TEST_F(DynamicModuleTransportSocketConfigTest, InvalidModuleName) {
   auto config = buildProtoConfig("nonexistent_module", "passthrough");
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_FALSE(factory_or_error.ok());
-  EXPECT_THAT(factory_or_error.status().message(), HasSubstr("Failed to load dynamic module"));
+  EXPECT_THAT(factory_or_error, HasStatusMessage(HasSubstr("Failed to load dynamic module")));
 
   EXPECT_EQ(1U, failureCounter(context_.server_context_.serverScope(), "module_load_error",
                                "passthrough"));
@@ -156,8 +159,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, MissingTransportSocketSymbols) {
                              TestEnvironment::substitute(kCModulesPath), 1);
   auto config = buildProtoConfig("no_op", "passthrough");
   auto factory_or_error = downstream_factory_.createTransportSocketFactory(config, context_, {});
-  EXPECT_FALSE(factory_or_error.ok());
-  EXPECT_THAT(factory_or_error.status().message(), HasSubstr("Failed to resolve symbol"));
+  EXPECT_THAT(factory_or_error, HasStatusMessage(HasSubstr("Failed to resolve symbol")));
 
   // The module loads fine but its config creation fails resolving a symbol, counted as
   // config_init_error.
@@ -170,7 +172,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ConfigInitializationFailure) {
   // The reference module returns null for an unknown socket name.
   auto config = buildProtoConfig(kReferenceModule, "unknown_socket");
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_FALSE(factory_or_error.ok());
+  EXPECT_THAT(factory_or_error, Not(IsOk()));
   EXPECT_THAT(factory_or_error.status().message(),
               HasSubstr("Failed to initialize dynamic module transport socket config"));
 
@@ -187,7 +189,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, MalformedTransportSocketConfig) {
   any->set_value("invalid_binary_data_that_cannot_be_unpacked_as_string_value");
 
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_FALSE(factory_or_error.ok());
+  EXPECT_THAT(factory_or_error, Not(IsOk()));
 
   auto& server_scope = context_.server_context_.serverScope();
   EXPECT_EQ(1U, failureCounter(server_scope, "config_init_error", "passthrough"));
@@ -199,7 +201,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, DoNotCloseAndLoadGloballyOptions)
   config.mutable_dynamic_module_config()->set_do_not_close(true);
   config.mutable_dynamic_module_config()->set_load_globally(true);
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  EXPECT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  EXPECT_OK(factory_or_error) << factory_or_error.status().message();
 }
 
 // Tests that exercise a transport socket instance against a mocked I/O handle.
@@ -220,7 +222,7 @@ public:
       std::ignore = config.mutable_transport_socket_config()->PackFrom(bytes_value);
     }
     auto factory_or_error = factory_.createTransportSocketFactory(config, context_, {});
-    EXPECT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+    EXPECT_OK(factory_or_error) << factory_or_error.status().message();
     factory_ptr_ = std::move(factory_or_error.value());
     auto socket = factory_ptr_->createDownstreamTransportSocket();
     socket->setTransportSocketCallbacks(callbacks_);
@@ -477,7 +479,7 @@ TEST_F(DynamicModuleTransportSocketTest, NullInModuleSocketDegradesSafely) {
 TEST_F(DynamicModuleTransportSocketTest, ConnectionCallbacksWithoutCallbacksAreSafe) {
   auto config = buildProtoConfig(kReferenceModule, "passthrough");
   auto factory_or_error = factory_.createTransportSocketFactory(config, context_, {});
-  ASSERT_TRUE(factory_or_error.ok()) << factory_or_error.status().message();
+  ASSERT_OK(factory_or_error) << factory_or_error.status().message();
   factory_ptr_ = std::move(factory_or_error.value());
   auto socket = factory_ptr_->createDownstreamTransportSocket();
   // setTransportSocketCallbacks is intentionally not called, so the callbacks pointer is null.

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -21,6 +21,7 @@
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::IsOkAndHolds;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::NiceMock;
@@ -123,7 +124,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ValidConfigWithLocalFile) {
   config.set_transport_socket_name("passthrough");
 
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_THAT(factory_or_error, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+  ASSERT_THAT(factory_or_error, IsOkAndHolds(::testing::NotNull()))
       << factory_or_error.status().message();
 }
 

--- a/test/extensions/transport_sockets/dynamic_modules/config_test.cc
+++ b/test/extensions/transport_sockets/dynamic_modules/config_test.cc
@@ -124,8 +124,7 @@ TEST_F(DynamicModuleTransportSocketConfigTest, ValidConfigWithLocalFile) {
   config.set_transport_socket_name("passthrough");
 
   auto factory_or_error = upstream_factory_.createTransportSocketFactory(config, context_);
-  ASSERT_THAT(factory_or_error, IsOkAndHolds(::testing::NotNull()))
-      << factory_or_error.status().message();
+  ASSERT_THAT(factory_or_error, IsOkAndHolds(::testing::NotNull()));
 }
 
 TEST_F(DynamicModuleTransportSocketConfigTest, ImplementsSecureTransport) {

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/BUILD
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/BUILD
@@ -32,6 +32,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/transport_sockets/tls/cert_validator/dynamic_modules/v3:pkg_cc_proto",
     ],

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -268,9 +268,8 @@ TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsReturnsVerifyMode) {
 
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, false, scope);
-  ASSERT_OK(result);
   // cert_validator_no_op returns SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x03.
-  EXPECT_EQ(0x03, result.value());
+  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(0x03));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCerts) {
@@ -281,8 +280,7 @@ TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCe
 
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, true, scope);
-  ASSERT_OK(result);
-  EXPECT_EQ(0x03, result.value());
+  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(0x03));
 }
 
 // =============================================================================
@@ -398,8 +396,7 @@ typed_config:
 
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_OK(result);
-  EXPECT_NE(result.value(), nullptr);
+  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test"));
@@ -425,8 +422,8 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_OK(result) << result.status().message();
-  EXPECT_NE(result.value(), nullptr);
+  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
+      << result.status().message();
 }
 
 // Remote module sources are not supported for cert validators (no init manager is wired up).
@@ -474,8 +471,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_OK(result);
-  EXPECT_NE(result.value(), nullptr);
+  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FactoryCreateCertValidatorInvalidValidatorConfig) {

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -26,6 +26,7 @@ namespace {
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
+using ::Envoy::StatusHelpers::IsOkAndHolds;
 using ::testing::NiceMock;
 using ::testing::Not;
 
@@ -269,7 +270,7 @@ TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsReturnsVerifyMode) {
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, false, scope);
   // cert_validator_no_op returns SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x03.
-  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(0x03));
+  ASSERT_THAT(result, IsOkAndHolds(0x03));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCerts) {
@@ -280,7 +281,7 @@ TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCe
 
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, true, scope);
-  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(0x03));
+  ASSERT_THAT(result, IsOkAndHolds(0x03));
 }
 
 // =============================================================================
@@ -396,7 +397,7 @@ typed_config:
 
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
+  ASSERT_THAT(result, IsOkAndHolds(::testing::NotNull()));
 
   // The happy path emits no load-failure counters.
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test"));
@@ -422,8 +423,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()))
-      << result.status().message();
+  ASSERT_THAT(result, IsOkAndHolds(::testing::NotNull())) << result.status().message();
 }
 
 // Remote module sources are not supported for cert validators (no init manager is wired up).
@@ -471,7 +471,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_THAT(result, ::Envoy::StatusHelpers::IsOkAndHolds(::testing::NotNull()));
+  ASSERT_THAT(result, IsOkAndHolds(::testing::NotNull()));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FactoryCreateCertValidatorInvalidValidatorConfig) {

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -423,7 +423,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_THAT(result, IsOkAndHolds(::testing::NotNull())) << result.status().message();
+  ASSERT_THAT(result, IsOkAndHolds(::testing::NotNull()));
 }
 
 // Remote module sources are not supported for cert validators (no init manager is wired up).

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -11,6 +11,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -23,7 +24,9 @@ namespace Tls {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::IsOk;
 using ::testing::NiceMock;
+using ::testing::Not;
 
 class DynamicModuleCertValidatorTest : public testing::Test {
 protected:
@@ -61,13 +64,13 @@ using ::Envoy::Extensions::DynamicModules::failureCounter;
 
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewSuccess) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
   EXPECT_NE(config_or_error.value()->in_module_config_, nullptr);
 }
 
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewReturnsNull) {
   auto config_or_error = createConfig("cert_validator_config_new_fail");
-  ASSERT_FALSE(config_or_error.ok());
+  ASSERT_THAT(config_or_error, Not(IsOk()));
   EXPECT_THAT(config_or_error.status().message(),
               testing::HasSubstr("Failed to initialize dynamic module cert validator config"));
 }
@@ -75,13 +78,13 @@ TEST_F(DynamicModuleCertValidatorTest, ConfigNewReturnsNull) {
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewModuleNotFound) {
   auto module =
       Envoy::Extensions::DynamicModules::newDynamicModuleByName("nonexistent_module", false, false);
-  EXPECT_FALSE(module.ok());
+  EXPECT_THAT(module, Not(IsOk()));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewMissingSymbol) {
   // The "no_op" module does not implement cert validator functions.
   auto config_or_error = createConfig("no_op");
-  ASSERT_FALSE(config_or_error.ok());
+  ASSERT_THAT(config_or_error, Not(IsOk()));
 }
 
 // =============================================================================
@@ -90,7 +93,7 @@ TEST_F(DynamicModuleCertValidatorTest, ConfigNewMissingSymbol) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainSuccess) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -113,7 +116,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainSuccess) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainFailure) {
   auto config_or_error = createConfig("cert_validator_fail");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -138,7 +141,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainFailure) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainEmptyChain) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -154,7 +157,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainEmptyChain) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainDerEncodingError) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -175,7 +178,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainDerEncodingError) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainNoClientCertificateStatus) {
   auto config_or_error = createConfig("cert_validator_no_client_cert");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -195,7 +198,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainNoClientCertificateStatus)
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainNotValidatedDefaultStatus) {
   auto config_or_error = createConfig("cert_validator_not_validated");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -215,7 +218,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainNotValidatedDefaultStatus)
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainMultipleCerts) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -237,7 +240,7 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainMultipleCerts) {
 
 TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainWithIsServerTrue) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -259,26 +262,26 @@ TEST_F(DynamicModuleCertValidatorTest, VerifyCertChainWithIsServerTrue) {
 
 TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsReturnsVerifyMode) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, false, scope);
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   // cert_validator_no_op returns SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x03.
   EXPECT_EQ(0x03, result.value());
 }
 
 TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCerts) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
   Stats::Scope& scope = *store_.rootScope();
   auto result = validator.initializeSslContexts({}, true, scope);
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_EQ(0x03, result.value());
 }
 
@@ -288,7 +291,7 @@ TEST_F(DynamicModuleCertValidatorTest, InitializeSslContextsHandshakerProvidesCe
 
 TEST_F(DynamicModuleCertValidatorTest, UpdateDigestForSessionId) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -308,7 +311,7 @@ TEST_F(DynamicModuleCertValidatorTest, UpdateDigestForSessionId) {
 
 TEST_F(DynamicModuleCertValidatorTest, UpdateDigestForSessionIdEmptyDigest) {
   auto config_or_error = createConfig("cert_validator_empty_digest");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
@@ -332,7 +335,7 @@ TEST_F(DynamicModuleCertValidatorTest, UpdateDigestForSessionIdEmptyDigest) {
 
 TEST_F(DynamicModuleCertValidatorTest, DaysUntilFirstCertExpiresReturnsNullopt) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
   EXPECT_FALSE(validator.daysUntilFirstCertExpires().has_value());
@@ -340,7 +343,7 @@ TEST_F(DynamicModuleCertValidatorTest, DaysUntilFirstCertExpiresReturnsNullopt) 
 
 TEST_F(DynamicModuleCertValidatorTest, GetCaFileNameReturnsEmpty) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
   EXPECT_EQ("", validator.getCaFileName());
@@ -348,7 +351,7 @@ TEST_F(DynamicModuleCertValidatorTest, GetCaFileNameReturnsEmpty) {
 
 TEST_F(DynamicModuleCertValidatorTest, GetCaCertInformationReturnsNull) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
   EXPECT_EQ(nullptr, validator.getCaCertInformation());
@@ -356,19 +359,19 @@ TEST_F(DynamicModuleCertValidatorTest, GetCaCertInformationReturnsNull) {
 
 TEST_F(DynamicModuleCertValidatorTest, AddClientValidationContext) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 
   CSmartPtr<SSL_CTX, SSL_CTX_free> ssl_ctx(SSL_CTX_new(TLS_method()));
   // With require_client_cert = true.
-  EXPECT_TRUE(validator.addClientValidationContext(ssl_ctx.get(), true).ok());
+  EXPECT_OK(validator.addClientValidationContext(ssl_ctx.get(), true));
   EXPECT_EQ(SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
             SSL_CTX_get_verify_mode(ssl_ctx.get()));
 
   // With require_client_cert = false.
   CSmartPtr<SSL_CTX, SSL_CTX_free> ssl_ctx2(SSL_CTX_new(TLS_method()));
-  EXPECT_TRUE(validator.addClientValidationContext(ssl_ctx2.get(), false).ok());
+  EXPECT_OK(validator.addClientValidationContext(ssl_ctx2.get(), false));
   EXPECT_EQ(SSL_VERIFY_PEER, SSL_CTX_get_verify_mode(ssl_ctx2.get()));
 }
 
@@ -395,7 +398,7 @@ typed_config:
 
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_NE(result.value(), nullptr);
 
   // The happy path emits no load-failure counters.
@@ -422,7 +425,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_OK(result) << result.status().message();
   EXPECT_NE(result.value(), nullptr);
 }
 
@@ -449,7 +452,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result, Not(IsOk()));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, FactoryCreateCertValidatorWithValidatorConfig) {
@@ -471,7 +474,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_TRUE(result.ok());
+  ASSERT_OK(result);
   EXPECT_NE(result.value(), nullptr);
 }
 
@@ -496,7 +499,7 @@ TEST_F(DynamicModuleCertValidatorTest, FactoryCreateCertValidatorInvalidValidato
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
 
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "config_init_error", "test"));
   EXPECT_EQ(0U, failureCounter(factory_context_.serverScope(), "module_load_error", "test"));
@@ -518,7 +521,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
   EXPECT_THAT(result.status().message(),
               testing::HasSubstr("Failed to initialize dynamic module cert validator config"));
 
@@ -543,7 +546,7 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_FALSE(result.ok());
+  ASSERT_THAT(result, Not(IsOk()));
 
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "module_load_error", "test"));
 }
@@ -554,7 +557,7 @@ typed_config:
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetAndGet) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   // Set up mock transport socket callbacks to provide filter state access.
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
@@ -580,7 +583,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetAndGet) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNonExisting) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   CertValidatorCallContext call_context;
@@ -597,7 +600,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNonExisting) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullCallbacks) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   // The call context has no callbacks, so filter state is unavailable.
   CertValidatorCallContext call_context;
@@ -612,7 +615,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullCallbacks) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullCallbacks) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   // The call context has no callbacks, so filter state is unavailable.
   CertValidatorCallContext call_context;
@@ -627,7 +630,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullCallbacks) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullKey) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   CertValidatorCallContext call_context;
@@ -642,7 +645,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullKey) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullValue) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   CertValidatorCallContext call_context;
@@ -656,7 +659,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateSetNullValue) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullKey) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   CertValidatorCallContext call_context;
@@ -672,7 +675,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateGetNullKey) {
 
 TEST_F(DynamicModuleCertValidatorTest, FilterStateSetEmptyValue) {
   auto config_or_error = createConfig("cert_validator_no_op");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks;
   CertValidatorCallContext call_context;
@@ -699,7 +702,7 @@ TEST_F(DynamicModuleCertValidatorTest, FilterStateViaDoVerifyCertChain) {
   // This test uses the cert_validator_filter_state C module which sets and reads
   // filter state during do_verify_cert_chain.
   auto config_or_error = createConfig("cert_validator_filter_state");
-  ASSERT_TRUE(config_or_error.ok());
+  ASSERT_OK(config_or_error);
 
   DynamicModuleCertValidator validator(config_or_error.value(), stats_);
 

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/dynamic_modules_cert_validator_test.cc
@@ -24,6 +24,7 @@ namespace Tls {
 namespace DynamicModules {
 namespace {
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::NiceMock;
 using ::testing::Not;
@@ -70,9 +71,8 @@ TEST_F(DynamicModuleCertValidatorTest, ConfigNewSuccess) {
 
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewReturnsNull) {
   auto config_or_error = createConfig("cert_validator_config_new_fail");
-  ASSERT_THAT(config_or_error, Not(IsOk()));
-  EXPECT_THAT(config_or_error.status().message(),
-              testing::HasSubstr("Failed to initialize dynamic module cert validator config"));
+  ASSERT_THAT(config_or_error, HasStatusMessage(testing::HasSubstr(
+                                   "Failed to initialize dynamic module cert validator config")));
 }
 
 TEST_F(DynamicModuleCertValidatorTest, ConfigNewModuleNotFound) {
@@ -521,9 +521,8 @@ typed_config:
   DynamicModuleCertValidatorFactory factory;
   auto result = factory.createCertValidator(&validation_config, stats_, factory_context_,
                                             *store_.rootScope());
-  ASSERT_THAT(result, Not(IsOk()));
-  EXPECT_THAT(result.status().message(),
-              testing::HasSubstr("Failed to initialize dynamic module cert validator config"));
+  ASSERT_THAT(result, HasStatusMessage(testing::HasSubstr(
+                          "Failed to initialize dynamic module cert validator config")));
 
   // The module loads fine but its config creation fails, counted as config_init_error.
   EXPECT_EQ(1U, failureCounter(factory_context_.serverScope(), "config_init_error", "test"));

--- a/test/extensions/upstreams/http/dynamic_modules/BUILD
+++ b/test/extensions/upstreams/http/dynamic_modules/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test(
         "//test/mocks/tcp:tcp_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:environment_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
@@ -11,15 +11,19 @@
 #include "test/mocks/tcp/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/environment.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatusMessage;
+using ::Envoy::StatusHelpers::IsOk;
 using testing::_;
 using testing::AnyNumber;
 using testing::Invoke;
 using testing::NiceMock;
+using ::testing::Not;
 using testing::Return;
 using testing::ReturnRef;
 
@@ -40,9 +44,9 @@ void setTestModulesSearchPath() {
 BridgeConfigSharedPtr createBridgeConfig(const std::string& module_name) {
   auto module =
       Envoy::Extensions::DynamicModules::newDynamicModuleByName(module_name, false, false);
-  EXPECT_TRUE(module.ok());
+  EXPECT_OK(module);
   auto config_or = BridgeConfig::create("test_bridge", "", std::move(module.value()));
-  EXPECT_TRUE(config_or.ok());
+  EXPECT_OK(config_or);
   return config_or.value();
 }
 
@@ -58,20 +62,20 @@ public:
 TEST_F(BridgeConfigTest, CreateSuccess) {
   auto module = Envoy::Extensions::DynamicModules::newDynamicModuleByName("upstream_bridge_no_op",
                                                                           false, false);
-  ASSERT_TRUE(module.ok());
+  ASSERT_OK(module);
 
   auto config = BridgeConfig::create("test_bridge", "test_config", std::move(module.value()));
-  ASSERT_TRUE(config.ok());
+  ASSERT_OK(config);
   EXPECT_NE(config.value()->in_module_config_, nullptr);
 }
 
 TEST_F(BridgeConfigTest, CreateFailConfigNewReturnsNull) {
   auto module = Envoy::Extensions::DynamicModules::newDynamicModuleByName(
       "upstream_bridge_config_new_fail", false, false);
-  ASSERT_TRUE(module.ok());
+  ASSERT_OK(module);
 
   auto config = BridgeConfig::create("test_bridge", "test_config", std::move(module.value()));
-  ASSERT_FALSE(config.ok());
+  ASSERT_THAT(config, Not(IsOk()));
   EXPECT_THAT(config.status().message(),
               testing::HasSubstr("failed to initialize dynamic module bridge configuration"));
 }
@@ -171,19 +175,19 @@ TEST_F(HttpTcpBridgeTest, EncodeHeadersNoOp) {
       {":method", "POST"}, {":path", "/test"}, {":authority", "example.com"}};
 
   auto status = bridge_->encodeHeaders(headers, false);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 TEST_F(HttpTcpBridgeTest, EncodeHeadersEndOfStream) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
 
   auto status = bridge_->encodeHeaders(headers, true);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 TEST_F(HttpTcpBridgeTest, EncodeData) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl data("hello");
   bridge_->encodeData(data, true);
@@ -191,7 +195,7 @@ TEST_F(HttpTcpBridgeTest, EncodeData) {
 
 TEST_F(HttpTcpBridgeTest, EncodeTrailers) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Envoy::Http::TestRequestTrailerMapImpl trailers{{"trailer-key", "trailer-value"}};
   bridge_->encodeTrailers(trailers);
@@ -199,7 +203,7 @@ TEST_F(HttpTcpBridgeTest, EncodeTrailers) {
 
 TEST_F(HttpTcpBridgeTest, OnUpstreamDataNoOp) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl data("response data");
   bridge_->onUpstreamData(data, false);
@@ -207,7 +211,7 @@ TEST_F(HttpTcpBridgeTest, OnUpstreamDataNoOp) {
 
 TEST_F(HttpTcpBridgeTest, RequestBufferRemainsReadableAfterEncodeData) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl data("hello");
   bridge_->encodeData(data, false);
@@ -229,7 +233,7 @@ TEST_F(HttpTcpBridgeTest, RequestBufferRemainsReadableAfterEncodeData) {
 
 TEST_F(HttpTcpBridgeTest, ResponseBufferRemainsReadableAfterOnUpstreamData) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl data("world");
   bridge_->onUpstreamData(data, false);
@@ -286,8 +290,7 @@ public:
 TEST_F(HttpTcpBridgeNullBridgeTest, EncodeHeadersReturnsError) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
   auto status = bridge_->encodeHeaders(headers, true);
-  EXPECT_FALSE(status.ok());
-  EXPECT_EQ(status.message(), "dynamic module bridge is null");
+  EXPECT_THAT(status, HasStatusMessage("dynamic module bridge is null"));
 }
 
 TEST_F(HttpTcpBridgeNullBridgeTest, EncodeDataIsNoOp) {
@@ -317,12 +320,12 @@ public:
 TEST_F(HttpTcpBridgeStopAndBufferTest, EncodeHeadersNoCallbacksCalled) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
   auto status = bridge_->encodeHeaders(headers, false);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 TEST_F(HttpTcpBridgeStopAndBufferTest, EncodeDataNoCallbacksCalled) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl chunk1("chunk1");
   bridge_->encodeData(chunk1, false);
@@ -333,7 +336,7 @@ TEST_F(HttpTcpBridgeStopAndBufferTest, EncodeDataNoCallbacksCalled) {
 
 TEST_F(HttpTcpBridgeStopAndBufferTest, OnUpstreamDataNoCallbacksCalled) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   Buffer::OwnedImpl data("upstream data");
   bridge_->onUpstreamData(data, false);
@@ -350,7 +353,7 @@ public:
 
 TEST_F(HttpTcpBridgeEndStreamTest, EncodeDataSendsResponse) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   EXPECT_CALL(mock_upstream_to_downstream_, decodeHeaders(_, false));
   EXPECT_CALL(mock_upstream_to_downstream_, decodeData(_, true));
@@ -361,7 +364,7 @@ TEST_F(HttpTcpBridgeEndStreamTest, EncodeDataSendsResponse) {
 
 TEST_F(HttpTcpBridgeEndStreamTest, EncodeTrailersSendsResponse) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   EXPECT_CALL(mock_upstream_to_downstream_, decodeHeaders(_, true));
 
@@ -371,7 +374,7 @@ TEST_F(HttpTcpBridgeEndStreamTest, EncodeTrailersSendsResponse) {
 
 TEST_F(HttpTcpBridgeEndStreamTest, OnUpstreamDataSendsResponseHeadersAndData) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, false).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, false));
 
   EXPECT_CALL(mock_upstream_to_downstream_, decodeHeaders(_, false));
   EXPECT_CALL(mock_upstream_to_downstream_, decodeData(_, true));
@@ -385,7 +388,7 @@ TEST_F(HttpTcpBridgeEndStreamTest, EncodeHeadersExercisesAbiCallbacks) {
       {":method", "POST"}, {":path", "/test"}, {"x-custom", "value"}};
 
   auto status = bridge_->encodeHeaders(headers, false);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 // =============================================================================
@@ -404,7 +407,7 @@ TEST_F(HttpTcpBridgeHeadersEndStreamTest, SendResponseWithBody) {
 
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
   auto status = bridge_->encodeHeaders(headers, true);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 TEST_F(HttpTcpBridgeHeadersEndStreamTest, SendResponseWithoutBody) {
@@ -415,7 +418,7 @@ TEST_F(HttpTcpBridgeHeadersEndStreamTest, SendResponseWithoutBody) {
 
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
   auto status = bridge_->encodeHeaders(headers, true);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 TEST_F(HttpTcpBridgeHeadersEndStreamTest, OnEventAfterResponseStarted) {
@@ -423,7 +426,7 @@ TEST_F(HttpTcpBridgeHeadersEndStreamTest, OnEventAfterResponseStarted) {
   EXPECT_CALL(mock_upstream_to_downstream_, decodeData(_, true));
 
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/test"}};
-  EXPECT_TRUE(bridge_->encodeHeaders(headers, true).ok());
+  EXPECT_OK(bridge_->encodeHeaders(headers, true));
 
   EXPECT_CALL(mock_upstream_to_downstream_, onResetStream(_, _));
   bridge_->onEvent(Network::ConnectionEvent::RemoteClose);
@@ -449,7 +452,7 @@ TEST_F(HttpTcpBridgeAbiEdgeCasesTest, EdgeCaseCallbacksExercised) {
 
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/test"}};
   auto status = bridge_->encodeHeaders(headers, false);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 }
 
 // =============================================================================

--- a/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
+++ b/test/extensions/upstreams/http/dynamic_modules/upstream_request_test.cc
@@ -18,12 +18,10 @@
 #include "gtest/gtest.h"
 
 using ::Envoy::StatusHelpers::HasStatusMessage;
-using ::Envoy::StatusHelpers::IsOk;
 using testing::_;
 using testing::AnyNumber;
 using testing::Invoke;
 using testing::NiceMock;
-using ::testing::Not;
 using testing::Return;
 using testing::ReturnRef;
 
@@ -75,9 +73,8 @@ TEST_F(BridgeConfigTest, CreateFailConfigNewReturnsNull) {
   ASSERT_OK(module);
 
   auto config = BridgeConfig::create("test_bridge", "test_config", std::move(module.value()));
-  ASSERT_THAT(config, Not(IsOk()));
-  EXPECT_THAT(config.status().message(),
-              testing::HasSubstr("failed to initialize dynamic module bridge configuration"));
+  ASSERT_THAT(config, HasStatusMessage(testing::HasSubstr(
+                          "failed to initialize dynamic module bridge configuration")));
 }
 
 // =============================================================================


### PR DESCRIPTION
Commit Message: Use status matchers where appropriate (12)
Additional Description: Part of a wide cleanup of status-related expectations - EXPECT_TRUE and EXPECT_FALSE have unhelpful output on test failure compared to the actual status matchers, and in some cases are less readable. A cleanup of this pattern will tend to also improve future code.
Risk Level: test-only

Note: AI (Codex 5.6) was used to generate this set of PRs; I have reviewed each PR manually before marking it ready for review.