### PR TITLE
proto_message_extraction: use ArenaWrappedProto for extracted message

### DIFF
--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/BUILD
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     ],
     deps = [
         "//source/common/protobuf",
+        "//source/common/protobuf:arena_wrapped_proto_lib",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@proto-field-extraction//:all_libs",
     ],

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor.cc
@@ -149,13 +149,13 @@ ProtoExtractor::ExtractMessage(const Protobuf::field_extraction::MessageData& ra
   // If there are no fields to retain, no need to scrub and only populate @type
   // property.
   if (scrubber_ == nullptr) {
-    (*extracted_message_metadata.extracted_message.mutable_fields())[kTypeProperty]
+    (*extracted_message_metadata.extracted_message->mutable_fields())[kTypeProperty]
         .set_string_value(ProtobufUtil::converter::GetFullTypeWithUrl(message_type_->name()));
     return extracted_message_metadata;
   }
 
   bool success = ScrubToStruct(scrubber_.get(), *message_type_, *type_helper_, &message_copy,
-                               &extracted_message_metadata.extracted_message);
+                               extracted_message_metadata.extracted_message.get());
 
   if (!success) {
     ENVOY_LOG_MISC(debug, "Failed to extract message.");
@@ -170,7 +170,7 @@ ProtoExtractor::ExtractMessage(const Protobuf::field_extraction::MessageData& ra
     for (const std::string& path : redact_field_mask->second.paths()) {
       redact_paths_camel_case.push_back(ProtobufUtil::converter::ToCamelCase(path));
     }
-    RedactPaths(redact_paths_camel_case, &extracted_message_metadata.extracted_message);
+    RedactPaths(redact_paths_camel_case, extracted_message_metadata.extracted_message.get());
   }
   return extracted_message_metadata;
 }

--- a/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
+++ b/source/extensions/filters/http/proto_message_extraction/extraction_util/proto_extractor_interface.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "source/common/protobuf/arena_wrapped_proto.h"
 #include "source/common/protobuf/protobuf.h"
 
 #include "absl/container/flat_hash_map.h"
@@ -30,7 +31,7 @@ struct ExtractedMessageMetadata {
   std::optional<std::string> target_resource;
   std::optional<std::string> target_resource_callback;
   std::optional<std::string> resource_location;
-  Protobuf::Struct extracted_message;
+  ArenaWrappedProto<Protobuf::Struct> extracted_message;
 };
 
 // A proto-extraction interface for extracting that converts a source message

--- a/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
+++ b/source/extensions/filters/http/proto_message_extraction/extractor_impl.cc
@@ -42,15 +42,15 @@ ABSL_CONST_INIT const char* const kTypeServiceBaseUrl = "type.googleapis.com";
 void extract(ProtoExtractorInterface& extractor, Protobuf::field_extraction::MessageData& message,
              std::vector<ExtractedMessageMetadata>& vect) {
   ExtractedMessageMetadata data = extractor.ExtractMessage(message);
-  ENVOY_LOG_MISC(debug, "Extracted fields: {}", data.extracted_message.DebugString());
+  ENVOY_LOG_MISC(debug, "Extracted fields: {}", data.extracted_message->DebugString());
 
   // Only need to keep the result from the first and the last.
   // Always overwrite the 2nd result as the last one.
   if (vect.size() < 2) {
-    vect.push_back(data);
+    vect.push_back(std::move(data));
   } else {
     // copy and override the second one as the last one.
-    vect[1] = data;
+    vect[1] = std::move(data);
   }
 }
 

--- a/source/extensions/filters/http/proto_message_extraction/filter.cc
+++ b/source/extensions/filters/http/proto_message_extraction/filter.cc
@@ -220,7 +220,7 @@ Filter::HandleDataStatus Filter::handleDecodeData(Envoy::Buffer::Instance& data,
 
     extractor_->processRequest(*message_data->message());
 
-    ExtractedMessageResult result = extractor_->GetResult();
+    const ExtractedMessageResult& result = extractor_->GetResult();
 
     if (result.request_data.empty()) {
       return HandleDataStatus(Envoy::Http::FilterDataStatus::StopIterationNoBuffer);
@@ -336,7 +336,7 @@ Filter::HandleDataStatus Filter::handleEncodeData(Envoy::Buffer::Instance& data,
 
     extractor_->processResponse(*stream_message->message());
 
-    ExtractedMessageResult result = extractor_->GetResult();
+    const ExtractedMessageResult& result = extractor_->GetResult();
 
     if (result.response_data.empty()) {
       return HandleDataStatus(Envoy::Http::FilterDataStatus::StopIterationNoBuffer);
@@ -372,14 +372,14 @@ void Filter::handleRequestExtractionResult(const std::vector<ExtractedMessageMet
 
   auto addResultToMetadata = [&](const std::string& category, const std::string& key,
                                  const ExtractedMessageMetadata& metadata) {
-    RELEASE_ASSERT(metadata.extracted_message.IsInitialized(),
+    RELEASE_ASSERT(metadata.extracted_message->IsInitialized(),
                    "`extracted_message` should be initialized");
 
     auto* category_field = (*dest_metadata.mutable_fields())[category].mutable_struct_value();
 
     auto* key_field = (*category_field->mutable_fields())[key].mutable_struct_value();
 
-    for (const auto& field : metadata.extracted_message.fields()) {
+    for (const auto& field : metadata.extracted_message->fields()) {
       (*key_field->mutable_fields())[field.first] = field.second;
     }
   };
@@ -406,14 +406,14 @@ void Filter::handleResponseExtractionResult(const std::vector<ExtractedMessageMe
 
   auto addResultToMetadata = [&](const std::string& category, const std::string& key,
                                  const ExtractedMessageMetadata& metadata) {
-    RELEASE_ASSERT(metadata.extracted_message.IsInitialized(),
+    RELEASE_ASSERT(metadata.extracted_message->IsInitialized(),
                    "`extracted_message` should be initialized");
 
     auto* category_field = (*dest_metadata.mutable_fields())[category].mutable_struct_value();
 
     auto* key_field = (*category_field->mutable_fields())[key].mutable_struct_value();
 
-    for (const auto& field : metadata.extracted_message.fields()) {
+    for (const auto& field : metadata.extracted_message->fields()) {
       (*key_field->mutable_fields())[field.first] = field.second;
     }
 


### PR DESCRIPTION
Optimizes protobuf copies in Proto Message Extraction Filter by using `ArenaWrappedProto` for `ExtractedMessageMetadata`.

This change was created with the help of the Gemini AI model. I have read and understand the code.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
