### PR TITLE
Fix CTAD warnings

### DIFF
--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -523,7 +523,7 @@ const std::string& ConnectionInfoImplBase::sessionId() const {
 
     unsigned int session_id_length = 0;
     const uint8_t* session_id = SSL_SESSION_get_id(session, &session_id_length);
-    return Hex::encode(absl::Span(session_id, session_id_length));
+    return Hex::encode(absl::Span<const uint8_t>(session_id, session_id_length));
   });
 }
 

--- a/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/filters/listener/proxy_protocol/proxy_protocol.cc
@@ -300,10 +300,10 @@ ReadOrParseState Filter::parseBuffer(Network::ListenerFilterBuffer& buffer) {
           Network::ProxyProtocolFilterState::key())) {
     auto buf = reinterpret_cast<const uint8_t*>(buffer.rawSlice().mem_);
     if (proxy_protocol_header_.value().local_command_) {
-      ENVOY_LOG(
-          trace, "Parsed proxy protocol header, cmd: LOCAL, length: {}, buffer: {}",
-          proxy_protocol_header_.value().wholeHeaderLength(),
-          Envoy::Hex::encode(absl::Span(buf, proxy_protocol_header_.value().wholeHeaderLength())));
+      ENVOY_LOG(trace, "Parsed proxy protocol header, cmd: LOCAL, length: {}, buffer: {}",
+                proxy_protocol_header_.value().wholeHeaderLength(),
+                Envoy::Hex::encode(absl::Span<const uint8_t>(
+                    buf, proxy_protocol_header_.value().wholeHeaderLength())));
 
       cb_->filterState().setData(
           Network::ProxyProtocolFilterState::key(),
@@ -318,11 +318,12 @@ ReadOrParseState Filter::parseBuffer(Network::ListenerFilterBuffer& buffer) {
           "Parsed proxy protocol header, cmd: PROXY, length: {}, buffer: {}, TLV length: {}, TLV "
           "buffer: {}",
           proxy_protocol_header_.value().wholeHeaderLength(),
-          Envoy::Hex::encode(absl::Span(buf, proxy_protocol_header_.value().wholeHeaderLength())),
-          proxy_protocol_header_.value().extensions_length_,
           Envoy::Hex::encode(
-              absl::Span(buf + proxy_protocol_header_.value().headerLengthWithoutExtension(),
-                         proxy_protocol_header_.value().extensions_length_)));
+              absl::Span<const uint8_t>(buf, proxy_protocol_header_.value().wholeHeaderLength())),
+          proxy_protocol_header_.value().extensions_length_,
+          Envoy::Hex::encode(absl::Span<const uint8_t>(
+              buf + proxy_protocol_header_.value().headerLengthWithoutExtension(),
+              proxy_protocol_header_.value().extensions_length_)));
       cb_->filterState().setData(
           Network::ProxyProtocolFilterState::key(),
           std::make_unique<Network::ProxyProtocolFilterState>(Network::ProxyProtocolDataWithVersion{

--- a/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
+++ b/source/extensions/filters/listener/tls_inspector/ja4_fingerprint.cc
@@ -201,7 +201,7 @@ std::string JA4Fingerprinter::getJA4CipherHash(const SSL_CLIENT_HELLO* ssl_clien
   std::array<uint8_t, SHA256_DIGEST_LENGTH> hash;
   EVP_Digest(cipher_list.data(), cipher_list.length(), hash.data(), nullptr, EVP_sha256(), nullptr);
 
-  return Envoy::Hex::encode(absl::Span(hash.data(), JA4_HASH_LENGTH / 2));
+  return Envoy::Hex::encode(absl::Span<const uint8_t>(hash.data(), JA4_HASH_LENGTH / 2));
 }
 
 std::string JA4Fingerprinter::getJA4ExtensionHash(const SSL_CLIENT_HELLO* ssl_client_hello) {
@@ -280,7 +280,7 @@ std::string JA4Fingerprinter::getJA4ExtensionHash(const SSL_CLIENT_HELLO* ssl_cl
   EVP_Digest(extension_list.data(), extension_list.length(), hash.data(), nullptr, EVP_sha256(),
              nullptr);
 
-  return Envoy::Hex::encode(absl::Span(hash.data(), JA4_HASH_LENGTH / 2));
+  return Envoy::Hex::encode(absl::Span<const uint8_t>(hash.data(), JA4_HASH_LENGTH / 2));
 }
 
 std::string JA4Fingerprinter::create(const SSL_CLIENT_HELLO* ssl_client_hello) {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -398,7 +398,7 @@ void Filter::createJA3Hash(const SSL_CLIENT_HELLO* ssl_client_hello) {
 
     uint8_t buf[MD5_DIGEST_LENGTH];
     MD5(reinterpret_cast<const uint8_t*>(fingerprint.data()), fingerprint.size(), buf);
-    std::string md5 = Envoy::Hex::encode(absl::Span(buf, MD5_DIGEST_LENGTH));
+    std::string md5 = Envoy::Hex::encode(absl::Span<const uint8_t>(buf, MD5_DIGEST_LENGTH));
     ENVOY_LOG(trace, "tls:createJA3Hash(), hash: {}", md5);
 
     cb_->socket().setJA3Hash(md5);

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -93,7 +93,7 @@ void UpstreamProxyProtocolSocket::generateHeaderV1() {
 namespace {
 std::string toHex(Buffer::Instance& buffer) {
   const uint8_t* data = static_cast<const uint8_t*>(buffer.linearize(buffer.length()));
-  return Hex::encode(absl::Span(data, buffer.length()));
+  return Hex::encode(absl::Span<const uint8_t>(data, buffer.length()));
 }
 } // namespace
 


### PR DESCRIPTION
Commit Message: Fix CTAD warnings
Additional Description: Clang reports CTAD (Class Template Argument Deduction) as an error. Fix explicit template arguments for absl::Span
Risk Level: low
Testing: Build
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
