### PR TITLE
ci: add PR comment on openssl pre-submit failure

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -47,6 +47,7 @@ jobs:
       catch-errors: ${{ matrix.catch-errors || false }}
       skip: ${{ matrix.skip != false && true || false }}
       slack-channel: ${{ matrix.slack-channel || '' }}
+      pr-comment-on-failure: ${{ matrix.pr-comment-on-failure || '' }}
       target: ${{ matrix.target }}
       timeout-minutes: 180
       trusted: ${{ inputs.trusted }}
@@ -70,3 +71,12 @@ jobs:
           name: OpenSSL (presubmit)
           skip: ${{ fromJSON(inputs.request).request.pr == '' || ! fromJSON(inputs.request).run.check-build-openssl-presubmit }}
           catch-errors: true
+          pr-comment-on-failure: >-
+            **OpenSSL pre-submit check failed**
+
+
+            The `openssl.presubmit` CI job detected test failures when running
+            affected tests with OpenSSL. This check is informational and does
+            not block merging.
+
+            cc: @envoyproxy/envoy-openssl-sync

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -109,27 +109,29 @@ jobs:
         token: ${{ steps.appauth.outputs.token }}
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-      name: Download PR comment artifacts
-      id: download-pr-comments
+      name: Download CI report artifacts
+      id: download-ci-reports
       continue-on-error: true
       with:
-        pattern: pr-comment-*
-        path: /tmp/pr-comments
-    - if: steps.download-pr-comments.outcome == 'success'
-      name: Post PR comments
+        pattern: ci-report-*
+        path: /tmp/ci-reports
+    - if: steps.download-ci-reports.outcome == 'success'
+      name: Post PR comments from CI reports
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
       with:
         github-token: ${{ steps.appauth.outputs.token }}
         script: |
           const fs = require('fs');
           const path = require('path');
-          const dir = '/tmp/pr-comments';
+          const dir = '/tmp/ci-reports';
           if (!fs.existsSync(dir)) return;
-          for (const subdir of fs.readdirSync(dir)) {
+          for (const artifactDir of fs.readdirSync(dir)) {
             try {
-              const filePath = path.join(dir, subdir, 'pr-comment.json');
-              if (!fs.existsSync(filePath)) continue;
-              const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              const reportPath = path.join(dir, artifactDir, 'report.json');
+              if (!fs.existsSync(reportPath)) continue;
+              const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+              if (!report['pr-comment']) continue;
+              const data = JSON.parse(report['pr-comment']);
               const jobUrl = `https://github.com/${data.repo}/actions/runs/${data.run_id}`;
               const body = data.message + '\n\n[View workflow run](' + jobUrl + ')';
               await github.rest.issues.createComment({
@@ -139,7 +141,7 @@ jobs:
                 body: body
               });
             } catch (error) {
-              console.error(`Failed to process ${subdir}:`, error);
+              console.error(`Failed to process ${artifactDir}:`, error);
             }
           }
 

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -108,6 +108,41 @@ jobs:
         checks: ${{ toJSON(fromJSON(steps.needs.outputs.value).checks) }}
         token: ${{ steps.appauth.outputs.token }}
 
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      name: Download PR comment artifacts
+      id: download-pr-comments
+      continue-on-error: true
+      with:
+        pattern: pr-comment-*
+        path: /tmp/pr-comments
+    - if: steps.download-pr-comments.outcome == 'success'
+      name: Post PR comments
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+      with:
+        github-token: ${{ steps.appauth.outputs.token }}
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const dir = '/tmp/pr-comments';
+          if (!fs.existsSync(dir)) return;
+          for (const subdir of fs.readdirSync(dir)) {
+            const filePath = path.join(dir, subdir, 'pr-comment.json');
+            if (!fs.existsSync(filePath)) continue;
+            const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+            const jobUrl = `https://github.com/${data.repo}/actions/runs/${data.run_id}`;
+            const body = data.message + '\n\n[View workflow run](' + jobUrl + ')';
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: data.pr,
+                body: body
+              });
+            } catch (error) {
+              console.error(`Failed to comment on PR #${data.pr}:`, error);
+            }
+          }
+
     # This is necessary to ensure that any retests have their checks updated
     - name: Fail the job
       if: ${{ fromJSON(steps.needs.outputs.value).conclusion != 'success' }}

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -126,12 +126,12 @@ jobs:
           const dir = '/tmp/pr-comments';
           if (!fs.existsSync(dir)) return;
           for (const subdir of fs.readdirSync(dir)) {
-            const filePath = path.join(dir, subdir, 'pr-comment.json');
-            if (!fs.existsSync(filePath)) continue;
-            const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-            const jobUrl = `https://github.com/${data.repo}/actions/runs/${data.run_id}`;
-            const body = data.message + '\n\n[View workflow run](' + jobUrl + ')';
             try {
+              const filePath = path.join(dir, subdir, 'pr-comment.json');
+              if (!fs.existsSync(filePath)) continue;
+              const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              const jobUrl = `https://github.com/${data.repo}/actions/runs/${data.run_id}`;
+              const body = data.message + '\n\n[View workflow run](' + jobUrl + ')';
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -139,7 +139,7 @@ jobs:
                 body: body
               });
             } catch (error) {
-              console.error(`Failed to comment on PR #${data.pr}:`, error);
+              console.error(`Failed to process ${subdir}:`, error);
             }
           }
 

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -128,6 +128,21 @@ on:
               df -h > "${TMP_REPORT}/df-post"
               (du -ch "%{{ inputs.temp-dir || runner.temp }}" | grep -E "[0-9]{2,}M|[0-9]G" || :) > "${TMP_REPORT}/du-post"
             shell: bash
+          - run: |
+              cat <<'CTXEOF' | jq '
+                if .run["exit-code"] != 0
+                   and .context["pr-comment-on-failure"] != ""
+                   and .context.pr != "" then
+                  {pr: (.context.pr | tonumber),
+                   message: .context["pr-comment-on-failure"],
+                   run_id: .context["run-id"],
+                   repo: .context.repo}
+                else empty end
+              ' > "${TMP_REPORT}/pr-comment"
+              %{{ inputs.context }}
+              CTXEOF
+              [[ -s "${TMP_REPORT}/pr-comment" ]] || rm -f "${TMP_REPORT}/pr-comment"
+            shell: bash
       request:
         type: string
         required: true
@@ -244,7 +259,11 @@ jobs:
           | {"target": "${{ inputs.target }}",
              "catch-errors": ${{ inputs.catch-errors }},
              "runs-on": $runsOn,
-             "job-started": ${{ steps.started.outputs.value }}}
+             "job-started": ${{ steps.started.outputs.value }},
+             "pr-comment-on-failure": ${{ toJSON(inputs.pr-comment-on-failure) }},
+             "pr": "${{ fromJSON(inputs.request).request.pr }}",
+             "run-id": "${{ github.run_id }}",
+             "repo": "${{ github.repository }}"}
           | . * {$config, $check}
 
     - run: |
@@ -489,28 +508,3 @@ jobs:
               type: mrkdwn
               text: ":x: *CI job failed:* `${{ inputs.target }}`\n<${{ env.JOB_URL }}|View workflow run>"
 
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
-      name: Save PR comment artifact
-      if: >-
-        steps.ci-run.outputs.exit-code != 0
-        && inputs.pr-comment-on-failure != ''
-        && fromJSON(inputs.request).request.pr != ''
-      with:
-        input: |
-          pr: ${{ fromJSON(inputs.request).request.pr }}
-          message: ${{ toJSON(inputs.pr-comment-on-failure) }}
-          run_id: "${{ github.run_id }}"
-          repo: "${{ github.repository }}"
-        input-format: yaml
-        output-path: /tmp/pr-comment.json
-        filter: .
-    - name: Upload PR comment artifact
-      if: >-
-        steps.ci-run.outputs.exit-code != 0
-        && inputs.pr-comment-on-failure != ''
-        && fromJSON(inputs.request).request.pr != ''
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-      with:
-        name: pr-comment-${{ inputs.target }}
-        path: /tmp/pr-comment.json
-        retention-days: 1

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -489,25 +489,21 @@ jobs:
               type: mrkdwn
               text: ":x: *CI job failed:* `${{ inputs.target }}`\n<${{ env.JOB_URL }}|View workflow run>"
 
-    - name: Save PR comment artifact
+    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      name: Save PR comment artifact
       if: >-
         steps.ci-run.outputs.exit-code != 0
         && inputs.pr-comment-on-failure != ''
         && fromJSON(inputs.request).request.pr != ''
-      run: |
-        jq -n \
-          --argjson pr "$PR_NUMBER" \
-          --arg message "$PR_MESSAGE" \
-          --arg run_id "$RUN_ID" \
-          --arg repo "$REPO" \
-          '{pr: $pr, message: $message, run_id: $run_id, repo: $repo}' \
-          > /tmp/pr-comment.json
-      shell: bash
-      env:
-        PR_NUMBER: ${{ fromJSON(inputs.request).request.pr }}
-        PR_MESSAGE: ${{ inputs.pr-comment-on-failure }}
-        RUN_ID: ${{ github.run_id }}
-        REPO: ${{ github.repository }}
+      with:
+        input: |
+          pr: ${{ fromJSON(inputs.request).request.pr }}
+          message: ${{ toJSON(inputs.pr-comment-on-failure) }}
+          run_id: "${{ github.run_id }}"
+          repo: "${{ github.repository }}"
+        input-format: yaml
+        output-path: /tmp/pr-comment.json
+        filter: .
     - name: Upload PR comment artifact
       if: >-
         steps.ci-run.outputs.exit-code != 0

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -141,6 +141,10 @@ on:
         type: string
         default: ''
         description: Slack channel for failure notifications (opt-in, e.g. '#envoy-ci'). Leave empty to disable.
+      pr-comment-on-failure:
+        type: string
+        default: ''
+        description: Post a PR comment with this message on failure (catch-errors only). Leave empty to disable.
       source:
         type: string
       summary-post:
@@ -484,3 +488,33 @@ jobs:
             text:
               type: mrkdwn
               text: ":x: *CI job failed:* `${{ inputs.target }}`\n<${{ env.JOB_URL }}|View workflow run>"
+
+    - name: Save PR comment artifact
+      if: >-
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.pr-comment-on-failure != ''
+        && fromJSON(inputs.request).request.pr != ''
+      run: |
+        jq -n \
+          --argjson pr "$PR_NUMBER" \
+          --arg message "$PR_MESSAGE" \
+          --arg run_id "$RUN_ID" \
+          --arg repo "$REPO" \
+          '{pr: $pr, message: $message, run_id: $run_id, repo: $repo}' \
+          > /tmp/pr-comment.json
+      shell: bash
+      env:
+        PR_NUMBER: ${{ fromJSON(inputs.request).request.pr }}
+        PR_MESSAGE: ${{ inputs.pr-comment-on-failure }}
+        RUN_ID: ${{ github.run_id }}
+        REPO: ${{ github.repository }}
+    - name: Upload PR comment artifact
+      if: >-
+        steps.ci-run.outputs.exit-code != 0
+        && inputs.pr-comment-on-failure != ''
+        && fromJSON(inputs.request).request.pr != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: pr-comment-${{ inputs.target }}
+        path: /tmp/pr-comment.json
+        retention-days: 1


### PR DESCRIPTION
When the `openssl.presubmit` job fails, post an informational comment on the PR so authors have visibility without digging into workflow logs.

Adds a generic `pr-comment-on-failure` input to `_run.yml` so any matrix entry with `catch-errors: true` can opt in by setting a message. The PR comment data flows through the existing report/context system and is posted by `_finish.yml` using the app auth token.