### PR TITLE
reverse_tunnel: count connection-limit denials as rejected

### DIFF
--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -194,7 +194,7 @@ bool ReverseTunnelFilterConfig::validateConnectionLimit(absl::string_view node_i
   return false;
 }
 
-bool ReverseTunnelFilterConfig::validateIdentifiers(
+ReverseTunnelValidationResult ReverseTunnelFilterConfig::validateIdentifiers(
     absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
     const Http::RequestHeaderMap& request_headers,
     const StreamInfo::StreamInfo& stream_info) const {
@@ -202,12 +202,12 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
   if (!validateConnectionLimit(node_id, tenant_id)) {
     ENVOY_LOG(debug, "reverse_tunnel: connection limit reached. node_id: {}, tenant_id: {}",
               node_id, tenant_id);
-    return false;
+    return ReverseTunnelValidationResult::Rejected;
   }
 
   // If no validation configured, pass validation.
   if (!node_id_formatter_ && !cluster_id_formatter_ && !tenant_id_formatter_) {
-    return true;
+    return ReverseTunnelValidationResult::ValidationPassed;
   }
 
   // Give the formatter the parsed handshake headers so validation strings can read them with
@@ -221,7 +221,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_node_id.empty() && expected_node_id != node_id) {
       ENVOY_LOG(debug, "reverse_tunnel: node_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_node_id, node_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
@@ -231,7 +231,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_cluster_id.empty() && expected_cluster_id != cluster_id) {
       ENVOY_LOG(debug, "reverse_tunnel: cluster_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_cluster_id, cluster_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
@@ -241,18 +241,16 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_tenant_id.empty() && expected_tenant_id != tenant_id) {
       ENVOY_LOG(debug, "reverse_tunnel: tenant_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_tenant_id, tenant_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
-  return true;
+  return ReverseTunnelValidationResult::ValidationPassed;
 }
 
-void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id,
-                                                       absl::string_view cluster_id,
-                                                       absl::string_view tenant_id,
-                                                       bool validation_passed,
-                                                       StreamInfo::StreamInfo& stream_info) const {
+void ReverseTunnelFilterConfig::emitValidationMetadata(
+    absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
+    ReverseTunnelValidationResult validation_result, StreamInfo::StreamInfo& stream_info) const {
   if (!emit_dynamic_metadata_) {
     return;
   }
@@ -266,7 +264,7 @@ void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id
   fields["tenant_id"].set_string_value(std::string(tenant_id));
 
   // Emit validation result.
-  fields["validation_result"].set_string_value(validation_passed ? "allowed" : "denied");
+  fields["validation_result"].set_string_value(toStringView(validation_result));
 
   // Set dynamic metadata on the stream info.
   stream_info.setDynamicMetadata(dynamic_metadata_namespace_, metadata);
@@ -275,7 +273,7 @@ void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id
             "reverse_tunnel: emitted dynamic metadata to namespace '{}': node_id={}, "
             "cluster_id={}, tenant_id={}, validation_result={}",
             dynamic_metadata_namespace_, node_id, cluster_id, tenant_id,
-            validation_passed ? "allowed" : "denied");
+            toStringView(validation_result));
 }
 
 // ReverseTunnelFilter implementation.
@@ -535,20 +533,28 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
   }
 
   // Validate node_id, cluster_id, and tenant_id if validation is configured.
-  const bool validation_passed = parent_.config_->validateIdentifiers(
+  const ReverseTunnelValidationResult validation_result = parent_.config_->validateIdentifiers(
       node_id, cluster_id, tenant_id, *headers_, connection.streamInfo());
 
   // Emit validation metadata if configured.
-  parent_.config_->emitValidationMetadata(node_id, cluster_id, tenant_id, validation_passed,
+  parent_.config_->emitValidationMetadata(node_id, cluster_id, tenant_id, validation_result,
                                           connection.streamInfo());
 
-  if (!validation_passed) {
-    parent_.stats_.validation_failed_.inc();
+  if (validation_result != ReverseTunnelValidationResult::ValidationPassed) {
+    if (validation_result == ReverseTunnelValidationResult::Rejected) {
+      parent_.stats_.rejected_.inc();
+    } else {
+      parent_.stats_.validation_failed_.inc();
+    }
     ENVOY_CONN_LOG(debug,
-                   "reverse_tunnel: validation failed for node '{}', cluster '{}', tenant '{}'",
-                   parent_.read_callbacks_->connection(), node_id, cluster_id, tenant_id);
-    sendLocalReply(Http::Code::Forbidden, "Validation failed", nullptr, std::nullopt,
-                   "reverse_tunnel_validation_failed");
+                   "reverse_tunnel: handshake denied for node '{}', cluster '{}', tenant '{}', "
+                   "result: {}",
+                   parent_.read_callbacks_->connection(), node_id, cluster_id, tenant_id,
+                   toStringView(validation_result));
+    sendLocalReply(
+        validation_result == ReverseTunnelValidationResult::Rejected ? Http::Code::TooManyRequests
+                                                                     : Http::Code::Forbidden,
+        toStringView(validation_result), nullptr, std::nullopt, toStringView(validation_result));
     parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
     return;
   }

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -179,19 +179,19 @@ bool ReverseTunnelFilterConfig::validateConnectionLimit(absl::string_view node_i
   return false;
 }
 
-bool ReverseTunnelFilterConfig::validateIdentifiers(
+ReverseTunnelValidationResult ReverseTunnelFilterConfig::validateIdentifiers(
     absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
     const StreamInfo::StreamInfo& stream_info) const {
 
   if (!validateConnectionLimit(node_id, tenant_id)) {
     ENVOY_LOG(debug, "reverse_tunnel: connection limit reached. node_id: {}, tenant_id: {}",
               node_id, tenant_id);
-    return false;
+    return ReverseTunnelValidationResult::Rejected;
   }
 
   // If no validation configured, pass validation.
   if (!node_id_formatter_ && !cluster_id_formatter_ && !tenant_id_formatter_) {
-    return true;
+    return ReverseTunnelValidationResult::ValidationPassed;
   }
 
   // Validate node_id if formatter is configured.
@@ -200,7 +200,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_node_id.empty() && expected_node_id != node_id) {
       ENVOY_LOG(debug, "reverse_tunnel: node_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_node_id, node_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
@@ -210,7 +210,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_cluster_id.empty() && expected_cluster_id != cluster_id) {
       ENVOY_LOG(debug, "reverse_tunnel: cluster_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_cluster_id, cluster_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
@@ -220,18 +220,16 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
     if (!expected_tenant_id.empty() && expected_tenant_id != tenant_id) {
       ENVOY_LOG(debug, "reverse_tunnel: tenant_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_tenant_id, tenant_id);
-      return false;
+      return ReverseTunnelValidationResult::ValidationFailed;
     }
   }
 
-  return true;
+  return ReverseTunnelValidationResult::ValidationPassed;
 }
 
-void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id,
-                                                       absl::string_view cluster_id,
-                                                       absl::string_view tenant_id,
-                                                       bool validation_passed,
-                                                       StreamInfo::StreamInfo& stream_info) const {
+void ReverseTunnelFilterConfig::emitValidationMetadata(
+    absl::string_view node_id, absl::string_view cluster_id, absl::string_view tenant_id,
+    ReverseTunnelValidationResult validation_result, StreamInfo::StreamInfo& stream_info) const {
   if (!emit_dynamic_metadata_) {
     return;
   }
@@ -245,7 +243,7 @@ void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id
   fields["tenant_id"].set_string_value(std::string(tenant_id));
 
   // Emit validation result.
-  fields["validation_result"].set_string_value(validation_passed ? "allowed" : "denied");
+  fields["validation_result"].set_string_value(toStringView(validation_result));
 
   // Set dynamic metadata on the stream info.
   stream_info.setDynamicMetadata(dynamic_metadata_namespace_, metadata);
@@ -254,7 +252,7 @@ void ReverseTunnelFilterConfig::emitValidationMetadata(absl::string_view node_id
             "reverse_tunnel: emitted dynamic metadata to namespace '{}': node_id={}, "
             "cluster_id={}, tenant_id={}, validation_result={}",
             dynamic_metadata_namespace_, node_id, cluster_id, tenant_id,
-            validation_passed ? "allowed" : "denied");
+            toStringView(validation_result));
 }
 
 // ReverseTunnelFilter implementation.
@@ -491,20 +489,28 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
 
   // Validate node_id, cluster_id, and tenant_id if validation is configured.
   auto& connection = parent_.read_callbacks_->connection();
-  const bool validation_passed =
+  const ReverseTunnelValidationResult validation_result =
       parent_.config_->validateIdentifiers(node_id, cluster_id, tenant_id, connection.streamInfo());
 
   // Emit validation metadata if configured.
-  parent_.config_->emitValidationMetadata(node_id, cluster_id, tenant_id, validation_passed,
+  parent_.config_->emitValidationMetadata(node_id, cluster_id, tenant_id, validation_result,
                                           connection.streamInfo());
 
-  if (!validation_passed) {
-    parent_.stats_.validation_failed_.inc();
+  if (validation_result != ReverseTunnelValidationResult::ValidationPassed) {
+    if (validation_result == ReverseTunnelValidationResult::Rejected) {
+      parent_.stats_.rejected_.inc();
+    } else {
+      parent_.stats_.validation_failed_.inc();
+    }
     ENVOY_CONN_LOG(debug,
-                   "reverse_tunnel: validation failed for node '{}', cluster '{}', tenant '{}'",
-                   parent_.read_callbacks_->connection(), node_id, cluster_id, tenant_id);
-    sendLocalReply(Http::Code::Forbidden, "Validation failed", nullptr, std::nullopt,
-                   "reverse_tunnel_validation_failed");
+                   "reverse_tunnel: handshake denied for node '{}', cluster '{}', tenant '{}', "
+                   "result: {}",
+                   parent_.read_callbacks_->connection(), node_id, cluster_id, tenant_id,
+                   toStringView(validation_result));
+    sendLocalReply(
+        validation_result == ReverseTunnelValidationResult::Rejected ? Http::Code::TooManyRequests
+                                                                     : Http::Code::Forbidden,
+        toStringView(validation_result), nullptr, std::nullopt, toStringView(validation_result));
     parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
     return;
   }

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -10,6 +10,7 @@
 #include "envoy/thread_local/thread_local.h"
 
 #include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/protobuf/protobuf.h"
@@ -34,6 +35,20 @@ inline const Extensions::Bootstrap::ReverseConnection::ReverseTunnelAcceptor* ge
 
   return dynamic_cast<const Extensions::Bootstrap::ReverseConnection::ReverseTunnelAcceptor*>(
       base_interface);
+}
+
+enum class ReverseTunnelValidationResult { ValidationPassed, ValidationFailed, Rejected };
+
+inline absl::string_view toStringView(ReverseTunnelValidationResult result) {
+  switch (result) {
+  case ReverseTunnelValidationResult::ValidationPassed:
+    return "validation_passed";
+  case ReverseTunnelValidationResult::ValidationFailed:
+    return "validation_failed";
+  case ReverseTunnelValidationResult::Rejected:
+    return "rejected";
+  }
+  PANIC_DUE_TO_CORRUPT_ENUM;
 }
 
 /**
@@ -64,15 +79,16 @@ public:
   // configured per-worker connection cap (or no cap is configured).
   bool validateConnectionLimit(absl::string_view node_id, absl::string_view tenant_id) const;
 
-  // Validates the extracted node_id, cluster_id, and tenant_id against expected values.
-  // Returns true if validation passes or no validation is configured.
-  bool validateIdentifiers(absl::string_view node_id, absl::string_view cluster_id,
-                           absl::string_view tenant_id,
-                           const StreamInfo::StreamInfo& stream_info) const;
+  // Validates identifiers (and the connection limit when enabled).
+  // Returns ValidationPassed, ValidationFailed, or Rejected (limit exceeded).
+  ReverseTunnelValidationResult
+  validateIdentifiers(absl::string_view node_id, absl::string_view cluster_id,
+                      absl::string_view tenant_id, const StreamInfo::StreamInfo& stream_info) const;
 
   // Emits validation results as dynamic metadata if configured.
   void emitValidationMetadata(absl::string_view node_id, absl::string_view cluster_id,
-                              absl::string_view tenant_id, bool validation_passed,
+                              absl::string_view tenant_id,
+                              ReverseTunnelValidationResult validation_result,
                               StreamInfo::StreamInfo& stream_info) const;
 
   // Returns the required cluster name for validation.

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.h
@@ -40,6 +40,20 @@ inline const Extensions::Bootstrap::ReverseConnection::ReverseTunnelAcceptor* ge
       base_interface);
 }
 
+enum class ReverseTunnelValidationResult { ValidationPassed, ValidationFailed, Rejected };
+
+inline absl::string_view toStringView(ReverseTunnelValidationResult result) {
+  switch (result) {
+  case ReverseTunnelValidationResult::ValidationPassed:
+    return "validation_passed";
+  case ReverseTunnelValidationResult::ValidationFailed:
+    return "validation_failed";
+  case ReverseTunnelValidationResult::Rejected:
+    return "rejected";
+  }
+  PANIC_DUE_TO_CORRUPT_ENUM;
+}
+
 /**
  * Configuration for the reverse tunnel network filter.
  */
@@ -71,13 +85,15 @@ public:
   // configured per-worker connection cap (or no cap is configured).
   bool validateConnectionLimit(absl::string_view node_id, absl::string_view tenant_id) const;
 
-  // Validates the extracted node_id, cluster_id, and tenant_id against expected values.
-  // Returns true if validation passes or no validation is configured. The parsed handshake
-  // request headers are passed so validation format strings can reference them via %REQ(...)%.
-  bool validateIdentifiers(absl::string_view node_id, absl::string_view cluster_id,
-                           absl::string_view tenant_id,
-                           const Http::RequestHeaderMap& request_headers,
-                           const StreamInfo::StreamInfo& stream_info) const;
+  // Validates connection limit then, if configured, node_id/cluster_id/tenant_id against expected
+  // values. Returns ValidationPassed when under the cap and identifiers match (or no identity
+  // validation is configured); Rejected when the per-node connection cap would be exceeded;
+  // ValidationFailed when an identity check fails. The parsed handshake request headers are
+  // passed so validation format strings can reference them via %REQ(...)%.
+  ReverseTunnelValidationResult
+  validateIdentifiers(absl::string_view node_id, absl::string_view cluster_id,
+                      absl::string_view tenant_id, const Http::RequestHeaderMap& request_headers,
+                      const StreamInfo::StreamInfo& stream_info) const;
 
   // Returns true if JWT handshake authentication is configured.
   bool jwtEnabled() const { return jwt_validator_ != nullptr; }
@@ -95,7 +111,8 @@ public:
 
   // Emits validation results as dynamic metadata if configured.
   void emitValidationMetadata(absl::string_view node_id, absl::string_view cluster_id,
-                              absl::string_view tenant_id, bool validation_passed,
+                              absl::string_view tenant_id,
+                              ReverseTunnelValidationResult validation_result,
                               StreamInfo::StreamInfo& stream_info) const;
 
   // Returns the required cluster name for validation.

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -67,6 +67,26 @@ public:
   }
 };
 
+uint64_t handshakeCounter(Stats::IsolatedStoreImpl& store, absl::string_view name) {
+  auto c = TestUtility::findCounter(store, std::string(name));
+  return c == nullptr ? 0 : c->value();
+}
+
+// Drives one reverse-tunnel handshake through `filter` and returns the response bytes.
+std::string driveFilterHandshake(ReverseTunnelFilter& filter,
+                                 NiceMock<Network::MockReadFilterCallbacks>& callbacks,
+                                 const std::string& request_str) {
+  std::string written;
+  EXPECT_CALL(callbacks.connection_, write(testing::_, testing::_))
+      .WillRepeatedly(testing::Invoke([&written](Buffer::Instance& data, bool) {
+        written.append(data.toString());
+        data.drain(data.length());
+      }));
+  Buffer::OwnedImpl request(request_str);
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter.onData(request, false));
+  return written;
+}
+
 class ReverseTunnelFilterUnitTest : public testing::Test {
 protected:
   void SetUp() override {
@@ -2560,6 +2580,269 @@ TEST_F(ReverseTunnelFilterWithTenantIsolationTest, ConnectionLimitScopedPerTenan
 
   EXPECT_FALSE(cfg->validateConnectionLimit("node", "tenant-a"));
   EXPECT_TRUE(cfg->validateConnectionLimit("node", "tenant-b"));
+}
+
+// exceeding the per-node cap denies the handshake with 429 and increments `rejected`, not
+// `validation_failed`.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ConnectionLimitHandshakeRejectsOverCap) {
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+  socket_manager->addConnectionSocket("capped-node", "cluster", createUpstreamSocket(3001),
+                                      std::chrono::seconds(30));
+
+  ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(), overload_manager_);
+  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+  filter.initializeReadFilterCallbacks(callbacks_);
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  const std::string written =
+      driveFilterHandshake(filter, callbacks_,
+                           makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                        "capped-node", "cluster", "tenant"));
+
+  EXPECT_THAT(written, testing::HasSubstr("429 Too Many Requests"));
+  EXPECT_EQ(1, handshakeCounter(stats_store_, "reverse_tunnel.handshake.rejected"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.validation_failed"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.accepted"));
+}
+
+// under the per-node cap the handshake is accepted and `rejected` stays at 0.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ConnectionLimitHandshakeAcceptsUnderCap) {
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+
+  // Closed socket skips registration in processAcceptedConnection; this test only asserts the
+  // handshake response/stats path gated by the connection-limit check.
+  auto closed_socket = std::make_unique<Network::MockConnectionSocket>();
+  EXPECT_CALL(*closed_socket, isOpen()).WillRepeatedly(testing::Return(false));
+  static Network::ConnectionSocketPtr stored_closed_socket_under_cap;
+  stored_closed_socket_under_cap = std::move(closed_socket);
+  EXPECT_CALL(callbacks_.connection_, getSocket())
+      .WillRepeatedly(testing::ReturnRef(stored_closed_socket_under_cap));
+
+  ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(), overload_manager_);
+  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+  filter.initializeReadFilterCallbacks(callbacks_);
+
+  const std::string written =
+      driveFilterHandshake(filter, callbacks_,
+                           makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                        "under-cap-node", "cluster", "tenant"));
+
+  EXPECT_THAT(written, testing::HasSubstr("200 OK"));
+  EXPECT_EQ(1, handshakeCounter(stats_store_, "reverse_tunnel.handshake.accepted"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.rejected"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.validation_failed"));
+}
+
+// identity mismatch under the cap still returns 403 / `validation_failed` (not `rejected`).
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ConnectionLimitHandshakeIdentityFailsUnderCap) {
+  proto_config_.set_enable_connection_limit(true);
+  proto_config_.mutable_validation()->set_node_id_format("expected-node");
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+
+  ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(), overload_manager_);
+  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+  filter.initializeReadFilterCallbacks(callbacks_);
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  const std::string written =
+      driveFilterHandshake(filter, callbacks_,
+                           makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                        "wrong-node", "cluster", "tenant"));
+
+  EXPECT_THAT(written, testing::HasSubstr("403 Forbidden"));
+  EXPECT_EQ(1, handshakeCounter(stats_store_, "reverse_tunnel.handshake.validation_failed"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.rejected"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.accepted"));
+}
+
+// Cap is checked before identity validation: at the limit the handshake is Rejected even when the
+// node_id would also fail identity checks.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ConnectionLimitHandshakeRejectsBeforeIdentityCheck) {
+  proto_config_.set_enable_connection_limit(true);
+  proto_config_.mutable_validation()->set_node_id_format("expected-node");
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+  socket_manager->addConnectionSocket("wrong-node", "cluster", createUpstreamSocket(3002),
+                                      std::chrono::seconds(30));
+
+  ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(), overload_manager_);
+  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+  filter.initializeReadFilterCallbacks(callbacks_);
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  const std::string written =
+      driveFilterHandshake(filter, callbacks_,
+                           makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                        "wrong-node", "cluster", "tenant"));
+
+  EXPECT_THAT(written, testing::HasSubstr("429 Too Many Requests"));
+  EXPECT_EQ(1, handshakeCounter(stats_store_, "reverse_tunnel.handshake.rejected"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.validation_failed"));
+}
+
+// validateIdentifiers returns Rejected / ValidationFailed / ValidationPassed distinctly.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ValidateIdentifiersDistinguishesLimitAndIdentity) {
+  proto_config_.set_enable_connection_limit(true);
+  proto_config_.mutable_validation()->set_node_id_format("expected-node");
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+  auto cfg = config_or_error.value();
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+
+  Http::TestRequestHeaderMapImpl headers;
+  auto& stream_info = callbacks_.connection_.streamInfo();
+
+  EXPECT_EQ(ReverseTunnelValidationResult::ValidationPassed,
+            cfg->validateIdentifiers("expected-node", "cluster", "tenant", headers, stream_info));
+  EXPECT_EQ(ReverseTunnelValidationResult::ValidationFailed,
+            cfg->validateIdentifiers("wrong-node", "cluster", "tenant", headers, stream_info));
+
+  socket_manager->addConnectionSocket("expected-node", "cluster", createUpstreamSocket(3003),
+                                      std::chrono::seconds(30));
+  EXPECT_EQ(ReverseTunnelValidationResult::Rejected,
+            cfg->validateIdentifiers("expected-node", "cluster", "tenant", headers, stream_info));
+}
+
+// Dynamic metadata carries the three-state validation_result string used for logging and
+// visibility.
+TEST_F(ReverseTunnelFilterWithUpstreamTest, ValidationMetadataEmitsTriStateResult) {
+  auto& stream_info = callbacks_.connection_.stream_info_;
+  ON_CALL(stream_info, setDynamicMetadata(testing::_, testing::_))
+      .WillByDefault(
+          testing::Invoke([&stream_info](const std::string& ns, const Protobuf::Struct& value) {
+            (*stream_info.metadata_.mutable_filter_metadata())[ns].MergeFrom(value);
+          }));
+
+  auto* socket_manager = upstream_thread_local_registry_->socketManager();
+  ASSERT_NE(socket_manager, nullptr);
+  socket_manager->setMaxConnectionsPerNode(1);
+
+  const auto metadata_result = [&stream_info]() -> std::string {
+    const auto& filter_metadata = stream_info.metadata_.filter_metadata();
+    const auto it = filter_metadata.find("envoy.filters.network.reverse_tunnel");
+    if (it == filter_metadata.end()) {
+      return "";
+    }
+    const auto& fields = it->second.fields();
+    const auto field = fields.find("validation_result");
+    return field == fields.end() ? "" : field->second.string_value();
+  };
+
+  // ValidationPassed.
+  {
+    envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+    cfg.set_enable_connection_limit(true);
+    cfg.mutable_validation()->set_emit_dynamic_metadata(true);
+    auto config_or_error = ReverseTunnelFilterConfig::create(cfg, factory_context_);
+    ASSERT_TRUE(config_or_error.ok());
+
+    auto closed_socket = std::make_unique<Network::MockConnectionSocket>();
+    EXPECT_CALL(*closed_socket, isOpen()).WillRepeatedly(testing::Return(false));
+    static Network::ConnectionSocketPtr stored_closed_socket_metadata_pass;
+    stored_closed_socket_metadata_pass = std::move(closed_socket);
+    EXPECT_CALL(callbacks_.connection_, getSocket())
+        .WillRepeatedly(testing::ReturnRef(stored_closed_socket_metadata_pass));
+
+    ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(),
+                               overload_manager_);
+    EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+    filter.initializeReadFilterCallbacks(callbacks_);
+    driveFilterHandshake(
+        filter, callbacks_,
+        makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request", "n", "c", "t"));
+    EXPECT_EQ("validation_passed", metadata_result());
+  }
+
+  stream_info.metadata_.mutable_filter_metadata()->clear();
+
+  // ValidationFailed (identity mismatch under the cap).
+  {
+    envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+    cfg.set_enable_connection_limit(true);
+    cfg.mutable_validation()->set_node_id_format("expected-node");
+    cfg.mutable_validation()->set_emit_dynamic_metadata(true);
+    auto config_or_error = ReverseTunnelFilterConfig::create(cfg, factory_context_);
+    ASSERT_TRUE(config_or_error.ok());
+    ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(),
+                               overload_manager_);
+    EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+    filter.initializeReadFilterCallbacks(callbacks_);
+    EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+    driveFilterHandshake(filter, callbacks_,
+                         makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
+                                                      "wrong-node", "c", "t"));
+    EXPECT_EQ("validation_failed", metadata_result());
+  }
+
+  stream_info.metadata_.mutable_filter_metadata()->clear();
+
+  // Rejected (at the connection cap).
+  socket_manager->addConnectionSocket("n", "c", createUpstreamSocket(3004),
+                                      std::chrono::seconds(30));
+  {
+    envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+    cfg.set_enable_connection_limit(true);
+    cfg.mutable_validation()->set_emit_dynamic_metadata(true);
+    auto config_or_error = ReverseTunnelFilterConfig::create(cfg, factory_context_);
+    ASSERT_TRUE(config_or_error.ok());
+    ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(),
+                               overload_manager_);
+    EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+    filter.initializeReadFilterCallbacks(callbacks_);
+    EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+    driveFilterHandshake(
+        filter, callbacks_,
+        makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request", "n", "c", "t"));
+    EXPECT_EQ("rejected", metadata_result());
+  }
+}
+
+// connection limit enabled without a thread-local socket manager fails closed on the full
+// handshake path (429 / rejected).
+TEST_F(ReverseTunnelFilterUnitTest, ConnectionLimitHandshakeFailsClosedWithoutSocketManager) {
+  setupUpstreamExtension();
+
+  proto_config_.set_enable_connection_limit(true);
+  auto config_or_error = ReverseTunnelFilterConfig::create(proto_config_, factory_context_);
+  ASSERT_TRUE(config_or_error.ok());
+
+  ReverseTunnelFilter filter(config_or_error.value(), *stats_store_.rootScope(), overload_manager_);
+  EXPECT_CALL(callbacks_, connection()).WillRepeatedly(ReturnRef(callbacks_.connection_));
+  filter.initializeReadFilterCallbacks(callbacks_);
+  EXPECT_CALL(callbacks_.connection_, close(Network::ConnectionCloseType::FlushWrite));
+
+  const std::string written = driveFilterHandshake(
+      filter, callbacks_,
+      makeHttpRequestWithRtHeaders("GET", "/reverse_connections/request", "n", "c", "t"));
+
+  EXPECT_THAT(written, testing::HasSubstr("429 Too Many Requests"));
+  EXPECT_EQ(1, handshakeCounter(stats_store_, "reverse_tunnel.handshake.rejected"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.validation_failed"));
+  EXPECT_EQ(0, handshakeCounter(stats_store_, "reverse_tunnel.handshake.accepted"));
 }
 
 // jwt_validator handshake authentication.

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -1635,14 +1635,15 @@ TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitRejectsBeyondCap) {
   client1->waitForData("HTTP/1.1 200 OK");
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
 
-  // Second connection for the same node exceeds the cap (1 is not < 1) -> rejected with 403.
+  // Second connection for the same node exceeds the cap (1 is not < 1) -> rejected with 429.
   std::string req2 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
                                                     "capped-node", "test-cluster", "test-tenant");
   IntegrationTcpClientPtr client2 = makeTcpConnection(lookupPort("listener_0"));
   (void)client2->write(req2);
-  client2->waitForData("HTTP/1.1 403 Forbidden");
+  client2->waitForData("HTTP/1.1 429 Too Many Requests");
   client2->waitForDisconnect();
-  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   // A different node has its own independent count and is still accepted.
   std::string req3 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
@@ -1673,6 +1674,9 @@ TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitAllowsWithinCap) {
       "GET", "/reverse_connections/request", "within-node", "test-cluster", "test-tenant")));
   client2->waitForData("HTTP/1.1 200 OK");
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2));
+
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Eq(0));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   client1->close();
   client2->close();
@@ -1729,9 +1733,10 @@ cluster_type:
   IntegrationTcpClientPtr client_a2 = makeTcpConnection(lookupPort("listener_0"));
   (void)client_a2->write(createHttpRequestWithRtHeaders(
       "GET", "/reverse_connections/request", "shared-node", "shared-cluster", "tenant-a"));
-  client_a2->waitForData("HTTP/1.1 403 Forbidden");
+  client_a2->waitForData("HTTP/1.1 429 Too Many Requests");
   client_a2->waitForDisconnect();
-  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   // tenant-b on the same node is an independent scope -> accepted.
   IntegrationTcpClientPtr client_b1 = makeTcpConnection(lookupPort("listener_0"));

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -1641,14 +1641,15 @@ TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitRejectsBeyondCap) {
   client1->waitForData("HTTP/1.1 200 OK");
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
 
-  // Second connection for the same node exceeds the cap (1 is not < 1) -> rejected with 403.
+  // Second connection for the same node exceeds the cap (1 is not < 1) -> rejected with 429.
   std::string req2 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
                                                     "capped-node", "test-cluster", "test-tenant");
   IntegrationTcpClientPtr client2 = makeTcpConnection(lookupPort("listener_0"));
   (void)client2->write(req2);
-  client2->waitForData("HTTP/1.1 403 Forbidden");
+  client2->waitForData("HTTP/1.1 429 Too Many Requests");
   client2->waitForDisconnect();
-  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   // A different node has its own independent count and is still accepted.
   std::string req3 = createHttpRequestWithRtHeaders("GET", "/reverse_connections/request",
@@ -1679,6 +1680,9 @@ TEST_P(ReverseTunnelFilterIntegrationTest, ConnectionLimitAllowsWithinCap) {
       "GET", "/reverse_connections/request", "within-node", "test-cluster", "test-tenant")));
   client2->waitForData("HTTP/1.1 200 OK");
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(2));
+
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Eq(0));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   client1->close();
   client2->close();
@@ -1735,9 +1739,10 @@ cluster_type:
   IntegrationTcpClientPtr client_a2 = makeTcpConnection(lookupPort("listener_0"));
   (void)client_a2->write(createHttpRequestWithRtHeaders(
       "GET", "/reverse_connections/request", "shared-node", "shared-cluster", "tenant-a"));
-  client_a2->waitForData("HTTP/1.1 403 Forbidden");
+  client_a2->waitForData("HTTP/1.1 429 Too Many Requests");
   client_a2->waitForDisconnect();
-  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.rejected", Ge(1));
+  test_server_->waitForCounter("reverse_tunnel.handshake.validation_failed", Eq(0));
 
   // tenant-b on the same node is an independent scope -> accepted.
   IntegrationTcpClientPtr client_b1 = makeTcpConnection(lookupPort("listener_0"));


### PR DESCRIPTION
## Commit Message 
reverse_tunnel: count connection-limit denials as rejected

## Additional Description
The reverse tunnel filter reported per-node connection-limit denials on the `reverse_tunnel.handshake.validation_failed` counter, making them indistinguishable from node/cluster/tenant identifier mismatches. The`rejected` counter was already declared but never incremented.

- connection limit exceeded -> `reverse_tunnel.handshake.rejected`, HTTP 429
- identifier mismatch       -> `reverse_tunnel.handshake.validation_failed`, HTTP 403

429 is the only status the downstream reverse tunnel initiator treats specially (it looks for a `Retry-After` cool-off hint). No `Retry-After` is sent, so the initiator falls back to its existing exponential backoff for now can be changed later based on need.

## Risk Level 
Low and all behavioural changes are internal nothing which is public facing is affected.

## Testing
Existing unit tests, updated integ tests.