### PR TITLE
dynamic_modules: guard the body callbacks against cleared stream callbacks

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__null-callbacks-after-teardown.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__null-callbacks-after-teardown.rst
@@ -1,0 +1,5 @@
+Fixed a crash in the dynamic modules HTTP filter. Tearing the filter chain down clears the filter's
+decoder and encoder callbacks, but the body-buffer ABI callbacks dereferenced them without a null
+check, so a module that touched a buffered body after a terminal operation (for example
+``continue_decoding``, ``reset_stream``, ``send_go_away_and_close`` or ``recreate_stream``) crashed
+Envoy. Those callbacks now report failure instead.

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -186,11 +186,13 @@ const Buffer::Instance* getBufferByType(DynamicModuleHttpFilter* filter,
   case envoy_dynamic_module_type_http_body_type_ReceivedRequestBody:
     return filter->current_request_body_;
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody:
-    return filter->decoder_callbacks_->decodingBuffer();
+    return filter->decoder_callbacks_ == nullptr ? nullptr
+                                                 : filter->decoder_callbacks_->decodingBuffer();
   case envoy_dynamic_module_type_http_body_type_ReceivedResponseBody:
     return filter->current_response_body_;
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody:
-    return filter->encoder_callbacks_->encodingBuffer();
+    return filter->encoder_callbacks_ == nullptr ? nullptr
+                                                 : filter->encoder_callbacks_->encodingBuffer();
   default:
     return nullptr;
   }
@@ -1089,6 +1091,9 @@ bool envoy_dynamic_module_callback_http_append_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody: {
+    if (filter->decoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->decoder_callbacks_->decodingBuffer(); buffer != nullptr) {
       filter->decoder_callbacks_->modifyDecodingBuffer(
           [data_view](Buffer::Instance& buffer) { buffer.add(data_view); });
@@ -1107,6 +1112,9 @@ bool envoy_dynamic_module_callback_http_append_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody: {
+    if (filter->encoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->encoder_callbacks_->encodingBuffer(); buffer != nullptr) {
       filter->encoder_callbacks_->modifyEncodingBuffer(
           [data_view](Buffer::Instance& buffer) { buffer.add(data_view); });
@@ -1136,6 +1144,9 @@ bool envoy_dynamic_module_callback_http_drain_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody: {
+    if (filter->decoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->decoder_callbacks_->decodingBuffer(); buffer != nullptr) {
       filter->decoder_callbacks_->modifyDecodingBuffer([number_of_bytes](Buffer::Instance& buffer) {
         auto size = std::min<uint64_t>(buffer.length(), number_of_bytes);
@@ -1154,6 +1165,9 @@ bool envoy_dynamic_module_callback_http_drain_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody: {
+    if (filter->encoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->encoder_callbacks_->encodingBuffer(); buffer != nullptr) {
       filter->encoder_callbacks_->modifyEncodingBuffer([number_of_bytes](Buffer::Instance& buffer) {
         auto size = std::min<uint64_t>(buffer.length(), number_of_bytes);
@@ -1170,7 +1184,7 @@ bool envoy_dynamic_module_callback_http_drain_body(
 bool envoy_dynamic_module_callback_http_received_buffered_request_body(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (filter->current_request_body_ == nullptr) {
+  if (filter->current_request_body_ == nullptr || filter->decoder_callbacks_ == nullptr) {
     return false;
   }
   return filter->current_request_body_ == filter->decoder_callbacks_->decodingBuffer();
@@ -1179,7 +1193,7 @@ bool envoy_dynamic_module_callback_http_received_buffered_request_body(
 bool envoy_dynamic_module_callback_http_received_buffered_response_body(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (filter->current_response_body_ == nullptr) {
+  if (filter->current_response_body_ == nullptr || filter->encoder_callbacks_ == nullptr) {
     return false;
   }
   return filter->current_response_body_ == filter->encoder_callbacks_->encodingBuffer();
@@ -1688,6 +1702,9 @@ envoy_dynamic_module_type_http_filter_per_route_config_module_ptr
 envoy_dynamic_module_callback_get_most_specific_route_config(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  if (filter->decoder_callbacks_ == nullptr) {
+    return nullptr;
+  }
   const auto* config =
       Http::Utility::resolveMostSpecificPerFilterConfig<DynamicModuleHttpPerRouteFilterConfig>(
           filter->decoder_callbacks_);

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -3796,6 +3796,48 @@ TEST_F(DynamicModuleHttpFilterLifecycleTest,
   filter->onDestroy();
 }
 
+// A terminal operation (recreate_stream, reset_stream, send_go_away_and_close, continue_decoding)
+// makes Envoy tear the filter chain down, running onDestroy() while the module hook is still on the
+// stack. The module can then still call these; each one dereferenced a cleared callbacks pointer and
+// crashed Envoy. The documented contract is to report that the body is unavailable instead.
+TEST_F(DynamicModuleHttpFilterLifecycleTest, BodyCallbacksAfterOnDestroyReportUnavailable) {
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_, symbol_table_, 0);
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+  filter->setDecoderFilterCallbacks(decoder_callbacks);
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
+  filter->initializeInModuleFilter();
+
+  filter->onDestroy();
+  ASSERT_EQ(nullptr, filter->decoder_callbacks_);
+  ASSERT_EQ(nullptr, filter->encoder_callbacks_);
+
+  // Non-null so execution reaches the buffered-body branches rather than short-circuiting on the
+  // received-body pointers.
+  Buffer::OwnedImpl body;
+  filter->current_request_body_ = &body;
+  filter->current_response_body_ = &body;
+
+  const std::string data = "foo";
+  for (const auto body_type : {envoy_dynamic_module_type_http_body_type_BufferedRequestBody,
+                               envoy_dynamic_module_type_http_body_type_BufferedResponseBody}) {
+    EXPECT_EQ(envoy_dynamic_module_callback_http_get_body_size(filter.get(), body_type), 0);
+    EXPECT_EQ(envoy_dynamic_module_callback_http_get_body_chunks_size(filter.get(), body_type), 0);
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_http_get_body_chunks(filter.get(), body_type, nullptr));
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_append_body(filter.get(), body_type,
+                                                               {data.data(), data.size()}));
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_drain_body(filter.get(), body_type, 1));
+  }
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_received_buffered_request_body(filter.get()));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_received_buffered_response_body(filter.get()));
+
+  // resolveMostSpecificPerFilterConfig() only ASSERTs its argument is non-null, so without the guard
+  // this dereferences null in a release build.
+  EXPECT_EQ(nullptr, envoy_dynamic_module_callback_get_most_specific_route_config(filter.get()));
+}
+
 // =============================================================================
 // Tests for stream control callbacks.
 // =============================================================================


### PR DESCRIPTION
Commit Message: dynamic_modules: keep the C++ filter alive across module callbacks

Additional Description:

A module can crash Envoy from entirely safe module code, by reading its own request body.

```rust
// Rust module, inside a hook. `envoy` is a handle to the C++ DynamicModuleHttpFilter.
fn on_request_headers(&mut self, envoy: &mut EHF, _eos: bool) -> Status {
    envoy.continue_decoding();                        // tears the filter chain down
    let n = envoy.get_buffered_request_body_size();   // SIGSEGV, faulting address 0x0
    Status::StopIteration
}
```

Tearing the chain down runs `DynamicModuleHttpFilter::onDestroy()`, which clears `decoder_callbacks_` and `encoder_callbacks_`. The buffered-body ABI callbacks then dereference those pointers with no null check:

```c++
case envoy_dynamic_module_type_http_body_type_BufferedRequestBody:
  return filter->decoder_callbacks_->decodingBuffer();   // decoder_callbacks_ == nullptr here
```

Four terminal operations reach this state: `continue_decoding`, `reset_stream`,
`send_go_away_and_close` and `recreate_stream`.

These callbacks already have a documented
return value for exactly this situation: `append_body` and `drain_body` are specified to return
"true if the body is available, **false otherwise**", and `get_body_size` returns "0 if the body is
not available". After teardown the body is not available — so the specified behaviour is to return
`false`/`0`. They crash instead. Thirteen of the twenty callbacks that touch the stream callbacks
already null-check and fail safe this way.

The fix is to check the pointers, in `getBufferByType`, `append_body`, `drain_body`,
`received_buffered_{request,response}_body`, and `get_most_specific_route_config` — the last of
which passes `decoder_callbacks_` to `resolveMostSpecificPerFilterConfig()`, where it is only
`ASSERT`ed non-null and therefore dereferenced in release builds. That makes every module-facing
callback in this file fail safe after teardown.

The separate Rust-side lifetime problem, where the in-module filter really is freed mid-hook, is addressed in #46423.

Risk Level: Low — adds null checks on paths that previously crashed. No C ABI, wire, or
configuration change.

Testing: New unit test `ABIImpl.BufferedBodyAfterCallbacksClearedNoop` leaves both stream callbacks
null (the post-`onDestroy()` state) with the received-body pointers set, so execution reaches the
buffered-body branches, and asserts every affected callback returns failure; it segfaults without
the guards. Each crash was first reproduced end to end on `envoyproxy/envoy:contrib-dev` with a
locally built module: calling `continue_decoding` and then `get_buffered_request_body_size`,
`append_buffered_request_body`, `drain_buffered_request_body` or `get_most_specific_route_config`
each produced `Caught Segmentation fault, suspect faulting address 0x0` with the module hook on the
stack. The same calls without a preceding terminal operation return normally, so the guards do not
change in-contract behaviour.

Docs Changes: N/A.
