### PR TITLE
http: add issuer support to the xfcc client

### DIFF
--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -283,7 +283,7 @@ message HttpConnectionManager {
     repeated config.core.v3.CidrRange cidr_ranges = 2;
   }
 
-  // [#next-free-field: 8]
+  // [#next-free-field: 9]
   message SetCurrentClientCertDetails {
     option (udpa.annotations.versioning).previous_message_type =
         "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager."
@@ -312,6 +312,9 @@ message HttpConnectionManager {
     // Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to
     // false.
     bool uri = 5;
+
+    // Whether to forward the issuer of the client cert. Defaults to false.
+    bool issuer = 8;
 
     // The format for the header. When the :ref:`forward_client_cert_details
     // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.forward_client_cert_details>`

--- a/changelogs/current/new_features/http__xfcc-issuer.rst
+++ b/changelogs/current/new_features/http__xfcc-issuer.rst
@@ -1,0 +1,5 @@
+Added support for forwarding the issuer of the client certificate in the
+``x-forwarded-client-cert`` (XFCC) header via the new
+:ref:`issuer <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.SetCurrentClientCertDetails.issuer>`
+field of ``SetCurrentClientCertDetails``. When enabled, the ``Issuer`` key is added in text format and
+the ``issuer`` field is added in JSON format. Defaults to disabled.

--- a/docs/root/configuration/http/http_conn_man/headers.rst
+++ b/docs/root/configuration/http/http_conn_man/headers.rst
@@ -193,6 +193,7 @@ The following keys are supported:
 5. ``Subject`` The Subject field of the current client certificate. The value is always double-quoted.
 6. ``URI`` The URI type Subject Alternative Name field of the current client certificate. A client certificate may contain multiple URI type Subject Alternative Names, each will be a separate key-value pair.
 7. ``DNS`` The DNS type Subject Alternative Name field of the current client certificate. A client certificate may contain multiple DNS type Subject Alternative Names, each will be a separate key-value pair.
+8. ``Issuer`` The Issuer field of the current client certificate. The value is always double-quoted.
 
 A client certificate may contain multiple Subject Alternative Name types. For details on different Subject Alternative Name types, please refer `RFC 5280`_.
 
@@ -216,7 +217,7 @@ text format are available as JSON object fields, but with the following structur
 * ``by``, ``uri``, ``dns``, and ``chain`` are JSON arrays of strings (since they can have multiple values).
   For ``chain``, each string is the PEM-encoded representation of a single certificate
   in the peer certificate chain. This is the peer provided chain, not the validated chain.
-* ``hash``, ``cert``, and ``subject`` are JSON strings.
+* ``hash``, ``cert``, ``subject``, and ``issuer`` are JSON strings.
 * Unlike the text format, ``cert`` and ``chain`` PEM values are not URL-encoded; instead,
   special characters (such as newlines in PEM data) are escaped using standard JSON escaping rules.
 * Only fields with non-empty values are included in the JSON object.

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -166,7 +166,7 @@ enum class ForwardClientCertType {
  * Configuration for the fields of the client cert, used for populating the current client cert
  * information to the next hop.
  */
-enum class ClientCertDetailsType { Cert, Chain, Subject, URI, DNS };
+enum class ClientCertDetailsType { Cert, Chain, Subject, URI, DNS, Issuer };
 
 enum class ClientCertFormat { Text, Json };
 

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -523,6 +523,14 @@ void appendXfccJsonObject(
         }
         break;
       }
+      case ClientCertDetailsType::Issuer: {
+        const std::string& issuer = connection.ssl()->issuerPeerCertificate();
+        if (!issuer.empty()) {
+          root->addKey("issuer");
+          root->addString(issuer);
+        }
+        break;
+      }
       }
     }
   }
@@ -641,6 +649,11 @@ void applyForwardClientCertConfig(
           }
           break;
         }
+        case ClientCertDetailsType::Issuer:
+          // The "Issuer" key still exists even if the issuer is empty.
+          client_cert_details.push_back(
+              absl::StrCat("Issuer=\"", connection.ssl()->issuerPeerCertificate(), "\""));
+          break;
         }
       }
       client_cert_details_str = absl::StrJoin(client_cert_details, ";");

--- a/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
+++ b/source/extensions/filters/network/http_connection_manager/forward_client_cert_details.cc
@@ -63,6 +63,9 @@ std::vector<Http::ClientCertDetailsType> convertSetCurrentClientCertDetails(
   if (details.dns()) {
     result.push_back(Http::ClientCertDetailsType::DNS);
   }
+  if (details.issuer()) {
+    result.push_back(Http::ClientCertDetailsType::Issuer);
+  }
   return result;
 }
 

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -1697,6 +1697,35 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCert) {
       headers.get_("x-forwarded-client-cert"));
 }
 
+// Verify the Issuer of the client cert is forwarded in the XFCC header when requested.
+TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCertWithIssuer) {
+  auto ssl = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(*ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
+  EXPECT_CALL(*ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
+  std::string expected_sha("abcdefg");
+  EXPECT_CALL(*ssl, sha256PeerCertificateDigest()).WillOnce(ReturnRef(expected_sha));
+  std::string peer_subject("/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=test.lyft.com");
+  EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(ReturnRef(peer_subject));
+  std::string peer_issuer("/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test CA");
+  EXPECT_CALL(*ssl, issuerPeerCertificate()).WillOnce(ReturnRef(peer_issuer));
+  ON_CALL(connection_, ssl()).WillByDefault(Return(ssl));
+  ON_CALL(config_, forwardClientCert())
+      .WillByDefault(Return(Http::ForwardClientCertType::SanitizeSet));
+  std::vector<Http::ClientCertDetailsType> details = {Http::ClientCertDetailsType::Subject,
+                                                      Http::ClientCertDetailsType::Issuer};
+  ON_CALL(config_, setCurrentClientCertDetails()).WillByDefault(ReturnRef(details));
+  TestRequestHeaderMapImpl headers;
+
+  EXPECT_EQ((MutateRequestRet{"10.0.0.3:50000", false, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_TRUE(headers.has("x-forwarded-client-cert"));
+  EXPECT_EQ("By=test://foo.com/be;Hash=abcdefg;Subject=\"/C=US/ST=CA/L=San "
+            "Francisco/OU=Lyft/CN=test.lyft.com\";Issuer=\"/C=US/ST=CA/L=San "
+            "Francisco/OU=Lyft/CN=Test CA\"",
+            headers.get_("x-forwarded-client-cert"));
+}
+
 // This test assumes the following scenario:
 // The client identity is foo.com/fe, and the server (local) identity is foo.com/be. The client
 // also sends the XFCC header with the authentication result of the previous hop, (bar.com/be
@@ -1945,6 +1974,35 @@ TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCertJsonFormat) {
   EXPECT_EQ(R"([{"by":["test://foo.com/be","http://backend.foo.com"],"hash":"abcdefg",)"
             R"("subject":"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=test.lyft.com",)"
             R"("uri":["test://foo.com/fe","http://frontend.foo.com"],"dns":["www.example.com"]}])",
+            headers.get_("x-forwarded-client-cert"));
+}
+
+// JSON format: the Issuer of the client cert is forwarded as the "issuer" field.
+TEST_F(ConnectionManagerUtilityTest, MtlsSanitizeSetClientCertJsonFormatWithIssuer) {
+  auto ssl = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(*ssl, peerCertificatePresented()).WillByDefault(Return(true));
+  const std::vector<std::string> local_uri_sans{"test://foo.com/be"};
+  EXPECT_CALL(*ssl, uriSanLocalCertificate()).WillOnce(Return(local_uri_sans));
+  std::string expected_sha("abcdefg");
+  EXPECT_CALL(*ssl, sha256PeerCertificateDigest()).WillOnce(ReturnRef(expected_sha));
+  std::string peer_subject("/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=test.lyft.com");
+  EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(ReturnRef(peer_subject));
+  std::string peer_issuer("/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test CA");
+  EXPECT_CALL(*ssl, issuerPeerCertificate()).WillOnce(ReturnRef(peer_issuer));
+  ON_CALL(connection_, ssl()).WillByDefault(Return(ssl));
+  ON_CALL(config_, forwardClientCert())
+      .WillByDefault(Return(Http::ForwardClientCertType::SanitizeSet));
+  ON_CALL(config_, clientCertFormat()).WillByDefault(Return(Http::ClientCertFormat::Json));
+  std::vector<Http::ClientCertDetailsType> details = {Http::ClientCertDetailsType::Subject,
+                                                      Http::ClientCertDetailsType::Issuer};
+  ON_CALL(config_, setCurrentClientCertDetails()).WillByDefault(ReturnRef(details));
+  TestRequestHeaderMapImpl headers;
+
+  EXPECT_EQ((MutateRequestRet{"10.0.0.3:50000", false, Tracing::Reason::NotTraceable}),
+            callMutateRequestHeaders(headers, Protocol::Http2));
+  EXPECT_EQ(R"([{"by":["test://foo.com/be"],"hash":"abcdefg",)"
+            R"("subject":"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=test.lyft.com",)"
+            R"("issuer":"/C=US/ST=CA/L=San Francisco/OU=Lyft/CN=Test CA"}])",
             headers.get_("x-forwarded-client-cert"));
 }
 

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -3504,6 +3504,32 @@ TEST_F(HttpConnectionManagerConfigTest, SetCurrentClientCertDetailsCertAndChain)
   EXPECT_EQ(Http::ClientCertDetailsType::Chain, config.setCurrentClientCertDetails()[1]);
 }
 
+TEST_F(HttpConnectionManagerConfigTest, SetCurrentClientCertDetailsIssuer) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  forward_client_cert_details: APPEND_FORWARD
+  set_current_client_cert_details:
+    subject: true
+    issuer: true
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     &scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_, creation_status_);
+  ASSERT_OK(creation_status_);
+  EXPECT_EQ(Http::ForwardClientCertType::AppendForward, config.forwardClientCert());
+  EXPECT_EQ(2, config.setCurrentClientCertDetails().size());
+  EXPECT_EQ(Http::ClientCertDetailsType::Subject, config.setCurrentClientCertDetails()[0]);
+  EXPECT_EQ(Http::ClientCertDetailsType::Issuer, config.setCurrentClientCertDetails()[1]);
+}
+
 TEST_F(HttpConnectionManagerConfigTest, ForwardClientCertMatcher) {
   // Test that forward_client_cert_matcher is properly parsed and can match on request headers.
   const std::string yaml_string = R"EOF(

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -243,6 +243,25 @@ TEST_P(XfccIntegrationTest, MtlsSanitizeSetSubject) {
                                        current_xfcc_by_hash_ + ";" + client_subject_);
 }
 
+TEST_P(XfccIntegrationTest, MtlsSanitizeSetIssuer) {
+  fcc_ = envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+      SANITIZE_SET;
+  sccd_.set_issuer(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_,
+                                       current_xfcc_by_hash_ + ";" + client_issuer_);
+}
+
+TEST_P(XfccIntegrationTest, MtlsSanitizeSetSubjectIssuer) {
+  fcc_ = envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
+      SANITIZE_SET;
+  sccd_.mutable_subject()->set_value(true);
+  sccd_.set_issuer(true);
+  initialize();
+  testRequestAndResponseWithXfccHeader(previous_xfcc_, current_xfcc_by_hash_ + ";" +
+                                                           client_subject_ + ";" + client_issuer_);
+}
+
 TEST_P(XfccIntegrationTest, MtlsSanitizeSetUri) {
   fcc_ = envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager::
       SANITIZE_SET;

--- a/test/integration/xfcc_integration_test.h
+++ b/test/integration/xfcc_integration_test.h
@@ -35,6 +35,9 @@ public:
       "Subject=\""
       "emailAddress=frontend-team@lyft.com,CN=Test Frontend Team,"
       "OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US\"";
+  const std::string client_issuer_ =
+      "Issuer=\""
+      "CN=Test CA,OU=Lyft Engineering,O=Lyft,L=San Francisco,ST=California,C=US\"";
   const std::string client_uri_san_ =
       "URI=spiffe://lyft.com/frontend-team;URI=http://frontend.lyft.com";
   const std::string client_dns_san_ = "DNS=lyft.com;DNS=www.lyft.com";


### PR DESCRIPTION
Commit Message: http: add issuer support to the xfcc client
Additional Description:

Now, allow we set `issuer` to the XFCC. Fixes https://github.com/envoyproxy/envoy/issues/46295

Risk Level: minor
Testing: unit/integration.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.
