### PR TITLE
ext_proc: Adding support to send empty body buffer with EoS = true

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1419,6 +1419,9 @@ ProcessingRequest Filter::setupBodyChunk(ProcessorState& state, const Buffer::In
   body_req->set_end_of_stream(end_stream);
   body_req->set_body(data.toString());
   encodeProtocolConfig(req);
+  if (end_stream) {
+    state.setEosSentToServerWithBody(true);
+  }
   return req;
 }
 

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -112,7 +112,10 @@ bool ProcessorState::restartMessageTimer(const uint32_t message_timeout_ms) {
 
 // Process the data being buffered in STREAMED or FULL_DUPLEX_STREAMED mode.
 void ProcessorState::sendBufferedDataInStreamedMode(bool end_stream) {
-  if (hasBufferedData()) {
+  if (hasBufferedData() ||
+      // This is to avoid send an empty body chunk which is created by filter manager
+      // after end_of_stream is already sent to the ext_proc server.
+      (bufferedData() && end_stream && !eosSentToServerWithBody())) {
     Buffer::OwnedImpl buffered_chunk;
     modifyBufferedData([&buffered_chunk](Buffer::Instance& data) { buffered_chunk.move(data); });
     ENVOY_STREAM_LOG(debug, "Sending a chunk of buffered data ({})", *filterCallbacks(),

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -178,6 +178,9 @@ public:
   bool trailersSentToServer() const { return trailers_sent_to_server_; }
   void setTrailersSentToServer(bool b) { trailers_sent_to_server_ = b; }
 
+  bool eosSentToServerWithBody() const { return eos_sent_to_server_with_body_; }
+  void setEosSentToServerWithBody(bool b) { eos_sent_to_server_with_body_ = b; }
+
   envoy::extensions::filters::http::ext_proc::v3::ProcessingMode_BodySendMode bodyMode() const {
     return body_mode_;
   }
@@ -370,6 +373,8 @@ protected:
   bool complete_body_available_ : 1 = false;
   // If true, the trailers is already sent to the server.
   bool trailers_sent_to_server_ : 1 = false;
+  // If true, the end_of_stream is already sent to the server with body.
+  bool eos_sent_to_server_with_body_ : 1 = false;
   // If true, then a CONTINUE_AND_REPLACE status was used on a response
   bool body_replaced_ : 1 = false;
   // If true, some of the body data is received.

--- a/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
@@ -1124,6 +1124,46 @@ TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersBothDuplexInBothDirectionWithTra
   EXPECT_THAT(response->headers(), ContainsHeader("x-new-header_1", "new_1"));
 }
 
+TEST_P(ExtProcIntegrationTest, ModeOverrideEmptyBodyBeforeHeadersResponse) {
+  // Set default mode to STREAMED for request body.
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+  proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SKIP);
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+
+  // Start request, headers only, end_stream = false
+  auto encoder_decoder = codec_client_->startRequest(headers);
+  request_encoder_ = &encoder_decoder.first;
+  IntegrationStreamDecoderPtr response = std::move(encoder_decoder.second);
+
+  // Send empty data with end_stream = true
+  codec_client_->sendData(*request_encoder_, 0, true);
+
+  // Process request header message.
+  // The server responds normally (no mode override).
+  processGenericMessage(*grpc_upstreams_[0], true,
+                        [](const ProcessingRequest&, ProcessingResponse& resp) {
+                          resp.mutable_request_headers();
+                          return true;
+                        });
+
+  // The server should receive the empty body chunk.
+  processRequestBodyMessage(*grpc_upstreams_[0], false,
+                            [](const HttpBody& body, BodyResponse& resp) {
+                              EXPECT_TRUE(body.end_of_stream());
+                              EXPECT_TRUE(body.body().empty());
+                              resp.mutable_response();
+                              return true;
+                            });
+
+  handleUpstreamRequest();
+  verifyDownstreamResponse(*response, 200);
+}
+
 } // namespace ExternalProcessing
 } // namespace HttpFilters
 } // namespace Extensions


### PR DESCRIPTION
This PR is fixing an issue that sometimes during mode override(BUFFERED to FULL_DUPLEX_STREAMED), an empty body chunk with Eos = true is not sent to the ext_proc server. This leads to the server does not know when to start send back the response.

While we are fixing the issue, it is noticed that sometimes after the last body chunk with EoS = true is already sent to the ext_proc server, the filter_manager creates a new empty buffer with Eos=true: https://github.com/envoyproxy/envoy/blob/d30d525cf8728628002a2a42b7b36b89aefd7222/source/common/http/filter_manager.cc#L241. We need to make sure do not send this body chunk to the ext_proc server. 