### PR TITLE
tls: key upstream session caches by SNI

### DIFF
--- a/changelogs/current/bug_fixes/tls__sni-keyed-upstream-session-cache.rst
+++ b/changelogs/current/bug_fixes/tls__sni-keyed-upstream-session-cache.rst
@@ -1,0 +1,3 @@
+Fixed upstream TLS session resumption for clusters that connect to multiple hostnames through a
+single TLS context. Cached sessions are now only offered when their SNI matches the requested
+hostname, preventing cross-host certificate validation failures.

--- a/source/common/tls/client_context_impl.cc
+++ b/source/common/tls/client_context_impl.cc
@@ -44,6 +44,14 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
+namespace {
+
+void freeServerName(void*, void* ptr, CRYPTO_EX_DATA*, int, long, void*) {
+  delete static_cast<std::string*>(ptr);
+}
+
+} // namespace
+
 absl::StatusOr<std::unique_ptr<ClientContextImpl>>
 ClientContextImpl::create(Stats::Scope& scope, const Envoy::Ssl::ClientContextConfig& config,
                           Server::Configuration::CommonFactoryContext& factory_context) {
@@ -145,6 +153,14 @@ ClientContextImpl::newSsl(const Network::TransportSocketOptionsConstSharedPtr& o
     }
   }
 
+  if (max_session_keys_ > 0) {
+    // SSL_get_servername() is only documented for servers. Keep the client-requested SNI
+    // separately so the session callback does not depend on undocumented client behavior.
+    auto* server_name = new std::string(server_name_indication);
+    RELEASE_ASSERT(SSL_set_ex_data(ssl_con.get(), sslServerNameIndex(), server_name) == 1,
+                   "Failed to store upstream SNI on SSL object");
+  }
+
   if (options && !options->verifySubjectAltNameListOverride().empty()) {
     SSL_set_verify(ssl_con.get(), SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nullptr);
   }
@@ -214,13 +230,23 @@ ClientContextImpl::newSsl(const Network::TransportSocketOptionsConstSharedPtr& o
   return ssl_con;
 }
 
+int ClientContextImpl::sslServerNameIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, [] {
+    const int index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, freeServerName);
+    RELEASE_ASSERT(index >= 0, "Failed to get SSL user data index.");
+    return index;
+  }());
+}
+
 int ClientContextImpl::newSessionKey(SSL* ssl, SSL_SESSION* session) {
   // In case we ever store single-use session key (TLS 1.3),
   // we need to switch to using write/write locks.
   if (SSL_SESSION_should_be_single_use(session)) {
     session_keys_single_use_ = true;
   }
-  const char* server_name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
+  const auto* server_name = static_cast<const std::string*>(
+      SSL_get_ex_data(ssl, sslServerNameIndex()));
+  RELEASE_ASSERT(server_name != nullptr, "Missing upstream SNI on SSL object");
   absl::WriterMutexLock l(session_keys_mu_);
   // Evict oldest entries.
   while (session_keys_.size() >= max_session_keys_) {
@@ -228,8 +254,7 @@ int ClientContextImpl::newSessionKey(SSL* ssl, SSL_SESSION* session) {
   }
   // Add new session key at the front of the queue, so that it's used first.
   session_keys_.push_front(
-      {server_name == nullptr ? std::string() : std::string(server_name),
-       bssl::UniquePtr<SSL_SESSION>(session)});
+      {*server_name, bssl::UniquePtr<SSL_SESSION>(session)});
   return 1; // Tell BoringSSL that we took ownership of the session.
 }
 

--- a/source/common/tls/client_context_impl.cc
+++ b/source/common/tls/client_context_impl.cc
@@ -99,7 +99,7 @@ ClientContextImpl::ClientContextImpl(
               static_cast<ContextImpl*>(SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl)));
           ClientContextImpl* client_context_impl = dynamic_cast<ClientContextImpl*>(context_impl);
           RELEASE_ASSERT(client_context_impl != nullptr, ""); // for Coverity
-          return client_context_impl->newSessionKey(session);
+          return client_context_impl->newSessionKey(ssl, session);
         });
   }
 
@@ -176,26 +176,36 @@ ClientContextImpl::newSsl(const Network::TransportSocketOptionsConstSharedPtr& o
   }
 
   if (max_session_keys_ > 0) {
+    // A resumed session does not send a new certificate, so only reuse sessions created for the
+    // same SNI to avoid validating a certificate for a different hostname.
     if (session_keys_single_use_) {
       // Stored single-use session keys, use write/write locks.
       absl::WriterMutexLock l(session_keys_mu_);
-      if (!session_keys_.empty()) {
+      auto session_it = std::find_if(
+          session_keys_.begin(), session_keys_.end(), [&server_name_indication](const auto& key) {
+            return key.server_name == server_name_indication;
+          });
+      if (session_it != session_keys_.end()) {
         // Use the most recently stored session key, since it has the highest
         // probability of still being recognized/accepted by the server.
-        SSL_SESSION* session = session_keys_.front().get();
+        SSL_SESSION* session = session_it->session.get();
         SSL_set_session(ssl_con.get(), session);
         // Remove single-use session key (TLS 1.3) after first use.
         if (SSL_SESSION_should_be_single_use(session)) {
-          session_keys_.pop_front();
+          session_keys_.erase(session_it);
         }
       }
     } else {
       // Never stored single-use session keys, use read/write locks.
       absl::ReaderMutexLock l(session_keys_mu_);
-      if (!session_keys_.empty()) {
+      auto session_it = std::find_if(
+          session_keys_.begin(), session_keys_.end(), [&server_name_indication](const auto& key) {
+            return key.server_name == server_name_indication;
+          });
+      if (session_it != session_keys_.end()) {
         // Use the most recently stored session key, since it has the highest
         // probability of still being recognized/accepted by the server.
-        SSL_SESSION* session = session_keys_.front().get();
+        SSL_SESSION* session = session_it->session.get();
         SSL_set_session(ssl_con.get(), session);
       }
     }
@@ -204,19 +214,22 @@ ClientContextImpl::newSsl(const Network::TransportSocketOptionsConstSharedPtr& o
   return ssl_con;
 }
 
-int ClientContextImpl::newSessionKey(SSL_SESSION* session) {
+int ClientContextImpl::newSessionKey(SSL* ssl, SSL_SESSION* session) {
   // In case we ever store single-use session key (TLS 1.3),
   // we need to switch to using write/write locks.
   if (SSL_SESSION_should_be_single_use(session)) {
     session_keys_single_use_ = true;
   }
+  const char* server_name = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   absl::WriterMutexLock l(session_keys_mu_);
   // Evict oldest entries.
   while (session_keys_.size() >= max_session_keys_) {
     session_keys_.pop_back();
   }
   // Add new session key at the front of the queue, so that it's used first.
-  session_keys_.push_front(bssl::UniquePtr<SSL_SESSION>(session));
+  session_keys_.push_front(
+      {server_name == nullptr ? std::string() : std::string(server_name),
+       bssl::UniquePtr<SSL_SESSION>(session)});
   return 1; // Tell BoringSSL that we took ownership of the session.
 }
 

--- a/source/common/tls/client_context_impl.h
+++ b/source/common/tls/client_context_impl.h
@@ -69,6 +69,7 @@ private:
 
   friend class ClientContextConfigImplTest;
 
+  static int sslServerNameIndex();
   int newSessionKey(SSL* ssl, SSL_SESSION* session);
 
   const std::string server_name_indication_;

--- a/source/common/tls/client_context_impl.h
+++ b/source/common/tls/client_context_impl.h
@@ -62,7 +62,14 @@ protected:
       absl::Status& creation_status);
 
 private:
-  int newSessionKey(SSL_SESSION* session);
+  struct SessionKey {
+    std::string server_name;
+    bssl::UniquePtr<SSL_SESSION> session;
+  };
+
+  friend class ClientContextConfigImplTest;
+
+  int newSessionKey(SSL* ssl, SSL_SESSION* session);
 
   const std::string server_name_indication_;
   const bool auto_host_sni_;
@@ -70,7 +77,7 @@ private:
 
   const size_t max_session_keys_;
   absl::Mutex session_keys_mu_;
-  std::deque<bssl::UniquePtr<SSL_SESSION>> session_keys_ ABSL_GUARDED_BY(session_keys_mu_);
+  std::deque<SessionKey> session_keys_ ABSL_GUARDED_BY(session_keys_mu_);
   bool session_keys_single_use_{false};
   Ssl::UpstreamTlsCertificateSelectorPtr tls_certificate_selector_;
 };

--- a/test/common/tls/client_context_config_impl_test.cc
+++ b/test/common/tls/client_context_config_impl_test.cc
@@ -1,3 +1,4 @@
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -9,10 +10,12 @@
 #include "source/common/common/base64.h"
 #include "source/common/crypto/utility.h"
 #include "source/common/json/json_loader.h"
+#include "source/common/network/transport_socket_options_impl.h"
 #include "source/common/secret/sds_api.h"
 #include "source/common/ssl/ssl.h"
 #include "source/common/stats/isolated_store_impl.h"
 #include "source/common/tls/cert_validator/default_validator.h"
+#include "source/common/tls/client_context_impl.h"
 #include "source/common/tls/context_config_impl.h"
 #include "source/common/tls/context_impl.h"
 #include "source/common/tls/server_context_config_impl.h"
@@ -60,6 +63,10 @@ public:
     }};
   }
 
+  int storeSessionKey(ClientContextImpl& context, SSL* ssl, SSL_SESSION* session) {
+    return context.newSessionKey(ssl, session);
+  }
+
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
   ContextManagerImpl manager_{server_factory_context_};
 };
@@ -75,6 +82,35 @@ TEST_F(ClientContextConfigImplTest, EmptyServerNameIndication) {
   tls_context.set_sni(std::string("a\000b", 3));
   EXPECT_EQ(ClientContextConfigImpl::create(tls_context, factory_context).status().message(),
             "SNI names containing NULL-byte are not allowed");
+}
+
+TEST_F(ClientContextConfigImplTest, SessionKeysAreScopedToServerName) {
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  tls_context.mutable_max_session_keys()->set_value(2);
+  auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
+  Stats::IsolatedStoreImpl store;
+  auto context = *manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto* client_context_impl = dynamic_cast<ClientContextImpl*>(context.get());
+  ASSERT_NE(client_context_impl, nullptr);
+
+  auto host_a = client_context_impl->newSsl(
+      std::make_shared<Network::TransportSocketOptionsImpl>("host-a.example"), nullptr);
+  ASSERT_TRUE(host_a.ok());
+  SSL_SESSION* session = SSL_SESSION_new();
+  ASSERT_NE(session, nullptr);
+  ASSERT_EQ(storeSessionKey(*client_context_impl, host_a->get(), session), 1);
+
+  auto host_b = client_context_impl->newSsl(
+      std::make_shared<Network::TransportSocketOptionsImpl>("host-b.example"), nullptr);
+  ASSERT_TRUE(host_b.ok());
+  EXPECT_EQ(SSL_get_session(host_b->get()), nullptr);
+
+  auto host_a_again = client_context_impl->newSsl(
+      std::make_shared<Network::TransportSocketOptionsImpl>("host-a.example"), nullptr);
+  ASSERT_TRUE(host_a_again.ok());
+  EXPECT_EQ(SSL_get_session(host_a_again->get()), session);
+
+  auto cleanup = cleanUpHelper(context);
 }
 
 // Validate that it is an error configure `auto_sni_san_validation` without configuring


### PR DESCRIPTION
Commit Message: tls: key upstream session caches by SNI

Additional Description:
Client TLS contexts can serve multiple upstream hostnames, such as a dynamic forward proxy cluster. Previously, the most recent cached TLS session was offered to every new connection in the context, regardless of SNI. A resumed session does not send a new certificate, so this could make a connection for one hostname inherit another hostname's certificate and fail SAN validation.

Cached sessions are now stored with their SNI and only offered to connections requesting the same hostname. The existing global max_session_keys bound is preserved. Added a regression test and release note.

Risk Level: Medium

Testing:
- `git diff --cached --check`
- Code and test formatting reviewed against the repository style
- Local Bazel/Docker test execution was not available in this environment; full CI is expected to run on this draft PR

Docs Changes: N/A

Release Notes: Added `changelogs/current/bug_fixes/tls__sni-keyed-upstream-session-cache.rst`.

Fixes #46243.

AI assistance: This change was prepared with AI assistance. The submitter has reviewed and understands the code and is responsible for the submission.