### PR TITLE
a2a: reject non-discovery GET requests in REJECT mode

### DIFF
--- a/source/extensions/filters/http/a2a/BUILD
+++ b/source/extensions/filters/http/a2a/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//source/common/common:logger_lib",
         "//source/common/http:headers_lib",
+        "//source/common/http:path_utility_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/extensions/filters/http/a2a/a2a_filter.cc
+++ b/source/extensions/filters/http/a2a/a2a_filter.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/http/a2a/a2a_filter.h"
 
 #include "source/common/http/headers.h"
+#include "source/common/http/path_utility.h"
 #include "source/common/protobuf/utility.h"
 
 #include "absl/strings/match.h"
@@ -12,6 +13,8 @@ namespace HttpFilters {
 namespace A2a {
 
 namespace {
+constexpr absl::string_view A2aWellKnownAgentCardPath = "/.well-known/agent-card.json";
+
 A2aFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = absl::StrCat(prefix, "a2a.");
   return A2aFilterStats{A2A_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -26,13 +29,16 @@ A2aFilterConfig::A2aFilterConfig(const envoy::extensions::filters::http::a2a::v3
       parser_config_(A2aParserConfig::createDefault()), stats_(generateStats(stats_prefix, scope)) {
 }
 
-// A2A support three discovery strategies with GET requests: 1) Well-Known URI 2) Curated Registries
-// 3) Private Discovery
-// Well-Known URI is recommended for public agents or agents intended for broad discovery
-// within a specific domain
+// A2A discovery standardizes GET requests for the Agent Card well-known URI. Registry and
+// private discovery paths are deployment-specific and cannot be inferred by the filter.
 // See: https://a2a-protocol.org/latest/topics/agent-discovery/#discovery-strategies
 bool A2aFilter::isValidA2aGetRequest(const Http::RequestHeaderMap& headers) const {
-  return headers.getMethodValue() == Http::Headers::get().MethodValues.Get;
+  if (headers.getMethodValue() != Http::Headers::get().MethodValues.Get) {
+    return false;
+  }
+
+  return Http::PathUtil::removeQueryAndFragment(headers.getPathValue()) ==
+         A2aWellKnownAgentCardPath;
 }
 
 bool A2aFilter::isValidA2aPostRequest(const Http::RequestHeaderMap& headers) const {

--- a/test/extensions/filters/http/a2a/a2a_filter_integration_test.cc
+++ b/test/extensions/filters/http/a2a/a2a_filter_integration_test.cc
@@ -312,6 +312,50 @@ TEST_P(A2aFilterIntegrationTest, RejectModeRejectsNonA2aContentType) {
   EXPECT_EQ("400", response->headers().getStatusValue());
 }
 
+TEST_P(A2aFilterIntegrationTest, RejectModeRejectsNonDiscoveryGetRequest) {
+  initializeFilter(R"EOF(
+    name: envoy.filters.http.a2a
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.a2a.v3.A2a
+      traffic_mode: REJECT
+  )EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/internal/admin"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"}});
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_FALSE(upstream_request_);
+  EXPECT_EQ("400", response->headers().getStatusValue());
+}
+
+TEST_P(A2aFilterIntegrationTest, RejectModeAllowsWellKnownDiscoveryGetRequest) {
+  initializeFilter(R"EOF(
+    name: envoy.filters.http.a2a
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.a2a.v3.A2a
+      traffic_mode: REJECT
+  )EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/.well-known/agent-card.json"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"}});
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("/.well-known/agent-card.json", upstream_request_->headers().getPathValue());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Test REJECT mode rejects GET requests with body
 TEST_P(A2aFilterIntegrationTest, RejectModeRejectsGetRequestWithBody) {
   initializeFilter(R"EOF(

--- a/test/extensions/filters/http/a2a/a2a_filter_test.cc
+++ b/test/extensions/filters/http/a2a/a2a_filter_test.cc
@@ -36,8 +36,15 @@ public:
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
 };
 
-TEST_F(A2aFilterTest, ValidGetRequest) {
-  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
+TEST_F(A2aFilterTest, ValidWellKnownGetRequest) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/.well-known/agent-card.json"}};
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
+}
+
+TEST_F(A2aFilterTest, ValidWellKnownGetRequestWithQuery) {
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/.well-known/agent-card.json?version=1"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
 }
 
@@ -100,6 +107,21 @@ TEST_F(A2aFilterTest, InvalidPostRequestRejectMode) {
 
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(Http::Code::BadRequest, _, _, _, _));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+}
+
+TEST_F(A2aFilterTest, RejectsNonDiscoveryGetRequestInRejectMode) {
+  envoy::extensions::filters::http::a2a::v3::A2a proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::a2a::v3::A2a::REJECT);
+  config_ = std::make_shared<A2aFilterConfig>(proto_config, "test_prefix", *scope_.rootScope());
+  filter_ = std::make_unique<A2aFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/internal/admin"}};
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest, "Only A2A traffic is allowed", _, _, _));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, true));
+  EXPECT_EQ(1, config_->stats().requests_rejected_.value());
 }
 
 TEST_F(A2aFilterTest, DecodeDataValidJson) {


### PR DESCRIPTION
Original author: @ekilmer 

--------------------------

What changed:

GET requests are now treated as valid A2A discovery only when the path is /.well-known/agent-card.json after removing query/fragment. Other bodyless GET requests in traffic_mode: REJECT now receive the local 400 response instead of passing upstream.

I used the current A2A discovery docs as the path source: https://a2a-protocol.org/latest/topics/agent-discovery/

Validation

Passed:

- git diff --check
- bazel test --config=clang -c opt --test_output=errors //test/extensions/filters/http/a2a:a2a_filter_test
- bazel test --config=clang -c opt --test_output=errors //test/extensions/filters/http/a2a:a2a_filter_integration_test --test_filter='*RejectModeRejectsNonDiscoveryGetRequest*:*RejectModeAllowsWellKnownDiscoveryGetRequest*'
- bazel run //tools/code_format:check_format -- check changelogs/current.yaml source/extensions/filters/http/a2a/BUILD source/extensions/filters/http/a2a/a2a_filter.cc test/extensions/filters/http/a2a/a2a_filter_test.cc test/extensions/filters/http/a2a/a2a_filter_integration_test.cc

Remaining risk:

A2A is alpha/unknown posture. This fix intentionally recognizes only the standardized well-known discovery path; deployments using proprietary/private GET discovery paths with REJECT mode will now need routing/config changes or a future explicit allowlist option.

Patched by GPT-5.5
Token usage: total=284,607 input=269,602 (+ 3,513,728 cached) output=15,005 (reasoning 5,090)

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
Fixes #46378
