### PR TITLE
[bp/1.39] compat/openssl: fix X509 refcount leak in SSL_get0_peer_certificates()

### DIFF
--- a/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
+++ b/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
@@ -1,0 +1,4 @@
+Fixed a memory leak in the OpenSSL compatibility layer where ``SSL_get0_peer_certificates()``
+called ``SSL_get_peer_certificate()`` without freeing the returned reference. Each call leaked
+one ``X509`` refcount, preventing the certificate and its sub-allocations from being freed when
+the connection closed, causing unbounded memory growth in certain deployments.

--- a/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
+++ b/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
@@ -2,3 +2,4 @@ Fixed a memory leak in the OpenSSL compatibility layer where ``SSL_get0_peer_cer
 called ``SSL_get_peer_certificate()`` without freeing the returned reference. Each call leaked
 one ``X509`` refcount, preventing the certificate and its sub-allocations from being freed when
 the connection closed, causing unbounded memory growth in certain deployments.
+

--- a/compat/openssl/source/SSL_get0_peer_certificates.cc
+++ b/compat/openssl/source/SSL_get0_peer_certificates.cc
@@ -2,8 +2,7 @@
 #include <ossl.h>
 
 const STACK_OF(CRYPTO_BUFFER)* SSL_get0_peer_certificates(const SSL* ssl) {
-  X509* x509Temp = SSL_get_peer_certificate(ssl);
-  if (x509Temp == NULL)
+  if(ossl.ossl_SSL_get0_peer_certificate(ssl) == NULL)
     return NULL;
   else {
     // Dummy buffer just to return a non null value


### PR DESCRIPTION
SSL_get0_peer_certificates() called SSL_get_peer_certificate() (which increments the X509 refcount) but never freed the result. Every call leaked one reference, preventing the X509 and its sub-allocation tree from being freed when the connection closed.

Replace with ossl_SSL_get0_peer_certificate() call which returns a borrowed pointer without incrementing the refcount.

Backport of #46416 