### PR TITLE
test: fix `-Wunused-result` warnings for `nodiscard` return values

### DIFF
--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -440,7 +440,7 @@ TEST(DefaultCertValidatorTest, TestMatchSubjectAltNameExactDNSFailure) {
 
   envoy::type::matcher::v3::StringMatcher matcher;
   matcher.set_exact("api.example.com");
-  EXPECT_DEATH(std::make_unique<StringSanMatcher>(GEN_DNS, matcher, context),
+  EXPECT_DEATH(std::ignore = std::make_unique<StringSanMatcher>(GEN_DNS, matcher, context),
                "general_name_type != 2 || matcher.match_pattern_case() != "
                "envoy::type::matcher::v3::StringMatcher::MatchPatternCase::kExact");
 #endif

--- a/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
+++ b/test/extensions/access_loggers/grpc/http_grpc_access_log_impl_test.cc
@@ -64,7 +64,7 @@ TEST(HttpGrpcAccessLog, TlsLifetimeCheck) {
                          common_config,
                      Common::GrpcAccessLoggerType type) {
           // This is a part of the actual getOrCreateLogger code path and shouldn't crash.
-          std::make_pair(MessageUtil::hash(common_config), type);
+          std::ignore = std::make_pair(MessageUtil::hash(common_config), type);
           return nullptr;
         });
     // Set tls callback in the HttpGrpcAccessLog constructor,

--- a/test/extensions/access_loggers/grpc/tcp_config_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_config_test.cc
@@ -127,7 +127,7 @@ TEST(TcpGrpcAccessLog, TlsLifetimeCheck) {
                          common_config,
                      Common::GrpcAccessLoggerType type) {
           // This is a part of the actual getOrCreateLogger code path and shouldn't crash.
-          std::make_pair(MessageUtil::hash(common_config), type);
+          std::ignore = std::make_pair(MessageUtil::hash(common_config), type);
           return nullptr;
         });
     // Set tls callback in the TcpGrpcAccessLog constructor,

--- a/test/extensions/common/wasm/remote_async_datasource_test.cc
+++ b/test/extensions/common/wasm/remote_async_datasource_test.cc
@@ -500,10 +500,11 @@ TEST_F(AsyncDataSourceTest, BaseIntervalGreaterThanMaxInterval) {
   TestUtility::loadFromYamlAndValidate(yaml, config);
   EXPECT_TRUE(config.has_remote());
 
-  EXPECT_THROW_WITH_MESSAGE(
-      std::make_unique<RemoteAsyncDataProvider>(cm_, init_manager_, config.remote(), dispatcher_,
-                                                random_, true, [&](const std::string&) {}),
-      EnvoyException, "max_interval must be greater than or equal to the base_interval");
+  EXPECT_THROW_WITH_MESSAGE(std::ignore = std::make_unique<RemoteAsyncDataProvider>(
+                                cm_, init_manager_, config.remote(), dispatcher_, random_, true,
+                                [&](const std::string&) {}),
+                            EnvoyException,
+                            "max_interval must be greater than or equal to the base_interval");
 }
 
 TEST_F(AsyncDataSourceTest, BaseIntervalTest) {

--- a/test/extensions/dynamic_modules/udp/filter_test.cc
+++ b/test/extensions/dynamic_modules/udp/filter_test.cc
@@ -69,7 +69,7 @@ TEST_F(DynamicModuleUdpListenerFilterTest, ConfigMissingSymbols) {
   proto_config.set_filter_name("test_filter");
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<DynamicModuleUdpListenerFilterConfig>(
+      std::ignore = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
           proto_config, std::move(dynamic_module.value()), *stats_.rootScope()),
       EnvoyException,
       "Dynamic module does not support UDP listener filters: Failed to resolve symbol "
@@ -255,7 +255,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingConfigDestroy) {
   proto_config.mutable_filter_config()->set_value("config");
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<DynamicModuleUdpListenerFilterConfig>(
+      std::ignore = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
           proto_config, std::move(dynamic_module.value()), *stats.rootScope()),
       EnvoyException,
       "Dynamic module does not support UDP listener filters: Failed to resolve symbol "
@@ -273,7 +273,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterNew) {
   proto_config.set_filter_name("test");
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<DynamicModuleUdpListenerFilterConfig>(
+      std::ignore = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
           proto_config, std::move(dynamic_module.value()), *stats.rootScope()),
       EnvoyException,
       "Dynamic module does not support UDP listener filters: Failed to resolve symbol "
@@ -291,7 +291,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingOnData) {
   proto_config.set_filter_name("test");
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<DynamicModuleUdpListenerFilterConfig>(
+      std::ignore = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
           proto_config, std::move(dynamic_module.value()), *stats.rootScope()),
       EnvoyException,
       "Dynamic module does not support UDP listener filters: Failed to resolve symbol "
@@ -309,7 +309,7 @@ TEST(DynamicModuleUdpListenerFilterConfigErrorTest, MissingFilterDestroy) {
   proto_config.set_filter_name("test");
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<DynamicModuleUdpListenerFilterConfig>(
+      std::ignore = std::make_shared<DynamicModuleUdpListenerFilterConfig>(
           proto_config, std::move(dynamic_module.value()), *stats.rootScope()),
       EnvoyException,
       "Dynamic module does not support UDP listener filters: Failed to resolve symbol "

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -708,8 +708,8 @@ TEST_F(OAuth2Test, InvalidAuthorizationEndpoint) {
   // Attempt to create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_, secret_reader,
-                                     scope_, "test."),
+      std::ignore = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
+                                                   secret_reader, scope_, "test."),
       EnvoyException, "OAuth2 filter: invalid authorization endpoint URL 'INVALID_URL' in config.");
 }
 
@@ -1403,13 +1403,13 @@ TEST_F(OAuth2Test, InvalidPostLogoutRedirectUriValidatedOnlyWhenUsed) {
 
   // End_session_endpoint is not defined: the invalid formatter is never compiled,
   // so the config loads without throwing.
-  EXPECT_NO_THROW(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                 secret_reader, scope_, "test."));
+  EXPECT_NO_THROW(std::ignore = std::make_shared<FilterConfig>(
+                      p, factory_context_.server_factory_context_, secret_reader, scope_, "test."));
 
   // End_session_endpoint is set: the invalid formatter is compiled and the config fails to load.
   p.set_end_session_endpoint("https://auth.example.com/oauth/logout");
-  EXPECT_THROW(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                              secret_reader, scope_, "test."),
+  EXPECT_THROW(std::ignore = std::make_shared<FilterConfig>(
+                   p, factory_context_.server_factory_context_, secret_reader, scope_, "test."),
                EnvoyException);
 }
 

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -95,14 +95,14 @@ matcher_tree:
 
   Stats::IsolatedStoreImpl store;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
+  EXPECT_THROW(std::ignore = std::make_shared<RoleBasedAccessControlFilterConfig>(
                    config, "test", *store.rootScope(), context,
                    ProtobufMessage::getStrictValidationVisitor()),
                Envoy::EnvoyException);
 
   config.clear_matcher();
   *config.mutable_shadow_matcher() = matcher_proto;
-  EXPECT_THROW(std::make_shared<RoleBasedAccessControlFilterConfig>(
+  EXPECT_THROW(std::ignore = std::make_shared<RoleBasedAccessControlFilterConfig>(
                    config, "test", *store.rootScope(), context,
                    ProtobufMessage::getStrictValidationVisitor()),
                Envoy::EnvoyException);

--- a/test/extensions/filters/network/rbac/config_test.cc
+++ b/test/extensions/filters/network/rbac/config_test.cc
@@ -72,14 +72,14 @@ private:
     Stats::IsolatedStoreImpl store;
     NiceMock<Server::Configuration::MockServerFactoryContext> context;
     EXPECT_THROW(
-        std::make_shared<RoleBasedAccessControlFilterConfig>(
+        std::ignore = std::make_shared<RoleBasedAccessControlFilterConfig>(
             config, *store.rootScope(), context, ProtobufMessage::getStrictValidationVisitor()),
         Envoy::EnvoyException);
 
     config.clear_matcher();
     *config.mutable_shadow_matcher() = matcher_proto;
     EXPECT_THROW(
-        std::make_shared<RoleBasedAccessControlFilterConfig>(
+        std::ignore = std::make_shared<RoleBasedAccessControlFilterConfig>(
             config, *store.rootScope(), context, ProtobufMessage::getStrictValidationVisitor()),
         Envoy::EnvoyException);
   }

--- a/test/extensions/filters/udp/udp_proxy/session_filters/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/session_filters/ext_authz/ext_authz_test.cc
@@ -343,9 +343,9 @@ TEST_F(ExtAuthzFilterTest, ConfigThrowsWhenGrpcClientFactoryFails) {
 
   FilterConfig proto_config;
   proto_config.set_stat_prefix("test");
-  EXPECT_THROW(
-      std::make_shared<Config>(proto_config, context_.scope(), context_.server_factory_context_),
-      EnvoyException);
+  EXPECT_THROW(std::ignore = std::make_shared<Config>(proto_config, context_.scope(),
+                                                      context_.server_factory_context_),
+               EnvoyException);
 }
 
 } // namespace

--- a/test/extensions/http/stateful_session/cookie/cookie_test.cc
+++ b/test/extensions/http/stateful_session/cookie/cookie_test.cc
@@ -19,11 +19,12 @@ TEST(CookieBasedSessionStateFactoryTest, EmptyCookieName) {
   Event::SimulatedTimeSystem time_simulator;
 
   EXPECT_THROW_WITH_MESSAGE(
-      std::make_shared<CookieBasedSessionStateFactory>(config, time_simulator), EnvoyException,
-      "Cookie key cannot be empty for cookie based stateful sessions");
+      std::ignore = std::make_shared<CookieBasedSessionStateFactory>(config, time_simulator),
+      EnvoyException, "Cookie key cannot be empty for cookie based stateful sessions");
   config.mutable_cookie()->set_name("override_host");
 
-  EXPECT_NO_THROW(std::make_shared<CookieBasedSessionStateFactory>(config, time_simulator));
+  EXPECT_NO_THROW(std::ignore =
+                      std::make_shared<CookieBasedSessionStateFactory>(config, time_simulator));
 }
 
 TEST(CookieBasedSessionStateFactoryTest, SessionStateTest) {

--- a/test/extensions/http/stateful_session/header/header_test.cc
+++ b/test/extensions/http/stateful_session/header/header_test.cc
@@ -13,7 +13,7 @@ namespace {
 
 TEST(HeaderBasedSessionStateFactoryTest, EmptyHeaderName) {
   HeaderBasedSessionStateProto config;
-  EXPECT_THROW_WITH_MESSAGE(std::make_shared<HeaderBasedSessionStateFactory>(config),
+  EXPECT_THROW_WITH_MESSAGE(std::ignore = std::make_shared<HeaderBasedSessionStateFactory>(config),
                             EnvoyException,
                             "Header name cannot be empty for header based stateful sessions")
 }

--- a/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
+++ b/test/extensions/tracers/opentelemetry/samplers/sampler_test.cc
@@ -110,7 +110,8 @@ TEST_F(SamplerFactoryTest, TestWithInvalidSampler) {
   envoy::config::trace::v3::OpenTelemetryConfig opentelemetry_config;
   TestUtility::loadFromYaml(yaml_string, opentelemetry_config);
 
-  EXPECT_THROW(std::make_unique<Driver>(opentelemetry_config, context), EnvoyException);
+  EXPECT_THROW(std::ignore = std::make_unique<Driver>(opentelemetry_config, context),
+               EnvoyException);
 }
 
 // Test OTLP tracer with a sampler

--- a/test/integration/socket_interface_integration_test.cc
+++ b/test/integration/socket_interface_integration_test.cc
@@ -130,8 +130,9 @@ TEST_P(SocketInterfaceIntegrationTest, UdpRecvFromInternalAddressWithSocketInter
       std::make_shared<Network::Address::EnvoyInternalInstance>("listener_0", "endpoint_id_0",
                                                                 sock_interface);
 
-  ASSERT_DEATH(std::make_unique<Network::SocketImpl>(Network::Socket::Type::Datagram, address,
-                                                     nullptr, Network::SocketCreationOptions{}),
+  ASSERT_DEATH(std::ignore =
+                   std::make_unique<Network::SocketImpl>(Network::Socket::Type::Datagram, address,
+                                                         nullptr, Network::SocketCreationOptions{}),
                "");
 }
 

--- a/test/server/hot_restart_impl_test.cc
+++ b/test/server/hot_restart_impl_test.cc
@@ -134,7 +134,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketAlreadyInUse) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
+  EXPECT_THROW(std::ignore = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
                Server::HotRestartDomainSocketInUseException);
 }
 
@@ -150,7 +150,7 @@ TEST_P(DomainSocketErrorTest, DomainSocketError) {
   });
   EXPECT_CALL(os_sys_calls_, close(_)).Times(GetParam());
 
-  EXPECT_THROW(std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
+  EXPECT_THROW(std::ignore = std::make_unique<HotRestartImpl>(0, 0, socket_addr_, 0, false, false),
                EnvoyException);
 }
 


### PR DESCRIPTION
Use `std::ignore =` to suppress `nodiscard` warnings from `std::make_shared`, `std::make_unique`, and `std::make_pair` calls inside gtest macros (`EXPECT_THROW`, `EXPECT_THROW_WITH_MESSAGE`, `EXPECT_NO_THROW`, `EXPECT_DEATH`, `ASSERT_DEATH`) where the return value is intentionally discarded.

These warnings surface with newer Clang versions that detect discarded `nodiscard` return values inside macro-expanded statement contexts.
