### PR TITLE
docs: fix /stats hidden= query param documentation

### DIFF
--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -499,15 +499,15 @@ modify different aspects of the server:
   Outputs statistics that Envoy has updated (counters incremented at least once, gauges changed at
   least once, and histograms added to at least once).
 
-  .. http::get:: /stats?hidden=showonly
+  .. http:get:: /stats?hidden=only
 
   Only outputs statistics that are internally marked as hidden.
 
-  .. http::get:: /stats?hidden=include
+  .. http:get:: /stats?hidden=include
 
   Hidden stats will be shown along side non-hidden stats.
 
-  .. http::get:: /stats?hidden=exclude
+  .. http:get:: /stats?hidden=exclude
 
   Hidden stats will be excluded from the output. This is the default behavior.
 


### PR DESCRIPTION
## Commit Message 
docs: fix /stats hidden= query param documentation
## Additional Description:
Corrects the admin interface docs for /stats hidden stats filtering. 
Currently the hidden query param is not shown in the [docs](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#get--stats)
The implementation accepts ``only``, not ``showonly`` (see [stats_params.cc](https://github.com/envoyproxy/envoy/blob/567796f912372576673d9da0ebfa83c8392beff5/source/server/admin/stats_params.cc#L79)). Also fixes the Sphinx HTTP directive from
``http::get`` to ``http:get`` for the hidden= entries.
## Risk Level
Low
## Testing 
Rendered locally and checked.
<img width="788" height="245" alt="Screenshot 2026-07-21 at 10 56 56 AM" src="https://github.com/user-attachments/assets/a6dd50bd-cc9c-4f21-8464-d0af08f8f290" />