### PR TITLE
docs: fix typos in configuration documentation

### DIFF
--- a/docs/root/configuration/http/http_filters/geoip_filter.rst
+++ b/docs/root/configuration/http/http_filters/geoip_filter.rst
@@ -5,7 +5,7 @@ IP Geolocation Filter
 This filter decorates HTTP requests with the geolocation data.
 Filter uses client address to lookup information (e.g., client's city, country) in the geolocation provider database.
 Upon a successful lookup request will be enriched with the configured geolocation header and the value from the database.
-In case the configured geolocation headers are present in the incoming request, they will be overriden by the filter.
+In case the configured geolocation headers are present in the incoming request, they will be overridden by the filter.
 Geolocation filter emits stats for the number of the successful lookups and the number of total lookups.
 English language is used for the geolocation lookups, the result of the lookup will be UTF-8 encoded.
 Please note that Geolocation filter and providers are not yet supported on Windows.

--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -423,5 +423,5 @@ The OAuth2 filter outputs statistics in the ``<stat_prefix>.`` namespace.
   oauth_passthrough, Counter, Total request that matched a passthrough header.
   oauth_success, Counter, Total requests that were allowed.
   oauth_unauthorization_rq, Counter, Total unauthorized requests.
-  oauth_refreshtoken_success, Counter, Total successfull requests for update access token using by refresh token
+  oauth_refreshtoken_success, Counter, Total successful requests for update access token using by refresh token
   oauth_refreshtoken_failure, Counter, Total failed requests for update access token using by refresh token

--- a/docs/root/configuration/security/secret.rst
+++ b/docs/root/configuration/security/secret.rst
@@ -399,7 +399,7 @@ downstream listener:
             "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.cert_mappers.filter_state_override.v3.Config
             default_value: "default_secret"
 
-For the *upstream* filter state override configuraton above to work, the value must be written in
+For the *upstream* filter state override configuration above to work, the value must be written in
 the downstream filter chain, e.g. using the following filter configuration:
 
 .. validated-code-block:: yaml


### PR DESCRIPTION
Commit Message: docs: fix typos in configuration documentation
Additional Description:

Fix three documentation typos in .rst files:
- `configuraton` → `configuration` (secret.rst) [rendered](https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#sds-configuration)

> For the upstream filter state override **configuraton** above to work, the value must be written in the downstream filter chain, > e.g. using the following filter configuration:

- `overriden` → `overridden` (geoip_filter.rst) [rendered](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/geoip_filter)

> In case the configured geolocation headers are present in the incoming request, they will be **overriden** by the filter.

- `successfull` → `successful` (oauth2_filter.rst) [rendered](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/oauth2_filter#statistics)

> Total **successfull** requests for update access token using by refresh token


Risk Level: Low
Testing: N/A (docs only)
Docs Changes: Yes (this PR)
Release Notes: N/A
Platform Specific Features: N/A