### PR TITLE
Migrate ABSL_ARRAYSIZE()/arraysize() to std::size()

### DIFF
--- a/source/common/http/http1/balsa_parser.cc
+++ b/source/common/http/http1/balsa_parser.cc
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 
 #include "source/common/common/assert.h"
 #include "source/common/http/headers.h"
@@ -73,7 +74,7 @@ bool isMethodValid(absl::string_view method, bool allow_custom_methods) {
       "SUBSCRIBE", "TRACE",   "UNBIND",   "UNLINK",  "UNLOCK",     "UNSUBSCRIBE"};
 
   const auto* begin = &kValidMethods[0];
-  const auto* end = &kValidMethods[ABSL_ARRAYSIZE(kValidMethods) - 1] + 1;
+  const auto* end = &kValidMethods[std::size(kValidMethods) - 1] + 1;
   return std::binary_search(begin, end, method);
 }
 

--- a/test/common/common/mem_block_builder_test.cc
+++ b/test/common/common/mem_block_builder_test.cc
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <vector>
 
 #include "source/common/common/mem_block_builder.h"
@@ -12,7 +13,7 @@ TEST(MemBlockBuilderTest, AppendUint8) {
   mem_block.appendOne(5);
   EXPECT_EQ(9, mem_block.capacityRemaining());
   const uint8_t foo[] = {6, 7};
-  mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo)));
+  mem_block.appendData(absl::MakeConstSpan(foo, std::size(foo)));
   EXPECT_EQ(7, mem_block.capacityRemaining());
 
   MemBlockBuilder<uint8_t> append;
@@ -43,7 +44,7 @@ TEST(MemBlockBuilderTest, AppendUint32) {
   mem_block.appendOne(100005);
   EXPECT_EQ(9, mem_block.capacityRemaining());
   const uint32_t foo[] = {100006, 100007};
-  mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo)));
+  mem_block.appendData(absl::MakeConstSpan(foo, std::size(foo)));
   EXPECT_EQ(7, mem_block.capacityRemaining());
 
   MemBlockBuilder<uint32_t> append;
@@ -85,8 +86,7 @@ TEST(MemBlockBuilderTest, AppendDataTooMuch) {
   MemBlockBuilder<uint8_t> mem_block(1);
   const uint8_t foo[] = {1, 2};
   EXPECT_DEATH(
-      { mem_block.appendData(absl::MakeConstSpan(foo, ABSL_ARRAYSIZE(foo))); },
-      expected_death_regex);
+      { mem_block.appendData(absl::MakeConstSpan(foo, std::size(foo))); }, expected_death_regex);
 }
 
 } // namespace Envoy

--- a/test/common/network/utility_test.cc
+++ b/test/common/network/utility_test.cc
@@ -9,6 +9,7 @@
 #endif
 
 #include <cstdint>
+#include <iterator>
 #include <list>
 #include <memory>
 #include <string>
@@ -800,9 +801,9 @@ TEST(PacketLoss, LossTest) {
 
   // Send a packet.
   char buf[2048];
-  memset(buf, 0, ABSL_ARRAYSIZE(buf));
-  EXPECT_EQ(ABSL_ARRAYSIZE(buf), sendto(fd, buf, ABSL_ARRAYSIZE(buf), 0,
-                                        reinterpret_cast<sockaddr*>(&storage), sizeof(storage)));
+  memset(buf, 0, std::size(buf));
+  EXPECT_EQ(std::size(buf), sendto(fd, buf, std::size(buf), 0,
+                                   reinterpret_cast<sockaddr*>(&storage), sizeof(storage)));
 
   // Verify the packet is dropped.
   IoSocketHandleImpl handle(fd);
@@ -824,8 +825,8 @@ TEST(PacketLoss, LossTest) {
   EXPECT_EQ(0, packets_read);
 
   // Send another packet.
-  EXPECT_EQ(ABSL_ARRAYSIZE(buf), sendto(fd, buf, ABSL_ARRAYSIZE(buf), 0,
-                                        reinterpret_cast<sockaddr*>(&storage), sizeof(storage)));
+  EXPECT_EQ(std::size(buf), sendto(fd, buf, std::size(buf), 0,
+                                   reinterpret_cast<sockaddr*>(&storage), sizeof(storage)));
 
   // Make sure the drop count is now 2.
   Utility::readFromSocket(handle, *address, processor, time_source, recv_msg_method,


### PR DESCRIPTION
ABSL_ARRAYSIZE is deprecated

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
