### PR TITLE
[DOCS] Fix incorrect Linux Capability for setns syscall into Network Namespace

### DIFF
--- a/api/envoy/config/core/v3/address.proto
+++ b/api/envoy/config/core/v3/address.proto
@@ -103,7 +103,7 @@ message SocketAddress {
   // network namespace.
   //
   // .. note::
-  //    Setting this parameter requires Envoy to run with the ``CAP_NET_ADMIN`` capability.
+  //    Setting this parameter requires Envoy to run with the ``CAP_SYS_ADMIN`` capability.
   //
   // .. attention::
   //     Network namespaces are only configurable on Linux. Otherwise, this field has no effect.


### PR DESCRIPTION
Using https://man7.org/linux/man-pages/man2/setns.2.html as a reference


<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
