### PR TITLE
upstream: refactor client codec factory to raw pointer

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -145,9 +145,9 @@ parseExtensionProtocolOptions(
 // Recovers the per-cluster upstream (client) codec factory from the parsed protocol options. Any
 // options object may expose one via ProtocolOptionsConfig::upstreamHttpClientCodecFactory(); at
 // most one is allowed across all configured options.
-absl::StatusOr<std::shared_ptr<const Http::ClientCodecFactory>> findUpstreamHttpClientCodecFactory(
+absl::StatusOr<const Http::ClientCodecFactory*> findUpstreamHttpClientCodecFactory(
     const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>& options) {
-  std::shared_ptr<const Http::ClientCodecFactory> found;
+  const Http::ClientCodecFactory* found = nullptr;
   for (const auto& [name, option] : options) {
     OptRef<const Http::ClientCodecFactory> factory = option->upstreamHttpClientCodecFactory();
     if (!factory.has_value()) {
@@ -158,9 +158,7 @@ absl::StatusOr<std::shared_ptr<const Http::ClientCodecFactory>> findUpstreamHttp
           "multiple upstream HTTP client codec factories configured on a single cluster via "
           "typed_extension_protocol_options; at most one is allowed");
     }
-    // Aliasing shared_ptr: shares ownership with the options object (the factory and the options
-    // object are the same instance) while exposing it as a ClientCodecFactory.
-    found = std::shared_ptr<const Http::ClientCodecFactory>(option, &factory.ref());
+    found = &factory.ref();
   }
   return found;
 }
@@ -1224,7 +1222,7 @@ ClusterInfoImpl::ClusterInfoImpl(
           parseExtensionProtocolOptions(config, factory_context), ProtocolOptionsHashMap)),
       upstream_client_codec_factory_(
           THROW_OR_RETURN_VALUE(findUpstreamHttpClientCodecFactory(extension_protocol_options_),
-                                std::shared_ptr<const Http::ClientCodecFactory>)),
+                                const Http::ClientCodecFactory*)),
       http_protocol_options_(THROW_OR_RETURN_VALUE(
           createOptions(config,
                         extensionProtocolOptionsTyped<HttpProtocolOptionsConfigImpl>(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -945,7 +945,7 @@ public:
   ProtocolOptionsConfigConstSharedPtr
   extensionProtocolOptions(const std::string& name) const override;
   OptRef<const Http::ClientCodecFactory> upstreamHttpClientCodecFactory() const override {
-    return makeOptRefFromPtr(upstream_client_codec_factory_.get());
+    return makeOptRefFromPtr(upstream_client_codec_factory_);
   }
   envoy::config::cluster::v3::Cluster::DiscoveryType type() const override { return type_; }
 
@@ -1132,7 +1132,7 @@ private:
   // Per-cluster upstream (client) codec factory, recovered from extension_protocol_options_ (an
   // options entry that also implements the factory interface). Held to pin lifetime;
   // upstreamHttpClientCodecFactory() returns a view into it.
-  const std::shared_ptr<const Http::ClientCodecFactory> upstream_client_codec_factory_;
+  const Http::ClientCodecFactory* upstream_client_codec_factory_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
   const std::shared_ptr<const TcpProtocolOptionsConfigImpl> tcp_protocol_options_;
   const uint32_t max_requests_per_connection_;

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1130,8 +1130,8 @@ private:
   const absl::flat_hash_map<std::string, ProtocolOptionsConfigConstSharedPtr>
       extension_protocol_options_;
   // Per-cluster upstream (client) codec factory, recovered from extension_protocol_options_ (an
-  // options entry that also implements the factory interface). Held to pin lifetime;
-  // upstreamHttpClientCodecFactory() returns a view into it.
+  // options entry that also implements the factory interface). Lifetime is pinned by
+  // extension_protocol_options_; upstreamHttpClientCodecFactory() returns a view into it.
   const Http::ClientCodecFactory* upstream_client_codec_factory_;
   const std::shared_ptr<const HttpProtocolOptionsConfigImpl> http_protocol_options_;
   const std::shared_ptr<const TcpProtocolOptionsConfigImpl> tcp_protocol_options_;


### PR DESCRIPTION
Replaces a `std::shared_ptr` with a regular pointer.

`ClusterInfoImpl` stores the codec factory in `upstream_client_codec_factory_` as a `std::shared_ptr`. But the factory is actually owned by `extension_protocol_options_`, which is also a member of `ClusterInfoImpl`.

Because `extension_protocol_options_` is declared before `upstream_client_codec_factory_`, it is guaranteed to outlive it.

`CodecClient` (the consumer) only uses the factory during construction to create the codec and does not store it.

*   **Risk Analysis:** **Low**.
    *   The primary danger is a dangling pointer if the factory is destroyed
        before `ClusterInfoImpl` finishes using it.
    *   However, the reference chain (`CodecClient` -> `HostDescription` ->
        `ClusterInfo` -> Factory) guarantees that the cluster (and thus the
        factory) outlives the connection setup.

This change was created with the help of the Gemini AI model. I have read and understand the code.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
