### PR TITLE
dynamic_modules: make recreate_stream unsafe + add safe deferred wrapper

### DIFF
--- a/changelogs/current/behavior_changes/dynamic_modules__recreate-stream-unsafe.rst
+++ b/changelogs/current/behavior_changes/dynamic_modules__recreate-stream-unsafe.rst
@@ -1,0 +1,7 @@
+Made the Rust dynamic module SDK ``EnvoyHttpFilter::recreate_stream`` an ``unsafe`` method, since a
+successful call synchronously destroys the current filter chain — freeing the filter that backs
+``self`` — before it returns, so any subsequent use of ``self`` is a use-after-free. A new safe
+``EnvoyHttpFilter::request_stream_recreation`` performs the recreation from the SDK event loop after
+the filter hook returns, when no reference to the filter remains. Modules that call
+``recreate_stream`` directly must now wrap it in ``unsafe`` or switch to
+``request_stream_recreation``.

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -2020,13 +2020,13 @@ pub trait EnvoyHttpFilter {
   /// # Safety
   ///
   /// When this returns `true`, Envoy synchronously destroys the current filter chain, including
-  /// the Envoy filter that backs `self` before this call returns. The caller MUST return 
-  /// `StopIteration` from the current event hook and MUST NOT touch `self` (or the [`HttpFilter`] 
-  /// that invoked the hook) again afterwards. 
+  /// the Envoy filter that backs `self` before this call returns. The caller MUST return
+  /// `StopIteration` from the current event hook and MUST NOT touch `self` (or the [`HttpFilter`]
+  /// that invoked the hook) again afterwards.
   unsafe fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool;
 
-  /// Safe counterpart to [`EnvoyHttpFilter::recreate_stream`]: request recreation from a
-  /// request-path hook and the SDK performs it after the hook returns.
+  /// Safe counterpart to [`EnvoyHttpFilter::recreate_stream`]: request recreation from an event
+  /// hook and the SDK performs it after the hook returns, once no reference to the filter remains.
   fn request_stream_recreation(&mut self);
 
   /// Clear only the cluster selection for the current route without clearing the entire route
@@ -4024,20 +4024,23 @@ impl EnvoyHttpFilterImpl {
     }
   }
 
-  /// Perform a recreation requested via [`EnvoyHttpFilter::request_stream_recreation`], if any,
-  /// returning `true` if one was performed (the trampoline must then return `StopIteration`).
+  /// Perform a recreation requested via [`EnvoyHttpFilter::request_stream_recreation`], if any.
+  ///
+  /// Returns `true` only if Envoy actually recreated the stream (and therefore destroyed the
+  /// filter); the trampoline must then return `StopIteration`. Returns `false` if no recreation was
+  /// requested, or if Envoy declined it (e.g. the request body was not fully received) — in that
+  /// case the filter is still alive and the hook's own status must be honored.
   ///
   /// # Safety
   ///
-  /// Recreation frees the filter, so this must be called from a request-path trampoline only after
-  /// the filter hook has returned and no reference to the filter (`&mut self`) remains.
+  /// Recreation frees the filter, so this must be called from an event trampoline only after the
+  /// filter hook has returned and no reference to the filter (`&mut self`) remains.
   pub(crate) unsafe fn take_and_perform_recreation(&mut self) -> bool {
     if !self.recreate_requested {
       return false;
     }
     self.recreate_requested = false;
-    self.recreate_stream(None);
-    true
+    self.recreate_stream(None)
   }
 
   /// Implement the common logic for getting all headers/trailers.
@@ -4580,7 +4583,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_headers(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_response_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_response_headers(&mut envoy, end_of_stream);
+    // See on_request_headers: recreate_stream is also reachable on the response path (e.g. internal
+    // redirects driven from upstream headers), so honor a deferred recreation here too.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic(
@@ -4604,7 +4615,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_body(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_response_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_response_body(&mut envoy, end_of_stream);
+    // See on_request_headers: perform any deferred recreation now that `filter` is unborrowed.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_response_body_status::StopIterationNoBuffer;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_response_body", panic);
@@ -4624,7 +4642,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_trailers(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_response_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_response_trailers(&mut envoy);
+    // See on_request_headers: perform any deferred recreation now that `filter` is unborrowed.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status::StopIteration;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic(
@@ -4673,13 +4698,11 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_callout_done(
     } else {
       None
     };
-    filter.on_http_callout_done(
-      &mut EnvoyHttpFilterImpl::new(envoy_ptr),
-      callout_id,
-      result,
-      headers,
-      body,
-    )
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    filter.on_http_callout_done(&mut envoy, callout_id, result, headers, body);
+    // This hook has no status to return, but a filter may still request recreation from it.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    unsafe { envoy.take_and_perform_recreation() };
   }))
   .map_err(|panic| {
     crate::log_ffi_panic(

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -2016,7 +2016,18 @@ pub trait EnvoyHttpFilter {
   ///
   /// Returns `true` if the stream recreation was initiated successfully, `false` otherwise (e.g.,
   /// if the request body has not been fully received yet or if the stream cannot be recreated).
-  fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool;
+  ///
+  /// # Safety
+  ///
+  /// When this returns `true`, Envoy synchronously destroys the current filter chain, including
+  /// the Envoy filter that backs `self` before this call returns. The caller MUST return 
+  /// `StopIteration` from the current event hook and MUST NOT touch `self` (or the [`HttpFilter`] 
+  /// that invoked the hook) again afterwards. 
+  unsafe fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool;
+
+  /// Safe counterpart to [`EnvoyHttpFilter::recreate_stream`]: request recreation from a
+  /// request-path hook and the SDK performs it after the hook returns.
+  fn request_stream_recreation(&mut self);
 
   /// Clear only the cluster selection for the current route without clearing the entire route
   /// cache.
@@ -2370,6 +2381,9 @@ impl Drop for EnvoyChildSpanImpl {
 /// This is not meant to be used directly.
 pub struct EnvoyHttpFilterImpl {
   pub(crate) raw_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+  /// Set by [`EnvoyHttpFilter::request_stream_recreation`]. The SDK event trampoline performs the
+  /// actual (freeing) recreation after the filter hook returns, when nothing borrows the filter.
+  recreate_requested: bool,
 }
 
 impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
@@ -3971,7 +3985,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool {
+  unsafe fn recreate_stream<'a>(&mut self, headers: Option<&'a [(&'a str, &'a [u8])]>) -> bool {
     match headers {
       Some(headers) => {
         let HeaderPairSlice(headers_ptr, headers_len) = headers.into();
@@ -3993,6 +4007,10 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
+  fn request_stream_recreation(&mut self) {
+    self.recreate_requested = true;
+  }
+
   fn clear_route_cluster_cache(&mut self) {
     unsafe { abi::envoy_dynamic_module_callback_http_clear_route_cluster_cache(self.raw_ptr) }
   }
@@ -4000,7 +4018,26 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
 
 impl EnvoyHttpFilterImpl {
   pub(crate) fn new(raw_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr) -> Self {
-    Self { raw_ptr }
+    Self {
+      raw_ptr,
+      recreate_requested: false,
+    }
+  }
+
+  /// Perform a recreation requested via [`EnvoyHttpFilter::request_stream_recreation`], if any,
+  /// returning `true` if one was performed (the trampoline must then return `StopIteration`).
+  ///
+  /// # Safety
+  ///
+  /// Recreation frees the filter, so this must be called from a request-path trampoline only after
+  /// the filter hook has returned and no reference to the filter (`&mut self`) remains.
+  pub(crate) unsafe fn take_and_perform_recreation(&mut self) -> bool {
+    if !self.recreate_requested {
+      return false;
+    }
+    self.recreate_requested = false;
+    self.recreate_stream(None);
+    true
   }
 
   /// Implement the common logic for getting all headers/trailers.
@@ -4385,9 +4422,7 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_new(
   filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_http_filter_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
-    let mut envoy_filter = EnvoyHttpFilterImpl {
-      raw_ptr: filter_envoy_ptr,
-    };
+    let mut envoy_filter = EnvoyHttpFilterImpl::new(filter_envoy_ptr);
     let filter_config = {
       let raw = filter_config_ptr as *const *const dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
       &**raw
@@ -4456,7 +4491,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_headers(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_request_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_request_headers(&mut envoy, end_of_stream);
+    // A deferred `request_stream_recreation` is performed here, after the hook returned and no
+    // reference to `filter` remains; it frees the filter, so the stream must stop iterating.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_request_headers", panic);
@@ -4478,7 +4521,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_body(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_request_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_request_body(&mut envoy, end_of_stream);
+    // See on_request_headers: perform any deferred recreation now that `filter` is unborrowed.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_request_body_status::StopIterationNoBuffer;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic("envoy_dynamic_module_on_http_filter_request_body", panic);
@@ -4499,7 +4549,14 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_trailers(
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
     let filter = &mut **filter;
-    filter.on_request_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
+    let mut envoy = EnvoyHttpFilterImpl::new(envoy_ptr);
+    let status = filter.on_request_trailers(&mut envoy);
+    // See on_request_headers: perform any deferred recreation now that `filter` is unborrowed.
+    // SAFETY: the hook has returned, so no reference to the filter remains.
+    if unsafe { envoy.take_and_perform_recreation() } {
+      return abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::StopIteration;
+    }
+    status
   }))
   .unwrap_or_else(|panic| {
     crate::log_ffi_panic(

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -135,9 +135,7 @@ fn test_envoy_dynamic_module_on_http_filter_new_destroy() {
 
   let mut filter_config = TestHttpFilterConfig;
   let result = envoy_dynamic_module_on_http_filter_new_impl(
-    &mut EnvoyHttpFilterImpl {
-      raw_ptr: std::ptr::null_mut(),
-    },
+    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
     &mut filter_config,
   );
   assert!(!result.is_null());
@@ -228,9 +226,7 @@ fn test_envoy_dynamic_module_on_http_filter_callbacks() {
 
   let mut filter_config = TestHttpFilterConfig;
   let filter = envoy_dynamic_module_on_http_filter_new_impl(
-    &mut EnvoyHttpFilterImpl {
-      raw_ptr: std::ptr::null_mut(),
-    },
+    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
     &mut filter_config,
   );
 
@@ -1918,9 +1914,7 @@ pub extern "C" fn envoy_dynamic_module_callback_http_get_upstream_connection_id(
 fn test_http_get_upstream_connection_id() {
   MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(98765, std::sync::atomic::Ordering::SeqCst);
 
-  let filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
 
   assert_eq!(filter.get_upstream_connection_id(), 98765);
   MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(0, std::sync::atomic::Ordering::SeqCst);
@@ -1930,9 +1924,7 @@ fn test_http_get_upstream_connection_id() {
 fn test_http_get_upstream_connection_id_unavailable() {
   MOCK_HTTP_UPSTREAM_CONNECTION_ID.store(0, std::sync::atomic::Ordering::SeqCst);
 
-  let filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
 
   assert_eq!(filter.get_upstream_connection_id(), 0);
 }
@@ -3994,6 +3986,18 @@ pub extern "C" fn envoy_dynamic_module_callback_http_send_response(
   SEND_RESPONSE_STATUS_CODE.store(status_code, std::sync::atomic::Ordering::SeqCst);
 }
 
+static RECREATE_STREAM_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_http_filter_recreate_stream(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_http_filter_envoy_ptr,
+  _headers: *mut abi::envoy_dynamic_module_type_module_http_header,
+  _headers_size: usize,
+) -> bool {
+  RECREATE_STREAM_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+  true
+}
+
 static RESET_STREAM_CALLED: AtomicBool = AtomicBool::new(false);
 
 #[no_mangle]
@@ -4043,9 +4047,7 @@ fn test_http_filter_state_object_round_trip() {
     drop(unsafe { Box::from_raw(object as *mut Live) });
   }
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let object = Box::into_raw(Box::new(Live)) as *mut std::ffi::c_void;
   // SAFETY: `object` is a freshly boxed Live and `destructor` frees exactly that type without
   // unwinding.
@@ -4067,6 +4069,57 @@ fn test_http_filter_state_object_round_trip() {
   // once with no double free.
   destructor(recovered.unwrap());
   assert_eq!(DROPPED.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn test_request_stream_recreation_deferred_to_trampoline() {
+  use std::sync::atomic::Ordering;
+
+  // A filter that requests recreation from a request-path hook using only the safe API, then
+  // returns Continue. If the SDK honored the request inline it would free the filter here; instead
+  // the trampoline must perform it after this hook returns and override the status to stop.
+  struct RecreatingFilter;
+  impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreatingFilter {
+    fn on_request_headers(
+      &mut self,
+      envoy_filter: &mut EHF,
+      _end_of_stream: bool,
+    ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+      envoy_filter.request_stream_recreation();
+      abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+    }
+  }
+
+  struct RecreatingFilterConfig;
+  impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for RecreatingFilterConfig {
+    fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+      Box::new(RecreatingFilter)
+    }
+  }
+
+  RECREATE_STREAM_CALL_COUNT.store(0, Ordering::SeqCst);
+
+  let mut filter_config = RecreatingFilterConfig;
+  let filter = envoy_dynamic_module_on_http_filter_new_impl(
+    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
+    &mut filter_config,
+  );
+
+  // The recreation FFI has not fired during construction.
+  assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 0);
+
+  let status =
+    unsafe { envoy_dynamic_module_on_http_filter_request_headers(std::ptr::null_mut(), filter, true) };
+
+  // The trampoline performed the deferred recreation exactly once, after the hook returned, and
+  // overrode the hook's Continue with StopIteration for the now-destroyed stream.
+  assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 1);
+  assert_eq!(
+    status,
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  );
+
+  unsafe { envoy_dynamic_module_on_http_filter_destroy(filter) };
 }
 
 static NETWORK_CLOSE_CALLED: AtomicBool = AtomicBool::new(false);
@@ -4104,9 +4157,7 @@ fn test_catch_unwind_http_filter_panic() {
 
   SEND_RESPONSE_STATUS_CODE.store(0, std::sync::atomic::Ordering::SeqCst);
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let mut wrapper = CatchUnwind::new(PanicFilter);
 
   let status = HttpFilter::on_request_headers(&mut wrapper, &mut envoy_filter, false);
@@ -4191,9 +4242,7 @@ fn test_catch_unwind_http_response_headers_panic() {
 
   RESET_STREAM_CALLED.store(false, std::sync::atomic::Ordering::SeqCst);
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let mut wrapper = CatchUnwind::new(PanicFilter);
 
   let status = HttpFilter::on_response_headers(&mut wrapper, &mut envoy_filter, false);
@@ -4274,9 +4323,7 @@ fn test_catch_unwind_http_callout_done_after_poison_is_skipped() {
     }
   }
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let mut wrapper = CatchUnwind::new(PanicFilter);
 
   let status = HttpFilter::on_request_headers(&mut wrapper, &mut envoy_filter, false);
@@ -4314,9 +4361,7 @@ fn test_catch_unwind_http_scheduled_after_poison_is_skipped() {
     }
   }
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let mut wrapper = CatchUnwind::new(PanicFilter);
 
   let status = HttpFilter::on_request_headers(&mut wrapper, &mut envoy_filter, false);
@@ -4369,9 +4414,7 @@ fn test_catch_unwind_http_reentrant_status_callback_is_not_poisoned() {
   RESET_STREAM_CALLED.store(false, std::sync::atomic::Ordering::SeqCst);
   RESPONSE_HEADERS_RAN.with(|c| c.set(false));
 
-  let mut envoy_filter = http::EnvoyHttpFilterImpl {
-    raw_ptr: std::ptr::null_mut(),
-  };
+  let mut envoy_filter = http::EnvoyHttpFilterImpl::new(std::ptr::null_mut());
   let mut wrapper = CatchUnwind::new(ReentrantFilter);
   WRAPPER_PTR
     .with(|p| p.set(&mut wrapper as *mut CatchUnwind<ReentrantFilter> as *mut std::ffi::c_void));
@@ -6565,9 +6608,7 @@ fn test_http_filter_callout_done_with_null_buffers_yields_none() {
 
   let filter_config = TestHttpFilterConfig;
   let filter = envoy_dynamic_module_on_http_filter_new_impl(
-    &mut EnvoyHttpFilterImpl {
-      raw_ptr: std::ptr::null_mut(),
-    },
+    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
     &filter_config,
   );
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -3987,6 +3987,9 @@ pub extern "C" fn envoy_dynamic_module_callback_http_send_response(
 }
 
 static RECREATE_STREAM_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+/// Controls the bool returned by the recreate_stream FFI stub, so tests can simulate Envoy
+/// declining the recreation (e.g. request body not fully received).
+static RECREATE_STREAM_RESULT: AtomicBool = AtomicBool::new(true);
 
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_http_filter_recreate_stream(
@@ -3995,7 +3998,7 @@ pub extern "C" fn envoy_dynamic_module_callback_http_filter_recreate_stream(
   _headers_size: usize,
 ) -> bool {
   RECREATE_STREAM_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-  true
+  RECREATE_STREAM_RESULT.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 static RESET_STREAM_CALLED: AtomicBool = AtomicBool::new(false);
@@ -4071,55 +4074,131 @@ fn test_http_filter_state_object_round_trip() {
   assert_eq!(DROPPED.load(Ordering::SeqCst), 1);
 }
 
+/// A filter that requests recreation from every event hook using only the safe API, and always
+/// returns the "continue" status so the trampoline's StopIteration override is observable.
+struct RecreatingFilter;
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreatingFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    envoy_filter.request_stream_recreation();
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    envoy_filter.request_stream_recreation();
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  }
+
+  fn on_http_callout_done(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _callout_id: u64,
+    _result: abi::envoy_dynamic_module_type_http_callout_result,
+    _response_headers: Option<&[(EnvoyBuffer, EnvoyBuffer)]>,
+    _response_body: Option<&[EnvoyBuffer]>,
+  ) {
+    envoy_filter.request_stream_recreation();
+  }
+}
+
+struct RecreatingFilterConfig;
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for RecreatingFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(RecreatingFilter)
+  }
+}
+
+fn new_recreating_filter() -> abi::envoy_dynamic_module_type_http_filter_module_ptr {
+  let mut filter_config = RecreatingFilterConfig;
+  envoy_dynamic_module_on_http_filter_new_impl(
+    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
+    &mut filter_config,
+  )
+}
+
+// The SDK must perform a deferred request_stream_recreation() from the request path AND the
+// response path, after the hook returns (never inline), overriding the hook's status with a stop
+// so the destroyed stream is not iterated further.
 #[test]
 fn test_request_stream_recreation_deferred_to_trampoline() {
   use std::sync::atomic::Ordering;
+  RECREATE_STREAM_RESULT.store(true, Ordering::SeqCst);
 
-  // A filter that requests recreation from a request-path hook using only the safe API, then
-  // returns Continue. If the SDK honored the request inline it would free the filter here; instead
-  // the trampoline must perform it after this hook returns and override the status to stop.
-  struct RecreatingFilter;
-  impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreatingFilter {
-    fn on_request_headers(
-      &mut self,
-      envoy_filter: &mut EHF,
-      _end_of_stream: bool,
-    ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-      envoy_filter.request_stream_recreation();
-      abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
-    }
-  }
-
-  struct RecreatingFilterConfig;
-  impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for RecreatingFilterConfig {
-    fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
-      Box::new(RecreatingFilter)
-    }
-  }
-
+  // Request path: on_request_headers.
   RECREATE_STREAM_CALL_COUNT.store(0, Ordering::SeqCst);
-
-  let mut filter_config = RecreatingFilterConfig;
-  let filter = envoy_dynamic_module_on_http_filter_new_impl(
-    &mut EnvoyHttpFilterImpl::new(std::ptr::null_mut()),
-    &mut filter_config,
-  );
-
-  // The recreation FFI has not fired during construction.
+  let filter = new_recreating_filter();
+  // Not recreated during construction.
   assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 0);
-
   let status =
     unsafe { envoy_dynamic_module_on_http_filter_request_headers(std::ptr::null_mut(), filter, true) };
-
-  // The trampoline performed the deferred recreation exactly once, after the hook returned, and
-  // overrode the hook's Continue with StopIteration for the now-destroyed stream.
   assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 1);
   assert_eq!(
     status,
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   );
+  unsafe { envoy_dynamic_module_on_http_filter_destroy(filter) };
+
+  // Response path: on_response_headers.
+  RECREATE_STREAM_CALL_COUNT.store(0, Ordering::SeqCst);
+  let filter = new_recreating_filter();
+  let status = unsafe {
+    envoy_dynamic_module_on_http_filter_response_headers(std::ptr::null_mut(), filter, true)
+  };
+  assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 1);
+  assert_eq!(
+    status,
+    abi::envoy_dynamic_module_type_on_http_filter_response_headers_status::StopIteration
+  );
+  unsafe { envoy_dynamic_module_on_http_filter_destroy(filter) };
+
+  // Callout hook: has no status to override, but the recreation must still be performed once.
+  RECREATE_STREAM_CALL_COUNT.store(0, Ordering::SeqCst);
+  let filter = new_recreating_filter();
+  unsafe {
+    envoy_dynamic_module_on_http_filter_http_callout_done(
+      std::ptr::null_mut(),
+      filter,
+      0,
+      abi::envoy_dynamic_module_type_http_callout_result::Success,
+      std::ptr::null(),
+      0,
+      std::ptr::null(),
+      0,
+    );
+  }
+  assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 1);
+  unsafe { envoy_dynamic_module_on_http_filter_destroy(filter) };
+}
+
+// If Envoy declines the recreation (recreate_stream returns false), the filter is NOT destroyed, so
+// the trampoline must honor the hook's own status rather than forcing StopIteration.
+#[test]
+fn test_request_stream_recreation_declined_keeps_hook_status() {
+  use std::sync::atomic::Ordering;
+  RECREATE_STREAM_RESULT.store(false, Ordering::SeqCst);
+  RECREATE_STREAM_CALL_COUNT.store(0, Ordering::SeqCst);
+
+  let filter = new_recreating_filter();
+  let status = unsafe {
+    envoy_dynamic_module_on_http_filter_request_headers(std::ptr::null_mut(), filter, true)
+  };
+
+  // The FFI was attempted once, but since it returned false the hook's Continue is preserved.
+  assert_eq!(RECREATE_STREAM_CALL_COUNT.load(Ordering::SeqCst), 1);
+  assert_eq!(
+    status,
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  );
 
   unsafe { envoy_dynamic_module_on_http_filter_destroy(filter) };
+  RECREATE_STREAM_RESULT.store(true, Ordering::SeqCst);
 }
 
 static NETWORK_CLOSE_CALLED: AtomicBool = AtomicBool::new(false);

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -502,6 +502,25 @@ TEST_P(DynamicModulesIntegrationTest, FilterStateObjectSurvivesRecreateStream) {
                           .getStringView());
 }
 
+// Regression test for the recreate_stream use-after-free. The recreate_stream_uaf filter requests
+// recreation via the safe request_stream_recreation() API and then writes through self; the SDK
+// defers the freeing recreate until after the hook returns, so self stays valid. Under
+// AddressSanitizer this passes cleanly — it would report a heap-use-after-free if the recreate were
+// performed inline (as a direct recreate_stream() call would).
+TEST_P(DynamicModulesIntegrationTest, RecreateStreamNoUseAfterFree) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the recreate_stream_uaf filter is only in the rust test module";
+  }
+  initializeFilter("recreate_stream_uaf");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
 TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnRequestBody) {
   initializeFilter("send_response", "on_request_body");
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -555,7 +555,7 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreateStreamFilter {
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
     // SAFETY: this hook does not touch `envoy_filter` again after recreate_stream succeeds.
     assert!(unsafe {
-      envoy_filter.recreate_stream(Some(&[(":status", b"302"), ("location", b"/recreated")]))
+      envoy_filter.recreate_stream(Some(&[(":status", b"302"), ("location", b"/recreated"),]))
     });
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -553,9 +553,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreateStreamFilter {
     envoy_filter: &mut EHF,
     _end_of_stream: bool,
   ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
-    assert!(
-      envoy_filter.recreate_stream(Some(&[(":status", b"302"), ("location", b"/recreated"),]))
-    );
+    // SAFETY: this hook does not touch `envoy_filter` again after recreate_stream succeeds.
+    assert!(unsafe {
+      envoy_filter.recreate_stream(Some(&[(":status", b"302"), ("location", b"/recreated")]))
+    });
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
   }
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -154,6 +154,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     },
     "list_metadata_callbacks" => Some(Box::new(ListMetadataCallbacksFilterConfig {})),
     "filter_state_object_recreate" => Some(Box::new(FilterStateObjectRecreateFilterConfig {})),
+    "recreate_stream_uaf" => Some(Box::new(RecreateStreamUafFilterConfig {})),
     "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig {})),
     "log_level" => Some(Box::new(LogLevelFilterConfig {})),
     _ => panic!("Unknown filter name: {name}"),
@@ -222,7 +223,9 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FilterStateObjectRecreateFilter {
             abi::envoy_dynamic_module_type_filter_state_life_span::Request,
           )
         });
-        assert!(envoy_filter.recreate_stream(None));
+        // SAFETY: this hook returns StopIteration immediately below and never touches
+        // `envoy_filter` again after recreate_stream succeeds.
+        assert!(unsafe { envoy_filter.recreate_stream(None) });
         abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
       },
       Some(object) => {
@@ -242,6 +245,51 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FilterStateObjectRecreateFilter {
         abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
       },
     }
+  }
+}
+
+/// Guards the recreate so the rebuilt instance does not recreate again. One Envoy runs per test, so
+/// a single static suffices.
+static RECREATE_UAF_DONE: AtomicBool = AtomicBool::new(false);
+
+/// Regression test for the `recreate_stream` use-after-free, exercising the safe deferred API.
+///
+/// `recreate_stream` synchronously frees the `Box<dyn HttpFilter>` backing `self`, so calling it
+/// directly and then touching `self` is a use-after-free. This filter uses the safe
+/// `request_stream_recreation`, which records the request and lets the SDK perform the recreation
+/// from the request-path trampoline after the hook returns — when nothing borrows the filter. After
+/// the deferred recreate the hook writes through `self` (the write that would be a UAF if the
+/// recreate had happened inline); it does not, so under AddressSanitizer this test passes cleanly.
+struct RecreateStreamUafFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for RecreateStreamUafFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(RecreateStreamUafFilter { marker: 0 })
+  }
+}
+
+struct RecreateStreamUafFilter {
+  /// Heap state owned by the filter `Box`, written after the recreate request to show `self` is
+  /// still valid (the deferred API did not free it inline).
+  marker: u64,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreateStreamUafFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    if RECREATE_UAF_DONE.swap(true, Ordering::SeqCst) {
+      // Rebuilt instance after the recreate: complete the request with a normal response.
+      envoy_filter.send_response(200, &[("x-recreate-uaf", b"done")], None, None);
+      return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
+    }
+    // Safe request: the SDK performs the freeing recreate after this hook returns, so `self` stays
+    // valid for the remainder of the hook.
+    envoy_filter.request_stream_recreation();
+    self.marker = self.marker.wrapping_add(1);
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
 }
 


### PR DESCRIPTION
### Commit Message

dynamic_modules: make recreate_stream unsafe + add safe deferred wrapper

`EnvoyHttpFilter::recreate_stream()` is a safe method today, but a successful call
synchronously destroys the current filter chain — freeing the `Box<dyn HttpFilter>`
that backs the running hook's `self` — before the FFI call returns. Because the
deallocation happens across the FFI boundary in Envoy's C++, the Rust borrow
checker cannot see it, so any use of `self` after the call is a use-after-free
reachable from ordinary safe Rust.

This change makes `recreate_stream` an `unsafe fn` with a `# Safety` contract
(matching the SDK's other caller-invariant FFI methods such as `reset_http_stream`,
`send_http_stream_data`, and `set_filter_state_object`), so safe Rust can no longer
reach the free. It also adds a safe `request_stream_recreation()`: the filter
records the intent, and the SDK performs the actual (freeing) recreation from the
event trampoline after the hook returns, when no reference to the filter remains.

### Additional Description

#### The problem

Any access to `self` **after** the `recreate_stream` call reads/writes freed
memory. The borrow checker permits it because `&mut self` and `&mut EnvoyHttpFilter`
are disjoint borrows and the free happens in opaque C++.

Assume a Rust HTTP filter (dynamic module) that calls `recreate_stream()` upon
receiving request headers. The synchronous teardown runs entirely inside the call:

<pre>
<b>envoy_dynamic_module_on_http_filter_request_headers</b>(envoy_ptr, filter_ptr, end_of_stream)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L4451">http.rs:4451</a>
│   let filter = filter_ptr as *mut *mut dyn HttpFilter&lt;…&gt;;  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L4457">http.rs:4457</a>
│   let filter = &amp;mut **filter;  // `self`: &amp;mut dyn HttpFilter into the inner filter object — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L4458">http.rs:4458</a>
└─► <b>HttpFilter::on_request_headers</b>(&amp;mut self, envoy, end_of_stream)   <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L4459">http.rs:4459</a>
    ├─► <b>EnvoyHttpFilter::recreate_stream</b>(&amp;mut self, None)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L3974">http.rs:3974</a>
    │   └─► <b>envoy_dynamic_module_callback_http_filter_recreate_stream</b>(raw_ptr, …)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L3987">http.rs:3987</a>
    │       └─► <b>envoy_dynamic_module_callback_http_filter_recreate_stream</b>(filter_envoy_ptr, …)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/abi_impl.cc#L2766">abi_impl.cc:2766</a>
    │           └─► <b>StreamDecoderFilterCallbacks::recreateStream</b>(response_headers)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/abi_impl.cc#L2788">abi_impl.cc:2788</a>
    │               └─► <b>ActiveStreamDecoderFilter::recreateStream</b>(const ResponseHeaderMap* headers)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/filter_manager.cc#L1890">filter_manager.cc:1890</a>
    │                   └─► <b>FilterManagerCallbacks::recreateStream</b>(streamInfo().filterState())  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/filter_manager.cc#L1917">filter_manager.cc:1917</a>
    │                       └─► <b>ConnectionManagerImpl::ActiveStream::recreateStream</b>(FilterStateSharedPtr)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L2525">conn_manager_impl.cc:2525</a>
    │                           │   // ⚠️ "This functionally deletes the stream ... do not reference anything beyond this point." ⚠️
    │                           └─► <b>ConnectionManagerImpl::doEndStream</b>(*this, /*check_for_deferred_close=*/false)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L2547">conn_manager_impl.cc:2547</a>
    │                               └─► <b>ConnectionManagerImpl::doEndStream</b>(stream, check_for_deferred_close)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L269">conn_manager_impl.cc:269</a>
    │                                   └─► <b>ConnectionManagerImpl::doDeferredStreamDestroy</b>(stream)  — call <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L319">conn_manager_impl.cc:319</a>, def <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L331">conn_manager_impl.cc:331</a>
    │                                       └─► <b>FilterManager::destroyFilters</b>()  — call <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/conn_manager_impl.cc#L387">conn_manager_impl.cc:387</a>, def <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/common/http/filter_manager.h#L754">filter_manager.h:754</a>
    │                                           └─► <b>DynamicModuleHttpFilter::onDestroy</b>()  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/filter.cc#L34">filter.cc:34</a>
    │                                               └─► <b>DynamicModuleHttpFilter::destroy</b>()  — call <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/filter.cc#L44">filter.cc:44</a>, def <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/filter.cc#L47">filter.cc:47</a>
    │                                                   └─► config_-&gt;<b>on_http_filter_destroy_</b>(in_module_filter_)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/filters/http/dynamic_modules/filter.cc#L52">filter.cc:52</a>
    │                                                       └─► <b>envoy_dynamic_module_on_http_filter_destroy</b>(filter_ptr)  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/http.rs#L4416">http.rs:4416</a>
    │                                                           └─► Box::from_raw(*config) → <b>drop(Box&lt;dyn HttpFilter&gt;)</b>  — <a href="https://github.com/envoyproxy/envoy/blob/ca1d68544c4b94c9fd9c26c54d5d647336239c39/source/extensions/dynamic_modules/sdk/rust/src/lib.rs#L605">lib.rs:605</a>
    │                                                               🚨🚨🚨 THE FREE: the inner filter object that `self` points at is deallocated here 🚨🚨🚨
    │
    │   ⬆ recreate_stream() returns all the way back up into the still-running on_request_headers hook,
    │     whose `&amp;mut self` now dangles (the Box it points at was freed by the subtree above)
    │
    └─  <b>self.marker = self.marker + 1;</b>   🚨🚨🚨 USE-AFTER-FREE: read+write through the freed `self` — pure safe Rust 🚨🚨🚨
</pre>

Minimal repro:

```rust
fn on_request_headers(&mut self, envoy: &mut EHF, _eos: bool) -> Status {
    envoy.recreate_stream(None);        // frees `self` (see callstack above)
    self.marker = self.marker + 1;      // safe Rust, yet `&self` points to freed memory
    Status::StopIteration
}
```

#### The fix

1. **`recreate_stream` becomes `unsafe fn`** with a `# Safety` contract documenting
   the synchronous cross-FFI teardown ("return `StopIteration`, never touch `self`
   again"). A `compile_fail,E0133` doctest locks in that safe Rust cannot call it.
2. **Safe `request_stream_recreation()`** records the intent; the SDK performs the
   freeing recreate from the request-path trampoline after the hook returns, when
   the `&mut self` borrow is already gone.

### Risk Level

Low. Rust dynamic-module SDK only; no data-plane or ABI change. The single change
in behavior for module authors is that `recreate_stream` now requires `unsafe`.

### Testing

- `//test/extensions/dynamic_modules:rust_sdk_doc_test` — a `compile_fail,E0133`
  doctest on `recreate_stream` proves safe Rust cannot call it (fails to compile on
  the missing-`unsafe`-block error, on both the trait and the generated
  `MockEnvoyHttpFilter`).
- `//test/extensions/dynamic_modules:rust_sdk_test` — new
  `test_request_stream_recreation_deferred_to_trampoline` asserts the recreate FFI
  fires exactly once, only after the hook returns, and that the trampoline
  overrides the hook's `Continue` with `StopIteration`.
- `//test/extensions/dynamic_modules:rust_sdk_clippy` — clean.
- `//test/extensions/dynamic_modules/http:integration_test`
  (`RecreateStreamNoUseAfterFree`, `--config=asan`) — drives the safe deferred path
  through a real Envoy compiled with AddressSanitizer; passes for both `rust` and
  `rust_static` with no heap-use-after-free.

I mainly relied on AI to identify where these tests should go, so I would
appreciate guidance on whether they are written and located appropriately.

### Docs Changes

N/A. The SDK is documented via rustdoc; the `# Safety` contract and the
`request_stream_recreation` doc comment are updated inline.

### Release Notes

Added `changelogs/current/behavior_changes/dynamic_modules__recreate-stream-unsafe.rst`
noting the backward-incompatible SDK interface change (`recreate_stream` is now
`unsafe`) and the new safe `request_stream_recreation`.

### Platform Specific Features

N/A.

### Generative AI disclosure

Generative AI was used to help author this change and its description; the author
fully understands the code.