### PR TITLE
ci: add PR comment on OpenSSL pre-submit failure

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -30,6 +30,7 @@ jobs:
       actions: read
       contents: read
       packages: read
+      pull-requests: write
     uses: ./.github/workflows/_run.yml
     name: ${{ matrix.name ||matrix.target }}
     with:
@@ -47,6 +48,7 @@ jobs:
       catch-errors: ${{ matrix.catch-errors || false }}
       skip: ${{ matrix.skip != false && true || false }}
       slack-channel: ${{ matrix.slack-channel || '' }}
+      pr-comment-on-failure: ${{ matrix.pr-comment-on-failure || '' }}
       target: ${{ matrix.target }}
       timeout-minutes: 180
       trusted: ${{ inputs.trusted }}
@@ -63,10 +65,19 @@ jobs:
           name: GCC
         - target: openssl
           name: OpenSSL
-          skip: ${{ ! fromJSON(inputs.request).run.check-build-openssl }}
+          skip: ${{ fromJSON(inputs.request).request.pr != '' || ! fromJSON(inputs.request).run.check-build-openssl }}
           catch-errors: true
           slack-channel: '#envoy-openssl'
         - target: openssl.presubmit
           name: OpenSSL (presubmit)
           skip: ${{ fromJSON(inputs.request).request.pr == '' || ! fromJSON(inputs.request).run.check-build-openssl-presubmit }}
           catch-errors: true
+          pr-comment-on-failure: >-
+            **OpenSSL pre-submit check failed**
+
+
+            The `openssl.presubmit` CI job detected test failures when running
+            affected tests with OpenSSL. This check is informational and does
+            not block merging.
+
+            cc: @envoyproxy/envoy-openssl-sync

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -141,6 +141,10 @@ on:
         type: string
         default: ''
         description: Slack channel for failure notifications (opt-in, e.g. '#envoy-ci'). Leave empty to disable.
+      pr-comment-on-failure:
+        type: string
+        default: ''
+        description: Post a PR comment with this message on failure (catch-errors only). Leave empty to disable.
       source:
         type: string
       summary-post:
@@ -210,6 +214,7 @@ jobs:
       actions: read
       contents: read
       packages: read
+      pull-requests: write
     if: ${{ ! inputs.skip }}
     runs-on: ${{ inputs.runs-on || fromJSON(inputs.request).config.ci.agent-ubuntu }}
     name: ${{ inputs.target-suffix && format('[{0}] ', inputs.target-suffix) || '' }}${{ inputs.command }} ${{ inputs.target }}
@@ -484,3 +489,26 @@ jobs:
             text:
               type: mrkdwn
               text: ":x: *CI job failed:* `${{ inputs.target }}`\n<${{ env.JOB_URL }}|View workflow run>"
+
+    - name: Comment on PR on failure
+      if: >-
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.pr-comment-on-failure != ''
+        && fromJSON(inputs.request).request.pr != ''
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+      env:
+        JOB_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        script: |
+          const message = ${{ toJSON(inputs.pr-comment-on-failure) }};
+          const body = message + '\n\n[View workflow run](' + process.env.JOB_URL + ')';
+          try {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ fromJSON(inputs.request).request.pr }},
+              body: body
+            });
+          } catch (error) {
+            console.error('Failed to comment on PR:', error);
+          }

--- a/.github/workflows/envoy-checks.yml
+++ b/.github/workflows/envoy-checks.yml
@@ -53,7 +53,7 @@ jobs:
       actions: read
       contents: read
       packages: read
-      pull-requests: read
+      pull-requests: write
     name: Check (${{ needs.load.outputs.request && fromJSON(needs.load.outputs.request).summary.title || 'SKIPPED' }})
     uses: ./.github/workflows/_check_build.yml
     if: ${{ fromJSON(needs.load.outputs.request).run.check-build }}


### PR DESCRIPTION
When the `openssl.presubmit` job fails, post an informational comment on the PR so authors have visibility without digging into workflow logs.

Adds a generic `pr-comment-on-failure` input to `_run.yml` — any job with `catch-errors: true` can opt in by setting a message. Propagates `pull-requests: write` through the workflow call chain (`envoy-checks.yml` -> `_check_build.yml` -> `_run.yml`).
