### PR TITLE
oauth2: make it exception free

### DIFF
--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -127,8 +127,11 @@ createFilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Con
   auto secret_reader = std::make_shared<SDSSecretReader>(
       std::move(secret_provider_client_secret), std::move(secret_provider_hmac_secret),
       server_context.threadLocal(), server_context.api());
-  return std::make_shared<FilterConfig>(proto_config, server_context, secret_reader, scope,
-                                        stats_prefix);
+  absl::Status creation_status = absl::OkStatus();
+  auto filter_config = std::make_shared<FilterConfig>(proto_config, server_context, secret_reader,
+                                                      scope, stats_prefix, creation_status);
+  RETURN_IF_NOT_OK_REF(creation_status);
+  return filter_config;
 }
 } // namespace
 

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -650,24 +650,15 @@ FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::oauth2::v3::OAuth2Config& proto_config,
     Server::Configuration::CommonFactoryContext& context,
     std::shared_ptr<SecretReader> secret_reader, Stats::Scope& scope,
-    const std::string& stats_prefix)
+    const std::string& stats_prefix, absl::Status& creation_status)
     : oauth_token_endpoint_(proto_config.token_endpoint()),
       authorization_endpoint_(proto_config.authorization_endpoint()),
       end_session_endpoint_(proto_config.end_session_endpoint()),
-      post_logout_redirect_uri_formatter_(
-          (proto_config.post_logout_redirect_uri().uri().empty() ||
-           proto_config.end_session_endpoint().empty())
-              ? nullptr
-              : THROW_OR_RETURN_VALUE(
-                    Formatter::FormatterImpl::create(proto_config.post_logout_redirect_uri().uri()),
-                    Formatter::FormatterPtr)),
       disable_post_logout_redirect_uri_(proto_config.post_logout_redirect_uri().disabled()),
       authorization_query_params_(buildAutorizationQueryParams(proto_config)),
       client_id_(proto_config.credentials().client_id()),
-      redirect_uri_(proto_config.redirect_uri()),
       allowed_redirect_domains_(proto_config.allowed_redirect_domains().begin(),
                                 proto_config.allowed_redirect_domains().end()),
-      original_request_uri_(proto_config.original_request_uri()),
       redirect_matcher_(proto_config.redirect_path_matcher(), context),
       signout_path_(proto_config.signout_path(), context), secret_reader_(secret_reader),
       stats_(FilterConfig::generateStats(stats_prefix, proto_config.stat_prefix(), scope)),
@@ -737,6 +728,28 @@ FilterConfig::FilterConfig(
            proto_config.cookie_configs().has_code_verifier_cookie_config())
               ? CookieSettings(proto_config.cookie_configs().code_verifier_cookie_config())
               : CookieSettings()) {
+
+  {
+    // Create the redirect URI formatter unconditionally.
+    auto formatter_or_error = Formatter::FormatterImpl::create(proto_config.redirect_uri());
+    SET_AND_RETURN_IF_NOT_OK(formatter_or_error.status(), creation_status);
+    redirect_uri_formatter_ = std::move(formatter_or_error.value());
+  }
+
+  if (!proto_config.end_session_endpoint().empty()) {
+    if (!proto_config.post_logout_redirect_uri().uri().empty()) {
+      auto formatter_or_error =
+          Formatter::FormatterImpl::create(proto_config.post_logout_redirect_uri().uri());
+      SET_AND_RETURN_IF_NOT_OK(formatter_or_error.status(), creation_status);
+      post_logout_redirect_uri_formatter_ = std::move(formatter_or_error.value());
+    }
+  }
+  if (!proto_config.original_request_uri().empty()) {
+    auto formatter_or_error = Formatter::FormatterImpl::create(proto_config.original_request_uri());
+    SET_AND_RETURN_IF_NOT_OK(formatter_or_error.status(), creation_status);
+    original_request_uri_formatter_ = std::move(formatter_or_error.value());
+  }
+
   if (!context.clusterManager().hasCluster(oauth_token_endpoint_.cluster())) {
     // This is not necessarily a configuration error — sometimes cluster is sent later than the
     // listener in the xDS stream.
@@ -745,9 +758,10 @@ FilterConfig::FilterConfig(
   }
   if (!authorization_endpoint_url_.initialize(authorization_endpoint_,
                                               /*is_connect_request=*/false)) {
-    throw EnvoyException(
+    creation_status = absl::InvalidArgumentError(
         fmt::format("OAuth2 filter: invalid authorization endpoint URL '{}' in config.",
                     authorization_endpoint_));
+    return;
   }
   if (!end_session_endpoint_.empty()) {
     bool is_oidc = false;
@@ -758,8 +772,9 @@ FilterConfig::FilterConfig(
       }
     }
     if (!is_oidc) {
-      throw EnvoyException(
+      creation_status = absl::InvalidArgumentError(
           "OAuth2 filter: end session endpoint is only supported for OpenID Connect.");
+      return;
     }
   }
 
@@ -770,7 +785,7 @@ FilterConfig::FilterConfig(
     // been validated during the config load.
     auto parsed_policy_or_error = Router::RetryPolicyImpl::create(
         retry_policy, ProtobufMessage::getNullValidationVisitor(), context);
-    THROW_IF_NOT_OK_REF(parsed_policy_or_error.status());
+    SET_AND_RETURN_IF_NOT_OK(parsed_policy_or_error.status(), creation_status);
     retry_policy_ = std::move(parsed_policy_or_error.value());
   }
 }
@@ -1055,9 +1070,8 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
 
   original_request_url_ = result.original_request_url_;
   auth_code_ = result.auth_code_;
-  Formatter::FormatterPtr formatter = THROW_OR_RETURN_VALUE(
-      Formatter::FormatterImpl::create(config_->redirectUri()), Formatter::FormatterPtr);
-  const auto redirect_uri = formatter->format({&headers}, decoder_callbacks_->streamInfo());
+  const auto redirect_uri =
+      config_->redirectUri().format({&headers}, decoder_callbacks_->streamInfo());
 
   std::optional<std::string> encrypted_code_verifier =
       readCookieValueWithSuffix(headers, config_->cookieNames().code_verifier_, result.flow_id_);
@@ -1245,10 +1259,8 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
 
   auto base_path = absl::StrCat(scheme, "://", host_);
 
-  if (!config_->originalRequestUri().empty()) {
-    Formatter::FormatterPtr base_path_formatter = THROW_OR_RETURN_VALUE(
-        Formatter::FormatterImpl::create(config_->originalRequestUri()), Formatter::FormatterPtr);
-    base_path = base_path_formatter->format({&headers}, decoder_callbacks_->streamInfo());
+  if (config_->originalRequestUri() != nullptr) {
+    base_path = config_->originalRequestUri()->format({&headers}, decoder_callbacks_->streamInfo());
   }
 
   if (!isHostAllowedDomain(base_path, config_->allowedRedirectDomains())) {
@@ -1290,11 +1302,9 @@ void OAuth2Filter::redirectToOAuthServer(Http::RequestHeaderMap& headers) {
   auto query_params = config_->authorizationQueryParams();
   query_params.overwrite(queryParamsState, state);
 
-  // Format redirect_uri — needed for the query param sent to the identity provider
-  Formatter::FormatterPtr redirect_uri_formatter = THROW_OR_RETURN_VALUE(
-      Formatter::FormatterImpl::create(config_->redirectUri()), Formatter::FormatterPtr);
+  // Format redirect_uri — needed for the query param sent to the identity provider.
   const auto redirect_uri =
-      redirect_uri_formatter->format({&headers}, decoder_callbacks_->streamInfo());
+      config_->redirectUri().format({&headers}, decoder_callbacks_->streamInfo());
   if (!isHostAllowedDomain(redirect_uri, config_->allowedRedirectDomains())) {
     sendUnauthorizedResponse(
         fmt::format("redirect_uri failed domain allow-list validation: {}", redirect_uri));
@@ -1409,11 +1419,11 @@ Http::FilterHeadersStatus OAuth2Filter::signOutUser(const Http::RequestHeaderMap
 
     if (!config_->disablePostLogoutRedirectUri()) {
       std::string redirect_uri;
-      if (config_->postLogoutRedirectUriFormatter() == nullptr) {
+      if (config_->postLogoutRedirectUri() == nullptr) {
         redirect_uri = default_post_logout_redirect_url;
       } else {
-        redirect_uri = config_->postLogoutRedirectUriFormatter()->format(
-            {&headers}, decoder_callbacks_->streamInfo());
+        redirect_uri =
+            config_->postLogoutRedirectUri()->format({&headers}, decoder_callbacks_->streamInfo());
       }
       absl::StrAppend(&oidc_logout_url,
                       fmt::format(OIDCLogoutUrlPostLogoutRedirectFormatString,

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -155,7 +155,7 @@ public:
   FilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Config& proto_config,
                Server::Configuration::CommonFactoryContext& context,
                std::shared_ptr<SecretReader> secret_reader, Stats::Scope& scope,
-               const std::string& stats_prefix);
+               const std::string& stats_prefix, absl::Status& creation_status);
   const std::string& clusterName() const { return oauth_token_endpoint_.cluster(); }
   const std::string& clientId() const { return client_id_; }
   bool forwardBearerToken() const { return forward_bearer_token_; }
@@ -181,18 +181,20 @@ public:
   const HttpUri& oauthTokenEndpoint() const { return oauth_token_endpoint_; }
   const Http::Utility::Url& authorizationEndpointUrl() const { return authorization_endpoint_url_; }
   const std::string& endSessionEndpoint() const { return end_session_endpoint_; }
-  const Formatter::Formatter* postLogoutRedirectUriFormatter() const {
+  const Formatter::Formatter* postLogoutRedirectUri() const {
     return post_logout_redirect_uri_formatter_.get();
   }
   bool disablePostLogoutRedirectUri() const { return disable_post_logout_redirect_uri_; }
   const Http::Utility::QueryParamsMulti& authorizationQueryParams() const {
     return authorization_query_params_;
   }
-  const std::string& redirectUri() const { return redirect_uri_; }
+  const Formatter::Formatter& redirectUri() const { return *redirect_uri_formatter_; }
   const std::vector<std::string>& allowedRedirectDomains() const {
     return allowed_redirect_domains_;
   }
-  const std::string& originalRequestUri() const { return original_request_uri_; }
+  const Formatter::Formatter* originalRequestUri() const {
+    return original_request_uri_formatter_.get();
+  }
   const Matchers::PathMatcher& redirectPathMatcher() const { return redirect_matcher_; }
   const Matchers::PathMatcher& signoutPath() const { return signout_path_; }
   std::string clientSecret() const { return secret_reader_->clientSecret(); }
@@ -271,9 +273,9 @@ private:
   const bool disable_post_logout_redirect_uri_ : 1;
   const Http::Utility::QueryParamsMulti authorization_query_params_;
   const std::string client_id_;
-  const std::string redirect_uri_;
+  Formatter::FormatterPtr redirect_uri_formatter_;
+  Formatter::FormatterPtr original_request_uri_formatter_;
   const std::vector<std::string> allowed_redirect_domains_;
-  const std::string original_request_uri_;
   const Matchers::PathMatcher redirect_matcher_;
   const Matchers::PathMatcher signout_path_;
   std::shared_ptr<SecretReader> secret_reader_;

--- a/test/extensions/filters/http/oauth2/BUILD
+++ b/test/extensions/filters/http/oauth2/BUILD
@@ -25,6 +25,9 @@ envoy_extension_cc_test(
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
+        # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
+        # so it needs the built-in HTTP command parsers registered.
+        "//source/common/formatter:http_speicific_formatter_extension_lib",
     ],
 )
 
@@ -39,6 +42,9 @@ envoy_extension_cc_test(
         "//test/mocks/server:factory_context_mocks",
         "//test/test_common:status_utility_lib",
         "@envoy_api//envoy/extensions/filters/http/oauth2/v3:pkg_cc_proto",
+        # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
+        # so it needs the built-in HTTP command parsers registered.
+        "//source/common/formatter:http_speicific_formatter_extension_lib",
     ],
 )
 
@@ -56,6 +62,9 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
         "//test/integration:integration_lib",
         "//test/mocks/server:factory_context_mocks",
+        # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
+        # so it needs the built-in HTTP command parsers registered.
+        "//source/common/formatter:http_speicific_formatter_extension_lib",
     ],
 )
 
@@ -77,6 +86,9 @@ envoy_extension_cc_test(
         "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/extensions/filters/http/oauth2/v3:pkg_cc_proto",
+        # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
+        # so it needs the built-in HTTP command parsers registered.
+        "//source/common/formatter:http_speicific_formatter_extension_lib",
     ],
 )
 
@@ -90,5 +102,8 @@ envoy_extension_cc_test(
         "//test/integration:http_integration_lib",
         "//test/mocks/server:server_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        # The filter builds %REQ%/%RESP%-style formatters (e.g. redirect_uri) at config load time,
+        # so it needs the built-in HTTP command parsers registered.
+        "//source/common/formatter:http_speicific_formatter_extension_lib",
     ],
 )

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -1017,9 +1017,10 @@ TEST(ConfigTest, EndSessionEndpointWithoutOpenId) {
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value(), EnvoyException,
-      "OAuth2 filter: end session endpoint is only supported for OpenID Connect.");
+  const auto result = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_THAT(result,
+              HasStatusMessage(
+                  "OAuth2 filter: end session endpoint is only supported for OpenID Connect."));
 }
 
 TEST(ConfigTest, ValidCookieDomainAndPath) {

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -354,10 +354,23 @@ public:
 
     // Create filter config.
     auto secret_reader = std::make_shared<MockSecretReader>();
-    FilterConfigSharedPtr c = std::make_shared<FilterConfig>(
-        p, factory_context_.server_factory_context_, secret_reader, scope_, "test.");
+    FilterConfigSharedPtr c = makeFilterConfig(p, secret_reader).value();
 
     return c;
+  }
+
+  // Builds a FilterConfig from `p`. Config-creation errors are returned via the StatusOr; callers
+  // that expect success use `.value()`, while tests asserting on failures use EXPECT_THAT.
+  absl::StatusOr<FilterConfigSharedPtr>
+  makeFilterConfig(const envoy::extensions::filters::http::oauth2::v3::OAuth2Config& p,
+                   std::shared_ptr<SecretReader> secret_reader) {
+    absl::Status creation_status = absl::OkStatus();
+    auto config = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
+                                                 secret_reader, scope_, "test.", creation_status);
+    if (!creation_status.ok()) {
+      return creation_status;
+    }
+    return config;
   }
 
   // Builds a minimal valid config that forwards the ID token on the given header. When
@@ -397,8 +410,7 @@ public:
     MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
 
     auto secret_reader = std::make_shared<MockSecretReader>();
-    return std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                          secret_reader, scope_, "test.");
+    return makeFilterConfig(p, secret_reader).value();
   }
 
   // Test helpers exposing private OAuth2Filter methods. OAuth2Filter declares
@@ -528,8 +540,7 @@ public:
     MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
 
     auto secret_reader = std::make_shared<MockSecretReader>();
-    return std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                          secret_reader, scope_, "test.");
+    return makeFilterConfig(p, secret_reader).value();
   }
 };
 
@@ -634,8 +645,7 @@ TEST_F(OAuth2Test, SecretsNotReadyReturnsServiceUnavailable) {
   credentials->mutable_hmac_secret()->set_name("hmac");
 
   MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
-  init(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_, secret_reader,
-                                      scope_, "test."));
+  init(makeFilterConfig(p, secret_reader).value());
 
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
@@ -675,8 +685,7 @@ TEST_F(OAuth2Test, TlsClientAuthDoesNotRequireClientSecret) {
   credentials->mutable_hmac_secret()->set_name("hmac");
 
   MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
-  init(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_, secret_reader,
-                                      scope_, "test."));
+  init(makeFilterConfig(p, secret_reader).value());
 
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
@@ -708,10 +717,9 @@ TEST_F(OAuth2Test, InvalidAuthorizationEndpoint) {
 
   // Attempt to create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
-  EXPECT_THROW_WITH_MESSAGE(
-      std::ignore = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                   secret_reader, scope_, "test."),
-      EnvoyException, "OAuth2 filter: invalid authorization endpoint URL 'INVALID_URL' in config.");
+  EXPECT_THAT(makeFilterConfig(p, secret_reader),
+              StatusHelpers::HasStatusMessage(
+                  "OAuth2 filter: invalid authorization endpoint URL 'INVALID_URL' in config."));
 }
 
 // Verifies that the OAuth config is created with a default value for auth_scopes field when it is
@@ -742,8 +750,7 @@ TEST_F(OAuth2Test, DefaultAuthScope) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
 
   // resource is optional
   EXPECT_EQ(test_config_->encodedResourceQueryParams(), "");
@@ -836,8 +843,7 @@ TEST_F(OAuth2Test, CustomCsrfTokenExpiresIn) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
 
   init(test_config_);
   Http::TestRequestHeaderMapImpl request_headers{
@@ -908,8 +914,7 @@ TEST_F(OAuth2Test, CustomCodeVerifierTokenExpiresIn) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
 
   init(test_config_);
   Http::TestRequestHeaderMapImpl request_headers{
@@ -973,8 +978,7 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpoint) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
@@ -1036,8 +1040,7 @@ TEST_F(OAuth2Test, PreservesQueryParametersInAuthorizationEndpointWithUrlEncodin
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
   Http::TestRequestHeaderMapImpl request_headers{
       {Http::Headers::get().Path.get(), "/original_path?var1=1&var2=2"},
@@ -1152,8 +1155,7 @@ TEST_F(OAuth2Test, RequestSignoutWhenEndSessionEndpointIsConfigured) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
 
   Http::TestRequestHeaderMapImpl request_headers{
@@ -1215,8 +1217,7 @@ TEST_F(OAuth2Test, RequestSignoutWithCustomPostLogoutRedirectUri) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
 
   Http::TestRequestHeaderMapImpl request_headers{
@@ -1277,8 +1278,7 @@ TEST_F(OAuth2Test, RequestSignoutWithFormattedPostLogoutRedirectUri) {
 
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
 
   Http::TestRequestHeaderMapImpl request_headers{
@@ -1340,8 +1340,7 @@ TEST_F(OAuth2Test, RequestSignoutWithDisabledPostLogoutRedirectUri) {
   // Create the OAuth config.
   auto secret_reader = std::make_shared<MockSecretReader>();
   FilterConfigSharedPtr test_config_;
-  test_config_ = std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_,
-                                                secret_reader, scope_, "test.");
+  test_config_ = makeFilterConfig(p, secret_reader).value();
   init(test_config_);
 
   Http::TestRequestHeaderMapImpl request_headers{
@@ -1403,15 +1402,12 @@ TEST_F(OAuth2Test, InvalidPostLogoutRedirectUriValidatedOnlyWhenUsed) {
   auto secret_reader = std::make_shared<MockSecretReader>();
 
   // End_session_endpoint is not defined: the invalid formatter is never compiled,
-  // so the config loads without throwing.
-  EXPECT_NO_THROW(std::ignore = std::make_shared<FilterConfig>(
-                      p, factory_context_.server_factory_context_, secret_reader, scope_, "test."));
+  // so the config loads successfully.
+  EXPECT_THAT(makeFilterConfig(p, secret_reader), StatusHelpers::IsOk());
 
   // End_session_endpoint is set: the invalid formatter is compiled and the config fails to load.
   p.set_end_session_endpoint("https://auth.example.com/oauth/logout");
-  EXPECT_THROW(std::ignore = std::make_shared<FilterConfig>(
-                   p, factory_context_.server_factory_context_, secret_reader, scope_, "test."),
-               EnvoyException);
+  EXPECT_THAT(makeFilterConfig(p, secret_reader), ::testing::Not(StatusHelpers::IsOk()));
 }
 
 /**
@@ -1863,8 +1859,7 @@ TEST_F(OAuth2Test, SetBearerTokenWithPrivateKeyJwt) {
   MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
 
   auto secret_reader = std::make_shared<PEMSecretReader>();
-  FilterConfigSharedPtr config = std::make_shared<FilterConfig>(
-      p, factory_context_.server_factory_context_, secret_reader, scope_, "test.");
+  FilterConfigSharedPtr config = makeFilterConfig(p, secret_reader).value();
   init(config);
 
   test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
@@ -1945,8 +1940,7 @@ TEST_F(OAuth2Test, RefreshTokenWithPrivateKeyJwt) {
   MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
 
   auto secret_reader = std::make_shared<PEMSecretReader>();
-  FilterConfigSharedPtr config = std::make_shared<FilterConfig>(
-      p, factory_context_.server_factory_context_, secret_reader, scope_, "test.");
+  FilterConfigSharedPtr config = makeFilterConfig(p, secret_reader).value();
   init(config);
 
   test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
@@ -5574,8 +5568,7 @@ TEST_F(OAuth2Test, RouteSpecificConfigOverridesGlobalConfig) {
   credentials->mutable_hmac_secret()->set_name("hmac");
 
   auto secret_reader = std::make_shared<MockSecretReader>();
-  auto route_config = std::make_shared<FilterConfig>(
-      route_proto, factory_context_.server_factory_context_, secret_reader, scope_, "test.");
+  auto route_config = makeFilterConfig(route_proto, secret_reader).value();
 
   ON_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
       .WillByDefault(Return(route_config.get()));
@@ -5677,8 +5670,7 @@ TEST_F(OAuth2Test, SecureAttributeAddedForSecureCookiePrefixesOnSignout) {
   auto run_test_with_prefix = [&](absl::string_view prefix, bool expect_secure) {
     auto p = make_config(prefix);
     auto secret_reader = std::make_shared<MockSecretReader>();
-    init(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_, secret_reader,
-                                        scope_, "test."));
+    init(makeFilterConfig(p, secret_reader).value());
 
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, true))
         .WillOnce(Invoke([&](Http::ResponseHeaderMap& passed_headers, bool) {
@@ -6337,8 +6329,7 @@ TEST_F(OAuth2Test, AllowFailedBlockedForCallbackPath) {
   credentials->mutable_hmac_secret()->set_name("hmac");
   MessageUtil::validate(p, ProtobufMessage::getStrictValidationVisitor());
   auto secret_reader = std::make_shared<MockSecretReader>();
-  init(std::make_shared<FilterConfig>(p, factory_context_.server_factory_context_, secret_reader,
-                                      scope_, "test."));
+  init(makeFilterConfig(p, secret_reader).value());
 
   // Make a callback request — asyncGetAccessToken is called and returns Idle (async pending).
   Http::TestRequestHeaderMapImpl request_headers{


### PR DESCRIPTION
Commit Message: oauth2: make it exception free

Additional Description:
Removes `throw`-based error handling from the OAuth2 filter config loading
path, following the broader effort to make Envoy config loading exception
free.

- `FilterConfig`'s constructor now takes an `absl::Status& creation_status`
  and reports configuration errors (invalid authorization endpoint URL,
  `end_session_endpoint` used without OpenID Connect, invalid retry policy)
  through it instead of throwing `EnvoyException`. The factory in `config.cc`
  propagates the status via `RETURN_IF_NOT_OK_REF`.
- The `redirect_uri`, `post_logout_redirect_uri` and `original_request_uri`
  substitution formatters are now compiled once at config load time and
  stored on the config, rather than being rebuilt (and potentially throwing)
  on every request in `decodeHeaders()` / `redirectToOAuthServer()` /
  `signOutUser()`. This both removes the per-request `THROW_OR_RETURN_VALUE`
  calls and moves formatter validation to load time. Formatter compilation
  errors are surfaced through `creation_status`.
- As before, the `post_logout_redirect_uri` formatter is only compiled when
  `end_session_endpoint` is set, preserving the existing behavior where an
  invalid post-logout redirect URI is only validated when it can actually be
  used.

There is no behavioral change for valid configs. Tests are updated to build
the config through a helper that returns `absl::StatusOr<FilterConfigSharedPtr>`
and to assert on status rather than thrown exceptions. The test targets gain
a dependency on the HTTP-specific formatter extension lib because formatters
(e.g. `redirect_uri`) are now built at config load time and the built-in
`%REQ%`/`%RESP%` command parsers must be registered.

Generative AI was used to help with this change. I have reviewed all changes.

Risk Level: Low (error-handling refactor, no behavioral change for valid configs)
Testing: Unit tests (oauth2 config_test and filter_test) updated and passing.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
