### PR TITLE
dym: add sds subscription support to the HTTP dynamic module

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-http-filter-generic-secret-subscription.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-filter-generic-secret-subscription.rst
@@ -1,0 +1,7 @@
+Added generic secret subscriptions to the dynamic modules HTTP filter. During filter config
+initialization a module can subscribe to a generic secret by name, optionally passing a JSON
+serialized :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>` to fetch it over SDS,
+and read the current value per-stream or from the config context afterwards. Values are kept
+up-to-date as the SDS server pushes new versions. Available through the Rust, Go and C++ SDKs as
+``subscribe_generic_secret``/``get_generic_secret``, ``SubscribeGenericSecret``/``GetGenericSecret``
+and ``subscribeGenericSecret``/``getGenericSecret`` respectively.

--- a/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
+++ b/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
@@ -125,3 +125,26 @@ In addition to the counters above, a module may define its own custom metrics. T
 under the configurable :ref:`metrics_namespace
 <envoy_v3_api_field_extensions.dynamic_modules.v3.DynamicModuleConfig.metrics_namespace>`
 (``dynamicmodulescustom`` by default), separately from the ``dynamic_modules.`` namespace above.
+
+Secrets
+---------------------------
+
+An HTTP filter module can subscribe to :ref:`generic secrets <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.GenericSecret>`
+rather than carrying credentials in its own configuration, so that secrets stay out of the module
+configuration and are rotated by Envoy.
+
+A subscription is created while the filter configuration is being loaded, and is identified by a
+name plus an optional :ref:`ConfigSource <envoy_v3_api_msg_config.core.v3.ConfigSource>`, serialized
+as JSON, that the module passes to Envoy:
+
+* Without a config source, the name refers to a secret in :ref:`static_resources.secrets
+  <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.StaticResources.secrets>`.
+* With a config source, the name is the resource requested over :ref:`SDS <config_secret_discovery_service>`.
+  Identical subscriptions are shared across filters, and the value the module reads is updated
+  whenever the SDS server pushes a new version. On the downstream HTTP filter chain the subscription
+  also participates in initialization, so the listener does not start serving until the secret has
+  been delivered.
+
+Reading a secret returns the value for the current worker thread, so a rotation is transparent to
+the module. The returned bytes are owned by Envoy and are only valid for the duration of the event
+hook, so a module that needs to retain a secret must copy it.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -1630,6 +1630,94 @@ envoy_dynamic_module_callback_http_filter_config_record_histogram_value(
     envoy_dynamic_module_type_module_buffer* label_values, size_t label_values_length,
     uint64_t value);
 
+// ----------------------------- Secret callbacks ------------------------------
+
+/**
+ * envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe is called by the module
+ * during initialization to subscribe to a generic secret so that its value can later be read via
+ * envoy_dynamic_module_callback_http_filter_get_generic_secret or
+ * envoy_dynamic_module_callback_http_filter_config_get_generic_secret.
+ *
+ * The subscription is resolved the same way as any other Envoy extension resolves an
+ * ``SdsSecretConfig``: when sds_config_source is empty the secret is looked up among the statically
+ * configured secrets by name, and otherwise an SDS subscription is created (or shared with an
+ * existing identical one) so that the value is updated whenever the SDS server pushes a new
+ * version.
+ *
+ * This can only be called during envoy_dynamic_module_on_http_filter_config_new. Calling it after
+ * the configuration has been loaded fails, since creating a subscription is only safe on the main
+ * thread before any worker observes the configuration.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig for which the
+ * secret will be subscribed.
+ * @param name is the name of the generic secret. For a static secret this is the name of the
+ * secret in the bootstrap configuration, and for a dynamic secret this is the resource name
+ * requested from the SDS server. This must not be empty.
+ * @param sds_config_source is the JSON serialized ``envoy.config.core.v3.ConfigSource`` describing
+ * where to fetch the secret from. When the length is 0 the secret is looked up among the static
+ * secrets instead.
+ * @return size_t the opaque ID that represents the subscribed secret, which can be passed to
+ * envoy_dynamic_module_callback_http_filter_get_generic_secret together with a filter_envoy_ptr
+ * created from filter_config_envoy_ptr, or to
+ * envoy_dynamic_module_callback_http_filter_config_get_generic_secret together with
+ * filter_config_envoy_ptr. Returning 0 indicates a failure to subscribe, e.g. the name is empty,
+ * the static secret does not exist, or sds_config_source is not a valid ConfigSource.
+ */
+size_t envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name,
+    envoy_dynamic_module_type_module_buffer sds_config_source);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_get_generic_secret is called by the module to read the
+ * current value of a previously subscribed generic secret.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object.
+ * @param id is the ID of the secret previously subscribed using the config that created
+ * filter_envoy_ptr.
+ * @param result is the buffer where the current value of the secret will be stored. The value is
+ * empty (length 0) when the secret has been subscribed but not yet delivered by the SDS server.
+ * @return true if the operation is successful, false if the id does not correspond to a subscribed
+ * secret.
+ *
+ * The value is read from thread local storage, so this must be called on the worker thread running
+ * the stream, not on a thread created by the module.
+ *
+ * OWNERSHIP: Envoy owns the returned buffer. It is only valid until the module returns from the
+ * current event hook, since a secret rotation replaces the value in between events. The module must
+ * copy the value if it needs to retain it.
+ */
+bool envoy_dynamic_module_callback_http_filter_get_generic_secret(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
+/**
+ * envoy_dynamic_module_callback_http_filter_config_get_generic_secret is called by the module to
+ * read the current value of a previously subscribed generic secret from the filter config context.
+ * Unlike envoy_dynamic_module_callback_http_filter_get_generic_secret, this does not require a
+ * per-stream filter and can be called outside of the request lifecycle, e.g. from a scheduled
+ * background task.
+ *
+ * @param filter_config_envoy_ptr is the pointer to the DynamicModuleHttpFilterConfig that
+ * subscribed the secret.
+ * @param id is the ID of the secret previously subscribed using filter_config_envoy_ptr.
+ * @param result is the buffer where the current value of the secret will be stored. The value is
+ * empty (length 0) when the secret has been subscribed but not yet delivered by the SDS server.
+ * @return true if the operation is successful, false if the id does not correspond to a subscribed
+ * secret.
+ *
+ * The value is read from thread local storage, so this must be called on an Envoy thread, i.e.
+ * during envoy_dynamic_module_on_http_filter_config_new or from an event hook such as
+ * envoy_dynamic_module_on_http_filter_config_scheduled, not on a thread created by the module.
+ *
+ * OWNERSHIP: Envoy owns the returned buffer. It is only valid until the module returns from the
+ * current event hook, since a secret rotation replaces the value in between events. The module must
+ * copy the value if it needs to retain it.
+ */
+bool envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_envoy_buffer* result);
+
 // ---------------------- HTTP Header/Trailer callbacks ------------------------
 
 /**

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -404,6 +404,12 @@ public:
 using MetricID = uint64_t;
 enum class MetricsResult : uint32_t { Success, NotFound, InvalidTags, Frozen };
 
+/**
+ * An opaque identifier for a generic secret subscribed to via
+ * HttpFilterConfigHandle::subscribeGenericSecret.
+ */
+using GenericSecretID = uint64_t;
+
 class HttpFilterHandle {
 public:
   virtual ~HttpFilterHandle();
@@ -943,6 +949,22 @@ public:
                                               std::span<const BufferView> tags_values = {}) = 0;
 
   /**
+   * Returns the current value of a generic secret subscribed to by the filter config via
+   * HttpFilterConfigHandle::subscribeGenericSecret. An empty value means the secret has been
+   * subscribed to but not yet delivered by the SDS server, which is distinct from an absent
+   * optional.
+   *
+   * The returned view aliases Envoy memory and must not be retained across events: a secret
+   * rotation replaces the value in between events on this worker thread. Copy it if it needs to
+   * outlive the current callback.
+   *
+   * @param id The secret ID returned by subscribeGenericSecret.
+   * @return The current value, or std::nullopt if the id does not correspond to a subscribed
+   * secret.
+   */
+  virtual std::optional<std::string_view> getGenericSecret(GenericSecretID id) = 0;
+
+  /**
    * Checks if logging is enabled for the given log level.
    * @param level The log level to check.
    * @return True if logging is enabled, false otherwise.
@@ -1047,6 +1069,42 @@ public:
    */
   virtual MetricsResult incrementCounterValue(MetricID id, uint64_t value,
                                               std::span<const BufferView> tags_values = {}) = 0;
+
+  /**
+   * Subscribes to a generic secret so that its value can later be read via getGenericSecret, either
+   * here or on HttpFilterHandle.
+   *
+   * This can only be called while the filter config is being created, i.e. from
+   * HttpFilterConfigFactory::onConfigNew.
+   *
+   * @param name The name of the secret: for a static secret the name in the bootstrap
+   * configuration, and for a dynamic secret the resource name requested from the SDS server.
+   * @param sds_config_source The JSON serialized ``envoy.config.core.v3.ConfigSource`` describing
+   * where to fetch the secret from, so that the value is updated whenever the SDS server pushes a
+   * new version. Pass an empty string to look the name up among the statically configured secrets
+   * instead.
+   * @return The secret ID, or std::nullopt if the secret cannot be subscribed to, for example when
+   * the static secret does not exist or sds_config_source is not a valid ConfigSource.
+   */
+  virtual std::optional<GenericSecretID>
+  subscribeGenericSecret(std::string_view name, std::string_view sds_config_source = {}) = 0;
+
+  /**
+   * Returns the current value of a previously subscribed generic secret. An empty value means the
+   * secret has been subscribed to but not yet delivered by the SDS server, which is distinct from
+   * an absent optional.
+   *
+   * Unlike HttpFilterHandle::getGenericSecret, this does not require a per-stream filter and can be
+   * called outside of the request lifecycle, for example from a scheduled background task.
+   *
+   * The returned view aliases Envoy memory and must not be retained across events. Copy it if it
+   * needs to outlive the current callback.
+   *
+   * @param id The secret ID returned by subscribeGenericSecret.
+   * @return The current value, or std::nullopt if the id does not correspond to a subscribed
+   * secret.
+   */
+  virtual std::optional<std::string_view> getGenericSecret(GenericSecretID id) = 0;
 
   /**
    * Checks if logging is enabled for the given log level.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -887,6 +887,20 @@ public:
             reinterpret_cast<const envoy_dynamic_module_type_module_buffer*>(tags_values.data())),
         tags_values.size(), value));
   }
+  std::optional<std::string_view> getGenericSecret(GenericSecretID id) override {
+    BufferView value{nullptr, 0};
+    const bool ret = envoy_dynamic_module_callback_http_filter_get_generic_secret(
+        host_plugin_ptr_, id, reinterpret_cast<envoy_dynamic_module_type_envoy_buffer*>(&value));
+    if (!ret) {
+      return {};
+    }
+    // Unlike the other getters, an empty value is meaningful here: it means the secret has not been
+    // delivered yet, so it stays distinct from std::nullopt.
+    if (value.data() == nullptr) {
+      return std::string_view{};
+    }
+    return value.toStringView();
+  }
   bool logEnabled(LogLevel level) override {
     return envoy_dynamic_module_callback_log_enabled(
         static_cast<envoy_dynamic_module_type_log_level>(level));
@@ -1012,6 +1026,35 @@ public:
                 reinterpret_cast<const envoy_dynamic_module_type_module_buffer*>(
                     tags_values.data())),
             tags_values.size(), value));
+  }
+
+  std::optional<GenericSecretID>
+  subscribeGenericSecret(std::string_view name, std::string_view sds_config_source) override {
+    const size_t id = envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+        host_config_ptr_, envoy_dynamic_module_type_module_buffer{name.data(), name.size()},
+        // An empty buffer tells Envoy to resolve the name as a static secret.
+        envoy_dynamic_module_type_module_buffer{sds_config_source.data(),
+                                                sds_config_source.size()});
+    // 0 is reserved to signal that the subscription could not be created.
+    if (id == 0) {
+      return {};
+    }
+    return id;
+  }
+
+  std::optional<std::string_view> getGenericSecret(GenericSecretID id) override {
+    BufferView value{nullptr, 0};
+    const bool ret = envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+        host_config_ptr_, id, reinterpret_cast<envoy_dynamic_module_type_envoy_buffer*>(&value));
+    if (!ret) {
+      return {};
+    }
+    // Unlike the other getters, an empty value is meaningful here: it means the secret has not been
+    // delivered yet, so it stays distinct from std::nullopt.
+    if (value.data() == nullptr) {
+      return std::string_view{};
+    }
+    return value.toStringView();
   }
 
   bool logEnabled(LogLevel level) override {

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -1566,6 +1566,21 @@ func (h *dymHttpFilterHandle) IncrementCounterValue(id shared.MetricID,
 	return shared.MetricsResult(ret)
 }
 
+func (h *dymHttpFilterHandle) GetGenericSecret(
+	id shared.GenericSecretID,
+) (shared.UnsafeEnvoyBuffer, bool) {
+	var value C.envoy_dynamic_module_type_envoy_buffer
+	ok := C.envoy_dynamic_module_callback_http_filter_get_generic_secret(
+		h.hostPluginPtr,
+		(C.size_t)(uint64(id)),
+		&value,
+	)
+	if !bool(ok) {
+		return shared.UnsafeEnvoyBuffer{}, false
+	}
+	return envoyBufferToUnsafeEnvoyBuffer(value), true
+}
+
 func newDymStreamPluginHandle(
 	hostPluginPtr C.envoy_dynamic_module_type_http_filter_envoy_ptr,
 ) *dymHttpFilterHandle {
@@ -1772,6 +1787,36 @@ func (h *dymConfigHandle) IncrementCounterValue(id shared.MetricID,
 	runtime.KeepAlive(tagsValues)
 	runtime.KeepAlive(tagValueViews)
 	return shared.MetricsResult(ret)
+}
+
+func (h *dymConfigHandle) SubscribeGenericSecret(
+	name string, sdsConfigSource string,
+) shared.GenericSecretID {
+	id := C.envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+		h.hostConfigPtr,
+		stringToModuleBuffer(name),
+		// An empty buffer tells Envoy to resolve the name as a static secret.
+		stringToModuleBuffer(sdsConfigSource),
+	)
+	runtime.KeepAlive(name)
+	runtime.KeepAlive(sdsConfigSource)
+	// 0 is reserved to signal that the subscription could not be created.
+	return shared.GenericSecretID(uint64(id))
+}
+
+func (h *dymConfigHandle) GetGenericSecret(
+	id shared.GenericSecretID,
+) (shared.UnsafeEnvoyBuffer, bool) {
+	var value C.envoy_dynamic_module_type_envoy_buffer
+	ok := C.envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+		h.hostConfigPtr,
+		(C.size_t)(uint64(id)),
+		&value,
+	)
+	if !bool(ok) {
+		return shared.UnsafeEnvoyBuffer{}, false
+	}
+	return envoyBufferToUnsafeEnvoyBuffer(value), true
 }
 
 func (h *dymConfigHandle) HttpCallout(

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -514,11 +514,21 @@ type HttpFilterHandle interface {
 	// IncrementCounterValue adds the given value to the counter metric. The order and
 	// size of tagsValues must match the tag keys defined when the metric was created.
 	IncrementCounterValue(id MetricID, value uint64, tagsValues ...string) MetricsResult
+
+	// GetGenericSecret returns the current value of a generic secret subscribed to by the filter
+	// config via HttpFilterConfigHandle.SubscribeGenericSecret. The second return value is false
+	// if the id does not correspond to a subscribed secret. The value is empty when the secret has
+	// been subscribed to but not yet delivered by the SDS server.
+	//
+	// The buffer aliases Envoy memory and must not be retained across events: a secret rotation
+	// replaces the value in between events on this worker thread. Copy it if it needs to outlive
+	// the current callback.
+	GetGenericSecret(id GenericSecretID) (UnsafeEnvoyBuffer, bool)
 }
 
 // HttpFilterConfigHandle is the per-filter-config handle exposed to HttpFilterConfig
-// implementations. It supports config-scoped logging, metric definition, and async I/O via
-// HttpCallout / StartHttpStream from the main thread.
+// implementations. It supports config-scoped logging, metric definition, generic secret
+// subscription, and async I/O via HttpCallout / StartHttpStream from the main thread.
 type HttpFilterConfigHandle interface {
 	// Log will log the given message via the host environment's logging mechanism.
 	Log(level LogLevel, format string, args ...any)
@@ -598,4 +608,31 @@ type HttpFilterConfigHandle interface {
 	// Unlike HttpFilterHandle.IncrementCounterValue, this does not require a per-stream filter and
 	// can be called outside of the request lifecycle, for example from a scheduled background task.
 	IncrementCounterValue(id MetricID, value uint64, tagsValues ...string) MetricsResult
+
+	// SubscribeGenericSecret subscribes to a generic secret so that its value can later be read
+	// via GetGenericSecret, either here or on HttpFilterHandle.
+	//
+	// name is the name of the secret: for a static secret the name in the bootstrap configuration,
+	// and for a dynamic secret the resource name requested from the SDS server.
+	//
+	// sdsConfigSource is the JSON serialized envoy.config.core.v3.ConfigSource describing where to
+	// fetch the secret from, so that the value is updated whenever the SDS server pushes a new
+	// version. Pass an empty string to look the name up among the statically configured secrets
+	// instead.
+	//
+	// This can only be called while the filter config is being created, i.e. from
+	// HttpFilterConfigFactory.Create. Returns a zero ID if the secret cannot be subscribed to, for
+	// example when the static secret does not exist or sdsConfigSource is not a valid ConfigSource.
+	SubscribeGenericSecret(name string, sdsConfigSource string) GenericSecretID
+
+	// GetGenericSecret returns the current value of a previously subscribed generic secret. The
+	// second return value is false if the id does not correspond to a subscribed secret. The value
+	// is empty when the secret has been subscribed to but not yet delivered by the SDS server.
+	//
+	// Unlike HttpFilterHandle.GetGenericSecret, this does not require a per-stream filter and can
+	// be called outside of the request lifecycle, for example from a scheduled background task.
+	//
+	// The buffer aliases Envoy memory and must not be retained across events. Copy it if it needs
+	// to outlive the current callback.
+	GetGenericSecret(id GenericSecretID) (UnsafeEnvoyBuffer, bool)
 }

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
@@ -860,6 +860,21 @@ func (mr *MockHttpFilterHandleMockRecorder) GetFilterStateTyped(key any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFilterStateTyped", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetFilterStateTyped), key)
 }
 
+// GetGenericSecret mocks base method.
+func (m *MockHttpFilterHandle) GetGenericSecret(id shared.GenericSecretID) (shared.UnsafeEnvoyBuffer, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGenericSecret", id)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetGenericSecret indicates an expected call of GetGenericSecret.
+func (mr *MockHttpFilterHandleMockRecorder) GetGenericSecret(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenericSecret", reflect.TypeOf((*MockHttpFilterHandle)(nil).GetGenericSecret), id)
+}
+
 // GetLogLevel mocks base method.
 func (m *MockHttpFilterHandle) GetLogLevel() shared.LogLevel {
 	m.ctrl.T.Helper()
@@ -1685,6 +1700,21 @@ func (mr *MockHttpFilterConfigHandleMockRecorder) DefineHistogram(name any, tagK
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefineHistogram", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).DefineHistogram), varargs...)
 }
 
+// GetGenericSecret mocks base method.
+func (m *MockHttpFilterConfigHandle) GetGenericSecret(id shared.GenericSecretID) (shared.UnsafeEnvoyBuffer, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGenericSecret", id)
+	ret0, _ := ret[0].(shared.UnsafeEnvoyBuffer)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetGenericSecret indicates an expected call of GetGenericSecret.
+func (mr *MockHttpFilterConfigHandleMockRecorder) GetGenericSecret(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenericSecret", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).GetGenericSecret), id)
+}
+
 // GetScheduler mocks base method.
 func (m *MockHttpFilterConfigHandle) GetScheduler() shared.Scheduler {
 	m.ctrl.T.Helper()
@@ -1860,4 +1890,18 @@ func (m *MockHttpFilterConfigHandle) StartHttpStream(cluster string, headers [][
 func (mr *MockHttpFilterConfigHandleMockRecorder) StartHttpStream(cluster, headers, body, endOfStream, timeoutMs, cb any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartHttpStream", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).StartHttpStream), cluster, headers, body, endOfStream, timeoutMs, cb)
+}
+
+// SubscribeGenericSecret mocks base method.
+func (m *MockHttpFilterConfigHandle) SubscribeGenericSecret(name, sdsConfigSource string) shared.GenericSecretID {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SubscribeGenericSecret", name, sdsConfigSource)
+	ret0, _ := ret[0].(shared.GenericSecretID)
+	return ret0
+}
+
+// SubscribeGenericSecret indicates an expected call of SubscribeGenericSecret.
+func (mr *MockHttpFilterConfigHandleMockRecorder) SubscribeGenericSecret(name, sdsConfigSource any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeGenericSecret", reflect.TypeOf((*MockHttpFilterConfigHandle)(nil).SubscribeGenericSecret), name, sdsConfigSource)
 }

--- a/source/extensions/dynamic_modules/sdk/go/shared/types.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/types.go
@@ -323,6 +323,11 @@ const (
 	MetricsFrozen
 )
 
+// GenericSecretID is an opaque identifier for a generic secret subscribed to via
+// HttpFilterConfigHandle.SubscribeGenericSecret. The zero value is never valid and is what
+// SubscribeGenericSecret returns when the subscription could not be created.
+type GenericSecretID uint64
+
 // HttpHeaderType identifies which HTTP header map to access. It corresponds to
 // envoy_dynamic_module_type_http_header_type. The values match the ABI's enum order:
 // RequestHeader, RequestTrailer, ResponseHeader, ResponseTrailer.

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -3,9 +3,10 @@ use crate::buffer::{EnvoyBuffer, EnvoyMutBuffer};
 use crate::utility::HeaderPairSlice;
 use crate::{
   abi, bytes_to_module_buffer, str_to_module_buffer, strs_to_module_buffers, ClusterHostCount,
-  EnvoyCounterId, EnvoyCounterVecId, EnvoyGaugeId, EnvoyGaugeVecId, EnvoyHistogramId,
-  EnvoyHistogramVecId, NewHttpFilterConfigFunction, NewHttpFilterPerRouteConfigFunction,
-  NEW_HTTP_FILTER_CONFIG_FUNCTION, NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
+  EnvoyCounterId, EnvoyCounterVecId, EnvoyGaugeId, EnvoyGaugeVecId, EnvoyGenericSecretId,
+  EnvoyHistogramId, EnvoyHistogramVecId, NewHttpFilterConfigFunction,
+  NewHttpFilterPerRouteConfigFunction, NEW_HTTP_FILTER_CONFIG_FUNCTION,
+  NEW_HTTP_FILTER_PER_ROUTE_CONFIG_FUNCTION,
 };
 use mockall::*;
 use std::any::Any;
@@ -390,6 +391,35 @@ pub trait EnvoyHttpFilterConfig {
     labels: &[&str],
   ) -> Result<EnvoyHistogramVecId, envoy_dynamic_module_type_metrics_result>;
 
+  /// Subscribe to a generic secret so that its value can later be read via
+  /// [`EnvoyHttpFilterConfig::get_generic_secret`] or [`EnvoyHttpFilter::get_generic_secret`].
+  ///
+  /// `name` is the name of the secret: for a static secret the name in the bootstrap
+  /// configuration, and for a dynamic secret the resource name requested from the SDS server.
+  ///
+  /// `sds_config_source` is the JSON serialized `envoy.config.core.v3.ConfigSource` describing where
+  /// to fetch the secret from, so that the value is updated whenever the SDS server pushes a new
+  /// version. Pass `None` to look the name up among the statically configured secrets instead.
+  ///
+  /// This can only be called while the filter config is being created, i.e. from
+  /// [`HttpFilterConfig`]'s constructor. Returns `None` if the secret cannot be subscribed to, for
+  /// example when the static secret does not exist or `sds_config_source` is not a valid
+  /// `ConfigSource`.
+  fn subscribe_generic_secret(
+    &mut self,
+    name: &str,
+    sds_config_source: Option<&str>,
+  ) -> Option<EnvoyGenericSecretId>;
+
+  /// Get the current value of a previously subscribed generic secret from the config context.
+  ///
+  /// Unlike [`EnvoyHttpFilter::get_generic_secret`], this does not require a per-stream filter and
+  /// can be called outside of the request lifecycle, for example from a scheduled background task.
+  ///
+  /// Returns `None` if the id does not correspond to a subscribed secret. The value is empty when
+  /// the secret has been subscribed to but not yet delivered by the SDS server.
+  fn get_generic_secret(&self, id: EnvoyGenericSecretId) -> Option<EnvoyBuffer<'_>>;
+
   /// Increment the counter with the given id from the config context.
   ///
   /// Unlike [`EnvoyHttpFilter::increment_counter`], this does not require a per-stream filter and
@@ -639,6 +669,48 @@ impl EnvoyHttpFilterConfig for EnvoyHttpFilterConfigImpl {
       )
     })?;
     Ok(EnvoyHistogramVecId(id))
+  }
+
+  fn subscribe_generic_secret(
+    &mut self,
+    name: &str,
+    sds_config_source: Option<&str>,
+  ) -> Option<EnvoyGenericSecretId> {
+    let id = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+        self.raw_ptr,
+        str_to_module_buffer(name),
+        // An empty buffer tells Envoy to resolve the name as a static secret.
+        sds_config_source.map_or_else(|| bytes_to_module_buffer(&[]), str_to_module_buffer),
+      )
+    };
+    // 0 is reserved to signal that the subscription could not be created.
+    if id == 0 {
+      None
+    } else {
+      Some(EnvoyGenericSecretId(id))
+    }
+  }
+
+  fn get_generic_secret(&self, id: EnvoyGenericSecretId) -> Option<EnvoyBuffer<'_>> {
+    let EnvoyGenericSecretId(id) = id;
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+        self.raw_ptr,
+        id,
+        &mut result as *mut _,
+      )
+    };
+    if !success {
+      return None;
+    }
+    // Safety: Envoy owns the buffer and keeps it alive until the module returns from the current
+    // event hook, which outlives the borrow of `self`.
+    Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const u8, result.length) })
   }
 
   fn increment_counter(
@@ -1749,6 +1821,17 @@ pub trait EnvoyHttpFilter {
   /// }
   /// ```
   fn new_scheduler(&self) -> impl EnvoyHttpFilterScheduler + 'static;
+
+  /// Get the current value of a generic secret subscribed to by the filter config via
+  /// [`EnvoyHttpFilterConfig::subscribe_generic_secret`].
+  ///
+  /// Returns `None` if the id does not correspond to a subscribed secret. The value is empty when
+  /// the secret has been subscribed to but not yet delivered by the SDS server.
+  ///
+  /// The returned buffer must not be retained across events: a secret rotation replaces the value
+  /// in between events on this worker thread. Copy the value if it needs to outlive the current
+  /// event hook.
+  fn get_generic_secret<'a>(&'a self, id: EnvoyGenericSecretId) -> Option<EnvoyBuffer<'a>>;
 
   /// Increment the counter with the given id.
   fn increment_counter(
@@ -3526,6 +3609,27 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
         raw_ptr: scheduler_ptr,
       }
     }
+  }
+
+  fn get_generic_secret(&self, id: EnvoyGenericSecretId) -> Option<EnvoyBuffer<'_>> {
+    let EnvoyGenericSecretId(id) = id;
+    let mut result = abi::envoy_dynamic_module_type_envoy_buffer {
+      ptr: std::ptr::null(),
+      length: 0,
+    };
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_http_filter_get_generic_secret(
+        self.raw_ptr,
+        id,
+        &mut result as *mut _,
+      )
+    };
+    if !success {
+      return None;
+    }
+    // Safety: Envoy owns the buffer and keeps it alive until the module returns from the current
+    // event hook, which outlives the borrow of `self`.
+    Some(unsafe { EnvoyBuffer::new_from_raw(result.ptr as *const u8, result.length) })
   }
 
   fn increment_counter(

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib.rs
@@ -561,6 +561,11 @@ pub struct EnvoyHistogramId(pub usize);
 #[repr(transparent)]
 pub struct EnvoyHistogramVecId(pub usize);
 
+/// The identifier for a generic secret subscribed to by the module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct EnvoyGenericSecretId(pub usize);
+
 impl From<envoy_dynamic_module_type_metrics_result>
   for Result<(), envoy_dynamic_module_type_metrics_result>
 {

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -14,8 +14,15 @@ envoy_cc_library(
     srcs = ["filter_config.cc"],
     hdrs = ["filter_config.h"],
     deps = [
+        "//envoy/secret:secret_manager_interface",
+        "//envoy/secret:secret_provider_interface",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/common:thread_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/common/secret:secret_provider_impl_lib",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -48,6 +48,26 @@ static Stats::StatNameTagVector buildTagsForModuleMetric(
   return tags;
 }
 
+// Converts a module owned buffer to a string view, tolerating the null buffer that a module passes
+// to mean "absent" rather than constructing a string view from a null pointer.
+absl::string_view moduleBufferToStringView(envoy_dynamic_module_type_module_buffer buffer) {
+  if (buffer.ptr == nullptr || buffer.length == 0) {
+    return {};
+  }
+  return absl::string_view(buffer.ptr, buffer.length);
+}
+
+// Hands a subscribed secret's current value to the module, or reports that the ID is unknown.
+bool secretToModuleBuffer(const std::string* secret,
+                          envoy_dynamic_module_type_envoy_buffer* result) {
+  if (secret == nullptr) {
+    return false;
+  }
+  result->ptr = secret->data();
+  result->length = secret->size();
+  return true;
+}
+
 using HeadersMapOptConstRef = OptRef<const Http::HeaderMap>;
 using HeadersMapOptRef = OptRef<Http::HeaderMap>;
 
@@ -898,6 +918,29 @@ envoy_dynamic_module_callback_http_filter_config_record_histogram_value(
                                        label_values_length);
   hist->recordValue(*filter_config->stats_scope_, tags, value);
   return envoy_dynamic_module_type_metrics_result_Success;
+}
+
+size_t envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer name,
+    envoy_dynamic_module_type_module_buffer sds_config_source) {
+  auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
+  return filter_config->subscribeGenericSecret(moduleBufferToStringView(name),
+                                               moduleBufferToStringView(sds_config_source));
+}
+
+bool envoy_dynamic_module_callback_http_filter_get_generic_secret(
+    envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  return secretToModuleBuffer(filter->getFilterConfig().getGenericSecretById(id), result);
+}
+
+bool envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+    envoy_dynamic_module_type_http_filter_config_envoy_ptr filter_config_envoy_ptr, size_t id,
+    envoy_dynamic_module_type_envoy_buffer* result) {
+  auto filter_config = static_cast<DynamicModuleHttpFilterConfig*>(filter_config_envoy_ptr);
+  return secretToModuleBuffer(filter_config->getGenericSecretById(id), result);
 }
 
 bool envoy_dynamic_module_callback_http_get_header(

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -15,9 +15,11 @@ namespace {
 
 // Builds a FilterFactoryCb from an already-loaded DynamicModule.
 // Extracted because both the synchronous path and the remote fetch callback need it.
-absl::StatusOr<Http::FilterFactoryCb> buildFilterFactoryCallback(
-    Extensions::DynamicModules::DynamicModulePtr dynamic_module, const FilterConfig& proto_config,
-    Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope) {
+absl::StatusOr<Http::FilterFactoryCb>
+buildFilterFactoryCallback(Extensions::DynamicModules::DynamicModulePtr dynamic_module,
+                           const FilterConfig& proto_config,
+                           Server::Configuration::ServerFactoryContext& context,
+                           Stats::Scope& scope, OptRef<Init::Manager> init_manager) {
 
   std::string config;
   if (proto_config.has_filter_config()) {
@@ -41,7 +43,7 @@ absl::StatusOr<Http::FilterFactoryCb> buildFilterFactoryCallback(
       filter_config =
           Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
               proto_config.filter_name(), config, metrics_namespace, proto_config.terminal_filter(),
-              std::move(dynamic_module), scope, context);
+              std::move(dynamic_module), scope, context, init_manager);
 
   if (!filter_config.ok()) {
     Extensions::DynamicModules::incrementLoadFailure(
@@ -109,8 +111,12 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
     if (!state) {
       return;
     }
-    auto cb_or_error =
-        buildFilterFactoryCallback(std::move(dynamic_module), proto_config, context, scope);
+    // No init manager here: this runs after the factory has already returned, so the filter chain
+    // factory context's init manager is long gone. Any secret subscription the module creates
+    // therefore starts immediately instead of gating initialization, which matches the fail-open
+    // nature of the remote fetch path.
+    auto cb_or_error = buildFilterFactoryCallback(std::move(dynamic_module), proto_config, context,
+                                                  scope, std::nullopt);
     if (!cb_or_error.ok()) {
       ENVOY_LOG_TO_LOGGER(Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules),
                           error, "Failed to create filter config from remote module: {}",
@@ -129,7 +135,8 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
 
   // Synchronous load (local file, by name, or remote cache hit): build the factory now.
   if (load_result->loaded != nullptr) {
-    return buildFilterFactoryCallback(std::move(load_result->loaded), proto_config, context, scope);
+    return buildFilterFactoryCallback(std::move(load_result->loaded), proto_config, context, scope,
+                                      init_manager);
   }
 
   ASSERT(load_result->async != nullptr, "Async loading state must be populated for async loads");

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -2,6 +2,14 @@
 
 #include <cstdint>
 
+#include "envoy/common/exception.h"
+#include "envoy/config/core/v3/config_source.pb.h"
+#include "envoy/secret/secret_manager.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/common/thread.h"
+#include "source/common/protobuf/utility.h"
+
 #include "absl/strings/str_cat.h"
 
 namespace Envoy {
@@ -13,13 +21,92 @@ DynamicModuleHttpFilterConfig::DynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
     const absl::string_view metrics_namespace,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-    Server::Configuration::ServerFactoryContext& context)
+    Server::Configuration::ServerFactoryContext& context, OptRef<Init::Manager> init_manager)
     : cluster_manager_(context.clusterManager()),
       main_thread_dispatcher_(context.mainThreadDispatcher()),
       stats_scope_(stats_scope.createScope(absl::StrCat(metrics_namespace, "."))),
-      stat_name_pool_(stats_scope_->symbolTable()), filter_name_(filter_name),
-      filter_config_(filter_config), metrics_namespace_(metrics_namespace),
-      dynamic_module_(std::move(dynamic_module)) {}
+      stat_name_pool_(stats_scope_->symbolTable()), init_manager_(init_manager),
+      server_context_(context), filter_name_(filter_name), filter_config_(filter_config),
+      metrics_namespace_(metrics_namespace), dynamic_module_(std::move(dynamic_module)) {}
+
+size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view name,
+                                                             absl::string_view sds_config_source) {
+  static constexpr absl::string_view failure_prefix =
+      "dynamic module failed to subscribe to the generic secret";
+
+  // Allocating the thread local slot below and reaching into the secret manager are both
+  // main-thread-only. The freeze flag stops a module from subscribing after its configuration has
+  // been loaded, but not from doing so on its own thread while ``config_new`` runs.
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+
+  // Acquire-load pairs with the release-store in ``newDynamicModuleHttpFilterConfig``. See
+  // filter_config.h for the memory-order contract.
+  if (secret_subscription_frozen_.load(std::memory_order_acquire)) {
+    ENVOY_LOG_MISC(error, "{} '{}': secrets can only be subscribed during config initialization",
+                   failure_prefix, name);
+    return 0;
+  }
+  if (name.empty()) {
+    ENVOY_LOG_MISC(error, "{}: the name is empty", failure_prefix);
+    return 0;
+  }
+
+  Secret::GenericSecretConfigProviderSharedPtr provider;
+  if (sds_config_source.empty()) {
+    // No config source: the name refers to a statically configured secret, mirroring how an
+    // ``SdsSecretConfig`` without ``sds_config`` is resolved.
+    provider = server_context_.secretManager().findStaticGenericSecretProvider(std::string(name));
+    if (provider == nullptr) {
+      ENVOY_LOG_MISC(error, "{} '{}': no such static secret", failure_prefix, name);
+      return 0;
+    }
+  } else {
+#ifdef ENVOY_ENABLE_YAML
+    envoy::config::core::v3::ConfigSource sds_config;
+    bool has_unknown_field = false;
+    if (absl::Status status =
+            MessageUtil::loadFromJsonNoThrow(sds_config_source, sds_config, has_unknown_field);
+        !status.ok()) {
+      ENVOY_LOG_MISC(error, "{} '{}': the config source is not a valid ConfigSource JSON: {}",
+                     failure_prefix, name, status.message());
+      return 0;
+    }
+    // Creating the subscription validates the config source and can throw, e.g. when the config
+    // source refers to a cluster that does not exist. This is called from the module via the C ABI,
+    // so the exception must not escape this frame.
+    TRY_ASSERT_MAIN_THREAD {
+      provider = server_context_.secretManager().findOrCreateGenericSecretProvider(
+          sds_config, std::string(name), server_context_, init_manager_);
+    }
+    END_TRY
+    CATCH(const EnvoyException& e, {
+      ENVOY_LOG_MISC(error, "{} '{}': {}", failure_prefix, name, e.what());
+      return 0;
+    });
+    if (provider == nullptr) {
+      ENVOY_LOG_MISC(error, "{} '{}': failed to create the SDS subscription", failure_prefix, name);
+      return 0;
+    }
+#else
+    ENVOY_LOG_MISC(error,
+                   "{} '{}': JSON support is not compiled in, so a config source cannot be "
+                   "parsed. Use a static secret instead.",
+                   failure_prefix, name);
+    return 0;
+#endif
+  }
+
+  auto thread_local_provider = Secret::ThreadLocalGenericSecretProvider::create(
+      std::move(provider), server_context_.threadLocal(), server_context_.api());
+  if (!thread_local_provider.ok()) {
+    ENVOY_LOG_MISC(error, "{} '{}': {}", failure_prefix, name,
+                   thread_local_provider.status().message());
+    return 0;
+  }
+  generic_secrets_.push_back(std::move(thread_local_provider.value()));
+  // IDs are 1-based so that 0 can signal failure to the module.
+  return generic_secrets_.size();
+}
 
 DynamicModuleHttpFilterConfig::~DynamicModuleHttpFilterConfig() {
   // When the initialization of the dynamic module fails, the in_module_config_ is nullptr,
@@ -88,7 +175,7 @@ absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilte
     const absl::string_view filter_name, const absl::string_view filter_config,
     const absl::string_view metrics_namespace, const bool terminal_filter,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context, OptRef<Init::Manager> init_manager) {
   auto constructor =
       dynamic_module->getFunctionPointer<decltype(&envoy_dynamic_module_on_http_filter_config_new)>(
           "envoy_dynamic_module_on_http_filter_config_new");
@@ -204,7 +291,7 @@ absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilte
 
   auto config = std::make_shared<DynamicModuleHttpFilterConfig>(
       filter_name, filter_config, metrics_namespace, std::move(dynamic_module), stats_scope,
-      context);
+      context, init_manager);
 
   const void* filter_config_envoy_ptr = (*constructor.value())(
       static_cast<void*>(config.get()), {filter_name.data(), filter_name.size()},
@@ -220,6 +307,10 @@ absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilte
   // adversarial module spawning a worker inside ``on_http_filter_config_new`` that reads the
   // flag before the C++-side shared_ptr publication establishes happens-before.
   config->stat_creation_frozen_.store(true, std::memory_order_release);
+  // Same contract for secret subscriptions, which are likewise only allowed while the module's
+  // ``config_new`` hook is running. The init manager reference does not outlive that hook either.
+  config->secret_subscription_frozen_.store(true, std::memory_order_release);
+  config->init_manager_ = std::nullopt;
 
   config->in_module_config_ = filter_config_envoy_ptr;
   config->on_http_filter_config_destroy_ = on_config_destroy.value();

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -42,12 +42,12 @@ size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view n
   // Acquire-load pairs with the release-store in ``newDynamicModuleHttpFilterConfig``. See
   // filter_config.h for the memory-order contract.
   if (secret_subscription_frozen_.load(std::memory_order_acquire)) {
-    ENVOY_LOG_MISC(error, "{} '{}': secrets can only be subscribed during config initialization",
-                   failure_prefix, name);
+    ENVOY_LOG(error, "{} '{}': secrets can only be subscribed during config initialization",
+              failure_prefix, name);
     return 0;
   }
   if (name.empty()) {
-    ENVOY_LOG_MISC(error, "{}: the name is empty", failure_prefix);
+    ENVOY_LOG(error, "{}: the name is empty", failure_prefix);
     return 0;
   }
 
@@ -57,7 +57,7 @@ size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view n
     // ``SdsSecretConfig`` without ``sds_config`` is resolved.
     provider = server_context_.secretManager().findStaticGenericSecretProvider(std::string(name));
     if (provider == nullptr) {
-      ENVOY_LOG_MISC(error, "{} '{}': no such static secret", failure_prefix, name);
+      ENVOY_LOG(error, "{} '{}': no such static secret", failure_prefix, name);
       return 0;
     }
   } else {
@@ -67,31 +67,33 @@ size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view n
     if (absl::Status status =
             MessageUtil::loadFromJsonNoThrow(sds_config_source, sds_config, has_unknown_field);
         !status.ok()) {
-      ENVOY_LOG_MISC(error, "{} '{}': the config source is not a valid ConfigSource JSON: {}",
-                     failure_prefix, name, status.message());
+      ENVOY_LOG(error, "{} '{}': the config source is not a valid ConfigSource JSON: {}",
+                failure_prefix, name, status.message());
       return 0;
     }
     // Creating the subscription validates the config source and can throw, e.g. when the config
     // source refers to a cluster that does not exist. This is called from the module via the C ABI,
     // so the exception must not escape this frame.
+    // TODO(wbpcode): remove the exception from the findOrCreateGenericSecretProvider
+    // and make it return a StatusOr instead, so that the exception handling can be removed here.
     TRY_ASSERT_MAIN_THREAD {
       provider = server_context_.secretManager().findOrCreateGenericSecretProvider(
           sds_config, std::string(name), server_context_, init_manager_);
     }
     END_TRY
     CATCH(const EnvoyException& e, {
-      ENVOY_LOG_MISC(error, "{} '{}': {}", failure_prefix, name, e.what());
+      ENVOY_LOG(error, "{} '{}': {}", failure_prefix, name, e.what());
       return 0;
     });
     if (provider == nullptr) {
-      ENVOY_LOG_MISC(error, "{} '{}': failed to create the SDS subscription", failure_prefix, name);
+      ENVOY_LOG(error, "{} '{}': failed to create the SDS subscription", failure_prefix, name);
       return 0;
     }
 #else
-    ENVOY_LOG_MISC(error,
-                   "{} '{}': JSON support is not compiled in, so a config source cannot be "
-                   "parsed. Use a static secret instead.",
-                   failure_prefix, name);
+    ENVOY_LOG(error,
+              "{} '{}': JSON support is not compiled in, so a config source cannot be "
+              "parsed. Use a static secret instead.",
+              failure_prefix, name);
     return 0;
 #endif
   }
@@ -99,8 +101,7 @@ size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view n
   auto thread_local_provider = Secret::ThreadLocalGenericSecretProvider::create(
       std::move(provider), server_context_.threadLocal(), server_context_.api());
   if (!thread_local_provider.ok()) {
-    ENVOY_LOG_MISC(error, "{} '{}': {}", failure_prefix, name,
-                   thread_local_provider.status().message());
+    ENVOY_LOG(error, "{} '{}': {}", failure_prefix, name, thread_local_provider.status().message());
     return 0;
   }
   generic_secrets_.push_back(std::move(thread_local_provider.value()));

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -77,7 +77,8 @@ using OnHttpFilterConfigHttpStreamResetType =
  * Each filter instance and the factory callback holds a shared pointer to this config.
  */
 class DynamicModuleHttpFilterConfig
-    : public std::enable_shared_from_this<DynamicModuleHttpFilterConfig> {
+    : public std::enable_shared_from_this<DynamicModuleHttpFilterConfig>,
+      public Logger::Loggable<Logger::Id::dynamic_modules> {
 public:
   /**
    * Constructor for the config.

--- a/source/extensions/filters/http/dynamic_modules/filter_config.h
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.h
@@ -2,9 +2,12 @@
 
 #include <atomic>
 
+#include "envoy/init/manager.h"
+#include "envoy/secret/secret_provider.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/upstream/cluster_manager.h"
 
+#include "source/common/secret/secret_provider_impl.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 
@@ -84,12 +87,16 @@ public:
    * @param dynamic_module the dynamic module to use.
    * @param stats_scope the stats scope for metric creation.
    * @param context the server factory context.
+   * @param init_manager the init manager to register dynamic secret subscriptions with, if any.
+   * This is only valid for the duration of ``envoy_dynamic_module_on_http_filter_config_new`` and
+   * is cleared afterwards.
    */
   DynamicModuleHttpFilterConfig(const absl::string_view filter_name,
                                 const absl::string_view filter_config,
                                 const absl::string_view metrics_namespace,
                                 DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-                                Server::Configuration::ServerFactoryContext& context);
+                                Server::Configuration::ServerFactoryContext& context,
+                                OptRef<Init::Manager> init_manager = std::nullopt);
 
   ~DynamicModuleHttpFilterConfig();
 
@@ -145,6 +152,20 @@ public:
   // adversarial module spawning a worker thread inside ``on_http_filter_config_new`` could
   // observe the stale ``false`` and reproduce the seed StatNamePool race.
   std::atomic<bool> stat_creation_frozen_{false};
+
+  // Set by the factory once ``envoy_dynamic_module_on_http_filter_config_new`` has returned, after
+  // which ``subscribeGenericSecret`` refuses to create new subscriptions. Uses the same
+  // release/acquire contract as ``stat_creation_frozen_`` above: subscribing allocates a thread
+  // local slot and mutates ``generic_secrets_``, neither of which is safe once a worker can read
+  // the config, so a module that spawns its own thread inside ``config_new`` must observe the
+  // freeze rather than a stale ``false``.
+  std::atomic<bool> secret_subscription_frozen_{false};
+
+  // The init manager to register dynamic secret subscriptions with, so that a listener does not
+  // start serving before its secrets have been delivered. Only valid while the module's
+  // ``config_new`` hook is running: the referenced init manager belongs to the filter chain factory
+  // context, so the factory clears this right after the hook returns.
+  OptRef<Init::Manager> init_manager_;
 
   bool terminal_filter_ = false;
 
@@ -323,7 +344,38 @@ public:
 
 #undef ID_TO_INDEX
 
+  /**
+   * Subscribes to a generic secret so that the module can read its value by the returned ID.
+   *
+   * This is only callable during ``envoy_dynamic_module_on_http_filter_config_new``: creating a
+   * subscription allocates a thread local slot and touches the secret manager, both of which are
+   * main-thread-only, and ``generic_secrets_`` must not be mutated once a worker can read it.
+   *
+   * @param name the name of the secret. For static secrets this is the name in the bootstrap
+   * configuration, and for dynamic secrets the resource name requested from the SDS server.
+   * @param sds_config_source the JSON serialized ``envoy.config.core.v3.ConfigSource`` to fetch the
+   * secret from, or empty to look the name up among the static secrets.
+   * @return a 1-based ID that can be passed to ``getGenericSecretById``, or 0 on failure.
+   */
+  size_t subscribeGenericSecret(absl::string_view name, absl::string_view sds_config_source);
+
+  /**
+   * @param id the ID previously returned by ``subscribeGenericSecret``.
+   * @return the current value of the secret on the calling thread, or nullptr if the ID does not
+   * correspond to a subscribed secret. The value is empty until the first SDS delivery. The
+   * returned reference is invalidated by a secret rotation, which happens between events on the
+   * calling thread, so it must not be retained across events.
+   */
+  const std::string* getGenericSecretById(size_t id) const {
+    if (id == 0 || id > generic_secrets_.size()) {
+      return nullptr;
+    }
+    return &generic_secrets_[id - 1]->secret();
+  }
+
 private:
+  Server::Configuration::ServerFactoryContext& server_context_;
+
   // The name of the filter passed in the constructor.
   const std::string filter_name_;
 
@@ -340,6 +392,12 @@ private:
   std::vector<ModuleGaugeVecHandle> gauge_vecs_;
   std::vector<ModuleHistogramHandle> hists_;
   std::vector<ModuleHistogramVecHandle> hist_vecs_;
+
+  // The generic secrets subscribed by the module during ``config_new``, indexed by ID - 1. Appended
+  // to only while ``secret_subscription_frozen_`` is false, and read-only afterwards, which is what
+  // makes the reads from worker threads safe. Each entry keeps its own thread local copy of the
+  // value so that a read is a thread local lookup rather than a lock.
+  std::vector<std::unique_ptr<Secret::ThreadLocalGenericSecretProvider>> generic_secrets_;
 
   // The handle for the module.
   Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
@@ -504,13 +562,17 @@ newDynamicModuleHttpPerRouteConfig(const absl::string_view filter_name,
  * @param dynamic_module the dynamic module to use.
  * @param stats_scope the stats scope for metric creation.
  * @param context the server factory context.
+ * @param init_manager the init manager that dynamic secret subscriptions created by the module are
+ * registered with. When absent, such subscriptions start immediately instead of gating the owner's
+ * initialization.
  * @return a shared pointer to the new config object or an error if the module could not be loaded.
  */
 absl::StatusOr<DynamicModuleHttpFilterConfigSharedPtr> newDynamicModuleHttpFilterConfig(
     const absl::string_view filter_name, const absl::string_view filter_config,
     const absl::string_view metrics_namespace, const bool terminal_filter,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module, Stats::Scope& stats_scope,
-    Server::Configuration::ServerFactoryContext& context);
+    Server::Configuration::ServerFactoryContext& context,
+    OptRef<Init::Manager> init_manager = std::nullopt);
 
 } // namespace HttpFilters
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -101,7 +101,10 @@ envoy_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
+        "//test/test_common:simulated_time_system_lib",
         "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )
 
@@ -132,6 +135,8 @@ envoy_cc_test(
         "//test/mocks/upstream:priority_set_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
         "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -6,6 +6,7 @@
 #include <set>
 #include <thread>
 
+#include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/router/string_accessor_impl.h"
@@ -2649,6 +2650,194 @@ TEST(ABIImpl, Log) {
                                     {msg.data(), msg.size()});
   envoy_dynamic_module_callback_log(envoy_dynamic_module_type_log_level_Off,
                                     {msg.data(), msg.size()});
+}
+
+// Builds an ``envoy_dynamic_module_type_module_buffer`` for a string owned by the caller, the way a
+// module passes strings to Envoy.
+envoy_dynamic_module_type_module_buffer moduleBuffer(const std::string& str) {
+  return {const_cast<char*>(str.data()), str.size()};
+}
+
+class ABIImplGenericSecretTest : public testing::Test {
+protected:
+  void addStaticSecret(const std::string& name, const std::string& value) {
+    const std::string yaml = fmt::format(R"EOF(
+name: "{}"
+generic_secret:
+  secret:
+    inline_string: "{}"
+)EOF",
+                                         name, value);
+    envoy::extensions::transport_sockets::tls::v3::Secret secret;
+    TestUtility::loadFromYaml(yaml, secret);
+    ASSERT_TRUE(context_.secret_manager_->addStaticSecret(secret).ok());
+  }
+
+  // Pushes an SDS update for the given dynamic secret, as the SDS server would.
+  void pushSdsUpdate(const std::string& name, const std::string& value) {
+    const std::string yaml = fmt::format(R"EOF(
+name: "{}"
+generic_secret:
+  secret:
+    inline_string: "{}"
+)EOF",
+                                         name, value);
+    envoy::extensions::transport_sockets::tls::v3::Secret secret;
+    TestUtility::loadFromYaml(yaml, secret);
+    const auto decoded_resources = TestUtility::decodeResources({secret});
+    EXPECT_TRUE(context_.cluster_manager_.subscription_factory_.callbacks_
+                    ->onConfigUpdate(decoded_resources.refvec_, "")
+                    .ok());
+  }
+
+  // Reads the secret through both the config level and the filter level callback, which must always
+  // agree, and returns the value.
+  std::optional<std::string> getSecret(size_t id) {
+    envoy_dynamic_module_type_envoy_buffer config_result{};
+    const bool config_ok = envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+        filter_config_.get(), id, &config_result);
+    envoy_dynamic_module_type_envoy_buffer filter_result{};
+    const bool filter_ok = envoy_dynamic_module_callback_http_filter_get_generic_secret(
+        filter_.get(), id, &filter_result);
+    EXPECT_EQ(config_ok, filter_ok);
+    if (!config_ok) {
+      return std::nullopt;
+    }
+    EXPECT_EQ(std::string(config_result.ptr, config_result.length),
+              std::string(filter_result.ptr, filter_result.length));
+    return std::string(config_result.ptr, config_result.length);
+  }
+
+  void createFilterConfig(OptRef<Init::Manager> init_manager = std::nullopt) {
+    filter_config_ = std::make_shared<DynamicModuleHttpFilterConfig>(
+        "some_name", "some_config", DefaultMetricsNamespace, nullptr, stats_scope_, context_,
+        init_manager);
+    filter_ =
+        std::make_unique<DynamicModuleHttpFilter>(filter_config_, stats_scope_.symbolTable(), 0);
+  }
+
+  Stats::TestUtil::TestStore stats_store_;
+  Stats::TestUtil::TestScope stats_scope_{"", stats_store_};
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  DynamicModuleHttpFilterConfigSharedPtr filter_config_;
+  std::unique_ptr<DynamicModuleHttpFilter> filter_;
+};
+
+// A name with no config source resolves against the statically configured secrets.
+TEST_F(ABIImplGenericSecretTest, StaticSecret) {
+  addStaticSecret("static_secret", "static_value");
+  createFilterConfig();
+
+  const std::string name = "static_secret";
+  const size_t id = envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+      filter_config_.get(), moduleBuffer(name), {nullptr, 0});
+  EXPECT_EQ(id, 1); // IDs are 1-based so that 0 can signal failure.
+  EXPECT_EQ(getSecret(id), "static_value");
+
+  // A second subscription gets its own ID.
+  addStaticSecret("other_secret", "other_value");
+  const std::string other_name = "other_secret";
+  const size_t other_id = envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+      filter_config_.get(), moduleBuffer(other_name), {nullptr, 0});
+  EXPECT_EQ(other_id, 2);
+  EXPECT_EQ(getSecret(other_id), "other_value");
+  EXPECT_EQ(getSecret(id), "static_value");
+}
+
+// A config source creates an SDS subscription, and the module observes rotations through it.
+TEST_F(ABIImplGenericSecretTest, DynamicSecret) {
+  createFilterConfig(context_.init_manager_);
+
+  const std::string name = "dynamic_secret";
+  const std::string sds_config_source =
+      R"({"api_config_source":{"api_type":"GRPC","transport_api_version":"V3",)"
+      R"("grpc_services":[{"envoy_grpc":{"cluster_name":"sds_cluster"}}]}})";
+  const size_t id = envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+      filter_config_.get(), moduleBuffer(name), moduleBuffer(sds_config_source));
+  ASSERT_EQ(id, 1);
+
+  // Nothing has been delivered yet, so the value is empty rather than unavailable.
+  EXPECT_EQ(getSecret(id), "");
+
+  pushSdsUpdate(name, "delivered_value");
+  EXPECT_EQ(getSecret(id), "delivered_value");
+
+  // A rotation is visible to the module without re-subscribing.
+  pushSdsUpdate(name, "rotated_value");
+  EXPECT_EQ(getSecret(id), "rotated_value");
+}
+
+TEST_F(ABIImplGenericSecretTest, SubscribeFailures) {
+  addStaticSecret("static_secret", "static_value");
+  createFilterConfig();
+
+  // An empty name.
+  const std::string empty_name;
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(empty_name), {nullptr, 0}),
+            0);
+
+  // A static secret that does not exist.
+  const std::string unknown_name = "not_configured";
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(unknown_name), {nullptr, 0}),
+            0);
+
+  // A config source that is not valid JSON.
+  const std::string name = "static_secret";
+  const std::string not_json = "{not json";
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(name), moduleBuffer(not_json)),
+            0);
+
+  // A config source that is valid JSON but not a ConfigSource.
+  const std::string wrong_message = R"({"not_a_config_source_field":true})";
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(name), moduleBuffer(wrong_message)),
+            0);
+
+  // A config source whose subscription cannot be created.
+  const std::string bad_config_source = R"({"api_config_source":{"api_type":"GRPC"}})";
+  EXPECT_CALL(context_.cluster_manager_.subscription_factory_,
+              subscriptionFromConfigSource(testing::_, testing::_, testing::_, testing::_,
+                                           testing::_, testing::_))
+      .WillOnce(testing::Return(absl::InvalidArgumentError("no gRPC services configured")));
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(name), moduleBuffer(bad_config_source)),
+            0);
+
+  // None of the failures consumed an ID, so the next successful subscription still gets 1.
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(name), {nullptr, 0}),
+            1);
+}
+
+// Secrets can only be subscribed to while the module's config_new hook is running.
+TEST_F(ABIImplGenericSecretTest, SubscribeAfterConfigLoaded) {
+  addStaticSecret("static_secret", "static_value");
+  createFilterConfig();
+  filter_config_->secret_subscription_frozen_.store(true, std::memory_order_release);
+
+  const std::string name = "static_secret";
+  EXPECT_EQ(envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+                filter_config_.get(), moduleBuffer(name), {nullptr, 0}),
+            0);
+}
+
+TEST_F(ABIImplGenericSecretTest, ReadUnknownId) {
+  addStaticSecret("static_secret", "static_value");
+  createFilterConfig();
+
+  // Nothing subscribed yet, so even the first ID is unknown.
+  EXPECT_EQ(getSecret(1), std::nullopt);
+
+  const std::string name = "static_secret";
+  const size_t id = envoy_dynamic_module_callback_http_filter_config_generic_secret_subscribe(
+      filter_config_.get(), moduleBuffer(name), {nullptr, 0});
+  ASSERT_EQ(id, 1);
+  // 0 is never a valid ID, and IDs past the end are unknown.
+  EXPECT_EQ(getSecret(0), std::nullopt);
+  EXPECT_EQ(getSecret(id + 1), std::nullopt);
 }
 
 TEST(ABIImpl, Stats) {

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -1,5 +1,6 @@
 #include <cstring>
 
+#include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/http/message_impl.h"
@@ -14,6 +15,7 @@
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
@@ -117,6 +119,81 @@ TEST_P(DynamicModuleHttpLanguageTests, ConfigInitializationFailure) {
       *stats_store.createScope(""), context);
   EXPECT_THAT(filter_config_or_status,
               HasStatusMessage(testing::HasSubstr("Failed to initialize dynamic module")));
+}
+
+// Creating an SDS subscription reaches for the dispatcher's time source, so the simulated time
+// system has to be established before the mocks that expect one (``MockStreamInfo``, reached via
+// the filter callbacks below).
+class DynamicModuleHttpFilterSecretsTest : public Event::TestUsingSimulatedTime,
+                                           public testing::Test {};
+
+// This drives the Rust module only; the integration test covers the Go and C++ SDK bindings against
+// a real server, so this is not parameterized over the languages like the tests around it.
+TEST_F(DynamicModuleHttpFilterSecretsTest, GenericSecretCallbacks) {
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
+  ASSERT_TRUE(dynamic_module.ok());
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  // The module subscribes to this one by name with no config source.
+  envoy::extensions::transport_sockets::tls::v3::Secret static_secret;
+  TestUtility::loadFromYaml(R"EOF(
+name: "static_secret"
+generic_secret:
+  secret:
+    inline_string: "static_value"
+)EOF",
+                            static_secret);
+  ASSERT_TRUE(context.secret_manager_->addStaticSecret(static_secret).ok());
+
+  Stats::IsolatedStoreImpl stats_store;
+  auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
+      "generic_secret_callbacks", "", DefaultMetricsNamespace, false,
+      std::move(dynamic_module.value()), *stats_store.createScope(""), context);
+  ASSERT_TRUE(filter_config_or_status.ok());
+
+  // The module also subscribed to a secret over SDS, whose value only arrives once the SDS server
+  // delivers it.
+  envoy::extensions::transport_sockets::tls::v3::Secret dynamic_secret;
+  TestUtility::loadFromYaml(R"EOF(
+name: "dynamic_secret"
+generic_secret:
+  secret:
+    inline_string: "dynamic_value"
+)EOF",
+                            dynamic_secret);
+  const auto decoded_resources = TestUtility::decodeResources({dynamic_secret});
+  ASSERT_TRUE(context.cluster_manager_.subscription_factory_.callbacks_
+                  ->onConfigUpdate(decoded_resources.refvec_, "")
+                  .ok());
+
+  // Check the values as Envoy sees them first, so that a mismatch below points at the SDK binding
+  // rather than at the subscriptions themselves. The module subscribed the static secret first, so
+  // it holds ID 1.
+  envoy_dynamic_module_type_envoy_buffer buffer{};
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+      filter_config_or_status.value().get(), 1, &buffer));
+  EXPECT_EQ(std::string(buffer.ptr, buffer.length), "static_value");
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_config_get_generic_secret(
+      filter_config_or_status.value().get(), 2, &buffer));
+  EXPECT_EQ(std::string(buffer.ptr, buffer.length), "dynamic_value");
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_store.symbolTable(), 0);
+  filter->initializeInModuleFilter();
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  filter->setDecoderFilterCallbacks(decoder_callbacks);
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+  filter->setEncoderFilterCallbacks(encoder_callbacks);
+
+  // The module copies both secret values onto the request headers. The header ABI reads the map
+  // back through the decoder callbacks, so those have to hand out the map under test.
+  Http::TestRequestHeaderMapImpl request_headers{};
+  EXPECT_CALL(decoder_callbacks, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<Http::RequestHeaderMap>(request_headers)));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
+  EXPECT_EQ(request_headers.get_("x-static-secret"), "static_value");
+  EXPECT_EQ(request_headers.get_("x-dynamic-secret"), "dynamic_value");
 }
 
 TEST_P(DynamicModuleHttpLanguageTests, StatsCallbacks) {

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -173,6 +173,35 @@ TEST_P(DynamicModulesIntegrationTest, PassThrough) {
   EXPECT_EQ(10U, response->body().size());
 }
 
+TEST_P(DynamicModulesIntegrationTest, GenericSecretCallbacks) {
+  // The module subscribes by name with no config source, so the name resolves against the
+  // statically configured secrets.
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* secret = bootstrap.mutable_static_resources()->add_secrets();
+    secret->set_name("test_secret");
+    secret->mutable_generic_secret()->mutable_secret()->set_inline_string("super_secret_value");
+  });
+
+  initializeFilter("generic_secret_callbacks", "test_secret");
+
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  Http::TestRequestHeaderMapImpl request_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  // The value the module read while handling the request.
+  EXPECT_EQ(
+      "super_secret_value",
+      response->headers().get(Http::LowerCaseString("x-secret-value"))[0]->value().getStringView());
+  // The value the module read from the config context while the configuration was being loaded.
+  EXPECT_EQ("super_secret_value", response->headers()
+                                      .get(Http::LowerCaseString("x-secret-value-at-config"))[0]
+                                      ->value()
+                                      .getStringView());
+}
+
 TEST_P(DynamicModulesIntegrationTest, UpstreamConnectionId) {
   if (GetParam() != "rust" && GetParam() != "rust_static") {
     GTEST_SKIP() << "the upstream_connection_id filter is only in the rust test module";

--- a/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
+++ b/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
@@ -81,6 +81,10 @@ public:
               (MetricID id, uint64_t value, std::span<const BufferView> tags_values), (override));
   MOCK_METHOD(MetricsResult, incrementCounterValue,
               (MetricID id, uint64_t value, std::span<const BufferView> tags_values), (override));
+  MOCK_METHOD((std::optional<GenericSecretID>), subscribeGenericSecret,
+              (std::string_view name, std::string_view sds_config_source), (override));
+  MOCK_METHOD((std::optional<std::string_view>), getGenericSecret, (GenericSecretID id),
+              (override));
   MOCK_METHOD(bool, logEnabled, (LogLevel level), (override));
   MOCK_METHOD(void, log, (LogLevel level, std::string_view message), (override));
   MOCK_METHOD((std::pair<HttpCalloutInitResult, uint64_t>), httpCallout,
@@ -215,6 +219,8 @@ public:
               (MetricID id, uint64_t value, std::span<const BufferView> tags_values), (override));
   MOCK_METHOD(MetricsResult, incrementCounterValue,
               (MetricID id, uint64_t value, std::span<const BufferView> tags_values), (override));
+  MOCK_METHOD((std::optional<std::string_view>), getGenericSecret, (GenericSecretID id),
+              (override));
   MOCK_METHOD(bool, logEnabled, (LogLevel level), (override));
   MOCK_METHOD(void, log, (LogLevel level, std::string_view message), (override));
 };

--- a/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
@@ -1829,5 +1829,86 @@ public:
 
 REGISTER_HTTP_FILTER_CONFIG_FACTORY(ListMetadataCallbacksConfigFactory, "list_metadata_callbacks");
 
+// -----------------------------------------------------------------------------
+// GenericSecretCallbacks
+// -----------------------------------------------------------------------------
+
+// Subscribes to a generic secret at config load and exposes the value on the response, both as read
+// per-stream and as read from the config context during initialization.
+class GenericSecretCallbacksFilter : public HttpFilter {
+public:
+  GenericSecretCallbacksFilter(HttpFilterHandle& handle, GenericSecretID secret,
+                               std::string value_at_config)
+      : handle_(handle), secret_(secret), value_at_config_(std::move(value_at_config)) {}
+
+  HeadersStatus onRequestHeaders(HeaderMap&, bool) override { return HeadersStatus::Continue; }
+  BodyStatus onRequestBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  TrailersStatus onRequestTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
+
+  HeadersStatus onResponseHeaders(HeaderMap& headers, bool) override {
+    auto value = handle_.getGenericSecret(secret_);
+    assert(value.has_value());
+    headers.set("x-secret-value", *value);
+    headers.set("x-secret-value-at-config", value_at_config_);
+
+    // An ID that was never returned by a subscription is not readable.
+    assert(!handle_.getGenericSecret(12345).has_value());
+
+    return HeadersStatus::Continue;
+  }
+
+  BodyStatus onResponseBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  TrailersStatus onResponseTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
+  void onStreamComplete() override {}
+  void onDestroy() override {}
+
+private:
+  HttpFilterHandle& handle_;
+  const GenericSecretID secret_;
+  const std::string value_at_config_;
+};
+
+class GenericSecretCallbacksFilterFactory : public HttpFilterFactory {
+public:
+  GenericSecretCallbacksFilterFactory(GenericSecretID secret, std::string value_at_config)
+      : secret_(secret), value_at_config_(std::move(value_at_config)) {}
+
+  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
+    return std::make_unique<GenericSecretCallbacksFilter>(handle, secret_, value_at_config_);
+  }
+
+private:
+  const GenericSecretID secret_;
+  const std::string value_at_config_;
+};
+
+class GenericSecretCallbacksConfigFactory : public HttpFilterConfigFactory {
+public:
+  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle& handle,
+                                            std::string_view config_view) override {
+    // A secret that is not configured anywhere cannot be subscribed to.
+    if (handle.subscribeGenericSecret("not_configured").has_value()) {
+      return nullptr;
+    }
+
+    auto secret = handle.subscribeGenericSecret(config_view);
+    if (!secret.has_value()) {
+      return nullptr;
+    }
+
+    // The value is readable right away from the config context, since a static secret is available
+    // before any request is served. The view aliases Envoy memory, so copy it.
+    auto value_at_config = handle.getGenericSecret(*secret);
+    if (!value_at_config.has_value()) {
+      return nullptr;
+    }
+    return std::make_unique<GenericSecretCallbacksFilterFactory>(*secret,
+                                                                 std::string(*value_at_config));
+  }
+};
+
+REGISTER_HTTP_FILTER_CONFIG_FACTORY(GenericSecretCallbacksConfigFactory,
+                                    "generic_secret_callbacks");
+
 } // namespace DynamicModules
 } // namespace Envoy

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -38,6 +38,7 @@ func init() {
 		"http_struct_config":           &HttpStructConfigFactory{},
 		"list_metadata_callbacks":      &ListMetadataCallbacksConfigFactory{},
 		"log_level":                    &LogLevelConfigFactory{},
+		"generic_secret_callbacks":     &GenericSecretCallbacksConfigFactory{},
 	})
 }
 
@@ -1510,5 +1511,76 @@ func (p *LogLevelFilter) OnResponseHeaders(headers shared.HeaderMap,
 	headers.Set("x-log-level", strconv.FormatUint(uint64(p.handle.GetLogLevel()), 10))
 	headers.Set("x-log-info-enabled", strconv.FormatBool(p.handle.IsLogLevelEnabled(shared.LogLevelInfo)))
 	headers.Set("x-log-error-enabled", strconv.FormatBool(p.handle.IsLogLevelEnabled(shared.LogLevelError)))
+	return shared.HeadersStatusContinue
+}
+
+// -----------------------------------------------------------------------------
+// GenericSecretCallbacks
+// -----------------------------------------------------------------------------
+
+// GenericSecretCallbacksConfigFactory subscribes to a generic secret at config load and exposes the
+// value on the response, both as read per-stream and as read from the config context during
+// initialization.
+type GenericSecretCallbacksConfigFactory struct {
+	shared.EmptyHttpFilterConfigFactory
+}
+
+func (f *GenericSecretCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
+	config []byte) (shared.HttpFilterFactory, error) {
+	// A secret that is not configured anywhere cannot be subscribed to.
+	if id := handle.SubscribeGenericSecret("not_configured", ""); id != 0 {
+		return nil, fmt.Errorf("subscribing to an unconfigured secret unexpectedly succeeded: %d", id)
+	}
+
+	secret := handle.SubscribeGenericSecret(string(config), "")
+	if secret == 0 {
+		return nil, fmt.Errorf("failed to subscribe to the secret %q", string(config))
+	}
+
+	// The value is readable right away from the config context, since a static secret is available
+	// before any request is served.
+	value, ok := handle.GetGenericSecret(secret)
+	if !ok {
+		return nil, fmt.Errorf("failed to read the secret %q", string(config))
+	}
+	return &GenericSecretCallbacksFilterFactory{
+		secret: secret,
+		// The buffer aliases Envoy memory that is only valid for this callback, so copy it.
+		valueAtConfig: string(value.ToBytes()),
+	}, nil
+}
+
+type GenericSecretCallbacksFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+	secret        shared.GenericSecretID
+	valueAtConfig string
+}
+
+func (f *GenericSecretCallbacksFilterFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
+	return &GenericSecretCallbacksFilter{
+		handle:        handle,
+		secret:        f.secret,
+		valueAtConfig: f.valueAtConfig,
+	}
+}
+
+type GenericSecretCallbacksFilter struct {
+	shared.EmptyHttpFilter
+	handle        shared.HttpFilterHandle
+	secret        shared.GenericSecretID
+	valueAtConfig string
+}
+
+func (p *GenericSecretCallbacksFilter) OnResponseHeaders(headers shared.HeaderMap,
+	endOfStream bool) shared.HeadersStatus {
+	value, ok := p.handle.GetGenericSecret(p.secret)
+	assertEq(ok, true, "reading the subscribed secret")
+	headers.Set("x-secret-value", value.ToUnsafeString())
+	headers.Set("x-secret-value-at-config", p.valueAtConfig)
+
+	// An ID that was never returned by a subscription is not readable.
+	_, ok = p.handle.GetGenericSecret(shared.GenericSecretID(12345))
+	assertEq(ok, false, "reading an unknown secret ID")
+
 	return shared.HeadersStatusContinue
 }

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -42,6 +42,42 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
         .define_histogram_vec("test_histogram_vec", &["test_label"])
         .expect("failed to define histogram vec"),
     })),
+    "generic_secret_callbacks" => {
+      // A secret that is not configured anywhere cannot be subscribed to.
+      assert!(envoy_filter_config
+        .subscribe_generic_secret("not_configured", None)
+        .is_none());
+      // Neither can one whose config source is not a valid ConfigSource.
+      assert!(envoy_filter_config
+        .subscribe_generic_secret("static_secret", Some("{not json"))
+        .is_none());
+
+      let static_secret = envoy_filter_config
+        .subscribe_generic_secret("static_secret", None)
+        .expect("failed to subscribe to the static secret");
+      // The value is readable from the config context as well as per-stream.
+      assert_eq!(
+        envoy_filter_config
+          .get_generic_secret(static_secret)
+          .expect("failed to read the static secret")
+          .as_slice(),
+        b"static_value"
+      );
+
+      let dynamic_secret = envoy_filter_config
+        .subscribe_generic_secret(
+          "dynamic_secret",
+          Some(
+            r#"{"api_config_source":{"api_type":"GRPC","transport_api_version":"V3",
+              "grpc_services":[{"envoy_grpc":{"cluster_name":"sds_cluster"}}]}}"#,
+          ),
+        )
+        .expect("failed to subscribe to the dynamic secret");
+      Some(Box::new(GenericSecretCallbacksFilterConfig {
+        static_secret,
+        dynamic_secret,
+      }))
+    },
     "header_callbacks" => Some(Box::new(HeaderCallbacksFilterConfig {})),
     "local_reply_callbacks" => Some(Box::new(LocalReplyCallbacksFilterConfig {})),
     "reset_stream" => Some(Box::new(ResetStreamFilterConfig {})),
@@ -170,6 +206,57 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for StatsCallbacksFilter {
 /// A HTTP filter configuration that implements
 /// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] to test the header/trailer
 /// related callbacks.
+/// An HTTP filter config that subscribes to generic secrets and exposes their values as request
+/// headers so that the test can observe them.
+struct GenericSecretCallbacksFilterConfig {
+  static_secret: EnvoyGenericSecretId,
+  dynamic_secret: EnvoyGenericSecretId,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for GenericSecretCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(GenericSecretCallbacksFilter {
+      static_secret: self.static_secret,
+      dynamic_secret: self.dynamic_secret,
+    })
+  }
+}
+
+/// An HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`].
+struct GenericSecretCallbacksFilter {
+  static_secret: EnvoyGenericSecretId,
+  dynamic_secret: EnvoyGenericSecretId,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for GenericSecretCallbacksFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    let static_secret = envoy_filter
+      .get_generic_secret(self.static_secret)
+      .expect("failed to read the static secret")
+      .as_slice()
+      .to_vec();
+    envoy_filter.set_request_header("x-static-secret", &static_secret);
+
+    let dynamic_secret = envoy_filter
+      .get_generic_secret(self.dynamic_secret)
+      .expect("failed to read the dynamic secret")
+      .as_slice()
+      .to_vec();
+    envoy_filter.set_request_header("x-dynamic-secret", &dynamic_secret);
+
+    // An ID that was never returned by a subscription is not readable.
+    assert!(envoy_filter
+      .get_generic_secret(EnvoyGenericSecretId(12345))
+      .is_none());
+
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+}
+
 struct HeaderCallbacksFilterConfig {}
 
 impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for HeaderCallbacksFilterConfig {

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -85,6 +85,27 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
         header_to_set: config_iter.next().unwrap().to_owned(),
       }))
     },
+    "generic_secret_callbacks" => {
+      let secret_name = String::from_utf8(config.to_owned()).unwrap();
+      // A secret that is not configured anywhere cannot be subscribed to.
+      assert!(envoy_filter_config
+        .subscribe_generic_secret("not_configured", None)
+        .is_none());
+      let secret = envoy_filter_config
+        .subscribe_generic_secret(&secret_name, None)
+        .expect("failed to subscribe to the secret");
+      // The value is readable right away from the config context, since a static secret is
+      // available before any request is served.
+      let value_at_config = envoy_filter_config
+        .get_generic_secret(secret)
+        .expect("failed to read the secret")
+        .as_slice()
+        .to_vec();
+      Some(Box::new(GenericSecretCallbacksFilterConfig {
+        secret,
+        value_at_config,
+      }))
+    },
     "streaming_terminal_filter" => Some(Box::new(StreamingTerminalFilterConfig {})),
     "streaming_response_reentry" => Some(Box::new(StreamingResponseReentryFilterConfig {})),
     "reentrant_stream_complete" => Some(Box::new(ReentrantStreamCompleteFilterConfig {
@@ -2220,6 +2241,50 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for ListMetadataCallbacksFilter {
       let header_name = format!("x-list-bool-{i}");
       envoy_filter.set_response_header(&header_name, val.to_string().as_bytes());
     }
+
+    envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
+  }
+}
+
+/// Subscribes to a generic secret at config load and exposes the value on the response, both as
+/// read per-stream and as read from the config context during initialization.
+struct GenericSecretCallbacksFilterConfig {
+  secret: EnvoyGenericSecretId,
+  value_at_config: Vec<u8>,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for GenericSecretCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(GenericSecretCallbacksFilter {
+      secret: self.secret,
+      value_at_config: self.value_at_config.clone(),
+    })
+  }
+}
+
+struct GenericSecretCallbacksFilter {
+  secret: EnvoyGenericSecretId,
+  value_at_config: Vec<u8>,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for GenericSecretCallbacksFilter {
+  fn on_response_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_response_headers_status {
+    let value = envoy_filter
+      .get_generic_secret(self.secret)
+      .expect("failed to read the secret")
+      .as_slice()
+      .to_vec();
+    envoy_filter.set_response_header("x-secret-value", &value);
+    envoy_filter.set_response_header("x-secret-value-at-config", &self.value_at_config);
+
+    // An ID that was never returned by a subscription is not readable.
+    assert!(envoy_filter
+      .get_generic_secret(EnvoyGenericSecretId(12345))
+      .is_none());
 
     envoy_dynamic_module_type_on_http_filter_response_headers_status::Continue
   }


### PR DESCRIPTION
Commit Message: dym: add sds subscription support to the HTTP dynamic module
Additional Description:

Now, it's possible to subscribe sds from sds server in the dynamic module.

Risk Level: low.
Testing: unit.
Docs Changes: added.
Release Notes: added.
Platform Specific Features: n/a.