### PR TITLE
dynamic_modules: let runtime cluster hosts carry logical hostnames

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
@@ -1,5 +1,5 @@
 Added the ``envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames`` ABI callback so
 dynamic-module clusters can assign logical hostnames independently of socket addresses. Upstream
-features such as automatic SNI and SAN validation can consume the logical hostname. Null or empty
-hostnames use the same synthesized hostname behavior as the existing callback. The Rust SDK exposes
-convenience and priority/locality-aware methods for the new callback.
+TLS options such as ``auto_host_sni`` and ``auto_sni_san_validation`` can consume the logical
+hostname. Null or empty hostnames use the same synthesized hostname behavior as the existing
+callback. The Rust SDK exposes convenience and priority/locality-aware methods for the new callback.

--- a/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
@@ -1,0 +1,5 @@
+Added the ``envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames`` ABI callback so
+dynamic-module clusters can assign logical hostnames independently of socket addresses. Upstream
+features such as automatic SNI and SAN validation can consume the logical hostname. Null or empty
+hostnames preserve the legacy synthesized hostname behavior. The Rust SDK exposes convenience and
+priority/locality-aware methods for the new callback.

--- a/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-cluster-hostnames.rst
@@ -1,5 +1,5 @@
 Added the ``envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames`` ABI callback so
 dynamic-module clusters can assign logical hostnames independently of socket addresses. Upstream
 features such as automatic SNI and SAN validation can consume the logical hostname. Null or empty
-hostnames preserve the legacy synthesized hostname behavior. The Rust SDK exposes convenience and
-priority/locality-aware methods for the new callback.
+hostnames use the same synthesized hostname behavior as the existing callback. The Rust SDK exposes
+convenience and priority/locality-aware methods for the new callback.

--- a/source/extensions/clusters/dynamic_modules/BUILD
+++ b/source/extensions/clusters/dynamic_modules/BUILD
@@ -31,6 +31,8 @@ envoy_cc_library(
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
+        "@abseil-cpp//absl/strings:string_view",
+        "@abseil-cpp//absl/types:span",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -113,29 +113,22 @@ Envoy::Stats::StatNameTagVector buildTagsForClusterMetric(
   return tags;
 }
 
-} // namespace
-
-extern "C" {
-
-bool envoy_dynamic_module_callback_cluster_add_hosts(
-    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr, uint32_t priority,
-    const envoy_dynamic_module_type_module_buffer* addresses, const uint32_t* weights,
-    const envoy_dynamic_module_type_module_buffer* regions,
-    const envoy_dynamic_module_type_module_buffer* zones,
-    const envoy_dynamic_module_type_module_buffer* sub_zones,
-    const envoy_dynamic_module_type_module_buffer* metadata_pairs, size_t metadata_pairs_per_host,
-    size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs) {
-  // `cluster_add_hosts` mutates `priority_set_` and runs member-update callbacks; both are
-  // main-thread-only. The previous `ASSERT_IS_MAIN_OR_TEST_THREAD` is compiled out under NDEBUG,
-  // so guard explicitly and fail closed.
-  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
-    IS_ENVOY_BUG(
-        "envoy_dynamic_module_callback_cluster_add_hosts must be called on the main thread");
-    return false;
-  }
+bool addHosts(envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr, uint32_t priority,
+              const envoy_dynamic_module_type_module_buffer* addresses,
+              const envoy_dynamic_module_type_module_buffer* hostnames, const uint32_t* weights,
+              const envoy_dynamic_module_type_module_buffer* regions,
+              const envoy_dynamic_module_type_module_buffer* zones,
+              const envoy_dynamic_module_type_module_buffer* sub_zones,
+              const envoy_dynamic_module_type_module_buffer* metadata_pairs,
+              size_t metadata_pairs_per_host, size_t count,
+              envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs) {
   auto* cluster = getCluster(cluster_envoy_ptr);
   std::vector<std::string> address_strings;
   address_strings.reserve(count);
+  std::vector<absl::string_view> hostname_views;
+  if (hostnames != nullptr) {
+    hostname_views.reserve(count);
+  }
   std::vector<uint32_t> weight_vec(weights, weights + count);
   std::vector<std::string> region_strings;
   region_strings.reserve(count);
@@ -145,6 +138,11 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
   sub_zone_strings.reserve(count);
   for (size_t i = 0; i < count; ++i) {
     address_strings.emplace_back(addresses[i].ptr, addresses[i].length);
+    if (hostnames != nullptr) {
+      hostname_views.emplace_back(hostnames[i].length == 0
+                                      ? absl::string_view()
+                                      : absl::string_view(hostnames[i].ptr, hostnames[i].length));
+    }
     region_strings.emplace_back(regions[i].ptr, regions[i].length);
     zone_strings.emplace_back(zones[i].ptr, zones[i].length);
     sub_zone_strings.emplace_back(sub_zones[i].ptr, sub_zones[i].length);
@@ -168,7 +166,7 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
   }
 
   std::vector<Envoy::Upstream::HostSharedPtr> result_hosts;
-  if (!cluster->addHosts(address_strings, weight_vec, region_strings, zone_strings,
+  if (!cluster->addHosts(address_strings, hostname_views, weight_vec, region_strings, zone_strings,
                          sub_zone_strings, metadata_vec, result_hosts, priority)) {
     return false;
   }
@@ -176,6 +174,48 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
     result_host_ptrs[i] = const_cast<Envoy::Upstream::Host*>(result_hosts[i].get());
   }
   return true;
+}
+
+} // namespace
+
+extern "C" {
+
+bool envoy_dynamic_module_callback_cluster_add_hosts(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr, uint32_t priority,
+    const envoy_dynamic_module_type_module_buffer* addresses, const uint32_t* weights,
+    const envoy_dynamic_module_type_module_buffer* regions,
+    const envoy_dynamic_module_type_module_buffer* zones,
+    const envoy_dynamic_module_type_module_buffer* sub_zones,
+    const envoy_dynamic_module_type_module_buffer* metadata_pairs, size_t metadata_pairs_per_host,
+    size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs) {
+  // `cluster_add_hosts` mutates `priority_set_` and runs member-update callbacks; both are
+  // main-thread-only. The previous `ASSERT_IS_MAIN_OR_TEST_THREAD` is compiled out under NDEBUG,
+  // so guard explicitly and fail closed.
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG(
+        "envoy_dynamic_module_callback_cluster_add_hosts must be called on the main thread");
+    return false;
+  }
+  return addHosts(cluster_envoy_ptr, priority, addresses, nullptr, weights, regions, zones,
+                  sub_zones, metadata_pairs, metadata_pairs_per_host, count, result_host_ptrs);
+}
+
+bool envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr, uint32_t priority,
+    const envoy_dynamic_module_type_module_buffer* addresses,
+    const envoy_dynamic_module_type_module_buffer* hostnames, const uint32_t* weights,
+    const envoy_dynamic_module_type_module_buffer* regions,
+    const envoy_dynamic_module_type_module_buffer* zones,
+    const envoy_dynamic_module_type_module_buffer* sub_zones,
+    const envoy_dynamic_module_type_module_buffer* metadata_pairs, size_t metadata_pairs_per_host,
+    size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs) {
+  if (!Envoy::Thread::MainThread::isMainOrTestThread()) {
+    IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames must be called on "
+                 "the main thread");
+    return false;
+  }
+  return addHosts(cluster_envoy_ptr, priority, addresses, hostnames, weights, regions, zones,
+                  sub_zones, metadata_pairs, metadata_pairs_per_host, count, result_host_ptrs);
 }
 
 size_t envoy_dynamic_module_callback_cluster_remove_hosts(

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -394,10 +394,21 @@ bool DynamicModuleCluster::addHosts(
     const std::vector<std::string>& sub_zones,
     const std::vector<std::vector<std::tuple<std::string, std::string, std::string>>>& metadata,
     std::vector<Upstream::HostSharedPtr>& result_hosts, uint32_t priority) {
+  return addHosts(addresses, absl::Span<const absl::string_view>(), weights, regions, zones,
+                  sub_zones, metadata, result_hosts, priority);
+}
+
+bool DynamicModuleCluster::addHosts(
+    const std::vector<std::string>& addresses, absl::Span<const absl::string_view> hostnames,
+    const std::vector<uint32_t>& weights, const std::vector<std::string>& regions,
+    const std::vector<std::string>& zones, const std::vector<std::string>& sub_zones,
+    const std::vector<std::vector<std::tuple<std::string, std::string, std::string>>>& metadata,
+    std::vector<Upstream::HostSharedPtr>& result_hosts, uint32_t priority) {
   ASSERT(addresses.size() == weights.size());
   ASSERT(addresses.size() == regions.size());
   ASSERT(addresses.size() == zones.size());
   ASSERT(addresses.size() == sub_zones.size());
+  ASSERT(hostnames.empty() || hostnames.size() == addresses.size());
   ASSERT(metadata.empty() || metadata.size() == addresses.size());
   result_hosts.clear();
   result_hosts.reserve(addresses.size());
@@ -448,9 +459,12 @@ bool DynamicModuleCluster::addHosts(
       endpoint_metadata = std::move(md);
     }
 
+    const std::string hostname = hostnames.empty() || hostnames[i].empty()
+                                     ? cluster_info->name() + addresses[i]
+                                     : std::string(hostnames[i]);
     auto host_result = Upstream::HostImpl::create(
-        cluster_info, cluster_info->name() + addresses[i], std::move(resolved_address),
-        std::move(endpoint_metadata), nullptr, weights[i], std::move(locality),
+        cluster_info, hostname, std::move(resolved_address), std::move(endpoint_metadata), nullptr,
+        weights[i], std::move(locality),
         envoy::config::endpoint::v3::Endpoint::HealthCheckConfig().default_instance(), 0,
         envoy::config::core::v3::UNKNOWN);
     if (!host_result.ok()) {

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -29,6 +29,8 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/functional/function_ref.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -335,6 +337,12 @@ public:
       const std::vector<std::string>& addresses, const std::vector<uint32_t>& weights,
       const std::vector<std::string>& regions, const std::vector<std::string>& zones,
       const std::vector<std::string>& sub_zones,
+      const std::vector<std::vector<std::tuple<std::string, std::string, std::string>>>& metadata,
+      std::vector<Upstream::HostSharedPtr>& result_hosts, uint32_t priority = 0);
+  bool addHosts(
+      const std::vector<std::string>& addresses, absl::Span<const absl::string_view> hostnames,
+      const std::vector<uint32_t>& weights, const std::vector<std::string>& regions,
+      const std::vector<std::string>& zones, const std::vector<std::string>& sub_zones,
       const std::vector<std::vector<std::tuple<std::string, std::string, std::string>>>& metadata,
       std::vector<Upstream::HostSharedPtr>& result_hosts, uint32_t priority = 0);
   size_t removeHosts(const std::vector<Upstream::HostSharedPtr>& hosts);

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -9802,6 +9802,31 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
     size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs);
 
 /**
+ * envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames is equivalent to
+ * envoy_dynamic_module_callback_cluster_add_hosts, but additionally assigns each host a logical
+ * hostname.
+ *
+ * A non-empty logical hostname is available to upstream features such as automatic SNI and SAN
+ * validation. An empty hostname entry preserves the legacy synthesized hostname behavior.
+ *
+ * @param hostnames is the optional array of logical hostnames corresponding to ``addresses``. Each
+ * entry is owned by the module. An entry with length 0 uses the legacy synthesized hostname. The
+ * entire array can be nullptr to use the legacy behavior for all hosts.
+ *
+ * See envoy_dynamic_module_callback_cluster_add_hosts for all other parameters and return
+ * semantics.
+ */
+bool envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr, uint32_t priority,
+    const envoy_dynamic_module_type_module_buffer* addresses,
+    const envoy_dynamic_module_type_module_buffer* hostnames, const uint32_t* weights,
+    const envoy_dynamic_module_type_module_buffer* regions,
+    const envoy_dynamic_module_type_module_buffer* zones,
+    const envoy_dynamic_module_type_module_buffer* sub_zones,
+    const envoy_dynamic_module_type_module_buffer* metadata_pairs, size_t metadata_pairs_per_host,
+    size_t count, envoy_dynamic_module_type_cluster_host_envoy_ptr* result_host_ptrs);
+
+/**
  * envoy_dynamic_module_callback_cluster_remove_hosts removes multiple hosts from the cluster in a
  * single batch operation. This triggers only one priority set update regardless of how many hosts
  * are removed.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -9807,11 +9807,13 @@ bool envoy_dynamic_module_callback_cluster_add_hosts(
  * hostname.
  *
  * A non-empty logical hostname is available to upstream features such as automatic SNI and SAN
- * validation. An empty hostname entry preserves the legacy synthesized hostname behavior.
+ * validation. An empty hostname entry uses the same synthesized hostname behavior as
+ * envoy_dynamic_module_callback_cluster_add_hosts.
  *
  * @param hostnames is the optional array of logical hostnames corresponding to ``addresses``. Each
- * entry is owned by the module. An entry with length 0 uses the legacy synthesized hostname. The
- * entire array can be nullptr to use the legacy behavior for all hosts.
+ * entry is owned by the module. An entry with length 0 uses the same synthesized hostname behavior
+ * as envoy_dynamic_module_callback_cluster_add_hosts. The entire array can be nullptr to use that
+ * behavior for all hosts.
  *
  * See envoy_dynamic_module_callback_cluster_add_hosts for all other parameters and return
  * semantics.

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -459,6 +459,18 @@ __attribute__((weak)) bool envoy_dynamic_module_callback_cluster_add_hosts(
   return false;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+    envoy_dynamic_module_type_cluster_envoy_ptr, uint32_t,
+    const envoy_dynamic_module_type_module_buffer*, const envoy_dynamic_module_type_module_buffer*,
+    const uint32_t*, const envoy_dynamic_module_type_module_buffer*,
+    const envoy_dynamic_module_type_module_buffer*, const envoy_dynamic_module_type_module_buffer*,
+    const envoy_dynamic_module_type_module_buffer*, size_t, size_t,
+    envoy_dynamic_module_type_cluster_host_envoy_ptr*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) size_t envoy_dynamic_module_callback_cluster_remove_hosts(
     envoy_dynamic_module_type_cluster_envoy_ptr,
     const envoy_dynamic_module_type_cluster_host_envoy_ptr*, size_t) {

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -370,6 +370,19 @@ pub trait EnvoyCluster: Send + Sync {
     weights: &[u32],
   ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>>;
 
+  /// Add multiple hosts with logical hostnames in a single batch operation.
+  ///
+  /// Each non-empty hostname is stored separately from its corresponding `ip:port` address and is
+  /// available to upstream features such as automatic SNI and SAN validation. An empty hostname
+  /// uses Envoy's legacy synthesized hostname. `hostnames` must have the same length as
+  /// `addresses`.
+  fn add_hosts_with_hostnames(
+    &self,
+    addresses: &[String],
+    hostnames: &[String],
+    weights: &[u32],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>>;
+
   /// Remove multiple hosts from the cluster in a single batch operation.
   ///
   /// The host pointers must have been returned by a previous [`EnvoyCluster::add_hosts`] call.
@@ -437,6 +450,23 @@ pub trait EnvoyCluster: Send + Sync {
     &self,
     priority: u32,
     addresses: &[String],
+    weights: &[u32],
+    localities: &[(String, String, String)],
+    metadata: &[Vec<(String, String, String)>],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>>;
+
+  /// Add multiple hosts with logical hostnames at the specified priority level, including
+  /// per-host locality and metadata.
+  ///
+  /// Each non-empty hostname is stored separately from its corresponding `ip:port` address and is
+  /// available to upstream features such as automatic SNI and SAN validation. An empty hostname
+  /// uses Envoy's legacy synthesized hostname. `hostnames` must have the same length as
+  /// `addresses`.
+  fn add_hosts_with_hostnames_and_locality_to_priority(
+    &self,
+    priority: u32,
+    addresses: &[String],
+    hostnames: &[String],
     weights: &[u32],
     localities: &[(String, String, String)],
     metadata: &[Vec<(String, String, String)>],
@@ -964,55 +994,27 @@ impl EnvoyClusterImpl {
   fn new(raw: abi::envoy_dynamic_module_type_cluster_envoy_ptr) -> Self {
     Self { raw }
   }
-}
 
-impl EnvoyCluster for EnvoyClusterImpl {
-  fn add_hosts(
-    &self,
-    addresses: &[String],
-    weights: &[u32],
-  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
-    let empty_localities: Vec<(String, String, String)> = addresses
-      .iter()
-      .map(|_| (String::new(), String::new(), String::new()))
-      .collect();
-    self.add_hosts_with_locality_to_priority(0, addresses, weights, &empty_localities, &[])
-  }
-
-  fn add_hosts_with_locality(
-    &self,
-    addresses: &[String],
-    weights: &[u32],
-    localities: &[(String, String, String)],
-    metadata: &[Vec<(String, String, String)>],
-  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
-    self.add_hosts_with_locality_to_priority(0, addresses, weights, localities, metadata)
-  }
-
-  fn add_hosts_to_priority(
+  fn add_hosts_to_priority_impl(
     &self,
     priority: u32,
     addresses: &[String],
-    weights: &[u32],
-  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
-    let empty_localities: Vec<(String, String, String)> = addresses
-      .iter()
-      .map(|_| (String::new(), String::new(), String::new()))
-      .collect();
-    self.add_hosts_with_locality_to_priority(priority, addresses, weights, &empty_localities, &[])
-  }
-
-  fn add_hosts_with_locality_to_priority(
-    &self,
-    priority: u32,
-    addresses: &[String],
+    hostnames: Option<&[String]>,
     weights: &[u32],
     localities: &[(String, String, String)],
     metadata: &[Vec<(String, String, String)>],
   ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
     let count = addresses.len();
+    if hostnames.is_some_and(|hostnames| hostnames.len() != count) {
+      return None;
+    }
     let address_buffers: Vec<abi::envoy_dynamic_module_type_module_buffer> =
       addresses.iter().map(|a| str_to_module_buffer(a)).collect();
+    let hostname_buffers: Vec<abi::envoy_dynamic_module_type_module_buffer> = hostnames
+      .unwrap_or_default()
+      .iter()
+      .map(|hostname| str_to_module_buffer(hostname))
+      .collect();
     let region_buffers: Vec<abi::envoy_dynamic_module_type_module_buffer> = localities
       .iter()
       .map(|(r, ..)| str_to_module_buffer(r))
@@ -1050,25 +1052,128 @@ impl EnvoyCluster for EnvoyClusterImpl {
     let mut result_ptrs: Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr> =
       vec![std::ptr::null_mut(); count];
     let success = unsafe {
-      abi::envoy_dynamic_module_callback_cluster_add_hosts(
-        self.raw,
-        priority,
-        address_buffers.as_ptr(),
-        weights.as_ptr(),
-        region_buffers.as_ptr(),
-        zone_buffers.as_ptr(),
-        sub_zone_buffers.as_ptr(),
-        metadata_ptr,
-        metadata_pairs_per_host,
-        count,
-        result_ptrs.as_mut_ptr(),
-      )
+      match hostnames {
+        Some(_) => abi::envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+          self.raw,
+          priority,
+          address_buffers.as_ptr(),
+          hostname_buffers.as_ptr(),
+          weights.as_ptr(),
+          region_buffers.as_ptr(),
+          zone_buffers.as_ptr(),
+          sub_zone_buffers.as_ptr(),
+          metadata_ptr,
+          metadata_pairs_per_host,
+          count,
+          result_ptrs.as_mut_ptr(),
+        ),
+        None => abi::envoy_dynamic_module_callback_cluster_add_hosts(
+          self.raw,
+          priority,
+          address_buffers.as_ptr(),
+          weights.as_ptr(),
+          region_buffers.as_ptr(),
+          zone_buffers.as_ptr(),
+          sub_zone_buffers.as_ptr(),
+          metadata_ptr,
+          metadata_pairs_per_host,
+          count,
+          result_ptrs.as_mut_ptr(),
+        ),
+      }
     };
     if success {
       Some(result_ptrs)
     } else {
       None
     }
+  }
+}
+
+impl EnvoyCluster for EnvoyClusterImpl {
+  fn add_hosts(
+    &self,
+    addresses: &[String],
+    weights: &[u32],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    let empty_localities: Vec<(String, String, String)> = addresses
+      .iter()
+      .map(|_| (String::new(), String::new(), String::new()))
+      .collect();
+    self.add_hosts_with_locality_to_priority(0, addresses, weights, &empty_localities, &[])
+  }
+
+  fn add_hosts_with_hostnames(
+    &self,
+    addresses: &[String],
+    hostnames: &[String],
+    weights: &[u32],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    let empty_localities: Vec<(String, String, String)> = addresses
+      .iter()
+      .map(|_| (String::new(), String::new(), String::new()))
+      .collect();
+    self.add_hosts_with_hostnames_and_locality_to_priority(
+      0,
+      addresses,
+      hostnames,
+      weights,
+      &empty_localities,
+      &[],
+    )
+  }
+
+  fn add_hosts_with_locality(
+    &self,
+    addresses: &[String],
+    weights: &[u32],
+    localities: &[(String, String, String)],
+    metadata: &[Vec<(String, String, String)>],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    self.add_hosts_with_locality_to_priority(0, addresses, weights, localities, metadata)
+  }
+
+  fn add_hosts_to_priority(
+    &self,
+    priority: u32,
+    addresses: &[String],
+    weights: &[u32],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    let empty_localities: Vec<(String, String, String)> = addresses
+      .iter()
+      .map(|_| (String::new(), String::new(), String::new()))
+      .collect();
+    self.add_hosts_with_locality_to_priority(priority, addresses, weights, &empty_localities, &[])
+  }
+
+  fn add_hosts_with_locality_to_priority(
+    &self,
+    priority: u32,
+    addresses: &[String],
+    weights: &[u32],
+    localities: &[(String, String, String)],
+    metadata: &[Vec<(String, String, String)>],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    self.add_hosts_to_priority_impl(priority, addresses, None, weights, localities, metadata)
+  }
+
+  fn add_hosts_with_hostnames_and_locality_to_priority(
+    &self,
+    priority: u32,
+    addresses: &[String],
+    hostnames: &[String],
+    weights: &[u32],
+    localities: &[(String, String, String)],
+    metadata: &[Vec<(String, String, String)>],
+  ) -> Option<Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>> {
+    self.add_hosts_to_priority_impl(
+      priority,
+      addresses,
+      Some(hostnames),
+      weights,
+      localities,
+      metadata,
+    )
   }
 
   fn update_host_health(
@@ -2806,6 +2911,78 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn add_hosts_with_hostnames_dispatches_and_validates_lengths() {
+    use std::sync::atomic::Ordering;
+
+    crate::mod_test::MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.store(0, Ordering::SeqCst);
+    crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS
+      .lock()
+      .unwrap()
+      .clear();
+
+    let cluster = EnvoyClusterImpl::new(std::ptr::null_mut());
+    let addresses = vec!["192.0.2.10:443".to_owned(), "192.0.2.11:443".to_owned()];
+    let hostnames = vec!["service-a.test".to_owned(), "service-b.test".to_owned()];
+    let weights = vec![1, 2];
+
+    assert!(cluster
+      .add_hosts_with_hostnames(&addresses, &hostnames[..1], &weights)
+      .is_none());
+    assert!(crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS
+      .lock()
+      .unwrap()
+      .is_empty());
+
+    let hosts = cluster
+      .add_hosts_with_hostnames(&addresses, &hostnames, &weights)
+      .expect("matching slices must call the hostname-aware ABI");
+    assert_eq!(hosts.len(), 2);
+    assert!(hosts.iter().all(|host| !host.is_null()));
+
+    let locality = vec![(
+      "region".to_owned(),
+      "zone".to_owned(),
+      "sub-zone".to_owned(),
+    )];
+    let metadata = vec![vec![(
+      "envoy.lb".to_owned(),
+      "service".to_owned(),
+      "service-c".to_owned(),
+    )]];
+    cluster
+      .add_hosts_with_hostnames_and_locality_to_priority(
+        2,
+        &["192.0.2.12:443".to_owned()],
+        &["service-c.test".to_owned()],
+        &[3],
+        &locality,
+        &metadata,
+      )
+      .expect("the full hostname-aware method must call the same ABI");
+
+    assert_eq!(
+      *crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS
+        .lock()
+        .unwrap(),
+      vec![
+        (
+          0,
+          vec![b"service-a.test".to_vec(), b"service-b.test".to_vec()]
+        ),
+        (2, vec![b"service-c.test".to_vec()])
+      ]
+    );
+
+    cluster
+      .add_hosts(&addresses, &weights)
+      .expect("the existing method must retain the legacy ABI");
+    assert_eq!(
+      crate::mod_test::MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.load(Ordering::SeqCst),
+      1
+    );
+  }
 
   // The per-request accessor callbacks are satisfied by the link-time stubs in lib_test.rs.
   #[test]

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -374,8 +374,8 @@ pub trait EnvoyCluster: Send + Sync {
   ///
   /// Each non-empty hostname is stored separately from its corresponding `ip:port` address and is
   /// available to upstream features such as automatic SNI and SAN validation. An empty hostname
-  /// uses Envoy's legacy synthesized hostname. `hostnames` must have the same length as
-  /// `addresses`.
+  /// uses the same synthesized hostname as [`EnvoyCluster::add_hosts`]. `hostnames` must have the
+  /// same length as `addresses`.
   fn add_hosts_with_hostnames(
     &self,
     addresses: &[String],
@@ -460,8 +460,8 @@ pub trait EnvoyCluster: Send + Sync {
   ///
   /// Each non-empty hostname is stored separately from its corresponding `ip:port` address and is
   /// available to upstream features such as automatic SNI and SAN validation. An empty hostname
-  /// uses Envoy's legacy synthesized hostname. `hostnames` must have the same length as
-  /// `addresses`.
+  /// uses the same synthesized hostname as [`EnvoyCluster::add_hosts_with_locality_to_priority`].
+  /// `hostnames` must have the same length as `addresses`.
   fn add_hosts_with_hostnames_and_locality_to_priority(
     &self,
     priority: u32,
@@ -2916,7 +2916,7 @@ mod tests {
   fn add_hosts_with_hostnames_dispatches_and_validates_lengths() {
     use std::sync::atomic::Ordering;
 
-    crate::mod_test::MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.store(0, Ordering::SeqCst);
+    crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_CALLS.store(0, Ordering::SeqCst);
     crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS
       .lock()
       .unwrap()
@@ -2977,9 +2977,9 @@ mod tests {
 
     cluster
       .add_hosts(&addresses, &weights)
-      .expect("the existing method must retain the legacy ABI");
+      .expect("the existing method must call the existing ABI callback");
     assert_eq!(
-      crate::mod_test::MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.load(Ordering::SeqCst),
+      crate::mod_test::MOCK_CLUSTER_ADD_HOSTS_CALLS.load(Ordering::SeqCst),
       1
     );
   }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4388,7 +4388,7 @@ fn test_catch_unwind_http_reentrant_status_callback_is_not_poisoned() {
 // Cluster Extension FFI stubs for testing.
 // =============================================================================
 
-pub(crate) static MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS: AtomicUsize = AtomicUsize::new(0);
+pub(crate) static MOCK_CLUSTER_ADD_HOSTS_CALLS: AtomicUsize = AtomicUsize::new(0);
 pub(crate) static MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS: std::sync::Mutex<
   Vec<(u32, Vec<Vec<u8>>)>,
 > = std::sync::Mutex::new(Vec::new());
@@ -4439,7 +4439,7 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_add_hosts(
   _count: usize,
   _result_host_ptrs: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
 ) -> bool {
-  MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+  MOCK_CLUSTER_ADD_HOSTS_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
   write_mock_cluster_host_ptrs(_result_host_ptrs, _count);
   true
 }

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4388,6 +4388,43 @@ fn test_catch_unwind_http_reentrant_status_callback_is_not_poisoned() {
 // Cluster Extension FFI stubs for testing.
 // =============================================================================
 
+pub(crate) static MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS: AtomicUsize = AtomicUsize::new(0);
+pub(crate) static MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS: std::sync::Mutex<
+  Vec<(u32, Vec<Vec<u8>>)>,
+> = std::sync::Mutex::new(Vec::new());
+
+fn copy_module_buffers(
+  buffers: *const abi::envoy_dynamic_module_type_module_buffer,
+  count: usize,
+) -> Vec<Vec<u8>> {
+  if count == 0 {
+    return Vec::new();
+  }
+  unsafe { std::slice::from_raw_parts(buffers, count) }
+    .iter()
+    .map(|buffer| {
+      if buffer.length == 0 {
+        Vec::new()
+      } else {
+        unsafe { std::slice::from_raw_parts(buffer.ptr as *const u8, buffer.length) }.to_vec()
+      }
+    })
+    .collect()
+}
+
+fn write_mock_cluster_host_ptrs(
+  result_host_ptrs: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+  count: usize,
+) {
+  for index in 0..count {
+    unsafe {
+      result_host_ptrs
+        .add(index)
+        .write((index + 1) as *mut std::ffi::c_void);
+    }
+  }
+}
+
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_cluster_add_hosts(
   _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
@@ -4402,7 +4439,32 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_add_hosts(
   _count: usize,
   _result_host_ptrs: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
 ) -> bool {
-  false
+  MOCK_CLUSTER_LEGACY_ADD_HOSTS_CALLS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+  write_mock_cluster_host_ptrs(_result_host_ptrs, _count);
+  true
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+  _cluster_envoy_ptr: abi::envoy_dynamic_module_type_cluster_envoy_ptr,
+  priority: u32,
+  _addresses: *const abi::envoy_dynamic_module_type_module_buffer,
+  hostnames: *const abi::envoy_dynamic_module_type_module_buffer,
+  _weights: *const u32,
+  _regions: *const abi::envoy_dynamic_module_type_module_buffer,
+  _zones: *const abi::envoy_dynamic_module_type_module_buffer,
+  _sub_zones: *const abi::envoy_dynamic_module_type_module_buffer,
+  _metadata_pairs: *const abi::envoy_dynamic_module_type_module_buffer,
+  _metadata_pairs_per_host: usize,
+  count: usize,
+  result_host_ptrs: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+) -> bool {
+  MOCK_CLUSTER_ADD_HOSTS_WITH_HOSTNAMES_CALLS
+    .lock()
+    .unwrap()
+    .push((priority, copy_module_buffers(hostnames, count)));
+  write_mock_cluster_host_ptrs(result_host_ptrs, count);
+  true
 }
 
 #[no_mangle]

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -51,6 +51,7 @@ envoy_cc_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [
+        "//test/config/integration/certs",
         "//test/extensions/dynamic_modules/test_data/rust:cluster_dynamic_metadata_test",
         "//test/extensions/dynamic_modules/test_data/rust:cluster_filter_state_test",
         "//test/extensions/dynamic_modules/test_data/rust:cluster_integration_test",
@@ -62,11 +63,13 @@ envoy_cc_test(
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:factory_registration",
         "//source/extensions/load_balancing_policies/cluster_provided:config",
+        "//source/extensions/transport_sockets/tls:config",
         "//test/extensions/dynamic_modules:util",
         "//test/integration:http_integration_lib",
         "//test/test_common:logging_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_modules/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -649,7 +649,7 @@ TEST_F(DynamicModuleClusterTest, AddHostsWithHostnamesDeduplicatesIncrementalSha
   EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_remove_hosts(cluster.get(), &host_ptrs[0], 1));
 }
 
-TEST_F(DynamicModuleClusterTest, AddHostsWithNullHostnamesABIUsesLegacyHostname) {
+TEST_F(DynamicModuleClusterTest, AddHostsWithNullHostnamesABIUsesExistingSynthesizedHostname) {
   auto result = createCluster(makeYamlConfig("cluster_no_op"));
   ASSERT_OK(result);
 

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -563,6 +563,10 @@ TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
                                                               nullptr, 0, 2, host_ptrs));
   EXPECT_NE(nullptr, host_ptrs[0]);
   EXPECT_NE(nullptr, host_ptrs[1]);
+  EXPECT_EQ(cluster->info()->name() + addr1,
+            static_cast<Upstream::Host*>(host_ptrs[0])->hostname());
+  EXPECT_EQ(cluster->info()->name() + addr2,
+            static_cast<Upstream::Host*>(host_ptrs[1])->hostname());
 
   // Test add_hosts with invalid address causes entire batch to fail.
   std::string bad_addr = "invalid";
@@ -587,6 +591,84 @@ TEST_F(DynamicModuleClusterTest, AbiCallbacksHostManagement) {
   EXPECT_EQ(2, envoy_dynamic_module_callback_cluster_remove_hosts(cluster.get(), host_ptrs, 2));
   // Removing again should return 0.
   EXPECT_EQ(0, envoy_dynamic_module_callback_cluster_remove_hosts(cluster.get(), host_ptrs, 2));
+}
+
+TEST_F(DynamicModuleClusterTest, AddHostsWithHostnamesABI) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_OK(result);
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_module_buffer addresses[] = {{"127.0.0.1:10001", 15},
+                                                         {"127.0.0.1:10002", 15}};
+  envoy_dynamic_module_type_module_buffer hostnames[] = {{"api.example.com", 15}, {nullptr, 0}};
+  uint32_t weights[] = {1, 1};
+  envoy_dynamic_module_type_module_buffer empty_localities[] = {{nullptr, 0}, {nullptr, 0}};
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptrs[2] = {nullptr, nullptr};
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+      cluster.get(), 0, addresses, hostnames, weights, empty_localities, empty_localities,
+      empty_localities, nullptr, 0, 2, host_ptrs));
+  ASSERT_NE(nullptr, host_ptrs[0]);
+  ASSERT_NE(nullptr, host_ptrs[1]);
+
+  const auto& hosts = cluster->prioritySet().hostSetsPerPriority()[0]->hosts();
+  ASSERT_EQ(2, hosts.size());
+  EXPECT_EQ("api.example.com", hosts[0]->hostname());
+  EXPECT_EQ("test_cluster127.0.0.1:10002", hosts[1]->hostname());
+}
+
+TEST_F(DynamicModuleClusterTest, AddHostsWithHostnamesDeduplicatesIncrementalSharedAddress) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_OK(result);
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_module_buffer address = {"127.0.0.1:10001", 15};
+  envoy_dynamic_module_type_module_buffer hostnames[] = {{"service-a.test", 14},
+                                                         {"service-b.test", 14}};
+  uint32_t weight = 1;
+  envoy_dynamic_module_type_module_buffer empty_locality = {nullptr, 0};
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptrs[] = {nullptr, nullptr};
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+      cluster.get(), 0, &address, &hostnames[0], &weight, &empty_locality, &empty_locality,
+      &empty_locality, nullptr, 0, 1, &host_ptrs[0]));
+  ASSERT_NE(nullptr, host_ptrs[0]);
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+      cluster.get(), 0, &address, &hostnames[1], &weight, &empty_locality, &empty_locality,
+      &empty_locality, nullptr, 0, 1, &host_ptrs[1]));
+  EXPECT_EQ(nullptr, host_ptrs[1]);
+
+  const auto& hosts = cluster->prioritySet().hostSetsPerPriority()[0]->hosts();
+  ASSERT_EQ(1, hosts.size());
+  EXPECT_EQ("service-a.test", hosts[0]->hostname());
+  EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_remove_hosts(cluster.get(), &host_ptrs[0], 1));
+}
+
+TEST_F(DynamicModuleClusterTest, AddHostsWithNullHostnamesABIUsesLegacyHostname) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_OK(result);
+
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_module_buffer address = {"127.0.0.1:10001", 15};
+  uint32_t weight = 1;
+  envoy_dynamic_module_type_module_buffer empty_locality = {nullptr, 0};
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;
+
+  ASSERT_TRUE(envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+      cluster.get(), 0, &address, nullptr, &weight, &empty_locality, &empty_locality,
+      &empty_locality, nullptr, 0, 1, &host_ptr));
+  ASSERT_NE(nullptr, host_ptr);
+
+  const auto& hosts = cluster->prioritySet().hostSetsPerPriority()[0]->hosts();
+  ASSERT_EQ(1, hosts.size());
+  EXPECT_EQ("test_cluster127.0.0.1:10001", hosts[0]->hostname());
 }
 
 // Test the LB ABI callback implementations directly.
@@ -4137,6 +4219,32 @@ TEST_F(DynamicModuleClusterTest, AddHostsOffMainThreadFailsClosed) {
         t.join();
       },
       "envoy_dynamic_module_callback_cluster_add_hosts must be called on the main thread");
+}
+
+TEST_F(DynamicModuleClusterTest, AddHostsWithHostnamesOffMainThreadFailsClosed) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_OK(result);
+  auto cluster = std::dynamic_pointer_cast<DynamicModuleCluster>(result->first);
+  ASSERT_NE(nullptr, cluster);
+
+  envoy_dynamic_module_type_module_buffer address = {"127.0.0.1:10001", 15};
+  envoy_dynamic_module_type_module_buffer hostname = {"api.example.com", 15};
+  uint32_t weight = 1;
+  envoy_dynamic_module_type_module_buffer empty = {nullptr, 0};
+  envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;
+  void* cluster_ptr = cluster.get();
+
+  EXPECT_ENVOY_BUG(
+      {
+        std::thread t([&] {
+          EXPECT_FALSE(envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(
+              cluster_ptr, 0, &address, &hostname, &weight, &empty, &empty, &empty, nullptr, 0, 1,
+              &host_ptr));
+        });
+        t.join();
+      },
+      "envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames must be called on the main "
+      "thread");
 }
 
 // Verifies that `cluster_remove_hosts` is fail-closed when called off the main thread.

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -1,6 +1,7 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/dynamic_modules/v3/cluster.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/tls.pb.h"
 #include "envoy/registry/registry.h"
 #include "envoy/stream_info/filter_state.h"
 
@@ -54,6 +55,25 @@ class DynamicModuleClusterIntegrationTest
       public HttpIntegrationTest {
 public:
   DynamicModuleClusterIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void configureUpstreamTlsForLogicalHostname() {
+    upstream_tls_ = true;
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
+
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+      auto* validation_context =
+          tls_context.mutable_common_tls_context()->mutable_validation_context();
+      validation_context->mutable_trusted_ca()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcacert.pem"));
+      tls_context.set_auto_host_sni(true);
+      tls_context.set_auto_sni_san_validation(true);
+
+      cluster->mutable_transport_socket()->set_name("envoy.transport_sockets.tls");
+      std::ignore =
+          cluster->mutable_transport_socket()->mutable_typed_config()->PackFrom(tls_context);
+    });
+  }
 
   void initializeWithDecCluster(const std::string& cluster_name,
                                 const std::string& cluster_config = "") {
@@ -125,6 +145,24 @@ TEST_P(DynamicModuleClusterIntegrationTest, SyncHostSelectionMultipleRequests) {
     EXPECT_TRUE(response->complete());
     EXPECT_EQ("200", response->headers().getStatusValue());
   }
+}
+
+// Verifies that a logical hostname supplied separately from the connection address is available
+// to upstream TLS for automatic SNI and SAN validation.
+TEST_P(DynamicModuleClusterIntegrationTest, LogicalHostnameDrivesUpstreamTls) {
+  configureUpstreamTlsForLogicalHostname();
+  initializeWithDecCluster("logical_hostname");
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(upstream_request_->complete());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  ASSERT_NE(fake_upstream_connection_, nullptr);
+  ASSERT_NE(fake_upstream_connection_->connection().ssl(), nullptr);
+  EXPECT_EQ("test.lyft.com", fake_upstream_connection_->connection().ssl()->sni());
 }
 
 // Verifies that a cluster with asynchronous host selection correctly routes requests.

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -392,6 +392,11 @@ WEAK_STUB(CertValidatorGetFilterState,
 WEAK_STUB(ClusterAddHosts,
           envoy_dynamic_module_callback_cluster_add_hosts(nullptr, 0, nullptr, nullptr, nullptr,
                                                           nullptr, nullptr, nullptr, 0, 0, nullptr))
+WEAK_STUB(ClusterAddHostsWithHostnames,
+          envoy_dynamic_module_callback_cluster_add_hosts_with_hostnames(nullptr, 0, nullptr,
+                                                                         nullptr, nullptr, nullptr,
+                                                                         nullptr, nullptr, nullptr,
+                                                                         0, 0, nullptr))
 WEAK_STUB(ClusterRemoveHosts,
           envoy_dynamic_module_callback_cluster_remove_hosts(nullptr, nullptr, 0))
 WEAK_STUB(ClusterPreInitComplete, envoy_dynamic_module_callback_cluster_pre_init_complete(nullptr))

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -28,6 +28,12 @@ fn new_cluster_config(
   match name {
     "sync_host_selection" => Some(Box::new(SyncHostSelectionClusterConfig {
       upstream_address: config_str.to_string(),
+      logical_hostname: None,
+      metrics: envoy_cluster_metrics,
+    })),
+    "logical_hostname" => Some(Box::new(SyncHostSelectionClusterConfig {
+      upstream_address: config_str.to_string(),
+      logical_hostname: Some("test.lyft.com".to_string()),
       metrics: envoy_cluster_metrics,
     })),
     "async_host_selection" => Some(Box::new(AsyncHostSelectionClusterConfig {
@@ -93,6 +99,7 @@ fn new_cluster_config(
 
 struct SyncHostSelectionClusterConfig {
   upstream_address: String,
+  logical_hostname: Option<String>,
   metrics: Arc<dyn EnvoyClusterMetrics>,
 }
 
@@ -101,6 +108,7 @@ impl ClusterConfig for SyncHostSelectionClusterConfig {
     let counter_id = self.metrics.define_counter("requests_routed").ok();
     Box::new(SyncHostSelectionCluster {
       upstream_address: self.upstream_address.clone(),
+      logical_hostname: self.logical_hostname.clone(),
       hosts: Arc::new(Mutex::new(HostList(Vec::new()))),
       counter_id,
       metrics: self.metrics.clone(),
@@ -110,6 +118,7 @@ impl ClusterConfig for SyncHostSelectionClusterConfig {
 
 struct SyncHostSelectionCluster {
   upstream_address: String,
+  logical_hostname: Option<String>,
   hosts: SharedHostList,
   counter_id: Option<EnvoyCounterId>,
   metrics: Arc<dyn EnvoyClusterMetrics>,
@@ -119,7 +128,13 @@ impl Cluster for SyncHostSelectionCluster {
   fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
     let addresses = vec![self.upstream_address.clone()];
     let weights = vec![1u32];
-    if let Some(host_ptrs) = envoy_cluster.add_hosts(&addresses, &weights) {
+    let host_ptrs = match &self.logical_hostname {
+      Some(hostname) => {
+        envoy_cluster.add_hosts_with_hostnames(&addresses, std::slice::from_ref(hostname), &weights)
+      },
+      None => envoy_cluster.add_hosts(&addresses, &weights),
+    };
+    if let Some(host_ptrs) = host_ptrs {
       self.hosts.lock().unwrap().0 = host_ptrs;
     }
     envoy_cluster.pre_init_complete();


### PR DESCRIPTION
Commit Message:

dynamic_modules: let runtime cluster hosts carry logical hostnames

Additional Description:

Add an opt-in C ABI callback and Rust SDK methods that let dynamic-module clusters set a logical hostname separately from the connection address. This enables existing features such as `auto_host_sni` and automatic SAN validation.

The existing callback and its behavior remain unchanged. Effective-SNI-scoped TLS session caching was handled in #45982; distinct logical hosts sharing one address can be considered separately.

AI assistance was used to help implement this change. I reviewed and understand the submitted code and take responsibility for it.

Risk Level:

Medium. This adds an opt-in extension ABI and SDK surface.

API Considerations:

Adds an opt-in C ABI callback and Rust SDK methods. Existing callbacks and behavior remain unchanged.

Testing:

- `//test/extensions/clusters/dynamic_modules:cluster_test`
- Envoy CI

Docs Changes:

Added C ABI and Rust SDK API documentation.

Release Notes:

Added a dynamic-modules release note.

Fixes #46387
Refs #45962