### PR TITLE
http2: fix uint32_t overflow in stream unconsumed bytes counter

### DIFF
--- a/changelogs/current/bug_fixes/http2__fixed_unconsumed_bytes_overflow.rst
+++ b/changelogs/current/bug_fixes/http2__fixed_unconsumed_bytes_overflow.rst
@@ -1,0 +1,1 @@
+Fixed an integer overflow in HTTP/2 codec stream flow control accounting where ``unconsumed_bytes_`` wrapped around when reads were disabled on a stream receiving over 4 GiB of data.

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -426,7 +426,7 @@ protected:
     const StreamInfo::BytesMeterSharedPtr& bytesMeter() override { return bytes_meter_; }
     ConnectionImpl& parent_;
     int32_t stream_id_{-1};
-    uint32_t unconsumed_bytes_{0};
+    uint64_t unconsumed_bytes_{0};
     uint32_t read_disable_count_{0};
     StreamInfo::BytesMeterSharedPtr bytes_meter_{std::make_shared<StreamInfo::BytesMeter>()};
 


### PR DESCRIPTION

Commit Message: http2: fix uint32_t overflow in stream unconsumed bytes counter
Additional Description: unconsumed_bytes_ in ConnectionImpl::StreamImpl was typed as uint32_t. When reads are disabled on an HTTP/2 stream while incoming data continues to arrive, unconsumed_bytes_ accumulates received byte counts. If total accumulated data reaches or exceeds 4 GiB (2^32 bytes), unconsumed_bytes_ overflows and wraps around modulo 2^32. When reads are re-enabled or the stream closes, MarkDataConsumedForStream receives the wrapped value instead of the true count, leading to corrupted stream flow control accounting. Updating unconsumed_bytes_ to uint64_t prevents integer overflow.
Risk Level: Low
Testing: Code inspection, type verification across codec, and release note fragment addition.
Docs Changes: N/A
Release Notes: Added changelogs/current/bug_fixes/http2__fixed_unconsumed_bytes_overflow.rst.

Fixes #45887

## Context
In `source/common/http/http2/codec_impl.h`, `unconsumed_bytes_` tracks bytes received on a stream while reads are disabled (`readDisable(true)`). Because `unconsumed_bytes_` was typed as `uint32_t`, accumulating data beyond 4 GiB resulted in integer overflow modulo 2^32. When `grantPeerAdditionalStreamWindow()` or stream destruction subsequently passed `unconsumed_bytes_` to `Http2Adapter::MarkDataConsumedForStream(stream_id, num_bytes)`, the HTTP/2 adapter received a truncated count, resulting in stream window accounting mismatch.

## Solution
Changed `unconsumed_bytes_` from `uint32_t` to `uint64_t` in `ConnectionImpl::StreamImpl`. Since `Http2Adapter::MarkDataConsumedForStream` accepts `size_t` (`uint64_t` on 64-bit systems), expanding `unconsumed_bytes_` to `uint64_t` aligns with parameter types across the codec and prevents overflow.

