### PR TITLE
Add mcp_json_rest_bridge filter to well known names

### DIFF
--- a/source/extensions/filters/http/well_known_names.h
+++ b/source/extensions/filters/http/well_known_names.h
@@ -108,6 +108,8 @@ public:
   const std::string ExternalProcessing = "envoy.filters.http.ext_proc";
   // Set metadata filter
   const std::string SetMetadata = "envoy.filters.http.set_metadata";
+  // MCP JSON REST bridge filter
+  const std::string McpJsonRestBridge = "envoy.filters.http.mcp_json_rest_bridge";
 };
 
 using HttpFilterNames = ConstSingleton<HttpFilterNameValues>;


### PR DESCRIPTION
Commit Message: add mcp_json_rest_bridge filter to the well-known names

Additional Description: this constant is useful for other module that want to refer to this filter, e.g. when accessing Dynamic Metadata

Risk Level: low
