### PR TITLE
Deflake circuit_breakers_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -624,7 +624,9 @@ envoy_cc_test(
     ],
     deps = [
         ":http_protocol_integration_lib",
+        "//envoy/thread_local:thread_local_interface",
         "//test/test_common:test_time_lib",
+        "@abseil-cpp//absl/synchronization",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
     ],
 )

--- a/test/integration/circuit_breakers_integration_test.cc
+++ b/test/integration/circuit_breakers_integration_test.cc
@@ -1,6 +1,9 @@
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "test/integration/http_protocol_integration.h"
+
+#include "absl/synchronization/notification.h"
 
 using testing::Eq;
 using testing::Ge;
@@ -204,6 +207,33 @@ TEST_P(CircuitBreakersIntegrationTest, CircuitBreakerRuntimeProto) {
 class OutlierDetectionIntegrationTest : public HttpProtocolIntegrationTest {
 public:
   void initialize() override { HttpProtocolIntegrationTest::initialize(); }
+
+  // Wait for worker thread to receive and process cluster membership update after
+  // main thread ejected unhealthy hosts.
+  void waitForLbUpdateOnWorkerThread() {
+    // Wait for main thread to update cluster members. Because update_merge_window == 0
+    // main thread will post updates to worker right after counter reaches 0.
+    test_server_->waitForGauge("cluster.cluster_0.membership_healthy", Eq(0));
+    absl::Notification done_notification;
+    ThreadLocal::TypedSlotPtr<> slot;
+    // After main thread sent LB update to workers, make main thread send a barrier event to worker
+    // thread and wait for notification from worker that it processed LB update. Since there
+    // is only one worker, one notification is enough.
+    test_server_->server().dispatcher().post([&] {
+      slot = ThreadLocal::TypedSlot<>::makeUnique(test_server_->server().threadLocal());
+      slot->set(
+          [](Envoy::Event::Dispatcher&) -> std::shared_ptr<Envoy::ThreadLocal::ThreadLocalObject> {
+            return nullptr;
+          });
+
+      slot->runOnAllThreads([](OptRef<ThreadLocal::ThreadLocalObject>) {},
+                            [&slot, &done_notification] {
+                              slot.reset(nullptr);
+                              done_notification.Notify();
+                            });
+    });
+    done_notification.WaitForNotification();
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(
@@ -220,6 +250,7 @@ TEST_P(OutlierDetectionIntegrationTest, NoClusterOverwrite) {
     auto* cluster = static_resources->mutable_clusters(0);
 
     cluster->mutable_common_lb_config()->mutable_healthy_panic_threshold()->set_value(0);
+    cluster->mutable_common_lb_config()->mutable_update_merge_window()->set_seconds(0);
 
     auto* outlier_detection = cluster->mutable_outlier_detection();
 
@@ -267,6 +298,7 @@ TEST_P(OutlierDetectionIntegrationTest, NoClusterOverwrite) {
   // Wait for the main thread to eject the host
   test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
                                Eq(1));
+  waitForLbUpdateOnWorkerThread();
   // Send another request. It should not reach upstream and should be handled by envoy.
   // The only existing endpoint in the cluster has been marked as unhealthy.
   IntegrationStreamDecoderPtr response =
@@ -286,6 +318,7 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteNon5xxAsErrors) {
     auto* cluster = static_resources->mutable_clusters(0);
 
     cluster->mutable_common_lb_config()->mutable_healthy_panic_threshold()->set_value(0);
+    cluster->mutable_common_lb_config()->mutable_update_merge_window()->set_seconds(0);
 
     auto* outlier_detection = cluster->mutable_outlier_detection();
 
@@ -361,6 +394,7 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteNon5xxAsErrors) {
   // Wait for the main thread to eject the host
   test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
                                Eq(1));
+  waitForLbUpdateOnWorkerThread();
   // Now send a request. It will be captured by Envoy and 503 will be returned as the only upstream
   // is unhealthy now..
   response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -378,6 +412,7 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteGatewayErrors) {
     auto* cluster = static_resources->mutable_clusters(0);
 
     cluster->mutable_common_lb_config()->mutable_healthy_panic_threshold()->set_value(0);
+    cluster->mutable_common_lb_config()->mutable_update_merge_window()->set_seconds(0);
 
     auto* outlier_detection = cluster->mutable_outlier_detection();
 
@@ -437,6 +472,7 @@ TEST_P(OutlierDetectionIntegrationTest, ClusterOverwriteGatewayErrors) {
   // Wait for the main thread to eject the host
   test_server_->waitForCounter("cluster.cluster_0.outlier_detection.ejections_enforced_total",
                                Eq(1));
+  waitForLbUpdateOnWorkerThread();
   // Now send a request. It will be captured by Envoy and 503 will be returned as the only upstream
   // is unhealthy now..
   IntegrationStreamDecoderPtr response =


### PR DESCRIPTION
The test had a race condition between main thread updating worker LB set and test thread sending validation request. When test thread was ahead of worker validation request would not result in the expected 503 status.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
