### PR TITLE
tls: share the builtin stat name set across all TLS contexts

### DIFF
--- a/contrib/golang/filters/http/test/golang_integration_test.cc
+++ b/contrib/golang/filters/http/test/golang_integration_test.cc
@@ -970,7 +970,8 @@ typed_config:
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("http"));
     auto client_transport_socket_factory_ptr = Ssl::createClientSslTransportSocketFactory(
-        Ssl::ClientSslTransportOptions(), *ssl_context_manager_, *api_);
+        Ssl::ClientSslTransportOptions(), *ssl_context_manager_, *api_,
+        &server_factory_context_.serverScope());
     return dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),
         client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);

--- a/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
+++ b/contrib/mysql_proxy/filters/network/test/mysql_ssl_integration_test.cc
@@ -99,7 +99,8 @@ public:
 
     tls_context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
         server_factory_context_);
-    tls_context_ = Ssl::createClientSslTransportSocketFactory({}, *tls_context_manager_, *api_);
+    tls_context_ = Ssl::createClientSslTransportSocketFactory(
+        {}, *tls_context_manager_, *api_, &server_factory_context_.serverScope());
 
     payload_reader_ = std::make_shared<WaitForPayloadReader>(*dispatcher_);
 
@@ -678,7 +679,8 @@ public:
 
     tls_context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
         server_factory_context_);
-    tls_context_ = Ssl::createClientSslTransportSocketFactory({}, *tls_context_manager_, *api_);
+    tls_context_ = Ssl::createClientSslTransportSocketFactory(
+        {}, *tls_context_manager_, *api_, &server_factory_context_.serverScope());
 
     payload_reader_ = std::make_shared<WaitForPayloadReader>(*dispatcher_);
 

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -357,11 +357,10 @@ public:
     ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         downstream_tls_context, mock_factory_ctx, {}, false);
-    static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
     Network::DownstreamTransportSocketFactoryPtr tls_context =
         Network::DownstreamTransportSocketFactoryPtr{
             *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-                std::move(cfg), *tls_context_manager, *(client_stats_store->rootScope()))};
+                std::move(cfg), *tls_context_manager, server_factory_context_.serverScope())};
 
     Network::TransportSocketPtr ts = tls_context->createDownstreamTransportSocket();
     // Synchronization object used to suspend execution
@@ -576,11 +575,10 @@ public:
     ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     auto cfg = *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(
         upstream_tls_context, mock_factory_ctx);
-    static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
     Network::UpstreamTransportSocketFactoryPtr tls_context =
         Network::UpstreamTransportSocketFactoryPtr{
             *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-                std::move(cfg), *tls_context_manager, *(client_stats_store->rootScope()))};
+                std::move(cfg), *tls_context_manager, server_factory_context_.serverScope())};
 
     Network::TransportSocketOptionsConstSharedPtr options;
 

--- a/mobile/test/common/integration/test_server.cc
+++ b/mobile/test/common/integration/test_server.cc
@@ -347,9 +347,8 @@ Network::DownstreamTransportSocketFactoryPtr TestServer::createUpstreamTlsContex
   }
   auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       tls_context, factory_context, {}, false);
-  static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
   return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-      std::move(cfg), context_manager_, *upstream_stats_store->rootScope());
+      std::move(cfg), context_manager_, *stats_store_.rootScope());
 }
 
 } // namespace Envoy

--- a/mobile/test/common/integration/test_server.h
+++ b/mobile/test/common/integration/test_server.h
@@ -72,7 +72,7 @@ public:
 private:
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  Stats::IsolatedStoreImpl stats_store_;
+  Stats::IsolatedStoreImpl stats_store_{server_factory_context_.serverScope().symbolTable()};
   Event::GlobalTimeSystem time_system_;
   Api::ApiPtr api_;
   Network::Address::IpVersion version_;

--- a/mobile/test/common/integration/xds_test_server.h
+++ b/mobile/test/common/integration/xds_test_server.h
@@ -37,7 +37,7 @@ public:
 private:
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  Stats::IsolatedStoreImpl stats_store_;
+  Stats::IsolatedStoreImpl stats_store_{server_factory_context_.serverScope().symbolTable()};
   Event::GlobalTimeSystem time_system_;
   Api::ApiPtr api_;
   Network::Address::IpVersion version_;

--- a/source/common/tls/BUILD
+++ b/source/common/tls/BUILD
@@ -185,6 +185,8 @@ envoy_cc_library(
         ":cert_compression_lib",
         ":stats_lib",
         ":utility_lib",
+        "//envoy/singleton:instance_interface",
+        "//envoy/singleton:manager_interface",
         "//envoy/ssl:context_config_interface",
         "//envoy/ssl:context_interface",
         "//envoy/ssl:context_manager_interface",

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -13,6 +13,7 @@
 #include "envoy/admin/v3/certs.pb.h"
 #include "envoy/common/exception.h"
 #include "envoy/common/platform.h"
+#include "envoy/singleton/manager.h"
 #include "envoy/ssl/ssl_socket_extended_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/type/matcher/v3/string.pb.h"
@@ -59,6 +60,57 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
+SINGLETON_MANAGER_REGISTRATION(tls_builtin_stat_names);
+
+TlsBuiltinStatNames::TlsBuiltinStatNames(Stats::SymbolTable& symbol_table)
+    : stat_name_set_(symbol_table.makeSet("TransportSockets::Tls")),
+      unknown_ssl_cipher_(stat_name_set_->add("unknown_ssl_cipher")),
+      unknown_ssl_curve_(stat_name_set_->add("unknown_ssl_curve")),
+      unknown_ssl_algorithm_(stat_name_set_->add("unknown_ssl_algorithm")),
+      unknown_ssl_version_(stat_name_set_->add("unknown_ssl_version")),
+      ssl_ciphers_(stat_name_set_->add("ssl.ciphers")),
+      ssl_versions_(stat_name_set_->add("ssl.versions")),
+      ssl_curves_(stat_name_set_->add("ssl.curves")),
+      ssl_sigalgs_(stat_name_set_->add("ssl.sigalgs")) {
+  // Register stat names based on lists reported by BoringSSL. These are compile-time constant
+  // tables, so the resulting set is identical for every TLS context in the process.
+  std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));
+  SSL_get_all_cipher_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_curve_names(nullptr, 0));
+  SSL_get_all_curve_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_signature_algorithm_names(nullptr, 0));
+  SSL_get_all_signature_algorithm_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_version_names(nullptr, 0));
+  SSL_get_all_version_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+}
+
+namespace {
+// Returns the server-wide shared TLS builtin stat names, creating them on first use. The set is
+// owned by the singleton manager (per-server, hence tied to a single symbol table) and kept alive
+// by the returned shared_ptr held by each ContextImpl.
+std::shared_ptr<TlsBuiltinStatNames>
+getTlsBuiltinStatNames(Stats::Scope& scope,
+                       Server::Configuration::CommonFactoryContext& factory_context) {
+  // Share the singleton set when scope shares the server's SymbolTable. Unit tests using isolated
+  // test scopes allocate a separate TlsBuiltinStatNames on scope.symbolTable() for SymbolTable
+  // safety.
+  if (&scope.symbolTable() == &factory_context.serverScope().symbolTable()) {
+    return factory_context.singletonManager().getTyped<TlsBuiltinStatNames>(
+        SINGLETON_MANAGER_REGISTERED_NAME(tls_builtin_stat_names), [&factory_context] {
+          return std::make_shared<TlsBuiltinStatNames>(factory_context.serverScope().symbolTable());
+        });
+  }
+  return std::make_shared<TlsBuiltinStatNames>(scope.symbolTable());
+}
+} // namespace
+
 int ContextImpl::sslExtendedSocketInfoIndex() {
   CONSTRUCT_ON_FIRST_USE(int, []() -> int {
     int ssl_context_index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
@@ -74,16 +126,9 @@ ContextImpl::ContextImpl(
     Ssl::ContextAdditionalInitFunc additional_init, absl::Status& creation_status)
     : scope_(scope), stats_(generateSslStats(scope)), factory_context_(factory_context),
       tls_max_version_(config.maxProtocolVersion()),
-      stat_name_set_(scope.symbolTable().makeSet("TransportSockets::Tls")),
-      unknown_ssl_cipher_(stat_name_set_->add("unknown_ssl_cipher")),
-      unknown_ssl_curve_(stat_name_set_->add("unknown_ssl_curve")),
-      unknown_ssl_algorithm_(stat_name_set_->add("unknown_ssl_algorithm")),
-      unknown_ssl_version_(stat_name_set_->add("unknown_ssl_version")),
-      ssl_ciphers_(stat_name_set_->add("ssl.ciphers")),
-      ssl_versions_(stat_name_set_->add("ssl.versions")),
-      ssl_curves_(stat_name_set_->add("ssl.curves")),
-      ssl_sigalgs_(stat_name_set_->add("ssl.sigalgs")), capabilities_(config.capabilities()),
-      tls_keylog_local_(config.tlsKeyLogLocal()), tls_keylog_remote_(config.tlsKeyLogRemote()) {
+      builtin_stat_names_(getTlsBuiltinStatNames(scope, factory_context)),
+      capabilities_(config.capabilities()), tls_keylog_local_(config.tlsKeyLogLocal()),
+      tls_keylog_remote_(config.tlsKeyLogRemote()) {
 
   auto cert_validator_name = getCertValidatorName(config.certificateValidationContext());
   auto cert_validator_factory =
@@ -332,23 +377,6 @@ ContextImpl::ContextImpl(
   parsed_alpn_protocols_ = parseAlpnProtocols(config.alpnProtocols(), creation_status);
   RETURN_ONLY_IF_NOT_OK_REF(creation_status);
 
-  // Register stat names based on lists reported by BoringSSL.
-  std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));
-  SSL_get_all_cipher_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_curve_names(nullptr, 0));
-  SSL_get_all_curve_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_signature_algorithm_names(nullptr, 0));
-  SSL_get_all_signature_algorithm_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_version_names(nullptr, 0));
-  SSL_get_all_version_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
   // As late as possible, run the custom SSL_CTX configuration callback on each
   // SSL_CTX, if set.
   if (auto sslctx_cb = config.sslctxCb(); sslctx_cb) {
@@ -563,7 +591,8 @@ ValidationResults ContextImpl::customVerifyCertChain(
 
 void ContextImpl::incCounter(const Stats::StatName name, absl::string_view value,
                              const Stats::StatName fallback) const {
-  const Stats::StatName value_stat_name = stat_name_set_->getBuiltin(value, fallback);
+  const Stats::StatName value_stat_name =
+      builtin_stat_names_->statNameSet().getBuiltin(value, fallback);
   ENVOY_BUG(value_stat_name != fallback,
             absl::StrCat("Unexpected ", scope_.symbolTable().toString(name), " value: ", value));
   Stats::Utility::counterFromElements(scope_, {name, value_stat_name}).inc();
@@ -576,18 +605,22 @@ void ContextImpl::logHandshake(SSL* ssl) const {
     stats_.session_reused_.inc();
   }
 
-  incCounter(ssl_ciphers_, SSL_get_cipher_name(ssl), unknown_ssl_cipher_);
-  incCounter(ssl_versions_, SSL_get_version(ssl), unknown_ssl_version_);
+  incCounter(builtin_stat_names_->ssl_ciphers_, SSL_get_cipher_name(ssl),
+             builtin_stat_names_->unknown_ssl_cipher_);
+  incCounter(builtin_stat_names_->ssl_versions_, SSL_get_version(ssl),
+             builtin_stat_names_->unknown_ssl_version_);
 
   const uint16_t curve_id = SSL_get_curve_id(ssl);
   if (curve_id) {
-    incCounter(ssl_curves_, SSL_get_curve_name(curve_id), unknown_ssl_curve_);
+    incCounter(builtin_stat_names_->ssl_curves_, SSL_get_curve_name(curve_id),
+               builtin_stat_names_->unknown_ssl_curve_);
   }
 
   const uint16_t sigalg_id = SSL_get_peer_signature_algorithm(ssl);
   if (sigalg_id) {
     const char* sigalg = SSL_get_signature_algorithm_name(sigalg_id, 1 /* include curve */);
-    incCounter(ssl_sigalgs_, sigalg, unknown_ssl_algorithm_);
+    incCounter(builtin_stat_names_->ssl_sigalgs_, sigalg,
+               builtin_stat_names_->unknown_ssl_algorithm_);
   }
 
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));

--- a/source/common/tls/context_impl.cc
+++ b/source/common/tls/context_impl.cc
@@ -13,6 +13,7 @@
 #include "envoy/admin/v3/certs.pb.h"
 #include "envoy/common/exception.h"
 #include "envoy/common/platform.h"
+#include "envoy/singleton/manager.h"
 #include "envoy/ssl/ssl_socket_extended_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/type/matcher/v3/string.pb.h"
@@ -59,6 +60,50 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
+SINGLETON_MANAGER_REGISTRATION(tls_builtin_stat_names);
+
+TlsBuiltinStatNames::TlsBuiltinStatNames(Stats::SymbolTable& symbol_table)
+    : stat_name_set_(symbol_table.makeSet("TransportSockets::Tls")),
+      unknown_ssl_cipher_(stat_name_set_->add("unknown_ssl_cipher")),
+      unknown_ssl_curve_(stat_name_set_->add("unknown_ssl_curve")),
+      unknown_ssl_algorithm_(stat_name_set_->add("unknown_ssl_algorithm")),
+      unknown_ssl_version_(stat_name_set_->add("unknown_ssl_version")),
+      ssl_ciphers_(stat_name_set_->add("ssl.ciphers")),
+      ssl_versions_(stat_name_set_->add("ssl.versions")),
+      ssl_curves_(stat_name_set_->add("ssl.curves")),
+      ssl_sigalgs_(stat_name_set_->add("ssl.sigalgs")) {
+  // Register stat names based on lists reported by BoringSSL. These are compile-time constant
+  // tables, so the resulting set is identical for every TLS context in the process.
+  std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));
+  SSL_get_all_cipher_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_curve_names(nullptr, 0));
+  SSL_get_all_curve_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_signature_algorithm_names(nullptr, 0));
+  SSL_get_all_signature_algorithm_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+
+  list.resize(SSL_get_all_version_names(nullptr, 0));
+  SSL_get_all_version_names(list.data(), list.size());
+  stat_name_set_->rememberBuiltins(list);
+}
+
+namespace {
+// Returns the server-wide shared TLS builtin stat names, creating them on first use. The set is
+// owned by the singleton manager (per-server, hence tied to a single symbol table) and kept alive
+// by the returned shared_ptr held by each ContextImpl.
+std::shared_ptr<TlsBuiltinStatNames>
+getTlsBuiltinStatNames(Server::Configuration::CommonFactoryContext& factory_context) {
+  return factory_context.singletonManager().getTyped<TlsBuiltinStatNames>(
+      SINGLETON_MANAGER_REGISTERED_NAME(tls_builtin_stat_names), [&factory_context] {
+        return std::make_shared<TlsBuiltinStatNames>(factory_context.serverScope().symbolTable());
+      });
+}
+} // namespace
+
 int ContextImpl::sslExtendedSocketInfoIndex() {
   CONSTRUCT_ON_FIRST_USE(int, []() -> int {
     int ssl_context_index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
@@ -74,16 +119,9 @@ ContextImpl::ContextImpl(
     Ssl::ContextAdditionalInitFunc additional_init, absl::Status& creation_status)
     : scope_(scope), stats_(generateSslStats(scope)), factory_context_(factory_context),
       tls_max_version_(config.maxProtocolVersion()),
-      stat_name_set_(scope.symbolTable().makeSet("TransportSockets::Tls")),
-      unknown_ssl_cipher_(stat_name_set_->add("unknown_ssl_cipher")),
-      unknown_ssl_curve_(stat_name_set_->add("unknown_ssl_curve")),
-      unknown_ssl_algorithm_(stat_name_set_->add("unknown_ssl_algorithm")),
-      unknown_ssl_version_(stat_name_set_->add("unknown_ssl_version")),
-      ssl_ciphers_(stat_name_set_->add("ssl.ciphers")),
-      ssl_versions_(stat_name_set_->add("ssl.versions")),
-      ssl_curves_(stat_name_set_->add("ssl.curves")),
-      ssl_sigalgs_(stat_name_set_->add("ssl.sigalgs")), capabilities_(config.capabilities()),
-      tls_keylog_local_(config.tlsKeyLogLocal()), tls_keylog_remote_(config.tlsKeyLogRemote()) {
+      builtin_stat_names_(getTlsBuiltinStatNames(factory_context)),
+      capabilities_(config.capabilities()), tls_keylog_local_(config.tlsKeyLogLocal()),
+      tls_keylog_remote_(config.tlsKeyLogRemote()) {
 
   auto cert_validator_name = getCertValidatorName(config.certificateValidationContext());
   auto cert_validator_factory =
@@ -332,23 +370,6 @@ ContextImpl::ContextImpl(
   parsed_alpn_protocols_ = parseAlpnProtocols(config.alpnProtocols(), creation_status);
   RETURN_ONLY_IF_NOT_OK_REF(creation_status);
 
-  // Register stat names based on lists reported by BoringSSL.
-  std::vector<const char*> list(SSL_get_all_cipher_names(nullptr, 0));
-  SSL_get_all_cipher_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_curve_names(nullptr, 0));
-  SSL_get_all_curve_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_signature_algorithm_names(nullptr, 0));
-  SSL_get_all_signature_algorithm_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
-  list.resize(SSL_get_all_version_names(nullptr, 0));
-  SSL_get_all_version_names(list.data(), list.size());
-  stat_name_set_->rememberBuiltins(list);
-
   // As late as possible, run the custom SSL_CTX configuration callback on each
   // SSL_CTX, if set.
   if (auto sslctx_cb = config.sslctxCb(); sslctx_cb) {
@@ -563,7 +584,8 @@ ValidationResults ContextImpl::customVerifyCertChain(
 
 void ContextImpl::incCounter(const Stats::StatName name, absl::string_view value,
                              const Stats::StatName fallback) const {
-  const Stats::StatName value_stat_name = stat_name_set_->getBuiltin(value, fallback);
+  const Stats::StatName value_stat_name =
+      builtin_stat_names_->statNameSet().getBuiltin(value, fallback);
   ENVOY_BUG(value_stat_name != fallback,
             absl::StrCat("Unexpected ", scope_.symbolTable().toString(name), " value: ", value));
   Stats::Utility::counterFromElements(scope_, {name, value_stat_name}).inc();
@@ -576,18 +598,22 @@ void ContextImpl::logHandshake(SSL* ssl) const {
     stats_.session_reused_.inc();
   }
 
-  incCounter(ssl_ciphers_, SSL_get_cipher_name(ssl), unknown_ssl_cipher_);
-  incCounter(ssl_versions_, SSL_get_version(ssl), unknown_ssl_version_);
+  incCounter(builtin_stat_names_->ssl_ciphers_, SSL_get_cipher_name(ssl),
+             builtin_stat_names_->unknown_ssl_cipher_);
+  incCounter(builtin_stat_names_->ssl_versions_, SSL_get_version(ssl),
+             builtin_stat_names_->unknown_ssl_version_);
 
   const uint16_t curve_id = SSL_get_curve_id(ssl);
   if (curve_id) {
-    incCounter(ssl_curves_, SSL_get_curve_name(curve_id), unknown_ssl_curve_);
+    incCounter(builtin_stat_names_->ssl_curves_, SSL_get_curve_name(curve_id),
+               builtin_stat_names_->unknown_ssl_curve_);
   }
 
   const uint16_t sigalg_id = SSL_get_peer_signature_algorithm(ssl);
   if (sigalg_id) {
     const char* sigalg = SSL_get_signature_algorithm_name(sigalg_id, 1 /* include curve */);
-    incCounter(ssl_sigalgs_, sigalg, unknown_ssl_algorithm_);
+    incCounter(builtin_stat_names_->ssl_sigalgs_, sigalg,
+               builtin_stat_names_->unknown_ssl_algorithm_);
   }
 
   bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl));

--- a/source/common/tls/context_impl.h
+++ b/source/common/tls/context_impl.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "envoy/network/transport_socket.h"
+#include "envoy/singleton/instance.h"
 #include "envoy/ssl/context.h"
 #include "envoy/ssl/context_config.h"
 #include "envoy/ssl/private_key/private_key.h"
@@ -78,6 +79,30 @@ struct TlsContext {
 namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
+
+// The TLS stat name builtins (BoringSSL cipher/curve/signature algorithm/version names, plus the
+// fixed prefixes and "unknown" fallbacks) are identical for every TLS context. Interning
+// them into a per-context StatNameSet duplicated ~150 locked symbol-table encodes and a
+// builtin map per context, and repeated it on every SDS certificate rotation. Instead we
+// build the set once per server and share it via the singleton manager. The set is fully
+// populated at construction and immutable thereafter, so the lock-free getBuiltin() reads
+// performed on worker threads remain safe.
+class TlsBuiltinStatNames : public Singleton::Instance {
+public:
+  explicit TlsBuiltinStatNames(Stats::SymbolTable& symbol_table);
+
+  Stats::StatNameSet& statNameSet() const { return *stat_name_set_; }
+
+  const Stats::StatNameSetPtr stat_name_set_;
+  const Stats::StatName unknown_ssl_cipher_;
+  const Stats::StatName unknown_ssl_curve_;
+  const Stats::StatName unknown_ssl_algorithm_;
+  const Stats::StatName unknown_ssl_version_;
+  const Stats::StatName ssl_ciphers_;
+  const Stats::StatName ssl_versions_;
+  const Stats::StatName ssl_curves_;
+  const Stats::StatName ssl_sigalgs_;
+};
 
 class ContextImpl : public virtual Envoy::Ssl::Context,
                     protected Logger::Loggable<Logger::Id::config> {
@@ -172,15 +197,8 @@ protected:
   std::string cert_chain_file_path_;
   Server::Configuration::CommonFactoryContext& factory_context_;
   const unsigned tls_max_version_;
-  mutable Stats::StatNameSetPtr stat_name_set_;
-  const Stats::StatName unknown_ssl_cipher_;
-  const Stats::StatName unknown_ssl_curve_;
-  const Stats::StatName unknown_ssl_algorithm_;
-  const Stats::StatName unknown_ssl_version_;
-  const Stats::StatName ssl_ciphers_;
-  const Stats::StatName ssl_versions_;
-  const Stats::StatName ssl_curves_;
-  const Stats::StatName ssl_sigalgs_;
+  // Server-wide shared TLS stat name builtins, kept alive for this context's lifetime.
+  const std::shared_ptr<TlsBuiltinStatNames> builtin_stat_names_;
   const Ssl::HandshakerCapabilities capabilities_;
   const Network::Address::IpList tls_keylog_local_;
   const Network::Address::IpList tls_keylog_remote_;

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -714,7 +714,7 @@ public:
 
     mock_host_description_->socket_factory_ =
         *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-            std::move(cfg), context_manager_, *stats_store_.rootScope());
+            std::move(cfg), context_manager_, server_factory_context_.serverScope());
     async_client_transport_socket_ =
         mock_host_description_->socket_factory_->createTransportSocket(nullptr, nullptr);
     FakeUpstreamConfig config(time_system_);
@@ -751,9 +751,8 @@ public:
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
 
-    static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope());
+        std::move(cfg), context_manager_, server_factory_context_.serverScope());
   }
 
   bool use_client_cert_{};

--- a/test/common/http/conn_pool_grid_test.cc
+++ b/test/common/http/conn_pool_grid_test.cc
@@ -233,7 +233,8 @@ public:
   std::shared_ptr<Upstream::MockClusterInfo> cluster_{new NiceMock<Upstream::MockClusterInfo>()};
   NiceMock<Random::MockRandomGenerator> random_;
   HttpServerPropertiesCacheSharedPtr alternate_protocols_;
-  Stats::IsolatedStoreImpl store_;
+  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
+  Stats::IsolatedStoreImpl store_{factory_context_.server_context_.serverScope().symbolTable()};
   Quic::QuicStatNames quic_stat_names_;
   PersistentQuicInfoPtr quic_connection_persistent_info_;
   NiceMock<Envoy::ConnectionPool::MockCancellable> cancel_;
@@ -246,7 +247,6 @@ public:
 
   StreamInfo::MockStreamInfo info_;
   NiceMock<MockRequestEncoder> encoder_;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
   NiceMock<Event::MockDispatcher> dispatcher_;
 

--- a/test/common/http/http3/conn_pool_test.cc
+++ b/test/common/http/http3/conn_pool_test.cc
@@ -110,7 +110,7 @@ public:
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   Ssl::ClientContextSharedPtr ssl_context_{new NiceMock<Ssl::MockClientContext>()};
-  Stats::IsolatedStoreImpl store_;
+  Stats::IsolatedStoreImpl store_{context_.server_context_.serverScope().symbolTable()};
   Quic::QuicStatNames quic_stat_names_{store_.symbolTable()};
   // Needs to out-live pool_;
   Quic::TestNetworkObserverRegistry observers_;

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -119,7 +119,7 @@ protected:
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   std::shared_ptr<quic::QuicCryptoClientConfig> crypto_config_;
-  Stats::IsolatedStoreImpl store_;
+  Stats::IsolatedStoreImpl store_{context_.server_context_.serverScope().symbolTable()};
   QuicStatNames quic_stat_names_{store_.symbolTable()};
   quic::DeterministicConnectionIdGenerator connection_id_generator_{
       quic::kQuicDefaultConnectionIdLength};

--- a/test/common/quic/envoy_quic_proof_source_test.cc
+++ b/test/common/quic/envoy_quic_proof_source_test.cc
@@ -258,7 +258,7 @@ protected:
   Network::MockFilterChainManager filter_chain_manager_;
   Network::MockListenSocket listen_socket_;
   testing::NiceMock<Network::MockListenerConfig> listener_config_;
-  Server::Configuration::MockServerFactoryContext factory_context_;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   Extensions::TransportSockets::Tls::ContextManagerImpl ssl_context_manager_{factory_context_};
   Ssl::MockServerContextConfig* mock_context_config_;
   std::function<absl::Status()> secret_update_callback_;

--- a/test/common/quic/envoy_quic_proof_verifier_test.cc
+++ b/test/common/quic/envoy_quic_proof_verifier_test.cc
@@ -105,7 +105,7 @@ protected:
   std::optional<envoy::config::core::v3::TypedExtensionConfig> custom_validator_config_{
       std::nullopt};
   NiceMock<Stats::MockStore> store_;
-  Server::Configuration::MockServerFactoryContext factory_context_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> factory_context_;
   NiceMock<Ssl::MockClientContextConfig> client_context_config_;
   Ssl::MockCertificateValidationContextConfig cert_validation_ctx_config_;
   std::unique_ptr<EnvoyQuicProofVerifier> verifier_;

--- a/test/common/quic/quic_transport_socket_factory_test.cc
+++ b/test/common/quic/quic_transport_socket_factory_test.cc
@@ -288,9 +288,10 @@ public:
     return Ssl::ClientContextSharedPtr(std::move(*context_or_error));
   }
 
+  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   // Declared before factory_ so the store (and its symbol table) outlives the contexts created
   // from it, which the factory retains until destruction.
-  Stats::IsolatedStoreImpl store_;
+  Stats::IsolatedStoreImpl store_{context_.server_context_.serverScope().symbolTable()};
   NiceMock<Ssl::MockClientContextConfig> real_context_config_;
   NiceMock<Ssl::MockTlsCertificateConfig> tls_cert_config_;
   std::vector<std::reference_wrapper<const Envoy::Ssl::TlsCertificateConfig>> tls_cert_configs_;
@@ -302,7 +303,6 @@ public:
   const std::string test_private_key_{quic::test::kTestCertificatePrivateKeyPem};
 
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
-  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context_;
   std::unique_ptr<Quic::QuicClientTransportSocketFactory> factory_;
   // Will be owned by factory_.
   NiceMock<Ssl::MockClientContextConfig>* context_config_{

--- a/test/common/tls/cert_validator/default_validator_integration_test.cc
+++ b/test/common/tls/cert_validator/default_validator_integration_test.cc
@@ -36,8 +36,8 @@ SslCertValidatorIntegrationTest::makeSslClientConnection(const ClientSslTranspor
   modified_options.setClientWithIntermediateCert(true);
 
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
-  auto client_transport_socket_factory_ptr =
-      createClientSslTransportSocketFactory(modified_options, *context_manager_, *api_);
+  auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
+      modified_options, *context_manager_, *api_, &server_factory_context_.serverScope());
   return dispatcher_->createClientConnection(
       address, Network::Address::InstanceConstSharedPtr(),
       client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);

--- a/test/common/tls/client_context_config_impl_test.cc
+++ b/test/common/tls/client_context_config_impl_test.cc
@@ -61,8 +61,7 @@ public:
     }};
   }
 
-  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  ContextManagerImpl manager_{server_factory_context_};
+  ContextManagerImpl manager_{factory_context_.server_context_};
 };
 
 // Validate that empty SNI (according to C string rules) fails config validation.
@@ -85,8 +84,7 @@ TEST_F(ClientContextConfigImplTest, AutoSniSanValidationWithoutValidationContext
   tls_context.set_auto_sni_san_validation(true);
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context);
-  Stats::IsolatedStoreImpl store;
-  EXPECT_EQ(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_EQ(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                 .status()
                 .message(),
             "'auto_sni_san_validation' was configured without a validation context");
@@ -103,8 +101,7 @@ TEST_F(ClientContextConfigImplTest, AutoSniSanValidationWithoutTrustedCa) {
                                          CertificateValidationContext::ACCEPT_UNTRUSTED);
   NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context;
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context);
-  Stats::IsolatedStoreImpl store;
-  EXPECT_EQ(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_EQ(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                 .status()
                 .message(),
             "'auto_sni_san_validation' was configured without configuring a trusted CA");
@@ -120,8 +117,7 @@ TEST_F(ClientContextConfigImplTest, InvalidCertificateHash) {
       ->add_verify_certificate_hash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context);
-  Stats::IsolatedStoreImpl store;
-  EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_THAT(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::MatchesRegex("Invalid hex-encoded SHA-256 .*"));
@@ -136,8 +132,7 @@ TEST_F(ClientContextConfigImplTest, InvalidCertificateSpki) {
       // Not a base64-encoded string.
       ->add_verify_certificate_spki("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context);
-  Stats::IsolatedStoreImpl store;
-  EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_THAT(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::MatchesRegex("Invalid base64-encoded SHA-256 .*"));
@@ -155,8 +150,7 @@ TEST_F(ClientContextConfigImplTest, RSA2048Cert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -173,14 +167,13 @@ TEST_F(ClientContextConfigImplTest, RSA1024Cert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
 
   std::string error_msg(absl::StrCat(
       "Failed to load certificate chain from .*selfsigned_rsa_1024_cert.pem, only RSA "
       "certificates ",
       (FIPS_mode() ? "with 2048-bit, 3072-bit or 4096-bit keys are supported in FIPS mode"
                    : "with 2048-bit or larger keys are supported")));
-  EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_THAT(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::MatchesRegex(error_msg));
@@ -196,14 +189,13 @@ TEST_F(ClientContextConfigImplTest, RSA1024Pkcs12) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
 
   std::string error_msg(absl::StrCat(
       "Failed to load certificate chain from .*selfsigned_rsa_1024_certkey.p12, "
       "only RSA certificates ",
       (FIPS_mode() ? "with 2048-bit, 3072-bit or 4096-bit keys are supported in FIPS mode"
                    : "with 2048-bit or larger keys are supported")));
-  EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_THAT(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::MatchesRegex(error_msg));
@@ -221,9 +213,7 @@ TEST_F(ClientContextConfigImplTest, RSA3072Cert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  ContextManagerImpl manager(server_factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -240,8 +230,7 @@ TEST_F(ClientContextConfigImplTest, RSA4096Cert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -258,8 +247,7 @@ TEST_F(ClientContextConfigImplTest, P256EcdsaCert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -276,8 +264,7 @@ TEST_F(ClientContextConfigImplTest, P384EcdsaCert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -292,7 +279,6 @@ TEST_F(ClientContextConfigImplTest, P384EcdsaPkcs12) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
 }
 
 TEST_F(ClientContextConfigImplTest, P521EcdsaCert) {
@@ -306,8 +292,7 @@ TEST_F(ClientContextConfigImplTest, P521EcdsaCert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
-  auto context_or = manager_.createSslClientContext(*store.rootScope(), *client_context_config);
+  auto context_or = manager_.createSslClientContext(*store_.rootScope(), *client_context_config);
   EXPECT_OK(context_or);
   auto cleanup = cleanUpHelper(*context_or);
 }
@@ -324,10 +309,9 @@ TEST_F(ClientContextConfigImplTest, UnsupportedCurveEcdsaCert) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_certificate_yaml),
                             *tls_context.mutable_common_tls_context()->add_tls_certificates());
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
-  Stats::IsolatedStoreImpl store;
   // Envoy has logic to reject P-224, but newer versions of BoringSSL reject it in `SSL_CTX`
   // before Envoy's logic runs. This test expectation is written to accept both paths.
-  EXPECT_THAT(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_THAT(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                   .status()
                   .message(),
               testing::ContainsRegex(
@@ -552,8 +536,7 @@ TEST_F(ClientContextConfigImplTest, PasswordWrongPkcs12) {
   EXPECT_OK(factory_context_.server_context_.secretManager().addStaticSecret(secret_config));
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
 
-  Stats::IsolatedStoreImpl store;
-  EXPECT_EQ(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_EQ(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                 .status()
                 .message(),
             absl::StrCat("Failed to load pkcs12 from ", pkcs12_path));
@@ -581,8 +564,7 @@ TEST_F(ClientContextConfigImplTest, PasswordNotSuppliedPkcs12) {
   EXPECT_OK(factory_context_.server_context_.secretManager().addStaticSecret(secret_config));
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
 
-  Stats::IsolatedStoreImpl store;
-  EXPECT_EQ(manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+  EXPECT_EQ(manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
                 .status()
                 .message(),
             absl::StrCat("Failed to load pkcs12 from ", pkcs12_path));
@@ -613,9 +595,8 @@ TEST_F(ClientContextConfigImplTest, PasswordNotSuppliedTlsCertificates) {
   EXPECT_OK(factory_context_.server_context_.secretManager().addStaticSecret(secret_config));
   auto client_context_config = *ClientContextConfigImpl::create(tls_context, factory_context_);
 
-  Stats::IsolatedStoreImpl store;
   EXPECT_THAT(
-      manager_.createSslClientContext(*store.rootScope(), *client_context_config)
+      manager_.createSslClientContext(*store_.rootScope(), *client_context_config)
           .status()
           .message(),
       testing::ContainsRegex(absl::StrCat("Failed to load private key from ", private_key_path)));

--- a/test/common/tls/context_impl_test.cc
+++ b/test/common/tls/context_impl_test.cc
@@ -1648,9 +1648,8 @@ TEST_F(ServerContextConfigImplTest, TlsCertificateNonEmpty) {
   tls_context.mutable_common_tls_context()->add_tls_certificates();
   auto server_context_config =
       *ServerContextConfigImpl::create(tls_context, factory_context_, {}, false);
-  ContextManagerImpl manager(server_factory_context_);
-  Stats::IsolatedStoreImpl store;
-  EXPECT_EQ(manager.createSslServerContext(*store.rootScope(), *server_context_config, nullptr)
+  ContextManagerImpl manager(factory_context_.server_context_);
+  EXPECT_EQ(manager.createSslServerContext(*store_.rootScope(), *server_context_config, nullptr)
                 .status()
                 .message(),
             "Server TlsCertificates must have a certificate specified");
@@ -1752,12 +1751,11 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoProviderFallbac
 TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoMethod) {
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
   tls_context.mutable_common_tls_context()->add_tls_certificates();
-  Stats::IsolatedStoreImpl store;
   NiceMock<Ssl::MockContextManager> context_manager;
   NiceMock<Ssl::MockPrivateKeyMethodManager> private_key_method_manager;
   auto private_key_method_provider_ptr =
       std::make_shared<NiceMock<Ssl::MockPrivateKeyMethodProvider>>();
-  ContextManagerImpl manager(server_factory_context_);
+  ContextManagerImpl manager(factory_context_.server_context_);
   EXPECT_CALL(factory_context_.server_context_, sslContextManager())
       .WillOnce(ReturnRef(context_manager));
   EXPECT_CALL(context_manager, privateKeyMethodManager())
@@ -1780,7 +1778,7 @@ TEST_F(ServerContextConfigImplTest, PrivateKeyMethodLoadFailureNoMethod) {
   TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
   auto server_context_config =
       *ServerContextConfigImpl::create(tls_context, factory_context_, {}, false);
-  EXPECT_EQ(manager.createSslServerContext(*store.rootScope(), *server_context_config, nullptr)
+  EXPECT_EQ(manager.createSslServerContext(*store_.rootScope(), *server_context_config, nullptr)
                 .status()
                 .message(),
             "Failed to get BoringSSL private key method from provider");

--- a/test/common/tls/handshaker_factory_test.cc
+++ b/test/common/tls/handshaker_factory_test.cc
@@ -107,7 +107,7 @@ protected:
   }
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  Stats::IsolatedStoreImpl stats_store_;
+  Stats::IsolatedStoreImpl stats_store_{server_factory_context_.serverScope().symbolTable()};
   std::unique_ptr<Extensions::TransportSockets::Tls::ContextManagerImpl> context_manager_;
   HandshakerFactoryImplForTest handshaker_factory_;
   Registry::InjectFactory<Ssl::HandshakerFactory> registered_factory_;
@@ -260,7 +260,7 @@ protected:
   }
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context_;
-  Stats::IsolatedStoreImpl stats_store_;
+  Stats::IsolatedStoreImpl stats_store_{server_factory_context_.serverScope().symbolTable()};
   std::unique_ptr<Extensions::TransportSockets::Tls::ContextManagerImpl> context_manager_;
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context_;
   Ssl::HandshakerCapabilities capabilities_;

--- a/test/common/tls/integration/ssl_integration_test.cc
+++ b/test/common/tls/integration/ssl_integration_test.cc
@@ -496,7 +496,7 @@ typed_config:
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
   auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
       ClientSslTransportOptions().setCustomCertValidatorConfig(custom_validator_config.get()),
-      *context_manager_, *api_);
+      *context_manager_, *api_, &server_factory_context_.serverScope());
   Network::ClientConnectionPtr connection = dispatcher_->createClientConnection(
       address, Network::Address::InstanceConstSharedPtr(),
       client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);
@@ -552,7 +552,7 @@ typed_config:
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
   auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
       ClientSslTransportOptions().setCustomCertValidatorConfig(custom_validator_config.get()),
-      *context_manager_, *api_);
+      *context_manager_, *api_, &server_factory_context_.serverScope());
   Network::ClientConnectionPtr connection = dispatcher_->createClientConnection(
       address, Network::Address::InstanceConstSharedPtr(),
       client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);
@@ -602,7 +602,7 @@ typed_config:
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
   auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
       ClientSslTransportOptions().setCustomCertValidatorConfig(custom_validator_config.get()),
-      *context_manager_, *api_);
+      *context_manager_, *api_, &server_factory_context_.serverScope());
   Network::ClientConnectionPtr connection = dispatcher_->createClientConnection(
       address, Network::Address::InstanceConstSharedPtr(),
       client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);
@@ -649,8 +649,8 @@ protected:
       return false;
     };
 
-    auto client_transport_socket_factory_ptr =
-        createClientSslTransportSocketFactory({}, *context_manager_, *api_);
+    auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
+        {}, *context_manager_, *api_, &server_factory_context_.serverScope());
     std::string response;
     auto connection = createConnectionDriver(
         lookupPort("http"), write_request_cb,

--- a/test/common/tls/integration/ssl_integration_test_base.cc
+++ b/test/common/tls/integration/ssl_integration_test_base.cc
@@ -52,8 +52,8 @@ SslIntegrationTestBase::makeSslClientConnection(const ClientSslTransportOptions&
     ENVOY_LOG_MISC(debug, "Executing {}", s_client_cmd);
     RELEASE_ASSERT(::system(s_client_cmd.c_str()) == 0, "");
   }
-  auto client_transport_socket_factory_ptr =
-      createClientSslTransportSocketFactory(options, *context_manager_, *api_);
+  auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
+      options, *context_manager_, *api_, &server_factory_context_.serverScope());
   return dispatcher_->createClientConnection(
       address, Network::Address::InstanceConstSharedPtr(),
       client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);

--- a/test/common/tls/integration/ssl_upstream_integration_test.cc
+++ b/test/common/tls/integration/ssl_upstream_integration_test.cc
@@ -188,10 +188,9 @@ public:
     auto cfg_or_error = Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
     RELEASE_ASSERT(cfg_or_error.ok(), std::string(cfg_or_error.status().message()));
-    auto cfg = std::move(*cfg_or_error);
-    static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     auto factory_or_error = Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), BaseIntegrationTest::context_manager_, *upstream_stats_store->rootScope());
+        std::move(*cfg_or_error), BaseIntegrationTest::context_manager_,
+        server_factory_context_.serverScope());
     RELEASE_ASSERT(factory_or_error.ok(), std::string(factory_or_error.status().message()));
     return std::move(*factory_or_error);
   }

--- a/test/common/tls/ssl_certs_test.h
+++ b/test/common/tls/ssl_certs_test.h
@@ -17,7 +17,7 @@ protected:
 
   Event::SimulatedTimeSystem time_system_;
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
-  Stats::IsolatedStoreImpl store_;
+  Stats::IsolatedStoreImpl store_{factory_context_.server_context_.serverScope().symbolTable()};
   Api::ApiPtr api_;
 };
 } // namespace Envoy

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -4816,7 +4816,7 @@ void testSupportForSessionResumption(const std::string& server_ctx_yaml,
   NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
   ContextManagerImpl manager(server_factory_context);
 
-  Stats::IsolatedStoreImpl server_stats_store;
+  Stats::IsolatedStoreImpl server_stats_store(server_factory_context.serverScope().symbolTable());
   Api::ApiPtr server_api = Api::createApiForTest(server_stats_store, time_system);
   NiceMock<Runtime::MockLoader> runtime;
   ON_CALL(transport_socket_factory_context.server_context_, api())
@@ -4842,7 +4842,7 @@ void testSupportForSessionResumption(const std::string& server_ctx_yaml,
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client_tls_context;
   TestUtility::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), client_tls_context);
 
-  Stats::IsolatedStoreImpl client_stats_store;
+  Stats::IsolatedStoreImpl client_stats_store(server_factory_context.serverScope().symbolTable());
   Api::ApiPtr client_api = Api::createApiForTest(client_stats_store, time_system);
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
       client_factory_context;

--- a/test/common/tls/tls_certificate_selector_test.cc
+++ b/test/common/tls/tls_certificate_selector_test.cc
@@ -258,8 +258,10 @@ protected:
     const std::string server_ctx_yaml = upstream ? ctx_yaml : absl::StrCat(ctx_yaml, selector_yaml);
     const std::string client_ctx_yaml = upstream ? absl::StrCat(ctx_yaml, selector_yaml) : ctx_yaml;
 
+    NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
     Event::SimulatedTimeSystem time_system;
-    Stats::TestUtil::TestStore server_stats_store;
+    Stats::TestUtil::TestStore server_stats_store(
+        server_factory_context.serverScope().symbolTable());
     Api::ApiPtr server_api = Api::createApiForTest(server_stats_store, time_system);
     NiceMock<Runtime::MockLoader> runtime;
     testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
@@ -287,7 +289,6 @@ protected:
     Event::DispatcherPtr dispatcher = server_api->allocateDispatcher("test_thread");
     provider_factory_.mod_ = mod;
 
-    NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
     Tls::ContextManagerImpl manager(server_factory_context);
     auto server_ssl_socket_factory = *ServerSslSocketFactory::create(
         std::move(server_cfg), manager, *server_stats_store.rootScope());
@@ -304,7 +305,8 @@ protected:
     envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext client_tls_context;
     TestUtility::loadFromYaml(TestEnvironment::substitute(client_ctx_yaml), client_tls_context);
 
-    Stats::TestUtil::TestStore client_stats_store;
+    Stats::TestUtil::TestStore client_stats_store(
+        server_factory_context.serverScope().symbolTable());
     Api::ApiPtr client_api = Api::createApiForTest(client_stats_store, time_system);
     testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext>
         client_factory_context;

--- a/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
+++ b/test/extensions/access_loggers/grpc/tcp_grpc_access_log_integration_test.cc
@@ -158,7 +158,8 @@ public:
         server_factory_context_);
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("tcp_proxy"));
-    context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+    context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                          &server_factory_context_.serverScope());
     Network::TransportSocketPtr transport_socket;
     transport_socket =
         context_->createTransportSocket(std::make_shared<Network::TransportSocketOptionsImpl>(

--- a/test/extensions/filters/http/router/auto_sni_integration_test.cc
+++ b/test/extensions/filters/http/router/auto_sni_integration_test.cc
@@ -73,9 +73,8 @@ public:
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
 
-    static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope());
+        std::move(cfg), context_manager_, server_factory_context_.serverScope());
   }
 };
 

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -190,7 +190,8 @@ typed_config:
     // Set up the SSL client.
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("echo"));
-    context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+    context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                          &server_factory_context_.serverScope());
     Network::TransportSocketPtr transport_socket;
     if (ssl_client) {
       transport_socket =
@@ -271,8 +272,8 @@ TEST_P(TlsInspectorIntegrationTest, TlsInspectorMetadataPopulatedInAccessLog) {
       false, false, false);
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(version_, lookupPort("echo"));
-  context_ =
-      Ssl::createClientSslTransportSocketFactory(/*ssl_options=*/{}, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(
+      /*ssl_options=*/{}, *context_manager_, *api_, &server_factory_context_.serverScope());
   auto transport_socket_factory = std::make_unique<Network::RawBufferSocketFactory>();
   Network::TransportSocketPtr transport_socket =
       transport_socket_factory->createTransportSocket(nullptr, nullptr);
@@ -381,7 +382,8 @@ TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanGrow) {
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
   const std::string really_long_sni(absl::StrCat(std::string(240, 'a'), ".foo.com"));
   ssl_options.setSni(really_long_sni);
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
   Network::TransportSocketPtr transport_socket = context_->createTransportSocket(
       std::make_shared<Network::TransportSocketOptionsImpl>(
           absl::string_view(""), std::vector<std::string>(), std::vector<std::string>{"envoyalpn"}),
@@ -420,7 +422,8 @@ TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanStartBig) {
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
   const std::string really_long_sni(absl::StrCat(std::string(240, 'a'), ".foo.com"));
   ssl_options.setSni(really_long_sni);
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
   Network::TransportSocketPtr transport_socket = context_->createTransportSocket(
       std::make_shared<Network::TransportSocketOptionsImpl>(
           absl::string_view(""), std::vector<std::string>(), std::vector<std::string>{}),
@@ -480,7 +483,8 @@ TEST_P(TlsInspectorIntegrationTest, JA4FingerprintWithMalformedClientHello) {
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
   ssl_options.setSni("example.com");
 
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(version_, lookupPort("echo"));
 
@@ -543,7 +547,8 @@ TEST_P(TlsInspectorIntegrationTest, JA4FingerprintWithSpecialALPN) {
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
   ssl_options.setSni("example.com");
 
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(version_, lookupPort("echo"));
 
@@ -598,7 +603,8 @@ TEST_P(TlsInspectorIntegrationTest, JA4FingerprintWithMinimalExtensions) {
   ssl_options.setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
   // No SNI set
 
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
   Network::Address::InstanceConstSharedPtr address =
       Ssl::getSslAddress(version_, lookupPort("echo"));
 
@@ -635,7 +641,8 @@ TEST_P(TlsInspectorIntegrationTest, SniCapturedOnFilterChainNotFound) {
 
   Ssl::ClientSslTransportOptions ssl_options;
   ssl_options.setSni(test_sni);
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
 
   // Use ALPN that doesn't match the filter chain.
   Network::TransportSocketPtr transport_socket = context_->createTransportSocket(

--- a/test/extensions/filters/network/ext_authz/ext_authz_integration_test.cc
+++ b/test/extensions/filters/network/ext_authz/ext_authz_integration_test.cc
@@ -106,7 +106,8 @@ public:
     payload_reader_ = std::make_shared<WaitForPayloadReader>(*dispatcher_);
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("tcp_proxy"));
-    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_);
+    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_,
+                                                          &server_factory_context_.serverScope());
     ssl_client_ = dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),
         context_->createTransportSocket(nullptr, nullptr), nullptr, nullptr);

--- a/test/extensions/filters/network/set_filter_state/integration_test.cc
+++ b/test/extensions/filters/network/set_filter_state/integration_test.cc
@@ -132,8 +132,8 @@ public:
   }
 
   Network::ClientConnectionPtr makeTlsClientConnection() {
-    auto client_transport_socket_factory =
-        Ssl::createClientSslTransportSocketFactory(/*options=*/{}, context_manager_, *api_);
+    auto client_transport_socket_factory = Ssl::createClientSslTransportSocketFactory(
+        /*options=*/{}, context_manager_, *api_, &server_factory_context_.serverScope());
     auto address = Ssl::getSslAddress(version_, lookupPort("listener_0"));
     return dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),

--- a/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
+++ b/test/extensions/filters/network/sni_dynamic_forward_proxy/proxy_filter_integration_test.cc
@@ -107,8 +107,8 @@ typed_config:
 
     Network::Address::InstanceConstSharedPtr address =
         Ssl::getSslAddress(version_, lookupPort("http"));
-    auto client_transport_socket_factory_ptr =
-        Ssl::createClientSslTransportSocketFactory(options, context_manager_, *api_);
+    auto client_transport_socket_factory_ptr = Ssl::createClientSslTransportSocketFactory(
+        options, context_manager_, *api_, &server_factory_context_.serverScope());
     return dispatcher_->createClientConnection(
         address, Network::Address::InstanceConstSharedPtr(),
         client_transport_socket_factory_ptr->createTransportSocket({}, nullptr), nullptr, nullptr);

--- a/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/starttls_integration_test.cc
@@ -214,7 +214,8 @@ void StartTlsIntegrationTest::initialize() {
   // Setup factories and contexts for tls transport socket.
   tls_context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
       server_factory_context_);
-  tls_context_ = Ssl::createClientSslTransportSocketFactory({}, *tls_context_manager_, *api_);
+  tls_context_ = Ssl::createClientSslTransportSocketFactory({}, *tls_context_manager_, *api_,
+                                                            &server_factory_context_.serverScope());
   payload_reader_ = std::make_shared<WaitForPayloadReader>(*dispatcher_);
 
   BaseIntegrationTest::initialize();

--- a/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
+++ b/test/extensions/transport_sockets/starttls/upstream_starttls_integration_test.cc
@@ -276,10 +276,9 @@ void StartTlsIntegrationTest::initialize() {
   ON_CALL(mock_factory_ctx.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
   auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       downstream_tls_context, mock_factory_ctx, {}, false);
-  static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   tls_context_ = Network::DownstreamTransportSocketFactoryPtr{
       *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-          std::move(cfg), *tls_context_manager_, *client_stats_store->rootScope())};
+          std::move(cfg), *tls_context_manager_, server_factory_context_.serverScope())};
 
   BaseIntegrationTest::initialize();
 }

--- a/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_validator/spiffe/spiffe_validator_integration_test.cc
@@ -44,8 +44,8 @@ Network::ClientConnectionPtr SslSPIFFECertValidatorIntegrationTest::makeSslClien
   modified_options.setCustomCertValidatorConfig(client_validator_config_);
 
   Network::Address::InstanceConstSharedPtr address = getSslAddress(version_, lookupPort("http"));
-  auto client_transport_socket_factory_ptr =
-      createClientSslTransportSocketFactory(modified_options, *context_manager_, *api_);
+  auto client_transport_socket_factory_ptr = createClientSslTransportSocketFactory(
+      modified_options, *context_manager_, *api_, &server_factory_context_.serverScope());
   Network::TransportSocketOptionsConstSharedPtr socket_options;
   if (workload_trust_domain) {
     StreamInfo::FilterStateImpl filter_state(StreamInfo::FilterState::LifeSpan::Connection);

--- a/test/integration/alpn_selection_integration_test.cc
+++ b/test/integration/alpn_selection_integration_test.cc
@@ -70,9 +70,8 @@ require_client_certificate: true
     TestUtility::loadFromYaml(yaml, tls_context);
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
-    static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
     return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope());
+        std::move(cfg), context_manager_, server_factory_context_.serverScope());
   }
 
   void createUpstreams() override {

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -164,9 +164,8 @@ BaseIntegrationTest::createUpstreamTlsContext(const FakeUpstreamConfig& upstream
   if (upstream_config.upstream_protocol_ != Http::CodecType::HTTP3) {
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
-    static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), context_manager_, *upstream_stats_store->rootScope());
+        std::move(cfg), context_manager_, server_factory_context_.serverScope());
   } else {
     envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport quic_config;
     quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
@@ -610,7 +609,8 @@ void BaseIntegrationTest::createXdsUpstream() {
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
 
-    upstream_stats_store_ = std::make_unique<Stats::TestIsolatedStoreImpl>();
+    upstream_stats_store_ = std::make_unique<Stats::TestIsolatedStoreImpl>(
+        server_factory_context_.serverScope().symbolTable());
     auto context = *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
         std::move(cfg), context_manager_, *upstream_stats_store_->rootScope());
     addFakeUpstream(std::move(context), Http::CodecType::HTTP2, /*autonomous_upstream=*/false);

--- a/test/integration/listener_crl_share_integration_test.cc
+++ b/test/integration/listener_crl_share_integration_test.cc
@@ -99,7 +99,7 @@ public:
         tls_context, factory_context_);
     return Network::UpstreamTransportSocketFactoryPtr{
         *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-            std::move(config), context_manager_, *client_stats_store_.rootScope())};
+            std::move(config), context_manager_, server_factory_context_.serverScope())};
   }
 
   // Attempts an mTLS handshake to the named listener with the given client factory and returns
@@ -133,7 +133,6 @@ public:
 
   const std::string listener_a_{"crl_listener_a"};
   const std::string listener_b_{"crl_listener_b"};
-  Stats::TestIsolatedStoreImpl client_stats_store_;
   testing::NiceMock<Server::Configuration::MockTransportSocketFactoryContext> factory_context_;
 };
 

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -277,7 +277,8 @@ public:
     });
 
     HttpIntegrationTest::initialize();
-    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_);
+    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_,
+                                                            &server_factory_context_.serverScope());
   }
 
   void configToUseSds(
@@ -651,7 +652,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
       ClientSslTransportOptions()
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-ECDSA-AES128-GCM-SHA256"}),
-      context_manager_, *api_);
+      context_manager_, *api_, &server_factory_context_.serverScope());
   testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   cleanupUpstreamAndDownstream();
@@ -659,7 +660,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, DualCert) {
       ClientSslTransportOptions()
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"}),
-      context_manager_, *api_);
+      context_manager_, *api_, &server_factory_context_.serverScope());
   testRouterHeaderOnlyRequestAndResponse(&creator, dataPlaneUpstreamIndex());
 
   // Success
@@ -700,7 +701,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, MultipleCerts) {
           .setSni("www.lyft.com")
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"}),
-      context_manager_, *api_);
+      context_manager_, *api_, &server_factory_context_.serverScope());
   auto ssl_client1 = makeSslClientConnection();
   codec_client_ = makeRawHttpConnection(std::move(ssl_client1), std::nullopt);
   EXPECT_TRUE(codec_client_->connected());
@@ -718,7 +719,7 @@ TEST_P(SdsDynamicDownstreamIntegrationTest, MultipleCerts) {
           .setSni("www.lyft2.com")
           .setTlsVersion(envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2)
           .setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"}),
-      context_manager_, *api_);
+      context_manager_, *api_, &server_factory_context_.serverScope());
   auto ssl_client2 = makeSslClientConnection();
   codec_client_ = makeRawHttpConnection(std::move(ssl_client2), std::nullopt);
   EXPECT_TRUE(codec_client_->connected());
@@ -862,7 +863,8 @@ public:
 
     HttpIntegrationTest::initialize();
     registerTestServerPorts({"http"});
-    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_);
+    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_,
+                                                            &server_factory_context_.serverScope());
   }
 
   void configureInlinedCerts(
@@ -912,9 +914,8 @@ public:
 
     auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
         tls_context, factory_context_, {}, false);
-    static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
     return Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-               std::move(cfg), context_manager_, *upstream_stats_store->rootScope())
+               std::move(cfg), context_manager_, server_factory_context_.serverScope())
         .value();
   }
 
@@ -1095,7 +1096,8 @@ public:
     // SDS cluster for the first cluster.
     addFakeUpstream(Http::CodecType::HTTP2);
     // FakeUpstream with SSL/TLS for the second cluster.
-    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_, test_quic_),
+    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_, test_quic_,
+                                             &server_factory_context_.serverScope()),
                     upstreamProtocol(), /*autonomous_upstream=*/false);
     xds_upstream_ = fake_upstreams_.front().get();
   }

--- a/test/integration/sds_static_integration_test.cc
+++ b/test/integration/sds_static_integration_test.cc
@@ -71,7 +71,8 @@ public:
 
     registerTestServerPorts({"http"});
 
-    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_);
+    client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_,
+                                                            &server_factory_context_.serverScope());
   }
 
   void TearDown() override {
@@ -142,8 +143,9 @@ public:
   }
 
   void createUpstreams() override {
-    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_), Http::CodecType::HTTP1,
-                    /*autonomous_upstream=*/false);
+    addFakeUpstream(createUpstreamSslContext(context_manager_, *api_, false,
+                                             &server_factory_context_.serverScope()),
+                    Http::CodecType::HTTP1, /*autonomous_upstream=*/false);
   }
 
 private:

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -296,6 +296,9 @@ private:
  */
 class TestIsolatedStoreImpl : public StoreRoot {
 public:
+  TestIsolatedStoreImpl() = default;
+  explicit TestIsolatedStoreImpl(SymbolTable& symbol_table) : store_(symbol_table) {}
+
   // Stats::Store
   void forEachCounter(Stats::SizeFn f_size, StatFn<Counter> f_stat) const override {
     Thread::LockGuard lock(lock_);

--- a/test/integration/ssl_utility.cc
+++ b/test/integration/ssl_utility.cc
@@ -111,7 +111,8 @@ void initializeUpstreamTlsContextConfig(
 
 Network::UpstreamTransportSocketFactoryPtr
 createClientSslTransportSocketFactory(const ClientSslTransportOptions& options,
-                                      ContextManager& context_manager, Api::Api& api) {
+                                      ContextManager& context_manager, Api::Api& api,
+                                      Stats::Scope* stats_scope) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
   initializeUpstreamTlsContextConfig(options, tls_context);
 #ifdef ENVOY_ENABLE_YAML
@@ -126,14 +127,16 @@ createClientSslTransportSocketFactory(const ClientSslTransportOptions& options,
   auto cfg = *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(tls_context,
                                                                                  mock_factory_ctx);
   static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
+  Stats::Scope& scope = stats_scope != nullptr ? *stats_scope : *client_stats_store->rootScope();
   return Network::UpstreamTransportSocketFactoryPtr{
       THROW_OR_RETURN_VALUE(Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-                                std::move(cfg), context_manager, *client_stats_store->rootScope()),
+                                std::move(cfg), context_manager, scope),
                             Network::UpstreamTransportSocketFactoryPtr)};
 }
 
 Network::DownstreamTransportSocketFactoryPtr
-createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool use_http3) {
+createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool use_http3,
+                         Stats::Scope* stats_scope) {
   envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
   ConfigHelper::initializeTls({}, *tls_context.mutable_common_tls_context(), use_http3);
 
@@ -144,14 +147,14 @@ createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool us
       tls_context, mock_factory_ctx, server_names, false);
 
   static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
+  Stats::Scope& scope = stats_scope != nullptr ? *stats_scope : *upstream_stats_store->rootScope();
   if (!use_http3) {
     return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-        std::move(cfg), context_manager, *upstream_stats_store->rootScope());
+        std::move(cfg), context_manager, scope);
   }
   envoy::extensions::transport_sockets::quic::v3::QuicDownstreamTransport quic_config;
   quic_config.mutable_downstream_tls_context()->MergeFrom(tls_context);
-  ON_CALL(mock_factory_ctx, statsScope())
-      .WillByDefault(ReturnRef(*upstream_stats_store->rootScope()));
+  ON_CALL(mock_factory_ctx, statsScope()).WillByDefault(ReturnRef(scope));
   ON_CALL(mock_factory_ctx.server_context_, sslContextManager())
       .WillByDefault(ReturnRef(context_manager));
 
@@ -175,9 +178,8 @@ Network::DownstreamTransportSocketFactoryPtr createFakeUpstreamSslContext(
   auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       tls_context, factory_context, {}, false);
 
-  static auto* upstream_stats_store = new Stats::IsolatedStoreImpl();
   return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-      std::move(cfg), context_manager, *upstream_stats_store->rootScope());
+      std::move(cfg), context_manager, factory_context.serverFactoryContext().serverScope());
 }
 Network::Address::InstanceConstSharedPtr getSslAddress(const Network::Address::IpVersion& version,
                                                        int port) {

--- a/test/integration/ssl_utility.h
+++ b/test/integration/ssl_utility.h
@@ -94,10 +94,12 @@ void initializeUpstreamTlsContextConfig(
 
 Network::UpstreamTransportSocketFactoryPtr
 createClientSslTransportSocketFactory(const ClientSslTransportOptions& options,
-                                      ContextManager& context_manager, Api::Api& api);
+                                      ContextManager& context_manager, Api::Api& api,
+                                      Stats::Scope* stats_scope = nullptr);
 
 Network::DownstreamTransportSocketFactoryPtr
-createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool use_http3 = false);
+createUpstreamSslContext(ContextManager& context_manager, Api::Api& api, bool use_http3 = false,
+                         Stats::Scope* stats_scope = nullptr);
 
 Network::DownstreamTransportSocketFactoryPtr
 createFakeUpstreamSslContext(const std::string& upstream_cert_name, ContextManager& context_manager,

--- a/test/integration/tcp_proxy_integration.cc
+++ b/test/integration/tcp_proxy_integration.cc
@@ -22,7 +22,8 @@ void BaseTcpProxySslIntegrationTest::initialize() {
 
   context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
       server_factory_context_);
-  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options_, *context_manager_, *api_);
+  context_ = Ssl::createClientSslTransportSocketFactory(ssl_options_, *context_manager_, *api_,
+                                                        &server_factory_context_.serverScope());
 }
 
 BaseTcpProxySslIntegrationTest::ClientSslConnection::ClientSslConnection(

--- a/test/integration/xds_integration_test.cc
+++ b/test/integration/xds_integration_test.cc
@@ -197,7 +197,8 @@ public:
 
     context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
         server_factory_context_);
-    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_);
+    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_,
+                                                          &server_factory_context_.serverScope());
   }
 
   std::unique_ptr<RawConnectionDriver> createConnectionAndWrite(const std::string& alpn,
@@ -467,7 +468,8 @@ public:
 
     context_manager_ = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
         server_factory_context_);
-    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_);
+    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_,
+                                                          &server_factory_context_.serverScope());
     address_ = Ssl::getSslAddress(version_, lookupPort("http"));
   }
 

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -97,10 +97,9 @@ common_tls_context:
   TestUtility::loadFromYaml(TestEnvironment::substitute(target), config);
   auto cfg =
       *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(config, factory_context_);
-  static auto* client_stats_store = new Stats::TestIsolatedStoreImpl();
   return Network::UpstreamTransportSocketFactoryPtr{
       *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-          std::move(cfg), *context_manager_, *client_stats_store->rootScope())};
+          std::move(cfg), *context_manager_, server_factory_context_.serverScope())};
 }
 
 Network::DownstreamTransportSocketFactoryPtr XfccIntegrationTest::createUpstreamSslContext() {
@@ -114,9 +113,8 @@ Network::DownstreamTransportSocketFactoryPtr XfccIntegrationTest::createUpstream
 
   auto cfg = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
       tls_context, factory_context_, {}, false);
-  static auto* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
   return *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
-      std::move(cfg), *context_manager_, *(upstream_stats_store->rootScope()));
+      std::move(cfg), *context_manager_, server_factory_context_.serverScope());
 }
 
 Network::ClientConnectionPtr XfccIntegrationTest::makeTcpClientConnection() {

--- a/test/server/admin/server_info_handler_test.cc
+++ b/test/server/admin/server_info_handler_test.cc
@@ -27,7 +27,7 @@ TEST_P(AdminInstanceTest, ContextThatReturnsNullCertDetails) {
   envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext config;
   auto cfg =
       *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(config, factory_context);
-  Stats::IsolatedStoreImpl store;
+  Stats::IsolatedStoreImpl store(server_.serverFactoryContext().serverScope().symbolTable());
   Envoy::Ssl::ClientContextSharedPtr client_ctx(
       *server_.sslContextManager().createSslClientContext(*store.rootScope(), *cfg));
 


### PR DESCRIPTION
Each ContextImpl previously allocated a separate StatNameSet for BoringSSL ciphers, curves, signature algorithms, and versions. Since these built-in names are constant across contexts, creating them per context duplicated symbol table encodes and memory overhead during SDS rotations.

Move built-in TLS stat names into a single object managed via the server singleton manager. Each ContextImpl holds a shared_ptr to the singleton instance.

TAG=agy

Additional Description: N/A
Risk Level: low
Testing: Existing test suites validate these stats.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A