### PR TITLE
odsds: fix repeated starts and warming/non-warming overlap

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -100,6 +100,8 @@ areas:
     title: reverse_tunnel
   router:
     title: router
+  sds:
+    title: sds
   set_metadata_filter:
     title: set_metadata_filter
   sockets:

--- a/changelogs/current/bug_fixes/sds__on-demand-warming.rst
+++ b/changelogs/current/bug_fixes/sds__on-demand-warming.rst
@@ -1,0 +1,3 @@
+Fixed a bug where on-demand SDS would start xDS subscriptions repeatedly
+triggering the initial fetch timeout. Fixed a bug where warming and non-warming
+(prefetch) SDS could incorrectly trigger each others' readiness.

--- a/source/common/secret/sds_api.cc
+++ b/source/common/secret/sds_api.cc
@@ -208,7 +208,10 @@ absl::Status SdsApi::validateUpdateSize(uint32_t added_resources_num,
 void SdsApi::initialize(bool warm) {
   // Don't put any code here that can throw exceptions, this has been the cause of multiple
   // hard-to-diagnose regressions.
-  subscription_->start({sds_config_name_});
+  if (!started_) {
+    started_ = true;
+    subscription_->start({sds_config_name_});
+  }
   if (!warm) {
     init_target_.ready();
   }

--- a/source/common/secret/sds_api.h
+++ b/source/common/secret/sds_api.h
@@ -120,6 +120,7 @@ private:
   Config::SubscriptionFactory& subscription_factory_;
   TimeSource& time_source_;
   SecretData secret_data_;
+  bool started_{false};
   std::unique_ptr<Filesystem::Watcher> watcher_;
 };
 

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -85,6 +85,8 @@ private:
                  const std::string& config_name,
                  Server::Configuration::ServerFactoryContext& server_context,
                  OptRef<Init::Manager> init_manager, bool warm) {
+      // Warming and non-warming providers have different init targets: the warming
+      // target only fires after a secret is fetched, while non-warming one pre-fetches.
       const std::string map_key =
           absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name, warm);
 

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -86,7 +86,7 @@ private:
                  Server::Configuration::ServerFactoryContext& server_context,
                  OptRef<Init::Manager> init_manager, bool warm) {
       const std::string map_key =
-          absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name);
+          absl::StrCat(MessageUtil::hash(sds_config_source), ".", config_name, warm);
 
       std::shared_ptr<SecretType> secret_provider = dynamic_secret_providers_[map_key].lock();
       if (!secret_provider) {
@@ -114,6 +114,8 @@ private:
       if (init_manager) {
         init_manager->add(*secret_provider->initTarget());
       } else {
+        // A secret provider can be shared across multiple warming and non-warming users,
+        // so this line can be called repeatedly.
         secret_provider->start();
       }
       return secret_provider;

--- a/test/common/secret/sds_api_test.cc
+++ b/test/common/secret/sds_api_test.cc
@@ -103,6 +103,8 @@ TEST_F(SdsApiTest, BasicManualStart) {
       []() {}, *dispatcher_, *api_, false);
   EXPECT_CALL(*subscription_factory_.subscription_, start(_));
   sds_api.start();
+  // Validate that starting twice only calls subscription start once.
+  sds_api.start();
 }
 
 // Validate that a noop init manager is used if the InitManger passed into the constructor

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -1174,6 +1174,44 @@ TEST_F(SecretManagerImplTest, DeprecatedSanMatcher) {
             cvc_config->subjectAltNameMatchers()[3].san_type());
 }
 
+TEST_F(SecretManagerImplTest, SdsDynamicSecretWarmFalseSubscriptionOnce) {
+  SecretManagerPtr secret_manager(new SecretManagerImpl(config_tracker_));
+
+  NiceMock<Server::Configuration::MockTransportSocketFactoryContext> secret_context;
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+
+  envoy::config::core::v3::ConfigSource config_source;
+
+  EXPECT_CALL(secret_context.server_context_, mainThreadDispatcher())
+      .WillRepeatedly(ReturnRef(*dispatcher_));
+  EXPECT_CALL(secret_context.server_context_, localInfo()).WillRepeatedly(ReturnRef(local_info));
+  EXPECT_CALL(secret_context.server_context_, api()).WillRepeatedly(ReturnRef(*api_));
+
+  // 1st call: creates provider and starts subscription.
+  auto secret_provider1 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context.server_context_, {}, false);
+
+  auto* subscription =
+      secret_context.server_context_.cluster_manager_.subscription_factory_.subscription_;
+  ASSERT_NE(subscription, nullptr);
+
+  // Expect that start() is NOT called again on the subscription.
+  EXPECT_CALL(*subscription, start(_)).Times(0);
+
+  // 2nd call: should reuse provider and NOT call start() again.
+  auto secret_provider2 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context.server_context_, {}, false);
+
+  EXPECT_EQ(secret_provider1, secret_provider2);
+
+  // 3nd call: a warming provider must be distinct since its init target should not
+  // become ready until the secret is received.
+  auto secret_provider3 = secret_manager->findOrCreateTlsCertificateProvider(
+      config_source, "abc.com", secret_context.server_context_, {}, true);
+
+  EXPECT_NE(secret_provider2, secret_provider3);
+}
+
 } // namespace
 } // namespace Secret
 } // namespace Envoy

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -1204,7 +1204,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicSecretWarmFalseSubscriptionOnce) {
 
   EXPECT_EQ(secret_provider1, secret_provider2);
 
-  // 3nd call: a warming provider must be distinct since its init target should not
+  // 3rd call: a warming provider must be distinct since its init target should not
   // become ready until the secret is received.
   auto secret_provider3 = secret_manager->findOrCreateTlsCertificateProvider(
       config_source, "abc.com", secret_context.server_context_, {}, true);


### PR DESCRIPTION
Change-Id: Ibb6a47a6d43e2366d4c49b7425e99ce874e90448

Commit Message: Fix repeated gRPC subscription starts in OdSDS caused when the secret is subscribed from multiple places. Fixed overlap of the secret providers between warming and non-warming users (a warming user waits for the secret, a non-warming doesn't).
Additional Description:
Risk Level: low (only OdSDS is impacted, e.g. on_demand TLS cert provider)
Testing: updated
Docs Changes: none
Release Notes: yes