### PR TITLE
compat/openssl: implement `BIO_number_read()`

### DIFF
--- a/compat/openssl/BUILD
+++ b/compat/openssl/BUILD
@@ -387,6 +387,7 @@ mapping_func_filegroup(
         "BIO_new_mem_buf",
         "BIO_new_socket",
         "BIO_new",
+        "BIO_number_read",
         "BIO_pending",
         "BIO_printf",
         "BIO_puts",

--- a/compat/openssl/patch/include/openssl/bio.h.sh
+++ b/compat/openssl/patch/include/openssl/bio.h.sh
@@ -35,6 +35,7 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-decl BIO_set_mem_eof_return \
   --uncomment-func-decl BIO_s_socket \
   --uncomment-func-decl BIO_new_connect \
+  --uncomment-func-decl BIO_number_read \
   --uncomment-func-decl BIO_new_bio_pair \
   --uncomment-func-decl ERR_print_errors \
   --uncomment-func-decl BIO_ctrl \

--- a/compat/openssl/source/BIO_number_read.cc
+++ b/compat/openssl/source/BIO_number_read.cc
@@ -1,0 +1,6 @@
+#include <openssl/bio.h>
+#include <ossl.h>
+
+extern "C" uint64_t BIO_number_read(const BIO* bio) {
+  return ossl_BIO_number_read(const_cast<BIO*>(bio));
+}


### PR DESCRIPTION
PR #46010 introduced usage of `BIO_number_read()` which is not yet implemented in the OpenSSL compat layer. BoringSSL declares `BIO_number_read(const BIO*)` but OpenSSL's signature is `BIO_number_read(BIO*)` (non-const). A handwritten mapping with `const_cast` bridges the difference, following the same pattern as `BIO_pending()`.
