### PR TITLE
mobile: fix integer overflow when setting connection keepalive

### DIFF
--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -799,12 +799,11 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
   alpn_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
   alpn_options.mutable_upstream_http_protocol_options()->set_auto_san_validation(true);
   auto* h2_options = alpn_options.mutable_auto_config()->mutable_http2_protocol_options();
-  if (h2_connection_keepalive_idle_interval_milliseconds_ > 1000) {
+  if (h2_connection_keepalive_idle_interval_milliseconds_ > 0) {
     h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_seconds(
         h2_connection_keepalive_idle_interval_milliseconds_ / 1000);
-  } else {
     h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_nanos(
-        h2_connection_keepalive_idle_interval_milliseconds_ * 1000 * 1000);
+        (h2_connection_keepalive_idle_interval_milliseconds_ % 1000) * 1000000);
   }
   h2_options->mutable_connection_keepalive()->mutable_timeout()->set_seconds(
       h2_connection_keepalive_timeout_seconds_);
@@ -909,8 +908,10 @@ std::unique_ptr<envoy::config::bootstrap::v3::Bootstrap> EngineBuilder::generate
           num_timeouts_to_trigger_port_migration_);
     }
     if (keepalive_initial_interval_ms_ > 0) {
-      quic_protocol_options->mutable_connection_keepalive()->mutable_initial_interval()->set_nanos(
-          keepalive_initial_interval_ms_ * 1000 * 1000);
+      auto* initial_interval =
+          quic_protocol_options->mutable_connection_keepalive()->mutable_initial_interval();
+      initial_interval->set_seconds(keepalive_initial_interval_ms_ / 1000);
+      initial_interval->set_nanos((keepalive_initial_interval_ms_ % 1000) * 1000000);
     }
     if (max_concurrent_streams_ > 0) {
       quic_protocol_options->mutable_max_concurrent_streams()->set_value(max_concurrent_streams_);

--- a/mobile/library/cc/mobile_engine_builder.cc
+++ b/mobile/library/cc/mobile_engine_builder.cc
@@ -714,12 +714,11 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
   alpn_options.mutable_upstream_http_protocol_options()->set_auto_sni(true);
   alpn_options.mutable_upstream_http_protocol_options()->set_auto_san_validation(true);
   auto* h2_options = alpn_options.mutable_auto_config()->mutable_http2_protocol_options();
-  if (h2_connection_keepalive_idle_interval_milliseconds_ > 1000) {
+  if (h2_connection_keepalive_idle_interval_milliseconds_ > 0) {
     h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_seconds(
         h2_connection_keepalive_idle_interval_milliseconds_ / 1000);
-  } else {
     h2_options->mutable_connection_keepalive()->mutable_connection_idle_interval()->set_nanos(
-        h2_connection_keepalive_idle_interval_milliseconds_ * 1000 * 1000);
+        (h2_connection_keepalive_idle_interval_milliseconds_ % 1000) * 1000000);
   }
   h2_options->mutable_connection_keepalive()->mutable_timeout()->set_seconds(
       h2_connection_keepalive_timeout_seconds_);
@@ -824,8 +823,10 @@ absl::Status MobileEngineBuilder::configureStaticClusters(
           num_timeouts_to_trigger_port_migration_);
     }
     if (keepalive_initial_interval_ms_ > 0) {
-      quic_protocol_options->mutable_connection_keepalive()->mutable_initial_interval()->set_nanos(
-          keepalive_initial_interval_ms_ * 1000 * 1000);
+      auto* initial_interval =
+          quic_protocol_options->mutable_connection_keepalive()->mutable_initial_interval();
+      initial_interval->set_seconds(keepalive_initial_interval_ms_ / 1000);
+      initial_interval->set_nanos((keepalive_initial_interval_ms_ % 1000) * 1000000);
     }
     if (max_concurrent_streams_ > 0) {
       quic_protocol_options->mutable_max_concurrent_streams()->set_value(max_concurrent_streams_);

--- a/mobile/test/cc/unit/envoy_config_test.cc
+++ b/mobile/test/cc/unit/envoy_config_test.cc
@@ -81,6 +81,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .addDnsQueryTimeoutSeconds(321)
       .addH2ConnectionKeepaliveIdleIntervalMilliseconds(222)
       .addH2ConnectionKeepaliveTimeoutSeconds(333)
+      .setKeepAliveInitialIntervalMilliseconds(3500)
       .setAppVersion("1.2.3")
       .setAppId("1234-1234-1234")
       .addRuntimeGuard("quic_no_tcp_delay", true)
@@ -100,6 +101,7 @@ TEST(TestConfig, ConfigIsApplied) {
       "dns_failure_refresh_rate { base_interval { seconds: 789 } max_interval { seconds: 987 } }",
       "connection_idle_interval { nanos: 222000000 }",
       "connection_keepalive { timeout { seconds: 333 }",
+      "initial_interval { seconds: 3 nanos: 500000000 }",
       "connection_options: \"AKDU,BWRS,5RTO,EVMB,10AF,MPQC\"",
       "client_connection_options: \"1RTT\"",
       "hostname: \"www.abc.com\"",
@@ -120,6 +122,15 @@ TEST(TestConfig, ConfigIsApplied) {
   for (const auto& string : must_contain) {
     EXPECT_THAT(config_str, HasSubstr(string)) << "'" << string << "' not found in " << config_str;
   }
+}
+
+TEST(TestConfig, SetKeepAliveInitialIntervalMilliseconds) {
+  EngineBuilder engine_builder;
+  engine_builder.setKeepAliveInitialIntervalMilliseconds(3000);
+
+  std::unique_ptr<Bootstrap> bootstrap = engine_builder.generateBootstrap();
+  const std::string config_str = bootstrap->ShortDebugString();
+  EXPECT_THAT(config_str, HasSubstr("initial_interval { seconds: 3 }"));
 }
 
 TEST(TestConfig, SameFlagMultiTimes) {


### PR DESCRIPTION
Previously, setKeepAliveInitialIntervalMilliseconds set the nanoseconds field of google::protobuf::Duration directly to keepalive_initial_interval_ms_ * 1000 * 1000. When keepalive_initial_interval_ms_ exceeded 2147ms (or 1000ms), this resulted in integer overflow and/or an invalid nanoseconds value exceeding 999,999,999 nanos, causing crashes.

This change populates both the seconds and nanos fields of google::protobuf::Duration correctly for keepalive_initial_interval_ms_ as well as h2_connection_keepalive_idle_interval_milliseconds_.

Risk Level: Low
Testing: Added unit tests to envoy_config_test.cc