### PR TITLE
ci: fix `build_openssl_presubmit()` merge-base in shallow clones

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -306,9 +306,10 @@ function build_openssl_presubmit() {
     local merge_base
     if [[ -n "${CI_TARGET_BRANCH}" ]]; then
         git fetch origin "${CI_TARGET_BRANCH}" 2>/dev/null || true
-        merge_base="$(git merge-base "origin/${CI_TARGET_BRANCH}" HEAD 2>/dev/null || echo "")"
-    fi
-    if [[ -z "${merge_base}" ]]; then
+        # Shallow clones may lack enough history for merge-base;
+        # fall back to diffing against the target branch directly.
+        merge_base="$(git merge-base "origin/${CI_TARGET_BRANCH}" HEAD 2>/dev/null || echo "origin/${CI_TARGET_BRANCH}")"
+    else
         merge_base="HEAD~1"
     fi
 


### PR DESCRIPTION
The CI checkout uses `fetch-depth: 1` for PRs, so both `git merge-base` and the `HEAD~1` fallback fail silently — resulting in no changed files detected and all tests skipped.

When `merge-base` fails, fall back to diffing against `origin/${CI_TARGET_BRANCH}` directly, which compares trees without needing history traversal.
