### PR TITLE
mcp_transcoder: return 200 for most errors.

### DIFF
--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -592,6 +592,10 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
     // cause MCP clients to fail at the transport layer. 401 and 403 are preserved
     // as required by the MCP auth spec to drive OAuth handshake and step-up scope flows:
     // https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
+    // Note on 400 Bad Request: While the MCP authorization spec also includes HTTP 400 for
+    // certain authorization errors, we assume authorization checks (e.g., OAuth token
+    // validation) occur in filters before MCP transcoding, so any 400 error from the REST
+    // backend is assumed to be an API error and is transformed into a standard JSON-RPC error.
     if (response_code != static_cast<int>(Http::Code::Unauthorized) &&
         response_code != static_cast<int>(Http::Code::Forbidden)) {
       response_headers.setStatus(enumToInt(Http::Code::OK));
@@ -622,6 +626,10 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
     // cause MCP clients to fail at the transport layer. 401 and 403 are preserved
     // as required by the MCP auth spec to drive OAuth handshake and step-up scope flows:
     // https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
+    // Note on 400 Bad Request: While the MCP authorization spec also includes HTTP 400 for
+    // certain authorization errors, we assume authorization checks (e.g., OAuth token
+    // validation) occur in filters before MCP transcoding, so any 400 error from the REST
+    // backend is assumed to be an API error and is transformed into a standard JSON-RPC error.
     if (response_code != static_cast<int>(Http::Code::Unauthorized) &&
         response_code != static_cast<int>(Http::Code::Forbidden)) {
       response_headers.setStatus(enumToInt(Http::Code::OK));
@@ -1062,6 +1070,10 @@ void McpJsonRestBridgeFilter::encodeJsonRpcData(Http::ResponseHeaderMapOptRef re
       // cause MCP clients to fail at the transport layer. 401 and 403 are preserved
       // as required by the MCP auth spec to drive OAuth handshake and step-up scope flows:
       // https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
+      // Note on 400 Bad Request: While the MCP authorization spec also includes HTTP 400 for
+      // certain authorization errors, we assume authorization checks (e.g., OAuth token
+      // validation) occur in filters before MCP transcoding, so any 400 error from the REST
+      // backend is assumed to be an API error and is transformed into a standard JSON-RPC error.
       if (status_code != static_cast<int>(Http::Code::Unauthorized) &&
           status_code != static_cast<int>(Http::Code::Forbidden)) {
         response_headers->setStatus(enumToInt(Http::Code::OK));

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -583,20 +583,20 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
     break;
   }
 
+  const int response_code = getResponseCode(response_headers);
   // Streaming mode: pre-build the JSON-RPC prefix/suffix, strip Content-Length
   // (final size is unknown), and let the headers flow through immediately so
   // the client can start receiving data without waiting for the full body.
   if (mcp_operation_ == McpOperation::ToolsCall && text_content_streaming_enabled_) {
-    const int status_code = getResponseCode(response_headers);
     // Overwrite response code to 200 OK unless it is 401 or 403. Non-200 responses
     // cause MCP clients to fail at the transport layer. 401 and 403 are preserved
     // as required by the MCP auth spec to drive OAuth handshake and step-up scope flows:
     // https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
-    if (status_code != static_cast<int>(Http::Code::Unauthorized) &&
-        status_code != static_cast<int>(Http::Code::Forbidden)) {
+    if (response_code != static_cast<int>(Http::Code::Unauthorized) &&
+        response_code != static_cast<int>(Http::Code::Forbidden)) {
       response_headers.setStatus(enumToInt(Http::Code::OK));
     }
-    buildStreamingPrefixAndSuffix(status_code >= static_cast<int>(Http::Code::BadRequest));
+    buildStreamingPrefixAndSuffix(response_code >= static_cast<int>(Http::Code::BadRequest));
     response_headers.removeContentLength();
     response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
     return Http::FilterHeadersStatus::Continue;
@@ -605,7 +605,6 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
   if (end_stream) {
     // Backend returned a headers-only response (e.g., 204 No Content). Synthesize a JSON-RPC
     // response body so MCP clients don't hang waiting for a body that will never arrive.
-    const int response_code = getResponseCode(response_headers);
     const bool is_error = response_code >= static_cast<int>(Http::Code::BadRequest);
     std::string synthetic;
     if (mcp_operation_ == McpOperation::ToolsCall) {
@@ -619,9 +618,13 @@ McpJsonRestBridgeFilter::encodeHeaders(Http::ResponseHeaderMap& response_headers
       };
       synthetic = ret.dump();
     }
-    // HTTP/2 disallows a body on 204/304. Promote to 200 so the synthesized body can be delivered.
-    if (response_code == static_cast<int>(Http::Code::NoContent) || response_code == 304) {
-      response_headers.setStatus(static_cast<uint64_t>(Http::Code::OK));
+    // Overwrite response code to 200 OK unless it is 401 or 403. Non-200 responses
+    // cause MCP clients to fail at the transport layer. 401 and 403 are preserved
+    // as required by the MCP auth spec to drive OAuth handshake and step-up scope flows:
+    // https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
+    if (response_code != static_cast<int>(Http::Code::Unauthorized) &&
+        response_code != static_cast<int>(Http::Code::Forbidden)) {
+      response_headers.setStatus(enumToInt(Http::Code::OK));
     }
     response_headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
     response_headers.setContentLength(synthetic.size());
@@ -854,7 +857,7 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
   std::string method = json_rpc[McpConstants::METHOD_FIELD];
   if (!validateRequestMcpVersion(method, request_headers, config_->fallbackProtocolVersion())) {
     sendErrorResponse(
-        Http::Code::BadRequest, BridgeStatus::RequestUnsupportedProtocolVersion,
+        Http::Code::OK, BridgeStatus::RequestUnsupportedProtocolVersion,
         generateErrorJsonResponse(-32602, "Unsupported protocol version").dump(), nullptr, method,
         json_rpc.contains(McpConstants::PARAMS_FIELD) ? json_rpc[McpConstants::PARAMS_FIELD]
                                                       : json::object());
@@ -934,7 +937,7 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
       return;
     }
     sendErrorResponse(
-        Http::Code::BadRequest, BridgeStatus::RequestInitializeNotValid,
+        Http::Code::OK, BridgeStatus::RequestInitializeNotValid,
         generateErrorJsonResponse(-32602, "Missing valid protocolVersion in initialize "
                                           "request")
             .dump(),
@@ -962,7 +965,7 @@ void McpJsonRestBridgeFilter::handleMcpMethod(
     mapMcpToolToApiBackend(json_rpc, per_route_config);
   } else {
     sendErrorResponse(
-        Http::Code::BadRequest, BridgeStatus::RequestMethodNotSupported,
+        Http::Code::OK, BridgeStatus::RequestMethodNotSupported,
         generateErrorJsonResponse(-32601, absl::StrCat("Method ", method, " is not supported"))
             .dump(),
         nullptr, method,
@@ -1085,7 +1088,7 @@ void McpJsonRestBridgeFilter::mapMcpToolToApiBackend(
     ENVOY_STREAM_LOG(error,
                      "The tool call request is missing 'params' field or it's not an object.",
                      *decoder_callbacks_);
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestToolParamsNotFound,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestToolParamsNotFound,
                       generateErrorJsonResponse(-32602, "Invalid params").dump(), nullptr,
                       McpConstants::Methods::TOOLS_CALL, json::object());
     return;
@@ -1096,7 +1099,7 @@ void McpJsonRestBridgeFilter::mapMcpToolToApiBackend(
   if (name_it == params.end() || !name_it->is_string()) {
     ENVOY_STREAM_LOG(error, "Failed to get the name of the tool call request.",
                      *decoder_callbacks_);
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestToolNameNotFound,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestToolNameNotFound,
                       generateErrorJsonResponse(-32602, "Tool name not found").dump(), nullptr,
                       McpConstants::Methods::TOOLS_CALL, params);
     return;
@@ -1110,7 +1113,7 @@ void McpJsonRestBridgeFilter::mapMcpToolToApiBackend(
   if (!http_rule.ok()) {
     ENVOY_STREAM_LOG(error, "Failed to get http rule for method: {}", *decoder_callbacks_,
                      tool_name);
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestUnknownTool,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestUnknownTool,
                       generateErrorJsonResponse(-32602, "Unknown tool").dump(), nullptr,
                       McpConstants::Methods::TOOLS_CALL, params);
     return;
@@ -1126,7 +1129,7 @@ void McpJsonRestBridgeFilter::mapMcpToolToApiBackend(
   if (arguments_it != params.end() && !arguments_it->is_object()) {
     ENVOY_STREAM_LOG(error, "The arguments of the tool call request must be an object.",
                      *decoder_callbacks_);
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestToolArgumentsInvalid,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestToolArgumentsInvalid,
                       generateErrorJsonResponse(-32602, "Tool arguments must be an object").dump(),
                       nullptr, McpConstants::Methods::TOOLS_CALL, params);
     return;
@@ -1139,7 +1142,7 @@ void McpJsonRestBridgeFilter::mapMcpToolToApiBackend(
   if (!http_request.ok()) {
     ENVOY_STREAM_LOG(error, "Failed to build HTTP request for method: {} with status: {}",
                      *decoder_callbacks_, tool_name, http_request.status());
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestToolTranscodingFailure,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestToolTranscodingFailure,
                       generateErrorJsonResponse(-32602, "Invalid tool arguments").dump(), nullptr,
                       McpConstants::Methods::TOOLS_CALL, params);
     return;
@@ -1251,19 +1254,19 @@ absl::Status McpJsonRestBridgeFilter::validateJsonRpcIdAndMethod(const nlohmann:
     session_id_ = *session_id;
   }
   if (!json_rpc.contains(McpConstants::METHOD_FIELD)) {
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestMethodNotFound,
-                      generateErrorJsonResponse(-32601, "Missing method field").dump());
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestMethodNotFound,
+                      generateErrorJsonResponse(-32600, "Missing method field").dump());
     return absl::InvalidArgumentError("Missing method field");
   } else if (!json_rpc[McpConstants::METHOD_FIELD].is_string()) {
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestMethodNotString,
-                      generateErrorJsonResponse(-32601, "Method field is not a string").dump());
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestMethodNotString,
+                      generateErrorJsonResponse(-32600, "Method field is not a string").dump());
     return absl::InvalidArgumentError("Method field is not a string");
   } else if (json_rpc[McpConstants::METHOD_FIELD] ==
              McpConstants::Methods::NOTIFICATION_INITIALIZED) {
     // The notifications/initialized request is not required to have an ID
     // field.
   } else if (!session_id.ok()) {
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestIdNotFound,
+    sendErrorResponse(Http::Code::OK, BridgeStatus::RequestIdNotFound,
                       generateErrorJsonResponse(-32600, "Missing ID field").dump(), nullptr,
                       json_rpc[McpConstants::METHOD_FIELD].get<std::string>(),
                       json_rpc.contains(McpConstants::PARAMS_FIELD)

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -696,7 +696,7 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::encodeData(Buffer::Instance& dat
                         getResponseCode(encoder_callbacks_->responseHeaders()));
     mcp_operation_ = McpOperation::OperationFailed;
     decoder_callbacks_->sendLocalReply(
-        Http::Code::InternalServerError, error_json.dump(),
+        Http::Code::OK, error_json.dump(),
         [](Http::ResponseHeaderMap& headers) {
           headers.setContentType(Http::Headers::get().ContentTypeValues.Json);
         },

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -264,6 +264,15 @@ private:
                               const McpJsonRestBridgePerRouteConfig* per_route_config);
 
   // Handles decoding errors: sets dynamic metadata and sends a local reply.
+  // IMPORTANT PROTOCOL RULE:
+  // 1. For JSON-RPC application/protocol errors (-32600, -32601, -32602), MUST use Http::Code::OK
+  //    (200). Many MCP SDK clients inspect HTTP status before JSON-RPC decoding and will fail with
+  //    a transport exception on non-200 responses, discarding the structured JSON-RPC error
+  //    code/message.
+  // 2. Only use non-200 HTTP codes (400, 405, 413) for transport-level or framing syntax failures:
+  //    - 405 Method Not Allowed (non-POST request)
+  //    - 413 Payload Too Large (exceeding maxRequestBodySize)
+  //    - 400 Bad Request for malformed JSON syntax (-32700 parse error)
   void sendErrorResponse(
       Http::Code response_code, BridgeStatus status, absl::string_view response_body,
       std::function<void(Http::ResponseHeaderMap&)> modify_headers = nullptr,

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -269,10 +269,21 @@ private:
   //    (200). Many MCP SDK clients inspect HTTP status before JSON-RPC decoding and will fail with
   //    a transport exception on non-200 responses, discarding the structured JSON-RPC error
   //    code/message.
-  // 2. Only use non-200 HTTP codes (400, 405, 413) for transport-level or framing syntax failures:
-  //    - 405 Method Not Allowed (non-POST request)
-  //    - 413 Payload Too Large (exceeding maxRequestBodySize)
-  //    - 400 Bad Request for malformed JSON syntax (-32700 parse error)
+  // 2. Only use non-200 HTTP codes (400, 401, 403, 405, 413) in the following cases:
+  //    - Transport-level or framing syntax failures (generated locally by this filter):
+  //      * 405 Method Not Allowed (non-POST request)
+  //      * 413 Payload Too Large (exceeding maxRequestBodySize)
+  //      * 400 Bad Request for malformed JSON syntax (-32700 parse error)
+  //    - Authorization errors preserved from upstream (401 Unauthorized, 403 Forbidden):
+  //      * 401 and 403 from upstream are preserved as non-200 HTTP responses as required by the MCP
+  //        authorization spec:
+  //        https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling
+  //      * Note on 400 Bad Request: Although the MCP authorization spec also includes HTTP 400 for
+  //        certain authorization errors, we assume authorization checks (e.g., OAuth token
+  //        validation) occur in filters before MCP transcoding. Therefore, any 400 error from the
+  //        REST backend is assumed to be an API error rather than an authorization error, so the
+  //        MCP transcoder transforms the REST 400 error into a standard JSON-RPC error (with HTTP
+  //        200 OK) and does not preserve it as an authorization error.
   void sendErrorResponse(
       Http::Code response_code, BridgeStatus status, absl::string_view response_body,
       std::function<void(Http::ResponseHeaderMap&)> modify_headers = nullptr,

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -1918,7 +1918,7 @@ tool_config:
   EXPECT_CALL(
       decoder_callbacks_,
       sendLocalReply(
-          Eq(Http::Code::InternalServerError),
+          Eq(Http::Code::OK),
           StrEq(
               R"json({"error":{"code":-32000,"message":"Response body too large"},"id":123,"jsonrpc":"2.0"})json"),
           _, _, StrEq("mcp_json_rest_bridge_response_too_large")));

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -186,11 +186,9 @@ TEST_F(McpJsonRestBridgeFilterTest, MissingMethodFieldReturnsError) {
   EXPECT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
 
-  // TODO(guoyilin42): Per JSON-RPC 2.0, a missing method field is an Invalid Request (-32600);
-  // -32601 is for a well-formed request naming a nonexistent method.
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
-                             StrEq(R"json({"code":-32601,"message":"Missing method field"})json"),
+              sendLocalReply(Eq(Http::Code::OK),
+                             StrEq(R"json({"code":-32600,"message":"Missing method field"})json"),
                              _, _, StrEq("mcp_json_rest_bridge_request_method_not_found")));
 
   Protobuf::Struct expected_metadata;
@@ -211,7 +209,7 @@ TEST_F(McpJsonRestBridgeFilterTest, MissingMethodFieldReturnsError) {
   response_headers_ = {{"content-type", "text/plain"}, {"content-length", "123456"}};
   EXPECT_EQ(filter_->encodeHeaders(response_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
-  Buffer::OwnedImpl response_body(R"json({"code":-32601,"message":"Missing method field"})json");
+  Buffer::OwnedImpl response_body(R"json({"code":-32600,"message":"Missing method field"})json");
   EXPECT_EQ(filter_->encodeData(response_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
   EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
@@ -220,7 +218,7 @@ TEST_F(McpJsonRestBridgeFilterTest, MissingMethodFieldReturnsError) {
   EXPECT_EQ(
       nlohmann::json::parse(response_body.toString()),
       nlohmann::json::parse(
-          R"json({"error":{"code":-32601,"message":"Missing method field"},"id":0,"jsonrpc":"2.0"})json"));
+          R"json({"error":{"code":-32600,"message":"Missing method field"},"id":0,"jsonrpc":"2.0"})json"));
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, UnsupportedMethodReturnsError) {
@@ -233,7 +231,7 @@ TEST_F(McpJsonRestBridgeFilterTest, UnsupportedMethodReturnsError) {
   EXPECT_CALL(
       decoder_callbacks_,
       sendLocalReply(
-          Eq(Http::Code::BadRequest),
+          Eq(Http::Code::OK),
           StrEq(
               R"json({"code":-32601,"message":"Method unsupported_method is not supported"})json"),
           _, _, StrEq("mcp_json_rest_bridge_request_method_not_supported")));
@@ -279,8 +277,8 @@ TEST_F(McpJsonRestBridgeFilterTest, NonStringMethodReturnsError) {
 
   EXPECT_CALL(
       decoder_callbacks_,
-      sendLocalReply(Eq(Http::Code::BadRequest),
-                     StrEq(R"json({"code":-32601,"message":"Method field is not a string"})json"),
+      sendLocalReply(Eq(Http::Code::OK),
+                     StrEq(R"json({"code":-32600,"message":"Method field is not a string"})json"),
                      _, _, StrEq("mcp_json_rest_bridge_request_method_not_string")));
 
   Protobuf::Struct expected_metadata;
@@ -302,7 +300,7 @@ TEST_F(McpJsonRestBridgeFilterTest, NonStringMethodReturnsError) {
   EXPECT_EQ(filter_->encodeHeaders(response_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
   Buffer::OwnedImpl response_body(
-      R"json({"code":-32601,"message":"Method field is not a string"})json");
+      R"json({"code":-32600,"message":"Method field is not a string"})json");
   EXPECT_EQ(filter_->encodeData(response_body, /*end_stream=*/true),
             Http::FilterDataStatus::Continue);
   EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
@@ -311,7 +309,7 @@ TEST_F(McpJsonRestBridgeFilterTest, NonStringMethodReturnsError) {
   EXPECT_EQ(
       nlohmann::json::parse(response_body.toString()),
       nlohmann::json::parse(
-          R"json({"error":{"code":-32601,"message":"Method field is not a string"},"id":0,"jsonrpc":"2.0"})json"));
+          R"json({"error":{"code":-32600,"message":"Method field is not a string"},"id":0,"jsonrpc":"2.0"})json"));
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, MissingIdFieldReturnsError) {
@@ -322,7 +320,7 @@ TEST_F(McpJsonRestBridgeFilterTest, MissingIdFieldReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32600,"message":"Missing ID field"})json"), _, _,
                              StrEq("mcp_json_rest_bridge_request_id_not_found")));
 
@@ -397,7 +395,7 @@ TEST_F(McpJsonRestBridgeFilterTest, IdFieldWithFloatReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32600,"message":"Missing ID field"})json"), _, _,
                              StrEq("mcp_json_rest_bridge_request_id_not_found")));
 
@@ -473,7 +471,7 @@ TEST_F(McpJsonRestBridgeFilterTest, InvalidProtocolVersionParamsReturnsError) {
   EXPECT_CALL(
       decoder_callbacks_,
       sendLocalReply(
-          Eq(Http::Code::BadRequest),
+          Eq(Http::Code::OK),
           StrEq(
               R"json({"code":-32602,"message":"Missing valid protocolVersion in initialize request"})json"),
           _, _, StrEq("mcp_json_rest_bridge_request_initialize_request_not_valid")));
@@ -653,7 +651,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolNameNotFoundReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Tool name not found"})json"), _,
                              _, StrEq("mcp_json_rest_bridge_request_tool_name_not_found")));
 
@@ -697,7 +695,7 @@ TEST_F(McpJsonRestBridgeFilterTest, InvalidToolNameReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Tool name not found"})json"), _,
                              _, StrEq("mcp_json_rest_bridge_request_tool_name_not_found")));
 
@@ -746,7 +744,7 @@ TEST_F(McpJsonRestBridgeFilterTest, UnknownToolReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Unknown tool"})json"), _, _,
                              StrEq("mcp_json_rest_bridge_request_unknown_tool")));
 
@@ -795,7 +793,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolParamsNotFoundReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Invalid params"})json"), _, _,
                              StrEq("mcp_json_rest_bridge_request_tool_params_not_found")));
 
@@ -839,7 +837,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolTranscodingFailureReturnsError) {
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Invalid tool arguments"})json"),
                              _, _, StrEq("mcp_json_rest_bridge_request_tool_transcoding_failure")));
 
@@ -891,7 +889,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolArgumentsMustBeObjectReturnsError) {
 
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(
-                  Eq(Http::Code::BadRequest),
+                  Eq(Http::Code::OK),
                   StrEq(R"json({"code":-32602,"message":"Tool arguments must be an object"})json"),
                   _, _, StrEq("mcp_json_rest_bridge_request_tool_arguments_invalid")));
 
@@ -1594,7 +1592,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ProtocolVersionFallsBackToLatestSupportedWhe
 }
 
 TEST_F(McpJsonRestBridgeFilterTest,
-       NotificationsInitializedUnsupportedProtocolVersionReturnsBadRequest) {
+       NotificationsInitializedUnsupportedProtocolVersionReturnsError) {
   makeFilter();
 
   request_headers_ = {
@@ -1605,7 +1603,7 @@ TEST_F(McpJsonRestBridgeFilterTest,
 
   EXPECT_CALL(
       decoder_callbacks_,
-      sendLocalReply(Eq(Http::Code::BadRequest),
+      sendLocalReply(Eq(Http::Code::OK),
                      StrEq(R"json({"code":-32602,"message":"Unsupported protocol version"})json"),
                      _, _, StrEq("mcp_json_rest_bridge_request_unsupported_protocol_version")));
   Buffer::OwnedImpl body(R"json({"jsonrpc":"2.0","method":"notifications/initialized"})json");
@@ -1662,7 +1660,7 @@ TEST_F(McpJsonRestBridgeFilterTest,
             Http::FilterHeadersStatus::Continue);
 }
 
-TEST_F(McpJsonRestBridgeFilterTest, ToolsListUnsupportedProtocolVersionReturnsBadRequest) {
+TEST_F(McpJsonRestBridgeFilterTest, ToolsListUnsupportedProtocolVersionReturnsError) {
   makeFilter();
 
   request_headers_ = {
@@ -1672,7 +1670,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListUnsupportedProtocolVersionReturnsBa
 
   EXPECT_CALL(
       decoder_callbacks_,
-      sendLocalReply(Eq(Http::Code::BadRequest),
+      sendLocalReply(Eq(Http::Code::OK),
                      StrEq(R"json({"code":-32602,"message":"Unsupported protocol version"})json"),
                      _, _, StrEq("mcp_json_rest_bridge_request_unsupported_protocol_version")));
 
@@ -1733,7 +1731,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListSupportedProtocolVersionProcessRequ
   EXPECT_THAT(request_headers_.getMethodValue(), StrEq("GET"));
 }
 
-TEST_F(McpJsonRestBridgeFilterTest, ToolsCallUnsupportedProtocolVersionReturnsBadRequest) {
+TEST_F(McpJsonRestBridgeFilterTest, ToolsCallUnsupportedProtocolVersionReturnsError) {
   makeFilter();
 
   request_headers_ = {
@@ -1743,7 +1741,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsCallUnsupportedProtocolVersionReturnsBa
 
   EXPECT_CALL(
       decoder_callbacks_,
-      sendLocalReply(Eq(Http::Code::BadRequest),
+      sendLocalReply(Eq(Http::Code::OK),
                      StrEq(R"json({"code":-32602,"message":"Unsupported protocol version"})json"),
                      _, _, StrEq("mcp_json_rest_bridge_request_unsupported_protocol_version")));
   Buffer::OwnedImpl body(
@@ -1952,6 +1950,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolCallHeadersOnly204EmitsSyntheticSuccessR
             Http::FilterHeadersStatus::Continue);
   EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
   EXPECT_THAT(response_headers_.getContentLengthValue(), StrEq(std::to_string(expected.size())));
+  EXPECT_EQ(response_headers_.getStatusValue(), "200");
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolCallHeadersOnly5xxEmitsSyntheticErrorResult) {
@@ -1977,6 +1976,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolCallHeadersOnly5xxEmitsSyntheticErrorRes
             Http::FilterHeadersStatus::Continue);
   EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
   EXPECT_THAT(response_headers_.getContentLengthValue(), StrEq(std::to_string(expected.size())));
+  EXPECT_EQ(response_headers_.getStatusValue(), "200");
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolsListHeadersOnly204EmitsSyntheticServerError) {
@@ -2000,6 +2000,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListHeadersOnly204EmitsSyntheticServerE
             Http::FilterHeadersStatus::Continue);
   EXPECT_THAT(response_headers_.getContentTypeValue(), StrEq("application/json"));
   EXPECT_THAT(response_headers_.getContentLengthValue(), StrEq(std::to_string(expected.size())));
+  EXPECT_EQ(response_headers_.getStatusValue(), "200");
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, DynamicMetadataNotStoredWhenNotConfigured) {
@@ -2839,7 +2840,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsCallPerRouteConfigOverridesStaticTool) 
             Http::FilterHeadersStatus::StopIteration);
 
   EXPECT_CALL(decoder_callbacks_,
-              sendLocalReply(Eq(Http::Code::BadRequest),
+              sendLocalReply(Eq(Http::Code::OK),
                              StrEq(R"json({"code":-32602,"message":"Unknown tool"})json"), _, _,
                              StrEq("mcp_json_rest_bridge_request_unknown_tool")));
 

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -198,13 +198,11 @@ TEST_P(McpJsonRestBridgeIntegrationTest, MissingMethod) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
-  // TODO(guoyilin42): Per JSON-RPC 2.0, a missing method field is an Invalid Request (-32600);
-  // -32601 is for a well-formed request naming a nonexistent method.
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
-          R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Missing method field"}})json"));
+          R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Missing method field"}})json"));
 }
 
 TEST_P(McpJsonRestBridgeIntegrationTest, MethodFieldNotString) {
@@ -233,11 +231,11 @@ TEST_P(McpJsonRestBridgeIntegrationTest, MethodFieldNotString) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
-          R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method field is not a string"}})json"));
+          R"json({"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Method field is not a string"}})json"));
 }
 
 TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallInvalidParams) {
@@ -267,7 +265,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallInvalidParams) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -303,7 +301,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallNonStringToolName) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -346,7 +344,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallNonObjectArguments) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -380,7 +378,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, UnsupportedMcpProtocolVersionHeader) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -412,7 +410,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, MissingIdField) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -445,7 +443,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, UnsupportedMethod) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -481,7 +479,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, InitializeMissingProtocolVersion) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -524,7 +522,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, UnknownTool) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -571,7 +569,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, InvalidArguments) {
       request_body);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("400"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_EQ(
       nlohmann::json::parse(response->body()),
       nlohmann::json::parse(
@@ -2095,6 +2093,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallHeadersOnly5xxSyntheticErrorRe
 
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
   EXPECT_THAT(response->headers().getContentLengthValue(),
               StrEq(std::to_string(response->body().size())));

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_integration_test.cc
@@ -1032,7 +1032,7 @@ TEST_P(McpJsonRestBridgeIntegrationTest, ToolsCallResponseBodyExceedsLimit) {
   upstream_request_->encodeData(response_data, true);
 
   ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_THAT(response->headers().getStatusValue(), StrEq("500"));
+  EXPECT_THAT(response->headers().getStatusValue(), StrEq("200"));
   EXPECT_THAT(response->headers().getContentTypeValue(), StrEq("application/json"));
   EXPECT_THAT(response->headers().getContentLengthValue(),
               StrEq(std::to_string(response->body().size())));


### PR DESCRIPTION
Commit Message: mcp_transcoder: return 200 for most errors.
Additional Description:
Returns an HTTP 200 OK status code for most JSON-RPC errors. This is to prevent MCP clients from failing at the transport layer due to non-200 responses. HTTP 401 and 403 status codes are preserved as they are required by the MCP authorization specification.
Risk Level: Low
Testing: Unit and Integ tests.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A

