### PR TITLE
Update QUICHE from 0580a14c2 to 3dccaa116

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -311,7 +311,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-07-22"
+  release_date: "2026-08-01"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "0580a14c23b7f7005abd2c18587f108ed6f1e93e",
-        sha256 = "30a8bbb156d5e3739dc19741837df2d8191d18dc0506727f08f2db5f88a72328",
+        version = "3dccaa1161bab5c5c2f40510dbc5c355123b2402",
+        sha256 = "8cb36ca5ffc69ebe2d6d0a2c7dbfacf1b478556b8ee504da2a9b4d85d2db69d0",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/0580a14c2..3dccaa116

```
$ git log 0580a14c2..3dccaa116 --date=short --no-merges --format="%ad %al %s"

2026-08-01 quiche-dev Fix 38 ClangInliner findings: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs. (38 times)
2026-07-31 apaseltiner Replace lone caller of deprecated TakeString method
2026-07-31 martinduke No public description
2026-07-31 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Fix 10 ClangInliner findings: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs. (10 times)
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 vasilvv Fix RelayTwoClientsQueueClose ASAN failures.
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 apaseltiner Add GetIf* methods to Item for each type
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-29 dschinazi Remove TODO
2026-07-29 ericorth Bonnet Tun Exchanger Refactor: Repurpose/cleanup Visitor for async exchanger
2026-07-29 vasilvv Split out REQUEST_UPDATE callback queue into a separate class.
2026-07-29 vasilvv Add support for ACK timestamp truncation.
2026-07-29 martinduke Prevent MoqtRelayTrackPublisher from calling OnNewFinAvailable multiple times.
2026-07-29 martinduke MoqtUniStream expects that MoqtTrackPublisher will not deliver empty object fragments. Fix MoqtRelayTrackPublisher (the only child class that can deliver fragments) to not do that, thus avoiding the QUICHE_BUG OutgoingSubgroupStream_empty_payload.
2026-07-29 quiche-dev Deprecate gfe2_restart_flag_quic_set_credential_ex_data.
2026-07-28 wub Roll back -gfe2_reloadable_flag_quic_fix_mtu_discovery.
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 rch Deprecate --gfe2_restart_flag_quic_shed_tls_handshake_config.
2026-07-27 vasilvv Refactor QUIC Receive Timestamp serialization into a separate class.
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 quiche-dev Add client manufacturer and ID attestation flag to AttestAndSignRequest.
2026-07-27 rch Deprecate --gfe2_reloadable_flag_quic_delete_config.
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-23 ericorth Bonnet Tun Exchanger Refactor: Drop the base class that barely did anything
2026-07-23 apaseltiner Add option to parse decimals and byte sequences strictly
2026-07-22 ericorth Bonnet Tun Exchanger Refactor: Divorce exchanger from QbonePacketWriter
```
