### PR TITLE
dynamic_modules: add set/get_filter_state_typed to listener filter

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-listener-filter-set-filter-state-typed.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-listener-filter-set-filter-state-typed.rst
@@ -1,0 +1,8 @@
+Added the ``envoy_dynamic_module_callback_listener_filter_set_filter_state_typed`` and
+``envoy_dynamic_module_callback_listener_filter_get_filter_state_typed`` ABI callbacks so a
+dynamic-module listener filter can write and read typed filter state, mirroring the existing bytes
+setter/getter. Unlike the bytes variant which stores a raw ``Router::StringAccessor``, the typed
+setter uses the key's registered ``ObjectFactory`` to build a properly typed filter state object,
+so a built-in Envoy filter that reads the key as a typed object can consume it. The Rust SDK
+exposes these as ``EnvoyListenerFilter::set_filter_state_typed`` and
+``EnvoyListenerFilter::get_filter_state_typed``.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -5737,6 +5737,41 @@ bool envoy_dynamic_module_callback_listener_filter_get_filter_state(
     envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* value_out);
 
+/**
+ * envoy_dynamic_module_callback_listener_filter_set_filter_state_typed is called by the module to
+ * set the typed filter state with the given key and Connection life span. Unlike
+ * envoy_dynamic_module_callback_listener_filter_set_filter_state which stores a raw
+ * ``Router::StringAccessor``, this uses the registered ``ObjectFactory`` for the key to create a
+ * properly typed filter state object via ``createFromBytes``, so a built-in Envoy filter that reads
+ * the key as a typed object can consume it.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object.
+ * @param key is the key string owned by the module. This must match a registered ObjectFactory
+ * name.
+ * @param value is the serialized bytes value used to construct the typed object.
+ * @return true if the operation was successful, false if the filter state is not accessible, no
+ * ObjectFactory is registered for the key, or the factory fails to create the object.
+ */
+bool envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value);
+
+/**
+ * envoy_dynamic_module_callback_listener_filter_get_filter_state_typed is called by the module to
+ * get the serialized value of a typed filter state object with the given key. The object must
+ * support ``serializeAsString()`` on the Envoy side.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleListenerFilter object.
+ * @param key is the key string owned by the module.
+ * @param value_out is the output buffer where the value owned by Envoy will be stored. The buffer
+ * is valid until the next call into the module on the same filter.
+ * @return true if the value was found and serialized, false if the key does not exist, the object
+ * does not support serialization, or the filter state is not accessible.
+ */
+bool envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_envoy_buffer* value_out);
+
 // ------------------------- Stream Info Operations -----------------------------
 
 /**

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4793,6 +4793,22 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_get_fil
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_set_filter_state_typed: not "
+               "implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_envoy_buffer*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_listener_filter_get_filter_state_typed: not "
+               "implemented in this context");
+  return false;
+}
+
 // ---------------------- Health Checker callbacks ------------------------
 // These are weak symbols that provide default stub implementations. The actual implementations
 // are provided in the health checker abi_impl.cc when the health checker extension is used.

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -228,6 +228,22 @@ pub trait EnvoyListenerFilter {
   /// Returns None if the value is not found.
   fn get_filter_state_bytes<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
 
+  /// Set a typed filter state value with the given key and connection life span. The value is
+  /// deserialized by a registered `StreamInfo::FilterState::ObjectFactory` on the Envoy side. This
+  /// is useful for setting filter state objects that other Envoy filters expect to read as specific
+  /// C++ types (e.g., `PerConnectionCluster` used by TCP Proxy).
+  ///
+  /// Returns true if the operation is successful. This can fail if no ObjectFactory is registered
+  /// for the key or if deserialization fails.
+  fn set_filter_state_typed(&mut self, key: &[u8], value: &[u8]) -> bool;
+
+  /// Get the serialized value of a typed filter state object with the given key. The object must
+  /// support `serializeAsString()` on the Envoy side.
+  ///
+  /// Returns None if the key does not exist, the object does not support serialization, or the
+  /// filter state is not accessible.
+  fn get_filter_state_typed<'a>(&'a self, key: &[u8]) -> Option<EnvoyBuffer<'a>>;
+
   /// Set the downstream transport failure reason.
   fn set_downstream_transport_failure_reason(&mut self, reason: &str);
 
@@ -939,6 +955,35 @@ impl EnvoyListenerFilter for EnvoyListenerFilterImpl {
     };
     let success = unsafe {
       abi::envoy_dynamic_module_callback_listener_filter_get_filter_state(
+        self.raw,
+        crate::bytes_to_module_buffer(key),
+        &mut result as *mut _ as *mut _,
+      )
+    };
+    if success && !result.ptr.is_null() && result.length > 0 {
+      Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const _, result.length) })
+    } else {
+      None
+    }
+  }
+
+  fn set_filter_state_typed(&mut self, key: &[u8], value: &[u8]) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+        self.raw,
+        crate::bytes_to_module_buffer(key),
+        crate::bytes_to_module_buffer(value),
+      )
+    }
+  }
+
+  fn get_filter_state_typed(&self, key: &[u8]) -> Option<EnvoyBuffer<'_>> {
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
         self.raw,
         crate::bytes_to_module_buffer(key),
         &mut result as *mut _ as *mut _,

--- a/source/extensions/filters/listener/dynamic_modules/BUILD
+++ b/source/extensions/filters/listener/dynamic_modules/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         "//envoy/network:filter_interface",
         "//envoy/network:listen_socket_interface",
         "//envoy/network:listener_filter_buffer_interface",
+        "//envoy/registry",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:logger_lib",
         "//source/common/http:message_lib",

--- a/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/listener/dynamic_modules/abi_impl.cc
@@ -2,6 +2,7 @@
 #include <chrono>
 
 #include "envoy/network/listen_socket.h"
+#include "envoy/registry/registry.h"
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -791,6 +792,78 @@ bool envoy_dynamic_module_callback_listener_filter_get_filter_state(
   absl::string_view value = accessor->asString();
   value_out->ptr = const_cast<char*>(value.data());
   value_out->length = value.size();
+  return true;
+}
+
+bool envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key, envoy_dynamic_module_type_module_buffer value) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+
+  if (callbacks == nullptr || key.ptr == nullptr || value.ptr == nullptr) {
+    return false;
+  }
+
+  absl::string_view key_view(key.ptr, key.length);
+  absl::string_view value_view(value.ptr, value.length);
+
+  auto* factory =
+      Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(key_view);
+  if (factory == nullptr) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "no ObjectFactory registered for filter state key '{}'", key_view);
+    return false;
+  }
+
+  auto object = factory->createFromBytes(value_view);
+  if (object == nullptr) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "ObjectFactory failed to create object for filter state key '{}'",
+                        key_view);
+    return false;
+  }
+
+  callbacks->filterState().setData(key_view, std::move(object),
+                                   StreamInfo::FilterState::LifeSpan::Connection);
+  return true;
+}
+
+bool envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+    envoy_dynamic_module_type_listener_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_envoy_buffer* value_out) {
+  auto* filter = static_cast<DynamicModuleListenerFilter*>(filter_envoy_ptr);
+  auto* callbacks = filter->callbacks();
+
+  if (callbacks == nullptr || key.ptr == nullptr) {
+    value_out->ptr = nullptr;
+    value_out->length = 0;
+    return false;
+  }
+
+  absl::string_view key_view(key.ptr, key.length);
+  const auto* object = callbacks->filterState().getDataReadOnlyGeneric(key_view);
+  if (object == nullptr) {
+    value_out->ptr = nullptr;
+    value_out->length = 0;
+    return false;
+  }
+
+  auto serialized = object->serializeAsString();
+  if (!serialized.has_value()) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), debug,
+                        "filter state object for key '{}' does not support serialization",
+                        key_view);
+    value_out->ptr = nullptr;
+    value_out->length = 0;
+    return false;
+  }
+
+  // Store the serialized string on the filter so it outlives the current event hook.
+  filter->last_serialized_filter_state_ = std::move(serialized.value());
+  value_out->ptr = const_cast<char*>(filter->last_serialized_filter_state_->data());
+  value_out->length = filter->last_serialized_filter_state_->size();
   return true;
 }
 

--- a/source/extensions/filters/listener/dynamic_modules/filter.h
+++ b/source/extensions/filters/listener/dynamic_modules/filter.h
@@ -41,6 +41,10 @@ public:
   Network::ListenerFilterBuffer* currentBuffer() { return current_buffer_; }
   Network::Address::InstanceConstSharedPtr& cachedOriginalDst() { return cached_original_dst_; }
 
+  // Temporary storage for the serialized typed filter state value returned by
+  // get_filter_state_typed. Valid until the next call into the module on the same filter.
+  std::optional<std::string> last_serialized_filter_state_;
+
   // Test-only setters.
   void setCallbacksForTest(Network::ListenerFilterCallbacks* callbacks) { callbacks_ = callbacks; }
   void setCurrentBufferForTest(Network::ListenerFilterBuffer* buffer) { current_buffer_ = buffer; }

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1730,6 +1730,14 @@ WEAK_STUB(ListenerFilterSetFilterState,
 WEAK_STUB(ListenerFilterGetFilterState,
           envoy_dynamic_module_callback_listener_filter_get_filter_state(nullptr, {nullptr, 0},
                                                                          nullptr))
+WEAK_STUB(ListenerFilterSetFilterStateTyped,
+          envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(nullptr,
+                                                                               {nullptr, 0},
+                                                                               {nullptr, 0}))
+WEAK_STUB(ListenerFilterGetFilterStateTyped,
+          envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(nullptr,
+                                                                               {nullptr, 0},
+                                                                               nullptr))
 
 WEAK_STUB(FormatterGetAccessLogType,
           envoy_dynamic_module_callback_formatter_get_access_log_type(nullptr))

--- a/test/extensions/dynamic_modules/listener/BUILD
+++ b/test/extensions/dynamic_modules/listener/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test(
     ],
     rbe_pool = "6gig",
     deps = [
+        "//envoy/registry",
         "//source/common/http:message_lib",
         "//source/common/network:address_lib",
         "//source/common/network:io_socket_error_lib",
@@ -86,10 +87,14 @@ envoy_cc_test(
     env = {"GODEBUG": "cgocheck=0"},
     rbe_pool = "6gig",
     deps = [
+        "//envoy/registry",
+        "//source/common/router:string_accessor_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:abi_impl",
         "//source/extensions/filters/listener/dynamic_modules:config",
+        "//source/extensions/filters/network/direct_response:config",
         "//source/extensions/filters/network/echo:config",
+        "//source/extensions/matching/network/common:inputs_lib",
         "//test/integration:integration_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/listener/dynamic_modules/v3:pkg_cc_proto",

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -2,6 +2,8 @@
 #include <thread>
 #include <vector>
 
+#include "envoy/registry/registry.h"
+
 #include "source/common/http/message_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/io_socket_error_impl.h"
@@ -27,6 +29,23 @@ namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
 namespace ListenerFilters {
+
+// ObjectFactory used by the typed filter-state tests: the module writes through this factory via
+// envoy_dynamic_module_callback_listener_filter_set_filter_state_typed. It returns nullptr for
+// "BAD_VALUE" to exercise the factory-failure branch.
+class ListenerTestTypedObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "envoy.test.listener_set_typed_object"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    if (data == "BAD_VALUE") {
+      return nullptr;
+    }
+    return std::make_unique<Router::StringAccessorImpl>(data);
+  }
+};
+
+REGISTER_FACTORY(ListenerTestTypedObjectFactory, StreamInfo::FilterState::ObjectFactory);
 
 #ifdef SOL_IP
 // Helper action to set sockaddr in arg2 for getSocketOption mocking.
@@ -1612,6 +1631,105 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetFilterStateNullKey) {
   bool found = envoy_dynamic_module_callback_listener_filter_get_filter_state(filterPtr(), key_buf,
                                                                               &result_buf);
   EXPECT_FALSE(found);
+  EXPECT_EQ(0, result_buf.length);
+  EXPECT_EQ(nullptr, result_buf.ptr);
+}
+
+// =============================================================================
+// Tests for set_filter_state_typed / get_filter_state_typed.
+// =============================================================================
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTyped) {
+  std::string key = "envoy.test.listener_set_typed_object";
+  std::string value = "typed_value";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      filterPtr(), key_buf, value_buf));
+
+  // The typed value is readable via the typed getter.
+  envoy_dynamic_module_type_envoy_buffer result_buf = {nullptr, 0};
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+      filterPtr(), key_buf, &result_buf));
+  EXPECT_EQ("typed_value", std::string(result_buf.ptr, result_buf.length));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTypedNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  filter->onAccept(callbacks_);
+  filter->setCallbacksForTest(nullptr);
+
+  std::string key = "envoy.test.listener_set_typed_object";
+  std::string value = "typed_value";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      static_cast<void*>(filter.get()), key_buf, value_buf));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTypedNullKey) {
+  std::string value = "typed_value";
+  envoy_dynamic_module_type_module_buffer key_buf = {nullptr, 8};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      filterPtr(), key_buf, value_buf));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTypedNullValue) {
+  std::string key = "envoy.test.listener_set_typed_object";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {nullptr, 8};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      filterPtr(), key_buf, value_buf));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTypedNoFactory) {
+  std::string key = "nonexistent.factory.key";
+  std::string value = "typed_value";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      filterPtr(), key_buf, value_buf));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, SetFilterStateTypedBadValue) {
+  std::string key = "envoy.test.listener_set_typed_object";
+  std::string value = "BAD_VALUE";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_module_buffer value_buf = {value.data(), value.size()};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_set_filter_state_typed(
+      filterPtr(), key_buf, value_buf));
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetFilterStateTypedNonExisting) {
+  std::string key = "envoy.test.listener_set_typed_object";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_envoy_buffer result_buf = {nullptr, 0};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+      filterPtr(), key_buf, &result_buf));
+  EXPECT_EQ(0, result_buf.length);
+  EXPECT_EQ(nullptr, result_buf.ptr);
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetFilterStateTypedNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
+  filter->onAccept(callbacks_);
+  filter->setCallbacksForTest(nullptr);
+
+  std::string key = "envoy.test.listener_set_typed_object";
+  envoy_dynamic_module_type_module_buffer key_buf = {key.data(), key.size()};
+  envoy_dynamic_module_type_envoy_buffer result_buf = {nullptr, 0};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+      static_cast<void*>(filter.get()), key_buf, &result_buf));
+  EXPECT_EQ(0, result_buf.length);
+  EXPECT_EQ(nullptr, result_buf.ptr);
+}
+
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetFilterStateTypedNullKey) {
+  envoy_dynamic_module_type_module_buffer key_buf = {nullptr, 8};
+  envoy_dynamic_module_type_envoy_buffer result_buf = {nullptr, 0};
+  EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_filter_state_typed(
+      filterPtr(), key_buf, &result_buf));
   EXPECT_EQ(0, result_buf.length);
   EXPECT_EQ(nullptr, result_buf.ptr);
 }

--- a/test/extensions/dynamic_modules/listener/integration_test.cc
+++ b/test/extensions/dynamic_modules/listener/integration_test.cc
@@ -1,12 +1,46 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/extensions/filters/listener/dynamic_modules/v3/dynamic_modules.pb.h"
 #include "envoy/extensions/filters/network/echo/v3/echo.pb.h"
+#include "envoy/registry/registry.h"
+
+#include "source/common/router/string_accessor_impl.h"
 
 #include "test/integration/integration.h"
 #include "test/test_common/environment.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
+
+namespace {
+// ObjectFactory used by the typed filter-state integration test: the dynamic-module listener filter
+// writes through this factory via
+// envoy_dynamic_module_callback_listener_filter_set_filter_state_typed on accept and reads it back
+// on the same connection.
+class ListenerWrittenTypedObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "envoy.test.listener_written_typed_object"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<Router::StringAccessorImpl>(data);
+  }
+};
+
+REGISTER_FACTORY(ListenerWrittenTypedObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
+// ObjectFactory used by the filter-chain selection integration test: the listener filter writes the
+// selection value through this factory, and the filter chain matcher reads it back as a string via
+// envoy.matching.inputs.filter_state to pick a filter chain.
+class FilterChainSelectorObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "envoy.test.filter_chain_selector"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    return std::make_unique<Router::StringAccessorImpl>(data);
+  }
+};
+
+REGISTER_FACTORY(FilterChainSelectorObjectFactory, StreamInfo::FilterState::ObjectFactory);
+} // namespace
 
 class DynamicModulesListenerSdkIntegrationTest : public testing::TestWithParam<std::string>,
                                                  public BaseIntegrationTest {
@@ -120,6 +154,116 @@ TEST_P(DynamicModulesListenerSdkIntegrationTest, DynamicMetadataBatch) {
   ASSERT_TRUE(tcp_client->write("ping"));
   tcp_client->waitForData("ping");
   tcp_client->close();
+}
+
+TEST_P(DynamicModulesListenerSdkIntegrationTest, FilterStateTyped) {
+  if (GetParam() != "rust") {
+    GTEST_SKIP() << "the filter_state_typed filter is only in the rust test module";
+  }
+  initializeFilter("filter_state_typed");
+
+  // The filter writes a typed filter state through the harness-registered ObjectFactory and reads
+  // it back on accept, asserting in the module. A failure there stops the chain and the echo
+  // upstream never returns the payload.
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  ASSERT_TRUE(tcp_client->write("ping"));
+  tcp_client->waitForData("ping");
+  tcp_client->close();
+}
+
+// Proves a filter chain matcher selects a filter chain from filter state that a dynamic-module
+// listener filter set. The listener filter writes a per-connection selection value into typed
+// filter state on accept; the matcher then reads it back via envoy.matching.inputs.filter_state and
+// routes the connection to one of two otherwise-identical direct_response chains. The distinct
+// direct_response payloads prove which chain the matcher chose, i.e. that a succeeding chain
+// consumed the listener-filter-set filter state.
+class DynamicModulesListenerFilterChainSelectionIntegrationTest : public BaseIntegrationTest,
+                                                                  public testing::Test {
+public:
+  DynamicModulesListenerFilterChainSelectionIntegrationTest()
+      : BaseIntegrationTest(Network::Address::IpVersion::v4, ConfigHelper::baseConfig() + R"EOF(
+    filter_chain_matcher:
+      matcher_tree:
+        input:
+          name: filter_state
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.FilterStateInput
+            key: envoy.test.filter_chain_selector
+        exact_match_map:
+          map:
+            "chain_a":
+              action:
+                name: filter-chain-name
+                typed_config:
+                  "@type": type.googleapis.com/google.protobuf.StringValue
+                  value: chain_a
+            "chain_b":
+              action:
+                name: filter-chain-name
+                typed_config:
+                  "@type": type.googleapis.com/google.protobuf.StringValue
+                  value: chain_b
+    filter_chains:
+    - name: chain_a
+      filters:
+      - name: envoy.filters.network.direct_response
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.direct_response.v3.Config
+          response:
+            inline_string: "served_by_chain_a"
+    - name: chain_b
+      filters:
+      - name: envoy.filters.network.direct_response
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.direct_response.v3.Config
+          response:
+            inline_string: "served_by_chain_b"
+)EOF") {}
+
+protected:
+  // Initializes the listener filter with a fixed selection value, mimicking a deterministic
+  // per-endpoint routing decision made inside the filter.
+  void initializeWithSelection(const std::string& selection) {
+    TestEnvironment::setEnvVar(
+        "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+        TestEnvironment::substitute(
+            "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/rust"),
+        1);
+
+    config_helper_.addConfigModifier([selection](
+                                         envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* listener = bootstrap.mutable_static_resources()->mutable_listeners(0);
+      auto* filter = listener->add_listener_filters();
+      filter->set_name("envoy.filters.listener.dynamic_modules");
+
+      envoy::extensions::filters::listener::dynamic_modules::v3::DynamicModuleListenerFilter
+          dynamic_module_config;
+      dynamic_module_config.mutable_dynamic_module_config()->set_name("listener_integration_test");
+      dynamic_module_config.set_filter_name("filter_chain_selector");
+      Protobuf::StringValue selection_config;
+      selection_config.set_value(selection);
+      std::ignore = dynamic_module_config.mutable_filter_config()->PackFrom(selection_config);
+      std::ignore = filter->mutable_typed_config()->PackFrom(dynamic_module_config);
+    });
+
+    BaseIntegrationTest::initialize();
+  }
+};
+
+TEST_F(DynamicModulesListenerFilterChainSelectionIntegrationTest, SelectsChainA) {
+  initializeWithSelection("chain_a");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  tcp_client->waitForData("served_by_chain_a");
+  tcp_client->waitForDisconnect();
+}
+
+TEST_F(DynamicModulesListenerFilterChainSelectionIntegrationTest, SelectsChainB) {
+  initializeWithSelection("chain_b");
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  tcp_client->waitForData("served_by_chain_b");
+  tcp_client->waitForDisconnect();
 }
 
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs
@@ -12,7 +12,7 @@ fn init() -> bool {
 fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListenerFilter>(
   _envoy_filter_config: &mut EC,
   name: &str,
-  _config: &[u8],
+  config: &[u8],
 ) -> Option<Box<dyn ListenerFilterConfig<ELF>>> {
   match name {
     "write_to_socket" => Some(Box::new(WriteToSocketFilterConfig)),
@@ -20,6 +20,10 @@ fn new_listener_filter_config_fn<EC: EnvoyListenerFilterConfig, ELF: EnvoyListen
     "http_callout_on_accept" => Some(Box::new(HttpCalloutOnAcceptFilterConfig)),
     "dynamic_metadata" => Some(Box::new(DynamicMetadataFilterConfig)),
     "read_attributes" => Some(Box::new(ReadAttributesFilterConfig)),
+    "filter_state_typed" => Some(Box::new(FilterStateTypedFilterConfig)),
+    "filter_chain_selector" => Some(Box::new(FilterChainSelectorFilterConfig {
+      selection: config.to_vec(),
+    })),
     _ => panic!("unknown filter name: {name}"),
   }
 }
@@ -242,6 +246,86 @@ impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for ReadAttributesFilter {
     assert!(envoy_filter
       .get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::DestinationAddress)
       .is_some());
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+}
+
+// =============================================================================
+// Typed Filter State Test Filter
+// =============================================================================
+
+// Writes a typed filter state on accept via set_filter_state_typed, using a key backed by an
+// ObjectFactory the C++ test harness registers, then reads it back with get_filter_state_typed to
+// prove the typed write/read round trips through the ABI. A failed assertion stops the chain and
+// the echo upstream never returns the payload.
+struct FilterStateTypedFilterConfig;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for FilterStateTypedFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(FilterStateTypedFilter)
+  }
+}
+
+struct FilterStateTypedFilter;
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for FilterStateTypedFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    const TYPED_KEY: &[u8] = b"envoy.test.listener_written_typed_object";
+    const TYPED_VALUE: &[u8] = b"typed_value";
+
+    // Writing without a registered ObjectFactory fails.
+    assert!(!envoy_filter.set_filter_state_typed(b"nonexistent.factory.key", TYPED_VALUE));
+
+    // Writing through the registered factory succeeds and round trips via the typed getter.
+    assert!(envoy_filter.set_filter_state_typed(TYPED_KEY, TYPED_VALUE));
+    assert_eq!(
+      envoy_filter
+        .get_filter_state_typed(TYPED_KEY)
+        .map(|value| value.as_slice().to_vec()),
+      Some(TYPED_VALUE.to_vec())
+    );
+
+    abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
+  }
+}
+
+// =============================================================================
+// Filter Chain Selector Test Filter
+// =============================================================================
+
+// Writes a per-connection selection value into typed filter state on accept, so a filter chain
+// matcher running after the listener filters can pick a filter chain from it via
+// envoy.matching.inputs.filter_state. The value is taken verbatim from the filter's config, letting
+// a caller steer a connection to a different chain without changing the module. This is the pattern
+// used to gate traffic between two otherwise-identical chains from a listener filter.
+struct FilterChainSelectorFilterConfig {
+  selection: Vec<u8>,
+}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilterConfig<ELF> for FilterChainSelectorFilterConfig {
+  fn new_listener_filter(&self, _envoy: &mut ELF) -> Box<dyn ListenerFilter<ELF>> {
+    Box::new(FilterChainSelectorFilter {
+      selection: self.selection.clone(),
+    })
+  }
+}
+
+// Key backed by an ObjectFactory the C++ test harness registers. The matcher reads the same key.
+const SELECTOR_KEY: &[u8] = b"envoy.test.filter_chain_selector";
+
+struct FilterChainSelectorFilter {
+  selection: Vec<u8>,
+}
+
+impl<ELF: EnvoyListenerFilter> ListenerFilter<ELF> for FilterChainSelectorFilter {
+  fn on_accept(
+    &mut self,
+    envoy_filter: &mut ELF,
+  ) -> abi::envoy_dynamic_module_type_on_listener_filter_status {
+    assert!(envoy_filter.set_filter_state_typed(SELECTOR_KEY, &self.selection));
     abi::envoy_dynamic_module_type_on_listener_filter_status::Continue
   }
 }


### PR DESCRIPTION
Commit Message: dynamic_modules: add set/get_filter_state_typed to listener filter
Additional Description:
Listener filters written as dynamic modules could set filter state only as raw bytes (a `StringAccessor` keyed by the module). That value is readable by the same module, but a *later* consumer, e.g. a `filter_chain_matcher` reading `envoy.matching.inputs.filter_state` needs the object to have been created by the key's registered `ObjectFactory` so it deserializes as the expected type.

This adds typed filter-state get/set to the listener filter ABI and Rust SDK. The value is stored as a properly typed object with connection lifespan, so a later filter chain can read it back as its expected type.

```
    listener filter (dynamic module)     filter_chain_matcher
      writes a per-connection value  ───────────► selects a filter chain
```

This lets a listener filter record a per-connection decision that a succeeding filter chain selects on. This behavior
is also covered by the [added integration test](test/extensions/dynamic_modules/test_data/rust/listener_integration_test.rs).

Risk Level: Low
Testing: Integration Tests Added
Docs Changes: ChangeLog Added
Release Notes: N.A
Platform Specific Features: N.A

