### PR TITLE
openssl/tools: exclude .tmp dirs from header grep in generate.c.sh

### DIFF
--- a/compat/openssl/tools/generate.c.sh
+++ b/compat/openssl/tools/generate.c.sh
@@ -31,7 +31,7 @@ INCLUDE_DIR="${3?"INCLUDE_DIR not specified"}"
 ################################################################################
 # Find out which header file the function is declared in
 ################################################################################
-HDR_FILE=$(grep -r "OPENSSL_EXPORT.*[^A-Za-z0-9_]${FUNC_NAME}[ \t]*(" "${INCLUDE_DIR}"/openssl/* | cut -d: -f1)
+HDR_FILE=$(grep -r --exclude-dir='*.tmp' "OPENSSL_EXPORT.*[^A-Za-z0-9_]${FUNC_NAME}[ \t]*(" "${INCLUDE_DIR}"/openssl/* | cut -d: -f1)
 if [ ! -f "$HDR_FILE" ]; then
   error "Failed to determine header file for $FUNC_NAME"
 fi


### PR DESCRIPTION
Commit Message: openssl/tools: exclude .tmp dirs from header grep in generate.c.sh
Additional Description:
When using --spawn_strategy=local (no sandbox), .tmp directories left by the patching genrule persist in the include tree. This causes the grep for OPENSSL_EXPORT to return multiple matches, which makes the subsequent [ -f "$HDR_FILE" ] check fail.

--spawn_strategy=local could be used for example when building envoy as an rpm.
Risk Level: low
Testing: local
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
