### PR TITLE
reverse_tunnel: fix downstream connection state gauge cleanup

### DIFF
--- a/changelogs/current/bug_fixes/reverse_tunnel__connection-state-gauges.rst
+++ b/changelogs/current/bug_fixes/reverse_tunnel__connection-state-gauges.rst
@@ -1,0 +1,2 @@
+Fixed a bug in the reverse tunnel downstream socket interface where the per-host and per-cluster
+``connected`` and ``connecting`` gauges were not decremented on some connection teardown paths.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -33,6 +33,9 @@ DownstreamReverseConnectionIOHandle::~DownstreamReverseConnectionIOHandle() {
       "DownstreamReverseConnectionIOHandle: destroying handle for FD: {} with connection key: {}",
       fd_, connection_key_);
   if (parent_ != nullptr) {
+    if (fd_ >= 0) {
+      parent_->onDownstreamConnectionClosed(connection_key_);
+    }
     parent_->unregisterChildIoHandle(*this);
   }
   SET_SOCKET_INVALID(fd_);

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -86,6 +86,7 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
             connection_->id());
   connection_->addConnectionCallbacks(*this);
   connection_->connect();
+  connection_key_ = connection_->connectionInfoProvider().localAddress()->asString();
 
   // Use HTTP handshake.
   ENVOY_LOG(debug,
@@ -213,7 +214,7 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
     onHandshakeFailure(HandshakeFailureReason::encodeError());
   }
 
-  return connection_->connectionInfoProvider().localAddress()->asString();
+  return connection_key_;
 }
 
 void RCConnectionWrapper::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool) {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -216,6 +216,8 @@ public:
    */
   Network::ClientConnection* getConnection() { return connection_.get(); }
 
+  const std::string& connectionKey() const { return connection_key_; }
+
   /**
    * Get the host description.
    * @return shared pointer to the host description

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -82,6 +82,11 @@ void ReverseConnectionIOHandle::emitAccessLog(const std::string& event,
 void ReverseConnectionIOHandle::cleanup() {
   ENVOY_LOG_MISC(debug, "Starting cleanup of reverse connection resources.");
 
+  for (const auto& [host, unused] : host_to_conn_info_map_) {
+    UNREFERENCED_PARAMETER(unused);
+    clearConnectionStates(host);
+  }
+
   // Detach any still-live child tunnel IoHandles so their parent() returns nullptr instead of a
   // dangling pointer after this object is destroyed.
   for (auto* child : child_io_handles_) {
@@ -515,8 +520,24 @@ void ReverseConnectionIOHandle::removeStaleHostAndCloseConnections(const std::st
   // Clear connection keys from host info.
   auto host_it = host_to_conn_info_map_.find(host);
   if (host_it != host_to_conn_info_map_.end()) {
+    clearConnectionStates(host);
     host_it->second.connection_keys.clear();
   }
+}
+
+void ReverseConnectionIOHandle::clearConnectionStates(const std::string& host) {
+  auto host_it = host_to_conn_info_map_.find(host);
+  if (host_it == host_to_conn_info_map_.end()) {
+    return;
+  }
+
+  auto& host_info = host_it->second;
+  for (const auto& [connection_key, state] : host_info.connection_states) {
+    UNREFERENCED_PARAMETER(connection_key);
+    updateStateGauge(host, host_info.cluster_name, state, false);
+  }
+  host_info.connection_states.clear();
+  host_info.connecting_count = 0;
 }
 
 void ReverseConnectionIOHandle::maintainClusterConnections(
@@ -1176,18 +1197,23 @@ void ReverseConnectionIOHandle::onConnectionDone(
     return;
   }
 
+  connection_key = wrapper->connectionKey();
+
   // Safely get connection info if wrapper is still valid.
   auto* connection = wrapper->getConnection();
-  if (connection) {
+  if (connection_key.empty() && connection) {
     connection_key = connection->connectionInfoProvider().localAddress()->asString();
+  }
+  if (!connection_key.empty()) {
     ENVOY_LOG(debug,
               "reverse_tunnel: Processing connection event for host '{}', cluster "
               "'{}', key '{}'",
               host_address, cluster_name, connection_key);
   } else {
-    connection_key = "cleanup_" + host_address + "_" + std::to_string(rand());
-    ENVOY_LOG(debug, "reverse_tunnel: Connection already null, using fallback key '{}'",
-              connection_key);
+    ENVOY_LOG(error,
+              "reverse_tunnel: Connection key unavailable for host '{}' in cluster '{}'; "
+              "state transition cannot be correlated",
+              host_address, cluster_name);
   }
 
   // Process connection result safely.
@@ -1199,8 +1225,10 @@ void ReverseConnectionIOHandle::onConnectionDone(
     ENVOY_LOG(error, "reverse_tunnel: Connection failed - error '{}', cleaning up host {}", error,
               host_address);
 
-    updateConnectionState(host_address, cluster_name, connection_key,
-                          ReverseConnectionState::Failed);
+    if (!connection_key.empty()) {
+      updateConnectionState(host_address, cluster_name, connection_key,
+                            ReverseConnectionState::Failed);
+    }
 
     // Safely close connection if still valid.
     if (connection) {

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -468,6 +468,8 @@ private:
    */
   void removeStaleHostAndCloseConnections(const std::string& host);
 
+  void clearConnectionStates(const std::string& host);
+
   /**
    * Per-host connection tracking for better management.
    * Contains all information needed to track and manage connections to a specific host.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -57,6 +57,9 @@ protected:
     // Create the socket interface.
     socket_interface_ = std::make_unique<ReverseTunnelInitiator>(context_);
 
+    config_.set_stat_prefix("reverse_connections");
+    config_.set_enable_detailed_stats(true);
+
     // Create the extension.
     extension_ = std::make_unique<ReverseTunnelInitiatorExtension>(context_, config_);
 
@@ -107,6 +110,8 @@ protected:
   std::unique_ptr<ReverseTunnelInitiator> socket_interface_;
   std::unique_ptr<ReverseTunnelInitiatorExtension> extension_;
   std::unique_ptr<ReverseConnectionIOHandle> io_handle_;
+  std::unique_ptr<ThreadLocal::TypedSlot<DownstreamSocketThreadLocal>> tls_slot_;
+  std::shared_ptr<DownstreamSocketThreadLocal> thread_local_registry_;
 
   // Mock cluster manager.
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
@@ -166,6 +171,31 @@ protected:
                                                                  connection_key);
   }
 
+  void setupThreadLocalSlot() {
+    thread_local_registry_ =
+        std::make_shared<DownstreamSocketThreadLocal>(dispatcher_, *stats_scope_);
+    tls_slot_ = ThreadLocal::TypedSlot<DownstreamSocketThreadLocal>::makeUnique(thread_local_);
+    thread_local_.setDispatcher(&dispatcher_);
+    tls_slot_->set([registry = thread_local_registry_](Event::Dispatcher&) { return registry; });
+    extension_->setTestOnlyTLSRegistry(std::move(tls_slot_));
+  }
+
+  void addConnectedTunnel(const std::string& host, const std::string& cluster,
+                          const std::string& connection_key) {
+    io_handle_->host_to_conn_info_map_[host] = ReverseConnectionIOHandle::HostConnectionInfo{
+        host,
+        cluster,
+        {},
+        1,
+        0,
+        std::chrono::steady_clock::now(), // NO_CHECK_FORMAT(real_time)
+        std::chrono::steady_clock::time_point{},
+        {}};
+    io_handle_->host_to_conn_info_map_[host].connection_keys.insert(connection_key);
+    io_handle_->updateConnectionState(host, cluster, connection_key,
+                                      ReverseConnectionState::Connected);
+  }
+
   // Test fixtures.
   std::unique_ptr<NiceMock<Network::MockConnectionSocket>> mock_socket_;
   NiceMock<Network::MockIoHandle>* mock_io_handle_; // Raw pointer, managed by socket
@@ -199,6 +229,22 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, ParentTeardownDetachesChild) {
   // Destroying the parent runs cleanup(), which detaches its registered children.
   io_handle_.reset();
   EXPECT_EQ(child->parent(), nullptr);
+}
+
+TEST_F(DownstreamReverseConnectionIOHandleTest, DestructorDecrementsConnectedGauge) {
+  setupThreadLocalSlot();
+
+  const std::string host = "192.168.1.1";
+  const std::string cluster = "test-cluster";
+  const std::string connection_key = "192.168.1.1:12345";
+  addConnectedTunnel(host, cluster, connection_key);
+
+  auto handle = createHandle(io_handle_.get(), connection_key);
+  handle.reset();
+
+  const auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.host.192.168.1.1.connected"), 0);
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.cluster.test-cluster.connected"), 0);
 }
 
 // Test close() method and all edge cases.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -3430,6 +3430,89 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedUnknownKeyIsNo
   EXPECT_TRUE(getHostToConnInfoMap().empty());
 }
 
+TEST_F(ReverseConnectionIOHandleTest, HostRemovalDecrementsConnectedGauge) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+
+  const std::string host = "192.168.1.1";
+  const std::string cluster = "test-cluster";
+  const std::string connection_key = "192.168.1.1:12345";
+  addHostConnectionInfo(host, cluster, 1);
+  getMutableHostConnectionInfo(host).connection_keys.insert(connection_key);
+  io_handle_->updateConnectionState(host, cluster, connection_key,
+                                    ReverseConnectionState::Connected);
+
+  auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.connected"], 1);
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.cluster.test-cluster.connected"], 1);
+
+  removeStaleHostAndCloseConnections(host);
+
+  stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.host.192.168.1.1.connected"], 0);
+  EXPECT_EQ(stat_map["test_scope.reverse_connections.cluster.test-cluster.connected"], 0);
+}
+
+TEST_F(ReverseConnectionIOHandleTest, NullConnectionFailureDecrementsConnectingGauge) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+  auto mock_connection = setupMockConnection();
+  Upstream::MockHost::MockCreateConnectionData connection_data;
+  connection_data.connection_ = mock_connection.get();
+  connection_data.host_description_ = mock_host;
+  EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(connection_data));
+  mock_connection.release();
+
+  ASSERT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  RCConnectionWrapper* wrapper = getConnectionWrappers()[0].get();
+  auto released_connection = wrapper->releaseConnection();
+  ASSERT_NE(released_connection, nullptr);
+
+  io_handle_->onConnectionDone("connection closed", wrapper, true);
+
+  const auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.host.192.168.1.1.connecting"), 0);
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.cluster.test-cluster.connecting"), 0);
+}
+
+TEST_F(ReverseConnectionIOHandleTest, CleanupDecrementsConnectedGauge) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+
+  const std::string host = "192.168.1.1";
+  const std::string cluster = "test-cluster";
+  const std::string connection_key = "192.168.1.1:12345";
+  addHostConnectionInfo(host, cluster, 1);
+  getMutableHostConnectionInfo(host).connection_keys.insert(connection_key);
+  io_handle_->updateConnectionState(host, cluster, connection_key,
+                                    ReverseConnectionState::Connected);
+
+  cleanup();
+
+  const auto stat_map = extension_->getCrossWorkerStatMap();
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.host.192.168.1.1.connected"), 0);
+  EXPECT_EQ(stat_map.at("test_scope.reverse_connections.cluster.test-cluster.connected"), 0);
+}
+
 } // namespace ReverseConnection
 } // namespace Bootstrap
 } // namespace Extensions


### PR DESCRIPTION
## 🥞 Stacked PR

Commit Message: reverse_tunnel: fix downstream connection state gauge cleanup
Additional Description: Reverse-tunnel `connected` and `connecting` gauges could remain incremented when connections were removed, failed after releasing their socket, or were destroyed during cleanup. Preserve each connection's stable key and clear tracked states across all teardown paths.
Risk Level: Low
Testing: Both downstream reverse-connection IO handle Bazel unit-test targets passed, including the new regression coverage described below. `runtests` could not start because this upstream Envoy checkout does not contain the Databricks-specific `capabilities.textproto` required by that wrapper.
Docs Changes: Added a release-note fragment.
Release Notes: Fixed reverse-tunnel per-host and per-cluster connection-state gauges not decrementing on some teardown paths.

## How do you know it works?

1. `runtests` could not start because the checkout lacks its required `capabilities.textproto`; the complete relevant Bazel unit-test targets passed.
2. New tests: unit tests covering host removal, null-connection handshake failure, parent cleanup, and child-handle destruction.
3. Manual testing: _[Joy to fill in]_

## AI assistance

Cursor AI assisted with diagnosis, implementation, regression tests, and PR preparation. The submitter must review and understand the changes before submission.