### PR TITLE
Replace hard crash with returning an empty value

### DIFF
--- a/envoy/config/BUILD
+++ b/envoy/config/BUILD
@@ -12,8 +12,8 @@ envoy_cc_library(
     name = "config_provider_interface",
     hdrs = ["config_provider.h"],
     deps = [
+        "//envoy/common:pure_lib",
         "//envoy/common:time_interface",
-        "//source/common/common:assert_lib",
         "//source/common/protobuf",
     ],
 )

--- a/envoy/config/config_provider.h
+++ b/envoy/config/config_provider.h
@@ -2,10 +2,12 @@
 
 #include <memory>
 #include <optional>
+#include <type_traits>
+#include <vector>
 
+#include "envoy/common/pure.h"
 #include "envoy/common/time.h"
 
-#include "source/common/common/assert.h"
 #include "source/common/protobuf/protobuf.h"
 
 namespace Envoy {
@@ -116,7 +118,7 @@ protected:
    * @return const ConfigProtoVector the config protos corresponding to the Config instantiated by
    *         the provider.
    */
-  virtual ConfigProtoVector getConfigProtos() const { PANIC("not implemented"); }
+  virtual ConfigProtoVector getConfigProtos() const PURE;
 
   /**
    * Returns the config implementation associated with the provider.

--- a/source/common/config/config_provider_impl.h
+++ b/source/common/config/config_provider_impl.h
@@ -336,6 +336,7 @@ protected:
 
   // Envoy::Config::ConfigProvider
   ConfigConstSharedPtr getConfig() const override { return subscription_->getConfig(); }
+  ConfigProtoVector getConfigProtos() const override { return {}; }
 
   ConfigSubscriptionCommonBaseSharedPtr subscription_;
 


### PR DESCRIPTION
Replacing hard crashing with returning an empty value from the only place that did not have an override. The change is safe, since we know that MutableConfigProviderCommonBase:: getConfigProtos() was never called as it would have resulted in a PANIC.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
