### PR TITLE
dynamic_modules: deny unsafe_op_in_unsafe_fn in the Rust SDK

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -1435,7 +1435,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_config_destroy(
   config_ptr: *const c_void,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    drop(Box::from_raw(config_ptr as *mut AccessLoggerConfigHandle));
+    // SAFETY: `config_ptr` is the handle leaked by
+    // `envoy_dynamic_module_on_access_logger_config_new`. Envoy calls this destroy hook exactly
+    // once, so reclaiming the box here cannot double-free.
+    drop(unsafe { Box::from_raw(config_ptr as *mut AccessLoggerConfigHandle) });
   }))
   .map_err(|panic| {
     crate::log_ffi_panic(
@@ -1455,7 +1458,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_new(
   logger_envoy_ptr: *mut c_void,
 ) -> *const c_void {
   catch_unwind(AssertUnwindSafe(|| {
-    let handle = &*(config_ptr as *const AccessLoggerConfigHandle);
+    // SAFETY: `config_ptr` is the handle leaked by
+    // `envoy_dynamic_module_on_access_logger_config_new`, which Envoy keeps alive for the
+    // lifetime of every logger created from it.
+    let handle = unsafe { &*(config_ptr as *const AccessLoggerConfigHandle) };
     let metrics = MetricsContext::new(handle.config_envoy_ptr);
     let logger: Box<dyn AccessLogger> = handle.inner.create_logger(metrics, logger_envoy_ptr);
     crate::wrap_into_c_void_ptr!(logger)
@@ -1477,7 +1483,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_log(
   log_type: abi::envoy_dynamic_module_type_access_log_type,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+    // SAFETY: `logger_ptr` is the boxed logger returned by
+    // `envoy_dynamic_module_on_access_logger_new`. Envoy drives a logger from a single worker
+    // thread, so this is the only live reference for the duration of the call.
+    let logger = unsafe { &mut *(logger_ptr as *mut Box<dyn AccessLogger>) };
     let access_log_type = AccessLogType::from_abi(log_type);
     let ctx = LogContext::new(envoy_ptr, access_log_type);
     logger.log(&ctx);
@@ -1508,7 +1517,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_destroy(logger_pt
 #[no_mangle]
 pub unsafe extern "C" fn envoy_dynamic_module_on_access_logger_flush(logger_ptr: *mut c_void) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let logger = &mut *(logger_ptr as *mut Box<dyn AccessLogger>);
+    // SAFETY: `logger_ptr` is the boxed logger returned by
+    // `envoy_dynamic_module_on_access_logger_new`. Envoy drives a logger from a single worker
+    // thread, so this is the only live reference for the duration of the call.
+    let logger = unsafe { &mut *(logger_ptr as *mut Box<dyn AccessLogger>) };
     logger.flush();
   }))
   .map_err(|panic| {

--- a/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/bootstrap.rs
@@ -1388,7 +1388,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_new(
     let mut envoy_extension = EnvoyBootstrapExtensionImpl::new(envoy_extension_ptr);
     let extension_config = {
       let raw = extension_config_ptr as *const *const dyn BootstrapExtensionConfig;
-      &**raw
+      // SAFETY: `extension_config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_bootstrap_extension_config_new`. Envoy keeps that config alive
+      // for the lifetime of every extension created from it.
+      unsafe { &**raw }
     };
     envoy_dynamic_module_on_bootstrap_extension_new_impl(&mut envoy_extension, extension_config)
   }))
@@ -1677,10 +1680,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_bootstrap_extension_admin_reque
         ptr: response_str.as_ptr() as *const _,
         length: response_str.len(),
       };
-      abi::envoy_dynamic_module_callback_bootstrap_extension_admin_set_response(
-        envoy_ptr,
-        response_buf,
-      );
+      // SAFETY: `envoy_ptr` is the admin-request handle Envoy passed to this callback, and
+      // `response_buf` borrows `response_str`, which outlives the call. Envoy copies the buffer
+      // before returning.
+      unsafe {
+        abi::envoy_dynamic_module_callback_bootstrap_extension_admin_set_response(
+          envoy_ptr,
+          response_buf,
+        );
+      }
     }
 
     status_code

--- a/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/buffer.rs
@@ -93,7 +93,9 @@ impl EnvoyMutBuffer<'_> {
   pub unsafe fn new(static_buf: *mut [u8]) -> Self {
     Self {
       raw_ptr: static_buf as *mut u8,
-      length: (*static_buf).len(),
+      // SAFETY: the caller guarantees `static_buf` points to a live `[u8]`; reading its length
+      // through the raw slice pointer only touches the pointer metadata, not the pointee.
+      length: unsafe { (*static_buf).len() },
       _marker: std::marker::PhantomData,
     }
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cert_validator.rs
@@ -304,6 +304,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_config_destroy(
   });
 }
 
+// SAFETY invariant shared by the `envoy_dynamic_module_on_cert_validator_*` entry points below:
+// `config_module_ptr` is the module pointer returned by
+// `envoy_dynamic_module_on_cert_validator_config_new`, which Envoy keeps alive until the
+// matching destroy callback.
 /// # Safety
 ///
 /// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
@@ -320,7 +324,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_do_verify_cert_c
   catch_unwind(AssertUnwindSafe(|| {
     let config = {
       let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-      &**raw
+      // SAFETY: see the shared invariant above.
+      unsafe { &**raw }
     };
 
     let envoy_cert_validator = EnvoyCertValidator::new(config_envoy_ptr);
@@ -328,15 +333,22 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_do_verify_cert_c
     // `certs` may be null when `certs_count` is 0 (for example, a TLS handshake with no
     // client certificate). `slice_from_raw_or_empty` returns an empty slice for null without
     // dereferencing.
+    // SAFETY: Envoy guarantees `certs` addresses `certs_count` live buffers for the duration of
+    // the call, and each buffer's `(ptr, length)` describes live certificate bytes.
     let cert_buffers: &[crate::abi::envoy_dynamic_module_type_envoy_buffer] =
-      crate::ffi_helpers::slice_from_raw_or_empty(certs, certs_count);
+      unsafe { crate::ffi_helpers::slice_from_raw_or_empty(certs, certs_count) };
     let cert_slices: Vec<&[u8]> = cert_buffers
       .iter()
-      .map(|buf| crate::ffi_helpers::slice_from_raw_or_empty(buf.ptr as *const u8, buf.length))
+      .map(|buf| unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(buf.ptr as *const u8, buf.length)
+      })
       .collect();
 
-    let host_name_str =
-      crate::ffi_helpers::str_lossy_from_raw(host_name.ptr as *const u8, host_name.length);
+    // SAFETY: `host_name` is an Envoy-owned buffer valid for the duration of the call. The SNI
+    // value is attacker-influenced and not contractually UTF-8, so the lossy helper is used.
+    let host_name_str = unsafe {
+      crate::ffi_helpers::str_lossy_from_raw(host_name.ptr as *const u8, host_name.length)
+    };
 
     let result = config.do_verify_cert_chain(
       &envoy_cert_validator,
@@ -352,10 +364,15 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_do_verify_cert_c
         ptr: error.as_ptr() as *const _,
         length: error.len(),
       };
-      abi::envoy_dynamic_module_callback_cert_validator_set_error_details(
-        config_envoy_ptr,
-        error_buf,
-      );
+      // SAFETY: `config_envoy_ptr` is the Envoy-owned validator handle passed to this callback,
+      // and `error_buf` borrows `error`, which outlives the call. Envoy copies the buffer before
+      // returning.
+      unsafe {
+        abi::envoy_dynamic_module_callback_cert_validator_set_error_details(
+          config_envoy_ptr,
+          error_buf,
+        );
+      }
     }
 
     abi::envoy_dynamic_module_type_cert_validator_validation_result::from(&result)
@@ -384,7 +401,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_get_ssl_verify_m
   catch_unwind(AssertUnwindSafe(|| {
     let config = {
       let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-      &**raw
+      // SAFETY: see the shared invariant above.
+      unsafe { &**raw }
     };
     config.get_ssl_verify_mode(handshaker_provides_certificates)
   }))
@@ -411,11 +429,17 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_update_digest(
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = {
       let raw = config_module_ptr as *const *const dyn CertValidatorConfig;
-      &**raw
+      // SAFETY: see the shared invariant above.
+      unsafe { &**raw }
     };
     let digest = config.update_digest();
-    (*out_data).ptr = digest.as_ptr() as *const _;
-    (*out_data).length = digest.len();
+    // SAFETY: the ABI contract guarantees `out_data` points to a writable buffer struct owned by
+    // Envoy. `update_digest` returns a slice borrowed from the config, which outlives this call,
+    // so the pointer handed to Envoy stays valid.
+    unsafe {
+      (*out_data).ptr = digest.as_ptr() as *const _;
+      (*out_data).length = digest.len();
+    }
   }))
   .map_err(|panic| {
     crate::log_ffi_panic(
@@ -425,8 +449,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cert_validator_update_digest(
     // On panic, leave `out_data` as an empty buffer so Envoy contributes nothing to the
     // session context hash and avoids reading uninitialized memory.
     if !out_data.is_null() {
-      (*out_data).ptr = std::ptr::null();
-      (*out_data).length = 0;
+      // SAFETY: `out_data` was just checked non-null and, per the ABI contract, points to a
+      // writable buffer struct owned by Envoy.
+      unsafe {
+        (*out_data).ptr = std::ptr::null();
+        (*out_data).length = 0;
+      }
     }
   });
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -2394,6 +2394,11 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_config_destroy(
   });
 }
 
+// SAFETY invariant shared by the `envoy_dynamic_module_on_cluster_*` entry points below:
+// `cluster_module_ptr` is the boxed cluster returned by `envoy_dynamic_module_on_cluster_new`
+// and `config_module_ptr` the config returned by `envoy_dynamic_module_on_cluster_config_new`.
+// Envoy owns each allocation until its matching destroy hook and does not invoke cluster
+// callbacks on it concurrently, so a recovered reference is the only live one for the call.
 /// # Safety
 ///
 /// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
@@ -2405,7 +2410,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_new(
 ) -> abi::envoy_dynamic_module_type_cluster_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let config = config_module_ptr as *const *const dyn ClusterConfig;
-    let config = &**config;
+    // SAFETY: `config_module_ptr` is the module pointer returned by
+    // `envoy_dynamic_module_on_cluster_config_new`. Envoy keeps that config alive for the
+    // lifetime of every cluster created from it.
+    let config = unsafe { &**config };
     let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
     let cluster = config.new_cluster(&envoy_cluster);
     wrap_into_c_void_ptr!(cluster)
@@ -2427,7 +2435,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_init(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-    let cluster = &mut *cluster;
+    // SAFETY: see the shared invariant above; exclusively ours for this call.
+    let cluster = unsafe { &mut *cluster };
     let envoy_cluster = EnvoyClusterImpl::new(cluster_envoy_ptr);
     cluster.on_init(&envoy_cluster);
   }))
@@ -2471,7 +2480,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_new(
 ) -> abi::envoy_dynamic_module_type_cluster_lb_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *const *const dyn Cluster;
-    let cluster = &**cluster;
+    // SAFETY: see the shared invariant above; outlives every LB created from it.
+    let cluster = unsafe { &**cluster };
     let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
     let lb = cluster.new_load_balancer(&envoy_lb);
     let wrapper = Box::new(ClusterLbWrapper { lb, lb_envoy_ptr });
@@ -2493,7 +2503,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_destroy(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let wrapper = lb_module_ptr as *mut ClusterLbWrapper;
-    let _ = Box::from_raw(wrapper);
+    // SAFETY: `lb_module_ptr` is the wrapper leaked by
+    // `envoy_dynamic_module_on_cluster_lb_new`. Envoy calls this destroy hook exactly once, so
+    // reclaiming the box here cannot double-free.
+    let _ = unsafe { Box::from_raw(wrapper) };
   }))
   .map_err(|panic| {
     crate::log_ffi_panic("envoy_dynamic_module_on_cluster_lb_destroy", panic);
@@ -2512,7 +2525,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_choose_host(
   async_handle_out: *mut abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    // SAFETY: `lb_module_ptr` is the wrapper leaked by
+    // `envoy_dynamic_module_on_cluster_lb_new`. Envoy drives a load balancer from a single worker
+    // thread, so this is the only live reference for the duration of the call.
+    let wrapper = unsafe { &mut *(lb_module_ptr as *mut ClusterLbWrapper) };
     let context = if context_envoy_ptr.is_null() {
       None
     } else {
@@ -2532,20 +2548,25 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_choose_host(
       async_completion,
     );
 
-    match result {
-      HostSelectionResult::Selected(host) => {
-        *host_out = host;
-        *async_handle_out = std::ptr::null_mut();
-      },
-      HostSelectionResult::NoHost => {
-        *host_out = std::ptr::null_mut();
-        *async_handle_out = std::ptr::null_mut();
-      },
-      HostSelectionResult::AsyncPending(handle) => {
-        *host_out = std::ptr::null_mut();
-        *async_handle_out = Box::into_raw(Box::new(handle))
-          as abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr;
-      },
+    // SAFETY: the ABI contract guarantees `host_out` and `async_handle_out` point to writable
+    // out-parameters owned by Envoy for the duration of the call. Every match arm writes both,
+    // so Envoy never observes an uninitialised out-parameter.
+    unsafe {
+      match result {
+        HostSelectionResult::Selected(host) => {
+          *host_out = host;
+          *async_handle_out = std::ptr::null_mut();
+        },
+        HostSelectionResult::NoHost => {
+          *host_out = std::ptr::null_mut();
+          *async_handle_out = std::ptr::null_mut();
+        },
+        HostSelectionResult::AsyncPending(handle) => {
+          *host_out = std::ptr::null_mut();
+          *async_handle_out = Box::into_raw(Box::new(handle))
+            as abi::envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr;
+        },
+      }
     }
   }))
   .map_err(|panic| {
@@ -2553,10 +2574,18 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_choose_host(
     // Fail-closed: signal NoHost so Envoy returns 503 rather than dispatching to
     // a stale or uninitialised pointer.
     if !host_out.is_null() {
-      *host_out = std::ptr::null_mut();
+      // SAFETY: just checked non-null; per the ABI contract it points to a writable
+      // Envoy-owned out-parameter.
+      unsafe {
+        *host_out = std::ptr::null_mut();
+      }
     }
     if !async_handle_out.is_null() {
-      *async_handle_out = std::ptr::null_mut();
+      // SAFETY: just checked non-null; per the ABI contract it points to a writable
+      // Envoy-owned out-parameter.
+      unsafe {
+        *async_handle_out = std::ptr::null_mut();
+      }
     }
   });
 }
@@ -2572,7 +2601,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_cancel_host_selectio
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let handle = async_handle_module_ptr as *mut Box<dyn AsyncHostSelectionHandle>;
-    let mut handle = Box::from_raw(handle);
+    // SAFETY: `async_handle_module_ptr` is the handle leaked by
+    // `envoy_dynamic_module_on_cluster_lb_choose_host` on its `AsyncPending` path. Envoy cancels
+    // a pending selection at most once, so reclaiming the box here cannot double-free.
+    let mut handle = unsafe { Box::from_raw(handle) };
     handle.cancel();
   }))
   .map_err(|panic| {
@@ -2595,7 +2627,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_lb_on_host_membership_u
   num_hosts_removed: usize,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    // SAFETY: `lb_module_ptr` is the wrapper leaked by
+    // `envoy_dynamic_module_on_cluster_lb_new`. Envoy drives a load balancer from a single worker
+    // thread, so this is the only live reference for the duration of the call.
+    let wrapper = unsafe { &mut *(lb_module_ptr as *mut ClusterLbWrapper) };
     let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
     wrapper
       .lb
@@ -2620,7 +2655,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_worker_timer_fired(
   timer_ptr: abi::envoy_dynamic_module_type_cluster_worker_timer_module_ptr,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let wrapper = &mut *(lb_module_ptr as *mut ClusterLbWrapper);
+    // SAFETY: `lb_module_ptr` is the wrapper leaked by
+    // `envoy_dynamic_module_on_cluster_lb_new`. Envoy drives a load balancer from a single worker
+    // thread, so this is the only live reference for the duration of the call.
+    let wrapper = unsafe { &mut *(lb_module_ptr as *mut ClusterLbWrapper) };
     let envoy_lb = EnvoyClusterLoadBalancerImpl::new(lb_envoy_ptr);
     // Non-owning reference so the module can re-arm the timer it already owns.
     let timer_ref = EnvoyClusterWorkerTimerRef { raw_ptr: timer_ptr };
@@ -2643,7 +2681,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_scheduled(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *const *const dyn Cluster;
-    let cluster = &**cluster;
+    // SAFETY: see the shared invariant above; outlives every LB created from it.
+    let cluster = unsafe { &**cluster };
     cluster.on_scheduled(&EnvoyClusterImpl::new(cluster_envoy_ptr), event_id);
   }))
   .map_err(|panic| {
@@ -2663,7 +2702,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_worker_event(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *const *const dyn Cluster;
-    let cluster = &**cluster;
+    // SAFETY: see the shared invariant above; outlives every LB created from it.
+    let cluster = unsafe { &**cluster };
     cluster.on_worker_event(&EnvoyClusterImpl::new(cluster_envoy_ptr), event_id);
   }))
   .map_err(|panic| {
@@ -2684,7 +2724,11 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_worker_slot_data_destro
       return;
     }
     // Reclaim the outer Box; dropping it drops the inner Arc<T> via vtable dispatch.
-    let _: Box<WorkerSlotPayload> = Box::from_raw(data_module_ptr as *mut WorkerSlotPayload);
+    // SAFETY: `data_module_ptr` was just checked non-null and is the payload leaked when the
+    // worker slot was populated. Envoy destroys a slot exactly once, so reclaiming the box here
+    // cannot double-free.
+    let _: Box<WorkerSlotPayload> =
+      unsafe { Box::from_raw(data_module_ptr as *mut WorkerSlotPayload) };
   }))
   .map_err(|panic| {
     crate::log_ffi_panic(
@@ -2705,7 +2749,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_server_initialized(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-    let cluster = &mut *cluster;
+    // SAFETY: see the shared invariant above; exclusively ours for this call.
+    let cluster = unsafe { &mut *cluster };
     cluster.on_server_initialized(&EnvoyClusterImpl::new(cluster_envoy_ptr));
   }))
   .map_err(|panic| {
@@ -2724,7 +2769,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_drain_started(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-    let cluster = &mut *cluster;
+    // SAFETY: see the shared invariant above; exclusively ours for this call.
+    let cluster = unsafe { &mut *cluster };
     cluster.on_drain_started(&EnvoyClusterImpl::new(cluster_envoy_ptr));
   }))
   .map_err(|panic| {
@@ -2745,7 +2791,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_shutdown(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-    let cluster = &mut *cluster;
+    // SAFETY: see the shared invariant above; exclusively ours for this call.
+    let cluster = unsafe { &mut *cluster };
     let completion = CompletionCallback::new(completion_callback, completion_context);
     cluster.on_shutdown(&EnvoyClusterImpl::new(cluster_envoy_ptr), completion);
   }))
@@ -2771,21 +2818,31 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let cluster = cluster_module_ptr as *mut Box<dyn Cluster>;
-    let cluster = &mut *cluster;
+    // SAFETY: see the shared invariant above; exclusively ours for this call.
+    let cluster = unsafe { &mut *cluster };
 
+    // SAFETY: when the corresponding size is non-zero, Envoy guarantees the pointer addresses
+    // that many live header pairs / body chunks for the duration of the call. The layout of
+    // `(EnvoyBuffer, EnvoyBuffer)` and `EnvoyBuffer` is asserted to match the ABI structs in
+    // `buffer.rs`.
     let headers = if headers_size > 0 {
-      Some(crate::ffi_helpers::slice_from_raw_or_empty(
-        headers as *const (EnvoyBuffer, EnvoyBuffer),
-        headers_size,
-      ))
+      Some(unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          headers as *const (EnvoyBuffer, EnvoyBuffer),
+          headers_size,
+        )
+      })
     } else {
       None
     };
+    // SAFETY: as above, for the body chunk array.
     let body = if body_chunks_size > 0 {
-      Some(crate::ffi_helpers::slice_from_raw_or_empty(
-        body_chunks as *const EnvoyBuffer,
-        body_chunks_size,
-      ))
+      Some(unsafe {
+        crate::ffi_helpers::slice_from_raw_or_empty(
+          body_chunks as *const EnvoyBuffer,
+          body_chunks_size,
+        )
+      })
     } else {
       None
     };

--- a/source/extensions/dynamic_modules/sdk/rust/src/formatter.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/formatter.rs
@@ -396,7 +396,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_formatter_parse(
   max_length: usize,
 ) -> *const c_void {
   catch_unwind(AssertUnwindSafe(|| {
-    let config = &*(config_ptr as *const Box<dyn FormatterConfig>);
+    // SAFETY: `config_ptr` is the boxed config returned by
+    // `envoy_dynamic_module_on_formatter_config_new`, which Envoy keeps alive until the matching
+    // destroy callback.
+    let config = unsafe { &*(config_ptr as *const Box<dyn FormatterConfig>) };
     // SAFETY: `command` and `command_arg` are format-string tokens (UTF-8 by contract). The
     // helpers tolerate empty inputs and substitute `U+FFFD` for malformed UTF-8.
     let command_str =
@@ -447,7 +450,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_formatter_format(
   result: *mut abi::envoy_dynamic_module_type_module_buffer,
 ) -> bool {
   catch_unwind(AssertUnwindSafe(|| {
-    let provider = &*(provider_ptr as *const Box<dyn FormatterProvider>);
+    // SAFETY: `provider_ptr` is the boxed provider returned by
+    // `envoy_dynamic_module_on_formatter_provider_new`, which Envoy keeps alive until the
+    // matching destroy callback.
+    let provider = unsafe { &*(provider_ptr as *const Box<dyn FormatterProvider>) };
     let ctx = FormatterContext::new(formatter_context_envoy_ptr);
     match provider.format(&ctx) {
       Some(value) => {

--- a/source/extensions/dynamic_modules/sdk/rust/src/health_checker.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/health_checker.rs
@@ -282,7 +282,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_health_checker_session_new(
   session_envoy_ptr: abi::envoy_dynamic_module_type_health_checker_session_envoy_ptr,
 ) -> abi::envoy_dynamic_module_type_health_checker_session_module_ptr {
   let result = catch_unwind(AssertUnwindSafe(|| {
-    let config = &*(config_ptr as *const Box<dyn HealthCheckerConfig>);
+    // SAFETY: `config_ptr` is the boxed config returned by
+    // `envoy_dynamic_module_on_health_checker_config_new`, which Envoy keeps alive for the
+    // lifetime of every session created from it.
+    let config = unsafe { &*(config_ptr as *const Box<dyn HealthCheckerConfig>) };
     let host = HealthCheckHost::new(session_envoy_ptr);
     let session: Box<dyn HealthCheckerSession> = config.new_session(&host);
     crate::wrap_into_c_void_ptr!(session)
@@ -306,7 +309,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_health_checker_session_on_inter
   session_envoy_ptr: abi::envoy_dynamic_module_type_health_checker_session_envoy_ptr,
 ) {
   if let Err(panic) = catch_unwind(AssertUnwindSafe(|| {
-    let session = &mut *(session_ptr as *mut Box<dyn HealthCheckerSession>);
+    // SAFETY: `session_ptr` is the boxed session returned by
+    // `envoy_dynamic_module_on_health_checker_session_new`. Envoy drives a session from a single
+    // thread, so this is the only live reference for the duration of the call.
+    let session = unsafe { &mut *(session_ptr as *mut Box<dyn HealthCheckerSession>) };
     let host = HealthCheckHost::new(session_envoy_ptr);
     let reporter = Reporter::new(session_envoy_ptr);
     session.on_interval(&host, reporter);
@@ -327,7 +333,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_health_checker_session_on_timeo
   session_ptr: abi::envoy_dynamic_module_type_health_checker_session_module_ptr,
 ) {
   if let Err(panic) = catch_unwind(AssertUnwindSafe(|| {
-    let session = &mut *(session_ptr as *mut Box<dyn HealthCheckerSession>);
+    // SAFETY: `session_ptr` is the boxed session returned by
+    // `envoy_dynamic_module_on_health_checker_session_new`. Envoy drives a session from a single
+    // thread, so this is the only live reference for the duration of the call.
+    let session = unsafe { &mut *(session_ptr as *mut Box<dyn HealthCheckerSession>) };
     session.on_timeout();
   })) {
     crate::log_ffi_panic(

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -4282,6 +4282,11 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_destroy(
   });
 }
 
+// SAFETY invariant shared by the `envoy_dynamic_module_on_http_filter_*` entry points below:
+// `filter_ptr` is the module pointer returned by `envoy_dynamic_module_on_http_filter_new`, and
+// `config_ptr` the one returned by `envoy_dynamic_module_on_http_filter_config_new`. Envoy keeps
+// each alive until its matching destroy hook, and drives a stream from a single worker thread
+// without re-entering the filter, so a recovered reference is the only live one for the call.
 /// # Safety
 ///
 /// This is an FFI function called by Envoy. All pointer arguments must be valid as guaranteed
@@ -4294,7 +4299,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_scheduled(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     config.on_scheduled(event_id);
   }))
   .map_err(|panic| {
@@ -4351,7 +4357,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_per_route_config_de
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let ptr = config_ptr as *mut std::sync::Arc<dyn Any>;
-    std::mem::drop(Box::from_raw(ptr));
+    // SAFETY: `config_ptr` is the boxed `Arc` leaked by
+    // `envoy_dynamic_module_on_http_filter_per_route_config_new`. Envoy calls this destroy hook
+    // exactly once, so reclaiming the box here cannot double-free.
+    std::mem::drop(unsafe { Box::from_raw(ptr) });
   }))
   .map_err(|panic| {
     crate::log_ffi_panic(
@@ -4390,7 +4399,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_new(
     };
     let filter_config = {
       let raw = filter_config_ptr as *const *const dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-      &**raw
+      // SAFETY: `filter_config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_http_filter_config_new`. Envoy keeps that config alive for the
+      // lifetime of every filter created from it.
+      unsafe { &**raw }
     };
     envoy_dynamic_module_on_http_filter_new_impl(&mut envoy_filter, filter_config)
   }))
@@ -4435,7 +4447,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_stream_complete(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
   }))
   .map_err(|panic| {
@@ -4455,7 +4468,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_headers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_request_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
   }))
   .unwrap_or_else(|panic| {
@@ -4477,7 +4491,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_body(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_body_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_request_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
   }))
   .unwrap_or_else(|panic| {
@@ -4498,7 +4513,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_request_trailers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_request_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
   }))
   .unwrap_or_else(|panic| {
@@ -4522,7 +4538,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_headers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_headers_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_response_headers(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
   }))
   .unwrap_or_else(|panic| {
@@ -4546,7 +4563,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_body(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_body_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_response_body(&mut EnvoyHttpFilterImpl::new(envoy_ptr), end_of_stream)
   }))
   .unwrap_or_else(|panic| {
@@ -4566,7 +4584,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_response_trailers(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_response_trailers_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_response_trailers(&mut EnvoyHttpFilterImpl::new(envoy_ptr))
   }))
   .unwrap_or_else(|panic| {
@@ -4595,7 +4614,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_callout_done(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     let headers = if headers_size > 0 {
       Some(unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -4644,7 +4664,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_scheduled(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_scheduled(&mut EnvoyHttpFilterImpl::new(envoy_ptr), event_id);
   }))
   .map_err(|panic| {
@@ -4663,7 +4684,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_downstream_above_wr
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter
       .on_downstream_above_write_buffer_high_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
   }))
@@ -4686,7 +4708,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_downstream_below_wr
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_downstream_below_write_buffer_low_watermark(&mut EnvoyHttpFilterImpl::new(envoy_ptr));
   }))
   .map_err(|panic| {
@@ -4711,8 +4734,12 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_local_reply(
 ) -> abi::envoy_dynamic_module_type_on_http_filter_local_reply_status {
   catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
-    let details_buffer = EnvoyBuffer::new_from_raw(details.ptr as *const u8, details.length);
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
+    // SAFETY: `details` is an Envoy-owned buffer describing the local-reply detail string; it
+    // stays valid for the duration of the call, which bounds the returned `EnvoyBuffer`.
+    let details_buffer =
+      unsafe { EnvoyBuffer::new_from_raw(details.ptr as *const u8, details.length) };
     filter.on_local_reply(
       &mut EnvoyHttpFilterImpl::new(envoy_ptr),
       response_code,
@@ -4742,7 +4769,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_headers
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     let headers = if headers_size > 0 {
       unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -4783,7 +4811,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_data(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     let data = if data_count > 0 {
       unsafe { crate::ffi_helpers::slice_from_raw_or_empty(data as *const EnvoyBuffer, data_count) }
     } else {
@@ -4818,7 +4847,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_trailer
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     let trailers = if trailers_size > 0 {
       unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -4855,7 +4885,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_complet
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_http_stream_complete(&mut EnvoyHttpFilterImpl::new(envoy_ptr), stream_handle);
   }))
   .map_err(|panic| {
@@ -4879,7 +4910,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_http_stream_reset(
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let filter = filter_ptr as *mut *mut dyn HttpFilter<EnvoyHttpFilterImpl>;
-    let filter = &mut **filter;
+    // SAFETY: see the shared invariant above; `filter_ptr` is live and exclusively ours here.
+    let filter = unsafe { &mut **filter };
     filter.on_http_stream_reset(
       &mut EnvoyHttpFilterImpl::new(envoy_ptr),
       stream_handle,
@@ -4911,7 +4943,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_callout
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     let headers = if headers_size > 0 {
       Some(unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -4965,7 +4998,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     let headers = if headers_size > 0 {
       unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -5008,7 +5042,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     let data = if data_count > 0 {
       unsafe { crate::ffi_helpers::slice_from_raw_or_empty(data as *const EnvoyBuffer, data_count) }
     } else {
@@ -5045,7 +5080,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     let trailers = if trailers_size > 0 {
       unsafe {
         crate::ffi_helpers::slice_from_raw_or_empty(
@@ -5084,7 +5120,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     config.on_http_stream_complete(
       &mut EnvoyHttpFilterConfigImpl {
         raw_ptr: envoy_config_ptr,
@@ -5113,7 +5150,8 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_http_filter_config_http_stream_
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
     let config = config_ptr as *mut *mut dyn HttpFilterConfig<EnvoyHttpFilterImpl>;
-    let config = &**config;
+    // SAFETY: see the shared invariant above; `config_ptr` outlives this call.
+    let config = unsafe { &**config };
     config.on_http_stream_reset(
       &mut EnvoyHttpFilterConfigImpl {
         raw_ptr: envoy_config_ptr,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -1,4 +1,11 @@
 #![deny(warnings)]
+// Every unsafe operation inside an `unsafe fn` must be wrapped in its own `unsafe` block with a
+// `SAFETY:` comment naming the ABI invariant it relies on. Without this, an `unsafe fn` body is
+// one big implicit unsafe block, so the raw-pointer work at the FFI seam is indistinguishable
+// from the safe code around it and new unsafe operations can be added unreviewed. This is the
+// default in Rust edition 2024; denying it here gets the same guarantee on edition 2021 and
+// prevents backsliding.
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/listener.rs
@@ -1690,7 +1690,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_listener_filter_new(
     let filter_config = {
       let raw =
         filter_config_ptr as *const *const dyn ListenerFilterConfig<EnvoyListenerFilterImpl>;
-      &**raw
+      // SAFETY: `filter_config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_listener_filter_config_new`. Envoy keeps that config alive for
+      // the lifetime of every filter created from it.
+      unsafe { &**raw }
     };
     envoy_dynamic_module_on_listener_filter_new_impl(&mut envoy_filter, filter_config)
   }))

--- a/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/load_balancer.rs
@@ -1299,7 +1299,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_new(
     let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
     let lb_config = {
       let raw = config_ptr as *const *const dyn LoadBalancerConfig;
-      &**raw
+      // SAFETY: `config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_lb_config_new`. Envoy keeps that config alive for the lifetime
+      // of every load balancer created from it.
+      unsafe { &**raw }
     };
     let lb = lb_config.new_load_balancer(&envoy_lb);
     wrap_into_c_void_ptr!(lb)
@@ -1326,12 +1329,20 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_choose_host(
     let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, context_envoy_ptr);
     let lb = {
       let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
-      &mut **raw
+      // SAFETY: `lb_module_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_lb_new`. Envoy drives a load balancer from a single worker
+      // thread, so this is the only live reference for the duration of the call.
+      unsafe { &mut **raw }
     };
     match lb.choose_host(&envoy_lb) {
       Some(selection) => {
-        *result_priority = selection.priority;
-        *result_index = selection.index;
+        // SAFETY: the ABI contract guarantees `result_priority` and `result_index` point to
+        // writable `u32`s owned by Envoy for the duration of the call. They are only written on
+        // the `true` path, which is the only path where Envoy reads them.
+        unsafe {
+          *result_priority = selection.priority;
+          *result_index = selection.index;
+        }
         true
       },
       None => false,
@@ -1360,7 +1371,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_lb_on_host_membership_update(
     let envoy_lb = EnvoyLoadBalancerImpl::new(lb_envoy_ptr, std::ptr::null_mut());
     let lb = {
       let raw = lb_module_ptr as *mut *mut dyn LoadBalancer;
-      &mut **raw
+      // SAFETY: `lb_module_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_lb_new`. Envoy drives a load balancer from a single worker
+      // thread, so this is the only live reference for the duration of the call.
+      unsafe { &mut **raw }
     };
     lb.on_host_membership_update(&envoy_lb, num_hosts_added, num_hosts_removed);
   }))

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -1941,7 +1941,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_network_filter_new(
     let mut envoy_filter = EnvoyNetworkFilterImpl::new(envoy_filter_ptr);
     let filter_config = {
       let raw = filter_config_ptr as *const *const dyn NetworkFilterConfig<EnvoyNetworkFilterImpl>;
-      &**raw
+      // SAFETY: `filter_config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_network_filter_config_new`. Envoy keeps that config alive for
+      // the lifetime of every filter created from it.
+      unsafe { &**raw }
     };
     envoy_dynamic_module_on_network_filter_new_impl(&mut envoy_filter, filter_config)
   }))

--- a/source/extensions/dynamic_modules/sdk/rust/src/stats_sink.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/stats_sink.rs
@@ -667,7 +667,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_stat_sink_flush(
   snapshot_envoy_ptr: *mut c_void,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let sink = &*(config_ptr as *const Box<dyn StatSink>);
+    // SAFETY: `config_ptr` is the boxed sink returned by
+    // `envoy_dynamic_module_on_stat_sink_config_new`, which Envoy keeps alive until the matching
+    // destroy callback.
+    let sink = unsafe { &*(config_ptr as *const Box<dyn StatSink>) };
     let snapshot = MetricSnapshot::new(snapshot_envoy_ptr);
     sink.on_flush(&snapshot);
   }))
@@ -687,7 +690,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_stat_sink_on_histogram_complete
   value: u64,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let sink = &*(config_ptr as *const Box<dyn StatSink>);
+    // SAFETY: `config_ptr` is the boxed sink returned by
+    // `envoy_dynamic_module_on_stat_sink_config_new`, which Envoy keeps alive until the matching
+    // destroy callback.
+    let sink = unsafe { &*(config_ptr as *const Box<dyn StatSink>) };
     let name =
       unsafe { EnvoyBuffer::new_from_raw(histogram_name.ptr as *const u8, histogram_name.length) };
     sink.on_histogram_complete(name, value);
@@ -711,7 +717,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_stat_sink_config_scheduled(
   event_id: u64,
 ) {
   let _ = catch_unwind(AssertUnwindSafe(|| {
-    let sink = &*(config_ptr as *const Box<dyn StatSink>);
+    // SAFETY: `config_ptr` is the boxed sink returned by
+    // `envoy_dynamic_module_on_stat_sink_config_new`, which Envoy keeps alive until the matching
+    // destroy callback.
+    let sink = unsafe { &*(config_ptr as *const Box<dyn StatSink>) };
     let mut envoy_config = EnvoyStatSinkConfig::new(config_envoy_ptr);
     sink.on_config_scheduled(&mut envoy_config, event_id);
   }))

--- a/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/udp_listener.rs
@@ -588,7 +588,10 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_udp_listener_filter_new(
     let filter_config = {
       let raw =
         filter_config_ptr as *const *const dyn UdpListenerFilterConfig<EnvoyUdpListenerFilterImpl>;
-      &**raw
+      // SAFETY: `filter_config_ptr` is the module pointer returned by
+      // `envoy_dynamic_module_on_udp_listener_filter_config_new`. Envoy keeps that config alive
+      // for the lifetime of every filter created from it.
+      unsafe { &**raw }
     };
     envoy_dynamic_module_on_udp_listener_filter_new_impl(&mut envoy_filter, filter_config)
   }))

--- a/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/upstream_http_tcp_bridge.rs
@@ -376,7 +376,10 @@ unsafe extern "C" fn envoy_dynamic_module_on_upstream_http_tcp_bridge_new(
 ) -> abi::envoy_dynamic_module_type_upstream_http_tcp_bridge_module_ptr {
   catch_unwind(AssertUnwindSafe(|| {
     let config = config_module_ptr as *const *const dyn UpstreamHttpTcpBridgeConfig;
-    let config = &**config;
+    // SAFETY: `config_module_ptr` is the module pointer returned by
+    // `envoy_dynamic_module_on_upstream_http_tcp_bridge_config_new`. Envoy keeps that config
+    // alive for the lifetime of every bridge created from it.
+    let config = unsafe { &**config };
     let envoy_bridge = EnvoyUpstreamHttpTcpBridgeImpl::new(bridge_envoy_ptr);
     let bridge = config.new_bridge(&envoy_bridge);
     wrap_into_c_void_ptr!(bridge)


### PR DESCRIPTION
Fixes #46376.

### What

Adds `#![deny(unsafe_op_in_unsafe_fn)]` to the dynamic modules Rust SDK and makes the 127 operations
it flags explicit. The lint is allow-by-default on edition 2021, so the crate's existing
`#![deny(warnings)]` does not cover it — today an `unsafe fn` body is one implicit unsafe block, so
the raw-pointer work at the FFI seam is indistinguishable from the safe code around it.

The 127 sites span 14 files and are all ABI-contract operations: raw-pointer derefs recovering
module-owned state, `Box::from_raw` reclaims in destroy hooks, writes through caller-supplied
out-parameters, and direct `abi::envoy_dynamic_module_callback_*` calls. 126 are inside
`#[no_mangle] unsafe extern "C" fn envoy_dynamic_module_*` entry points; the remaining one is
`EnvoyMutBuffer::new` in `buffer.rs`.

Same seam as #44850 and #44846, on the entry-point side rather than the helper side.

### Shape

+310 / −108 across 15 files. 79 new `unsafe` blocks cover all 127 operations — one per statement, so
a single block covers both derefs of a `&**ptr` state recovery — under 78 `SAFETY:` comments (one in
`cert_validator.rs` governs an adjacent pair). Where an entry-point family shares an invariant it is
stated once above the family and referenced per site rather than repeated.

No behaviour change, no API change, no BUILD/Bazel change — source-only, so `rustc` enforces the
attribute and Bazel picks it up automatically. No changelog fragment: not user-facing.

### Verification

- Without the attribute the crate builds clean, confirming the lint is allow-by-default here.
- With it, the unpatched tree fails with exactly **127 `E0133`** across 14 files.
- With the patch, `cargo build` and `cargo clippy --lib` are clean. Deleting any one new block
  reproduces `E0133` at that site — the anti-backsliding guarantee is checked, not asserted.
- Verified with rustc 1.97.1 locally; the lint has been stable since 1.52, so the 1.88.0 CI pin is
  unaffected.

I was not able to run the Bazel build or the SDK unit tests locally — the test binary needs the
`envoy_dynamic_module_callback_*` host symbols the Envoy binary provides at runtime. Relying on CI.

### Relationship to #46367

#46367 touches `http.rs` and will conflict — 6 hunks, all the same one-line shape in the
request/response trampolines. It should land first; I'll merge `main` in and resolve on my side, no
action needed from @bonnetn.

Worth noting because it argues *for* the lint rather than against it: #46367 adds
`pub(crate) unsafe fn take_and_perform_recreation`, whose body ends in a bare
`self.recreate_stream(None)`, and makes `recreate_stream` an `unsafe fn` in the same PR. That is
`E0133` under this lint. It compiles today and is not a defect — it is simply invisible at review
time, which is what this changes.

### AI assistance

Generative AI was used to help author this change and its description; the author
fully understands the code.
