### PR TITLE
router: removes `RouteMatcher::vhost_scope_` member variable

### DIFF
--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1951,13 +1951,13 @@ RouteMatcher::RouteMatcher(const envoy::config::route::v3::RouteConfiguration& r
                            Server::Configuration::ServerFactoryContext& factory_context,
                            ProtobufMessage::ValidationVisitor& validator, bool validate_clusters,
                            absl::Status& creation_status)
-    : vhost_scope_(factory_context.scope().scopeFromStatName(
-          factory_context.routerContext().virtualClusterStatNames().vhost_)),
-      ignore_port_in_host_matching_(route_config.ignore_port_in_host_matching()),
+    : ignore_port_in_host_matching_(route_config.ignore_port_in_host_matching()),
       vhost_header_(route_config.vhost_header()) {
+  Stats::ScopeSharedPtr vhost_scope = factory_context.scope().scopeFromStatName(
+      factory_context.routerContext().virtualClusterStatNames().vhost_);
   for (const auto& virtual_host_config : route_config.virtual_hosts()) {
     VirtualHostImplSharedPtr virtual_host = std::make_shared<VirtualHostImpl>(
-        virtual_host_config, global_route_config, factory_context, *vhost_scope_, validator,
+        virtual_host_config, global_route_config, factory_context, *vhost_scope, validator,
         validate_clusters, creation_status);
     SET_AND_RETURN_IF_NOT_OK(creation_status, creation_status);
     for (const std::string& domain_name : virtual_host_config.domains()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1313,7 +1313,6 @@ private:
                                                  SubstringFunction substring_function) const;
   bool ignorePortInHostMatching() const { return ignore_port_in_host_matching_; }
 
-  Stats::ScopeSharedPtr vhost_scope_;
   absl::flat_hash_map<std::string, VirtualHostImplSharedPtr> virtual_hosts_;
   // std::greater as a minor optimization to iterate from more to less specific
   //


### PR DESCRIPTION
The `vhost_scope_` is only used during `RouteMatcher` construction. The sub-scopes created for virtual hosts (`vcluster_scope_` inside `CommonVirtualHostImpl` created via `Stats::Utility::scopeFromStatNames`) copy the joined names and increment ref counts of symbols in the central symbol table. They do not keep a reference to the parent `vhost_scope_` object. Therefore, the parent `vhost_scope_` does not need to be kept alive by `RouteMatcher` after construction.

This change was created with the help of the Gemini AI model. I have read and understand the code.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
