### PR TITLE
health_check: gracefully handle upstream connection creation failure

### DIFF
--- a/changelogs/current/bug_fixes/sockets__health_check_network_namespace.rst
+++ b/changelogs/current/bug_fixes/sockets__health_check_network_namespace.rst
@@ -1,0 +1,5 @@
+Fixed a crash in the TCP, HTTP, gRPC, and Thrift active health checkers that could occur when the
+upstream health check connection could not be created, for example when the configured Linux
+network namespace (:ref:`network_namespace_filepath
+<envoy_v3_api_field_config.core.v3.SocketAddress.network_namespace_filepath>`) became unavailable at
+runtime. The health check now reports a network failure instead of dereferencing a null connection.

--- a/source/extensions/health_checkers/grpc/health_checker_impl.cc
+++ b/source/extensions/health_checkers/grpc/health_checker_impl.cc
@@ -188,6 +188,13 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
     Upstream::Host::CreateConnectionData conn =
         host_->createHealthCheckConnection(parent_.dispatcher_, parent_.transportSocketOptions(),
                                            parent_.transportSocketMatchMetadata().get());
+    // Connection creation can fail, e.g. when binding to a configured network namespace that is
+    // no longer available. Treat this as a network failure rather than crashing on a null
+    // dereference below.
+    if (conn.connection_ == nullptr) {
+      handleFailure(envoy::data::core::v3::NETWORK);
+      return;
+    }
     client_ = parent_.createCodecClient(conn);
     client_->addConnectionCallbacks(connection_callback_impl_);
     client_->setCodecConnectionCallbacks(http_connection_callback_impl_);
@@ -345,6 +352,11 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::resetState() {
 }
 
 void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onTimeout() {
+  // client_ can be null if the connection failed to be created on this interval (e.g. a network
+  // namespace binding failure). The failure has already been reported, so there is nothing to do.
+  if (client_ == nullptr) {
+    return;
+  }
   ENVOY_CONN_LOG(debug, "connection/stream timeout health_flags={}", *client_,
                  HostUtility::healthFlagsToString(*host_));
   expect_reset_ = true;

--- a/source/extensions/health_checkers/http/health_checker_impl.cc
+++ b/source/extensions/health_checkers/http/health_checker_impl.cc
@@ -272,6 +272,13 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
     Upstream::Host::CreateConnectionData conn =
         host_->createHealthCheckConnection(parent_.dispatcher_, parent_.transportSocketOptions(),
                                            parent_.transportSocketMatchMetadata().get());
+    // Connection creation can fail, e.g. when binding to a configured network namespace that is
+    // no longer available. Treat this as a network failure rather than crashing on a null
+    // dereference below.
+    if (conn.connection_ == nullptr) {
+      handleFailure(envoy::data::core::v3::NETWORK);
+      return;
+    }
     client_.reset(parent_.createCodecClient(conn));
     client_->addConnectionCallbacks(connection_callback_impl_);
     client_->setCodecConnectionCallbacks(http_connection_callback_impl_);

--- a/source/extensions/health_checkers/tcp/health_checker_impl.cc
+++ b/source/extensions/health_checkers/tcp/health_checker_impl.cc
@@ -136,6 +136,13 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onInterval() {
             ->createHealthCheckConnection(parent_.dispatcher_, parent_.transportSocketOptions(),
                                           parent_.transportSocketMatchMetadata().get())
             .connection_;
+    // Connection creation can fail, e.g. when binding to a configured network namespace that is
+    // no longer available. Treat this as a network failure rather than crashing on a null
+    // dereference below.
+    if (client_ == nullptr) {
+      handleFailure(envoy::data::core::v3::NETWORK);
+      return;
+    }
     session_callbacks_ = std::make_shared<TcpSessionCallbacks>(*this);
     client_->addConnectionCallbacks(*session_callbacks_);
     client_->addReadFilter(session_callbacks_);
@@ -172,6 +179,11 @@ void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onInterval() {
 }
 
 void TcpHealthCheckerImpl::TcpActiveHealthCheckSession::onTimeout() {
+  // client_ can be null if the connection failed to be created on this interval (e.g. a network
+  // namespace binding failure). The failure has already been reported, so there is nothing to do.
+  if (client_ == nullptr) {
+    return;
+  }
   ENVOY_CONN_LOG(debug, "hc tcp connection timeout, health_flags={}, health_check_address={}",
                  *client_, HostUtility::healthFlagsToString(*host_),
                  host_->healthCheckAddress()->asString());

--- a/source/extensions/health_checkers/thrift/client.h
+++ b/source/extensions/health_checkers/thrift/client.h
@@ -35,8 +35,10 @@ class Client : public Event::DeferredDeletable {
 public:
   /**
    * Initialize the connection.
+   * @return false if the underlying connection could not be created (e.g. a network namespace
+   *         binding failure), in which case the client is unusable; true otherwise.
    */
-  virtual void start() PURE;
+  virtual bool start() PURE;
 
   /**
    * Send the health check request.

--- a/source/extensions/health_checkers/thrift/client_impl.cc
+++ b/source/extensions/health_checkers/thrift/client_impl.cc
@@ -60,10 +60,16 @@ Network::FilterStatus ThriftSessionCallbacks::onData(Buffer::Instance& data, boo
   return Network::FilterStatus::StopIteration;
 }
 
-void ClientImpl::start() {
+bool ClientImpl::start() {
   Upstream::Host::CreateConnectionData conn_data = parent_.createConnection();
   connection_ = std::move(conn_data.connection_);
   host_description_ = std::move(conn_data.host_description_);
+  // Connection creation can fail, e.g. when binding to a configured network namespace that is no
+  // longer available. Report this so the health check fails gracefully instead of crashing on a
+  // null dereference below.
+  if (connection_ == nullptr) {
+    return false;
+  }
   session_callbacks_ = std::make_unique<ThriftSessionCallbacks>(*this);
   connection_->addConnectionCallbacks(*session_callbacks_);
   connection_->addReadFilter(session_callbacks_);
@@ -72,6 +78,7 @@ void ClientImpl::start() {
   connection_->noDelay(true);
 
   ENVOY_CONN_LOG(trace, "ThriftHealthChecker ClientImpl start", *connection_);
+  return true;
 }
 
 bool ClientImpl::sendRequest() {

--- a/source/extensions/health_checkers/thrift/client_impl.h
+++ b/source/extensions/health_checkers/thrift/client_impl.h
@@ -88,7 +88,7 @@ public:
   void onData(Buffer::Instance& data);
 
   // Client
-  void start() override;
+  bool start() override;
   bool sendRequest() override;
   void close() override;
 

--- a/source/extensions/health_checkers/thrift/thrift.cc
+++ b/source/extensions/health_checkers/thrift/thrift.cc
@@ -64,8 +64,14 @@ void ThriftHealthChecker::ThriftActiveHealthCheckSession::onInterval() {
     client_ = parent_.client_factory_.create(
         *this, parent_.transport_, parent_.protocol_, parent_.method_name_, host_,
         /* health checker seq id */ 0, /* fixed_seq_id */ true);
-    client_->start();
     expect_close_ = false;
+    // The underlying connection can fail to be created (e.g. a network namespace binding failure).
+    // Report a network failure and stop rather than crashing on a null dereference.
+    if (!client_->start()) {
+      handleFailure(envoy::data::core::v3::NETWORK);
+      client_.reset();
+      return;
+    }
   }
 
   client_->sendRequest();

--- a/test/common/upstream/grpc_health_checker_impl_test.cc
+++ b/test/common/upstream/grpc_health_checker_impl_test.cc
@@ -927,6 +927,43 @@ TEST_F(GrpcHealthCheckerImplTest, GrpcHealthFail) {
   expectHostHealthy(true);
 }
 
+// Tests that a failure to create the health check connection (e.g. a network namespace binding
+// failure that makes the upstream connection factory return a null connection) is handled as a
+// network health check failure instead of crashing on a null dereference. Also exercises the
+// re-armed timeout timer firing against a session that has no client.
+TEST_F(GrpcHealthCheckerImplTest, ConnectionCreateFailure) {
+  setupHC();
+  EXPECT_CALL(*this, onHostStatus(_, _)).Times(testing::AnyNumber());
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+
+  // Create only the session timers; the connection cannot be created, so no client connection or
+  // codec mocks must be allocated for this session.
+  TestSessionPtr new_test_session(new TestSession());
+  new_test_session->timeout_timer_ = new Event::MockTimer(&dispatcher_);
+  new_test_session->interval_timer_ = new Event::MockTimer(&dispatcher_);
+  test_sessions_.emplace_back(std::move(new_test_session));
+
+  // The upstream connection cannot be created; the factory returns a null connection.
+  EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, _, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  // The first check fails gracefully instead of crashing.
+  health_checker_->start();
+  // Fire the re-armed timeout timer; onTimeout must tolerate the null client without crashing.
+  test_sessions_[0]->timeout_timer_->invokeCallback();
+
+  EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_GE(cluster_->info_->stats_store_.counter("health_check.failure").value(), 1UL);
+  EXPECT_GE(cluster_->info_->stats_store_.counter("health_check.network_failure").value(), 1UL);
+  expectHostHealthy(false);
+}
+
 // Test disconnects produce network-type failures which does not lead to immediate unhealthy state.
 TEST_F(GrpcHealthCheckerImplTest, Disconnect) {
   setupHC();

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -4935,6 +4935,34 @@ TEST_F(TcpHealthCheckerImplTest, ConnectionLocalFailure) {
   EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.passive_failure").value());
 }
 
+// Tests that a failure to create the health check connection (e.g. a network namespace binding
+// failure that makes the upstream connection factory return a null connection) is handled as a
+// network health check failure instead of crashing on a null dereference. Also exercises the
+// re-armed timeout timer firing against a session that has no client.
+TEST_F(TcpHealthCheckerImplTest, ConnectionCreateFailure) {
+  setupData();
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+  expectSessionCreate();
+
+  // The upstream connection cannot be created; the factory returns a null connection.
+  EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, _, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*timeout_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*timeout_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*interval_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*interval_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  // First check fails gracefully instead of crashing.
+  health_checker_->start();
+  // Fire the re-armed timeout timer; onTimeout must tolerate the null client without crashing.
+  timeout_timer_->invokeCallback();
+
+  EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_GE(cluster_->info_->stats_store_.counter("health_check.failure").value(), 1UL);
+}
+
 TEST_F(TcpHealthCheckerImplTest, SuccessProxyProtocol) {
   InSequence s;
 

--- a/test/common/upstream/health_checker_impl_test.cc
+++ b/test/common/upstream/health_checker_impl_test.cc
@@ -958,6 +958,39 @@ TEST_F(HttpHealthCheckerImplTest, LastHealthCheckHttpStatusClearedOnNetworkFailu
                    .has_value());
 }
 
+// Tests that a failure to create the health check connection (e.g. a network namespace binding
+// failure that makes the upstream connection factory return a null connection) is handled as a
+// network health check failure instead of crashing on a null dereference.
+TEST_F(HttpHealthCheckerImplTest, ConnectionCreateFailure) {
+  setupNoServiceValidationHC();
+  EXPECT_CALL(*this, onHostStatus(_, _)).Times(testing::AnyNumber());
+  cluster_->prioritySet().getMockHostSet(0)->hosts_ = {
+      makeTestHost(cluster_->info_, "tcp://127.0.0.1:80")};
+
+  // Create only the session timers; the connection cannot be created, so no client connection or
+  // codec mocks must be allocated for this session.
+  TestSessionPtr new_test_session(new TestSession());
+  new_test_session->timeout_timer_ = new Event::MockTimer(&dispatcher_);
+  new_test_session->interval_timer_ = new Event::MockTimer(&dispatcher_);
+  test_sessions_.emplace_back(std::move(new_test_session));
+
+  // The upstream connection cannot be created; the factory returns a null connection.
+  EXPECT_CALL(dispatcher_, createClientConnection_(_, _, _, _)).WillRepeatedly(Return(nullptr));
+  EXPECT_CALL(event_logger_, logUnhealthy(_, _, _, _, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(event_logger_, logEjectUnhealthy(_, _, _, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->timeout_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*test_sessions_[0]->interval_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  // The first check fails gracefully instead of crashing.
+  health_checker_->start();
+
+  EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_GE(cluster_->info_->stats_store_.counter("health_check.failure").value(), 1UL);
+  EXPECT_GE(cluster_->info_->stats_store_.counter("health_check.network_failure").value(), 1UL);
+}
+
 TEST_F(HttpHealthCheckerImplTest, Degraded) {
   setupNoServiceValidationHC();
   EXPECT_CALL(*this, onHostStatus(_, HealthTransition::Changed)).Times(2);

--- a/test/extensions/health_checkers/thrift/client_impl_test.cc
+++ b/test/extensions/health_checkers/thrift/client_impl_test.cc
@@ -136,6 +136,18 @@ TEST_F(ThriftClientImplTest, Success) {
   client_->close();
 }
 
+// Tests that start() reports failure when the underlying connection cannot be created (e.g. a
+// network namespace binding failure makes the connection factory return a null connection).
+TEST_F(ThriftClientImplTest, ConnectionCreateFailure) {
+  Upstream::MockHost::MockCreateConnectionData conn_info;
+  EXPECT_CALL(client_callback_, createConnection_).WillOnce(Return(conn_info));
+
+  ClientFactoryImpl& factory = ClientFactoryImpl::instance_;
+  client_ = factory.create(client_callback_, transport_, protocol_, method_name_, host_,
+                           initial_seq_id_, false);
+  EXPECT_FALSE(client_->start());
+}
+
 TEST_F(ThriftClientImplTest, Execption) {
   InSequence s;
 

--- a/test/extensions/health_checkers/thrift/mocks.cc
+++ b/test/extensions/health_checkers/thrift/mocks.cc
@@ -15,7 +15,7 @@ namespace HealthCheckers {
 namespace ThriftHealthChecker {
 
 MockClient::MockClient(ClientCallback& callback) : callback_(callback) {
-  ON_CALL(*this, start()).WillByDefault(testing::Return());
+  ON_CALL(*this, start()).WillByDefault(testing::Return(true));
   ON_CALL(*this, close()).WillByDefault(Invoke([this]() -> void {
     raiseEvent(Network::ConnectionEvent::LocalClose);
   }));

--- a/test/extensions/health_checkers/thrift/mocks.h
+++ b/test/extensions/health_checkers/thrift/mocks.h
@@ -25,7 +25,7 @@ public:
 
   void runLowWatermarkCallbacks() { callback_.onBelowWriteBufferLowWatermark(); }
 
-  MOCK_METHOD(void, start, ());
+  MOCK_METHOD(bool, start, ());
   MOCK_METHOD(bool, sendRequest, ());
   MOCK_METHOD(void, close, ());
 

--- a/test/extensions/health_checkers/thrift/thrift_test.cc
+++ b/test/extensions/health_checkers/thrift/thrift_test.cc
@@ -249,6 +249,33 @@ TEST_F(ThriftHealthCheckerTest, PingAndVariousFailures) {
   EXPECT_EQ(2UL, cluster_->info_->stats_store_.counter("health_check.network_failure").value());
 }
 
+// Tests that a client whose underlying connection cannot be created (e.g. a network namespace
+// binding failure) results in a network health check failure instead of a crash.
+TEST_F(ThriftHealthCheckerTest, ConnectionCreateFailure) {
+  setup();
+
+  expectSessionCreate();
+  EXPECT_CALL(*this, create_(_)).WillOnce(testing::Invoke([&](ClientCallback& callback) {
+    client_ = new NiceMock<MockClient>(callback);
+    EXPECT_CALL(*client_, start()).WillOnce(Return(false));
+    return client_;
+  }));
+  EXPECT_CALL(*event_logger_, logUnhealthy(_, _, _, _, _)).Times(testing::AtLeast(1));
+  EXPECT_CALL(*event_logger_, logEjectUnhealthy(_, _, _, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*timeout_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*timeout_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+  EXPECT_CALL(*interval_timer_, disableTimer()).Times(testing::AnyNumber());
+  EXPECT_CALL(*interval_timer_, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  // The first check fails gracefully instead of crashing.
+  health_checker_->start();
+
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.attempt").value());
+  EXPECT_EQ(0UL, cluster_->info_->stats_store_.counter("health_check.success").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.failure").value());
+  EXPECT_EQ(1UL, cluster_->info_->stats_store_.counter("health_check.network_failure").value());
+}
+
 TEST_F(ThriftHealthCheckerTest, AlwaysLogHealthCheckFailures) {
   InSequence s;
   setupAlwaysLogHealthCheckFailures();


### PR DESCRIPTION
### Commit Message
health_check: gracefully handle upstream connection creation failure

### Additional Description
Follow-up to #45975, which made `HostImplBase::createConnection` return a null connection
(instead of crashing) when the upstream connection cannot be created — for example when binding
to a configured Linux network namespace (`SocketAddress.network_namespace_filepath`) that became
unavailable at runtime. The connection pools were taught to surface that as a pool failure, but
the active health checkers create connections directly via `createHealthCheckConnection` and
still dereference the result unconditionally, so they crash in the same scenario.

This change makes the TCP, HTTP, gRPC, and Thrift active health checkers treat a null connection
as a `NETWORK` health-check failure instead of dereferencing it. The TCP and gRPC `onTimeout`
handlers also tolerate a null client, because the interval base re-arms the timeout timer after a
failed interval. Thrift's `Client::start` now returns whether the connection was created so the
session can fail gracefully.

The redis proxy upstream client has the same direct-call pattern; making it graceful requires
threading a connection-creation failure through the redis connection pool and is left as a
follow-up.

### Risk Level
Low — converts a crash into the existing graceful network-failure path.

### Testing
Unit tests: a TCP health checker test covering a null connection and the re-armed timeout firing
against a session with no client (`test/common/upstream/health_checker_impl_test.cc`); Thrift
mock updated for the new `Client::start` return value.

### Docs Changes
N/A

### Release Notes
Included (`changelogs/current/bug_fixes/sockets__health_check_network_namespace.rst`).

### Platform Specific Features
N/A
