### PR TITLE
test: increase coverage for `listener_manager` and `cache_v2`

### DIFF
--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -329,6 +329,21 @@ TEST_P(FilterChainManagerImplTest, CreatedFilterChainFactoryContextHasIndependen
   EXPECT_FALSE(context1->drainDecision().drainClose(Network::DrainDirection::All));
 }
 
+TEST_P(FilterChainManagerImplTest, FilterChainFactoryContextDelegatesAccessors) {
+  envoy::config::listener::v3::FilterChain filter_chain = filter_chain_template_;
+  auto context = filter_chain_manager_->createFilterChainFactoryContext(&filter_chain);
+
+  EXPECT_CALL(parent_context_, direction())
+      .WillOnce(Return(envoy::config::core::v3::TrafficDirection::INBOUND));
+  EXPECT_EQ(context->direction(), envoy::config::core::v3::TrafficDirection::INBOUND);
+
+  EXPECT_CALL(parent_context_, isQuic()).WillOnce(Return(true));
+  EXPECT_TRUE(context->isQuic());
+
+  EXPECT_CALL(parent_context_, shouldBypassOverloadManager()).WillOnce(Return(true));
+  EXPECT_TRUE(context->shouldBypassOverloadManager());
+}
+
 TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {
   envoy::config::listener::v3::FilterChain new_filter_chain1 = filter_chain_template_;
   new_filter_chain1.mutable_filter_chain_match()->add_server_names("example.com");

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -924,6 +924,23 @@ TEST(InjectValidationHeaders, InjectsIfModifiedSince) {
   EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", mod_time));
 }
 
+TEST(InjectValidationHeaders, InjectsIfNoneMatchFromEtag) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  old_response_headers.setInline(CacheCustomHeaders::etag(), "\"strong-etag-value\"");
+  Http::TestRequestHeaderMapImpl request_headers;
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+  EXPECT_THAT(request_headers, ContainsHeader("if-none-match", "\"strong-etag-value\""));
+}
+
+TEST(InjectValidationHeaders, FallsBackToDateWhenLastModifiedMissing) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  constexpr absl::string_view date = "Fri, 01 Aug 2025 09:25:10 GMT";
+  old_response_headers.setDate(date);
+  Http::TestRequestHeaderMapImpl request_headers;
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+  EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", date));
+}
+
 TEST(ShouldUpdateCachedEntry, ComparesEtags) {
   Http::TestResponseHeaderMapImpl old_headers, new_headers;
   old_headers.setStatus(304);


### PR DESCRIPTION
Both directories dropped to 96.5% (below the 96.6% default threshold) due to LLVM 22 toolchain changes. Add tests for untested accessor methods and branches to restore coverage.
