### PR TITLE
LibeventScheduler: switch to user-managed memory for evwatch observers

### DIFF
--- a/envoy/event/BUILD
+++ b/envoy/event/BUILD
@@ -43,12 +43,17 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "evwatch_interface",
-    hdrs = [
-        "evwatch.h",
-        "evwatch_observer_manager.h",
-    ],
+    hdrs = ["evwatch.h"],
     deps = [
         "//envoy/common:time_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "evwatch_observer_manager_interface",
+    hdrs = ["evwatch_observer_manager.h"],
+    deps = [
+        ":evwatch_interface",
     ],
 )
 

--- a/envoy/event/BUILD
+++ b/envoy/event/BUILD
@@ -43,7 +43,10 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "evwatch_interface",
-    hdrs = ["evwatch.h"],
+    hdrs = [
+        "evwatch.h",
+        "evwatch_observer_manager.h",
+    ],
     deps = [
         "//envoy/common:time_interface",
     ],

--- a/envoy/event/dispatcher.h
+++ b/envoy/event/dispatcher.h
@@ -159,18 +159,18 @@ public:
                                 std::chrono::milliseconds min_touch_interval) PURE;
 
   /**
-   * Registers an Evwatch observer with this dispatcher.
+   * Registers a non-owning Evwatch observer with this dispatcher.
    * This should only be called on the dispatcher's thread.
    * @param observer supplies the observer to register.
    */
-  virtual void registerEvwatchObserver(Evwatch::ObserverPtr observer) PURE;
+  virtual void registerEvwatchObserver(Evwatch::Observer& observer) PURE;
 
   /**
-   * Unregisters an Evwatch observer from this dispatcher.
+   * Unregisters an Evwatch observer from this dispatcher and calls observer.onClose().
    * This should only be called on the dispatcher's thread.
    * @param observer supplies the observer to unregister.
    */
-  virtual void unregisterEvwatchObserver(Evwatch::Observer* observer) PURE;
+  virtual void unregisterEvwatchObserver(Evwatch::Observer& observer) PURE;
 
   /**
    * Returns a time-source to use with this dispatcher.

--- a/envoy/event/dispatcher.h
+++ b/envoy/event/dispatcher.h
@@ -162,10 +162,15 @@ public:
    * Registers an Evwatch observer with this dispatcher.
    * This should only be called on the dispatcher's thread.
    * @param observer supplies the observer to register.
-   * @return Evwatch::ObserverHandlePtr handle that automatically unregisters the observer when
-   * destroyed.
    */
-  virtual Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer) PURE;
+  virtual void registerEvwatchObserver(Evwatch::ObserverPtr observer) PURE;
+
+  /**
+   * Unregisters an Evwatch observer from this dispatcher.
+   * This should only be called on the dispatcher's thread.
+   * @param observer supplies the observer to unregister.
+   */
+  virtual void unregisterEvwatchObserver(Evwatch::Observer* observer) PURE;
 
   /**
    * Returns a time-source to use with this dispatcher.

--- a/envoy/event/evwatch.h
+++ b/envoy/event/evwatch.h
@@ -32,10 +32,13 @@ public:
    * @param check_time monotonic time at check.
    */
   virtual void onCheck(MonotonicTime check_time) = 0;
-};
 
-using ObserverPtr = std::unique_ptr<Observer>;
-using ObserverWeakPtr = std::weak_ptr<Observer>;
+  /**
+   * Called on the dispatcher thread when the observer is unregistered from the dispatcher
+   * or when the dispatcher loop is shutting down.
+   */
+  virtual void onClose() {}
+};
 
 } // namespace Evwatch
 } // namespace Event

--- a/envoy/event/evwatch.h
+++ b/envoy/event/evwatch.h
@@ -37,25 +37,6 @@ public:
 using ObserverPtr = std::unique_ptr<Observer>;
 using ObserverWeakPtr = std::weak_ptr<Observer>;
 
-/**
- * Handle returned when registering an Evwatch::Observer with a Dispatcher.
- * When this handle is destructed (on any thread), the associated observer is automatically
- * unregistered and lazily pruned from the dispatcher's event loop.
- */
-class ObserverHandle {
-public:
-  virtual ~ObserverHandle() = default;
-
-  /**
-   * Returns a weak reference to the underlying observer. This allows ad-hoc tracking lists
-   * (such as periodic metric readers) to safely reference the observer without interfering
-   * with RAII handle ownership and lifecycle unregistration.
-   */
-  virtual ObserverWeakPtr observer() const = 0;
-};
-
-using ObserverHandlePtr = std::unique_ptr<ObserverHandle>;
-
 } // namespace Evwatch
 } // namespace Event
 } // namespace Envoy

--- a/envoy/event/evwatch_observer_manager.h
+++ b/envoy/event/evwatch_observer_manager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/event/evwatch.h"
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * Interface for registering and unregistering Evwatch observers for a single libevent scheduler.
+ */
+class EvwatchObserverManager {
+public:
+  virtual ~EvwatchObserverManager() = default;
+
+  /**
+   * Registers a non-owning Evwatch observer.
+   * @param observer the observer to register.
+   */
+  virtual void registerObserver(Evwatch::Observer& observer) = 0;
+
+  /**
+   * Unregisters a non-owning Evwatch observer and invokes observer.onClose().
+   * @param observer the observer to unregister.
+   */
+  virtual void unregisterObserver(Evwatch::Observer& observer) = 0;
+};
+
+using EvwatchObserverManagerPtr = std::unique_ptr<EvwatchObserverManager>;
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -146,6 +146,7 @@ envoy_cc_library(
     hdrs = ["evwatch_observer_manager_impl.h"],
     deps = [
         "//bazel/foreign_cc:event",
+        "//envoy/common:optref_lib",
         "//envoy/common:time_interface",
         "//envoy/event:evwatch_interface",
     ],

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -149,6 +149,7 @@ envoy_cc_library(
         "//envoy/common:optref_lib",
         "//envoy/common:time_interface",
         "//envoy/event:evwatch_interface",
+        "//envoy/event:evwatch_observer_manager_interface",
     ],
 )
 
@@ -164,6 +165,7 @@ envoy_cc_library(
         "//bazel/foreign_cc:event",
         "//envoy/event:dispatcher_interface",
         "//envoy/event:evwatch_interface",
+        "//envoy/event:evwatch_observer_manager_interface",
         "//envoy/event:timer_interface",
         "//source/common/common:assert_lib",
     ],

--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -141,10 +141,22 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "evwatch_observer_manager_impl_lib",
+    srcs = ["evwatch_observer_manager_impl.cc"],
+    hdrs = ["evwatch_observer_manager_impl.h"],
+    deps = [
+        "//bazel/foreign_cc:event",
+        "//envoy/common:time_interface",
+        "//envoy/event:evwatch_interface",
+    ],
+)
+
+envoy_cc_library(
     name = "libevent_scheduler_lib",
     srcs = ["libevent_scheduler.cc"],
     hdrs = ["libevent_scheduler.h"],
     deps = [
+        ":evwatch_observer_manager_impl_lib",
         ":libevent_lib",
         ":schedulable_cb_lib",
         ":timer_lib",

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -98,9 +98,14 @@ void DispatcherImpl::registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
       std::make_unique<WatchdogRegistration>(watchdog, *scheduler_, min_touch_interval, *this);
 }
 
-Evwatch::ObserverHandlePtr DispatcherImpl::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
+void DispatcherImpl::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
   ASSERT(isThreadSafe());
-  return base_scheduler_.registerEvwatchObserver(std::move(observer));
+  base_scheduler_.registerEvwatchObserver(std::move(observer));
+}
+
+void DispatcherImpl::unregisterEvwatchObserver(Evwatch::Observer* observer) {
+  ASSERT(isThreadSafe());
+  base_scheduler_.unregisterEvwatchObserver(observer);
 }
 
 void DispatcherImpl::initializeStats(Stats::Scope& scope,

--- a/source/common/event/dispatcher_impl.cc
+++ b/source/common/event/dispatcher_impl.cc
@@ -98,12 +98,12 @@ void DispatcherImpl::registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
       std::make_unique<WatchdogRegistration>(watchdog, *scheduler_, min_touch_interval, *this);
 }
 
-void DispatcherImpl::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
+void DispatcherImpl::registerEvwatchObserver(Evwatch::Observer& observer) {
   ASSERT(isThreadSafe());
-  base_scheduler_.registerEvwatchObserver(std::move(observer));
+  base_scheduler_.registerEvwatchObserver(observer);
 }
 
-void DispatcherImpl::unregisterEvwatchObserver(Evwatch::Observer* observer) {
+void DispatcherImpl::unregisterEvwatchObserver(Evwatch::Observer& observer) {
   ASSERT(isThreadSafe());
   base_scheduler_.unregisterEvwatchObserver(observer);
 }

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -59,7 +59,8 @@ public:
   const std::string& name() override { return name_; }
   void registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
                         std::chrono::milliseconds min_touch_interval) override;
-  Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer) override;
+  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override;
+  void unregisterEvwatchObserver(Evwatch::Observer* observer) override;
   TimeSource& timeSource() override { return time_source_; }
   void initializeStats(Stats::Scope& scope, const std::optional<std::string>& prefix) override;
   void clearDeferredDeleteList() override;

--- a/source/common/event/dispatcher_impl.h
+++ b/source/common/event/dispatcher_impl.h
@@ -59,8 +59,8 @@ public:
   const std::string& name() override { return name_; }
   void registerWatchdog(const Server::WatchDogSharedPtr& watchdog,
                         std::chrono::milliseconds min_touch_interval) override;
-  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override;
-  void unregisterEvwatchObserver(Evwatch::Observer* observer) override;
+  void registerEvwatchObserver(Evwatch::Observer& observer) override;
+  void unregisterEvwatchObserver(Evwatch::Observer& observer) override;
   TimeSource& timeSource() override { return time_source_; }
   void initializeStats(Stats::Scope& scope, const std::optional<std::string>& prefix) override;
   void clearDeferredDeleteList() override;

--- a/source/common/event/evwatch_observer_manager_impl.cc
+++ b/source/common/event/evwatch_observer_manager_impl.cc
@@ -6,6 +6,19 @@
 namespace Envoy {
 namespace Event {
 
+namespace {
+
+class IterationGuard {
+public:
+  explicit IterationGuard(uint32_t& depth) : depth_(depth) { ++depth_; }
+  ~IterationGuard() { --depth_; }
+
+private:
+  uint32_t& depth_;
+};
+
+} // namespace
+
 EvwatchObserverManagerImpl::EvwatchObserverManagerImpl(event_base& libevent,
                                                        TimeSource& time_source)
     : libevent_(libevent), time_source_(time_source) {}
@@ -17,8 +30,13 @@ EvwatchObserverManagerImpl::~EvwatchObserverManagerImpl() {
   if (check_evwatch_ != nullptr) {
     evwatch_free(check_evwatch_);
   }
-  for (Evwatch::Observer& observer : observers_) {
-    observer.onClose();
+  IterationGuard guard(iteration_depth_);
+  for (size_t i = 0; i < observers_.size(); ++i) {
+    if (observers_[i].has_value()) {
+      Evwatch::Observer& obs = observers_[i].value();
+      observers_[i].reset();
+      obs.onClose();
+    }
   }
   observers_.clear();
 }
@@ -38,9 +56,16 @@ void EvwatchObserverManagerImpl::onPrepare(evwatch*, const evwatch_prepare_cb_in
 
   const MonotonicTime prepare_time = self->time_source_.monotonicTime();
 
-  for (Evwatch::Observer& observer : self->observers_) {
-    observer.onPrepare(prepare_time, timeout_duration);
+  {
+    IterationGuard guard(self->iteration_depth_);
+    const size_t size_at_start = self->observers_.size();
+    for (size_t i = 0; i < size_at_start; ++i) {
+      if (self->observers_[i].has_value()) {
+        self->observers_[i]->onPrepare(prepare_time, timeout_duration);
+      }
+    }
   }
+  self->cleanupNulledObservers();
 }
 
 void EvwatchObserverManagerImpl::onCheck(evwatch*, const evwatch_check_cb_info*, void* arg) {
@@ -50,14 +75,21 @@ void EvwatchObserverManagerImpl::onCheck(evwatch*, const evwatch_check_cb_info*,
   }
   const MonotonicTime check_time = self->time_source_.monotonicTime();
 
-  for (Evwatch::Observer& observer : self->observers_) {
-    observer.onCheck(check_time);
+  {
+    IterationGuard guard(self->iteration_depth_);
+    const size_t size_at_start = self->observers_.size();
+    for (size_t i = 0; i < size_at_start; ++i) {
+      if (self->observers_[i].has_value()) {
+        self->observers_[i]->onCheck(check_time);
+      }
+    }
   }
+  self->cleanupNulledObservers();
 }
 
 void EvwatchObserverManagerImpl::registerObserver(Evwatch::Observer& observer) {
   auto it = std::find_if(observers_.begin(), observers_.end(),
-                         [&observer](const auto& entry) { return &entry.get() == &observer; });
+                         [&observer](const auto& entry) { return entry.ptr() == &observer; });
   if (it != observers_.end()) {
     return;
   }
@@ -71,11 +103,26 @@ void EvwatchObserverManagerImpl::registerObserver(Evwatch::Observer& observer) {
 
 void EvwatchObserverManagerImpl::unregisterObserver(Evwatch::Observer& observer) {
   auto it = std::find_if(observers_.begin(), observers_.end(),
-                         [&observer](const auto& entry) { return &entry.get() == &observer; });
+                         [&observer](const auto& entry) { return entry.ptr() == &observer; });
   if (it != observers_.end()) {
-    observers_.erase(it);
+    if (iteration_depth_ > 0) {
+      it->reset();
+      has_nulled_observers_ = true;
+    } else {
+      observers_.erase(it);
+    }
     observer.onClose();
   }
+}
+
+void EvwatchObserverManagerImpl::cleanupNulledObservers() {
+  if (!has_nulled_observers_ || iteration_depth_ > 0) {
+    return;
+  }
+  observers_.erase(std::remove_if(observers_.begin(), observers_.end(),
+                                  [](const auto& entry) { return !entry.has_value(); }),
+                   observers_.end());
+  has_nulled_observers_ = false;
 }
 
 } // namespace Event

--- a/source/common/event/evwatch_observer_manager_impl.cc
+++ b/source/common/event/evwatch_observer_manager_impl.cc
@@ -1,0 +1,82 @@
+#include "source/common/event/evwatch_observer_manager_impl.h"
+
+#include <algorithm>
+#include <chrono>
+
+namespace Envoy {
+namespace Event {
+
+EvwatchObserverManagerImpl::EvwatchObserverManagerImpl(event_base& libevent,
+                                                       TimeSource& time_source)
+    : libevent_(libevent), time_source_(time_source) {}
+
+EvwatchObserverManagerImpl::~EvwatchObserverManagerImpl() {
+  if (prepare_evwatch_ != nullptr) {
+    evwatch_free(prepare_evwatch_);
+  }
+  if (check_evwatch_ != nullptr) {
+    evwatch_free(check_evwatch_);
+  }
+  for (Evwatch::Observer& observer : observers_) {
+    observer.onClose();
+  }
+  observers_.clear();
+}
+
+void EvwatchObserverManagerImpl::onPrepare(evwatch*, const evwatch_prepare_cb_info* info,
+                                           void* arg) {
+  auto* self = static_cast<EvwatchObserverManagerImpl*>(arg);
+  if (self->observers_.empty()) {
+    return;
+  }
+  timeval timeout;
+  const bool timeout_set = evwatch_prepare_get_timeout(info, &timeout);
+  const std::optional<MonotonicTime::duration> timeout_duration =
+      timeout_set ? std::make_optional(std::chrono::seconds(timeout.tv_sec) +
+                                       std::chrono::microseconds(timeout.tv_usec))
+                  : std::nullopt;
+
+  const MonotonicTime prepare_time = self->time_source_.monotonicTime();
+
+  for (Evwatch::Observer& observer : self->observers_) {
+    observer.onPrepare(prepare_time, timeout_duration);
+  }
+}
+
+void EvwatchObserverManagerImpl::onCheck(evwatch*, const evwatch_check_cb_info*, void* arg) {
+  auto* self = static_cast<EvwatchObserverManagerImpl*>(arg);
+  if (self->observers_.empty()) {
+    return;
+  }
+  const MonotonicTime check_time = self->time_source_.monotonicTime();
+
+  for (Evwatch::Observer& observer : self->observers_) {
+    observer.onCheck(check_time);
+  }
+}
+
+void EvwatchObserverManagerImpl::registerObserver(Evwatch::Observer& observer) {
+  auto it = std::find_if(observers_.begin(), observers_.end(),
+                         [&observer](const auto& entry) { return &entry.get() == &observer; });
+  if (it != observers_.end()) {
+    return;
+  }
+  if (!hooks_registered_) {
+    hooks_registered_ = true;
+    prepare_evwatch_ = evwatch_prepare_new(&libevent_, &onPrepare, this);
+    check_evwatch_ = evwatch_check_new(&libevent_, &onCheck, this);
+  }
+  observers_.push_back(observer);
+}
+
+void EvwatchObserverManagerImpl::unregisterObserver(Evwatch::Observer& observer) {
+  auto it = std::find_if(observers_.begin(), observers_.end(),
+                         [&observer](const auto& entry) { return &entry.get() == &observer; });
+  if (it != observers_.end()) {
+    observers_.erase(it);
+    observer.onClose();
+  }
+}
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/evwatch_observer_manager_impl.h
+++ b/source/common/event/evwatch_observer_manager_impl.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "envoy/common/time.h"
+#include "envoy/event/evwatch.h"
+#include "envoy/event/evwatch_observer_manager.h"
+
+#include "event2/event.h"
+#include "event2/watch.h"
+
+namespace Envoy {
+namespace Event {
+
+/**
+ * Manages Evwatch prepare/check hooks and observer registration for a libevent event_base.
+ */
+class EvwatchObserverManagerImpl : public EvwatchObserverManager {
+public:
+  EvwatchObserverManagerImpl(event_base& libevent, TimeSource& time_source);
+  ~EvwatchObserverManagerImpl() override;
+
+  void registerObserver(Evwatch::Observer& observer) override;
+  void unregisterObserver(Evwatch::Observer& observer) override;
+
+private:
+  static void onPrepare(evwatch* watch, const evwatch_prepare_cb_info* info, void* arg);
+  static void onCheck(evwatch* watch, const evwatch_check_cb_info* info, void* arg);
+
+  event_base& libevent_;
+  TimeSource& time_source_;
+  std::vector<std::reference_wrapper<Evwatch::Observer>> observers_;
+  bool hooks_registered_{false};
+  evwatch* prepare_evwatch_{nullptr};
+  evwatch* check_evwatch_{nullptr};
+};
+
+} // namespace Event
+} // namespace Envoy

--- a/source/common/event/evwatch_observer_manager_impl.h
+++ b/source/common/event/evwatch_observer_manager_impl.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <vector>
 
+#include "envoy/common/optref.h"
 #include "envoy/common/time.h"
 #include "envoy/event/evwatch.h"
 #include "envoy/event/evwatch_observer_manager.h"
@@ -28,10 +29,14 @@ private:
   static void onPrepare(evwatch* watch, const evwatch_prepare_cb_info* info, void* arg);
   static void onCheck(evwatch* watch, const evwatch_check_cb_info* info, void* arg);
 
+  void cleanupNulledObservers();
+
   event_base& libevent_;
   TimeSource& time_source_;
-  std::vector<std::reference_wrapper<Evwatch::Observer>> observers_;
+  std::vector<OptRef<Evwatch::Observer>> observers_;
   bool hooks_registered_{false};
+  uint32_t iteration_depth_{0};
+  bool has_nulled_observers_{false};
   evwatch* prepare_evwatch_{nullptr};
   evwatch* check_evwatch_{nullptr};
 };

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -16,22 +16,6 @@ namespace {
 void recordTimeval(Stats::Histogram& histogram, const timeval& tv) {
   histogram.recordValue(tv.tv_sec * 1000000 + tv.tv_usec);
 }
-
-void pruneExpiredObservers(std::vector<std::weak_ptr<Evwatch::Observer>>& observers) {
-  observers.erase(std::remove_if(observers.begin(), observers.end(),
-                                 [](const auto& entry) { return entry.expired(); }),
-                  observers.end());
-}
-
-class ObserverHandleImpl : public Evwatch::ObserverHandle {
-public:
-  explicit ObserverHandleImpl(Evwatch::ObserverPtr observer) : observer_(std::move(observer)) {}
-
-  Evwatch::ObserverWeakPtr observer() const override { return observer_; }
-
-private:
-  std::shared_ptr<Evwatch::Observer> observer_;
-};
 } // namespace
 
 LibeventScheduler::LibeventScheduler(TimeSource& time_source) : time_source_(time_source) {
@@ -177,13 +161,11 @@ void LibeventScheduler::onPrepareForObserver(evwatch*, const evwatch_prepare_cb_
 
   const MonotonicTime prepare_time = self->time_source_.monotonicTime();
 
-  const size_t size = self->evwatch_observers_.size();
-  for (size_t i = 0; i < size; ++i) {
-    if (auto observer = self->evwatch_observers_[i].lock()) {
+  for (const auto& observer : self->evwatch_observers_) {
+    if (observer != nullptr) {
       observer->onPrepare(prepare_time, timeout_duration);
     }
   }
-  pruneExpiredObservers(self->evwatch_observers_);
 }
 
 void LibeventScheduler::onCheckForObserver(evwatch*, const evwatch_check_cb_info*, void* arg) {
@@ -193,28 +175,33 @@ void LibeventScheduler::onCheckForObserver(evwatch*, const evwatch_check_cb_info
   }
   const MonotonicTime check_time = self->time_source_.monotonicTime();
 
-  const size_t size = self->evwatch_observers_.size();
-  for (size_t i = 0; i < size; ++i) {
-    if (auto observer = self->evwatch_observers_[i].lock()) {
+  for (const auto& observer : self->evwatch_observers_) {
+    if (observer != nullptr) {
       observer->onCheck(check_time);
     }
   }
-  pruneExpiredObservers(self->evwatch_observers_);
 }
 
-Evwatch::ObserverHandlePtr
-LibeventScheduler::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
+void LibeventScheduler::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
   if (observer == nullptr) {
-    return nullptr;
+    return;
   }
   if (!evwatch_observers_registered_) {
     evwatch_observers_registered_ = true;
     evwatch_prepare_new(libevent_.get(), &onPrepareForObserver, this);
     evwatch_check_new(libevent_.get(), &onCheckForObserver, this);
   }
-  auto handle = std::make_unique<ObserverHandleImpl>(std::move(observer));
-  evwatch_observers_.push_back(handle->observer());
-  return handle;
+  evwatch_observers_.push_back(std::move(observer));
+}
+
+void LibeventScheduler::unregisterEvwatchObserver(Evwatch::Observer* observer) {
+  if (observer == nullptr) {
+    return;
+  }
+  evwatch_observers_.erase(
+      std::remove_if(evwatch_observers_.begin(), evwatch_observers_.end(),
+                     [observer](const auto& obs) { return obs.get() == observer; }),
+      evwatch_observers_.end());
 }
 
 } // namespace Event

--- a/source/common/event/libevent_scheduler.cc
+++ b/source/common/event/libevent_scheduler.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 
 #include "source/common/common/assert.h"
+#include "source/common/event/evwatch_observer_manager_impl.h"
 #include "source/common/event/schedulable_cb_impl.h"
 #include "source/common/event/timer_impl.h"
 
@@ -36,6 +37,30 @@ LibeventScheduler::LibeventScheduler(TimeSource& time_source) : time_source_(tim
 
   // The dispatcher won't work as expected if libevent hasn't been configured to use threads.
   RELEASE_ASSERT(Libevent::Global::initialized(), "");
+
+  evwatch_manager_ = std::make_unique<EvwatchObserverManagerImpl>(*libevent_, time_source_);
+}
+
+LibeventScheduler::LibeventScheduler(TimeSource& time_source,
+                                     EvwatchObserverManagerPtr evwatch_manager)
+    : LibeventScheduler(time_source) {
+  if (evwatch_manager != nullptr) {
+    evwatch_manager_ = std::move(evwatch_manager);
+  }
+}
+
+LibeventScheduler::~LibeventScheduler() = default;
+
+void LibeventScheduler::registerEvwatchObserver(Evwatch::Observer& observer) {
+  if (evwatch_manager_ != nullptr) {
+    evwatch_manager_->registerObserver(observer);
+  }
+}
+
+void LibeventScheduler::unregisterEvwatchObserver(Evwatch::Observer& observer) {
+  if (evwatch_manager_ != nullptr) {
+    evwatch_manager_->unregisterObserver(observer);
+  }
 }
 
 TimerPtr LibeventScheduler::createTimer(const TimerCb& cb, Dispatcher& dispatcher) {
@@ -143,65 +168,6 @@ void LibeventScheduler::onCheckForStats(evwatch*, const evwatch_check_cb_info*, 
       recordTimeval(self->stats_->poll_delay_us_, delay);
     }
   }
-}
-
-void LibeventScheduler::onPrepareForObserver(evwatch*, const evwatch_prepare_cb_info* info,
-                                             void* arg) {
-  auto self = static_cast<LibeventScheduler*>(arg);
-  if (self->evwatch_observers_.empty()) {
-    return;
-  }
-  timeval timeout;
-  const bool timeout_set = evwatch_prepare_get_timeout(info, &timeout);
-  const std::optional<MonotonicTime::duration> timeout_duration =
-      timeout_set
-          ? std::optional<MonotonicTime::duration>(std::chrono::seconds(timeout.tv_sec) +
-                                                   std::chrono::microseconds(timeout.tv_usec))
-          : std::nullopt;
-
-  const MonotonicTime prepare_time = self->time_source_.monotonicTime();
-
-  for (const auto& observer : self->evwatch_observers_) {
-    if (observer != nullptr) {
-      observer->onPrepare(prepare_time, timeout_duration);
-    }
-  }
-}
-
-void LibeventScheduler::onCheckForObserver(evwatch*, const evwatch_check_cb_info*, void* arg) {
-  auto self = static_cast<LibeventScheduler*>(arg);
-  if (self->evwatch_observers_.empty()) {
-    return;
-  }
-  const MonotonicTime check_time = self->time_source_.monotonicTime();
-
-  for (const auto& observer : self->evwatch_observers_) {
-    if (observer != nullptr) {
-      observer->onCheck(check_time);
-    }
-  }
-}
-
-void LibeventScheduler::registerEvwatchObserver(Evwatch::ObserverPtr observer) {
-  if (observer == nullptr) {
-    return;
-  }
-  if (!evwatch_observers_registered_) {
-    evwatch_observers_registered_ = true;
-    evwatch_prepare_new(libevent_.get(), &onPrepareForObserver, this);
-    evwatch_check_new(libevent_.get(), &onCheckForObserver, this);
-  }
-  evwatch_observers_.push_back(std::move(observer));
-}
-
-void LibeventScheduler::unregisterEvwatchObserver(Evwatch::Observer* observer) {
-  if (observer == nullptr) {
-    return;
-  }
-  evwatch_observers_.erase(
-      std::remove_if(evwatch_observers_.begin(), evwatch_observers_.end(),
-                     [observer](const auto& obs) { return obs.get() == observer; }),
-      evwatch_observers_.end());
 }
 
 } // namespace Event

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -5,6 +5,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/evwatch.h"
+#include "envoy/event/evwatch_observer_manager.h"
 #include "envoy/event/schedulable_cb.h"
 #include "envoy/event/timer.h"
 
@@ -62,9 +63,11 @@ public:
   using OnCheckCallback = std::function<void()>;
 
   explicit LibeventScheduler(TimeSource& time_source);
+  LibeventScheduler(TimeSource& time_source, EvwatchObserverManagerPtr evwatch_manager);
+  ~LibeventScheduler() override;
 
-  void registerEvwatchObserver(Evwatch::ObserverPtr observer);
-  void unregisterEvwatchObserver(Evwatch::Observer* observer);
+  void registerEvwatchObserver(Evwatch::Observer& observer);
+  void unregisterEvwatchObserver(Evwatch::Observer& observer);
 
   // Scheduler
   TimerPtr createTimer(const TimerCb& cb, Dispatcher& dispatcher) override;
@@ -141,8 +144,7 @@ private:
   timeval check_time_{};     // timestamp immediately after polling
   OnPrepareCallback prepare_callback_; // callback to be called from onPrepareForCallback()
   OnCheckCallback check_callback_;     // callback to be called from onCheckForCallback()
-  std::vector<Evwatch::ObserverPtr> evwatch_observers_;
-  bool evwatch_observers_registered_{false};
+  EvwatchObserverManagerPtr evwatch_manager_;
 };
 
 } // namespace Event

--- a/source/common/event/libevent_scheduler.h
+++ b/source/common/event/libevent_scheduler.h
@@ -63,7 +63,8 @@ public:
 
   explicit LibeventScheduler(TimeSource& time_source);
 
-  Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer);
+  void registerEvwatchObserver(Evwatch::ObserverPtr observer);
+  void unregisterEvwatchObserver(Evwatch::Observer* observer);
 
   // Scheduler
   TimerPtr createTimer(const TimerCb& cb, Dispatcher& dispatcher) override;
@@ -140,7 +141,7 @@ private:
   timeval check_time_{};     // timestamp immediately after polling
   OnPrepareCallback prepare_callback_; // callback to be called from onPrepareForCallback()
   OnCheckCallback check_callback_;     // callback to be called from onCheckForCallback()
-  std::vector<std::weak_ptr<Evwatch::Observer>> evwatch_observers_;
+  std::vector<Evwatch::ObserverPtr> evwatch_observers_;
   bool evwatch_observers_registered_{false};
 };
 

--- a/test/common/event/BUILD
+++ b/test/common/event/BUILD
@@ -38,6 +38,17 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "evwatch_observer_manager_impl_test",
+    srcs = ["evwatch_observer_manager_impl_test.cc"],
+    deps = [
+        "//source/common/event:evwatch_observer_manager_impl_lib",
+        "//source/common/event:libevent_scheduler_lib",
+        "//test/mocks/event:event_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "file_event_impl_test",
     srcs = ["file_event_impl_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1531,27 +1531,25 @@ TEST(EvwatchObserverTest, RegisterEvwatchObserver) {
     MOCK_METHOD(void, onPrepare,
                 (MonotonicTime prepare_time, std::optional<MonotonicTime::duration> timeout));
     MOCK_METHOD(void, onCheck, (MonotonicTime check_time));
+    MOCK_METHOD(void, onClose, ());
   };
 
   Api::ApiPtr api = Api::createApiForTest();
   DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
 
-  dispatcher->registerEvwatchObserver(nullptr);
-  dispatcher->unregisterEvwatchObserver(nullptr);
+  NiceMock<MockEvwatchObserver> observer;
 
-  auto observer = std::make_unique<NiceMock<MockEvwatchObserver>>();
-  auto* observer_ptr = observer.get();
+  EXPECT_CALL(observer, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer, onClose());
 
-  EXPECT_CALL(*observer_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
-  EXPECT_CALL(*observer_ptr, onCheck(_)).Times(testing::AtLeast(1));
-
-  dispatcher->registerEvwatchObserver(std::move(observer));
+  dispatcher->registerEvwatchObserver(observer);
 
   auto cb = dispatcher->createSchedulableCallback([]() {});
   cb->scheduleCallbackCurrentIteration();
   dispatcher->run(Dispatcher::RunType::NonBlock);
 
-  dispatcher->unregisterEvwatchObserver(observer_ptr);
+  dispatcher->unregisterEvwatchObserver(observer);
 }
 
 } // namespace

--- a/test/common/event/dispatcher_impl_test.cc
+++ b/test/common/event/dispatcher_impl_test.cc
@@ -1536,7 +1536,8 @@ TEST(EvwatchObserverTest, RegisterEvwatchObserver) {
   Api::ApiPtr api = Api::createApiForTest();
   DispatcherPtr dispatcher = api->allocateDispatcher("test_thread");
 
-  EXPECT_EQ(nullptr, dispatcher->registerEvwatchObserver(nullptr));
+  dispatcher->registerEvwatchObserver(nullptr);
+  dispatcher->unregisterEvwatchObserver(nullptr);
 
   auto observer = std::make_unique<NiceMock<MockEvwatchObserver>>();
   auto* observer_ptr = observer.get();
@@ -1544,14 +1545,13 @@ TEST(EvwatchObserverTest, RegisterEvwatchObserver) {
   EXPECT_CALL(*observer_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
   EXPECT_CALL(*observer_ptr, onCheck(_)).Times(testing::AtLeast(1));
 
-  auto handle = dispatcher->registerEvwatchObserver(std::move(observer));
-  EXPECT_NE(nullptr, handle);
+  dispatcher->registerEvwatchObserver(std::move(observer));
 
   auto cb = dispatcher->createSchedulableCallback([]() {});
   cb->scheduleCallbackCurrentIteration();
   dispatcher->run(Dispatcher::RunType::NonBlock);
 
-  handle.reset();
+  dispatcher->unregisterEvwatchObserver(observer_ptr);
 }
 
 } // namespace

--- a/test/common/event/evwatch_observer_manager_impl_test.cc
+++ b/test/common/event/evwatch_observer_manager_impl_test.cc
@@ -8,6 +8,7 @@
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::InvokeWithoutArgs;
 using testing::StrictMock;
 
 namespace Envoy {
@@ -24,10 +25,20 @@ public:
 
 class EvwatchObserverManagerImplTest : public testing::Test {
 protected:
-  EvwatchObserverManagerImplTest() : scheduler_(time_source_) {}
+  EvwatchObserverManagerImplTest()
+      : scheduler_(time_source_), manager_(scheduler_.base(), time_source_) {}
+
+  void cycleLoop() {
+    auto cb = scheduler_.createSchedulableCallback([]() {});
+    cb->scheduleCallbackCurrentIteration();
+    scheduler_.run(Dispatcher::RunType::NonBlock);
+  }
 
   Event::TestRealTimeSystem time_source_;
+  // LibeventScheduler is used to schedule active events so libevent runs poll iterations and fires
+  // evwatch hooks.
   LibeventScheduler scheduler_;
+  EvwatchObserverManagerImpl manager_;
 };
 
 TEST_F(EvwatchObserverManagerImplTest, DuplicateRegistrationIgnored) {
@@ -38,14 +49,12 @@ TEST_F(EvwatchObserverManagerImplTest, DuplicateRegistrationIgnored) {
   EXPECT_CALL(observer, onClose());
 
   // Registering the same observer twice should be a safe no-op on the second call
-  scheduler_.registerEvwatchObserver(observer);
-  scheduler_.registerEvwatchObserver(observer);
+  manager_.registerObserver(observer);
+  manager_.registerObserver(observer);
 
-  auto cb = scheduler_.createSchedulableCallback([]() {});
-  cb->scheduleCallbackCurrentIteration();
-  scheduler_.run(Dispatcher::RunType::NonBlock);
+  cycleLoop();
 
-  scheduler_.unregisterEvwatchObserver(observer);
+  manager_.unregisterObserver(observer);
 }
 
 TEST_F(EvwatchObserverManagerImplTest, UnregisterObserverCallsOnClose) {
@@ -53,11 +62,11 @@ TEST_F(EvwatchObserverManagerImplTest, UnregisterObserverCallsOnClose) {
 
   EXPECT_CALL(observer, onClose());
 
-  scheduler_.registerEvwatchObserver(observer);
-  scheduler_.unregisterEvwatchObserver(observer);
+  manager_.registerObserver(observer);
+  manager_.unregisterObserver(observer);
 
   // Subsequent unregister calls on already unregistered observer should be safe no-ops
-  scheduler_.unregisterEvwatchObserver(observer);
+  manager_.unregisterObserver(observer);
 }
 
 TEST_F(EvwatchObserverManagerImplTest, DestructorCallsOnCloseForAllActiveObservers) {
@@ -68,9 +77,60 @@ TEST_F(EvwatchObserverManagerImplTest, DestructorCallsOnCloseForAllActiveObserve
   EXPECT_CALL(observer2, onClose());
 
   {
-    LibeventScheduler scheduler(time_source_);
-    scheduler.registerEvwatchObserver(observer1);
-    scheduler.registerEvwatchObserver(observer2);
+    EvwatchObserverManagerImpl manager(scheduler_.base(), time_source_);
+    manager.registerObserver(observer1);
+    manager.registerObserver(observer2);
+  }
+}
+
+TEST_F(EvwatchObserverManagerImplTest, UnregisterSelfDuringCallback) {
+  StrictMock<MockEvwatchObserver> observer;
+
+  EXPECT_CALL(observer, onPrepare(_, _)).WillOnce(InvokeWithoutArgs([&]() {
+    manager_.unregisterObserver(observer);
+  }));
+  EXPECT_CALL(observer, onClose());
+  // onCheck should NOT be called since observer unregistered during onPrepare
+
+  manager_.registerObserver(observer);
+
+  cycleLoop();
+
+  // Subsequent iterations should not invoke observer
+  cycleLoop();
+}
+
+TEST_F(EvwatchObserverManagerImplTest, UnregisterOtherObserverDuringCallback) {
+  StrictMock<MockEvwatchObserver> observer1;
+  StrictMock<MockEvwatchObserver> observer2;
+
+  EXPECT_CALL(observer1, onPrepare(_, _)).WillRepeatedly(InvokeWithoutArgs([&]() {
+    manager_.unregisterObserver(observer2);
+  }));
+  EXPECT_CALL(observer1, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer1, onClose());
+
+  // observer2 should receive onClose when unregistered by observer1 during onPrepare,
+  // but MUST NOT receive onPrepare or onCheck.
+  EXPECT_CALL(observer2, onClose());
+
+  manager_.registerObserver(observer1);
+  manager_.registerObserver(observer2);
+
+  cycleLoop();
+
+  manager_.unregisterObserver(observer1);
+}
+
+TEST_F(EvwatchObserverManagerImplTest, DestructorWithObserverUnregisteringSelfInOnClose) {
+  StrictMock<MockEvwatchObserver> observer;
+
+  {
+    EvwatchObserverManagerImpl manager(scheduler_.base(), time_source_);
+    EXPECT_CALL(observer, onClose()).WillOnce(InvokeWithoutArgs([&]() {
+      manager.unregisterObserver(observer);
+    }));
+    manager.registerObserver(observer);
   }
 }
 

--- a/test/common/event/evwatch_observer_manager_impl_test.cc
+++ b/test/common/event/evwatch_observer_manager_impl_test.cc
@@ -1,0 +1,79 @@
+#include "source/common/event/evwatch_observer_manager_impl.h"
+#include "source/common/event/libevent_scheduler.h"
+
+#include "test/mocks/event/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::StrictMock;
+
+namespace Envoy {
+namespace Event {
+namespace {
+
+class MockEvwatchObserver : public Evwatch::Observer {
+public:
+  MOCK_METHOD(void, onPrepare,
+              (MonotonicTime prepare_time, std::optional<MonotonicTime::duration> timeout));
+  MOCK_METHOD(void, onCheck, (MonotonicTime check_time));
+  MOCK_METHOD(void, onClose, ());
+};
+
+class EvwatchObserverManagerImplTest : public testing::Test {
+protected:
+  EvwatchObserverManagerImplTest() : scheduler_(time_source_) {}
+
+  Event::TestRealTimeSystem time_source_;
+  LibeventScheduler scheduler_;
+};
+
+TEST_F(EvwatchObserverManagerImplTest, DuplicateRegistrationIgnored) {
+  StrictMock<MockEvwatchObserver> observer;
+
+  EXPECT_CALL(observer, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer, onClose());
+
+  // Registering the same observer twice should be a safe no-op on the second call
+  scheduler_.registerEvwatchObserver(observer);
+  scheduler_.registerEvwatchObserver(observer);
+
+  auto cb = scheduler_.createSchedulableCallback([]() {});
+  cb->scheduleCallbackCurrentIteration();
+  scheduler_.run(Dispatcher::RunType::NonBlock);
+
+  scheduler_.unregisterEvwatchObserver(observer);
+}
+
+TEST_F(EvwatchObserverManagerImplTest, UnregisterObserverCallsOnClose) {
+  StrictMock<MockEvwatchObserver> observer;
+
+  EXPECT_CALL(observer, onClose());
+
+  scheduler_.registerEvwatchObserver(observer);
+  scheduler_.unregisterEvwatchObserver(observer);
+
+  // Subsequent unregister calls on already unregistered observer should be safe no-ops
+  scheduler_.unregisterEvwatchObserver(observer);
+}
+
+TEST_F(EvwatchObserverManagerImplTest, DestructorCallsOnCloseForAllActiveObservers) {
+  StrictMock<MockEvwatchObserver> observer1;
+  StrictMock<MockEvwatchObserver> observer2;
+
+  EXPECT_CALL(observer1, onClose());
+  EXPECT_CALL(observer2, onClose());
+
+  {
+    LibeventScheduler scheduler(time_source_);
+    scheduler.registerEvwatchObserver(observer1);
+    scheduler.registerEvwatchObserver(observer2);
+  }
+}
+
+} // namespace
+} // namespace Event
+} // namespace Envoy

--- a/test/common/event/libevent_scheduler_test.cc
+++ b/test/common/event/libevent_scheduler_test.cc
@@ -33,39 +33,34 @@ public:
   MOCK_METHOD(void, onPrepare,
               (MonotonicTime prepare_time, std::optional<MonotonicTime::duration> timeout));
   MOCK_METHOD(void, onCheck, (MonotonicTime check_time));
+  MOCK_METHOD(void, onClose, ());
 };
 
 TEST_F(LibeventSchedulerTest, RegisterAndUnregisterObservers) {
-  auto observer1 = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto observer2 = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto* observer1_ptr = observer1.get();
-  auto* observer2_ptr = observer2.get();
+  StrictMock<MockEvwatchObserver> observer1;
+  StrictMock<MockEvwatchObserver> observer2;
 
-  EXPECT_CALL(*observer1_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
-  EXPECT_CALL(*observer1_ptr, onCheck(_)).Times(testing::AtLeast(1));
-  EXPECT_CALL(*observer2_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
-  EXPECT_CALL(*observer2_ptr, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer1, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer1, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer1, onClose());
+  EXPECT_CALL(observer2, onPrepare(_, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer2, onCheck(_)).Times(testing::AtLeast(1));
+  EXPECT_CALL(observer2, onClose());
 
-  scheduler_.registerEvwatchObserver(std::move(observer1));
-  scheduler_.registerEvwatchObserver(std::move(observer2));
+  scheduler_.registerEvwatchObserver(observer1);
+  scheduler_.registerEvwatchObserver(observer2);
 
   cycleScheduler();
 
   // Unregister observer1; observer2 continues
-  scheduler_.unregisterEvwatchObserver(observer1_ptr);
+  scheduler_.unregisterEvwatchObserver(observer1);
   cycleScheduler();
 
   // Unregister observer2
-  scheduler_.unregisterEvwatchObserver(observer2_ptr);
+  scheduler_.unregisterEvwatchObserver(observer2);
   cycleScheduler();
 
   // Cycle again when evwatch_observers_ is empty
-  cycleScheduler();
-}
-
-TEST_F(LibeventSchedulerTest, RegisterNullObserver) {
-  scheduler_.registerEvwatchObserver(nullptr);
-  scheduler_.unregisterEvwatchObserver(nullptr);
   cycleScheduler();
 }
 
@@ -75,26 +70,54 @@ public:
   MOCK_METHOD(MonotonicTime, monotonicTime, (), (override));
 };
 
+TEST_F(LibeventSchedulerTest, OnCloseCalledDuringSchedulerDestruction) {
+  StrictMock<MockTimeSource> time_source;
+  StrictMock<MockEvwatchObserver> observer;
+
+  EXPECT_CALL(observer, onClose());
+
+  {
+    LibeventScheduler scheduler(time_source);
+    scheduler.registerEvwatchObserver(observer);
+  }
+}
+
 TEST_F(LibeventSchedulerTest, CustomTimeSourceUsedForObserverCallbacks) {
   StrictMock<MockTimeSource> time_source;
   LibeventScheduler scheduler(time_source);
 
-  auto observer = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto* observer_ptr = observer.get();
+  StrictMock<MockEvwatchObserver> observer;
 
   const MonotonicTime mock_time = MonotonicTime(std::chrono::nanoseconds(123456789));
 
   EXPECT_CALL(time_source, monotonicTime()).Times(2).WillRepeatedly(testing::Return(mock_time));
-  EXPECT_CALL(*observer_ptr, onPrepare(mock_time, _));
-  EXPECT_CALL(*observer_ptr, onCheck(mock_time));
+  EXPECT_CALL(observer, onPrepare(mock_time, _));
+  EXPECT_CALL(observer, onCheck(mock_time));
+  EXPECT_CALL(observer, onClose());
 
-  scheduler.registerEvwatchObserver(std::move(observer));
+  scheduler.registerEvwatchObserver(observer);
 
   auto cb = scheduler.createSchedulableCallback([]() {});
   cb->scheduleCallbackCurrentIteration();
   scheduler.run(Dispatcher::RunType::NonBlock);
 
-  scheduler.unregisterEvwatchObserver(observer_ptr);
+  scheduler.unregisterEvwatchObserver(observer);
+}
+
+TEST_F(LibeventSchedulerTest, EvwatchObserverManagerDelegation) {
+  StrictMock<MockTimeSource> time_source;
+  auto evwatch_manager = std::make_unique<StrictMock<MockEvwatchObserverManager>>();
+  auto* mock_manager = evwatch_manager.get();
+
+  StrictMock<MockEvwatchObserver> observer;
+
+  EXPECT_CALL(*mock_manager, registerObserver(testing::Ref(observer)));
+  EXPECT_CALL(*mock_manager, unregisterObserver(testing::Ref(observer)));
+
+  LibeventScheduler scheduler(time_source, std::move(evwatch_manager));
+
+  scheduler.registerEvwatchObserver(observer);
+  scheduler.unregisterEvwatchObserver(observer);
 }
 
 } // namespace

--- a/test/common/event/libevent_scheduler_test.cc
+++ b/test/common/event/libevent_scheduler_test.cc
@@ -35,7 +35,7 @@ public:
   MOCK_METHOD(void, onCheck, (MonotonicTime check_time));
 };
 
-TEST_F(LibeventSchedulerTest, RegisterMultipleObserversAndLazyPruning) {
+TEST_F(LibeventSchedulerTest, RegisterAndUnregisterObservers) {
   auto observer1 = std::make_unique<StrictMock<MockEvwatchObserver>>();
   auto observer2 = std::make_unique<StrictMock<MockEvwatchObserver>>();
   auto* observer1_ptr = observer1.get();
@@ -46,81 +46,27 @@ TEST_F(LibeventSchedulerTest, RegisterMultipleObserversAndLazyPruning) {
   EXPECT_CALL(*observer2_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
   EXPECT_CALL(*observer2_ptr, onCheck(_)).Times(testing::AtLeast(1));
 
-  // First observer registers libevent watchers (evwatch_observers_registered_ == false)
-  auto handle1 = scheduler_.registerEvwatchObserver(std::move(observer1));
-  EXPECT_NE(nullptr, handle1);
-
-  // Second observer appends to vector without re-registering libevent watchers
-  // (evwatch_observers_registered_ == true)
-  auto handle2 = scheduler_.registerEvwatchObserver(std::move(observer2));
-  EXPECT_NE(nullptr, handle2);
+  scheduler_.registerEvwatchObserver(std::move(observer1));
+  scheduler_.registerEvwatchObserver(std::move(observer2));
 
   cycleScheduler();
 
-  // Reset handle1; observer1 will hit the erase branch in both onPrepare and onCheck, while
-  // observer2 continues
-  handle1.reset();
+  // Unregister observer1; observer2 continues
+  scheduler_.unregisterEvwatchObserver(observer1_ptr);
   cycleScheduler();
 
-  // Reset handle2; observer2 is erased, leaving evwatch_observers_ empty
-  handle2.reset();
+  // Unregister observer2
+  scheduler_.unregisterEvwatchObserver(observer2_ptr);
   cycleScheduler();
 
-  // Cycle again when evwatch_observers_ is already empty at the start of onPrepare and onCheck
+  // Cycle again when evwatch_observers_ is empty
   cycleScheduler();
 }
 
 TEST_F(LibeventSchedulerTest, RegisterNullObserver) {
-  auto handle = scheduler_.registerEvwatchObserver(nullptr);
-  EXPECT_EQ(nullptr, handle);
+  scheduler_.registerEvwatchObserver(nullptr);
+  scheduler_.unregisterEvwatchObserver(nullptr);
   cycleScheduler();
-}
-
-TEST_F(LibeventSchedulerTest, DestructionDuringPrepareCallback) {
-  auto observer1 = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto observer2 = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto* observer1_ptr = observer1.get();
-  auto* observer2_ptr = observer2.get();
-
-  Evwatch::ObserverHandlePtr handle1, handle2;
-
-  EXPECT_CALL(*observer1_ptr, onPrepare(_, _))
-      .Times(testing::AtLeast(1))
-      .WillRepeatedly(testing::InvokeWithoutArgs([&]() {
-        // Destroy handle2 during onPrepare, causing observer2's lock() to fail during onCheck in
-        // the same iteration!
-        handle2.reset();
-      }));
-  EXPECT_CALL(*observer1_ptr, onCheck(_)).Times(testing::AtLeast(1));
-
-  // observer2 should receive onPrepare, but NOT onCheck since it gets reset during observer1's
-  // onPrepare
-  EXPECT_CALL(*observer2_ptr, onPrepare(_, _)).Times(testing::AtLeast(1));
-
-  // Register observer2 first so it receives onPrepare before observer1's onPrepare resets handle2!
-  handle2 = scheduler_.registerEvwatchObserver(std::move(observer2));
-  handle1 = scheduler_.registerEvwatchObserver(std::move(observer1));
-
-  cycleScheduler();
-
-  handle1.reset();
-  cycleScheduler();
-}
-
-TEST_F(LibeventSchedulerTest, ObserverHandleWeakPtrRef) {
-  auto observer = std::make_unique<StrictMock<MockEvwatchObserver>>();
-  auto* observer_ptr = observer.get();
-
-  auto handle = scheduler_.registerEvwatchObserver(std::move(observer));
-  ASSERT_NE(nullptr, handle);
-
-  Evwatch::ObserverWeakPtr weak_ref = handle->observer();
-  EXPECT_FALSE(weak_ref.expired());
-  EXPECT_EQ(observer_ptr, weak_ref.lock().get());
-
-  handle.reset();
-  EXPECT_TRUE(weak_ref.expired());
-  EXPECT_EQ(nullptr, weak_ref.lock());
 }
 
 class MockTimeSource : public TimeSource {
@@ -142,13 +88,13 @@ TEST_F(LibeventSchedulerTest, CustomTimeSourceUsedForObserverCallbacks) {
   EXPECT_CALL(*observer_ptr, onPrepare(mock_time, _));
   EXPECT_CALL(*observer_ptr, onCheck(mock_time));
 
-  auto handle = scheduler.registerEvwatchObserver(std::move(observer));
+  scheduler.registerEvwatchObserver(std::move(observer));
 
   auto cb = scheduler.createSchedulableCallback([]() {});
   cb->scheduleCallbackCurrentIteration();
   scheduler.run(Dispatcher::RunType::NonBlock);
 
-  handle.reset();
+  scheduler.unregisterEvwatchObserver(observer_ptr);
 }
 
 } // namespace

--- a/test/mocks/event/BUILD
+++ b/test/mocks/event/BUILD
@@ -16,6 +16,7 @@ envoy_cc_mock(
     deps = [
         "//envoy/event:deferred_deletable",
         "//envoy/event:dispatcher_interface",
+        "//envoy/event:evwatch_observer_manager_interface",
         "//envoy/event:file_event_interface",
         "//envoy/event:scaled_range_timer_manager_interface",
         "//envoy/event:signal_interface",

--- a/test/mocks/event/mocks.cc
+++ b/test/mocks/event/mocks.cc
@@ -119,6 +119,9 @@ MockSignalEvent::MockSignalEvent(MockDispatcher* dispatcher) {
 
 MockSignalEvent::~MockSignalEvent() = default;
 
+MockEvwatchObserverManager::MockEvwatchObserverManager() = default;
+MockEvwatchObserverManager::~MockEvwatchObserverManager() = default;
+
 MockFileEvent::MockFileEvent() = default;
 MockFileEvent::~MockFileEvent() = default;
 

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -114,14 +114,15 @@ public:
     return SignalEventPtr{listenForSignal_(signal_num, cb)};
   }
 
-  Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
-    return Evwatch::ObserverHandlePtr{registerEvwatchObserver_(observer.get())};
+  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
+    registerEvwatchObserver_(observer.get());
   }
 
   // Event::Dispatcher
   MOCK_METHOD(void, registerWatchdog,
               (const Server::WatchDogSharedPtr&, std::chrono::milliseconds));
-  MOCK_METHOD(Evwatch::ObserverHandle*, registerEvwatchObserver_, (Evwatch::Observer * observer));
+  MOCK_METHOD(void, registerEvwatchObserver_, (Evwatch::Observer * observer));
+  MOCK_METHOD(void, unregisterEvwatchObserver, (Evwatch::Observer * observer));
   MOCK_METHOD(void, initializeStats, (Stats::Scope&, const std::optional<std::string>&));
   MOCK_METHOD(void, clearDeferredDeleteList, ());
   MOCK_METHOD(Network::ServerConnection*, createServerConnection_, (StreamInfo::StreamInfo & info));

--- a/test/mocks/event/mocks.h
+++ b/test/mocks/event/mocks.h
@@ -9,6 +9,7 @@
 #include "envoy/common/time.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/event/evwatch_observer_manager.h"
 #include "envoy/event/file_event.h"
 #include "envoy/event/scaled_range_timer_manager.h"
 #include "envoy/event/signal.h"
@@ -114,15 +115,11 @@ public:
     return SignalEventPtr{listenForSignal_(signal_num, cb)};
   }
 
-  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
-    registerEvwatchObserver_(observer.get());
-  }
-
   // Event::Dispatcher
   MOCK_METHOD(void, registerWatchdog,
               (const Server::WatchDogSharedPtr&, std::chrono::milliseconds));
-  MOCK_METHOD(void, registerEvwatchObserver_, (Evwatch::Observer * observer));
-  MOCK_METHOD(void, unregisterEvwatchObserver, (Evwatch::Observer * observer));
+  MOCK_METHOD(void, registerEvwatchObserver, (Evwatch::Observer & observer));
+  MOCK_METHOD(void, unregisterEvwatchObserver, (Evwatch::Observer & observer));
   MOCK_METHOD(void, initializeStats, (Stats::Scope&, const std::optional<std::string>&));
   MOCK_METHOD(void, clearDeferredDeleteList, ());
   MOCK_METHOD(Network::ServerConnection*, createServerConnection_, (StreamInfo::StreamInfo & info));
@@ -199,6 +196,15 @@ public:
 
   // If not nullptr, will be set on dtor. This can help to verify that the timer was destroyed.
   bool* timer_destroyed_{};
+};
+
+class MockEvwatchObserverManager : public EvwatchObserverManager {
+public:
+  MockEvwatchObserverManager();
+  ~MockEvwatchObserverManager() override;
+
+  MOCK_METHOD(void, registerObserver, (Evwatch::Observer & observer), (override));
+  MOCK_METHOD(void, unregisterObserver, (Evwatch::Observer & observer), (override));
 };
 
 class MockScaledRangeTimerManager : public ScaledRangeTimerManager {

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -25,11 +25,11 @@ public:
     impl_.registerWatchdog(watchdog, min_touch_interval);
   }
 
-  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
-    impl_.registerEvwatchObserver(std::move(observer));
+  void registerEvwatchObserver(Evwatch::Observer& observer) override {
+    impl_.registerEvwatchObserver(observer);
   }
 
-  void unregisterEvwatchObserver(Evwatch::Observer* observer) override {
+  void unregisterEvwatchObserver(Evwatch::Observer& observer) override {
     impl_.unregisterEvwatchObserver(observer);
   }
 

--- a/test/mocks/event/wrapped_dispatcher.h
+++ b/test/mocks/event/wrapped_dispatcher.h
@@ -25,8 +25,12 @@ public:
     impl_.registerWatchdog(watchdog, min_touch_interval);
   }
 
-  Evwatch::ObserverHandlePtr registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
-    return impl_.registerEvwatchObserver(std::move(observer));
+  void registerEvwatchObserver(Evwatch::ObserverPtr observer) override {
+    impl_.registerEvwatchObserver(std::move(observer));
+  }
+
+  void unregisterEvwatchObserver(Evwatch::Observer* observer) override {
+    impl_.unregisterEvwatchObserver(observer);
   }
 
   TimeSource& timeSource() override { return impl_.timeSource(); }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: LibeventScheduler: switch to user-managed memory for evwatch observers
Additional Description:

This PR switches the libevent scheduler / dispatcher dynamic evwatcher registration API from RAII handle based registrations / unregistration to a user-managed memory model with explicit unregistration.

The API is now:

- user creates a evwatch observer (for example using make_unique). user owns the observer
- reference to observer is passed to dispatcher for registration
- libevent scheduler maintains reference

When the libevent scheduler is done with the observer (either because it was unregistered OR if the dispatcher is being torn down), the observer's onClose() will be called, signaling the user code that it's safe to destruct the observer.

This API is more flexible for the user (makes no assumptions about observer lifetimes other than that it will exist longer than it is registered) and makes the envoy core code simpler.

While doing this I cleaned up the code by putting the evwatch observer management code behind an interface so the libevent scheduler code and EvwatchObserverManagerImpl can be tested separately.

Risk Level: low / none (unused yet)
Testing: updated / improved
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

I used generative AI to help make this change.
