### PR TITLE
reverse_tunnel: allow requests without headers to reach clusters

### DIFF
--- a/source/extensions/clusters/reverse_connection/reverse_connection.cc
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.cc
@@ -36,22 +36,27 @@ RevConCluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) 
     return {nullptr};
   }
 
-  // Evaluate the configured host-id formatter to obtain the host identifier.
-  if (context->downstreamHeaders() == nullptr) {
-    ENVOY_LOG(error, "reverse_connection: missing downstream headers; cannot evaluate formatter.");
+  if (context->requestStreamInfo() == nullptr && context->downstreamConnection() == nullptr) {
+    ENVOY_LOG(error, "reverse_connection: chooseHost called without downstream connection or "
+                     "stream info");
     return {nullptr};
   }
-
-  // Format the host identifier using the configured formatter.
-  const Envoy::Formatter::Context formatter_context{
-      context->downstreamHeaders(),     nullptr /* response_headers */,
-      nullptr /* response_trailers */,  "" /* local_reply_body */,
-      AccessLog::AccessLogType::NotSet, nullptr /* active_span */};
 
   // Use request stream info if available, otherwise fall back to connection stream info.
   const StreamInfo::StreamInfo& stream_info = context->requestStreamInfo()
                                                   ? *context->requestStreamInfo()
                                                   : context->downstreamConnection()->streamInfo();
+
+  const Envoy::Formatter::Context formatter_context{
+      context->downstreamHeaders(),     nullptr /* response_headers */,
+      nullptr /* response_trailers */,  "" /* local_reply_body */,
+      AccessLog::AccessLogType::NotSet, nullptr /* active_span */};
+
+  if (context->downstreamHeaders() == nullptr) {
+    ENVOY_LOG(debug,
+              "reverse_connection: missing downstream headers; host_id_formatter will only be "
+              "valid if it is a constant.");
+  }
 
   const std::string host_id = parent_->host_id_formatter_->format(formatter_context, stream_info);
 

--- a/test/extensions/clusters/reverse_connection/reverse_connection_cluster_test.cc
+++ b/test/extensions/clusters/reverse_connection/reverse_connection_cluster_test.cc
@@ -442,6 +442,38 @@ TEST_F(ReverseConnectionClusterTest, NoHeaders) {
   }
 }
 
+// Test host creation with no headers and constant host_id_format.
+TEST_F(ReverseConnectionClusterTest, NoHeadersAndConstantHostIdFormat) {
+  const std::string yaml = R"EOF(
+    name: name
+    connect_timeout: 0.25s
+    lb_policy: CLUSTER_PROVIDED
+    cleanup_interval: 1s
+    cluster_type:
+      name: envoy.clusters.reverse_connection
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.reverse_connection.v3.ReverseConnectionClusterConfig
+        cleanup_interval: 10s
+        host_id_format: "test-uuid-123"
+  )EOF";
+
+  setupFromYaml(yaml);
+  setupUpstreamExtension();
+  setupThreadLocalSlot();
+
+  // Constant host_id_format is valid with no headers.
+  {
+    NiceMock<Network::MockConnection> connection;
+    NiceMock<StreamInfo::MockStreamInfo> stream_info;
+    TestLoadBalancerContext lb_context(&connection, &stream_info);
+    RevConCluster::LoadBalancer lb(cluster_);
+
+    Upstream::HostConstSharedPtr host = lb.chooseHost(&lb_context).host;
+    EXPECT_NE(host, nullptr);
+    EXPECT_EQ(host->address()->logicalName(), "test-uuid-123");
+  }
+}
+
 // Test host creation failure due to missing required headers.
 TEST_F(ReverseConnectionClusterTest, MissingRequiredHeaders) {
   const std::string yaml = R"EOF(


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Previously, for a request to be sent across the reverse tunnel, the HTTP headers were read to determine the destination. However, if a request is forwarded from the TCP proxy filter, the downstream HTTP headers are not available.

Thus, we allow requests to proceed to host selection even with no headers available. If the formatter context is a constant string, it will still able to evaluate to a valid host. A formatter context that parses headers and receives a downstream connection with no headers will still not evaluate to a host.

Additional Description:
Risk Level: Low
Testing: Unit Test Added
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
