### PR TITLE
bazel: add `use_host_tools` parameter for downstream builds

### DIFF
--- a/bazel/README.md
+++ b/bazel/README.md
@@ -342,6 +342,43 @@ bazel build envoy --config=docker-clang
 Tests can be run in docker sandbox too. Note that the network environment, such as IPv6, may be different in the docker sandbox so you may want
 set different options. See below to configure test IP versions.
 
+## Building with host-provided toolchains
+
+By default, Envoy's Bazel build downloads hermetic versions of several toolchains (Go, CMake/Make/Ninja,
+and Python). Downstream projects that embed Envoy may prefer to use the versions already installed on
+the build host instead.
+
+The `use_host_tools` parameter can be passed to `envoy_dependency_imports` and `envoy_dependencies_extra`
+in your WORKSPACE file to achieve this:
+
+```starlark
+envoy_dependency_imports(use_host_tools = True)
+envoy_dependencies_extra(use_host_tools = True)
+```
+
+When `use_host_tools = True`:
+
+- **Go**: Uses the Go SDK installed on the host (equivalent to `go_version = "host"`).
+- **CMake/Make/Ninja**: Uses the host-installed versions instead of downloading them
+  via `rules_foreign_cc`.
+- **Python**: Disables the hermetic Python toolchain and registers the host Python
+  autodetecting toolchain instead.
+
+Additionally, to use a host-installed Clang/LLVM toolchain instead of the hermetic one downloaded
+by Bazel, add the following to your `user.bazelrc`:
+
+```
+build --repo_env=BAZEL_USE_HOST_SYSROOT=True
+build --repo_env=BAZEL_LLVM_PATH=/usr
+build --config=clang-local
+```
+
+`BAZEL_LLVM_PATH` should point to the root of your LLVM installation.
+
+This is intended for downstream repositories that build inside controlled environments (e.g.
+container-based CI) where these tools are pre-installed at known versions. Upstream Envoy builds
+are unaffected when the parameter is omitted.
+
 ## Linking against libc++ on Linux
 
 When using `--config=clang`, Envoy is automatically linked against libc++. No additional configuration is needed.

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -375,8 +375,11 @@ build --config=clang-local
 
 `BAZEL_LLVM_PATH` should point to the root of your LLVM installation.
 
-This is intended for downstream repositories that build inside controlled environments (e.g.
-container-based CI) where these tools are pre-installed at known versions. Upstream Envoy builds
+**Note:** Building with host-provided toolchains is **not supported** by the Envoy project. The
+hermetic toolchain versions are the only configuration tested in CI. Using host tools may result
+in build failures or unexpected behavior depending on the versions installed. This option is
+provided as a convenience for downstream repositories that build inside controlled environments
+(e.g. container-based CI) where tools are pre-installed at known versions. Upstream Envoy builds
 are unaffected when the parameter is omitted.
 
 ## Linking against libc++ on Linux

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -43,9 +43,14 @@ def envoy_dependency_imports(
         # which can be used to workaround a rules_rust bug. See:
         # - https://github.com/bazelbuild/rules_rust/issues/3521
         # - https://github.com/envoyproxy/envoy/issues/38951
-        cargo_bazel_lockfile = "@envoy//:Cargo.Bazel.lock"):
+        cargo_bazel_lockfile = "@envoy//:Cargo.Bazel.lock",
+        use_host_tools = False):
     compatibility_proxy_repo()
-    rules_foreign_cc_dependencies()
+    if use_host_tools:
+        go_version = "host"
+        rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
+    else:
+        rules_foreign_cc_dependencies()
     go_rules_dependencies()
     go_register_toolchains(go_version)
     if go_version != "host":

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -46,6 +46,10 @@ def envoy_dependency_imports(
         cargo_bazel_lockfile = "@envoy//:Cargo.Bazel.lock",
         use_host_tools = False):
     compatibility_proxy_repo()
+
+    # When use_host_tools is True, skip downloading hermetic toolchains and use
+    # whatever is installed on the host. This is unsupported by the Envoy project
+    # and intended only for downstream builds in controlled environments.
     if use_host_tools:
         go_version = "host"
         rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -23,7 +23,8 @@ PYTHON_MINOR_VERSION = _python_minor_version(PYTHON_VERSION)
 def envoy_dependencies_extra(
         glibc_version = GLIBC_VERSION,
         python_version = PYTHON_VERSION,
-        ignore_root_user_error = False):
+        ignore_root_user_error = False,
+        use_host_tools = False):
     compatibility_proxy_repo()
     java_compatibility_proxy_repo()
     bazel_toolchain_dependencies()
@@ -39,7 +40,11 @@ def envoy_dependencies_extra(
         name = "python%s" % _python_minor_version(python_version),
         python_version = python_version,
         ignore_root_user_error = ignore_root_user_error,
+        register_toolchains = not use_host_tools,
     )
+
+    if use_host_tools:
+        native.register_toolchains("@rules_python//python:autodetecting_toolchain")
 
     aspect_bazel_lib_dependencies()
 

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -36,6 +36,9 @@ def envoy_dependencies_extra(
     py_repositories()
 
     # Registers underscored Python minor version - eg `python3_10`
+    # When use_host_tools is True, skip registering the hermetic Python toolchain
+    # and use the host Python instead. This is unsupported by the Envoy project
+    # and intended only for downstream builds in controlled environments.
     python_register_toolchains(
         name = "python%s" % _python_minor_version(python_version),
         python_version = python_version,


### PR DESCRIPTION
Add a `use_host_tools` parameter to `envoy_dependency_imports` and `envoy_dependencies_extra` that allows downstream repositories to use host-installed toolchains (Go, CMake/Make/Ninja, Python) instead of Bazel-downloaded hermetic versions.

When `use_host_tools = True`:
- Go uses the host SDK (equivalent to `go_version = "host"`)
- `rules_foreign_cc` skips downloading its own CMake/Make/Ninja
- Python hermetic toolchain registration is disabled in favor of the host autodetecting toolchain

This eliminates the need for downstream projects to maintain patches against envoy's bazel files to achieve this behavior.

Also update bazel's README with information on how to build using local toolchains.
