### PR TITLE
mcp_json_rest_bridge: align BridgeStatusValues with literal strings

### DIFF
--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -185,8 +185,8 @@ absl::string_view bridgeStatusToString(BridgeStatus status) {
     return BridgeStatusValues::REQUEST_NOT_POST;
   case BridgeStatus::RequestTooLarge:
     return BridgeStatusValues::REQUEST_TOO_LARGE;
-  case BridgeStatus::RequestParseError:
-    return BridgeStatusValues::REQUEST_PARSE_ERROR;
+  case BridgeStatus::RequestFailedToParseJsonRpc:
+    return BridgeStatusValues::REQUEST_FAILED_TO_PARSE_JSON_RPC;
   case BridgeStatus::RequestUnsupportedProtocolVersion:
     return BridgeStatusValues::REQUEST_UNSUPPORTED_PROTOCOL_VERSION;
   case BridgeStatus::RequestInitializeNotValid:
@@ -217,8 +217,8 @@ absl::string_view bridgeStatusToString(BridgeStatus status) {
     return BridgeStatusValues::RESPONSE_INVALID_UTF8;
   case BridgeStatus::ResponseBackendError:
     return BridgeStatusValues::RESPONSE_BACKEND_ERROR;
-  case BridgeStatus::ResponseParseError:
-    return BridgeStatusValues::RESPONSE_PARSE_ERROR;
+  case BridgeStatus::ResponseFailedToParseJsonRpc:
+    return BridgeStatusValues::RESPONSE_FAILED_TO_PARSE_JSON_RPC;
   }
   return "UNKNOWN";
 }
@@ -547,7 +547,7 @@ Http::FilterDataStatus McpJsonRestBridgeFilter::decodeData(Buffer::Instance& dat
 
   if (request_body_json.is_discarded()) {
     ENVOY_STREAM_LOG(error, "Failed to parse JSON-RPC request body.", *decoder_callbacks_);
-    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestParseError,
+    sendErrorResponse(Http::Code::BadRequest, BridgeStatus::RequestFailedToParseJsonRpc,
                       generateErrorJsonResponse(-32700, "JSON parse error").dump());
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
@@ -965,7 +965,7 @@ void McpJsonRestBridgeFilter::encodeJsonRpcData(Http::ResponseHeaderMapOptRef re
       setResponseMetadata(getResponseCode(response_headers) >=
                                   static_cast<int>(Http::Code::BadRequest)
                               ? BridgeStatus::ResponseBackendError
-                              : BridgeStatus::ResponseParseError,
+                              : BridgeStatus::ResponseFailedToParseJsonRpc,
                           getResponseCode(response_headers));
       break;
     }

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.h
@@ -48,7 +48,7 @@ enum class BridgeStatus {
   Ok,
   RequestNotPost,
   RequestTooLarge,
-  RequestParseError,
+  RequestFailedToParseJsonRpc,
   RequestUnsupportedProtocolVersion,
   RequestInitializeNotValid,
   RequestMethodNotSupported,
@@ -64,7 +64,7 @@ enum class BridgeStatus {
   ResponseTooLarge,
   ResponseInvalidUtf8,
   ResponseBackendError,
-  ResponseParseError,
+  ResponseFailedToParseJsonRpc,
 };
 
 absl::string_view bridgeStatusToString(BridgeStatus status);
@@ -74,12 +74,12 @@ inline constexpr absl::string_view STATUS = "status";
 inline constexpr absl::string_view OK = "mcp_json_rest_bridge_ok";
 inline constexpr absl::string_view REQUEST_NOT_POST = "mcp_json_rest_bridge_request_not_post";
 inline constexpr absl::string_view REQUEST_TOO_LARGE = "mcp_json_rest_bridge_request_too_large";
-inline constexpr absl::string_view REQUEST_PARSE_ERROR =
+inline constexpr absl::string_view REQUEST_FAILED_TO_PARSE_JSON_RPC =
     "mcp_json_rest_bridge_request_failed_to_parse_json_rpc";
 inline constexpr absl::string_view REQUEST_UNSUPPORTED_PROTOCOL_VERSION =
     "mcp_json_rest_bridge_request_unsupported_protocol_version";
 inline constexpr absl::string_view REQUEST_INITIALIZE_NOT_VALID =
-    "mcp_json_rest_bridge_request_initialize_request_not_valid";
+    "mcp_json_rest_bridge_request_initialize_not_valid";
 inline constexpr absl::string_view REQUEST_METHOD_NOT_SUPPORTED =
     "mcp_json_rest_bridge_request_method_not_supported";
 inline constexpr absl::string_view REQUEST_METHOD_NOT_FOUND =
@@ -104,7 +104,7 @@ inline constexpr absl::string_view RESPONSE_INVALID_UTF8 =
     "mcp_json_rest_bridge_response_invalid_utf8";
 inline constexpr absl::string_view RESPONSE_BACKEND_ERROR =
     "mcp_json_rest_bridge_response_backend_error";
-inline constexpr absl::string_view RESPONSE_PARSE_ERROR =
+inline constexpr absl::string_view RESPONSE_FAILED_TO_PARSE_JSON_RPC =
     "mcp_json_rest_bridge_response_failed_to_parse_json";
 } // namespace BridgeStatusValues
 

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -473,11 +473,11 @@ TEST_F(McpJsonRestBridgeFilterTest, InvalidProtocolVersionParamsReturnsError) {
           Eq(Http::Code::BadRequest),
           StrEq(
               R"json({"code":-32602,"message":"Missing valid protocolVersion in initialize request"})json"),
-          _, _, StrEq("mcp_json_rest_bridge_request_initialize_request_not_valid")));
+          _, _, StrEq("mcp_json_rest_bridge_request_initialize_not_valid")));
 
   Protobuf::Struct expected_metadata;
   MessageUtil::loadFromJson(R"json({
-    "status": "mcp_json_rest_bridge_request_initialize_request_not_valid",
+    "status": "mcp_json_rest_bridge_request_initialize_not_valid",
     "method": "initialize",
     "params": {
       "protocolVersion": 123


### PR DESCRIPTION
Commit Message: align BridgeStatusValues with literal strings

Additional Description: some of the enums and literal strings for the bridge status did not match. since this is new code, it is better to fix that now.

Risk Level: low

Testing: unit tests pass