### PR TITLE
Remove exceptions from test only StreamInfoFormatter

### DIFF
--- a/test/common/formatter/BUILD
+++ b/test/common/formatter/BUILD
@@ -72,6 +72,7 @@ envoy_cc_test(
         "//test/test_common:test_runtime_lib",
         "//test/test_common:threadsafe_singleton_injector_lib",
         "//test/test_common:utility_lib",
+        "@abseil-cpp//absl/status",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -36,6 +36,7 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+#include "absl/status/status.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -44,6 +45,7 @@ namespace Formatter {
 namespace {
 
 using StatusHelpers::HasStatus;
+using StatusHelpers::HasStatusCode;
 using testing::Const;
 using testing::ContainsRegex;
 using testing::HasSubstr;
@@ -57,18 +59,32 @@ using testing::StartsWith;
 // Helper class to test StreamInfoFormatter.
 class StreamInfoFormatter : public FormatterProvider {
 public:
+  // This constructor expects well formed format.
   StreamInfoFormatter(const std::string& command, const std::string& sub_command = "",
                       std::optional<size_t> max_length = std::nullopt) {
     DefaultBuiltInStreamInfoCommandParserFactory factory;
     auto parser = factory.createCommandParser();
     auto formatter_or = parser->parse(command, sub_command, max_length);
-    if (!formatter_or.ok()) {
-      throwEnvoyExceptionOrPanic(std::string(formatter_or.status().message()));
-    }
+    ASSERT(formatter_or.ok(), std::string(formatter_or.status().message()));
     formatter_ = std::move(formatter_or).value();
-    if (formatter_ == nullptr) {
-      throwEnvoyExceptionOrPanic(fmt::format("Not supported command in StreamInfo: {}", command));
+    ASSERT(formatter_ != nullptr, fmt::format("Not supported command in StreamInfo: {}", command));
+  }
+
+  explicit StreamInfoFormatter(FormatterProviderPtr formatter) : formatter_(std::move(formatter)) {}
+
+  // Factory method is for testing cases with malformed format.
+  static absl::StatusOr<StreamInfoFormatter>
+  create(const std::string& command, const std::string& sub_command = "",
+         std::optional<size_t> max_length = std::nullopt) {
+    DefaultBuiltInStreamInfoCommandParserFactory factory;
+    auto parser = factory.createCommandParser();
+    auto formatter = parser->parse(command, sub_command, max_length);
+    RETURN_IF_NOT_OK(formatter.status());
+    if (*formatter == nullptr) {
+      return absl::InvalidArgumentError(
+          fmt::format("Not supported command in StreamInfo: {}", command));
     }
+    return StreamInfoFormatter(std::move(*formatter));
   }
 
   // FormatterProvider
@@ -292,7 +308,8 @@ TEST(SubstitutionFormatterTest, inFlightDuration) {
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatter) {
-  EXPECT_THROW(StreamInfoFormatter formatter("unknown_field"), EnvoyException);
+  EXPECT_THAT(StreamInfoFormatter::create("unknown_field"),
+              HasStatusCode(absl::StatusCode::kInvalidArgument));
 
   // Used to replace the default one in the upstream info.
   auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
@@ -1667,27 +1684,27 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter upstream_format("COMMON_DURATION"); }, EnvoyException,
-        "COMMON_DURATION requires parameters");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "COMMON_DURATION requires parameters"));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a"); }, EnvoyException,
-        "Invalid common duration configuration: a.");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION", "a"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "Invalid common duration configuration: a."));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a:b:c:d"); }, EnvoyException,
-        "Invalid common duration configuration: a:b:c:d.");
+    EXPECT_THAT(StreamInfoFormatter::create("COMMON_DURATION", "a:b:c:d"),
+                HasStatus(absl::StatusCode::kInvalidArgument,
+                          "Invalid common duration configuration: a:b:c:d."));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a:b:zs"); }, EnvoyException,
-        "Invalid common duration precision: zs.");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION", "a:b:zs"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "Invalid common duration precision: zs."));
   }
 
   {
@@ -1868,7 +1885,8 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {
-  EXPECT_THROW(StreamInfoFormatter formatter("unknown_field"), EnvoyException);
+  EXPECT_THAT(StreamInfoFormatter::create("unknown_field"),
+              HasStatusCode(absl::StatusCode::kInvalidArgument));
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -36,6 +36,7 @@
 #include "test/test_common/threadsafe_singleton_injector.h"
 #include "test/test_common/utility.h"
 
+#include "absl/status/status.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -45,6 +46,7 @@ namespace {
 
 using ::Envoy::StatusHelpers::IsOk;
 using StatusHelpers::HasStatus;
+using StatusHelpers::HasStatusCode;
 using testing::Const;
 using testing::ContainsRegex;
 using testing::HasSubstr;
@@ -59,18 +61,32 @@ using testing::StartsWith;
 // Helper class to test StreamInfoFormatter.
 class StreamInfoFormatter : public FormatterProvider {
 public:
+  // This constructor expects well formed format.
   StreamInfoFormatter(const std::string& command, const std::string& sub_command = "",
                       std::optional<size_t> max_length = std::nullopt) {
     DefaultBuiltInStreamInfoCommandParserFactory factory;
     auto parser = factory.createCommandParser();
     auto formatter_or = parser->parse(command, sub_command, max_length);
-    if (!formatter_or.ok()) {
-      throwEnvoyExceptionOrPanic(std::string(formatter_or.status().message()));
-    }
+    ASSERT(formatter_or.ok(), std::string(formatter_or.status().message()));
     formatter_ = std::move(formatter_or).value();
-    if (formatter_ == nullptr) {
-      throwEnvoyExceptionOrPanic(fmt::format("Not supported command in StreamInfo: {}", command));
+    ASSERT(formatter_ != nullptr, fmt::format("Not supported command in StreamInfo: {}", command));
+  }
+
+  explicit StreamInfoFormatter(FormatterProviderPtr formatter) : formatter_(std::move(formatter)) {}
+
+  // Factory method is for testing cases with malformed format.
+  static absl::StatusOr<StreamInfoFormatter>
+  create(const std::string& command, const std::string& sub_command = "",
+         std::optional<size_t> max_length = std::nullopt) {
+    DefaultBuiltInStreamInfoCommandParserFactory factory;
+    auto parser = factory.createCommandParser();
+    auto formatter = parser->parse(command, sub_command, max_length);
+    RETURN_IF_NOT_OK(formatter.status());
+    if (*formatter == nullptr) {
+      return absl::InvalidArgumentError(
+          fmt::format("Not supported command in StreamInfo: {}", command));
     }
+    return StreamInfoFormatter(std::move(*formatter));
   }
 
   // FormatterProvider
@@ -294,7 +310,8 @@ TEST(SubstitutionFormatterTest, inFlightDuration) {
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatter) {
-  EXPECT_THROW(StreamInfoFormatter formatter("unknown_field"), EnvoyException);
+  EXPECT_THAT(StreamInfoFormatter::create("unknown_field"),
+              HasStatusCode(absl::StatusCode::kInvalidArgument));
 
   // Used to replace the default one in the upstream info.
   auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
@@ -1687,27 +1704,27 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter upstream_format("COMMON_DURATION"); }, EnvoyException,
-        "COMMON_DURATION requires parameters");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "COMMON_DURATION requires parameters"));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a"); }, EnvoyException,
-        "Invalid common duration configuration: a.");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION", "a"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "Invalid common duration configuration: a."));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a:b:c:d"); }, EnvoyException,
-        "Invalid common duration configuration: a:b:c:d.");
+    EXPECT_THAT(StreamInfoFormatter::create("COMMON_DURATION", "a:b:c:d"),
+                HasStatus(absl::StatusCode::kInvalidArgument,
+                          "Invalid common duration configuration: a:b:c:d."));
   }
 
   {
-    EXPECT_THROW_WITH_MESSAGE(
-        { StreamInfoFormatter duration_format("COMMON_DURATION", "a:b:zs"); }, EnvoyException,
-        "Invalid common duration precision: zs.");
+    EXPECT_THAT(
+        StreamInfoFormatter::create("COMMON_DURATION", "a:b:zs"),
+        HasStatus(absl::StatusCode::kInvalidArgument, "Invalid common duration precision: zs."));
   }
 
   {
@@ -1899,7 +1916,8 @@ TEST(SubstitutionFormatterTest, streamInfoFormatter) {
 }
 
 TEST(SubstitutionFormatterTest, streamInfoFormatterWithSsl) {
-  EXPECT_THROW(StreamInfoFormatter formatter("unknown_field"), EnvoyException);
+  EXPECT_THAT(StreamInfoFormatter::create("unknown_field"),
+              HasStatusCode(absl::StatusCode::kInvalidArgument));
 
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;


### PR DESCRIPTION
Added a new factory method that returns StatusOr for tests of error cases, to minimize the change to the entire test suite.

Risk Level: none (test only)
Testing: unit test
Docs Changes: no
Release Notes: no
Platform Specific Features: no
