### PR TITLE
quic: skip stack trace validation in quic_platform_test on optimized s390x builds

### DIFF
--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -146,10 +146,11 @@ TEST_F(QuicPlatformTest, QuicServerStats) {
 }
 
 TEST_F(QuicPlatformTest, QuicStackTraceTest) {
-#if !defined(ENVOY_CONFIG_COVERAGE) && !defined(GCC_COMPILER)
+#if !defined(ENVOY_CONFIG_COVERAGE) && !defined(GCC_COMPILER) && !(defined(__s390x__) && defined(NDEBUG))
   // This doesn't work in coverage build because part of the stacktrace will be overwritten by
   // __llvm_coverage_mapping
   // Stack trace under gcc with optimizations on (-c opt) doesn't include the test name
+  // Stack trace on s390x optimized builds do not preserve the test name
   EXPECT_THAT(QuicStackTrace(), HasSubstr("QuicStackTraceTest"));
 #endif
 }

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -151,7 +151,9 @@ TEST_F(QuicPlatformTest, QuicStackTraceTest) {
   // This doesn't work in coverage build because part of the stacktrace will be overwritten by
   // __llvm_coverage_mapping
   // Stack trace under gcc with optimizations on (-c opt) doesn't include the test name
-  // Stack trace on s390x optimized builds do not preserve the test name
+  // On s390x, backtrace_symbols in Clang optimized builds (-c opt, which sets NDEBUG) omits frame
+  // pointers, so QuicStackTrace() cannot resolve the test name. The test still runs in
+  // debug mode on s390x where frame information is preserved.
   EXPECT_THAT(QuicStackTrace(), HasSubstr("QuicStackTraceTest"));
 #endif
 }

--- a/test/common/quic/platform/quic_platform_test.cc
+++ b/test/common/quic/platform/quic_platform_test.cc
@@ -146,7 +146,8 @@ TEST_F(QuicPlatformTest, QuicServerStats) {
 }
 
 TEST_F(QuicPlatformTest, QuicStackTraceTest) {
-#if !defined(ENVOY_CONFIG_COVERAGE) && !defined(GCC_COMPILER) && !(defined(__s390x__) && defined(NDEBUG))
+#if !defined(ENVOY_CONFIG_COVERAGE) && !defined(GCC_COMPILER) &&                                   \
+    !(defined(__s390x__) && defined(NDEBUG))
   // This doesn't work in coverage build because part of the stacktrace will be overwritten by
   // __llvm_coverage_mapping
   // Stack trace under gcc with optimizations on (-c opt) doesn't include the test name


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: quic: skip stack trace validation in quic_platform_test for optimized s390x builds

Additional Description: Skip the stack trace validation in `quic_platform_test` for optimized (`NDEBUG`)
s390x builds. This change limits the exclusion to optimized s390x builds while preserving validation for
all other platforms and build configurations.

Fixes:

//test/common/quic/platform:quic_platform_test

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: s390x
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
