### PR TITLE
reverse tunnel: read handshake headers from the live extension

### DIFF
--- a/changelogs/current/bug_fixes/reverse_tunnel__handshake-headers-snapshot-before-init.rst
+++ b/changelogs/current/bug_fixes/reverse_tunnel__handshake-headers-snapshot-before-init.rst
@@ -1,0 +1,9 @@
+Fixed a bug in the reverse tunnel downstream socket interface
+(``envoy.bootstrap.reverse_tunnel.downstream_socket_interface``) where handshake
+``additional_headers`` values that use a substitution formatter (such as ``%FILE_CONTENT%``, or
+secret/SDS-backed formatters) were sent as the raw, unsubstituted template on every reverse
+connection. The reverse connection listen socket snapshots the handshake formatters when it is
+created, which can happen before ``onServerInitialized()`` builds them; that null snapshot is then
+reused for every re-dial, so the handshake fell back to emitting the literal ``additional_headers``
+value. The handshake headers are now resolved from the live bootstrap extension when the request is
+assembled, so post-initialization dials substitute the value correctly.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -193,11 +193,12 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
   };
 
   // Read the handshake formatters from the live extension, not from the io_handle's snapshot. The
-  // listen socket can be created before onServerInitialized() builds the formatters, so the snapshot
-  // taken at socket creation (parent_.handshakeHeaders()) may be null. That snapshot is reused for
-  // every re-dial, so trusting it would send the raw additional_headers() value instead of the
-  // formatted one. The extension always has the built formatters by the time we send a handshake;
-  // fall back to the snapshot only when the extension has none (it's just a copy of it anyway).
+  // listen socket can be created before onServerInitialized() builds the formatters, so the
+  // snapshot taken at socket creation (parent_.handshakeHeaders()) may be null. That snapshot is
+  // reused for every re-dial, so trusting it would send the raw additional_headers() value instead
+  // of the formatted one. The extension always has the built formatters by the time we send a
+  // handshake; fall back to the snapshot only when the extension has none (it's just a copy of it
+  // anyway).
   ReverseTunnelInitiatorExtension* extension = getDownstreamExtension();
   const HandshakeHeadersConstSharedPtr handshake_headers =
       (extension != nullptr && extension->handshakeHeaders() != nullptr)

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -192,7 +192,18 @@ std::string RCConnectionWrapper::connect(const std::string& src_tenant_id,
     }
   };
 
-  if (const auto& handshake_headers = parent_.handshakeHeaders(); handshake_headers != nullptr) {
+  // Read the handshake formatters from the live extension, not from the io_handle's snapshot. The
+  // listen socket can be created before onServerInitialized() builds the formatters, so the snapshot
+  // taken at socket creation (parent_.handshakeHeaders()) may be null. That snapshot is reused for
+  // every re-dial, so trusting it would send the raw additional_headers() value instead of the
+  // formatted one. The extension always has the built formatters by the time we send a handshake;
+  // fall back to the snapshot only when the extension has none (it's just a copy of it anyway).
+  ReverseTunnelInitiatorExtension* extension = getDownstreamExtension();
+  const HandshakeHeadersConstSharedPtr handshake_headers =
+      (extension != nullptr && extension->handshakeHeaders() != nullptr)
+          ? extension->handshakeHeaders()
+          : parent_.handshakeHeaders();
+  if (handshake_headers != nullptr) {
     StreamInfo::StreamInfoImpl stream_info(connection_->dispatcher().timeSource(), nullptr,
                                            StreamInfo::FilterState::LifeSpan::Connection);
     for (const auto& hdr : *handshake_headers) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -136,14 +136,17 @@ envoy_cc_test(
     deps = [
         "//source/common/buffer:buffer_lib",
         "//source/common/formatter:substitution_formatter_lib",
+        "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_address_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_extension_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_initiator_lib",
         "//test/common/formatter:command_extension_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/server:instance_mocks",
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:registry_lib",
         "@envoy_api//envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -7,7 +7,9 @@
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/formatter/substitution_formatter.h"
 #include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/protobuf.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h"
+#include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
@@ -15,8 +17,10 @@
 #include "test/common/formatter/command_extension.h"
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/server/instance.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/registry.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -627,6 +631,96 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeLiteralHeaders) {
 
   const std::string encoded_request = captured_buffer.toString();
   EXPECT_NE(encoded_request.find("x-literal: 100% literal"), std::string::npos);
+}
+
+// Exercises the full ReverseTunnelInitiator::socket() -> io_handle -> wrapper path. socket()
+// snapshots the handshake formatters into the io_handle's config at creation time; when that happens
+// before onServerInitialized() builds them, the snapshot is null and gets reused for every re-dial.
+// This creates the socket while the extension is still uninitialized (and checks the snapshot really
+// is null), then initializes, dials, and checks the formatted value is sent -- not the raw literal.
+// Fails if the wrapper goes back to trusting the snapshot.
+TEST_F(RCConnectionWrapperTest, HandshakeHeadersResolvedThroughSocketPathAfterInit) {
+  Envoy::Formatter::TestCommandFactory factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(factory);
+
+  // Build a handshake-configured extension, but do NOT initialize it yet: at server startup the
+  // ListenerManager can create the reverse-connection listen socket before onServerInitialized()
+  // runs, which is precisely what triggers the bug.
+  auto handshake_config = config_;
+  auto* hdr = handshake_config.mutable_http_handshake()->add_additional_headers();
+  hdr->mutable_header()->set_key("authorization");
+  hdr->mutable_header()->set_value("Bearer %COMMAND_EXTENSION()%");
+  auto* formatter = handshake_config.mutable_http_handshake()->add_formatters();
+  formatter->set_name("envoy.formatter.TestFormatter");
+  std::ignore = formatter->mutable_typed_config()->PackFrom(Protobuf::StringValue());
+
+  auto live_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, handshake_config);
+  auto live_tls_slot =
+      ThreadLocal::TypedSlot<DownstreamSocketThreadLocal>::makeUnique(thread_local_);
+  live_tls_slot->set([registry = thread_local_registry_](Event::Dispatcher&) { return registry; });
+  live_extension->setTestOnlyTLSRegistry(std::move(live_tls_slot));
+
+  // Create the reverse-connection socket through the genuine initiator path while the extension is
+  // still uninitialized. This is the step that snapshots the (still null) formatters into the
+  // io_handle's config.
+  ReverseTunnelInitiator initiator(context_);
+  initiator.extension_ = live_extension.get();
+  ReverseConnectionAddress::ReverseConnectionConfig addr_config;
+  addr_config.src_cluster_id = "test-cluster";
+  addr_config.src_node_id = "test-node";
+  addr_config.src_tenant_id = "test-tenant";
+  addr_config.remote_cluster = "remote-cluster";
+  addr_config.connection_count = 1;
+  auto reverse_address = std::make_shared<ReverseConnectionAddress>(addr_config);
+  auto socket = initiator.socket(Network::Socket::Type::Stream, reverse_address,
+                                 Network::SocketCreationOptions{});
+  auto* io_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
+  ASSERT_NE(io_handle, nullptr);
+  // Root cause: the socket captured a null formatter snapshot because it was created before
+  // onServerInitialized(). A wrapper trusting this snapshot would emit the raw literal on every dial.
+  ASSERT_EQ(io_handle->handshakeHeaders(), nullptr);
+
+  // The worker registers and the formatters are built only now, after the socket already exists.
+  NiceMock<Server::MockInstance> server;
+  live_extension->onServerInitialized(server);
+  ASSERT_NE(live_extension->handshakeHeaders(), nullptr);
+  // The io_handle's own snapshot is still null -- the fix must not depend on it.
+  ASSERT_EQ(io_handle->handshakeHeaders(), nullptr);
+
+  // Drive a handshake on the real io_handle and confirm the live formatter value is sent.
+  auto mock_connection = getDeletableConn(dispatcher_);
+  EXPECT_CALL(*mock_connection, addConnectionCallbacks(_));
+  EXPECT_CALL(*mock_connection, addReadFilter(_));
+  EXPECT_CALL(*mock_connection, connect());
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(12345));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+
+  auto mock_address = std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1", 8080);
+  auto mock_local_address = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 12345);
+  EXPECT_CALL(*mock_connection, connectionInfoProvider())
+      .WillRepeatedly(Invoke([mock_address,
+                              mock_local_address]() -> const Network::ConnectionInfoProvider& {
+        static auto mock_provider =
+            std::make_unique<Network::ConnectionInfoSetterImpl>(mock_local_address, mock_address);
+        return *mock_provider;
+      }));
+
+  Buffer::OwnedImpl captured_buffer;
+  EXPECT_CALL(*mock_connection, write(_, _))
+      .WillOnce(Invoke([&captured_buffer](Buffer::Instance& buffer, bool) {
+        captured_buffer.add(buffer);
+        buffer.drain(buffer.length());
+      }));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  RCConnectionWrapper wrapper(*io_handle, std::move(mock_connection), mock_host, "test-cluster");
+  wrapper.connect("test-tenant", "test-cluster", "test-node");
+
+  const std::string encoded_request = captured_buffer.toString();
+  // The live formatter resolves the value; the raw literal must not leak through.
+  EXPECT_NE(encoded_request.find("authorization: Bearer TestFormatter"), std::string::npos);
+  EXPECT_EQ(encoded_request.find("%COMMAND_EXTENSION()%"), std::string::npos);
 }
 
 // Test that connect() includes an x-envoy-reverse-tunnel-initiation-time header

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -634,11 +634,11 @@ TEST_F(RCConnectionWrapperTest, ConnectHttpHandshakeLiteralHeaders) {
 }
 
 // Exercises the full ReverseTunnelInitiator::socket() -> io_handle -> wrapper path. socket()
-// snapshots the handshake formatters into the io_handle's config at creation time; when that happens
-// before onServerInitialized() builds them, the snapshot is null and gets reused for every re-dial.
-// This creates the socket while the extension is still uninitialized (and checks the snapshot really
-// is null), then initializes, dials, and checks the formatted value is sent -- not the raw literal.
-// Fails if the wrapper goes back to trusting the snapshot.
+// snapshots the handshake formatters into the io_handle's config at creation time; when that
+// happens before onServerInitialized() builds them, the snapshot is null and gets reused for every
+// re-dial. This creates the socket while the extension is still uninitialized (and checks the
+// snapshot really is null), then initializes, dials, and checks the formatted value is sent -- not
+// the raw literal. Fails if the wrapper goes back to trusting the snapshot.
 TEST_F(RCConnectionWrapperTest, HandshakeHeadersResolvedThroughSocketPathAfterInit) {
   Envoy::Formatter::TestCommandFactory factory;
   Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(factory);
@@ -678,7 +678,8 @@ TEST_F(RCConnectionWrapperTest, HandshakeHeadersResolvedThroughSocketPathAfterIn
   auto* io_handle = dynamic_cast<ReverseConnectionIOHandle*>(socket.get());
   ASSERT_NE(io_handle, nullptr);
   // Root cause: the socket captured a null formatter snapshot because it was created before
-  // onServerInitialized(). A wrapper trusting this snapshot would emit the raw literal on every dial.
+  // onServerInitialized(). A wrapper trusting this snapshot would emit the raw literal on every
+  // dial.
   ASSERT_EQ(io_handle->handshakeHeaders(), nullptr);
 
   // The worker registers and the formatters are built only now, after the socket already exists.


### PR DESCRIPTION
Commit Message: reverse tunnel: read handshake headers from the live extension
Additional Description:

The reverse-connection listen socket grabs a snapshot of the handshake formatters when it's created. Problem is, that can happen *before* `onServerInitialized()` builds them — so the snapshot is null, and since the same socket config gets reused for every re-dial, the handshake keeps going out with the raw `additional_headers` template instead of the resolved value.

So a header like `authorization: B**rer %FILE_CONTENT(/etc/tunnel-jwt/token.jwt)%` gets sent literally, on every dial.

Fix: when we assemble the handshake, read the formatters straight from the live extension instead of trusting the snapshot. Fall back to the snapshot only if the extension has none built.

This is a follow-up to #46168 — that one fixed the same symptom in the extension constructor, but didn't cover the `socket() => io_handle => wrapper` snapshot path.

Risk Level: Low
Testing: Added a new test to exercise the actual path. It asserts the snapshot is null at socket creation, then that the dial after init sends the resolved value
Docs Changes:
Release Notes:
Platform Specific Features:
