### PR TITLE
Update QUICHE from 7a02e7746 to 0580a14c2

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -321,7 +321,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-07-15"
+  release_date: "2026-07-22"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -559,8 +559,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "7a02e774630152a6f67f12458f9545ae3dabfc9b",
-        sha256 = "529c4b61254429e2953a8944ff6fd7583aacafe07a5e7e5b19f74fb17cf26394",
+        version = "0580a14c23b7f7005abd2c18587f108ed6f1e93e",
+        sha256 = "30a8bbb156d5e3739dc19741837df2d8191d18dc0506727f08f2db5f88a72328",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/7a02e7746..0580a14c2

```
$ git log 7a02e7746..0580a14c2 --date=short --no-merges --format="%ad %al %s"

2026-07-22 quiche-dev Enable QUIC spin bit configuration via QuicConfig: Only enable spin bit if both config requests it and ShouldEnableSpinBit() allows it (GFE flag is true and coin flip success).
2026-07-22 quiche-dev Fix 4 ClangInliner findings:
2026-07-22 ricea Add QUICHE_EXPORT to Oblivious HTTP helper functions.
2026-07-22 quiche-dev Fix 4 ClangInliner findings:
2026-07-21 rch Deprecate --gfe2_reloadable_flag_quic_fix_gquic_header_size_limit.
2026-07-21 quiche-dev Fix 13 ClangInliner findings: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs. (13 times)
2026-07-21 quiche-dev Fix 1 ClangInliner finding: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs.
2026-07-21 rch Add VLOG(1)s for logging the compressed and uncompressed QPACK header bytes.
2026-07-21 martinduke Fix ASAN error in MoqtBidiStreamTest.
2026-07-17 quiche-dev Cleanup: Delete QuicCryptoStream::TlsVersion().
2026-07-17 martinduke Split SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS. Remove SubscribeNamespaceOption, maintain SUBSCRIBE_NAMESPACE functionality, and provide stubs and parser/framer support for SUBSCRIBE_TRACKS.
2026-07-17 wub Deprecate --gfe2_reloadable_flag_quic_neuter_packets_on_migration.
2026-07-17 martinduke Mass renaming of Moqt classes
2026-07-17 martinduke Move SUBSCRIBE to a dedicated bidirectional stream.
2026-07-16 martinduke Fix use-after-free in RESET_STREAM_AT processing.
2026-07-16 reubent Allow responses to HEAD requests to contain Content-Length or Transfer-Encoding
2026-07-15 asedeno Fix OSS QUICHE build.
2026-07-15 quiche-dev Get sigalg and server cert type in CryptoContext
```


Risk Level: low
Testing: existing tests pass
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
