### PR TITLE
geoip: add MaxMind latitude/longitude support

### DIFF
--- a/api/envoy/extensions/geoip_providers/common/v3/common.proto
+++ b/api/envoy/extensions/geoip_providers/common/v3/common.proto
@@ -98,7 +98,7 @@ message CommonGeoipProviderConfig {
   // - The :ref:`Network GeoIP filter <config_network_filters_geoip>` stores results in the
   //   connection's filter state under the well-known key ``envoy.geoip``.
   //
-  // [#next-free-field: 13]
+  // [#next-free-field: 15]
   message GeolocationFieldKeys {
     // If set, the key will be used to populate the country ISO code associated with the IP address.
     string country = 1;
@@ -147,6 +147,14 @@ message CommonGeoipProviderConfig {
     // and the result will be stored with this key. Value will be set to either ``true`` or ``false``
     // depending on the check result.
     string apple_private_relay = 11;
+
+    // If set, the key will be used to populate the latitude (in degrees, as a decimal string)
+    // associated with the IP address. Populated from the city database ``location.latitude`` field.
+    string lat = 13;
+
+    // If set, the key will be used to populate the longitude (in degrees, as a decimal string)
+    // associated with the IP address. Populated from the city database ``location.longitude`` field.
+    string lon = 14;
   }
 
   // Configuration for geolocation headers to add to HTTP requests.

--- a/changelogs/current/new_features/http__add-maxmind-latitude-longitude.rst
+++ b/changelogs/current/new_features/http__add-maxmind-latitude-longitude.rst
@@ -1,0 +1,5 @@
+Added support for populating client latitude and longitude from the Maxmind city database via the
+new :ref:`lat <envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.lat>`
+and :ref:`lon <envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys.lon>`
+geolocation field keys. Coordinates are read from the ``location.latitude`` and ``location.longitude``
+``double`` fields and rendered as decimal-degree strings (e.g. ``58.4167``).

--- a/docs/root/configuration/http/http_filters/geoip_filter.rst
+++ b/docs/root/configuration/http/http_filters/geoip_filter.rst
@@ -8,6 +8,9 @@ Upon a successful lookup request will be enriched with the configured geolocatio
 In case the configured geolocation headers are present in the incoming request, they will be overriden by the filter.
 Geolocation filter emits stats for the number of the successful lookups and the number of total lookups.
 English language is used for the geolocation lookups, the result of the lookup will be UTF-8 encoded.
+When configured via :ref:`geo_field_keys <envoy_v3_api_field_extensions.geoip_providers.common.v3.CommonGeoipProviderConfig.GeolocationFieldKeys>`,
+the ``lat`` and ``lon`` keys are populated from the city database ``location.latitude`` and ``location.longitude`` fields
+as decimal-degree strings (e.g. ``58.4167``), which is useful for plotting client locations on a map.
 Please note that Geolocation filter and providers are not yet supported on Windows.
 
 Configuration

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.cc
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/geoip_providers/maxmind/geoip_provider.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/common/fmt.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/runtime/runtime_features.h"
 
@@ -12,6 +13,8 @@ namespace Maxmind {
 namespace {
 static constexpr const char* MMDB_CITY_LOOKUP_ARGS[] = {"city", "names", "en"};
 static constexpr const char* MMDB_REGION_LOOKUP_ARGS[] = {"subdivisions", "0", "iso_code"};
+static constexpr const char* MMDB_LAT_LOOKUP_ARGS[] = {"location", "latitude"};
+static constexpr const char* MMDB_LON_LOOKUP_ARGS[] = {"location", "longitude"};
 static constexpr const char* MMDB_COUNTRY_LOOKUP_ARGS[] = {"country", "iso_code"};
 static constexpr const char* MMDB_ASN_LOOKUP_ARGS[] = {"autonomous_system_number"};
 static constexpr const char* MMDB_ASN_ORG_LOOKUP_ARGS[] = {"autonomous_system_organization"};
@@ -51,6 +54,8 @@ GeoipProviderConfig::GeoipProviderConfig(
     country_header_ = getOptionalString(keys.country());
     city_header_ = getOptionalString(keys.city());
     region_header_ = getOptionalString(keys.region());
+    lat_header_ = getOptionalString(keys.lat());
+    lon_header_ = getOptionalString(keys.lon());
     asn_header_ = getOptionalString(keys.asn());
     asn_org_header_ = getOptionalString(keys.asn_org());
     anon_header_ = getOptionalString(keys.anon());
@@ -210,6 +215,8 @@ void GeoipProvider::lookupInCityDb(
       !config_->isCountryDbPathSet() && config_->isLookupEnabledForHeader(config_->countryHeader());
   if (config_->isLookupEnabledForHeader(config_->cityHeader()) ||
       config_->isLookupEnabledForHeader(config_->regionHeader()) ||
+      config_->isLookupEnabledForHeader(config_->latHeader()) ||
+      config_->isLookupEnabledForHeader(config_->lonHeader()) ||
       should_lookup_country_from_city_db) {
     int mmdb_error;
     auto city_db_ptr = getCityDb();
@@ -237,6 +244,14 @@ void GeoipProvider::lookupInCityDb(
           populateGeoLookupResult(mmdb_lookup_result, lookup_result,
                                   config_->regionHeader().value(), MMDB_REGION_LOOKUP_ARGS[0],
                                   MMDB_REGION_LOOKUP_ARGS[1], MMDB_REGION_LOOKUP_ARGS[2]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->latHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result, config_->latHeader().value(),
+                                  MMDB_LAT_LOOKUP_ARGS[0], MMDB_LAT_LOOKUP_ARGS[1]);
+        }
+        if (config_->isLookupEnabledForHeader(config_->lonHeader())) {
+          populateGeoLookupResult(mmdb_lookup_result, lookup_result, config_->lonHeader().value(),
+                                  MMDB_LON_LOOKUP_ARGS[0], MMDB_LON_LOOKUP_ARGS[1]);
         }
         // Country lookup from City DB only when Country DB is not configured.
         if (should_lookup_country_from_city_db) {
@@ -585,6 +600,10 @@ void GeoipProvider::populateGeoLookupResult(
     } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_UINT32 &&
                entry_data.uint32 > 0) {
       result_value = std::to_string(entry_data.uint32);
+    } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_DOUBLE) {
+      // Used for coordinate fields (latitude/longitude). ``fmt`` renders the shortest
+      // representation that round-trips to the stored double (e.g. "58.4167").
+      result_value = fmt::format("{}", entry_data.double_value);
     } else if (entry_data.has_data && entry_data.type == MMDB_DATA_TYPE_BOOLEAN) {
       result_value = entry_data.boolean ? "true" : "false";
     }

--- a/source/extensions/geoip_providers/maxmind/geoip_provider.h
+++ b/source/extensions/geoip_providers/maxmind/geoip_provider.h
@@ -34,6 +34,8 @@ public:
   const std::optional<std::string>& countryHeader() const { return country_header_; }
   const std::optional<std::string>& cityHeader() const { return city_header_; }
   const std::optional<std::string>& regionHeader() const { return region_header_; }
+  const std::optional<std::string>& latHeader() const { return lat_header_; }
+  const std::optional<std::string>& lonHeader() const { return lon_header_; }
   const std::optional<std::string>& asnHeader() const { return asn_header_; }
   const std::optional<std::string>& asnOrgHeader() const { return asn_org_header_; }
 
@@ -91,6 +93,8 @@ private:
   std::optional<std::string> country_header_;
   std::optional<std::string> city_header_;
   std::optional<std::string> region_header_;
+  std::optional<std::string> lat_header_;
+  std::optional<std::string> lon_header_;
   std::optional<std::string> asn_header_;
   std::optional<std::string> asn_org_header_;
 

--- a/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
+++ b/test/extensions/geoip_providers/maxmind/geoip_provider_test.cc
@@ -228,6 +228,8 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndAsnDbsSuccessfulLookup) {
         country: "x-geo-country"
         region: "x-geo-region"
         city: "x-geo-city"
+        lat: "x-geo-lat"
+        lon: "x-geo-lon"
         asn: "x-geo-asn"
     city_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoLite2-City-Test.mmdb"
     asn_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoLite2-ASN-Test.mmdb"
@@ -240,17 +242,45 @@ TEST_F(GeoipProviderTest, ValidConfigCityAndAsnDbsSuccessfulLookup) {
   auto lookup_cb_std = lookup_cb.AsStdFunction();
   EXPECT_CALL(lookup_cb, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
   provider_->lookup(std::move(lookup_rq), std::move(lookup_cb_std));
-  EXPECT_EQ(4, captured_lookup_response_.size());
+  EXPECT_EQ(6, captured_lookup_response_.size());
   const auto& city_it = captured_lookup_response_.find("x-geo-city");
   EXPECT_EQ("Linköping", city_it->second);
   const auto& region_it = captured_lookup_response_.find("x-geo-region");
   EXPECT_EQ("E", region_it->second);
   const auto& country_it = captured_lookup_response_.find("x-geo-country");
   EXPECT_EQ("SE", country_it->second);
+  const auto& lat_it = captured_lookup_response_.find("x-geo-lat");
+  EXPECT_EQ("58.4167", lat_it->second);
+  const auto& lon_it = captured_lookup_response_.find("x-geo-lon");
+  EXPECT_EQ("15.6167", lon_it->second);
   const auto& asn_it = captured_lookup_response_.find("x-geo-asn");
   EXPECT_EQ("29518", asn_it->second);
   expectStats("city_db");
   expectStats("asn_db");
+}
+
+TEST_F(GeoipProviderTest, ValidConfigCityDbLatLonOnlySuccessfulLookup) {
+  const std::string config_yaml = R"EOF(
+    common_provider_config:
+      geo_field_keys:
+        lat: "x-geo-lat"
+        lon: "x-geo-lon"
+    city_db_path: "{{ test_rundir }}/test/extensions/geoip_providers/maxmind/test_data/GeoLite2-City-Test.mmdb"
+  )EOF";
+  initializeProvider(config_yaml, cb_added_nullopt);
+  Network::Address::InstanceConstSharedPtr remote_address =
+      Network::Utility::parseInternetAddressNoThrow("89.160.20.112");
+  Geolocation::LookupRequest lookup_rq{std::move(remote_address)};
+  testing::MockFunction<void(Geolocation::LookupResult&&)> lookup_cb;
+  auto lookup_cb_std = lookup_cb.AsStdFunction();
+  EXPECT_CALL(lookup_cb, Call(_)).WillRepeatedly(SaveArg<0>(&captured_lookup_response_));
+  provider_->lookup(std::move(lookup_rq), std::move(lookup_cb_std));
+  EXPECT_EQ(2, captured_lookup_response_.size());
+  const auto& lat_it = captured_lookup_response_.find("x-geo-lat");
+  EXPECT_EQ("58.4167", lat_it->second);
+  const auto& lon_it = captured_lookup_response_.find("x-geo-lon");
+  EXPECT_EQ("15.6167", lon_it->second);
+  expectStats("city_db");
 }
 
 TEST_F(GeoipProviderTest, ValidConfigAsnDbsSuccessfulLookup) {


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: geoip: add MaxMind latitude/longitude support

Additional Description: Adds optional `lat` and `lon` field keys populated from the MaxMind city database. AI assistance was used; the resulting changes were reviewed and understood by the author.

Risk Level: Low

Testing: Updated MaxMind provider unit tests for combined and coordinate-only lookups.

Docs Changes: Updated the GeoIP filter documentation.

Release Notes: Added a new-feature changelog entry.

Platform Specific Features: N/A

[Optional Runtime guard:] N/A

[Optional Fixes #Issue] N/A

[Optional Fixes commit #PR or SHA] N/A

[Optional Deprecated:] N/A

[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):] Adds backward-compatible optional fields with no default behavior change.