### PR TITLE
tls: remove unused default_tls_certificate_selector.h include from server_context_impl.h

### DIFF
--- a/source/common/tls/server_context_impl.h
+++ b/source/common/tls/server_context_impl.h
@@ -23,7 +23,6 @@
 #include "source/common/tls/cert_validator/cert_validator.h"
 #include "source/common/tls/context_impl.h"
 #include "source/common/tls/context_manager_impl.h"
-#include "source/common/tls/default_tls_certificate_selector.h"
 #include "source/common/tls/ocsp/ocsp.h"
 #include "source/common/tls/stats.h"
 


### PR DESCRIPTION
`server_context_impl.h` includes `default_tls_certificate_selector.h`, and that header includes `server_context_impl.h` back, forming an include cycle.

`server_context_impl.h` does not use anything from `default_tls_certificate_selector.h`: it never names the concrete `DefaultTlsCertificateSelector`, `DefaultTlsCertificateSelectorFactory` or `TlsCertificateSelectorConfigFactoryImpl`. The only certificate-selector type it uses is the abstract `Ssl::TlsCertificateSelectorPtr`, which comes from `envoy/ssl/handshaker.h` (already included directly).

Removing the include breaks the cycle with no call-site changes. The files that use the concrete `DefaultTlsCertificateSelector` (`server_context_config_impl.cc` and the QUIC proof-source test) already include `default_tls_certificate_selector.h` directly.

---

AI assistance: this cleanup was found with an open-source include-graph checker ([archcheck](https://github.com/blurman-ai/archcheck)) run over the Envoy include graph, and the verification above was assisted by an AI tool; I understand and take full ownership of the change.

## Commit Message

tls: remove unused default_tls_certificate_selector.h include from server_context_impl.h

## Additional Description

Pure include-cleanup, no functional change.

## Risk Level

Low

## Testing

N/A (removes an unused include; existing CI build/link covers it)

## Docs Changes

N/A

## Release Notes

None
