### PR TITLE
compat/openssl: fix X509 refcount leak in SSL_get0_peer_certificates()

### DIFF
--- a/compat/openssl/source/SSL_get0_peer_certificates.cc
+++ b/compat/openssl/source/SSL_get0_peer_certificates.cc
@@ -2,8 +2,7 @@
 #include <ossl.h>
 
 const STACK_OF(CRYPTO_BUFFER)* SSL_get0_peer_certificates(const SSL* ssl) {
-  X509* x509Temp = SSL_get_peer_certificate(ssl);
-  if (x509Temp == NULL)
+  if(ossl.ossl_SSL_get0_peer_certificate(ssl) == NULL)
     return NULL;
   else {
     // Dummy buffer just to return a non null value


### PR DESCRIPTION
`SSL_get0_peer_certificates()` called `SSL_get_peer_certificate()` (which increments the `X509` refcount) but never freed the result. Every call leaked one reference, preventing the `X509` and its sub-allocation tree from being freed when the connection closed.

Replace with `ossl_SSL_get0_peer_certificate()` call which returns a borrowed pointer without incrementing the refcount.