### PR TITLE
reflip the coalesce_lb_rebuilds_on_batch_update flag default value to true

### DIFF
--- a/changelogs/current/minor_behavior_changes/upstream__coalesce-lb-rebuilds-on-batch-update-enabled-by-default.rst
+++ b/changelogs/current/minor_behavior_changes/upstream__coalesce-lb-rebuilds-on-batch-update-enabled-by-default.rst
@@ -1,0 +1,7 @@
+The runtime guard ``envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update`` now defaults
+to ``true``. A thread-aware load balancer (for example ``RING_HASH`` or ``MAGLEV``) rebuilds its
+factory state once at the end of a batch host update, from the single end-of-cycle member-update
+callback, instead of once per priority from the per-priority update callback. The rebuild still
+lands before the cluster manager posts the update to the worker threads, so this only removes the
+redundant per-priority rebuilds of a batch. This can be reverted by setting
+``envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update`` to ``false``.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -36,6 +36,7 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_cel_message_serialize_text_format);
+RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);
 RUNTIME_GUARD(envoy_reloadable_features_codec_client_enable_idle_timer_only_when_connected);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_fix_reentrancy);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_grid_early_return_on_teardown);
@@ -248,9 +249,6 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_allow_multiplexed_upstream_half_cl
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_ext_proc_graceful_grpc_close);
 
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_getaddrinfo_no_ai_flags);
-
-// See: `https://github.com/envoyproxy/envoy/issues/45212` for more details.
-FALSE_RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);
 
 // Flag to remove legacy route formatter support in header parser
 // Flip to true after two release periods.


### PR DESCRIPTION
Commit Message:
Additional Description:

The https://github.com/envoyproxy/envoy/pull/45266 flipped the runtime flag to false because the issue https://github.com/envoyproxy/envoy/issues/45212.

Now, I have resolved it at https://github.com/envoyproxy/envoy/pull/46302. So, we should flip the runtime flag back.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.