### PR TITLE
ai_protocol_manager: support upstream HTTP filter chains

### DIFF
--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -25,6 +25,25 @@ the headers before the payload they depend on is available.
   in-memory store. The filter performs a straight offload-then-replay; streaming
   payload parsing and admission control will be layered on top of this plumbing.
 
+The filter is a dual filter: besides the downstream HTTP filter chain shown
+below, it can also be placed in a cluster's upstream HTTP filter chain via
+:ref:`http_filters <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.http_filters>`,
+where the offload/replay round-trip runs after load balancing and host
+selection (and therefore once per retry or hedged attempt).
+
+.. note::
+
+  Two caveats apply to the upstream placement. The filter holds the request
+  headers until the payload has been fully offloaded, and upstream filter
+  chains have no per-upgrade-type chain selection (the
+  :ref:`upgrade_configs <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpConnectionManager.upgrade_configs>`
+  escape hatch is downstream-only), so the filter must not front upgrade or
+  CONNECT routes, or other requests whose body does not end promptly: such
+  streams would stall until the request times out. Additionally, local replies
+  raised from an upstream filter chain (such as this filter's external-buffer
+  error reply) are delivered directly to the downstream client without
+  consulting the router's retry or hedging logic.
+
 * This filter should be configured with the type URL ``type.googleapis.com/envoy.extensions.filters.http.ai_protocol_manager.v3.AiProtocolManager``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManager>`
 

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -317,8 +317,10 @@ envoy.filters.http.admission_control:
 envoy.filters.http.ai_protocol_manager:
   categories:
   - envoy.filters.http
+  - envoy.filters.http.upstream
   security_posture: unknown
   status: alpha
+  status_upstream: alpha
   type_urls:
   - envoy.extensions.filters.http.ai_protocol_manager.v3.AiProtocolManager
 envoy.filters.http.alternate_protocols_cache:

--- a/source/extensions/filters/http/ai_protocol_manager/config.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/config.cc
@@ -10,9 +10,10 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
 
-Http::FilterFactoryCb AiProtocolManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AiProtocolManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager&,
-    const std::string&, Server::Configuration::FactoryContext&) {
+    const std::string&, DualInfo, Server::Configuration::ServerFactoryContext&) {
   // One factory is shared by every stream on the chain. The in-memory
   // implementation is stateless, so a single shared instance is safe.
   auto buffer_factory = std::make_shared<InMemoryExternalBufferFactory>();
@@ -22,10 +23,13 @@ Http::FilterFactoryCb AiProtocolManagerFilterConfigFactory::createFilterFactoryF
 }
 
 /**
- * Static registration for the AI Protocol Manager filter. @see RegisterFactory.
+ * Static registration for the AI Protocol Manager filter as a downstream and an
+ * upstream HTTP filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(AiProtocolManagerFilterConfigFactory,
                  Server::Configuration::NamedHttpFilterConfigFactory);
+REGISTER_FACTORY(UpstreamAiProtocolManagerFilterConfigFactory,
+                 Server::Configuration::UpstreamHttpFilterConfigFactory);
 
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ai_protocol_manager/config.h
+++ b/source/extensions/filters/http/ai_protocol_manager/config.h
@@ -11,17 +11,21 @@ namespace HttpFilters {
 namespace AiProtocolManager {
 
 class AiProtocolManagerFilterConfigFactory
-    : public Common::FactoryBase<
+    : public Common::DualFactoryBase<
           envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager> {
 public:
-  AiProtocolManagerFilterConfigFactory() : FactoryBase("envoy.filters.http.ai_protocol_manager") {}
+  AiProtocolManagerFilterConfigFactory()
+      : DualFactoryBase("envoy.filters.http.ai_protocol_manager") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager&
           proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      const std::string& stats_prefix, DualInfo info,
+      Server::Configuration::ServerFactoryContext& context) override;
 };
+
+using UpstreamAiProtocolManagerFilterConfigFactory = AiProtocolManagerFilterConfigFactory;
 
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/ai_protocol_manager_integration_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/ai_protocol_manager_integration_test.cc
@@ -11,14 +11,18 @@ namespace {
 // real requests through a configured Envoy and assert that the upstream still
 // observes the headers, the complete body (across a range of sizes), and any
 // trailers unchanged -- i.e. the offload/replay round-trip is transparent.
+//
+// The filter is a dual filter: each scenario runs once with the filter in the
+// downstream HTTP filter chain and once in the upstream (cluster) filter chain.
 class AiProtocolManagerIntegrationTest : public HttpProtocolIntegrationTest {
 protected:
-  void prependFilter() {
+  void prependFilter(bool downstream = true) {
     config_helper_.prependFilter(R"EOF(
 name: envoy.filters.http.ai_protocol_manager
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.ai_protocol_manager.v3.AiProtocolManager
-)EOF");
+)EOF",
+                                 downstream);
   }
 
   Http::TestRequestHeaderMapImpl requestHeaders() {
@@ -30,6 +34,14 @@ typed_config:
                                           {":scheme", "http"},
                                           {":authority", "sni.lyft.com"}};
   }
+
+  // Shared scenario bodies; each is driven with the filter in either chain.
+  void runHeaderOnly();
+  void runHeaderAndBody();
+  void runHeaderAndBodyMultipleFrames();
+  void runHeaderAndBodyAndTrailers();
+  void runHeaderAndTrailersNoBody();
+  void runLocalReplyDuringReplay(bool downstream);
 };
 
 INSTANTIATE_TEST_SUITE_P(Protocols, AiProtocolManagerIntegrationTest,
@@ -38,8 +50,7 @@ INSTANTIATE_TEST_SUITE_P(Protocols, AiProtocolManagerIntegrationTest,
 
 // Headers-only request: the filter must let the headers flow immediately (there
 // is no payload to offload), and the round-trip must complete normally.
-TEST_P(AiProtocolManagerIntegrationTest, HeaderOnly) {
-  prependFilter();
+void AiProtocolManagerIntegrationTest::runHeaderOnly() {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -56,11 +67,20 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderOnly) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+TEST_P(AiProtocolManagerIntegrationTest, HeaderOnly) {
+  prependFilter();
+  runHeaderOnly();
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamHeaderOnly) {
+  prependFilter(/*downstream=*/false);
+  runHeaderOnly();
+}
+
 // Header + body: the offloaded body must be replayed in full to the upstream.
 // Parameterized over a range of sizes to exercise empty, sub-chunk, and
 // multi-chunk payloads through the offload/replay path.
-TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBody) {
-  prependFilter();
+void AiProtocolManagerIntegrationTest::runHeaderAndBody() {
   initialize();
 
   for (const uint64_t body_size : {0u, 1u, 16u, 1024u, 64u * 1024u, 1024u * 1024u}) {
@@ -82,10 +102,19 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBody) {
   }
 }
 
+TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBody) {
+  prependFilter();
+  runHeaderAndBody();
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamHeaderAndBody) {
+  prependFilter(/*downstream=*/false);
+  runHeaderAndBody();
+}
+
 // Header + body sent as several explicit frames before end_stream. Verifies the
 // filter reassembles a body delivered across multiple decodeData() calls.
-TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyMultipleFrames) {
-  prependFilter();
+void AiProtocolManagerIntegrationTest::runHeaderAndBodyMultipleFrames() {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -107,11 +136,20 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyMultipleFrames) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyMultipleFrames) {
+  prependFilter();
+  runHeaderAndBodyMultipleFrames();
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamHeaderAndBodyMultipleFrames) {
+  prependFilter(/*downstream=*/false);
+  runHeaderAndBodyMultipleFrames();
+}
+
 // Header + body + trailers: the stream is terminated by trailers rather than an
 // end_stream data frame. The filter must replay the buffered body and then
 // release the trailers, so the upstream observes both intact.
-TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyAndTrailers) {
-  prependFilter();
+void AiProtocolManagerIntegrationTest::runHeaderAndBodyAndTrailers() {
   // HTTP/1.1 codecs only parse/emit trailers when explicitly enabled, on both
   // the downstream (to read client trailers) and upstream (to forward them).
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
@@ -152,6 +190,16 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyAndTrailers) {
   }
 }
 
+TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyAndTrailers) {
+  prependFilter();
+  runHeaderAndBodyAndTrailers();
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamHeaderAndBodyAndTrailers) {
+  prependFilter(/*downstream=*/false);
+  runHeaderAndBodyAndTrailers();
+}
+
 // The stream is torn down *during replay*: a buffer filter placed downstream of
 // the AiProtocolManager trips its request-size limit as the offloaded body is
 // replayed back into the chain, so Envoy emits a 413 local reply from inside the
@@ -164,17 +212,19 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderAndBodyAndTrailers) {
 // cleanly (guarding on destroyed_) rather than touch its released buffer/bridge.
 // The round-trip must fail cleanly with 413 (and, under ASAN, without touching a
 // torn-down manager), and Envoy must stay healthy for a subsequent request.
-TEST_P(AiProtocolManagerIntegrationTest, LocalReplyDuringReplayTearsDownCleanly) {
+void AiProtocolManagerIntegrationTest::runLocalReplyDuringReplay(bool downstream) {
   // Order matters: AiProtocolManager must run first (it offloads the body), the
   // buffer filter after it (it sees the body only when the manager replays it).
-  // prependFilter() inserts at the head, so add the buffer filter first.
+  // prependFilter() inserts at the head of the chosen chain, so add the buffer
+  // filter (also a dual filter) first.
   config_helper_.prependFilter(R"EOF(
 name: envoy.filters.http.buffer
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
   max_request_bytes: 1024
-)EOF");
-  prependFilter();
+)EOF",
+                               downstream);
+  prependFilter(downstream);
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -190,6 +240,20 @@ typed_config:
   EXPECT_EQ("413", response->headers().getStatusValue());
   codec_client_->close();
 
+  if (!downstream) {
+    // With the filter chain in the upstream request, the aborted request above already
+    // dispatched to the cluster: the connection pool opened an upstream connection even
+    // though the 413 fired before the held headers reached the codec, so no stream was
+    // ever sent on it. Depending on reset timing Envoy either keeps that pristine
+    // connection idle for reuse or closes it, which would leave the follow-up request's
+    // waitForNextUpstreamRequest() watching the wrong connection. Drain it from the test
+    // side so the follow-up request deterministically arrives on a fresh connection.
+    FakeHttpConnectionPtr aborted_connection;
+    ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, aborted_connection));
+    ASSERT_TRUE(aborted_connection->close());
+    ASSERT_TRUE(aborted_connection->waitForDisconnect());
+  }
+
   // The worker survived the mid-replay teardown: a fresh request round-trips. A
   // small body stays under the buffer filter's limit, so it replays and reaches
   // the upstream normally.
@@ -202,9 +266,16 @@ typed_config:
   EXPECT_EQ("200", ok_response->headers().getStatusValue());
 }
 
+TEST_P(AiProtocolManagerIntegrationTest, LocalReplyDuringReplayTearsDownCleanly) {
+  runLocalReplyDuringReplay(/*downstream=*/true);
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamLocalReplyDuringReplayTearsDownCleanly) {
+  runLocalReplyDuringReplay(/*downstream=*/false);
+}
+
 // Trailers immediately after headers, with no body in between.
-TEST_P(AiProtocolManagerIntegrationTest, HeaderAndTrailersNoBody) {
-  prependFilter();
+void AiProtocolManagerIntegrationTest::runHeaderAndTrailersNoBody() {
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
   initialize();
@@ -226,6 +297,16 @@ TEST_P(AiProtocolManagerIntegrationTest, HeaderAndTrailersNoBody) {
   ASSERT_TRUE(response->waitForEndStream());
   ASSERT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, HeaderAndTrailersNoBody) {
+  prependFilter();
+  runHeaderAndTrailersNoBody();
+}
+
+TEST_P(AiProtocolManagerIntegrationTest, UpstreamHeaderAndTrailersNoBody) {
+  prependFilter(/*downstream=*/false);
+  runHeaderAndTrailersNoBody();
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/config_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/config_test.cc
@@ -61,6 +61,34 @@ TEST(AiProtocolManagerConfigTest, IsRegistered) {
   EXPECT_EQ(factory->name(), "envoy.filters.http.ai_protocol_manager");
 }
 
+// The filter is a dual factory: it is also registered in the upstream HTTP
+// filter registry so it can be placed in upstream filter chains.
+TEST(AiProtocolManagerConfigTest, IsRegisteredAsUpstreamFilter) {
+  Server::Configuration::UpstreamHttpFilterConfigFactory* factory =
+      Registry::FactoryRegistry<Server::Configuration::UpstreamHttpFilterConfigFactory>::getFactory(
+          "envoy.filters.http.ai_protocol_manager");
+  ASSERT_NE(factory, nullptr);
+  // The upstream registration resolves to the dual factory itself, not merely a
+  // same-named factory.
+  EXPECT_THAT(factory, testing::WhenDynamicCastTo<AiProtocolManagerFilterConfigFactory*>(
+                           testing::NotNull()));
+}
+
+// Creating the filter from an upstream factory context yields the same stream
+// filter as the downstream path.
+TEST(AiProtocolManagerConfigTest, CreatesStreamFilterFromUpstreamContext) {
+  envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
+  NiceMock<Server::Configuration::MockUpstreamFactoryContext> context;
+
+  AiProtocolManagerFilterConfigFactory factory;
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(proto_config, "stats", context).value();
+
+  Http::MockFilterChainFactoryCallbacks filter_callbacks;
+  EXPECT_CALL(filter_callbacks, addStreamFilter(_));
+  cb(filter_callbacks);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters


### PR DESCRIPTION
Commit Message:
Register the AI Protocol Manager filter as a dual filter (DualFactoryBase) so it can run in a cluster's upstream HTTP filter chain as well as the downstream chain.

Additional Description:
Scoped to the dual registration only — no core flow-control changes. Pacing the filter's replay against upstream back-pressure in upstream chains (fanning the upstream filter manager's watermarks out to addUpstreamWatermarkCallbacks subscribers, the upstream-chain analogue of #46020) is deliberately left to a follow-up PR. Docs note the upstream caveats: no per-upgrade-type chain selection upstream, and upstream local replies bypass router retry/hedging arbitration.

This PR was generated with AI assistance. I have read and understand the code.

Risk Level: Low — additive factory registration; no core behavior changes.
Testing: unit tests for the dual factory (upstream registry resolution asserted via dynamic cast, creation from an upstream factory context); integration tests run every scenario with the filter in both chains across protocol combinations.
Docs Changes: ai_protocol_manager_filter.rst — upstream configuration pointer and caveats.
Release Notes: n/a (work-in-progress extension, consistent with #45899/#46020).
Platform Specific Features: n/a