### PR TITLE
test: increase coverage for `listener_manager` and `cache_v2`

### DIFF
--- a/test/common/listener_manager/filter_chain_manager_impl_test.cc
+++ b/test/common/listener_manager/filter_chain_manager_impl_test.cc
@@ -13,6 +13,7 @@
 #include "source/common/config/metadata.h"
 #include "source/common/listener_manager/filter_chain_manager_impl.h"
 #include "source/common/listener_manager/listener_impl.h"
+#include "source/common/listener_manager/listener_info_impl.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/network/listen_socket_impl.h"
@@ -342,6 +343,16 @@ TEST_P(FilterChainManagerImplTest, FilterChainFactoryContextDelegatesAccessors) 
 
   EXPECT_CALL(parent_context_, shouldBypassOverloadManager()).WillOnce(Return(true));
   EXPECT_TRUE(context->shouldBypassOverloadManager());
+
+  context->scope();
+  context->prefixedScope();
+  EXPECT_EQ(&context->initManager(), &init_manager_);
+  context->messageValidationVisitor();
+  context->serverFactoryContext();
+
+  EXPECT_ENVOY_BUG(std::ignore = context->drainDecision().addOnDrainCloseCb(
+                       Network::DrainDirection::All, nullptr),
+                   "Unexpected function call");
 }
 
 TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {
@@ -365,6 +376,28 @@ TEST_P(FilterChainManagerImplTest, DuplicateFilterChainMatchFails) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Matcher, FilterChainManagerImplTest, ::testing::Values(true, false));
+
+TEST(ListenerInfoImplTest, DefaultConstructor) {
+  ListenerInfoImpl info;
+  EXPECT_TRUE(info.name().empty());
+  EXPECT_EQ(info.direction(), envoy::config::core::v3::TrafficDirection::UNSPECIFIED);
+  EXPECT_FALSE(info.isQuic());
+  EXPECT_FALSE(info.shouldBypassOverloadManager());
+  info.metadata();
+  info.typedMetadata();
+}
+
+TEST(ListenerInfoImplTest, FromConfig) {
+  envoy::config::listener::v3::Listener config;
+  config.set_name("test_listener");
+  config.set_traffic_direction(envoy::config::core::v3::TrafficDirection::INBOUND);
+  ListenerInfoImpl info(config);
+  EXPECT_EQ(info.name(), "test_listener");
+  EXPECT_EQ(info.direction(), envoy::config::core::v3::TrafficDirection::INBOUND);
+  EXPECT_FALSE(info.isQuic());
+  info.metadata();
+  info.typedMetadata();
+}
 
 } // namespace Server
 } // namespace Envoy

--- a/test/extensions/filters/http/cache_v2/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_test.cc
@@ -653,6 +653,19 @@ TEST_F(CacheFilterTest, FilterResetDuringEncodeTrailersResetsDownstream) {
   EXPECT_THAT(decoder_callbacks_.details(), Eq("cache.aborted_trailers"));
 }
 
+TEST_F(CacheFilterTest, LowWatermarkWithoutHighIsEnvoyBug) {
+  auto filter = makeFilter(mock_cache_);
+  EXPECT_ENVOY_BUG(filter->onBelowWriteBufferLowWatermark(),
+                   "low watermark not preceded by high watermark should not happen");
+}
+
+TEST_F(CacheFilterTest, ConfigVaryAllowListIsAccessible) {
+  auto config =
+      std::make_shared<CacheFilterConfig>(config_, mock_cache_, context_.server_factory_context_);
+  const VaryAllowList& vary = config->varyAllowList();
+  EXPECT_FALSE(vary.allowsValue("anything"));
+}
+
 } // namespace
 } // namespace CacheV2
 } // namespace HttpFilters

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -952,6 +952,142 @@ TEST(ShouldUpdateCachedEntry, ComparesEtags) {
   EXPECT_FALSE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
 }
 
+TEST(ShouldUpdateCachedEntry, NoEtagInResponseAllowsUpdate) {
+  Http::TestResponseHeaderMapImpl old_headers, new_headers;
+  old_headers.setStatus(304);
+  new_headers.setStatus(304);
+  old_headers.setInline(CacheCustomHeaders::etag(), "abc");
+  EXPECT_TRUE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
+}
+
+TEST(ShouldUpdateCachedEntry, EtagInResponseButNotCachedBlocksUpdate) {
+  Http::TestResponseHeaderMapImpl old_headers, new_headers;
+  old_headers.setStatus(304);
+  new_headers.setStatus(304);
+  new_headers.setInline(CacheCustomHeaders::etag(), "abc");
+  EXPECT_FALSE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
+}
+
+TEST(MakeKey, SetsFieldsCorrectly) {
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/foo?bar=baz"}, {":method", "GET"}, {":scheme", "https"}, {":authority", "x.com"}};
+  Key key = CacheHeadersUtils::makeKey(headers, "my_cluster");
+  EXPECT_EQ(key.cluster_name(), "my_cluster");
+  EXPECT_EQ(key.host(), "x.com");
+  EXPECT_EQ(key.path(), "/foo?bar=baz");
+  EXPECT_EQ(key.scheme(), Key::HTTPS);
+}
+
+TEST(MakeKey, HttpScheme) {
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {":method", "GET"}, {":scheme", "http"}, {":authority", "example.com"}};
+  Key key = CacheHeadersUtils::makeKey(headers, "cluster");
+  EXPECT_EQ(key.scheme(), Key::HTTP);
+}
+
+TEST(RequestCacheControl, QuotedMaxAge) {
+  RequestCacheControl cc("max-age=\"3600\"");
+  EXPECT_TRUE(cc.max_age_.has_value());
+  EXPECT_EQ(cc.max_age_.value(), Seconds(3600));
+}
+
+TEST(InjectValidationHeaders, BothEtagAndInvalidLastModified) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  old_response_headers.setInline(CacheCustomHeaders::etag(), "\"etag-value\"");
+  old_response_headers.setInline(CacheCustomHeaders::lastModified(), "garbage-date");
+  constexpr absl::string_view date = "Fri, 01 Aug 2025 09:25:10 GMT";
+  old_response_headers.setDate(date);
+  Http::TestRequestHeaderMapImpl request_headers;
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+  EXPECT_THAT(request_headers, ContainsHeader("if-none-match", "\"etag-value\""));
+  EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", date));
+}
+
+TEST(ResponseCacheControl, SMaxageTakesPrecedenceOverMaxAge) {
+  ResponseCacheControl cc("s-maxage=100, max-age=200");
+  EXPECT_TRUE(cc.max_age_.has_value());
+  EXPECT_EQ(cc.max_age_.value(), Seconds(100));
+}
+
+TEST(ResponseCacheControl, ProxyRevalidateSetsNoStale) {
+  ResponseCacheControl cc("proxy-revalidate");
+  EXPECT_TRUE(cc.no_stale_);
+  EXPECT_FALSE(cc.must_validate_);
+  EXPECT_FALSE(cc.no_store_);
+}
+
+TEST(RequestCacheControl, MaxStaleWithoutValue) {
+  RequestCacheControl cc("max-stale");
+  EXPECT_TRUE(cc.max_stale_.has_value());
+  EXPECT_EQ(cc.max_stale_.value(), SystemTime::duration::max());
+}
+
+TEST(ShouldUpdateCachedEntry, NeitherHasEtag) {
+  Http::TestResponseHeaderMapImpl old_headers, new_headers;
+  old_headers.setStatus(304);
+  new_headers.setStatus(304);
+  EXPECT_TRUE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
+}
+
+TEST(ShouldUpdateCachedEntry, MatchingEtagsAllowUpdate) {
+  Http::TestResponseHeaderMapImpl old_headers, new_headers;
+  old_headers.setStatus(304);
+  new_headers.setStatus(304);
+  old_headers.setInline(CacheCustomHeaders::etag(), "\"same\"");
+  new_headers.setInline(CacheCustomHeaders::etag(), "\"same\"");
+  EXPECT_TRUE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
+}
+
+TEST(ShouldUpdateCachedEntry, MismatchedEtagsBlockUpdate) {
+  Http::TestResponseHeaderMapImpl old_headers, new_headers;
+  old_headers.setStatus(304);
+  new_headers.setStatus(304);
+  old_headers.setInline(CacheCustomHeaders::etag(), "\"old\"");
+  new_headers.setInline(CacheCustomHeaders::etag(), "\"new\"");
+  EXPECT_FALSE(CacheHeadersUtils::shouldUpdateCachedEntry(new_headers, old_headers));
+}
+
+TEST(InjectValidationHeaders, BothEtagAndValidLastModified) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  old_response_headers.setInline(CacheCustomHeaders::etag(), "\"etag-value\"");
+  constexpr absl::string_view mod_time = "Fri, 01 Aug 2025 09:25:10 GMT";
+  old_response_headers.setInline(CacheCustomHeaders::lastModified(), mod_time);
+  Http::TestRequestHeaderMapImpl request_headers;
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+  EXPECT_THAT(request_headers, ContainsHeader("if-none-match", "\"etag-value\""));
+  EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", mod_time));
+}
+
+TEST(ResponseCacheControl, MustRevalidateSetsNoStale) {
+  ResponseCacheControl cc("must-revalidate");
+  EXPECT_TRUE(cc.no_stale_);
+  EXPECT_FALSE(cc.must_validate_);
+  EXPECT_FALSE(cc.no_store_);
+}
+
+TEST(RequestCacheControl, QuotedMinFresh) {
+  RequestCacheControl cc("min-fresh=\"60\"");
+  EXPECT_TRUE(cc.min_fresh_.has_value());
+  EXPECT_EQ(cc.min_fresh_.value(), Seconds(60));
+}
+
+TEST(ResponseCacheControl, NoTransformAlone) {
+  ResponseCacheControl cc("no-transform");
+  EXPECT_TRUE(cc.no_transform_);
+  EXPECT_FALSE(cc.must_validate_);
+  EXPECT_FALSE(cc.no_store_);
+  EXPECT_FALSE(cc.no_stale_);
+  EXPECT_FALSE(cc.is_public_);
+}
+
+TEST(RequestCacheControl, OnlyIfCachedAlone) {
+  RequestCacheControl cc("only-if-cached");
+  EXPECT_TRUE(cc.only_if_cached_);
+  EXPECT_FALSE(cc.must_validate_);
+  EXPECT_FALSE(cc.no_store_);
+  EXPECT_FALSE(cc.no_transform_);
+}
+
 } // namespace
 } // namespace CacheV2
 } // namespace HttpFilters

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -884,6 +884,42 @@ TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWit
   EXPECT_THAT(headers2, IsNull());
 }
 
+TEST_F(CacheSessionsTest, UpstreamResetDuringCacheMissReportsUpstreamReset) {
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequest("/a"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+  ASSERT_THAT(fake_upstreams_.size(), Eq(1));
+  ASSERT_THAT(fake_upstream_get_headers_callbacks_.size(), Eq(1));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(nullptr, EndStream::Reset);
+  pumpDispatcher();
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::UpstreamReset));
+}
+
+TEST_F(CacheSessionsTest, VaryHeaderInUpstreamResponseTreatedAsUncacheable) {
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequest("/a"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+  ASSERT_THAT(fake_upstreams_.size(), Eq(1));
+  ASSERT_THAT(fake_upstream_get_headers_callbacks_.size(), Eq(1));
+  auto headers = cacheableResponseHeaders();
+  headers->addCopy(Http::CustomHeaders::get().Vary, "accept");
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(headers), EndStream::End);
+  pumpDispatcher();
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Uncacheable));
+}
+
 // TODO: UpdateHeadersSkipSpecificHeaders
 // TODO: Vary
 

--- a/test/extensions/filters/http/cache_v2/range_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/range_utils_test.cc
@@ -328,6 +328,19 @@ TEST(GetRangeDetailsTest, NotSatisfiableRange) {
   ASSERT_TRUE(result->ranges_.empty());
 }
 
+TEST(AdjustByteRange, ContentLengthZeroIsUnsatisfiable) {
+  RangeDetails result = RangeUtils::createAdjustedRangeDetails({{0, 5}}, 0);
+  ASSERT_FALSE(result.satisfiable_);
+  EXPECT_TRUE(result.ranges_.empty());
+}
+
+TEST(CreateRangeDetailsTest, MultipleRangeHeadersReturnsNullopt) {
+  Envoy::Http::TestRequestHeaderMapImpl headers{
+      {":method", "GET"}, {"range", "bytes=0-5"}, {"range", "bytes=6-10"}};
+  std::optional<RangeDetails> result = RangeUtils::createRangeDetails(headers, 100);
+  ASSERT_FALSE(result.has_value());
+}
+
 // operator<<(ostream&, const AdjustedByteRange&) is only used in tests, but lives in //source,
 // and so needs test coverage. This test provides that coverage, to keep the coverage test happy.
 TEST(AdjustedByteRange, StreamingTest) {


### PR DESCRIPTION
LLVM 22 instruments code differently, causing both directories to drop to 96.5% (below the 96.6% default threshold).
