### PR TITLE
listener: reject bind_to_port: false on UDP listeners

### DIFF
--- a/changelogs/current/bug_fixes/listener__reject-no-bind-udp.rst
+++ b/changelogs/current/bug_fixes/listener__reject-no-bind-udp.rst
@@ -1,0 +1,3 @@
+Fixed a crash at startup when a UDP or QUIC listener was configured with ``bind_to_port: false``.
+This combination was never functional and is now rejected at configuration load with a validation
+error.

--- a/source/common/listener_manager/listener_impl.cc
+++ b/source/common/listener_manager/listener_impl.cc
@@ -603,6 +603,12 @@ absl::Status ListenerImpl::validateConfig() {
           name_));
     }
   }
+  // UDP listeners always carry socket options (e.g. packet info), but with bind_to_port
+  // disabled no socket is created to apply them to, which previously crashed at startup.
+  if (!bind_to_port_ && socket_type_ == Network::Socket::Type::Datagram) {
+    return absl::InvalidArgumentError(
+        fmt::format("listener {}: bind_to_port: false is not supported for UDP listeners", name_));
+  }
   return absl::OkStatus();
 }
 

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -7130,6 +7130,44 @@ TEST_P(ListenerManagerImplWithRealFiltersTest, MptcpOnUdp) {
                             "listener mptcp-udp: enable_mptcp can only be used with TCP listeners");
 }
 
+TEST_P(ListenerManagerImplWithRealFiltersTest, NoBindToPortOnUdp) {
+  envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
+      name: udp-no-bind
+      bind_to_port: false
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1111
+          protocol: UDP
+      filter_chains:
+      - filters: []
+        name: foo
+    )EOF");
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(listener), EnvoyException,
+      "listener udp-no-bind: bind_to_port: false is not supported for UDP listeners");
+}
+
+TEST_P(ListenerManagerImplWithRealFiltersTest, NoBindToPortOnQuic) {
+  envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
+      name: quic-no-bind
+      bind_to_port: false
+      udp_listener_config:
+        quic_options: {}
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1111
+          protocol: UDP
+      filter_chains:
+      - filters: []
+        name: foo
+    )EOF");
+  EXPECT_THROW_WITH_MESSAGE(
+      addOrUpdateListener(listener), EnvoyException,
+      "listener quic-no-bind: bind_to_port: false is not supported for UDP listeners");
+}
+
 TEST_P(ListenerManagerImplWithRealFiltersTest, MptcpOnUnixDomainSocket) {
   envoy::config::listener::v3::Listener listener = parseListenerFromV3Yaml(R"EOF(
       name: mptcp-udp


### PR DESCRIPTION
Commit Message: listener: reject bind_to_port: false on UDP listeners

Additional Description:
Follows the direction from the review of #46264: reject the combination in `ListenerImpl::validateConfig()` next to the existing mptcp checks, instead of guarding the socket creation path.

Why rejection is safe: UDP listeners unconditionally add socket options (packet info etc.), and with `bind_to_port: false` no socket is created to apply them to, so startup always dereferenced a null socket handle. There is also no fd-injection path for no-bind UDP: the hot-restart parent socket duplication in `createListenSocketInternal()` only runs when `bind_type != NoBind`, so this configuration could never have been used for passing pre-bound sockets.

Opened as a public PR per the issue: "Crash on startup with specific config. Ok to fix in the open."

Risk Level: Low. Configurations that previously crashed at startup now fail config validation; no functional configuration is affected.

Testing: two new listener manager unit tests (plain UDP and QUIC listener with bind_to_port: false), mirroring the adjacent MptcpOnUdp validation test.

Docs Changes: n/a

Release Notes: changelogs/current/bug_fixes/listener__reject-no-bind-udp.rst

Platform Specific Features: n/a

Fixes #46231
