### PR TITLE
ci: skip full openssl target on PRs

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -63,7 +63,7 @@ jobs:
           name: GCC
         - target: openssl
           name: OpenSSL
-          skip: ${{ ! fromJSON(inputs.request).run.check-build-openssl }}
+          skip: ${{ fromJSON(inputs.request).request.pr != '' || ! fromJSON(inputs.request).run.check-build-openssl }}
           catch-errors: true
           slack-channel: '#envoy-openssl'
         - target: openssl.presubmit


### PR DESCRIPTION
The full `openssl` CI target is intended for post-submit only. Since `openssl.presubmit` now handles pre-submit (#46422), skip the full target when the trigger is a pull request.
