### PR TITLE
dynamic_modules: add http set_dynamic_metadata_struct and set_dynamic_typed_metadata ABI callbacks

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-struct.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-struct.rst
@@ -1,0 +1,4 @@
+Added ``envoy_dynamic_module_callback_http_set_dynamic_metadata_struct`` ABI callback that
+sets an entire dynamic metadata namespace from a serialized ``google.protobuf.Struct`` in one
+call, letting a module publish nested/structured metadata instead of only flat scalar keys. The
+Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_metadata_struct``.

--- a/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-typed-metadata.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-typed-metadata.rst
@@ -1,0 +1,6 @@
+Added ``envoy_dynamic_module_callback_http_set_dynamic_typed_metadata`` ABI callback that sets a
+typed dynamic metadata namespace from a serialized ``google.protobuf.Any``. Unlike
+``envoy_dynamic_module_callback_http_set_dynamic_metadata_struct`` it preserves the exact message
+type (via the Any ``type_url``) in ``typed_filter_metadata``, so consumers such as ext_authz
+(``typed_metadata_context_namespaces``) receive the original message rather than a lossy Struct. The
+Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_typed_metadata``.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -2069,6 +2069,38 @@ void envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
     const envoy_dynamic_module_type_module_key_value_pair* entries, size_t entries_size);
 
 /**
+ * envoy_dynamic_module_callback_http_set_dynamic_metadata_struct is called by the module to set an
+ * entire dynamic metadata namespace from a serialized google.protobuf.Struct. The struct is merged
+ * into the namespace and existing entries with the same key are overwritten. If the buffer does not
+ * parse as a google.protobuf.Struct, this is a no-op.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param ns is the namespace of the dynamic metadata.
+ * @param serialized_struct is the serialized google.protobuf.Struct value to set.
+ */
+void envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_struct);
+
+/**
+ * envoy_dynamic_module_callback_http_set_dynamic_typed_metadata is called by the module to set an
+ * entire typed dynamic metadata namespace from a serialized google.protobuf.Any. The Any is merged
+ * into the namespace's typed_filter_metadata entry. If the buffer does not parse as a
+ * google.protobuf.Any, this is a no-op.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
+ * corresponding HTTP filter.
+ * @param ns is the namespace of the dynamic metadata.
+ * @param serialized_any is the serialized google.protobuf.Any value to set.
+ */
+void envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_any);
+
+/**
  * envoy_dynamic_module_callback_http_get_metadata_string is called by the module to get
  * the string value of the dynamic metadata with the given namespace and key. If the metadata is not
  * accessible, the namespace does not exist, the key does not exist or the value is not a string,

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -4251,6 +4251,20 @@ __attribute__((weak)) void envoy_dynamic_module_callback_http_set_dynamic_metada
                "implemented in this context");
 }
 
+__attribute__((weak)) void envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_set_dynamic_metadata_struct: not "
+               "implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_http_set_dynamic_typed_metadata: not "
+               "implemented in this context");
+}
+
 __attribute__((weak)) bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr, envoy_dynamic_module_type_metadata_source,
     envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer,

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -1187,6 +1187,16 @@ pub trait EnvoyHttpFilter {
     entries: &'a [(&'a str, &'a str)],
   );
 
+  /// Set an entire dynamic metadata namespace from a serialized `google.protobuf.Struct`.
+  /// The struct is merged into the namespace and existing entries with the same key are
+  /// overwritten. A buffer that does not parse as a `google.protobuf.Struct` is a no-op.
+  fn set_dynamic_metadata_struct(&mut self, namespace: &str, serialized_struct: &[u8]);
+
+  /// Set an entire typed dynamic metadata namespace from a serialized `google.protobuf.Any`.
+  /// The Any is merged into the namespace's `typed_filter_metadata` entry. A buffer that does not
+  /// parse as a `google.protobuf.Any` is a no-op.
+  fn set_dynamic_typed_metadata(&mut self, namespace: &str, serialized_any: &[u8]);
+
   /// Get the bool-typed metadata value with the given key.
   /// Use the `source` parameter to specify which metadata to use.
   /// If the metadata is not found or is the wrong type, this returns `None`.
@@ -2711,6 +2721,26 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         str_to_module_buffer(namespace),
         pairs.as_ptr(),
         pairs.len(),
+      )
+    }
+  }
+
+  fn set_dynamic_metadata_struct(&mut self, namespace: &str, serialized_struct: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+        self.raw_ptr,
+        str_to_module_buffer(namespace),
+        bytes_to_module_buffer(serialized_struct),
+      )
+    }
+  }
+
+  fn set_dynamic_typed_metadata(&mut self, namespace: &str, serialized_any: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+        self.raw_ptr,
+        str_to_module_buffer(namespace),
+        bytes_to_module_buffer(serialized_any),
       )
     }
   }

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1263,6 +1263,47 @@ void envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(
   metadata_namespace->MergeFrom(metadata_value);
 }
 
+void envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_struct) {
+  Protobuf::Struct metadata_value;
+  if (!metadata_value.ParseFromArray(serialized_struct.ptr,
+                                     static_cast<int>(serialized_struct.length))) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+                        "envoy_dynamic_module_callback_http_set_dynamic_metadata_struct: failed to "
+                        "parse serialized google.protobuf.Struct");
+    return;
+  }
+  auto metadata_namespace = getDynamicMetadataNamespace(filter_envoy_ptr, ns);
+  if (!metadata_namespace) {
+    // If stream info is not available, we cannot guarantee that the namespace is created.
+    return;
+  }
+  metadata_namespace->MergeFrom(metadata_value);
+}
+
+void envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_any) {
+  Protobuf::Any typed_value;
+  if (!typed_value.ParseFromArray(serialized_any.ptr, static_cast<int>(serialized_any.length))) {
+    ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), error,
+                        "envoy_dynamic_module_callback_http_set_dynamic_typed_metadata: failed to "
+                        "parse serialized google.protobuf.Any");
+    return;
+  }
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  auto stream_info = filter->streamInfo();
+  if (!stream_info) {
+    // If stream info is not available, we cannot set the typed metadata.
+    return;
+  }
+  auto& typed_metadata = *stream_info->dynamicMetadata().mutable_typed_filter_metadata();
+  typed_metadata[std::string(ns.ptr, ns.length)].MergeFrom(typed_value);
+}
+
 bool envoy_dynamic_module_callback_http_get_metadata_string(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr,
     envoy_dynamic_module_type_metadata_source metadata_source,

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1560,6 +1560,9 @@ WEAK_STUB(HttpSetDynamicMetadataStringBatch,
           envoy_dynamic_module_callback_http_set_dynamic_metadata_string_batch(nullptr,
                                                                                {nullptr, 0},
                                                                                nullptr, 0))
+WEAK_STUB(HttpSetDynamicMetadataStruct,
+          envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(nullptr, {nullptr, 0},
+                                                                         {nullptr, 0}))
 WEAK_STUB(HttpGetMetadataString, envoy_dynamic_module_callback_http_get_metadata_string(
                                      nullptr, envoy_dynamic_module_type_metadata_source_Dynamic,
                                      {nullptr, 0}, {nullptr, 0}, nullptr))

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -837,6 +837,97 @@ TEST_F(DynamicModuleHttpFilterTest, DownstreamSocketOptionBytesSetFailure) {
       envoy_dynamic_module_type_socket_direction_Downstream, {value.data(), value.size()}));
 }
 
+TEST(ABIImpl, SetDynamicMetadataStruct) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  const std::string ns = "foo";
+
+  // A nested Struct ({"outer": {"inner": "value"}}) round-trips into the namespace.
+  Protobuf::Struct input;
+  Protobuf::Struct nested;
+  (*nested.mutable_fields())["inner"].set_string_value("value");
+  (*input.mutable_fields())["outer"].mutable_struct_value()->CopyFrom(nested);
+  std::string serialized;
+  ASSERT_TRUE(input.SerializeToString(&serialized));
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+      &filter, {ns.data(), ns.size()}, {serialized.data(), serialized.size()});
+
+  ASSERT_TRUE(metadata.filter_metadata().contains(ns));
+  EXPECT_EQ(metadata.filter_metadata()
+                .at(ns)
+                .fields()
+                .at("outer")
+                .struct_value()
+                .fields()
+                .at("inner")
+                .string_value(),
+            "value");
+
+  // A second struct is merged in: new keys are added, existing keys are preserved.
+  Protobuf::Struct second;
+  (*second.mutable_fields())["extra"].set_string_value("bar");
+  std::string serialized2;
+  ASSERT_TRUE(second.SerializeToString(&serialized2));
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+      &filter, {ns.data(), ns.size()}, {serialized2.data(), serialized2.size()});
+  EXPECT_EQ(metadata.filter_metadata().at(ns).fields().at("extra").string_value(), "bar");
+  EXPECT_TRUE(metadata.filter_metadata().at(ns).fields().contains("outer"));
+
+  // A buffer that does not parse as a google.protobuf.Struct is a no-op (wire type 7 is invalid).
+  const std::string garbage("\x0f", 1);
+  envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(&filter, {ns.data(), ns.size()},
+                                                                 {garbage.data(), garbage.size()});
+  EXPECT_TRUE(metadata.filter_metadata().at(ns).fields().contains("extra"));
+  EXPECT_TRUE(metadata.filter_metadata().at(ns).fields().contains("outer"));
+}
+
+TEST(ABIImpl, SetDynamicTypedMetadata) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  envoy::config::core::v3::Metadata metadata;
+  EXPECT_CALL(stream_info, dynamicMetadata()).WillRepeatedly(testing::ReturnRef(metadata));
+  EXPECT_CALL(testing::Const(stream_info), dynamicMetadata())
+      .WillRepeatedly(testing::ReturnRef(metadata));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  const std::string ns = "foo";
+
+  // A packed Any round-trips into typed_filter_metadata with its type_url preserved.
+  Protobuf::StringValue payload;
+  payload.set_value("hello");
+  Protobuf::Any any;
+  ASSERT_TRUE(any.PackFrom(payload));
+  std::string serialized;
+  ASSERT_TRUE(any.SerializeToString(&serialized));
+  envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+      &filter, {ns.data(), ns.size()}, {serialized.data(), serialized.size()});
+
+  ASSERT_TRUE(metadata.typed_filter_metadata().contains(ns));
+  Protobuf::StringValue unpacked;
+  ASSERT_TRUE(metadata.typed_filter_metadata().at(ns).UnpackTo(&unpacked));
+  EXPECT_EQ(unpacked.value(), "hello");
+
+  // A buffer that does not parse as a google.protobuf.Any is a no-op (wire type 7 is invalid).
+  const std::string garbage("\x0f", 1);
+  envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(&filter, {ns.data(), ns.size()},
+                                                                {garbage.data(), garbage.size()});
+  Protobuf::StringValue still;
+  ASSERT_TRUE(metadata.typed_filter_metadata().at(ns).UnpackTo(&still));
+  EXPECT_EQ(still.value(), "hello");
+}
+
 TEST(ABIImpl, metadata) {
   Stats::SymbolTableImpl symbol_table;
   DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -396,6 +396,17 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
     auto bytes_key = ns_req_header_bytes->second.fields().find("key");
     ASSERT_NE(bytes_key, ns_req_header_bytes->second.fields().end());
     EXPECT_EQ(bytes_key->second.string_value(), std::string("\xff\x00\xfe", 3));
+    // A whole namespace set from a serialized google.protobuf.Struct via the struct setter.
+    auto ns_req_header_struct = metadata.filter_metadata().find("ns_req_header_struct");
+    ASSERT_NE(ns_req_header_struct, metadata.filter_metadata().end());
+    auto struct_k = ns_req_header_struct->second.fields().find("k");
+    ASSERT_NE(struct_k, ns_req_header_struct->second.fields().end());
+    EXPECT_EQ(struct_k->second.string_value(), "v");
+    // A whole typed namespace set from a serialized google.protobuf.Any via the typed setter.
+    auto ns_req_header_typed = metadata.typed_filter_metadata().find("ns_req_header_typed");
+    ASSERT_NE(ns_req_header_typed, metadata.typed_filter_metadata().end());
+    EXPECT_EQ(ns_req_header_typed->second.type_url(), "t/x");
+    EXPECT_EQ(ns_req_header_typed->second.value(), std::string("\x01\x02", 2));
   }
   auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
   ASSERT_NE(ns_req_body, metadata.filter_metadata().end());

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -732,6 +732,27 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DynamicMetadataCallbacksFilter {
     // Set a non-UTF-8 byte value, asserted end-to-end by the C++ integration test in filter_test.cc.
     envoy_filter.set_dynamic_metadata_bytes("ns_req_header_bytes", "key", &[0xff, 0x00, 0xfe]);
 
+    // Set a whole namespace from a serialized google.protobuf.Struct { "k": "v" }, asserted
+    // end-to-end by the C++ integration test in filter_test.cc. The bytes are hand-encoded because
+    // the test module has no protobuf dependency:
+    //   0a 08              field 1 (fields), LEN 8
+    //     0a 01 6b           entry.key   = "k"
+    //     12 03 1a 01 76     entry.value = Value { string_value = "v" }
+    envoy_filter.set_dynamic_metadata_struct(
+      "ns_req_header_struct",
+      &[0x0a, 0x08, 0x0a, 0x01, 0x6b, 0x12, 0x03, 0x1a, 0x01, 0x76],
+    );
+
+    // Set a whole typed namespace from a serialized google.protobuf.Any, asserted end-to-end by
+    // the C++ integration test in filter_test.cc. The bytes are hand-encoded because the test
+    // module has no protobuf dependency:
+    //   0a 03 74 2f 78     field 1 (type_url) = "t/x"
+    //   12 02 01 02        field 2 (value)    = 0x01 0x02
+    envoy_filter.set_dynamic_typed_metadata(
+      "ns_req_header_typed",
+      &[0x0a, 0x03, 0x74, 0x2f, 0x78, 0x12, 0x02, 0x01, 0x02],
+    );
+
     // Try getting metadata from rotuer cluster and host.
     let metadata = envoy_filter.get_metadata_string(
       abi::envoy_dynamic_module_type_metadata_source::Route,

--- a/test/extensions/dynamic_modules/test_data/rust/http_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_test.rs
@@ -327,6 +327,24 @@ fn test_dynamic_metadata_callbacks_on_response_body() {
     })
     .return_const(())
     .once();
+  // Whole-namespace metadata from a serialized google.protobuf.Struct.
+  envoy_filter
+    .expect_set_dynamic_metadata_struct()
+    .withf(|ns, bytes| {
+      ns == "ns_req_header_struct"
+        && bytes == &[0x0a, 0x08, 0x0a, 0x01, 0x6b, 0x12, 0x03, 0x1a, 0x01, 0x76]
+    })
+    .return_const(())
+    .once();
+  // Whole-namespace typed metadata from a serialized google.protobuf.Any.
+  envoy_filter
+    .expect_set_dynamic_typed_metadata()
+    .withf(|ns, bytes| {
+      ns == "ns_req_header_typed"
+        && bytes == &[0x0a, 0x03, 0x74, 0x2f, 0x78, 0x12, 0x02, 0x01, 0x02]
+    })
+    .return_const(())
+    .once();
   // Route/Cluster/Host metadata.
   envoy_filter
     .expect_get_metadata_string()


### PR DESCRIPTION
## Description

This PR adds two HTTP-filter dynamic-module ABI callbacks that set an entire dynamic-metadata namespace in a single call, rather than only flat top-level keys as the existing `envoy_dynamic_module_callback_http_set_dynamic_metadata_string` / `_number` / `_bool` do:

- `envoy_dynamic_module_callback_http_set_dynamic_metadata_struct` - sets a namespace from a serialized `google.protobuf.Struct`, merged into `filter_metadata`.
- `envoy_dynamic_module_callback_http_set_dynamic_typed_metadata` - sets a namespace from a serialized `google.protobuf.Any`, merged into `typed_filter_metadata` via `StreamInfo::setDynamicTypedMetadata`. Unlike the Struct variant, it preserves the exact message type (through the Any `type_url`), so consumers such as `ext_authz` `typed_metadata_context_namespaces` receive the original message rather than a lossy Struct.

The Rust SDK exposes these as `EnvoyHttpFilter::set_dynamic_metadata_struct` and `EnvoyHttpFilter::set_dynamic_typed_metadata`.

---

**Commit Message:** dynamic_modules: add http set_dynamic_metadata_struct and set_dynamic_typed_metadata ABI callbacks
**Additional Description:**
**Risk Level:** Low
**Testing:** Added unit tests (`abi_impl_test`) for both callbacks
**Docs Changes:** N/A
**Release Notes:** Added (changelog entries for both callbacks)
