### PR TITLE
common: removes unused `SharedString` and `SharedStringSet`

### DIFF
--- a/source/common/common/hash.h
+++ b/source/common/common/hash.h
@@ -158,37 +158,6 @@ private:
   static inline uint64_t shiftMix(uint64_t v) { return v ^ (v >> 47); }
 };
 
-using SharedString = std::shared_ptr<std::string>;
-
-struct HeterogeneousStringHash {
-  // Specifying is_transparent indicates to the library infrastructure that
-  // type-conversions should not be applied when calling find(), but instead
-  // pass the actual types of the contained and searched-for objects directly to
-  // these functors. See
-  // https://en.cppreference.com/w/cpp/utility/functional/less_void for an
-  // official reference, and https://abseil.io/tips/144 for a description of
-  // using it in the context of absl.
-  using is_transparent = void; // NOLINT(readability-identifier-naming)
-
-  size_t operator()(absl::string_view a) const { return HashUtil::xxHash64(a); }
-  size_t operator()(const SharedString& a) const { return HashUtil::xxHash64(*a); }
-};
-
-struct HeterogeneousStringEqual {
-  // See description for HeterogeneousStringHash::is_transparent.
-  using is_transparent = void; // NOLINT(readability-identifier-naming)
-
-  size_t operator()(absl::string_view a, absl::string_view b) const { return a == b; }
-  size_t operator()(const SharedString& a, const SharedString& b) const { return *a == *b; }
-  size_t operator()(absl::string_view a, const SharedString& b) const { return a == *b; }
-  size_t operator()(const SharedString& a, absl::string_view b) const { return *a == b; }
-};
-
-// We use heterogeneous hash/equal functors to do a find() without constructing
-// a shared_string, which would entail making a full copy of the stat name.
-using SharedStringSet =
-    absl::flat_hash_set<SharedString, HeterogeneousStringHash, HeterogeneousStringEqual>;
-
 // A special heterogeneous comparator is not needed for maps of strings; absl
 // hashes allow for looking up a string-container with a string-view by default.
 template <class Value> using StringMap = absl::flat_hash_map<std::string, Value>;

--- a/test/common/common/hash_test.cc
+++ b/test/common/common/hash_test.cc
@@ -71,12 +71,4 @@ TEST(Hash, stdhash) {
 }
 #endif
 
-TEST(Hash, sharedStringSet) {
-  SharedStringSet set;
-  auto foo = std::make_shared<std::string>("foo");
-  set.insert(foo);
-  auto pos = set.find("foo");
-  EXPECT_EQ(pos->get(), foo.get());
-}
-
 } // namespace Envoy


### PR DESCRIPTION
Removes `SharedString` and `SharedStringSet` definitions from `hash.h`
and associated tests, as they are not used anywhere.

This change was created with the help of the Gemini AI model. I have read and understand the code.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
