### PR TITLE
config: add missing `optref_lib` dep to `subscription_interface`

### DIFF
--- a/envoy/config/BUILD
+++ b/envoy/config/BUILD
@@ -100,6 +100,7 @@ envoy_cc_library(
     name = "subscription_interface",
     hdrs = ["subscription.h"],
     deps = [
+        "//envoy/common:optref_lib",
         "//envoy/stats:stats_macros",
         "//source/common/protobuf",
         "@envoy_api//envoy/service/discovery/v3:pkg_cc_proto",


### PR DESCRIPTION
`subscription.h` includes `envoy/common/optref.h` (added in #23485) but the BUILD target never declared the dependency. This went unnoticed because transitive includes satisfied the header, but it breaks under stricter sandbox configurations.
