### PR TITLE
conn_pool: fix ENVOY_BUG for negative connection capacity

### DIFF
--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -203,10 +203,8 @@ struct ClusterConnectivityState {
   // goes up by 100. If the connection is established and 2 streams are in use, it
   // would be reduced to 98 (as 2 of the 100 are not available).
   //
-  // Note that if more HTTP/2 streams have been established than are allowed by
-  // a late-received SETTINGS frame, this MAY BE NEGATIVE.
   // Note this tracks the sum of multiple 32 bit stream capacities so must remain 64 bit.
-  int64_t connecting_and_connected_stream_capacity_{};
+  uint64_t connecting_and_connected_stream_capacity_{};
 };
 
 /**

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -12,8 +12,8 @@
 namespace Envoy {
 namespace ConnectionPool {
 namespace {
-int64_t currentUnusedCapacity(const std::list<ActiveClientPtr>& connecting_clients) {
-  int64_t ret = 0;
+uint64_t currentUnusedCapacity(const std::list<ActiveClientPtr>& connecting_clients) {
+  uint64_t ret = 0;
   for (const auto& client : connecting_clients) {
     ret += client->currentUnusedCapacity();
   }
@@ -24,28 +24,29 @@ int64_t currentUnusedCapacity(const std::list<ActiveClientPtr>& connecting_clien
 std::string ConnPoolImplBase::dumpState() const { return fmt::format("State: {}", *this); }
 
 void ConnPoolImplBase::assertCapacityCountsAreCorrect() {
-  SLOW_ASSERT(static_cast<int64_t>(connecting_stream_capacity_) ==
+  SLOW_ASSERT(connecting_stream_capacity_ ==
                   currentUnusedCapacity(connecting_clients_) +
                       currentUnusedCapacity(early_data_clients_),
               dumpState());
 
-  // Note: must include `busy_clients_` because they can have negative current unused capacity,
-  // which is included in `connecting_and_connected_stream_capacity_`.
+  // Busy clients always have currentUnusedCapacity() == 0 (clamped), so their contribution
+  // to the pool is zero. The invariant is that pool capacity equals connecting capacity plus
+  // the sum of ready clients' unused capacity.
   SLOW_ASSERT(
       connecting_and_connected_stream_capacity_ ==
-          (static_cast<int64_t>(connecting_stream_capacity_) +
+          (connecting_stream_capacity_ +
            currentUnusedCapacity(ready_clients_) + currentUnusedCapacity(busy_clients_)),
       fmt::format(
           "{} currentUnusedCapacity(ready_clients_) {}, currentUnusedCapacity(busy_clients_) {}",
           *this, currentUnusedCapacity(ready_clients_), currentUnusedCapacity(busy_clients_)));
 
-  SLOW_ASSERT(currentUnusedCapacity(busy_clients_) <= 0, dumpState());
+  SLOW_ASSERT(currentUnusedCapacity(busy_clients_) == 0, dumpState());
 
   if (ready_clients_.empty()) {
-    ENVOY_BUG((connecting_and_connected_stream_capacity_ - connecting_stream_capacity_) <= 0,
+    ENVOY_BUG(connecting_and_connected_stream_capacity_ == connecting_stream_capacity_,
               dumpState());
   } else {
-    ENVOY_BUG((connecting_and_connected_stream_capacity_ - connecting_stream_capacity_) > 0,
+    ENVOY_BUG(connecting_and_connected_stream_capacity_ > connecting_stream_capacity_,
               dumpState());
   }
 }
@@ -92,7 +93,7 @@ void ConnPoolImplBase::destructAllConnections() {
 }
 
 bool ConnPoolImplBase::shouldConnect(size_t pending_streams, size_t active_streams,
-                                     int64_t connecting_and_connected_capacity,
+                                     uint64_t connecting_and_connected_capacity,
                                      float preconnect_ratio, bool anticipate_incoming_stream) {
   // This is set to true any time global preconnect is being calculated.
   // ClusterManagerImpl::maybePreconnect is called directly before a stream is created, so the
@@ -215,7 +216,7 @@ ConnPoolImplBase::tryCreateNewConnection(float global_preconnect_ratio) {
     }
     ASSERT(client->state() == ActiveClient::State::Connecting, dumpState());
     ENVOY_BUG(std::numeric_limits<uint64_t>::max() - connecting_stream_capacity_ >=
-                  static_cast<uint64_t>(client->currentUnusedCapacity()),
+                  client->currentUnusedCapacity(),
               dumpState());
     ASSERT(client->real_host_description_);
     // Increase the connecting capacity to reflect the streams this connection can serve.
@@ -298,12 +299,17 @@ void ConnPoolImplBase::onStreamClosed(Envoy::ConnectionPool::ActiveClient& clien
     bool limited_by_concurrency =
         client.remaining_streams_ > client.concurrent_stream_limit_ - client.numActiveStreams() - 1;
     // The capacity calculated by concurrency could be negative if a SETTINGS frame lowered the
-    // number of allowed streams. In this case, connecting_and_connected_stream_capacity_ can be
-    // negative, and effective client capacity was still limited by concurrency. Compare
-    // client.concurrent_stream_limit_ and client.numActiveStreams() directly to avoid overflow.
+    // number of allowed streams. Compare client.concurrent_stream_limit_ and
+    // client.numActiveStreams() directly to avoid overflow.
     bool negative_capacity = client.concurrent_stream_limit_ < client.numActiveStreams() + 1;
     if (negative_capacity || limited_by_concurrency) {
-      incrConnectingAndConnectedStreamCapacity(1, client);
+      if (client.capacity_debt_ > 0) {
+        // The client has negative capacity not tracked in the pool. Absorb this stream closure
+        // into the debt rather than incrementing pool capacity.
+        client.capacity_debt_--;
+      } else {
+        incrConnectingAndConnectedStreamCapacity(1, client);
+      }
     }
   }
   if (client.state() == ActiveClient::State::Draining && client.numActiveStreams() == 0) {
@@ -570,7 +576,13 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
       client.connect_timer_->disableTimer();
       client.connect_timer_.reset();
     }
-    decrConnectingAndConnectedStreamCapacity(client.currentUnusedCapacity(), client);
+    // The pool tracks each client's contribution as currentUnusedCapacity() (already clamped
+    // to 0 for clients with negative raw capacity). Don't clear debt here — subsequent
+    // onStreamClosed calls will consume it as streams are destroyed on this connection.
+    uint32_t pool_contribution = client.currentUnusedCapacity();
+    if (pool_contribution > 0) {
+      decrConnectingAndConnectedStreamCapacity(pool_contribution, client);
+    }
 
     // Make sure that onStreamClosed won't double count.
     client.remaining_streams_ = 0;
@@ -932,7 +944,7 @@ void ActiveClient::onConnectionDurationTimeout() {
 }
 
 void ActiveClient::drain() {
-  const int64_t unused = currentUnusedCapacity();
+  const uint32_t unused = currentUnusedCapacity();
 
   // Remove draining client's capacity from the pool.
   //

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -24,9 +24,8 @@ uint64_t currentUnusedCapacity(const std::list<ActiveClientPtr>& connecting_clie
 std::string ConnPoolImplBase::dumpState() const { return fmt::format("State: {}", *this); }
 
 void ConnPoolImplBase::assertCapacityCountsAreCorrect() {
-  SLOW_ASSERT(connecting_stream_capacity_ ==
-                  currentUnusedCapacity(connecting_clients_) +
-                      currentUnusedCapacity(early_data_clients_),
+  SLOW_ASSERT(connecting_stream_capacity_ == currentUnusedCapacity(connecting_clients_) +
+                                                 currentUnusedCapacity(early_data_clients_),
               dumpState());
 
   // Busy clients always have currentUnusedCapacity() == 0 (clamped), so their contribution
@@ -34,8 +33,8 @@ void ConnPoolImplBase::assertCapacityCountsAreCorrect() {
   // the sum of ready clients' unused capacity.
   SLOW_ASSERT(
       connecting_and_connected_stream_capacity_ ==
-          (connecting_stream_capacity_ +
-           currentUnusedCapacity(ready_clients_) + currentUnusedCapacity(busy_clients_)),
+          (connecting_stream_capacity_ + currentUnusedCapacity(ready_clients_) +
+           currentUnusedCapacity(busy_clients_)),
       fmt::format(
           "{} currentUnusedCapacity(ready_clients_) {}, currentUnusedCapacity(busy_clients_) {}",
           *this, currentUnusedCapacity(ready_clients_), currentUnusedCapacity(busy_clients_)));
@@ -46,8 +45,7 @@ void ConnPoolImplBase::assertCapacityCountsAreCorrect() {
     ENVOY_BUG(connecting_and_connected_stream_capacity_ == connecting_stream_capacity_,
               dumpState());
   } else {
-    ENVOY_BUG(connecting_and_connected_stream_capacity_ > connecting_stream_capacity_,
-              dumpState());
+    ENVOY_BUG(connecting_and_connected_stream_capacity_ > connecting_stream_capacity_, dumpState());
   }
 }
 

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -61,11 +61,11 @@ public:
   // Returns the application protocol, or std::nullopt for TCP.
   virtual std::optional<Http::Protocol> protocol() const PURE;
 
-  virtual int64_t currentUnusedCapacity() const {
-    int64_t remaining_concurrent_streams =
-        static_cast<int64_t>(concurrent_stream_limit_) - numActiveStreams();
-
-    return std::min<int64_t>(remaining_streams_, remaining_concurrent_streams);
+  virtual uint32_t currentUnusedCapacity() const {
+    if (concurrent_stream_limit_ <= numActiveStreams()) {
+      return 0;
+    }
+    return std::min(remaining_streams_, concurrent_stream_limit_ - numActiveStreams());
   }
 
   // Initialize upstream read filters. Called when connected.
@@ -138,6 +138,11 @@ public:
   // and can be adjusted by SETTINGS frame, but the max value of it can't exceed
   // `configured_stream_limit_`.
   uint32_t concurrent_stream_limit_;
+  // When a SETTINGS frame reduces concurrent_stream_limit_ below the active stream count,
+  // the raw capacity would be negative. This debt tracks that negative portion which is NOT
+  // reflected in the pool-level connecting_and_connected_stream_capacity_, preventing that
+  // aggregate from going negative and confusing preconnect logic.
+  uint32_t capacity_debt_{0};
   Upstream::HostDescriptionConstSharedPtr real_host_description_;
   Stats::TimespanPtr conn_connect_ms_;
   Stats::TimespanPtr conn_length_;
@@ -209,7 +214,7 @@ public:
   // If anticipate_incoming_stream is true this assumes a call to newStream is
   // pending, which is true for global preconnect.
   static bool shouldConnect(size_t pending_streams, size_t active_streams,
-                            int64_t connecting_and_connected_capacity, float preconnect_ratio,
+                            uint64_t connecting_and_connected_capacity, float preconnect_ratio,
                             bool anticipate_incoming_stream = false);
 
   // Envoy::ConnectionPool::Instance implementation helpers
@@ -283,6 +288,7 @@ public:
   bool hasPendingStreams() const { return !pending_streams_.empty(); }
 
   void decrClusterStreamCapacity(uint32_t delta) {
+    ASSERT(connecting_and_connected_stream_capacity_ >= delta);
     cluster_connectivity_state_.decrConnectingAndConnectedStreamCapacity(delta);
     connecting_and_connected_stream_capacity_ -= delta;
   }
@@ -406,7 +412,7 @@ private:
 
   // The number of streams that can be immediately dispatched from the current
   // `ready_clients_` plus `connecting_stream_capacity_`.
-  int64_t connecting_and_connected_stream_capacity_{0};
+  uint64_t connecting_and_connected_stream_capacity_{0};
 
   // The number of streams currently attached to clients.
   uint32_t num_active_streams_{0};

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -138,11 +138,9 @@ void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
         std::min(settings.maxConcurrentStreams().value(), configured_stream_limit_);
 
     // Compute raw signed capacity to determine debt (the negative portion not tracked in pool).
-    int64_t new_raw_capacity =
-        static_cast<int64_t>(concurrent_stream_limit_) - numActiveStreams();
+    int64_t new_raw_capacity = static_cast<int64_t>(concurrent_stream_limit_) - numActiveStreams();
     new_raw_capacity = std::min<int64_t>(remaining_streams_, new_raw_capacity);
-    uint32_t new_pool_contribution =
-        static_cast<uint32_t>(std::max<int64_t>(0, new_raw_capacity));
+    uint32_t new_pool_contribution = static_cast<uint32_t>(std::max<int64_t>(0, new_raw_capacity));
 
     if (state() == ActiveClient::State::Ready && new_raw_capacity <= 0) {
       parent_.transitionActiveClientState(*this, ActiveClient::State::Busy);

--- a/source/common/http/conn_pool_base.cc
+++ b/source/common/http/conn_pool_base.cc
@@ -129,9 +129,7 @@ void MultiplexedActiveClientBase::onGoAway(Http::GoAwayErrorCode) {
 // received, but that would result in a latency penalty instead.
 void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
   if (settings.maxConcurrentStreams().has_value()) {
-    int64_t old_unused_capacity = currentUnusedCapacity();
-    // Given config limits old_unused_capacity should never exceed int32_t.
-    ASSERT(std::numeric_limits<int32_t>::max() >= old_unused_capacity);
+    uint32_t old_pool_contribution = currentUnusedCapacity();
     if (parent().cache() && parent().origin().has_value()) {
       parent().cache()->setConcurrentStreams(*parent().origin(),
                                              settings.maxConcurrentStreams().value());
@@ -139,19 +137,29 @@ void MultiplexedActiveClientBase::onSettings(ReceivedSettings& settings) {
     concurrent_stream_limit_ =
         std::min(settings.maxConcurrentStreams().value(), configured_stream_limit_);
 
-    int64_t delta = old_unused_capacity - currentUnusedCapacity();
-    if (state() == ActiveClient::State::Ready && currentUnusedCapacity() <= 0) {
+    // Compute raw signed capacity to determine debt (the negative portion not tracked in pool).
+    int64_t new_raw_capacity =
+        static_cast<int64_t>(concurrent_stream_limit_) - numActiveStreams();
+    new_raw_capacity = std::min<int64_t>(remaining_streams_, new_raw_capacity);
+    uint32_t new_pool_contribution =
+        static_cast<uint32_t>(std::max<int64_t>(0, new_raw_capacity));
+
+    if (state() == ActiveClient::State::Ready && new_raw_capacity <= 0) {
       parent_.transitionActiveClientState(*this, ActiveClient::State::Busy);
-    } else if (state() == ActiveClient::State::Busy && currentUnusedCapacity() > 0) {
+    } else if (state() == ActiveClient::State::Busy && new_raw_capacity > 0) {
       parent_.transitionActiveClientState(*this, ActiveClient::State::Ready);
     }
 
-    if (delta > 0) {
-      parent_.decrClusterStreamCapacity(delta);
-      ENVOY_CONN_LOG(trace, "Decreasing stream capacity by {}", *codec_client_, delta);
-    } else if (delta < 0) {
-      parent_.incrClusterStreamCapacity(-delta);
-      ENVOY_CONN_LOG(trace, "Increasing stream capacity by {}", *codec_client_, -delta);
+    capacity_debt_ = static_cast<uint32_t>(std::max<int64_t>(0, -new_raw_capacity));
+
+    if (old_pool_contribution > new_pool_contribution) {
+      uint32_t pool_delta = old_pool_contribution - new_pool_contribution;
+      parent_.decrClusterStreamCapacity(pool_delta);
+      ENVOY_CONN_LOG(trace, "Decreasing stream capacity by {}", *codec_client_, pool_delta);
+    } else if (new_pool_contribution > old_pool_contribution) {
+      uint32_t pool_delta = new_pool_contribution - old_pool_contribution;
+      parent_.incrClusterStreamCapacity(pool_delta);
+      ENVOY_CONN_LOG(trace, "Increasing stream capacity by {}", *codec_client_, pool_delta);
     }
   }
 }

--- a/source/common/http/http3/conn_pool.h
+++ b/source/common/http/http3/conn_pool.h
@@ -65,8 +65,9 @@ public:
 
   // Overload the default capacity calculations to return the quic capacity
   // (modified by any stream limits in Envoy config)
-  int64_t currentUnusedCapacity() const override {
-    return std::min<int64_t>(quiche_capacity_, effectiveConcurrentStreamLimit());
+  uint32_t currentUnusedCapacity() const override {
+    return static_cast<uint32_t>(
+        std::min<uint64_t>(quiche_capacity_, effectiveConcurrentStreamLimit()));
   }
 
   // Overridden to return true as long as the client is doing handshake even when it is ready for

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -43,7 +43,7 @@ public:
     ASSERT_TRUE(testClient != nullptr);
     testClient->active_streams_++;
   }
-  int64_t currentUnusedCapacity() const override {
+  uint32_t currentUnusedCapacity() const override {
     if (capacity_override_.has_value()) {
       return capacity_override_.value();
     }
@@ -68,7 +68,7 @@ public:
   bool supportsEarlyData() const override { return supports_early_data_; }
   uint32_t active_streams_{};
 
-  std::optional<uint64_t> capacity_override_;
+  std::optional<uint32_t> capacity_override_;
 
 private:
   bool supports_early_data_;

--- a/test/common/http/http2/conn_pool_test.cc
+++ b/test/common/http/http2/conn_pool_test.cc
@@ -1550,11 +1550,12 @@ TEST_F(Http2ConnPoolImplTest, DisconnectWithNegativeCapacity) {
   CHECK_STATE(5 /*active*/, 0 /*pending*/, 1 /*capacity*/);
   EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
 
-  // Settings frame results in -2 capacity.
+  // Settings frame results in negative per-client capacity, but pool capacity is clamped to 0
+  // because the negative portion is tracked as debt on the client.
   NiceMock<MockReceivedSettings> settings;
   settings.max_concurrent_streams_ = 3;
   test_clients_[0].codec_client_->onSettings(settings);
-  CHECK_STATE(5 /*active*/, 0 /*pending*/, -2 /*capacity*/);
+  CHECK_STATE(5 /*active*/, 0 /*pending*/, 0 /*capacity*/);
   EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
   // Close 1 stream, concurrency capacity goes to -1, still no ready client available.
@@ -1567,13 +1568,73 @@ TEST_F(Http2ConnPoolImplTest, DisconnectWithNegativeCapacity) {
   EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
   CHECK_STATE(2 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
-  // Another settings frame results in -1 capacity.
+  // Another settings frame results in negative per-client capacity, pool clamped to 0.
   settings.max_concurrent_streams_ = 1;
   test_clients_[0].codec_client_->onSettings(settings);
-  CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
   EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 0);
 
   // Close connection with negative capacity.
+  closeAllClients();
+  CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/46234
+// When a SETTINGS frame reduces max_concurrent_streams below the active stream count on a busy
+// client, the pool capacity should not go negative — a ready client on a different connection
+// should still reflect positive capacity.
+TEST_F(Http2ConnPoolImplTest, NegativeCapacityDoesNotAffectReadyClient) {
+  cluster_->http2_options_.mutable_max_concurrent_streams()->set_value(4);
+  ON_CALL(*cluster_, perUpstreamPreconnectRatio).WillByDefault(Return(1.5));
+
+  // 3 pending requests with preconnect 1.5 triggers creation of 2 connections (each cap=4).
+  expectClientsCreate(2);
+  ActiveTestRequest r1(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 1 /*pending*/, 4 /*capacity*/);
+  ActiveTestRequest r2(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 2 /*pending*/, 4 /*capacity*/);
+  ActiveTestRequest r3(*this, 0, false);
+  CHECK_STATE(0 /*active*/, 3 /*pending*/, 8 /*capacity*/);
+
+  // Connect connection 0, dispatches all 3 pending streams.
+  EXPECT_CALL(*test_clients_[0].codec_, newStream(_))
+      .WillOnce(DoAll(SaveArgAddress(&r1.inner_decoder_), ReturnRef(r1.inner_encoder_)))
+      .WillOnce(DoAll(SaveArgAddress(&r2.inner_decoder_), ReturnRef(r2.inner_encoder_)))
+      .WillOnce(DoAll(SaveArgAddress(&r3.inner_decoder_), ReturnRef(r3.inner_encoder_)));
+  EXPECT_CALL(r1.callbacks_.pool_ready_, ready());
+  EXPECT_CALL(r2.callbacks_.pool_ready_, ready());
+  EXPECT_CALL(r3.callbacks_.pool_ready_, ready());
+  expectClientConnect(0);
+  // Connection 0: 3 active, capacity=1. Connection 1: still connecting, capacity=4. Total=5.
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 5 /*capacity*/);
+
+  // Connect connection 1 (idle, ready with capacity 4).
+  expectClientConnect(1);
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 5 /*capacity*/);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 2);
+
+  // SETTINGS frame on connection 0 reduces max_concurrent_streams to 1 (below 3 active).
+  // Connection 0 transitions to Busy with per-client capacity of -2 (tracked as debt).
+  // Pool capacity only reflects real available capacity: connection 1's 4 + connection 0's 0 = 4.
+  NiceMock<MockReceivedSettings> settings;
+  settings.max_concurrent_streams_ = 1;
+  test_clients_[0].codec_client_->onSettings(settings);
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 4 /*capacity*/);
+  EXPECT_EQ(pool_->owningList(Envoy::ConnectionPool::ActiveClient::State::Ready).size(), 1);
+
+  // As streams close on connection 0, capacity stays at 4 until debt is repaid.
+  completeRequest(r1);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 4 /*capacity*/);
+  completeRequest(r2);
+  CHECK_STATE(1 /*active*/, 0 /*pending*/, 4 /*capacity*/);
+
+  // Final stream closes on connection 0 — debt fully repaid, capacity restored to 1.
+  // Pool increments: connection 0's 1 + connection 1's 4 = 5.
+  completeRequest(r3);
+  CHECK_STATE(0 /*active*/, 0 /*pending*/, 5 /*capacity*/);
+
+  // Clean up.
+  pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
   closeAllClients();
   CHECK_STATE(0 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 }
@@ -1634,7 +1695,7 @@ TEST_F(Http2ConnPoolImplTest, PreconnectWithSettings) {
   settings.max_concurrent_streams_ = 1;
   test_clients_[0].codec_client_->onSettings(settings);
   test_clients_[1].codec_client_->onSettings(settings);
-  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
   // Clean up.
   pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);
@@ -1846,20 +1907,20 @@ TEST_F(Http2ConnPoolImplTest, TestNegativeUnusedCapacity) {
   ActiveTestRequest r3(*this, 0, true);
   CHECK_STATE(3 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
-  // Settings frame results in negative unused capacity.
+  // Settings frame results in negative per-client capacity, pool clamped to 0.
   NiceMock<MockReceivedSettings> settings;
   settings.max_concurrent_streams_ = 1;
   test_clients_[0].codec_client_->onSettings(settings);
-  CHECK_STATE(3 /*active*/, 0 /*pending*/, -2 /*capacity*/);
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   completeRequest(r1);
-  CHECK_STATE(2 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+  CHECK_STATE(2 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
-  // With negative capacity, verify that a new request creates a new connection.
+  // With zero capacity, verify that a new request creates a new connection.
   ActiveTestRequest r4(*this, 1, false);
-  CHECK_STATE(2 /*active*/, 1 /*pending*/, 3 /*capacity*/);
+  CHECK_STATE(2 /*active*/, 1 /*pending*/, 4 /*capacity*/);
   expectClientConnect(1, r4);
-  CHECK_STATE(3 /*active*/, 0 /*pending*/, 2 /*capacity*/);
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 3 /*capacity*/);
 
   completeRequest(r2);
   CHECK_STATE(2 /*active*/, 0 /*pending*/, 3 /*capacity*/);
@@ -1889,11 +1950,11 @@ TEST_F(Http2ConnPoolImplTest, TestDrainingNegativeUnusedCapacity) {
   ActiveTestRequest r3(*this, 0, true);
   CHECK_STATE(3 /*active*/, 0 /*pending*/, 1 /*capacity*/);
 
-  // Settings frame results in negative unused capacity.
+  // Settings frame results in negative per-client capacity, pool clamped to 0.
   NiceMock<MockReceivedSettings> settings;
   settings.max_concurrent_streams_ = 2;
   test_clients_[0].codec_client_->onSettings(settings);
-  CHECK_STATE(3 /*active*/, 0 /*pending*/, -1 /*capacity*/);
+  CHECK_STATE(3 /*active*/, 0 /*pending*/, 0 /*capacity*/);
 
   // Clean up with an outstanding stream.
   pool_->drainConnections(Envoy::ConnectionPool::DrainBehavior::DrainExistingConnections);


### PR DESCRIPTION
Fixed an ENVOY_BUG when an HTTP/2 SETTINGS frame reduced stream capacity on a connection, when other connections still had available capacity.

The fix is to track this negative capacity in the connection, and not have it reduce the total capacity of the pool. This makes all capacity numbers on the pool become unsigned, which is simpler and more accurately tracks the current capacity of the pool.

Fixes #46234

Risk Level: Medium
Testing: Existing tests pass; new test added for this case
Docs Changes: None
Release Notes:
Platform Specific Features: None