### PR TITLE
ci: add PR comment on openssl pre-submit failure

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -47,6 +47,7 @@ jobs:
       catch-errors: ${{ matrix.catch-errors || false }}
       skip: ${{ matrix.skip != false && true || false }}
       slack-channel: ${{ matrix.slack-channel || '' }}
+      pr-comment-on-failure: ${{ matrix.pr-comment-on-failure || '' }}
       target: ${{ matrix.target }}
       timeout-minutes: 180
       trusted: ${{ inputs.trusted }}
@@ -70,3 +71,12 @@ jobs:
           name: OpenSSL (presubmit)
           skip: ${{ fromJSON(inputs.request).request.pr == '' || ! fromJSON(inputs.request).run.check-build-openssl-presubmit }}
           catch-errors: true
+          pr-comment-on-failure: >-
+            **OpenSSL pre-submit check failed**
+
+
+            The `openssl.presubmit` CI job detected test failures when running
+            affected tests with OpenSSL. This check is informational and does
+            not block merging.
+
+            cc: @envoyproxy/envoy-openssl-sync

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -141,6 +141,10 @@ on:
         type: string
         default: ''
         description: Slack channel for failure notifications (opt-in, e.g. '#envoy-ci'). Leave empty to disable.
+      pr-comment-on-failure:
+        type: string
+        default: ''
+        description: Post a PR comment with this message on failure (catch-errors only). Leave empty to disable.
       source:
         type: string
       summary-post:
@@ -484,3 +488,33 @@ jobs:
             text:
               type: mrkdwn
               text: ":x: *CI job failed:* `${{ inputs.target }}`\n<${{ env.JOB_URL }}|View workflow run>"
+
+    - name: Save PR comment artifact
+      if: >-
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.pr-comment-on-failure != ''
+        && fromJSON(inputs.request).request.pr != ''
+      run: |
+        jq -n \
+          --argjson pr "$PR_NUMBER" \
+          --arg message "$PR_MESSAGE" \
+          --arg run_id "$RUN_ID" \
+          --arg repo "$REPO" \
+          '{pr: $pr, message: $message, run_id: $run_id, repo: $repo}' \
+          > /tmp/pr-comment.json
+      shell: bash
+      env:
+        PR_NUMBER: ${{ fromJSON(inputs.request).request.pr }}
+        PR_MESSAGE: ${{ inputs.pr-comment-on-failure }}
+        RUN_ID: ${{ github.run_id }}
+        REPO: ${{ github.repository }}
+    - name: Upload PR comment artifact
+      if: >-
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.pr-comment-on-failure != ''
+        && fromJSON(inputs.request).request.pr != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: pr-comment-${{ inputs.target }}
+        path: /tmp/pr-comment.json
+        retention-days: 1

--- a/.github/workflows/envoy-pr-comment.yml
+++ b/.github/workflows/envoy-pr-comment.yml
@@ -1,0 +1,57 @@
+name: PR comment on CI failure
+
+on:
+  workflow_run:
+    workflows:
+    - Envoy/Checks
+    types:
+    - completed
+
+permissions:
+  contents: read
+
+
+jobs:
+  comment:
+    permissions:
+      actions: read
+      pull-requests: write
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.repository.full_name == github.repository
+      && (github.repository == 'envoyproxy/envoy' || vars.ENVOY_CI)
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      id: download
+      continue-on-error: true
+      with:
+        pattern: pr-comment-*
+        path: /tmp/pr-comments
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+    - if: steps.download.outcome == 'success'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const dir = '/tmp/pr-comments';
+          if (!fs.existsSync(dir)) return;
+          for (const subdir of fs.readdirSync(dir)) {
+            const filePath = path.join(dir, subdir, 'pr-comment.json');
+            if (!fs.existsSync(filePath)) continue;
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+            const jobUrl = `https://github.com/${data.repo}/actions/runs/${data.run_id}`;
+            const body = data.message + '\n\n[View workflow run](' + jobUrl + ')';
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: data.pr,
+                body: body
+              });
+            } catch (error) {
+              console.error(`Failed to comment on PR #${data.pr}:`, error);
+            }
+          }


### PR DESCRIPTION
When the `openssl.presubmit` job fails, post an informational comment on the PR so authors have visibility without digging into workflow logs.

Uses an artifact-based approach to keep `pull-requests: write` fully outside the existing CI call chain. `_run.yml` uploads a small JSON artifact with the failure details (no permission changes needed). A new standalone workflow (`envoy-pr-comment.yml`), triggered by `workflow_run` on "Envoy/Checks" completion, downloads the artifact and posts the comment — following the same pattern as `envoy-security-check.yml`.

Adds a generic `pr-comment-on-failure` input to `_run.yml` so any matrix entry with `catch-errors: true` can opt in by setting a message.
