### PR TITLE
grpc_field_extraction: add support for overriding dynamic metadata key

### DIFF
--- a/api/envoy/extensions/filters/http/grpc_field_extraction/v3/config.proto
+++ b/api/envoy/extensions/filters/http/grpc_field_extraction/v3/config.proto
@@ -139,6 +139,37 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // 	  "baz":[
 // 	  ]
 // 	}
+//
+// Normalizing the metadata key
+// ----------------------------
+//
+// By default the dynamic metadata key is the field path. ``metadata_key`` overrides it, which
+// allows different gRPC methods to write the same logical value under a common key.
+//
+// .. code-block:: json
+//
+// 	{
+// 	  "descriptor_set":{},
+// 	  "extractions_by_method":{
+// 	     "pkg.svc.Method":{
+// 	        "request_field_extractions":{
+// 	           "nested.bar":{
+// 	              "metadata_key":"bar"
+// 	           }
+// 	        }
+// 	     }
+// 	  }
+// 	}
+//
+// writes
+//
+// .. code-block:: json
+//
+// 	{
+// 	  "bar":[
+// 	     "val_bar1", "val_bar2"
+// 	  ]
+// 	}
 
 message GrpcFieldExtractionConfig {
   // The proto descriptor set binary for the gRPC services.
@@ -187,4 +218,14 @@ message RequestFieldValueDisposition {
     // Unimplemented. Uses "envoy.filters.http.grpc_field_extraction" for now.
     string dynamic_metadata = 1;
   }
+
+  // The key that the extracted value is written to within the dynamic metadata.
+  // If empty, the field path (the key of ``request_field_extractions``) is used.
+  //
+  // This is useful for normalizing the metadata written by different gRPC methods whose
+  // request messages name the same logical field differently.
+  //
+  // Within a single gRPC method, two field extractions must not resolve to the same
+  // metadata key, otherwise the configuration is rejected.
+  string metadata_key = 2;
 }

--- a/changelogs/current/new_features/grpc_field_extraction__added-metadata-key-override.rst
+++ b/changelogs/current/new_features/grpc_field_extraction__added-metadata-key-override.rst
@@ -1,0 +1,4 @@
+Added :ref:`metadata_key
+<envoy_v3_api_field_extensions.filters.http.grpc_field_extraction.v3.RequestFieldValueDisposition.metadata_key>`
+to allow overriding the dynamic metadata key that an extracted field value is written to. If unset,
+the request field path is used, which is the previous behavior.

--- a/source/extensions/filters/http/grpc_field_extraction/BUILD
+++ b/source/extensions/filters/http/grpc_field_extraction/BUILD
@@ -30,6 +30,7 @@ envoy_cc_library(
         "//envoy/common:exception_lib",
         "//source/common/common:minimal_logger_lib",
         "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/strings",
         "@envoy_api//envoy/extensions/filters/http/grpc_field_extraction/v3:pkg_cc_proto",
         "@proto-field-extraction//:all_libs",
     ],

--- a/source/extensions/filters/http/grpc_field_extraction/extractor.h
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor.h
@@ -21,8 +21,9 @@ namespace GrpcFieldExtraction {
 
 using TypeFinder = std::function<const Protobuf::Type*(const std::string&)>;
 struct RequestField {
-  // The request field path.
-  absl::string_view path;
+  // The dynamic metadata key that the value is written to. This is the configured
+  // metadata_key, or the request field path if it isn't set.
+  absl::string_view metadata_key;
 
   // The request field value.
   Protobuf::Value value;

--- a/source/extensions/filters/http/grpc_field_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor_impl.cc
@@ -7,6 +7,7 @@
 
 #include "source/common/common/logger.h"
 
+#include "absl/strings/str_cat.h"
 #include "proto_field_extraction/field_value_extractor/field_value_extractor_factory.h"
 #include "proto_field_extraction/field_value_extractor/field_value_extractor_interface.h"
 
@@ -38,7 +39,15 @@ absl::Status ExtractorImpl::init(
   for (const auto& it : field_extractions.request_field_extractions()) {
     auto extractor_or_error = extractor_factory.Create(request_type_url, it.first);
     RETURN_IF_NOT_OK(extractor_or_error.status());
-    per_field_extractors_.emplace(it.first, std::move(extractor_or_error.value()));
+
+    const std::string& metadata_key =
+        it.second.metadata_key().empty() ? it.first : it.second.metadata_key();
+    PerFieldExtractor entry{it.first, std::move(extractor_or_error.value())};
+    if (!per_field_extractors_.emplace(metadata_key, std::move(entry)).second) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("multiple field extractions are configured for the dynamic metadata key `",
+                       metadata_key, "`"));
+    }
   }
   return absl::OkStatus();
 }
@@ -48,13 +57,12 @@ ExtractorImpl::processRequest(Protobuf::field_extraction::MessageData& message) 
 
   ExtractionResult result;
   for (const auto& it : per_field_extractors_) {
-    absl::StatusOr<Protobuf::Value> extracted_value = it.second->ExtractValue(message);
+    absl::StatusOr<Protobuf::Value> extracted_value = it.second.extractor->ExtractValue(message);
     if (!extracted_value.ok()) {
       return extracted_value.status();
     }
-
-    ENVOY_LOG_MISC(debug, "extracted the following resource values from the {} field: {}", it.first,
-                   extracted_value->DebugString());
+    ENVOY_LOG_MISC(debug, "extracted the following resource values from the {} field: {}",
+                   it.second.path, extracted_value->DebugString());
     result.push_back({it.first, std::move(*extracted_value)});
   }
 

--- a/source/extensions/filters/http/grpc_field_extraction/extractor_impl.h
+++ b/source/extensions/filters/http/grpc_field_extraction/extractor_impl.h
@@ -38,7 +38,15 @@ private:
        const envoy::extensions::filters::http::grpc_field_extraction::v3::FieldExtractions&
            field_extractions);
 
-  absl::flat_hash_map<absl::string_view, FieldValueExtractorPtr> per_field_extractors_;
+  struct PerFieldExtractor {
+    // The request field path, used for logging.
+    absl::string_view path;
+
+    FieldValueExtractorPtr extractor;
+  };
+
+  // Keyed by the dynamic metadata key the extracted value is written to.
+  absl::flat_hash_map<absl::string_view, PerFieldExtractor> per_field_extractors_;
 };
 
 class ExtractorFactoryImpl : public ExtractorFactory {

--- a/source/extensions/filters/http/grpc_field_extraction/filter.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/filter.cc
@@ -213,12 +213,12 @@ void Filter::handleExtractionResult(const ExtractionResult& result) {
 
   Protobuf::Struct dest_metadata;
   for (const auto& req_field : result) {
-    RELEASE_ASSERT(!req_field.path.empty(), "`req_field.path` shouldn't be empty");
+    RELEASE_ASSERT(!req_field.metadata_key.empty(), "`req_field.metadata_key` shouldn't be empty");
     if (req_field.value.kind_case() == ::google::protobuf::Value::KindCase::KIND_NOT_SET) {
       // Initialize an empty ListValue for any unset field.
-      (*dest_metadata.mutable_fields())[req_field.path].mutable_list_value();
+      (*dest_metadata.mutable_fields())[req_field.metadata_key].mutable_list_value();
     } else {
-      (*dest_metadata.mutable_fields())[req_field.path] = req_field.value;
+      (*dest_metadata.mutable_fields())[req_field.metadata_key] = req_field.value;
     }
   }
   if (dest_metadata.fields_size() > 0) {

--- a/test/extensions/filters/http/grpc_field_extraction/filter_config_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/filter_config_test.cc
@@ -243,8 +243,7 @@ extractions_by_method: {
 })pb");
   *proto_config_.mutable_descriptor_set()->mutable_filename() =
       TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
-  filter_config_ = std::make_unique<FilterConfig>(proto_config_,
-                                                  std::make_unique<ExtractorFactoryImpl>(), *api_);
+  ASSERT_OK(makeConfig());
   EXPECT_NE(filter_config_->findExtractor("apikeys.ApiKeys.CreateApiKey"), nullptr);
 }
 
@@ -272,12 +271,12 @@ extractions_by_method: {
   *proto_config_.mutable_descriptor_set()->mutable_filename() =
       TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
 
-  EXPECT_THAT_THROWS_MESSAGE(
-      static_cast<void>(std::make_unique<FilterConfig>(
-          proto_config_, std::make_unique<ExtractorFactoryImpl>(), *api_)),
-      EnvoyException,
-      testing::HasSubstr(
-          "multiple field extractions are configured for the dynamic metadata key `name`"));
+  EXPECT_THAT(
+      makeConfig(),
+      HasStatus(
+          absl::StatusCode::kInvalidArgument,
+          testing::HasSubstr(
+              "multiple field extractions are configured for the dynamic metadata key `name`")));
 }
 
 TEST_F(FilterConfigTestException, MetadataKeyCollidesWithFieldPath) {
@@ -302,12 +301,12 @@ extractions_by_method: {
   *proto_config_.mutable_descriptor_set()->mutable_filename() =
       TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
 
-  EXPECT_THAT_THROWS_MESSAGE(
-      static_cast<void>(std::make_unique<FilterConfig>(
-          proto_config_, std::make_unique<ExtractorFactoryImpl>(), *api_)),
-      EnvoyException,
-      testing::HasSubstr(
-          "multiple field extractions are configured for the dynamic metadata key `parent`"));
+  EXPECT_THAT(
+      makeConfig(),
+      HasStatus(
+          absl::StatusCode::kInvalidArgument,
+          testing::HasSubstr(
+              "multiple field extractions are configured for the dynamic metadata key `parent`")));
 }
 
 TEST_F(FilterConfigTestException, ErrorParsingDescriptorInline) {

--- a/test/extensions/filters/http/grpc_field_extraction/filter_config_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/filter_config_test.cc
@@ -223,7 +223,93 @@ extractions_by_method: {
   EXPECT_NE(filter_config_->findExtractor("apikeys.ApiKeys.CreateApiKey"), nullptr);
 }
 
+TEST_F(FilterConfigTestOk, CustomMetadataKey) {
+  parseConfigProto(R"pb(
+extractions_by_method: {
+  key: "apikeys.ApiKeys.CreateApiKey"
+  value: {
+    request_field_extractions: {
+      key: "parent"
+      value: {
+        metadata_key: "normalized_parent"
+      }
+    }
+    request_field_extractions: {
+      key: "key.name"
+      value: {
+      }
+    }
+  }
+})pb");
+  *proto_config_.mutable_descriptor_set()->mutable_filename() =
+      TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
+  filter_config_ = std::make_unique<FilterConfig>(proto_config_,
+                                                  std::make_unique<ExtractorFactoryImpl>(), *api_);
+  EXPECT_NE(filter_config_->findExtractor("apikeys.ApiKeys.CreateApiKey"), nullptr);
+}
+
 using FilterConfigTestException = FilterConfigTestBase;
+TEST_F(FilterConfigTestException, DuplicateMetadataKeys) {
+  parseConfigProto(R"pb(
+extractions_by_method: {
+  key: "apikeys.ApiKeys.CreateApiKey"
+  value: {
+    request_field_extractions: {
+      key: "parent"
+      value: {
+        metadata_key: "name"
+      }
+    }
+    request_field_extractions: {
+      key: "key.name"
+      value: {
+        metadata_key: "name"
+      }
+    }
+  }
+}
+    )pb");
+  *proto_config_.mutable_descriptor_set()->mutable_filename() =
+      TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
+
+  EXPECT_THAT_THROWS_MESSAGE(
+      static_cast<void>(std::make_unique<FilterConfig>(
+          proto_config_, std::make_unique<ExtractorFactoryImpl>(), *api_)),
+      EnvoyException,
+      testing::HasSubstr(
+          "multiple field extractions are configured for the dynamic metadata key `name`"));
+}
+
+TEST_F(FilterConfigTestException, MetadataKeyCollidesWithFieldPath) {
+  parseConfigProto(R"pb(
+extractions_by_method: {
+  key: "apikeys.ApiKeys.CreateApiKey"
+  value: {
+    request_field_extractions: {
+      key: "parent"
+      value: {
+      }
+    }
+    request_field_extractions: {
+      key: "key.name"
+      value: {
+        metadata_key: "parent"
+      }
+    }
+  }
+}
+    )pb");
+  *proto_config_.mutable_descriptor_set()->mutable_filename() =
+      TestEnvironment::runfilesPath("test/proto/apikeys.descriptor");
+
+  EXPECT_THAT_THROWS_MESSAGE(
+      static_cast<void>(std::make_unique<FilterConfig>(
+          proto_config_, std::make_unique<ExtractorFactoryImpl>(), *api_)),
+      EnvoyException,
+      testing::HasSubstr(
+          "multiple field extractions are configured for the dynamic metadata key `parent`"));
+}
+
 TEST_F(FilterConfigTestException, ErrorParsingDescriptorInline) {
   parseConfigProto();
   *proto_config_.mutable_descriptor_set()->mutable_inline_bytes() = "123";

--- a/test/extensions/filters/http/grpc_field_extraction/filter_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/filter_test.cc
@@ -189,6 +189,107 @@ TEST_F(FilterTestExtractOk, MissingFieldProducesListValue) {
   checkSerializedData<CreateApiKeyRequest>(*request_data, {request});
 }
 
+TEST_F(FilterTestExtractOk, CustomMetadataKey) {
+  setUp(R"pb(
+extractions_by_method: {
+  key: "apikeys.ApiKeys.CreateApiKey"
+  value: {
+    request_field_extractions: {
+      key: "parent"
+      value: {
+        metadata_key: "normalized_parent"
+      }
+    }
+    request_field_extractions: {
+      key: "key.name"
+      value: {
+      }
+    }
+  }
+})pb");
+  TestRequestHeaderMapImpl req_headers =
+      TestRequestHeaderMapImpl{{":method", "POST"},
+                               {":path", "/apikeys.ApiKeys/CreateApiKey"},
+                               {"content-type", "application/grpc"}};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(req_headers, true));
+
+  CreateApiKeyRequest request = makeCreateApiKeyRequest(R"pb(
+      parent: "project-id"
+      key { name: "api-key-name" }
+    )pb");
+  Envoy::Buffer::InstancePtr request_data = Envoy::Grpc::Common::serializeToGrpcFrame(request);
+  EXPECT_CALL(mock_decoder_callbacks_.stream_info_, setDynamicMetadata(_, _))
+      .WillOnce(Invoke([](const std::string& ns, const Protobuf::Struct& new_dynamic_metadata) {
+        EXPECT_EQ(ns, "envoy.filters.http.grpc_field_extraction");
+        checkProtoStruct(new_dynamic_metadata, R"pb(
+fields {
+  key: "normalized_parent"
+  value {
+    list_value {
+      values {
+        string_value: "project-id"
+      }
+    }
+  }
+}
+fields {
+  key: "key.name"
+  value {
+    list_value {
+      values {
+        string_value: "api-key-name"
+      }
+    }
+  }
+})pb");
+      }));
+  EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(*request_data, true));
+
+  // No data modification.
+  checkSerializedData<CreateApiKeyRequest>(*request_data, {request});
+}
+
+TEST_F(FilterTestExtractOk, CustomMetadataKeyWithEmptyField) {
+  setUp(R"pb(
+extractions_by_method: {
+  key: "apikeys.ApiKeys.CreateApiKey"
+  value: {
+    request_field_extractions: {
+      key: "parent"
+      value: {
+        metadata_key: "normalized_parent"
+      }
+    }
+  }
+})pb");
+  TestRequestHeaderMapImpl req_headers =
+      TestRequestHeaderMapImpl{{":method", "POST"},
+                               {":path", "/apikeys.ApiKeys/CreateApiKey"},
+                               {"content-type", "application/grpc"}};
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(req_headers, true));
+
+  CreateApiKeyRequest request = makeCreateApiKeyRequest("");
+  Envoy::Buffer::InstancePtr request_data = Envoy::Grpc::Common::serializeToGrpcFrame(request);
+  EXPECT_CALL(mock_decoder_callbacks_.stream_info_, setDynamicMetadata(_, _))
+      .WillOnce(Invoke([](const std::string& ns, const Protobuf::Struct& new_dynamic_metadata) {
+        EXPECT_EQ(ns, "envoy.filters.http.grpc_field_extraction");
+        checkProtoStruct(new_dynamic_metadata, R"pb(
+fields {
+  key: "normalized_parent"
+  value {
+    list_value {
+    }
+  }
+})pb");
+      }));
+  EXPECT_EQ(Envoy::Http::FilterDataStatus::Continue, filter_->decodeData(*request_data, true));
+
+  // No data modification.
+  checkSerializedData<CreateApiKeyRequest>(*request_data, {request});
+}
+
 TEST_F(FilterTestExtractOk, UnaryMultipeBuffers) {
   setUp();
   TestRequestHeaderMapImpl req_headers =

--- a/test/extensions/filters/http/grpc_field_extraction/integration_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/integration_test.cc
@@ -49,9 +49,13 @@ typed_config:
     apikeys.ApiKeys.CreateApiKey:
       request_field_extractions:
         parent:
+        key.name:
+          metadata_key: api_key_name
     apikeys.ApiKeys.CreateApiKeyInStream:
       request_field_extractions:
         parent:
+        key.name:
+          metadata_key: api_key_name
 )EOF",
                            TestEnvironment::runfilesPath("test/proto/apikeys.descriptor"));
   }
@@ -59,6 +63,7 @@ typed_config:
 
 CreateApiKeyRequest makeCreateApiKeyRequest(absl::string_view pb = R"pb(
       parent: "project-id"
+      key { name: "api-key-name" }
     )pb") {
   CreateApiKeyRequest request;
   std::ignore = Protobuf::TextFormat::ParseFromString(pb, &request);
@@ -85,7 +90,9 @@ TEST_P(IntegrationTest, Unary) {
   // Send response.
   sendResponse(response.get());
 
-  EXPECT_THAT(waitForAccessLog(access_log_name_), R"({"parent":["project-id"]})");
+  EXPECT_THAT(waitForAccessLog(access_log_name_),
+              testing::AllOf(testing::HasSubstr(R"("parent":["project-id"])"),
+                             testing::HasSubstr(R"("api_key_name":["api-key-name"])")));
 }
 
 TEST_P(IntegrationTest, Streaming) {
@@ -100,16 +107,19 @@ TEST_P(IntegrationTest, Streaming) {
   CreateApiKeyRequest request1 = makeCreateApiKeyRequest(
       R"pb(
       parent: "from-req1"
+      key { name: "key-from-req1" }
 )pb");
   Envoy::Buffer::InstancePtr request_data1 = Envoy::Grpc::Common::serializeToGrpcFrame(request1);
   CreateApiKeyRequest request2 = makeCreateApiKeyRequest(
       R"pb(
       parent: "from-req2"
+      key { name: "key-from-req2" }
 )pb");
   Envoy::Buffer::InstancePtr request_data2 = Envoy::Grpc::Common::serializeToGrpcFrame(request2);
   CreateApiKeyRequest request3 = makeCreateApiKeyRequest(
       R"pb(
       parent: "from-req3"
+      key { name: "key-from-req3" }
 )pb");
   Envoy::Buffer::InstancePtr request_data3 = Envoy::Grpc::Common::serializeToGrpcFrame(request3);
 
@@ -134,7 +144,9 @@ TEST_P(IntegrationTest, Streaming) {
   // Send response.
   sendResponse(response.get());
 
-  EXPECT_THAT(waitForAccessLog(access_log_name_), R"({"parent":["from-req1"]})");
+  EXPECT_THAT(waitForAccessLog(access_log_name_),
+              testing::AllOf(testing::HasSubstr(R"("parent":["from-req1"])"),
+                             testing::HasSubstr(R"("api_key_name":["key-from-req1"])")));
 }
 
 INSTANTIATE_TEST_SUITE_P(Protocols, IntegrationTest,


### PR DESCRIPTION
Commit Message: grpc_field_extraction: add support for overriding dynamic metadata key
Additional Description: Added a new `metadata_key` field to `RequestFieldValueDisposition` to allow overriding the dynamic metadata key that an extracted field value is written to. If unset, the request field path is used as before to preserve backwards compatibility. This is useful for normalizing the metadata written by different gRPC methods whose request messages name the same logical field differently. For example, `Foo.Create(name)` and `Foo.BatchCreate(request.name)` can publish the resource `name` under a single key so one route match, access-log field, etc. covers both methods.
Risk Level: Low.
Testing: Unit and integration tests added.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A