### PR TITLE
docs: replace dead communityinviter link with Envoy maintained redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ involved and how Envoy plays a role, read the CNCF
 * [envoy-maintainers](https://groups.google.com/forum/#!forum/envoy-maintainers): Use this list
   to reach all core Envoy maintainers.
 * [Twitter](https://twitter.com/EnvoyProxy/): Follow along on Twitter!
-* [Slack](https://envoyproxy.slack.com/): Slack, to get invited go [here](https://communityinviter.com/apps/envoyproxy/envoy).
+* [Slack](https://envoyproxy.slack.com/): Slack, to get invited go [here](https://www.envoyproxy.io/slack).
   * NOTE: Response to user questions is best effort on Slack. For a "guaranteed" response please email
     envoy-users@ per the guidance in the following linked thread.
 


### PR DESCRIPTION
**Commit Message:** 

docs: replace dead communityinviter link with Envoy maintained redirect

**Additional Description:**

Made sure there is nowhere else that references the communityinviter service
```
$ grep -rE "communityinvite" ./* 
$ 
```
Interestingly, mobile had the right link already
```
$ grep -r "envoyproxy.io/slack" ./*
./mobile/README.md:  [here](https://envoyproxy.io/slack). We can be found in the **#envoy-mobile** room.
./README.md:* [Slack](https://envoyproxy.slack.com/): Slack, to get invited go [here](https://www.envoyproxy.io/slack).
```

**Risk Level:** Low

Fixes #46347