### PR TITLE
[bp/1.38] compat/openssl: fix X509 refcount leak in SSL_get0_peer_certificates()

### DIFF
--- a/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
+++ b/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
@@ -1,0 +1,4 @@
+Fixed a memory leak in the OpenSSL compatibility layer where ``SSL_get0_peer_certificates()``
+called ``SSL_get_peer_certificate()`` without freeing the returned reference. Each call leaked
+one ``X509`` refcount, preventing the certificate and its sub-allocations from being freed when
+the connection closed, causing unbounded memory growth in certain deployments.

--- a/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
+++ b/changelogs/current/bug_fixes/tls__fix-x509-refcount-leak-in-openssl-compat.rst
@@ -2,3 +2,4 @@ Fixed a memory leak in the OpenSSL compatibility layer where ``SSL_get0_peer_cer
 called ``SSL_get_peer_certificate()`` without freeing the returned reference. Each call leaked
 one ``X509`` refcount, preventing the certificate and its sub-allocations from being freed when
 the connection closed, causing unbounded memory growth in certain deployments.
+


### PR DESCRIPTION
Added missing changelog entry