### PR TITLE
redis filter: support `CLUSTER SHARDS`

### DIFF
--- a/changelogs/current/new_features/redis_proxy__cluster-shards-command.rst
+++ b/changelogs/current/new_features/redis_proxy__cluster-shards-command.rst
@@ -1,0 +1,3 @@
+Added support for proxying the ``CLUSTER SHARDS`` command. Like the other supported ``CLUSTER``
+introspection subcommands (``INFO``, ``SLOTS``, ``KEYSLOT``, ``NODES``), it is forwarded to a
+single random upstream shard and the reply is returned to the client unmodified.

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -225,6 +225,7 @@ For details on each command's usage see the official
   CLUSTER SLOTS, Generic
   CLUSTER KEYSLOT, Generic
   CLUSTER NODES, Generic
+  CLUSTER SHARDS, Generic
   RANDOMKEY, Generic
   OBJECT, Generic
   GEOADD, Geo

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -103,7 +103,7 @@ struct SupportedCommands {
   static const CommandSubcommandMap& commandSubcommandValidationMap() {
     CONSTRUCT_ON_FIRST_USE(CommandSubcommandMap,
                            // Command name - Sub commands that are allowed
-                           {{"cluster", {"info", "slots", "keyslot", "nodes"}}});
+                           {{"cluster", {"info", "slots", "keyslot", "nodes", "shards"}}});
     // Add other commands with restricted subcommands here:
   }
 

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -3090,6 +3090,22 @@ TEST_F(RandomShardRequestTest, ClusterNodes) {
   EXPECT_EQ(1UL, store_.counter("redis.foo.command.cluster.success").value());
 }
 
+TEST_F(RandomShardRequestTest, ClusterShards) {
+  InSequence s;
+
+  setup({"cluster", "shards"});
+  EXPECT_NE(nullptr, handle_);
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(10));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+                          Property(&Stats::Metric::name, "redis.foo.command.cluster.latency"), 10));
+  EXPECT_CALL(callbacks_, onResponse_(_));
+  pool_callbacks_[0]->onResponse(response());
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.cluster.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.cluster.success").value());
+}
+
 TEST_F(RandomShardRequestTest, UnsupportedSubcommand) {
   // Test unsupported subcommand for random shard commands (e.g., cluster reset)
   Common::Redis::RespValue expected_response;
@@ -4090,7 +4106,7 @@ TEST_F(ClusterScopeCommandRoutingTest, NoShardsAvailable) {
 
 TEST_F(ClusterScopeCommandRoutingTest, InvalidSubcommand) {
   // Test that CLUSTER command with invalid subcommand is rejected
-  // Only "cluster" has subcommand validation: {"info", "slots", "keyslot", "nodes"}
+  // Only "cluster" has subcommand validation: {"info", "slots", "keyslot", "nodes", "shards"}
   InSequence s;
 
   Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};


### PR DESCRIPTION
**Commit Message**: redis filter: support `CLUSTER SHARDS`

Adds ``shards`` to the CLUSTER subcommand allowlist so cluster-aware clients can issue CLUSTER SHARDS (Redis 7.0+, the successor to the deprecated CLUSTER SLOTS) through the proxy. Like the other supported CLUSTER introspection subcommands (INFO, SLOTS, KEYSLOT, NODES), the command is forwarded to a single random upstream shard and the reply is returned to the client unmodified.

See [here](https://redis.io/docs/latest/commands/cluster-shards/) for `CLUSTER SHARDS` docs.

**Additional Description**:
This builds on the random-shard command framework introduced in #41381: subcommand validation is data-driven via `commandSubcommandValidationMap()`, and routing/response handling reuse the existing `RandomShardRequest` passthrough (works identically for RESP2 and RESP3 connections since the reply is relayed verbatim). On upstreams older than Redis 7.0, the upstream's `ERR unknown subcommand` error is passed through to the client unchanged.

I guess I can also add a small comment on why this is needed - we have a case where we want to use Envoy to fetch Redis cluster state before initializing a client, e.g. ruby `redis-cluster-client`. This library, however, first calls `CLUSTER SHARDS` and only then falls back to `CLUSTER NODES`. See [here](https://github.com/redis-rb/redis-cluster-client/blob/25603bb42d15e3c719a3e505891ce3e425a4d225/lib/redis_client/cluster/node.rb#L357-L365).

Having Envoy support `CLUSTER SHARDS` would help us save some network roundtrips and potentially avoid thundering herd problem on our network links during large scale app rollouts.

**Related issues, not fixed by this PR**: #38492 tracks broader redis_proxy command coverage; #36975 asks for Envoy's own cluster topology discovery to use CLUSTER SHARDS, which is out of scope here (discovery still uses CLUSTER SLOTS).

**Per the generative AI policy**: this change was developed with the assistance of an AI tool (Claude Code). I have reviewed the change, understand it fully, and take ownership of it.

**Risk Level**: Low — additive one-line allowlist change enabling passthrough of a single read-only introspection subcommand; no behavior change for any existing command.

**Testing**: New unit test `RandomShardRequestTest.ClusterShards`, mirroring the existing `ClusterNodes` test. The full `//test/extensions/filters/network/redis_proxy:command_splitter_impl_test` target passes (249/249 tests), including the existing unsupported-subcommand rejection tests. `ci/do_ci.sh format` passes.

**Docs Changes**: Added a ``CLUSTER SHARDS, Generic`` row to the supported commands table in `docs/root/intro/arch_overview/other_protocols/redis.rst`.

**Release Notes**: `changelogs/current/new_features/redis_proxy__cluster-shards-command.rst`

**Platform Specific Features**: N/A
