### PR TITLE
[release/v1.38] http: add connection-duration jitter and drain-timeout jitter to stagger downstream reconnections (backport of #45101)

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -284,7 +284,7 @@ message AlternateProtocolsCacheOptions {
   repeated string canonical_suffixes = 5;
 }
 
-// [#next-free-field: 8]
+// [#next-free-field: 9]
 message HttpProtocolOptions {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.api.v2.core.HttpProtocolOptions";
@@ -337,6 +337,22 @@ message HttpProtocolOptions {
   // if there are no active streams. See :ref:`drain_timeout
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout>`.
   google.protobuf.Duration max_connection_duration = 3;
+
+  // Percentage-based jitter for ``max_connection_duration``. If set, the actual connection duration
+  // limit is extended by a random duration up to ``max_connection_duration * jitter / 100``.
+  // This staggers connection teardowns across time and prevents a thundering-herd of reconnects
+  // when many connections are established at roughly the same time.
+  // This field is ignored if ``max_connection_duration`` is not set. If not set, no jitter is added.
+  //
+  // .. note::
+  //   This field is currently only honored for downstream connections by the HTTP connection
+  //   manager. It is not yet supported for upstream cluster connections.
+  //
+  // This is analogous to
+  // :ref:`max_downstream_connection_duration_jitter_percentage
+  // <envoy_v3_api_field_extensions.filters.network.tcp_proxy.v3.TcpProxy.max_downstream_connection_duration_jitter_percentage>`
+  // in the TCP proxy filter.
+  type.v3.Percent max_connection_duration_jitter = 8;
 
   // The maximum number of headers (request headers if configured on HttpConnectionManager,
   // response headers when configured on a cluster).

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -39,7 +39,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 // [#extension: envoy.filters.network.http_connection_manager]
 
-// [#next-free-field: 62]
+// [#next-free-field: 63]
 message HttpConnectionManager {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager";
@@ -663,6 +663,18 @@ message HttpConnectionManager {
   // is reached, or during general server draining. The default grace period is
   // 5000 milliseconds (5 seconds) if this option is not specified.
   google.protobuf.Duration drain_timeout = 12;
+
+  // Percentage-based jitter for ``drain_timeout``. If set, the actual drain grace period
+  // is extended by a random duration up to ``drain_timeout * jitter / 100`` per connection.
+  // This staggers the final GOAWAY (and connection close) across time so that connections
+  // entering the drain state simultaneously do not all complete draining at the same instant,
+  // mitigating thundering-herd reconnects. If not set, no jitter is added.
+  //
+  // This is analogous to
+  // :ref:`max_connection_duration_jitter
+  // <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration_jitter>`,
+  // but applied to the drain grace timer rather than the connection duration timer.
+  type.v3.Percent drain_timeout_jitter = 62;
 
   // The delayed close timeout is for downstream connections managed by the HTTP connection manager.
   // It is defined as a grace period after connection close processing has been locally initiated

--- a/changelogs/current/new_features/http__drain-timeout-jitter.rst
+++ b/changelogs/current/new_features/http__drain-timeout-jitter.rst
@@ -1,0 +1,6 @@
+Added :ref:`drain_timeout_jitter
+<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout_jitter>`
+to ``HttpConnectionManager``. When set, the drain grace period (between the shutdown notice
+``GOAWAY`` and the final ``GOAWAY``) is extended by a random amount up to ``drain_timeout * jitter / 100``,
+staggering the final ``GOAWAY`` across simultaneously-draining connections to mitigate
+thundering-herd reconnects.

--- a/changelogs/current/new_features/http__max-connection-duration-jitter.rst
+++ b/changelogs/current/new_features/http__max-connection-duration-jitter.rst
@@ -1,0 +1,6 @@
+Added :ref:`max_connection_duration_jitter
+<envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration_jitter>` to
+``HttpProtocolOptions``. When set, the ``max_connection_duration`` timer is extended by a random
+amount up to ``max_connection_duration * jitter / 100``, preventing a thundering-herd of
+reconnects when many connections are established at roughly the same time. This follows the same
+pattern as TCP proxy's ``max_downstream_connection_duration_jitter_percentage``.

--- a/docs/root/faq/configuration/timeouts.rst
+++ b/docs/root/faq/configuration/timeouts.rst
@@ -57,7 +57,12 @@ Connection timeouts apply to the entire HTTP connection and all streams the conn
   lifetime in this scenario prevents holding onto healthy connections even after they would otherwise be
   undiscoverable. To modify the max connection duration for downstream connections use the
   :ref:`common_http_protocol_options <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.common_http_protocol_options>`
-  field in the HTTP connection manager configuration. To modify the max connection duration for upstream connections use the
+  field in the HTTP connection manager configuration. Optionally, :ref:`max_connection_duration_jitter
+  <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration_jitter>` (downstream
+  only) can extend the effective duration by a random amount up to
+  ``max_connection_duration * jitter / 100``, preventing a thundering-herd of reconnects when many
+  connections are established at roughly the same time. To modify the max connection duration for
+  upstream connections use the
   :ref:`common_http_protocol_options <envoy_v3_api_field_config.cluster.v3.Cluster.common_http_protocol_options>` field in the cluster configuration.
 
 * The HTTP connection manager :ref:`drain_timeout
@@ -72,7 +77,11 @@ Connection timeouts apply to the entire HTTP connection and all streams the conn
   connection hits the :ref:`idle_timeout <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.idle_timeout>`,
   when :ref:`max_connection_duration <envoy_v3_api_field_config.core.v3.HttpProtocolOptions.max_connection_duration>`
   is reached, or during general server draining. The default grace period is *5000 milliseconds (5 seconds)*
-  if this option is not specified.
+  if this option is not specified. Optionally, :ref:`drain_timeout_jitter
+  <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.drain_timeout_jitter>`
+  can extend the grace period by a random amount up to ``drain_timeout * jitter / 100``, staggering
+  the final ``GOAWAY`` across simultaneously-draining connections to mitigate thundering-herd
+  reconnects.
 
 See :ref:`below <faq_configuration_timeouts_transport_socket>` for other connection timeouts.
 

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -253,7 +253,10 @@ public:
 
   /**
    * @return the time in milliseconds the connection manager will wait between issuing a "shutdown
-   *         notice" to the time it will issue a full GOAWAY and not accept any new streams.
+   *         notice" to the time it will issue a full GOAWAY and not accept any new streams. If
+   *         ``drain_timeout_jitter`` is configured, each call returns the base timeout extended
+   *         by a random amount up to ``drainTimeout * jitter / 100``. The jittering is an
+   *         implementation detail and not exposed as a separate interface method.
    */
   virtual std::chrono::milliseconds drainTimeout() const PURE;
 
@@ -291,7 +294,12 @@ public:
   virtual bool isRoutable() const PURE;
 
   /**
-   * @return optional maximum connection duration timeout for manager connections.
+   * @return optional maximum connection duration timeout for manager connections. If
+   *         ``max_connection_duration_jitter`` is configured, each call returns the
+   *         base duration extended by a random amount up to
+   *         ``max_connection_duration * jitter / 100``. The jittering is an
+   *         implementation detail and not exposed as a separate interface method;
+   *         callers should arm their timer with whatever value this returns.
    */
   virtual absl::optional<std::chrono::milliseconds> maxConnectionDuration() const PURE;
 

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -200,11 +200,11 @@ void ConnectionManagerImpl::initializeReadFilterCallbacks(Network::ReadFilterCal
     connection_idle_timer_->enableTimer(config_->idleTimeout().value());
   }
 
-  if (config_->maxConnectionDuration()) {
+  if (auto max_connection_duration = config_->maxConnectionDuration(); max_connection_duration) {
     connection_duration_timer_ =
         dispatcher_->createScaledTimer(Event::ScaledTimerType::HttpDownstreamMaxConnectionTimeout,
                                        [this]() -> void { onConnectionDurationTimeout(); });
-    connection_duration_timer_->enableTimer(config_->maxConnectionDuration().value());
+    connection_duration_timer_->enableTimer(max_connection_duration.value());
   }
 
   read_callbacks_->connection().setDelayedCloseTimeout(config_->delayedCloseTimeout());

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/network/http_connection_manager/config.h"
 
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -392,6 +393,11 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), idle_timeout)),
       max_connection_duration_(
           PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), max_connection_duration)),
+      max_connection_duration_jitter_percentage_(
+          config.common_http_protocol_options().has_max_connection_duration_jitter()
+              ? absl::optional<double>(
+                    config.common_http_protocol_options().max_connection_duration_jitter().value())
+              : absl::nullopt),
       http1_safe_max_connection_duration_(config.http1_safe_max_connection_duration()),
       max_stream_duration_(
           PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), max_stream_duration)),
@@ -403,6 +409,10 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       request_headers_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, request_headers_timeout, RequestHeaderTimeoutMs)),
       drain_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, drain_timeout, 5000)),
+      drain_timeout_jitter_percentage_(
+          config.has_drain_timeout_jitter()
+              ? absl::optional<double>(config.drain_timeout_jitter().value())
+              : absl::nullopt),
       generate_request_id_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, generate_request_id, true)),
       preserve_external_request_id_(config.preserve_external_request_id()),
       always_set_request_id_in_response_(config.always_set_request_id_in_response()),
@@ -760,6 +770,51 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
           std::make_pair(name, FilterConfig{std::move(factories), enabled}));
     }
   }
+}
+
+absl::optional<std::chrono::milliseconds>
+HttpConnectionManagerConfig::maxConnectionDuration() const {
+  if (!max_connection_duration_.has_value()) {
+    return absl::nullopt;
+  }
+  std::chrono::milliseconds duration = max_connection_duration_.value();
+  // Apply jitter: extend the base duration by a random amount up to
+  // base_duration * jitter_percentage / 100. The jittering is an internal
+  // implementation detail of the HttpConnectionManagerConfig and not exposed
+  // as a separate interface method: callers receive a freshly jittered value
+  // on every call and arm the timer with it directly.
+  if (max_connection_duration_jitter_percentage_.has_value() &&
+      max_connection_duration_jitter_percentage_.value() > 0) {
+    const uint64_t max_jitter_ms = static_cast<uint64_t>(
+        std::ceil(duration.count() * (max_connection_duration_jitter_percentage_.value() / 100.0)));
+    if (max_jitter_ms > 0) {
+      const uint64_t jitter_ms =
+          context_.serverFactoryContext().api().randomGenerator().random() % max_jitter_ms;
+      duration = std::chrono::milliseconds(static_cast<uint64_t>(duration.count()) + jitter_ms);
+    }
+  }
+  return duration;
+}
+
+std::chrono::milliseconds HttpConnectionManagerConfig::drainTimeout() const {
+  std::chrono::milliseconds timeout = drain_timeout_;
+  // Apply jitter: extend the drain grace period (between the shutdown notice
+  // GOAWAY and the final GOAWAY) by a random amount up to
+  // drain_timeout * jitter_percentage / 100. The jittering is an internal
+  // implementation detail of the HttpConnectionManagerConfig and not exposed
+  // as a separate interface method: callers receive a freshly jittered value
+  // on every call and arm the timer with it directly.
+  if (drain_timeout_jitter_percentage_.has_value() &&
+      drain_timeout_jitter_percentage_.value() > 0) {
+    const uint64_t max_jitter_ms = static_cast<uint64_t>(
+        std::ceil(timeout.count() * (drain_timeout_jitter_percentage_.value() / 100.0)));
+    if (max_jitter_ms > 0) {
+      const uint64_t jitter_ms =
+          context_.serverFactoryContext().api().randomGenerator().random() % max_jitter_ms;
+      timeout = std::chrono::milliseconds(static_cast<uint64_t>(timeout.count()) + jitter_ms);
+    }
+  }
+  return timeout;
 }
 
 Http::ServerConnectionPtr HttpConnectionManagerConfig::createCodec(

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -166,7 +166,7 @@ public:
                                         Http::ServerConnectionCallbacks& callbacks,
                                         Server::OverloadManager& overload_manager) override;
   Http::DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() const override { return drain_timeout_; }
+  std::chrono::milliseconds drainTimeout() const override;
   FilterChainFactory& filterFactory() override { return *this; }
   bool generateRequestId() const override { return generate_request_id_; }
   bool preserveExternalRequestId() const override { return preserve_external_request_id_; }
@@ -175,9 +175,7 @@ public:
   uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   bool isRoutable() const override { return true; }
-  absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
-    return max_connection_duration_;
-  }
+  absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override;
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
   }
@@ -340,6 +338,7 @@ private:
   const uint32_t max_request_headers_count_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
+  absl::optional<double> max_connection_duration_jitter_percentage_;
   const bool http1_safe_max_connection_duration_;
   absl::optional<std::chrono::milliseconds> max_stream_duration_;
   std::chrono::milliseconds stream_idle_timeout_;
@@ -352,6 +351,7 @@ private:
   Router::ScopeKeyBuilderPtr scope_key_builder_;
   Config::ConfigProviderPtr scoped_routes_config_provider_;
   std::chrono::milliseconds drain_timeout_;
+  absl::optional<double> drain_timeout_jitter_percentage_;
   bool generate_request_id_;
   const bool preserve_external_request_id_;
   const bool always_set_request_id_in_response_;

--- a/test/common/http/conn_manager_impl_test_2.cc
+++ b/test/common/http/conn_manager_impl_test_2.cc
@@ -497,6 +497,69 @@ TEST_F(HttpConnectionManagerImplTest, ConnectionDurationNoCodec) {
   EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
 }
 
+// Verify that max_connection_duration_jitter extends the duration timer.
+TEST_F(HttpConnectionManagerImplTest, ConnectionDurationJitter) {
+  // Not used in the test.
+  delete codec_;
+
+  max_connection_duration_ = std::chrono::milliseconds(10000); // 10s base
+  max_connection_duration_jitter_percentage_ = 50.0;           // 50% jitter -> up to 5s extra
+
+  // random() returns 2500 -> jitter_ms = 2500 % 5000 = 2500 -> effective = 12500ms
+  EXPECT_CALL(random_, random()).WillOnce(Return(2500));
+
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(12500), _));
+  setup();
+
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
+// Verify that 0% jitter means no jitter is added.
+TEST_F(HttpConnectionManagerImplTest, ConnectionDurationJitterZeroPercent) {
+  // Not used in the test.
+  delete codec_;
+
+  max_connection_duration_ = std::chrono::milliseconds(10000);
+  max_connection_duration_jitter_percentage_ = 0.0;
+
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(10000), _));
+  setup();
+
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
+// Verify that when jitter is not set, the base duration is used unchanged.
+TEST_F(HttpConnectionManagerImplTest, ConnectionDurationNoJitter) {
+  // Not used in the test.
+  delete codec_;
+
+  max_connection_duration_ = std::chrono::milliseconds(10000);
+  // max_connection_duration_jitter_percentage_ is absl::nullopt by default
+
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(10000), _));
+  setup();
+
+  EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
 // Regression test for https://github.com/envoyproxy/envoy/issues/19045
 TEST_F(HttpConnectionManagerImplTest, MaxRequests) {
   max_requests_per_connection_ = 1;
@@ -2282,6 +2345,125 @@ TEST_F(HttpConnectionManagerImplTest, ZombieStreamClosesConnectionOnCodecLowLeve
   EXPECT_CALL(filter_callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite, _));
 
   response_encoder_.stream_.codec_callbacks_->onCodecLowLevelReset();
+}
+
+// Verify that drain_timeout_jitter extends the drain grace period.
+TEST_F(HttpConnectionManagerImplTest, DrainTimeoutJitter) {
+  max_connection_duration_ = std::chrono::milliseconds(10000);
+  drain_timeout_jitter_percentage_ = 50.0; // 50% jitter on the 100ms default drain_timeout
+                                           // -> up to 50ms extra
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(10000), _));
+  setup();
+
+  MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
+        return true;
+      }));
+  EXPECT_CALL(*filter, decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+  EXPECT_CALL(*filter, decodeData(_, true))
+      .WillOnce(Return(FilterDataStatus::StopIterationNoBuffer));
+  startRequest(true, "hello");
+  ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
+  filter->callbacks_->streamInfo().setResponseCodeDetails("");
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
+  response_encoder_.stream_.codec_callbacks_->onCodecEncodeComplete();
+
+  // random() returns 30 -> jitter_ms = 30 % 50 = 30 -> effective drain timeout = 130ms
+  EXPECT_CALL(random_, random()).WillOnce(Return(30));
+  Event::MockTimer* drain_timer = setUpTimer();
+  EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(130), _));
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_CALL(*codec_, goAway());
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::FlushWriteAndDelay, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+  EXPECT_CALL(*drain_timer, disableTimer());
+  drain_timer->invokeCallback();
+
+  EXPECT_EQ(1U, stats_.named_.downstream_cx_max_duration_reached_.value());
+}
+
+// Verify that 0% jitter means no jitter is added to the drain timer.
+TEST_F(HttpConnectionManagerImplTest, DrainTimeoutJitterZeroPercent) {
+  max_connection_duration_ = std::chrono::milliseconds(10000);
+  drain_timeout_jitter_percentage_ = 0.0;
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(10000), _));
+  setup();
+
+  MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
+        return true;
+      }));
+  EXPECT_CALL(*filter, decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+  EXPECT_CALL(*filter, decodeData(_, true))
+      .WillOnce(Return(FilterDataStatus::StopIterationNoBuffer));
+  startRequest(true, "hello");
+  ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
+  filter->callbacks_->streamInfo().setResponseCodeDetails("");
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
+  response_encoder_.stream_.codec_callbacks_->onCodecEncodeComplete();
+
+  Event::MockTimer* drain_timer = setUpTimer();
+  EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(100), _));
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_CALL(*codec_, goAway());
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::FlushWriteAndDelay, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+  EXPECT_CALL(*drain_timer, disableTimer());
+  drain_timer->invokeCallback();
+}
+
+// Verify that when drain jitter is not set, the base drain timeout is used unchanged.
+TEST_F(HttpConnectionManagerImplTest, DrainTimeoutNoJitter) {
+  max_connection_duration_ = std::chrono::milliseconds(10000);
+  // drain_timeout_jitter_percentage_ is absl::nullopt by default
+  Event::MockTimer* connection_duration_timer = setUpTimer();
+  EXPECT_CALL(*connection_duration_timer, enableTimer(std::chrono::milliseconds(10000), _));
+  setup();
+
+  MockStreamDecoderFilter* filter = new NiceMock<MockStreamDecoderFilter>();
+  EXPECT_CALL(filter_factory_, createFilterChain(_))
+      .WillOnce(Invoke([&](FilterChainFactoryCallbacks& callbacks) -> bool {
+        auto factory = createDecoderFilterFactoryCb(StreamDecoderFilterSharedPtr{filter});
+        callbacks.setFilterConfigName("");
+        factory(callbacks);
+        return true;
+      }));
+  EXPECT_CALL(*filter, decodeHeaders(_, false))
+      .WillOnce(Return(FilterHeadersStatus::StopIteration));
+  EXPECT_CALL(*filter, decodeData(_, true))
+      .WillOnce(Return(FilterDataStatus::StopIterationNoBuffer));
+  startRequest(true, "hello");
+  ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};
+  filter->callbacks_->streamInfo().setResponseCodeDetails("");
+  filter->callbacks_->encodeHeaders(std::move(response_headers), true, "details");
+  response_encoder_.stream_.codec_callbacks_->onCodecEncodeComplete();
+
+  Event::MockTimer* drain_timer = setUpTimer();
+  EXPECT_CALL(*drain_timer, enableTimer(std::chrono::milliseconds(100), _));
+  connection_duration_timer->invokeCallback();
+
+  EXPECT_CALL(*codec_, goAway());
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::FlushWriteAndDelay, _));
+  EXPECT_CALL(*connection_duration_timer, disableTimer());
+  EXPECT_CALL(*drain_timer, disableTimer());
+  drain_timer->invokeCallback();
 }
 
 } // namespace Http

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+
 #include "source/common/http/conn_manager_impl.h"
 #include "source/common/http/context_impl.h"
 #include "source/common/http/date_provider_impl.h"
@@ -106,7 +108,19 @@ public:
     return ServerConnectionPtr{codec_};
   }
   DateProvider& dateProvider() override { return date_provider_; }
-  std::chrono::milliseconds drainTimeout() const override { return std::chrono::milliseconds(100); }
+  std::chrono::milliseconds drainTimeout() const override {
+    std::chrono::milliseconds timeout(100);
+    if (drain_timeout_jitter_percentage_.has_value() &&
+        drain_timeout_jitter_percentage_.value() > 0) {
+      const uint64_t max_jitter_ms = static_cast<uint64_t>(
+          std::ceil(timeout.count() * (drain_timeout_jitter_percentage_.value() / 100.0)));
+      if (max_jitter_ms > 0) {
+        const uint64_t jitter_ms = random_.random() % max_jitter_ms;
+        timeout = std::chrono::milliseconds(static_cast<uint64_t>(timeout.count()) + jitter_ms);
+      }
+    }
+    return timeout;
+  }
   FilterChainFactory& filterFactory() override { return filter_factory_; }
   bool generateRequestId() const override { return true; }
   bool preserveExternalRequestId() const override { return false; }
@@ -116,7 +130,20 @@ public:
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   bool isRoutable() const override { return true; }
   absl::optional<std::chrono::milliseconds> maxConnectionDuration() const override {
-    return max_connection_duration_;
+    if (!max_connection_duration_.has_value()) {
+      return absl::nullopt;
+    }
+    std::chrono::milliseconds duration = max_connection_duration_.value();
+    if (max_connection_duration_jitter_percentage_.has_value() &&
+        max_connection_duration_jitter_percentage_.value() > 0) {
+      const uint64_t max_jitter_ms = static_cast<uint64_t>(std::ceil(
+          duration.count() * (max_connection_duration_jitter_percentage_.value() / 100.0)));
+      if (max_jitter_ms > 0) {
+        const uint64_t jitter_ms = random_.random() % max_jitter_ms;
+        duration = std::chrono::milliseconds(static_cast<uint64_t>(duration.count()) + jitter_ms);
+      }
+    }
+    return duration;
   }
   bool http1SafeMaxConnectionDuration() const override {
     return http1_safe_max_connection_duration_;
@@ -298,6 +325,8 @@ public:
   uint32_t max_requests_per_connection_{};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::chrono::milliseconds> max_connection_duration_;
+  absl::optional<double> max_connection_duration_jitter_percentage_;
+  absl::optional<double> drain_timeout_jitter_percentage_;
   bool http1_safe_max_connection_duration_{false};
   std::chrono::milliseconds stream_idle_timeout_{};
   absl::optional<std::chrono::milliseconds> stream_flush_timeout_;
@@ -305,7 +334,7 @@ public:
   std::chrono::milliseconds request_headers_timeout_{};
   std::chrono::milliseconds delayed_close_timeout_{};
   absl::optional<std::chrono::milliseconds> max_stream_duration_;
-  NiceMock<Random::MockRandomGenerator> random_;
+  mutable NiceMock<Random::MockRandomGenerator> random_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
   NiceMock<Server::Configuration::MockFactoryContext> factory_context_;
   RequestDecoder* decoder_{};

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -1107,6 +1107,107 @@ TEST_F(HttpConnectionManagerConfigTest, StreamFlushTimeoutAndStreamIdleTimeoutSe
   EXPECT_EQ(20 * 1000, config.streamFlushTimeout().value().count());
 }
 
+// Validate max_connection_duration_jitter is parsed from common_http_protocol_options.
+TEST_F(HttpConnectionManagerConfigTest, MaxConnectionDurationJitter) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  common_http_protocol_options:
+    max_connection_duration: 10s
+    max_connection_duration_jitter:
+      value: 50.0
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     &scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_, creation_status_);
+  ASSERT_TRUE(creation_status_.ok());
+  // With jitter configured (50%), each call returns a value in [10000, 15000].
+  // The jittering is internal to the config; we observe it by sampling.
+  for (int i = 0; i < 5; ++i) {
+    const auto value = config.maxConnectionDuration().value().count();
+    EXPECT_GE(value, 10000);
+    EXPECT_LE(value, 15000);
+  }
+}
+
+// Validate that max_connection_duration_jitter defaults to unset.
+TEST_F(HttpConnectionManagerConfigTest, MaxConnectionDurationJitterDefault) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  common_http_protocol_options:
+    max_connection_duration: 10s
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     &scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_, creation_status_);
+  ASSERT_TRUE(creation_status_.ok());
+  EXPECT_EQ(10000, config.maxConnectionDuration().value().count());
+}
+
+// Validate drain_timeout_jitter is parsed from HCM config.
+TEST_F(HttpConnectionManagerConfigTest, DrainTimeoutJitter) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  drain_timeout: 5s
+  drain_timeout_jitter:
+    value: 25.0
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     &scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_, creation_status_);
+  ASSERT_TRUE(creation_status_.ok());
+  // With jitter configured (25%), each call returns a value in [5000, 6250].
+  for (int i = 0; i < 5; ++i) {
+    const auto value = config.drainTimeout().count();
+    EXPECT_GE(value, 5000);
+    EXPECT_LE(value, 6250);
+  }
+}
+
+// Validate that drain_timeout_jitter defaults to unset.
+TEST_F(HttpConnectionManagerConfigTest, DrainTimeoutJitterDefault) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.filters.http.router
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     &scoped_routes_config_provider_manager_, tracer_manager_,
+                                     filter_config_provider_manager_, creation_status_);
+  ASSERT_TRUE(creation_status_.ok());
+  // No jitter configured: drainTimeout() returns its base (default 5s).
+  EXPECT_EQ(5000, config.drainTimeout().count());
+}
+
 // Validate that idle_timeout set in common_http_protocol_options is used.
 TEST_F(HttpConnectionManagerConfigTest, CommonHttpProtocolIdleTimeout) {
   const std::string yaml_string = R"EOF(

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1499,6 +1499,7 @@ tchars
 tcmalloc
 tcpdump
 teardown
+teardowns
 tempdir
 templated
 templating


### PR DESCRIPTION
Backport of #45101 to `release/v1.38`.

**Original PR:** #45101
**Original commit:** 8bf1b2d7b28c1404c8acd42cbea6aef068164c08
Cherry-picked cleanly onto `release/v1.38` (no conflicts).

## Why this should be backported

Per RELEASES.md, backports are limited to security fixes, stability fixes (anything that can result in a crash, including crashes triggered by a trusted control plane), and maintainer-approved bugfixes.

This change mitigates a thundering-herd reconnection storm: when many long-lived downstream HTTP/2 or gRPC connections share the same `max_connection_duration`, they can all reach the limit and drain at the same instant, causing a large simultaneous reconnect spike.

**We are encountering this scenario in production, where the synchronized reconnection storm leads to service instability and has resulted in Envoy crashes under load**. Adding jitter staggers connection draining and reconnections, significantly reducing these traffic spikes and improving stability.

The two new fields (`max_connection_duration_jitter`, `drain_timeout_jitter`) are individually opt-in and default to unset (no behavior change), so this is a low-risk, additive stability improvement for operators who hit this failure mode in production.

cc @wbpcode @adisuissa (original reviewers) - could this be considered for backport/review?