### PR TITLE
[bp/v1.38] dfp: fix a bug when cluster is removed before async lb be completed (#45064)

### DIFF
--- a/changelogs/current/bug_fixes/router__fixed-a-lifetime-bug-in-dfp-proxy-async-load-selection.rst
+++ b/changelogs/current/bug_fixes/router__fixed-a-lifetime-bug-in-dfp-proxy-async-load-selection.rst
@@ -1,0 +1,3 @@
+Fixed a lifetime bug in dynamic forward proxy async host selection when the cluster is removed
+while lookup is still pending. Pending lookups are now cleaned up on DFP load balancer teardown,
+and the router no longer resumes async completion through a stale cluster reference.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1546,6 +1546,8 @@ public:
   virtual bool valid() const PURE;
 };
 
+using GenericConnPoolPtr = std::unique_ptr<GenericConnPool>;
+
 /**
  * An API for the interactions the upstream stream needs to have with the downstream stream
  * and/or router components
@@ -1673,8 +1675,6 @@ public:
    */
   virtual const StreamInfo::BytesMeterSharedPtr& bytesMeter() PURE;
 };
-
-using GenericConnPoolPtr = std::unique_ptr<GenericConnPool>;
 
 /*
  * A factory for creating generic connection pools.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -731,11 +731,18 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
     if (host_selection_response.cancelable) {
       host_selection_response.cancelable->cancel();
     }
+
+    GenericConnPoolPtr generic_conn_pool = createConnPoolOrHandleFailure(
+        std::move(host_selection_response.host), cluster, host_selection_response.details,
+        host_selection_response.failure_status);
+    if (generic_conn_pool == nullptr) {
+      return Http::FilterHeadersStatus::StopIteration;
+    }
+
     // This branch handles the common case of synchronous host selection, as
     // well as handling unsupported asynchronous host selection by treating it
     // as host selection failure and calling sendNoHealthyUpstreamResponse.
-    continueDecodeHeaders(cluster, headers, end_stream, std::move(host_selection_response.host),
-                          host_selection_response.details, host_selection_response.failure_status);
+    continueDecodeHeaders(headers, end_stream, std::move(generic_conn_pool));
     return Http::FilterHeadersStatus::StopIteration;
   }
 
@@ -744,14 +751,12 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
   // like stream timeout.
   host_selection_cancelable_ = std::move(host_selection_response.cancelable);
   // Configure a callback to be called on asynchronous host selection.
-  on_host_selected_ = ([this, cluster,
-                        end_stream](Upstream::HostConstSharedPtr&& host,
-                                    absl::string_view host_selection_details) -> void {
+  on_host_selected_ = ([this, end_stream](GenericConnPoolPtr generic_conn_pool) -> void {
     // It should always be safe to call continueDecodeHeaders. In the case the
     // stream had a local reply before host selection completed,
     // the lookup should be canceled.
-    const bool should_continue_decoding = continueDecodeHeaders(
-        cluster, *downstream_headers_, end_stream, std::move(host), host_selection_details);
+    const bool should_continue_decoding =
+        continueDecodeHeaders(*downstream_headers_, end_stream, std::move(generic_conn_pool));
     // continueDecodeHeaders can itself send a local reply, in which case should_continue_decoding
     // should be false. If this is not the case, we can continue the filter chain due to successful
     // asynchronous host selection.
@@ -771,22 +776,19 @@ void Filter::onAsyncHostSelection(Upstream::HostConstSharedPtr&& host, std::stri
   ENVOY_STREAM_LOG(debug, "Completing asynchronous host selection [{}]\n", *callbacks_, details);
   std::unique_ptr<Upstream::AsyncHostSelectionHandle> local_scope =
       std::move(host_selection_cancelable_);
-  on_host_selected_(std::move(host), details);
+
+  // The cluster argument should always be nullptr here to force refetching the cluster because
+  // the cluster may have been updated during the asynchronous host selection.
+  GenericConnPoolPtr generic_conn_pool =
+      createConnPoolOrHandleFailure(std::move(host), nullptr, details, absl::nullopt);
+  if (generic_conn_pool != nullptr) {
+    on_host_selected_(std::move(generic_conn_pool));
+  }
 }
 
-bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
-                                   Http::RequestHeaderMap& headers, bool end_stream,
-                                   Upstream::HostConstSharedPtr&& selected_host,
-                                   absl::string_view host_selection_details,
-                                   absl::optional<Http::Code> failure_status) {
-  callbacks_->streamInfo().downstreamTiming().setValue(
-      "envoy.router.host_selection_end_ms", callbacks_->dispatcher().timeSource().monotonicTime());
-
-  std::unique_ptr<GenericConnPool> generic_conn_pool = createConnPool(*cluster, selected_host);
-  if (!generic_conn_pool) {
-    sendNoHealthyUpstreamResponse(host_selection_details, failure_status);
-    return false;
-  }
+bool Filter::continueDecodeHeaders(Http::RequestHeaderMap& headers, bool end_stream,
+                                   GenericConnPoolPtr generic_conn_pool) {
+  ASSERT(generic_conn_pool != nullptr);
   Upstream::HostDescriptionConstSharedPtr host = generic_conn_pool->host();
 
   // If we've been instructed not to forward the request upstream, send an empty local response.
@@ -929,11 +931,8 @@ bool Filter::continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster,
   return true;
 }
 
-std::unique_ptr<GenericConnPool> Filter::createConnPool(Upstream::ThreadLocalCluster& cluster,
-                                                        Upstream::HostConstSharedPtr host) {
-  if (host == nullptr) {
-    return nullptr;
-  }
+GenericConnPoolPtr Filter::createConnPool(Upstream::ThreadLocalCluster& cluster,
+                                          const Upstream::HostConstSharedPtr& host) {
   GenericConnPoolFactory* factory = nullptr;
   ProtobufTypes::MessagePtr message;
   if (cluster_->upstreamConfig().has_value()) {
@@ -972,6 +971,33 @@ std::unique_ptr<GenericConnPool> Filter::createConnPool(Upstream::ThreadLocalClu
 
   return factory->createGenericConnPool(host, cluster, upstream_protocol, route_entry_->priority(),
                                         callbacks_->streamInfo().protocol(), this, *message);
+}
+
+GenericConnPoolPtr Filter::createConnPoolOrHandleFailure(
+    Upstream::HostConstSharedPtr host, Upstream::ThreadLocalCluster* cluster,
+    absl::string_view selection_details, absl::optional<Http::Code> failure_status) {
+  callbacks_->streamInfo().downstreamTiming().setValue(
+      "envoy.router.host_selection_end_ms", callbacks_->dispatcher().timeSource().monotonicTime());
+
+  GenericConnPoolPtr generic_conn_pool;
+  if (host != nullptr) {
+    if (cluster == nullptr) {
+      // Refetch the cluster because the cluster may be deleted/updated during the asynchronous host
+      // selection.
+      cluster = config_->cm_.getThreadLocalCluster(host->cluster().name());
+    }
+    if (cluster != nullptr) {
+      generic_conn_pool = createConnPool(*cluster, host);
+    }
+  }
+
+  if (generic_conn_pool == nullptr) {
+    sendNoHealthyUpstreamResponse(selection_details, failure_status);
+    cleanup();
+    return nullptr;
+  }
+
+  return generic_conn_pool;
 }
 
 void Filter::sendNoHealthyUpstreamResponse(absl::string_view optional_details,
@@ -2289,39 +2315,34 @@ void Filter::doRetry(bool can_send_early_data, bool can_use_http3, TimeoutRetry 
     if (host_selection_response.cancelable) {
       host_selection_response.cancelable->cancel();
     }
-    // This branch handles the common case of synchronous host selection, as
-    // well as handling unsupported asynchronous host selection (by treating it
-    // as host selection failure).
-    continueDoRetry(can_send_early_data, can_use_http3, is_timeout_retry,
-                    std::move(host_selection_response.host), *cluster,
-                    host_selection_response.details, host_selection_response.failure_status);
+
+    GenericConnPoolPtr generic_conn_pool = createConnPoolOrHandleFailure(
+        std::move(host_selection_response.host), cluster, host_selection_response.details,
+        host_selection_response.failure_status);
+    if (generic_conn_pool != nullptr) {
+      // This branch handles the common case of synchronous host selection, as
+      // well as handling unsupported asynchronous host selection (by treating it
+      // as host selection failure).
+      continueDoRetry(can_send_early_data, can_use_http3, is_timeout_retry,
+                      std::move(generic_conn_pool));
+    }
+    return;
   }
 
   ENVOY_STREAM_LOG(debug, "Handling asynchronous host selection for retry\n", *callbacks_);
   // Again latch the cancel handle, and set up the callback to be called when host
   // selection is complete.
   host_selection_cancelable_ = std::move(host_selection_response.cancelable);
-  on_host_selected_ =
-      ([this, can_send_early_data, can_use_http3, is_timeout_retry, cluster](
-           Upstream::HostConstSharedPtr&& host, absl::string_view host_selection_details) -> void {
-        continueDoRetry(can_send_early_data, can_use_http3, is_timeout_retry, std::move(host),
-                        *cluster, host_selection_details);
-      });
+  on_host_selected_ = ([this, can_send_early_data, can_use_http3,
+                        is_timeout_retry](GenericConnPoolPtr generic_conn_pool) -> void {
+    continueDoRetry(can_send_early_data, can_use_http3, is_timeout_retry,
+                    std::move(generic_conn_pool));
+  });
 }
 
 void Filter::continueDoRetry(bool can_send_early_data, bool can_use_http3,
-                             TimeoutRetry is_timeout_retry, Upstream::HostConstSharedPtr&& host,
-                             Upstream::ThreadLocalCluster& cluster,
-                             absl::string_view host_selection_details,
-                             absl::optional<Http::Code> failure_status) {
-  callbacks_->streamInfo().downstreamTiming().setValue(
-      "envoy.router.host_selection_end_ms", callbacks_->dispatcher().timeSource().monotonicTime());
-  std::unique_ptr<GenericConnPool> generic_conn_pool = createConnPool(cluster, host);
-  if (!generic_conn_pool) {
-    sendNoHealthyUpstreamResponse(host_selection_details, failure_status);
-    cleanup();
-    return;
-  }
+                             TimeoutRetry is_timeout_retry, GenericConnPoolPtr generic_conn_pool) {
+  ASSERT(generic_conn_pool != nullptr);
   UpstreamRequestPtr upstream_request = std::make_unique<UpstreamRequest>(
       *this, std::move(generic_conn_pool), can_send_early_data, can_use_http3,
       allow_multiplexed_upstream_half_close_ /*enable_half_close*/);

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -331,10 +331,8 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
 
-  bool continueDecodeHeaders(Upstream::ThreadLocalCluster* cluster, Http::RequestHeaderMap& headers,
-                             bool end_stream, Upstream::HostConstSharedPtr&& host,
-                             absl::string_view host_selection_details = {},
-                             absl::optional<Http::Code> failure_status = absl::nullopt);
+  bool continueDecodeHeaders(Http::RequestHeaderMap& headers, bool end_stream,
+                             GenericConnPoolPtr generic_conn_pool);
 
   Http::FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap& trailers) override;
@@ -574,9 +572,8 @@ private:
                                          Event::Dispatcher& dispatcher,
                                          Upstream::ResourcePriority priority) PURE;
 
-  std::unique_ptr<GenericConnPool>
-  createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
-                 Upstream::HostConstSharedPtr host);
+  GenericConnPoolPtr createConnPool(Upstream::ThreadLocalCluster& thread_local_cluster,
+                                    const Upstream::HostConstSharedPtr& host);
   UpstreamRequestPtr createUpstreamRequest();
   absl::optional<absl::string_view> getShadowCluster(const ShadowPolicy& shadow_policy,
                                                      const Http::HeaderMap& headers) const;
@@ -617,9 +614,7 @@ private:
                               absl::optional<uint64_t> code);
   void doRetry(bool can_send_early_data, bool can_use_http3, TimeoutRetry is_timeout_retry);
   void continueDoRetry(bool can_send_early_data, bool can_use_http3, TimeoutRetry is_timeout_retry,
-                       Upstream::HostConstSharedPtr&& host, Upstream::ThreadLocalCluster& cluster,
-                       absl::string_view host_selection_details,
-                       absl::optional<Http::Code> failure_status = absl::nullopt);
+                       GenericConnPoolPtr generic_conn_pool);
   void updateStatsOnNoRetry(RetryStatus retry_status);
   void updateStatsOnDoRetry(RetryState::DoRetryType do_retry_type);
 
@@ -638,6 +633,10 @@ private:
   void maybeProcessOrcaLoadReport(const Envoy::Http::HeaderMap& headers_or_trailers,
                                   UpstreamRequest& upstream_request);
   bool isEarlyConnectData();
+  GenericConnPoolPtr createConnPoolOrHandleFailure(Upstream::HostConstSharedPtr host,
+                                                   Upstream::ThreadLocalCluster* cluster,
+                                                   absl::string_view selection_details,
+                                                   absl::optional<Http::Code> failure_status);
 
   RetryStatePtr retry_state_;
   const FilterConfigSharedPtr config_;
@@ -648,8 +647,7 @@ private:
   std::unique_ptr<Stats::StatNameDynamicStorage> alt_stat_prefix_;
   const VirtualCluster* request_vcluster_{};
   RouteStatsContextOptRef route_stats_context_;
-  std::function<void(Upstream::HostConstSharedPtr&& host, absl::string_view details)>
-      on_host_selected_;
+  std::function<void(GenericConnPoolPtr)> on_host_selected_;
   std::unique_ptr<Upstream::AsyncHostSelectionHandle> host_selection_cancelable_;
   Event::TimerPtr response_timeout_;
   TimeoutData timeout_;

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -362,12 +362,17 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return {nullptr};
   }
 
+  auto cluster = cluster_.lock();
+  if (!cluster) {
+    return {nullptr};
+  }
+
   // For host lookup, we need to make sure to match the host of any DNS cache
   // insert. Two code points currently do DNS cache insert: the http DFP filter,
   // which inserts for HTTP traffic, and sets port based on the cluster's
   // security level, and the SNI DFP network filter which sets port based on
   // stream metadata, or configuration (which is then added as stream metadata).
-  const bool is_secure = cluster_.info()
+  const bool is_secure = cluster->info()
                              ->transportSocketMatcher()
                              .resolve(nullptr, nullptr)
                              .factory_.implementsSecureTransport();
@@ -426,8 +431,8 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   std::string hostname =
       Common::DynamicForwardProxy::DnsHostInfo::normalizeHostForDfp(raw_host, port);
 
-  if (cluster_.enableSubCluster()) {
-    return cluster_.chooseHost(hostname, context);
+  if (cluster->enableSubCluster()) {
+    return cluster->chooseHost(hostname, context);
   }
   Upstream::HostConstSharedPtr host = findHostByName(hostname);
   bool force_refresh =
@@ -440,7 +445,7 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
   }
 
   // If the host is not found, the DFP cluster can now do asynchronous lookup.
-  Upstream::ResourceAutoIncDecPtr handle = cluster_.dns_cache_->canCreateDnsRequest();
+  Upstream::ResourceAutoIncDecPtr handle = cluster->dns_cache_->canCreateDnsRequest();
 
   // Return an immediate failure if there's too many requests already.
   if (!handle) {
@@ -449,10 +454,10 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
 
   // Attempt to load the host from cache. Generally this will result in async
   // resolution so create a DFPHostSelectionHandle to handle this.
-  std::unique_ptr<DFPHostSelectionHandle> cancelable =
-      std::make_unique<DFPHostSelectionHandle>(context, cluster_, hostname);
+  std::unique_ptr<DFPHostSelectionHandle> cancelable = std::make_unique<DFPHostSelectionHandle>(
+      context, cluster_, hostname, pending_host_selection_handles_);
   bool is_proxying = isProxying(context->requestStreamInfo());
-  auto result = cluster_.dns_cache_->loadDnsCacheEntryWithForceRefresh(raw_host, port, is_proxying,
+  auto result = cluster->dns_cache_->loadDnsCacheEntryWithForceRefresh(raw_host, port, is_proxying,
                                                                        force_refresh, *cancelable);
   switch (result.status_) {
   case Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus::InCache:
@@ -463,6 +468,7 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     // resolution is canceled by the stream.
     cancelable->setHandle(std::move(result.handle_));
     cancelable->setAutoDec(std::move(handle));
+    pending_host_selection_handles_.insert(cancelable.get());
     return Upstream::HostSelectionResponse{nullptr, std::move(cancelable)};
   case Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus::Overflow:
     // In the case of overflow, return immediate failure.
@@ -473,7 +479,10 @@ Cluster::LoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
 }
 
 Upstream::HostConstSharedPtr Cluster::LoadBalancer::findHostByName(const std::string& host) const {
-  return cluster_.findHostByName(host);
+  if (auto cluster = cluster_.lock()) {
+    return cluster->findHostByName(host);
+  }
+  return nullptr;
 }
 
 Upstream::HostConstSharedPtr Cluster::findHostByName(const std::string& host) const {
@@ -491,6 +500,20 @@ Upstream::HostConstSharedPtr Cluster::findHostByName(const std::string& host) co
       host_it->second.shared_host_info_->touch();
       return host_it->second.logical_host_;
     }
+  }
+}
+
+Cluster::LoadBalancer::~LoadBalancer() {
+  // Clean up pending host selection handles to avoid calling back into a destroyed load
+  // balancer. Notify each pending callback that host selection was aborted because the load
+  // balancer was destroyed.
+  while (!pending_host_selection_handles_.empty()) {
+    auto handle = *pending_host_selection_handles_.begin();
+    // Defensively removal to avoid endless loop in case the handle's cancel() does not remove
+    // itself from the set.
+    pending_host_selection_handles_.erase(handle);
+    handle->cancel();
+    handle->context_->onAsyncHostSelection(nullptr, "load_balancer_destroyed");
   }
 }
 
@@ -524,10 +547,13 @@ Cluster::LoadBalancer::selectExistingConnection(Upstream::LoadBalancerContext* /
 
 OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>
 Cluster::LoadBalancer::lifetimeCallbacks() {
-  if (!cluster_.allowCoalescedConnections()) {
-    return {};
+  if (auto cluster = cluster_.lock()) {
+    if (!cluster->allowCoalescedConnections()) {
+      return {};
+    }
+    return makeOptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>(*this);
   }
-  return makeOptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>(*this);
+  return {};
 }
 
 void Cluster::LoadBalancer::onConnectionOpen(Envoy::Http::ConnectionPool::Instance& pool,
@@ -610,7 +636,7 @@ ClusterFactory::createClusterWithConfig(
         "unsupported lb_policy 'CLUSTER_PROVIDED' in sub_cluster_config");
   }
 
-  auto lb = std::make_unique<Cluster::ThreadAwareLoadBalancer>(*new_cluster);
+  auto lb = std::make_unique<Cluster::ThreadAwareLoadBalancer>(new_cluster);
   return std::make_pair(new_cluster, std::move(lb));
 }
 

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -90,11 +90,14 @@ private:
 
   using HostInfoMap = absl::flat_hash_map<std::string, HostInfo>;
 
+  class DFPHostSelectionHandle;
+
   class LoadBalancer : public Upstream::LoadBalancer,
                        public Extensions::Common::DynamicForwardProxy::DfpLb,
                        public Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks {
   public:
-    LoadBalancer(const Cluster& cluster) : cluster_(cluster) {}
+    LoadBalancer(std::weak_ptr<const Cluster> cluster) : cluster_(cluster) {}
+    ~LoadBalancer() override;
 
     // DfpLb
     Upstream::HostConstSharedPtr findHostByName(const std::string& host) const override;
@@ -137,8 +140,8 @@ private:
     };
 
     absl::flat_hash_map<LookupKey, std::vector<ConnectionInfo>, LookupKeyHash> connection_info_map_;
-
-    const Cluster& cluster_;
+    absl::flat_hash_set<DFPHostSelectionHandle*> pending_host_selection_handles_;
+    std::weak_ptr<const Cluster> cluster_;
   };
 
   // This acts as the bridge for asynchronous host lookup. If the host is not
@@ -150,19 +153,41 @@ private:
       : public Upstream::AsyncHostSelectionHandle,
         public Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryCallbacks {
   public:
-    DFPHostSelectionHandle(Upstream::LoadBalancerContext* context, const Cluster& cluster,
-                           std::string hostname)
-        : context_(context), cluster_(cluster), hostname_(hostname) {};
+    DFPHostSelectionHandle(
+        Upstream::LoadBalancerContext* context, std::weak_ptr<const Cluster> cluster,
+        std::string hostname,
+        absl::flat_hash_set<DFPHostSelectionHandle*>& pending_host_selection_handles)
+        : context_(context), cluster_(cluster), hostname_(hostname),
+          pending_host_selection_handles_(pending_host_selection_handles) {}
+
+    // Ideally the cancel() will be called to cancel the async host selection before the handle is
+    // destructed. In case it is not, the destructor will also ensure the cancellation of the async
+    // host selection to avoid calling back into the load balancer after it is destructed.
+    ~DFPHostSelectionHandle() override { cancel(); }
 
     virtual void cancel() {
       // Cancels the DNS callback.
       handle_.reset();
+
+      if (pending_host_selection_handles_.has_value()) {
+        // Removes itself from the pending host selection handles so that the cluster will not
+        // attempt to call onLoadDnsCacheComplete after cancellation.
+        pending_host_selection_handles_->erase(this);
+        pending_host_selection_handles_.reset();
+      }
     }
 
-    virtual void
-    onLoadDnsCacheComplete(const Common::DynamicForwardProxy::DnsHostInfoSharedPtr& info) {
-      Upstream::HostConstSharedPtr host = cluster_.findHostByName(hostname_);
+    void
+    onLoadDnsCacheComplete(const Common::DynamicForwardProxy::DnsHostInfoSharedPtr& info) override {
+      Upstream::HostConstSharedPtr host;
+      if (auto cluster = cluster_.lock()) {
+        host = cluster->findHostByName(hostname_);
+      }
       std::string details = info->details();
+      if (pending_host_selection_handles_.has_value()) {
+        pending_host_selection_handles_->erase(this);
+        pending_host_selection_handles_.reset();
+      }
       context_->onAsyncHostSelection(std::move(host), std::move(details));
     }
 
@@ -172,29 +197,34 @@ private:
     void setAutoDec(Upstream::ResourceAutoIncDecPtr&& dec) { auto_dec_ = std::move(dec); }
 
   private:
+    friend class LoadBalancer;
+
     Upstream::LoadBalancerContext* context_;
     Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryHandlePtr handle_;
     Upstream::ResourceAutoIncDecPtr auto_dec_;
-    const Cluster& cluster_;
+    std::weak_ptr<const Cluster> cluster_;
     std::string hostname_;
+    OptRef<absl::flat_hash_set<DFPHostSelectionHandle*>> pending_host_selection_handles_;
   };
 
   class LoadBalancerFactory : public Upstream::LoadBalancerFactory {
   public:
-    LoadBalancerFactory(Cluster& cluster) : cluster_(cluster) {}
+    LoadBalancerFactory(std::weak_ptr<const Cluster> cluster) : cluster_(std::move(cluster)) {}
 
     // Upstream::LoadBalancerFactory
     Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams) override {
       return std::make_unique<LoadBalancer>(cluster_);
     }
+    // The DFP load balancer does not need to be recreated on host changes.
+    bool recreateOnHostChange() const override { return false; }
 
   private:
-    Cluster& cluster_;
+    std::weak_ptr<const Cluster> cluster_;
   };
 
   class ThreadAwareLoadBalancer : public Upstream::ThreadAwareLoadBalancer {
   public:
-    ThreadAwareLoadBalancer(Cluster& cluster) : cluster_(cluster) {}
+    ThreadAwareLoadBalancer(std::weak_ptr<const Cluster> cluster) : cluster_(std::move(cluster)) {}
 
     // Upstream::ThreadAwareLoadBalancer
     Upstream::LoadBalancerFactorySharedPtr factory() override {
@@ -203,7 +233,7 @@ private:
     absl::Status initialize() override { return absl::OkStatus(); }
 
   private:
-    Cluster& cluster_;
+    std::weak_ptr<const Cluster> cluster_;
   };
 
   absl::Status

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.h
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.h
@@ -165,7 +165,7 @@ private:
     // host selection to avoid calling back into the load balancer after it is destructed.
     ~DFPHostSelectionHandle() override { cancel(); }
 
-    virtual void cancel() {
+    void cancel() override {
       // Cancels the DNS callback.
       handle_.reset();
 

--- a/test/common/router/router_test.cc
+++ b/test/common/router/router_test.cc
@@ -79,6 +79,11 @@ private:
   std::function<void(const StreamInfo::StreamInfo&)> func_;
 };
 
+class TestAsyncHostSelectionHandle : public Upstream::AsyncHostSelectionHandle {
+public:
+  void cancel() override {}
+};
+
 class RouterTest : public RouterTestBase {
 public:
   RouterTest()
@@ -1031,6 +1036,34 @@ TEST_F(RouterTest, NoHost) {
   EXPECT_EQ(0U,
             callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
   EXPECT_EQ(callbacks_.details(), "no_healthy_upstream");
+}
+
+TEST_F(RouterTest, AsyncHostSelectionClusterRemovedBeforeCompletion) {
+  EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
+      .WillOnce(Invoke([](Upstream::LoadBalancerContext*) {
+        return Upstream::HostSelectionResponse{nullptr,
+                                               std::make_unique<TestAsyncHostSelectionHandle>()};
+      }));
+
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            router_->decodeHeaders(headers, true));
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "503"}, {"content-length", "19"}, {"content-type", "text/plain"}};
+  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
+  EXPECT_CALL(callbacks_, encodeData(_, true));
+  EXPECT_CALL(callbacks_, continueDecoding()).Times(0);
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream));
+
+  router_->onAsyncHostSelection(nullptr, "load_balancer_destroyed");
+
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
+  EXPECT_EQ(0U,
+            callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
+  EXPECT_EQ(callbacks_.details(), "load_balancer_destroyed");
 }
 
 TEST_F(RouterTest, RouterLoadShedTest) {
@@ -4069,6 +4102,49 @@ TEST_F(RouterTest, RetryNoneHealthy) {
   // Pool failure for the first try, so only 1 upstream request was made.
   EXPECT_EQ(1U,
             callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
+}
+
+TEST_F(RouterTest, RetryAsyncHostSelectionClusterRemovedBeforeCompletion) {
+  NiceMock<Http::MockRequestEncoder> encoder1;
+  Http::ResponseDecoder* response_decoder = nullptr;
+  expectNewStreamWithImmediateEncoder(encoder1, &response_decoder, Http::Protocol::Http10);
+
+  expectResponseTimerCreate();
+
+  Http::TestRequestHeaderMapImpl headers{{"x-envoy-retry-on", "5xx"}, {"x-envoy-internal", "true"}};
+  HttpTestUtility::addDefaultHeaders(headers);
+  router_->decodeHeaders(headers, true);
+  EXPECT_EQ(1U,
+            callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
+
+  router_->retry_state_->expectHeadersRetry();
+  Http::ResponseHeaderMapPtr response_headers1(
+      new Http::TestResponseHeaderMapImpl{{":status", "503"}});
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_.host_->outlier_detector_,
+              putResult(_, absl::optional<uint64_t>(503)));
+  response_decoder->decodeHeaders(std::move(response_headers1), true);
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
+
+  EXPECT_CALL(cm_.thread_local_cluster_, chooseHost(_))
+      .WillOnce(Invoke([](Upstream::LoadBalancerContext*) {
+        return Upstream::HostSelectionResponse{nullptr,
+                                               std::make_unique<TestAsyncHostSelectionHandle>()};
+      }));
+  router_->retry_state_->callback_();
+
+  Http::TestResponseHeaderMapImpl response_headers{
+      {":status", "503"}, {"content-length", "19"}, {"content-type", "text/plain"}};
+  EXPECT_CALL(callbacks_, encodeHeaders_(HeaderMapEqualRef(&response_headers), false));
+  EXPECT_CALL(callbacks_, encodeData(_, true));
+  EXPECT_CALL(callbacks_.stream_info_,
+              setResponseFlag(StreamInfo::CoreResponseFlag::NoHealthyUpstream));
+
+  router_->onAsyncHostSelection(nullptr, "load_balancer_destroyed");
+
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 1));
+  EXPECT_EQ(1U,
+            callbacks_.route_->virtual_host_->virtual_cluster_.stats().upstream_rq_total_.value());
+  EXPECT_EQ(callbacks_.details(), "load_balancer_destroyed");
 }
 
 TEST_F(RouterTest, RetryUpstreamReset) {

--- a/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_forward_proxy/cluster_test.cc
@@ -63,7 +63,7 @@ public:
     cluster_.reset(new Cluster(cluster_config, std::move(cache), config, factory_context,
                                this->get(), creation_status));
     THROW_IF_NOT_OK_REF(creation_status);
-    thread_aware_lb_ = std::make_unique<Cluster::ThreadAwareLoadBalancer>(*cluster_);
+    thread_aware_lb_ = std::make_unique<Cluster::ThreadAwareLoadBalancer>(cluster_);
     lb_factory_ = thread_aware_lb_->factory();
     refreshLb();
 
@@ -235,6 +235,37 @@ TEST_F(ClusterTest, CreateSubClusterConfig) {
   EXPECT_EQ(false, sub_cluster_pair.second.has_value());
 }
 
+// Sub cluster does not exist and load balancer should return nullptr.
+TEST_F(ClusterTest, SubClusterNotExist) {
+  initialize(sub_cluster_yaml_config_, false);
+
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("DFPCluster:localhost:80"))
+      .WillOnce(Return(nullptr));
+
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("localhost")).host);
+}
+
+// Load balancer will return null host if the cluster is destroyed in the main thread.
+TEST_F(ClusterTest, ClusterDestroyedInMainThread) {
+  initialize(default_yaml_config_, false);
+  makeTestHost("host1:0", "1.2.3.4");
+  InSequence s;
+
+  // LB will immediately resolve host1.
+  EXPECT_CALL(*this, onMemberUpdateCb(SizeIs(1), SizeIs(0)));
+  EXPECT_TRUE(update_callbacks_->onDnsHostAddOrUpdate("host1:0", host_map_["host1:0"]).ok());
+  EXPECT_EQ(1UL, cluster_->prioritySet().hostSetsPerPriority()[0]->hosts().size());
+  EXPECT_EQ("1.2.3.4:0",
+            cluster_->prioritySet().hostSetsPerPriority()[0]->hosts()[0]->address()->asString());
+  EXPECT_CALL(*host_map_["host1:0"], touch());
+  EXPECT_EQ("1.2.3.4:0",
+            lb_->chooseHost(setHostAndReturnContext("host1:0")).host->address()->asString());
+
+  // Destroy the cluster, LB will return nullptr without accessing the cluster.
+  cluster_.reset();
+  EXPECT_EQ(nullptr, lb_->chooseHost(setHostAndReturnContext("host1:0")).host);
+}
+
 // Basic flow of the cluster including adding hosts and removing them.
 TEST_F(ClusterTest, BasicFlow) {
   initialize(default_yaml_config_, false);
@@ -314,6 +345,40 @@ TEST_F(ClusterTest, InvalidLbContext) {
   ON_CALL(lb_context_, downstreamHeaders()).WillByDefault(Return(nullptr));
   EXPECT_EQ(nullptr, lb_->chooseHost(&lb_context_).host);
   EXPECT_EQ(nullptr, lb_->chooseHost(nullptr).host);
+}
+
+TEST_F(ClusterTest, LoadBalancer_CleansUpPendingAsyncHostSelectionOnDestroy) {
+  initialize(default_yaml_config_, false);
+
+  NiceMock<Upstream::MockBasicResourceLimit> resource_limit;
+  auto* dns_cache_handle =
+      new NiceMock<Extensions::Common::DynamicForwardProxy::MockLoadDnsCacheEntryHandle>();
+
+  EXPECT_CALL(resource_limit, inc());
+  auto* dns_request = new Upstream::ResourceAutoIncDec(resource_limit);
+  EXPECT_CALL(resource_limit, dec());
+  EXPECT_CALL(*dns_cache_handle, onDestroy());
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, canCreateDnsRequest_())
+      .WillOnce(Return(dns_request));
+  EXPECT_CALL(*dns_cache_manager_->dns_cache_, loadDnsCacheEntry_("host1", 80, _, _))
+      .WillOnce(Invoke([dns_cache_handle](absl::string_view, uint16_t, bool,
+                                          Extensions::Common::DynamicForwardProxy::DnsCache::
+                                              LoadDnsCacheEntryCallbacks&) {
+        return Extensions::Common::DynamicForwardProxy::MockDnsCache::MockLoadDnsCacheEntryResult{
+            Extensions::Common::DynamicForwardProxy::DnsCache::LoadDnsCacheEntryStatus::Loading,
+            dns_cache_handle, absl::nullopt};
+      }));
+  EXPECT_CALL(lb_context_, onAsyncHostSelection(_, _))
+      .WillOnce([](Upstream::HostConstSharedPtr&& host, std::string&& details) {
+        EXPECT_EQ(host, nullptr);
+        EXPECT_EQ(details, "load_balancer_destroyed");
+      });
+
+  auto host_selection = lb_->chooseHost(setHostAndReturnContext("host1"));
+  ASSERT_EQ(nullptr, host_selection.host);
+  ASSERT_NE(nullptr, host_selection.cancelable);
+
+  lb_.reset();
 }
 
 TEST_F(ClusterTest, FilterStateHostOverride) {


### PR DESCRIPTION
Commit Message: dfp: fix a bug when cluster is removed before async lb be completed
Additional Description:

In the previous implementation, both the router/DFP cluster may access invalid pointer if a cluster is removed then the request is pending and waiting the async load balancing result.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API
Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
