### PR TITLE
odsds: fix repeated subscription starts

### DIFF
--- a/envoy/secret/secret_manager.h
+++ b/envoy/secret/secret_manager.h
@@ -111,15 +111,13 @@ public:
    * secret provider.
    * @param init_manager if supplied, register to the initialization sequence; otherwise, start
    * immediately
-   * @param warm if true, wait for the update to complete initialization; otherwise, unblock
-   * immediately.
    * @return TlsCertificateConfigProviderSharedPtr the dynamic TLS secret provider.
    */
   virtual TlsCertificateConfigProviderSharedPtr
   findOrCreateTlsCertificateProvider(const envoy::config::core::v3::ConfigSource& config_source,
                                      const std::string& config_name,
                                      Server::Configuration::ServerFactoryContext& server_context,
-                                     OptRef<Init::Manager> init_manager, bool warm) PURE;
+                                     OptRef<Init::Manager> init_manager) PURE;
 
   /**
    * Finds and returns a dynamic secret provider associated to SDS config. Create

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -19,9 +19,8 @@ SdsApiStats SdsApi::generateStats(Stats::Scope& scope) {
 SdsApi::SdsApi(envoy::config::core::v3::ConfigSource sds_config, absl::string_view sds_config_name,
                Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
                ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
-               std::function<void()> destructor_cb, Event::Dispatcher& dispatcher, Api::Api& api,
-               bool warm)
-    : init_target_(fmt::format("SdsApi {}", sds_config_name), [this, warm] { initialize(warm); }),
+               std::function<void()> destructor_cb, Event::Dispatcher& dispatcher, Api::Api& api)
+    : init_target_(fmt::format("SdsApi {}", sds_config_name), [this] { initialize(); }),
       dispatcher_(dispatcher), api_(api),
       scope_(stats.createScope(absl::StrCat("sds.", sds_config_name, "."))),
       sds_api_stats_(generateStats(*scope_)), resource_type_helper_(validation_visitor, "name"),
@@ -205,12 +204,12 @@ absl::Status SdsApi::validateUpdateSize(uint32_t added_resources_num,
   return absl::OkStatus();
 }
 
-void SdsApi::initialize(bool warm) {
+void SdsApi::initialize() {
   // Don't put any code here that can throw exceptions, this has been the cause of multiple
   // hard-to-diagnose regressions.
-  subscription_->start({sds_config_name_});
-  if (!warm) {
-    init_target_.ready();
+  if (!started_) {
+    started_ = true;
+    subscription_->start({sds_config_name_});
   }
 }
 
@@ -238,7 +237,7 @@ TlsCertificateSdsApiSharedPtr
 TlsCertificateSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
                              const envoy::config::core::v3::ConfigSource& sds_config,
                              const std::string& sds_config_name,
-                             std::function<void()> destructor_cb, bool warm) {
+                             std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
   THROW_IF_NOT_OK(
@@ -247,7 +246,7 @@ TlsCertificateSdsApi::create(Server::Configuration::ServerFactoryContext& server
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
       server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
       server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
-      server_context.api(), warm);
+      server_context.api());
 }
 
 std::vector<std::string> TlsCertificateSdsApi::getDataSourceFilenames() {
@@ -300,7 +299,7 @@ void TlsCertificateSdsApi::resolveSecret(const FileContentMap& files) {
 CertificateValidationContextSdsApiSharedPtr CertificateValidationContextSdsApi::create(
     Server::Configuration::ServerFactoryContext& server_context,
     const envoy::config::core::v3::ConfigSource& sds_config, const std::string& sds_config_name,
-    std::function<void()> destructor_cb, bool warm) {
+    std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
   THROW_IF_NOT_OK(Config::Utility::checkLocalInfo("CertificateValidationContextSdsApi",
@@ -309,7 +308,7 @@ CertificateValidationContextSdsApiSharedPtr CertificateValidationContextSdsApi::
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
       server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
       server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
-      server_context.api(), warm);
+      server_context.api());
 }
 
 void CertificateValidationContextSdsApi::validateConfig(
@@ -375,7 +374,7 @@ TlsSessionTicketKeysSdsApiSharedPtr
 TlsSessionTicketKeysSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
                                    const envoy::config::core::v3::ConfigSource& sds_config,
                                    const std::string& sds_config_name,
-                                   std::function<void()> destructor_cb, bool warm) {
+                                   std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
   THROW_IF_NOT_OK(
@@ -384,7 +383,7 @@ TlsSessionTicketKeysSdsApi::create(Server::Configuration::ServerFactoryContext& 
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
       server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
       server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
-      server_context.api(), warm);
+      server_context.api());
 }
 
 void TlsSessionTicketKeysSdsApi::validateConfig(
@@ -397,8 +396,8 @@ std::vector<std::string> TlsSessionTicketKeysSdsApi::getDataSourceFilenames() { 
 GenericSecretSdsApiSharedPtr
 GenericSecretSdsApi::create(Server::Configuration::ServerFactoryContext& server_context,
                             const envoy::config::core::v3::ConfigSource& sds_config,
-                            const std::string& sds_config_name, std::function<void()> destructor_cb,
-                            bool warm) {
+                            const std::string& sds_config_name,
+                            std::function<void()> destructor_cb) {
   // We need to do this early as we invoke the subscription factory during initialization, which
   // is too late to throw.
   THROW_IF_NOT_OK(
@@ -407,7 +406,7 @@ GenericSecretSdsApi::create(Server::Configuration::ServerFactoryContext& server_
       sds_config, sds_config_name, server_context.clusterManager().subscriptionFactory(),
       server_context.mainThreadDispatcher().timeSource(), server_context.messageValidationVisitor(),
       server_context.serverScope().store(), destructor_cb, server_context.mainThreadDispatcher(),
-      server_context.api(), warm);
+      server_context.api());
 }
 
 void GenericSecretSdsApi::validateConfig(

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -57,8 +57,7 @@ public:
   SdsApi(envoy::config::core::v3::ConfigSource sds_config, absl::string_view sds_config_name,
          Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
          ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
-         std::function<void()> destructor_cb, Event::Dispatcher& dispatcher, Api::Api& api,
-         bool warm);
+         std::function<void()> destructor_cb, Event::Dispatcher& dispatcher, Api::Api& api);
 
   const SecretData& secretData() const;
 
@@ -96,7 +95,7 @@ protected:
   void onWatchUpdate();
 
   // Initializes the SDS API.
-  void initialize(bool warm);
+  void initialize();
 
 private:
   absl::Status validateUpdateSize(uint32_t added_resources_num,
@@ -120,6 +119,7 @@ private:
   Config::SubscriptionFactory& subscription_factory_;
   TimeSource& time_source_;
   SecretData secret_data_;
+  bool started_{false};
   std::unique_ptr<Filesystem::Watcher> watcher_;
 };
 
@@ -144,9 +144,9 @@ public:
                         Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
                         ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
                         std::function<void()> destructor_cb, Event::Dispatcher& dispatcher,
-                        Api::Api& api, bool warm)
+                        Api::Api& api)
       : SdsApi(sds_config, sds_config_name, subscription_factory, time_source, validation_visitor,
-               stats, std::move(destructor_cb), dispatcher, api, warm) {}
+               stats, std::move(destructor_cb), dispatcher, api) {}
 
   const SecretType* secret() const override PURE;
 
@@ -168,7 +168,7 @@ public:
   }
 
   const Init::Target* initTarget() override { return &init_target_; }
-  void start() override { initialize(false); }
+  void start() override { initialize(); }
 
 protected:
   Common::CallbackManager<absl::Status, const SecretType&> validation_callback_manager_;
@@ -183,17 +183,17 @@ public:
   static TlsCertificateSdsApiSharedPtr
   create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
-         const std::string& sds_config_name, std::function<void()> destructor_cb, bool warm);
+         const std::string& sds_config_name, std::function<void()> destructor_cb);
 
   TlsCertificateSdsApi(const envoy::config::core::v3::ConfigSource& sds_config,
                        const std::string& sds_config_name,
                        Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
                        ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
                        std::function<void()> destructor_cb, Event::Dispatcher& dispatcher,
-                       Api::Api& api, bool warm)
+                       Api::Api& api)
       : DynamicSecretProvider(sds_config, sds_config_name, subscription_factory, time_source,
-                              validation_visitor, stats, std::move(destructor_cb), dispatcher, api,
-                              warm) {}
+                              validation_visitor, stats, std::move(destructor_cb), dispatcher,
+                              api) {}
 
   // SecretProvider
   const envoy::extensions::transport_sockets::tls::v3::TlsCertificate* secret() const override {
@@ -234,17 +234,17 @@ public:
   static CertificateValidationContextSdsApiSharedPtr
   create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
-         const std::string& sds_config_name, std::function<void()> destructor_cb, bool warm);
+         const std::string& sds_config_name, std::function<void()> destructor_cb);
   CertificateValidationContextSdsApi(const envoy::config::core::v3::ConfigSource& sds_config,
                                      const std::string& sds_config_name,
                                      Config::SubscriptionFactory& subscription_factory,
                                      TimeSource& time_source,
                                      ProtobufMessage::ValidationVisitor& validation_visitor,
                                      Stats::Store& stats, std::function<void()> destructor_cb,
-                                     Event::Dispatcher& dispatcher, Api::Api& api, bool warm)
+                                     Event::Dispatcher& dispatcher, Api::Api& api)
       : DynamicSecretProvider(sds_config, sds_config_name, subscription_factory, time_source,
-                              validation_visitor, stats, std::move(destructor_cb), dispatcher, api,
-                              warm) {}
+                              validation_visitor, stats, std::move(destructor_cb), dispatcher,
+                              api) {}
 
   // SecretProvider
   const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext*
@@ -281,7 +281,7 @@ public:
   static TlsSessionTicketKeysSdsApiSharedPtr
   create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
-         const std::string& sds_config_name, std::function<void()> destructor_cb, bool warm);
+         const std::string& sds_config_name, std::function<void()> destructor_cb);
 
   TlsSessionTicketKeysSdsApi(const envoy::config::core::v3::ConfigSource& sds_config,
                              const std::string& sds_config_name,
@@ -289,10 +289,10 @@ public:
                              TimeSource& time_source,
                              ProtobufMessage::ValidationVisitor& validation_visitor,
                              Stats::Store& stats, std::function<void()> destructor_cb,
-                             Event::Dispatcher& dispatcher, Api::Api& api, bool warm)
+                             Event::Dispatcher& dispatcher, Api::Api& api)
       : DynamicSecretProvider(sds_config, sds_config_name, subscription_factory, time_source,
-                              validation_visitor, stats, std::move(destructor_cb), dispatcher, api,
-                              warm) {}
+                              validation_visitor, stats, std::move(destructor_cb), dispatcher,
+                              api) {}
 
   // SecretProvider
   const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys*
@@ -324,17 +324,17 @@ public:
   static GenericSecretSdsApiSharedPtr
   create(Server::Configuration::ServerFactoryContext& server_context,
          const envoy::config::core::v3::ConfigSource& sds_config,
-         const std::string& sds_config_name, std::function<void()> destructor_cb, bool warm);
+         const std::string& sds_config_name, std::function<void()> destructor_cb);
 
   GenericSecretSdsApi(const envoy::config::core::v3::ConfigSource& sds_config,
                       const std::string& sds_config_name,
                       Config::SubscriptionFactory& subscription_factory, TimeSource& time_source,
                       ProtobufMessage::ValidationVisitor& validation_visitor, Stats::Store& stats,
                       std::function<void()> destructor_cb, Event::Dispatcher& dispatcher,
-                      Api::Api& api, bool warm)
+                      Api::Api& api)
       : DynamicSecretProvider(sds_config, sds_config_name, subscription_factory, time_source,
-                              validation_visitor, stats, std::move(destructor_cb), dispatcher, api,
-                              warm) {}
+                              validation_visitor, stats, std::move(destructor_cb), dispatcher,
+                              api) {}
 
   // SecretProvider
   const envoy::extensions::transport_sockets::tls::v3::GenericSecret* secret() const override {

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -129,10 +129,10 @@ GenericSecretConfigProviderSharedPtr SecretManagerImpl::createInlineGenericSecre
 
 TlsCertificateConfigProviderSharedPtr SecretManagerImpl::findOrCreateTlsCertificateProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::ServerFactoryContext& server_context, OptRef<Init::Manager> init_manager,
-    bool warm) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    OptRef<Init::Manager> init_manager) {
   return certificate_providers_.findOrCreate(sds_config_source, config_name, server_context,
-                                             init_manager, warm);
+                                             init_manager);
 }
 
 CertificateValidationContextConfigProviderSharedPtr
@@ -140,7 +140,7 @@ SecretManagerImpl::findOrCreateCertificateValidationContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
     Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
   return validation_context_providers_.findOrCreate(sds_config_source, config_name, server_context,
-                                                    init_manager, true);
+                                                    init_manager);
 }
 
 TlsSessionTicketKeysConfigProviderSharedPtr
@@ -148,7 +148,7 @@ SecretManagerImpl::findOrCreateTlsSessionTicketKeysContextProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
     Server::Configuration::ServerFactoryContext& server_context, Init::Manager& init_manager) {
   return session_ticket_keys_providers_.findOrCreate(sds_config_source, config_name, server_context,
-                                                     init_manager, true);
+                                                     init_manager);
 }
 
 GenericSecretConfigProviderSharedPtr SecretManagerImpl::findOrCreateGenericSecretProvider(
@@ -156,7 +156,7 @@ GenericSecretConfigProviderSharedPtr SecretManagerImpl::findOrCreateGenericSecre
     Server::Configuration::ServerFactoryContext& server_context,
     OptRef<Init::Manager> init_manager) {
   return generic_secret_providers_.findOrCreate(sds_config_source, config_name, server_context,
-                                                init_manager, true);
+                                                init_manager);
 }
 
 ProtobufTypes::MessagePtr

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -54,7 +54,7 @@ public:
   findOrCreateTlsCertificateProvider(const envoy::config::core::v3::ConfigSource& config_source,
                                      const std::string& config_name,
                                      Server::Configuration::ServerFactoryContext& server_context,
-                                     OptRef<Init::Manager> init_manager, bool warm) override;
+                                     OptRef<Init::Manager> init_manager) override;
 
   CertificateValidationContextConfigProviderSharedPtr
   findOrCreateCertificateValidationContextProvider(
@@ -84,7 +84,7 @@ private:
     findOrCreate(const envoy::config::core::v3::ConfigSource& sds_config_source,
                  const std::string& config_name,
                  Server::Configuration::ServerFactoryContext& server_context,
-                 OptRef<Init::Manager> init_manager, bool warm) {
+                 OptRef<Init::Manager> init_manager) {
       const std::string map_key =
           absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
 
@@ -96,7 +96,7 @@ private:
           removeDynamicSecretProvider(map_key);
         };
         secret_provider = SecretType::create(server_context, sds_config_source, config_name,
-                                             unregister_secret_provider, warm);
+                                             unregister_secret_provider);
         dynamic_secret_providers_[map_key] = secret_provider;
       }
       // It is important to add the init target to the manager regardless the secret provider is new
@@ -114,6 +114,8 @@ private:
       if (init_manager) {
         init_manager->add(*secret_provider->initTarget());
       } else {
+        // A secret provider can be shared across multiple warming and non-warming users,
+        // so this line can be called repeatedly.
         secret_provider->start();
       }
       return secret_provider;

--- a/source/common/tls/context_config_impl.cc
+++ b/source/common/tls/context_config_impl.cc
@@ -74,7 +74,7 @@ std::vector<TlsCertificateConfigProviderSharedPtrWithName> getTlsCertificateConf
                 .secretManager()
                 .findOrCreateTlsCertificateProvider(
                     sds_secret_config.sds_config(), sds_secret_config.name(),
-                    factory_context.serverFactoryContext(), factory_context.initManager(), true)});
+                    factory_context.serverFactoryContext(), factory_context.initManager())});
       } else {
         // Load static secret.
         auto secret_provider =

--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
@@ -19,7 +19,7 @@ AsyncContextConfig::AsyncContextConfig(absl::string_view cert_name,
                                        RemoveCb remove_cb)
     : factory_context_(factory_context), cert_name_(cert_name),
       cert_provider_(factory_context_.secretManager().findOrCreateTlsCertificateProvider(
-          config_source, cert_name_, factory_context_, init_manager, false)),
+          config_source, cert_name_, factory_context_, init_manager)),
       update_cb_(update_cb),
       update_cb_handle_(cert_provider_->addUpdateCallback([this]() { return loadCert(); })),
       remove_cb_(remove_cb), remove_cb_handle_(cert_provider_->addRemoveCallback(

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -76,21 +76,8 @@ TEST_F(SdsApiTest, BasicTest) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
-  initialize();
-}
-
-// Validate that target initializes when no warming is requested.
-TEST_F(SdsApiTest, BasicNoWarmTest) {
-  ::testing::InSequence s;
-  envoy::config::core::v3::ConfigSource config_source;
-  setupMocks();
-  TlsCertificateSdsApi sds_api(
-      config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, false);
-  init_manager_.add(*sds_api.initTarget());
-  init_watcher_.expectReady();
   initialize();
 }
 
@@ -100,8 +87,10 @@ TEST_F(SdsApiTest, BasicManualStart) {
   envoy::config::core::v3::ConfigSource config_source;
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, false);
+      []() {}, *dispatcher_, *api_);
   EXPECT_CALL(*subscription_factory_.subscription_, start(_));
+  sds_api.start();
+  // Validate that starting twice only calls subscription start once.
   sds_api.start();
 }
 
@@ -152,7 +141,7 @@ TEST_F(SdsApiTest, InitManagerInitialised) {
   EXPECT_EQ(Init::Manager::State::Initializing, init_manager.state());
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   EXPECT_NO_THROW(init_manager.add(*sds_api.initTarget()));
 }
 
@@ -168,7 +157,7 @@ TEST_F(SdsApiTest, BadConfigSource) {
       }));
   EXPECT_THROW_WITH_MESSAGE(TlsCertificateSdsApi(
                                 config_source, "abc.com", subscription_factory_, time_system_,
-                                validation_visitor_, stats_, []() {}, *dispatcher_, *api_, true),
+                                validation_visitor_, stats_, []() {}, *dispatcher_, *api_),
                             EnvoyException, "bad config");
 }
 
@@ -179,7 +168,7 @@ TEST_F(SdsApiTest, DynamicTlsCertificateUpdateSuccess) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
   initialize();
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -219,7 +208,7 @@ TEST_F(SdsApiTest, CertificateRemoval) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
   initialize();
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -259,7 +248,7 @@ protected:
     envoy::config::core::v3::ConfigSource config_source;
     sds_api_ = std::make_unique<TlsCertificateSdsApi>(
         config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-        []() {}, mock_dispatcher_, *api_, true);
+        []() {}, mock_dispatcher_, *api_);
     init_manager_.add(*sds_api_->initTarget());
     initialize();
     handle_ =
@@ -331,7 +320,7 @@ protected:
     envoy::config::core::v3::ConfigSource config_source;
     sds_api_ = std::make_unique<CertificateValidationContextSdsApi>(
         config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-        []() {}, mock_dispatcher_, *api_, true);
+        []() {}, mock_dispatcher_, *api_);
     init_manager_.add(*sds_api_->initTarget());
     initialize();
     handle_ =
@@ -562,7 +551,7 @@ protected:
     envoy::config::core::v3::ConfigSource config_source;
     sds_api_ = std::make_unique<TlsCertificateSdsApi>(
         config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-        []() {}, mock_dispatcher_, *api_, true);
+        []() {}, mock_dispatcher_, *api_);
     init_manager_.add(*sds_api_->initTarget());
     initialize();
     handle_ =
@@ -716,7 +705,7 @@ protected:
     envoy::config::core::v3::ConfigSource config_source;
     sds_api_ = std::make_unique<TlsCertificateSdsApi>(
         config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-        []() {}, mock_dispatcher_, *api_, true);
+        []() {}, mock_dispatcher_, *api_);
     init_manager_.add(*sds_api_->initTarget());
     initialize();
     handle_ =
@@ -915,7 +904,7 @@ public:
                  Event::Dispatcher& dispatcher, Api::Api& api)
       : SdsApi(
             config_source, "abc.com", subscription_factory, time_source, validation_visitor_, stats,
-            []() {}, dispatcher, api, true) {
+            []() {}, dispatcher, api) {
     init_manager.add(init_target_);
   }
 
@@ -972,7 +961,7 @@ TEST_F(SdsApiTest, DeltaUpdateSuccess) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1015,7 +1004,7 @@ TEST_F(SdsApiTest, DynamicCertificateValidationContextUpdateSuccess) {
   setupMocks();
   CertificateValidationContextSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1052,7 +1041,7 @@ TEST_F(SdsApiTest, CertificateValidationContextNoTrustedCa) {
   setupMocks();
   CertificateValidationContextSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1083,7 +1072,7 @@ TEST_F(SdsApiTest, CertificateValidationContextNoTrustedCa_NoRejectEmptyTrustedC
   setupMocks();
   CertificateValidationContextSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1130,7 +1119,7 @@ TEST_F(SdsApiTest, DefaultCertificateValidationContextTest) {
   setupMocks();
   CertificateValidationContextSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1227,7 +1216,7 @@ TEST_F(SdsApiTest, GenericSecretSdsApiTest) {
   setupMocks();
   GenericSecretSdsApi sds_api(
       config_source, "encryption_key", subscription_factory_, time_system_, validation_visitor_,
-      stats_, []() {}, *dispatcher_, *api_, true);
+      stats_, []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   NiceMock<Secret::MockSecretCallbacks> secret_callback;
@@ -1269,7 +1258,7 @@ TEST_F(SdsApiTest, EmptyResource) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   initialize();
@@ -1283,7 +1272,7 @@ TEST_F(SdsApiTest, SecretUpdateWrongSize) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   std::string yaml =
@@ -1319,7 +1308,7 @@ TEST_F(SdsApiTest, SecretUpdateWrongSecretName) {
   setupMocks();
   TlsCertificateSdsApi sds_api(
       config_source, "abc.com", subscription_factory_, time_system_, validation_visitor_, stats_,
-      []() {}, *dispatcher_, *api_, true);
+      []() {}, *dispatcher_, *api_);
   init_manager_.add(*sds_api.initTarget());
 
   std::string yaml =

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -315,7 +315,7 @@ api_config_source:
       ->set_value(Base64::decode("CjUKMy92YXIvcnVuL3NlY3JldHMva3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3Vud"
                                  "C90b2tlbhILeC10b2tlbi1iaW4="));
   auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   // The base64 encoded proto binary is identical to the one above, but in different field order.
   // It is also identical to the YAML below.
@@ -328,7 +328,7 @@ api_config_source:
       ->set_value(Base64::decode("Egt4LXRva2VuLWJpbgo1CjMvdmFyL3J1bi9zZWNyZXRzL2t1YmVybmV0ZXMuaW8vc"
                                  "2VydmljZWFjY291bnQvdG9rZW4="));
   auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   API_NO_BOOST(envoy::config::grpc_credential::v2alpha::FileBasedMetadataConfig)
   file_based_metadata_config;
@@ -346,7 +346,7 @@ secret_data:
                     ->mutable_typed_config()
                     ->PackFrom(file_based_metadata_config);
   auto secret_provider3 = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
 
   EXPECT_EQ(secret_provider1, secret_provider2);
   EXPECT_EQ(secret_provider2, secret_provider3);
@@ -375,7 +375,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretUpdateSuccess) {
   EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -401,6 +401,37 @@ tls_certificate:
   const std::string key_pem = "{{ test_rundir }}/test/common/tls/test_data/selfsigned_key.pem";
   EXPECT_EQ(TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(key_pem)),
             tls_config.privateKey());
+}
+
+TEST_F(SecretManagerImplTest, SdsDynamicSecretWarmFalseSubscriptionOnce) {
+  SecretManagerPtr secret_manager(new SecretManagerImpl(config_tracker_));
+
+  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> secret_context;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+
+  envoy::config::core::v3::ConfigSource config_source;
+
+  EXPECT_CALL(secret_context.server_context_, mainThreadDispatcher())
+      .WillRepeatedly(ReturnRef(*dispatcher_));
+  EXPECT_CALL(secret_context.server_context_, localInfo()).WillOnce(ReturnRef(local_info));
+  EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
+
+  // 1st call: creates provider and starts subscription.
+  auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context.server_context_, {});
+
+  auto* subscription =
+      secret_context.server_context_.cluster_manager_.subscription_factory_.subscription_;
+  ASSERT_NE(subscription, nullptr);
+
+  // Expect that start() is NOT called again on the subscription.
+  EXPECT_CALL(*subscription, start(_)).Times(0);
+
+  // 2nd call: should reuse provider and NOT call start() again.
+  auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context.server_context_, {});
+
+  EXPECT_EQ(secret_provider1, secret_provider2);
 }
 
 TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
@@ -472,7 +503,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandler) {
   EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"
@@ -745,7 +776,7 @@ TEST_F(SecretManagerImplTest, ConfigDumpHandlerWarmingSecrets) {
   EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string expected_secrets_config_dump = R"EOF(
 dynamic_warming_secrets:
 - name: "abc.com"
@@ -1093,7 +1124,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretPrivateKeyProviderUpdateSuccess) {
   EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
 
   auto secret_provider = secret_manager->findOrCreateTlsCertificateProvider(
-      config_source, "abc.com", secret_context.server_context_, init_manager, true);
+      config_source, "abc.com", secret_context.server_context_, init_manager);
   const std::string yaml =
       R"EOF(
 name: "abc.com"

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -42,8 +42,7 @@ public:
               (const envoy::extensions::transport_sockets::tls::v3::GenericSecret& generic_secret));
   MOCK_METHOD(TlsCertificateConfigProviderSharedPtr, findOrCreateTlsCertificateProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::ServerFactoryContext&, OptRef<Init::Manager> init_manager,
-               bool warm));
+               Server::Configuration::ServerFactoryContext&, OptRef<Init::Manager> init_manager));
   MOCK_METHOD(CertificateValidationContextConfigProviderSharedPtr,
               findOrCreateCertificateValidationContextProvider,
               (const envoy::config::core::v3::ConfigSource& config_source,


### PR DESCRIPTION
Change-Id: I1457c9983b6d5053368eb4af51af9ae32b7eaeba

Commit Message: Fix repeated gRPC subscription starts in OdSDS caused when the secret is subscribed from multiple places. Also, removed "warm" parameter since it is directly related to whether the init manager is passed or not (if passed, initialization happens via it; otherwise, it happens immediately). The latter part would cause issues if the same secret is requested in warming and non-warming contexts (the target would immediately unblock by a warming user).
Additional Description: 
Risk Level: low (only OdSDS is impacted, e.g. on_demand TLS cert provider)
Testing: updated
Docs Changes: none
Release Notes: yes