### PR TITLE
[proto] Replace builtin casts with proto-specific casts for protobuf types.

### DIFF
--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_test.cc
@@ -128,9 +128,9 @@ TEST_F(ReverseTunnelInitiatorTest, CreateEmptyConfigProto) {
   EXPECT_NE(config, nullptr);
 
   // Should be able to cast to the correct type.
-  auto* typed_config =
-      dynamic_cast<envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
-                       DownstreamReverseConnectionSocketInterface*>(config.get());
+  auto* typed_config = Protobuf::DynamicCastMessage<
+      envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+          DownstreamReverseConnectionSocketInterface>(config.get());
   EXPECT_NE(typed_config, nullptr);
 }
 

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/reverse_tunnel_acceptor_extension_test.cc
@@ -464,9 +464,9 @@ TEST_F(ReverseTunnelAcceptorExtensionTest, CreateEmptyConfigProto) {
   auto proto = socket_interface_->createEmptyConfigProto();
   EXPECT_NE(proto, nullptr);
 
-  auto* typed_proto =
-      dynamic_cast<envoy::extensions::bootstrap::reverse_tunnel::upstream_socket_interface::v3::
-                       UpstreamReverseConnectionSocketInterface*>(proto.get());
+  auto* typed_proto = Protobuf::DynamicCastMessage<
+      envoy::extensions::bootstrap::reverse_tunnel::upstream_socket_interface::v3::
+          UpstreamReverseConnectionSocketInterface>(proto.get());
   EXPECT_NE(typed_proto, nullptr);
 }
 

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -1129,7 +1129,7 @@ public:
   absl::StatusOr<Network::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& proto,
                                Server::Configuration::FactoryContext&) override {
-    const auto& config = dynamic_cast<const Protobuf::Struct&>(proto);
+    const auto& config = Protobuf::DynamicCastMessage<Protobuf::Struct>(proto);
 
     // Extract namespace and metadata from config.
     std::string namespace_key = "envoy.test.reverse_tunnel";


### PR DESCRIPTION
Commit Message: Replace builtin casts with proto-specific casts for protobuf types.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: no
