### PR TITLE
bazel/ci: Prevent unnecessary redownloads of LLVM

### DIFF
--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -66,6 +66,9 @@ def envoy_toolchains():
     llvm_toolchain(
         name = "llvm_toolchain",
         llvm_version = LLVM_VERSION,
+        # NOTE: This MUST remain stable for Envoy CI to prevent redownload of the LLVM binaries due to
+        #   mismatched OS data between cache/host/workers
+        exec_os = None if LLVM_PATH else "linux",
         extra_llvm_distributions = {
             "LLVM-22.1.8-Linux-ARM64.tar.xz": "805efad2bb91cb4967fa569e0881d10c0f69c04461cf671cccbae19f547acc34",
             "LLVM-22.1.8-Linux-X64.tar.xz": "df0e1ecf16caf3489a272a5eea4eec9b0d82878f6477fa309504f918a0006384",


### PR DESCRIPTION
this should provide a massive speedup for CI

