### PR TITLE
github/ci: Bump toolshed actions -> 0.4.21

### DIFF
--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -61,7 +61,7 @@ jobs:
           upload-name: coverage
           upload-path: generated/coverage/html
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 output-path: generated/coverage/html/gcs-metadata.json
                 input-format: yaml
@@ -82,7 +82,7 @@ jobs:
         - target: fuzz_coverage
           name: Fuzz coverage
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 output-path: generated/fuzz_coverage/html/gcs-metadata.json
                 input-format: yaml

--- a/.github/workflows/_cve_fetch.yml
+++ b/.github/workflows/_cve_fetch.yml
@@ -35,7 +35,7 @@ jobs:
         else
             echo "weekly_run=false" >> $GITHUB_OUTPUT
         fi
-    - uses: envoyproxy/toolshed/actions/gcp/setup@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/gcp/setup@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Setup GCP
       with:
         key: ${{ secrets.gcs-cve-key }}

--- a/.github/workflows/_cve_scan.yml
+++ b/.github/workflows/_cve_scan.yml
@@ -28,7 +28,7 @@ jobs:
       id: vars
       run: |
         echo "cve-data-path=${{ inputs.cve-data-path }}" > $GITHUB_OUTPUT
-    - uses: envoyproxy/toolshed/actions/gcp/setup@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/gcp/setup@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Setup GCP
       with:
         key: ${{ secrets.gcs-cve-key }}

--- a/.github/workflows/_finish.yml
+++ b/.github/workflows/_finish.yml
@@ -47,21 +47,20 @@ jobs:
       actions: read
       contents: read
     steps:
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Incoming data
       id: needs
       with:
         input: |
-          check_name: ${{ fromJSON(inputs.needs).load.outputs.check-name }}
-          repo: ${{ github.repository }}
-          run_id: ${{ github.run_id }}
-          branch: ${{ github.event.workflow_run.head_branch }}
-          outcomes: ${{ toJSON(fromJSON(inputs.needs)) }}
-          allowed_to_fail: ${{ toJSON(inputs.allowed-to-fail) }}
-          load: ${{ toJSON(fromJSON(inputs.needs).load.outputs) }}
-          slack_channel: ${{ toJSON(inputs.slack-channel) }}
-          slack_channel_allowed_failure: ${{ toJSON(inputs.slack-channel-allowed-failure) }}
-        input-format: yaml
+          {"check_name": ${{ toJSON(fromJSON(inputs.needs).load.outputs.check-name) }},
+           "repo": ${{ toJSON(github.repository) }},
+           "run_id": ${{ toJSON(github.run_id) }},
+           "branch": ${{ toJSON(github.event.workflow_run.head_branch) }},
+           "outcomes": ${{ toJSON(fromJSON(inputs.needs)) }},
+           "allowed_to_fail": ${{ toJSON(inputs.allowed-to-fail) }},
+           "load": ${{ toJSON(fromJSON(inputs.needs).load.outputs) }},
+           "slack_channel": ${{ toJSON(inputs.slack-channel) }},
+           "slack_channel_allowed_failure": ${{ toJSON(inputs.slack-channel-allowed-failure) }}}
         print-result: ${{ fromJSON(env.CI_DEBUG || 'false') && true || false }}
         filter: |
           .repo as $repo
@@ -129,7 +128,7 @@ jobs:
                    summary: "Check has finished",
                    text: ($text + $allowed_failure_text)}}}}
 
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Print summary
       with:
         input: ${{ toJSON(steps.needs.outputs.value).summary-title }}
@@ -137,13 +136,13 @@ jobs:
           "## \(.)"
         options: -Rr
         output-path: GITHUB_STEP_SUMMARY
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/actions/github/checks@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checks@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Update check
       with:
         action: update

--- a/.github/workflows/_load.yml
+++ b/.github/workflows/_load.yml
@@ -102,7 +102,7 @@ jobs:
     # Handle any failure in triggering job
     # Remove any `checks` we dont care about
     # Prepare a check request
-    - uses: envoyproxy/toolshed/actions/github/env/load@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/env/load@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Load env
       id: data
       with:
@@ -113,13 +113,13 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     #  Update the check
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/actions/github/checks@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checks@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Update check
       if: ${{ fromJSON(steps.data.outputs.data).data.check.action == 'RUN' }}
       with:
@@ -127,13 +127,12 @@ jobs:
         checks: ${{ toJSON(fromJSON(steps.data.outputs.data).checks) }}
         token: ${{ steps.appauth.outputs.token }}
 
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Print request summary
       with:
         input: |
-          action: ${{ fromJSON(steps.data.outputs.data).data.check.action }}
-          summary: ${{ toJSON(fromJSON(steps.data.outputs.data).data.summary) }}
-        input-format: yaml
+          {"action": ${{ toJSON(fromJSON(steps.data.outputs.data).data.check.action) }},
+           "summary": ${{ toJSON(fromJSON(steps.data.outputs.data).data.summary) }}}
         output-path: GITHUB_STEP_SUMMARY
         options: -r
         filter: |
@@ -147,17 +146,16 @@ jobs:
           | $summary.summary as $summary
           | "${{ inputs.template-request-summary }}"
 
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: request-output
       name: Load request
       with:
         input: |
-          check: ${{ toJSON(fromJSON(steps.data.outputs.data).data.check) }}
-          config: ${{ toJSON(fromJSON(steps.data.outputs.data).data.config) }}
-          request: ${{ toJSON(fromJSON(steps.data.outputs.data).data.request) }}
-          run: ${{ toJSON(fromJSON(steps.data.outputs.data).data.run) }}
-          summary_title: ${{ fromJSON(steps.data.outputs.data).data.summary.title }}
-        input-format: yaml
+          {"check": ${{ toJSON(fromJSON(steps.data.outputs.data).data.check) }},
+           "config": ${{ toJSON(fromJSON(steps.data.outputs.data).data.config) }},
+           "request": ${{ toJSON(fromJSON(steps.data.outputs.data).data.request) }},
+           "run": ${{ toJSON(fromJSON(steps.data.outputs.data).data.run) }},
+           "summary_title": ${{ toJSON(fromJSON(steps.data.outputs.data).data.summary.title) }}}
         filter: |
           .
           | .summary = {title: .summary_title}

--- a/.github/workflows/_load_env.yml
+++ b/.github/workflows/_load_env.yml
@@ -62,18 +62,18 @@ jobs:
       request: ${{ steps.env.outputs.data }}
       trusted: true
     steps:
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout
       name: Checkout Envoy repository
     - name: Generate environment variables
-      uses: envoyproxy/toolshed/actions/envoy/ci/env@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/envoy/ci/env@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: env
       with:
         branch-name: ${{ inputs.branch-name }}
@@ -85,7 +85,7 @@ jobs:
 
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/actions/github/env/summary@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/env/summary@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -88,7 +88,7 @@ jobs:
           upload-name: docs
           upload-path: generated/docs
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 output-path: generated/docs/gcs-metadata.json
                 input-format: yaml

--- a/.github/workflows/_publish_release.yml
+++ b/.github/workflows/_publish_release.yml
@@ -142,12 +142,12 @@ jobs:
     needs:
     - release
     steps:
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
-    - uses: envoyproxy/toolshed/actions/dispatch@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/dispatch@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         ref: main
         repository: ${{ fromJSON(inputs.request).request.version.dev && 'envoyproxy/envoy-website' || 'envoyproxy/archive' }}

--- a/.github/workflows/_publish_release_container.yml
+++ b/.github/workflows/_publish_release_container.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Generate manifest configuration (dev)
       id: dev-config
       if: ${{ inputs.dev && inputs.target-branch == 'main' }}
-      uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         input-format: yaml
         filter: >-
@@ -137,7 +137,7 @@ jobs:
             - tools-dev-${{ github.sha }}
 
     - name: Generate manifest configuration (release)
-      uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: release-config
       if: ${{ ! inputs.dev || ! inputs.target-branch != 'main' }}
       with:
@@ -227,7 +227,7 @@ jobs:
             - tools-v${{ inputs.version-major }}.${{ inputs.version-minor }}-latest
 
     - name: Collect and push OCI artifacts
-      uses: envoyproxy/toolshed/actions/oci/collector@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/oci/collector@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         artifacts-pattern: oci.*
         manifest-config: ${{ steps.dev-config.outputs.value || steps.release-config.outputs.value }}

--- a/.github/workflows/_publish_verify.yml
+++ b/.github/workflows/_publish_verify.yml
@@ -114,7 +114,7 @@ jobs:
             export NO_BUILD_SETUP=1
           steps-pre: |
             - id: version-support
-              uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+              uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 input: |
                   version_major: ${{ fromJSON(inputs.request).request.version.major }}

--- a/.github/workflows/_request.yml
+++ b/.github/workflows/_request.yml
@@ -56,14 +56,14 @@ jobs:
       caches: ${{ steps.caches.outputs.value }}
       config: ${{ steps.config.outputs.config }}
     steps:
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: started
       name: Create timestamp
       with:
         options: -r
         filter: |
           now
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout
       name: Checkout Envoy repository (requested)
       with:
@@ -77,7 +77,7 @@ jobs:
     # *ALL* variables collected should be treated as untrusted and should be sanitized before
     # use
     - name: Generate environment variables from commit
-      uses: envoyproxy/toolshed/actions/envoy/ci/request@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/envoy/ci/request@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: env
       with:
         branch-name: ${{ steps.checkout.outputs.branch-name }}
@@ -88,7 +88,7 @@ jobs:
         vars: ${{ toJSON(vars) }}
         working-directory: requested
 
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout-target
       name: Checkout Envoy repository (target branch)
       with:
@@ -96,7 +96,7 @@ jobs:
         config: |
           fetch-depth: 1
           path: target
-    - uses: envoyproxy/toolshed/actions/hashfiles@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/hashfiles@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: bazel-cache-hash
       name: Bazel cache hash
       with:
@@ -105,7 +105,7 @@ jobs:
 
     - name: Request summary
       id: summary
-      uses: envoyproxy/toolshed/actions/github/env/summary@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/env/summary@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         actor: ${{ toJSON(fromJSON(steps.env.outputs.data).request.actor) }}
         base-sha: ${{ fromJSON(steps.env.outputs.data).request.base-sha }}
@@ -121,28 +121,28 @@ jobs:
         target-branch: ${{ fromJSON(steps.env.outputs.data).request.target-branch }}
 
     - id: cache-id-bazel-x64
-      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         name: ${{ steps.bazel-cache-hash.outputs.value }}-x64
         wf-path: .github/workflows/request.yml
     - id: cache-id-bazel-arm64
-      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         name: ${{ steps.bazel-cache-hash.outputs.value }}-arm64
         wf-path: .github/workflows/request.yml
     - id: cache-id-bazel-docs-x64
-      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         name: ${{ steps.bazel-cache-hash.outputs.value }}-docs-x64
         wf-path: .github/workflows/request.yml
     - id: cache-id-bazel-external-x64
-      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/artifact/cache/id@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         name: ${{ steps.bazel-cache-hash.outputs.value }}-external-x64
         wf-path: .github/workflows/request.yml
 
     - name: Environment data
-      uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: data
       with:
         input: |
@@ -190,7 +190,7 @@ jobs:
         path: /tmp/cache
         key: ${{ fromJSON(steps.data.outputs.value).request.build-image.default }}-arm64
     - name: Caches
-      uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: caches
       with:
         input-format: yaml

--- a/.github/workflows/_request_cache_bazel.yml
+++ b/.github/workflows/_request_cache_bazel.yml
@@ -59,7 +59,7 @@ jobs:
             && ! fromJSON(inputs.caches).bazel[format('{0}-{1}', inputs.output-base, inputs.arch)])
       }}
     steps:
-    - uses: envoyproxy/toolshed/actions/bind-mounts@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bind-mounts@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         mounts: |
           - src: /mnt/workspace
@@ -73,9 +73,9 @@ jobs:
             target: /build
             chown: "runner:docker"
     - name: Free diskspace
-      uses: envoyproxy/toolshed/actions/diskspace@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/diskspace@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: inputs.arch == 'x64' && github.event.repository.private
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout-target
       name: Checkout Envoy repository (target branch)
       with:
@@ -83,14 +83,14 @@ jobs:
         config: |
           fetch-depth: 1
 
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: appauth
       name: Appauth (mutex lock)
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
 
-    - uses: envoyproxy/toolshed/actions/cache/prime@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/cache/prime@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: bazel-cache
       name: Prime Bazel cache
       with:

--- a/.github/workflows/_request_cache_docker.yml
+++ b/.github/workflows/_request_cache_docker.yml
@@ -39,7 +39,7 @@ on:
 # For a job that does, you can restore with something like:
 #
 #    steps:
-#    - uses: envoyproxy/toolshed/actions/docker/cache/restore@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+#    - uses: envoyproxy/toolshed/actions/docker/cache/restore@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
 #      with:
 #        key: "${{ needs.env.outputs.build-image }}"
 #
@@ -51,13 +51,13 @@ jobs:
     name: "[${{ inputs.arch }}] Prime Docker cache"
     if: ${{ ! fromJSON(inputs.caches).docker[inputs.arch] }}
     steps:
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: appauth
       name: Appauth (mutex lock)
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/actions/docker/cache/prime@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/docker/cache/prime@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: docker
       name: Prime Docker cache (${{ inputs.image-tag }}${{ inputs.cache-suffix }})
       with:
@@ -65,7 +65,7 @@ jobs:
         key-suffix: ${{ inputs.cache-suffix }}
         lock-token: ${{ steps.appauth.outputs.token }}
         lock-repository: ${{ inputs.lock-repository }}
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: data
       name: Cache data
       with:
@@ -73,7 +73,7 @@ jobs:
         input: |
           cached: ${{ steps.docker.outputs.cached }}
           key: ${{ inputs.image-tag }}${{ inputs.cache-suffix }}
-    - uses: envoyproxy/toolshed/actions/json/table@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/json/table@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Summary
       with:
         json: ${{ steps.data.outputs.value }}

--- a/.github/workflows/_request_checks.yml
+++ b/.github/workflows/_request_checks.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.env).config.ci.agent-ubuntu }}
     name: Start checks
     steps:
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: check-config
       name: Prepare check data
       with:
@@ -78,13 +78,13 @@ jobs:
           | .skipped.output.summary = "${{ inputs.skipped-summary }}"
           | .skipped.output.text = ""
 
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Appauth
       id: appauth
       with:
         app_id: ${{ secrets.app-id }}
         key: ${{ secrets.app-key }}
-    - uses: envoyproxy/toolshed/actions/github/checks@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checks@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Start checks
       id: checks
       with:
@@ -95,7 +95,7 @@ jobs:
 
           ${{ fromJSON(inputs.env).summary.summary }}
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/actions/json/table@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/json/table@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Summary
       with:
         collapse-open: true
@@ -119,7 +119,7 @@ jobs:
         output-path: GITHUB_STEP_SUMMARY
         title: Checks started/skipped
 
-    - uses: envoyproxy/toolshed/actions/github/env/save@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/env/save@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Save env
       id: data
       with:

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -141,7 +141,7 @@ on:
       summary-post:
         type: string
         default: |
-          - uses: envoyproxy/toolshed/actions/envoy/run/summary@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+          - uses: envoyproxy/toolshed/actions/envoy/run/summary@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
             with:
               context: %{{ inputs.context }}
       steps-pre:
@@ -210,7 +210,7 @@ jobs:
     name: ${{ inputs.target-suffix && format('[{0}] ', inputs.target-suffix) || '' }}${{ inputs.command }} ${{ inputs.target }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: started
       name: Create timestamp
       with:
@@ -218,7 +218,7 @@ jobs:
         filter: |
           now
     # This controls which input vars are exposed to the run action (and related steps)
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Context
       id: context
       with:
@@ -251,14 +251,14 @@ jobs:
         fi
         echo "mnt-available=$MNT_AVAILABLE" >> "$GITHUB_OUTPUT"
       id: disk
-    - uses: envoyproxy/toolshed/actions/github/remnt@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/remnt@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: steps.disk.outputs.should-remnt == 'true'
-    - uses: envoyproxy/toolshed/actions/bind-mounts@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bind-mounts@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: inputs.bind-mount && steps.disk.outputs.mnt-available == 'true'
       with:
         mounts: ${{ inputs.bind-mounts }}
     - name: Free diskspace
-      uses: envoyproxy/toolshed/actions/diskspace@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/diskspace@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: inputs.diskspace-hack || steps.disk.outputs.mnt-available != 'true'
       with:
         to_remove: ${{ inputs.diskspace-hack-paths }}
@@ -266,7 +266,7 @@ jobs:
         mount
         df -h
 
-    - uses: envoyproxy/toolshed/actions/bson@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bson@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Configure Docker
       if: runner.os == 'Linux'
       with:
@@ -282,7 +282,7 @@ jobs:
           | "${{ inputs.template-docker-configure }}"
 
     # Caches
-    - uses: envoyproxy/toolshed/actions/cache/restore@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/cache/restore@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: >-
         fromJSON(inputs.bazel-cache)
       name: >-
@@ -323,12 +323,12 @@ jobs:
         key: ${{ inputs.cache-build-image }}${{ inputs.cache-build-image-key-suffix }}
     - if: ${{ inputs.cache-build-image && steps.cache-lookup.outputs.cache-hit == 'true' }}
       name: Restore Docker cache ${{ inputs.cache-build-image && format('({0})', inputs.cache-build-image) || '' }}
-      uses: envoyproxy/toolshed/actions/docker/cache/restore@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/docker/cache/restore@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         image-tag: ${{ inputs.cache-build-image }}
         key-suffix: ${{ inputs.cache-build-image-key-suffix }}
 
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: appauth
       name: Appauth
       if: ${{ inputs.trusted }}
@@ -339,7 +339,7 @@ jobs:
         # - the workaround is to allow the token to be passed through.
         token: ${{ github.token }}
         token-ok: true
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -355,7 +355,7 @@ jobs:
         token: ${{ inputs.trusted && steps.appauth.outputs.token || github.token }}
 
     # This is currently only use by mobile-docs and can be removed once they are updated to the newer website
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout-extra
       name: Checkout extra repository (for publishing)
       if: ${{ inputs.checkout-extra }}
@@ -364,7 +364,7 @@ jobs:
         ssh-key: ${{ inputs.trusted && inputs.ssh-key-extra || '' }}
 
     - name: Import GPG key
-      uses: envoyproxy/toolshed/actions/gpg/import@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/gpg/import@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: ${{ inputs.import-gpg }}
       with:
         key: ${{ secrets.gpg-key }}
@@ -402,7 +402,7 @@ jobs:
 
     # NOTE: This is where untrusted code can be run!!!
     #  It MUST be the last step in the workflow
-    - uses: envoyproxy/toolshed/actions/github/run@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/run@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: ci-run
       name: Run CI ${{ inputs.command }} ${{ inputs.target }}
       with:

--- a/.github/workflows/_upload_gcs.yml
+++ b/.github/workflows/_upload_gcs.yml
@@ -29,17 +29,17 @@ jobs:
       with:
         name: ${{ matrix.artifact }}
         path: ${{ matrix.artifact }}
-    - uses: envoyproxy/toolshed/actions/jq@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/jq@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: metadata
       with:
         input: ${{ matrix.artifact }}/gcs-metadata.json
         input-format: json-path
     - run: |
         rm -rf ${{ matrix.artifact }}/gcs-metadata.json
-    - uses: envoyproxy/toolshed/actions/gcp/setup@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/gcp/setup@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         key: ${{ secrets.gcp-key }}
-    - uses: envoyproxy/toolshed/actions/gcs/artefact/sync@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/gcs/artefact/sync@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         bucket: ${{ fromJSON(steps.metadata.outputs.value).bucket }}
         path: ${{ matrix.artifact }}

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
 
-    - uses: envoyproxy/toolshed/actions/bind-mounts@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bind-mounts@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: |
         ! github.event.repository.private
       with:
@@ -43,7 +43,7 @@ jobs:
       if: |
         env.BUILD_TARGETS != ''
         && github.event.repository.private
-      uses: envoyproxy/toolshed/actions/diskspace@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/diskspace@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         to_remove: |
           /usr/local/.ghcup

--- a/.github/workflows/codeql-push.yml
+++ b/.github/workflows/codeql-push.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.repository == 'envoyproxy/envoy'
     steps:
-    - uses: envoyproxy/toolshed/actions/bind-mounts@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bind-mounts@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         mounts: |
           - src: /mnt/workspace
@@ -61,7 +61,7 @@ jobs:
 
     - name: Free disk space
       if: env.CPP_CHANGED == 'true'
-      uses: envoyproxy/toolshed/actions/diskspace@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/diskspace@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         to_remove: |
           /usr/local/.ghcup

--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -28,7 +28,7 @@ jobs:
          && github.actor != 'dependabot[bot]'
       }}
     steps:
-    - uses: envoyproxy/toolshed/actions/github/command@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/command@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Parse command from comment
       id: command
       with:
@@ -37,14 +37,14 @@ jobs:
           ^/(retest)
 
     # /retest
-    - uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: ${{ steps.command.outputs.command == 'retest' }}
       id: appauth-retest
       name: Appauth (retest)
       with:
         key: ${{ secrets.ENVOY_CI_APP_KEY }}
         app_id: ${{ secrets.ENVOY_CI_APP_ID }}
-    - uses: envoyproxy/toolshed/actions/retest@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/retest@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: ${{ steps.command.outputs.command == 'retest' }}
       name: Retest
       with:

--- a/.github/workflows/envoy-dependency.yml
+++ b/.github/workflows/envoy-dependency.yml
@@ -53,16 +53,16 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/actions/bson@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bson@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: update
       name: Update dependency (${{ inputs.dependency }})
       with:
@@ -97,13 +97,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: envoyproxy/toolshed/actions/upload/diff@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/upload/diff@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Upload diff
       with:
         name: ${{ inputs.dependency }}-${{ steps.update.outputs.output }}
     - name: Create a PR
       if: ${{ inputs.pr }}
-      uses: envoyproxy/toolshed/actions/github/pr@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/pr@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         base: main
         body: |
@@ -134,11 +134,11 @@ jobs:
     steps:
     - id: appauth
       name: Appauth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_DEP_APP_ID }}
         key: ${{ secrets.ENVOY_CI_DEP_APP_KEY }}
-    - uses: envoyproxy/toolshed/actions/bind-mounts@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/bind-mounts@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       if: ! github.event.repository.private
       with:
         mounts: |
@@ -150,12 +150,12 @@ jobs:
             chown: "runner:runner"
     - name: Free disk space
       if: github.event.repository.private
-      uses: envoyproxy/toolshed/actions/diskspace@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/diskspace@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         to_remove: |
           /usr/local/.ghcup
           /usr/local/lib/android
-    - uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: checkout
       name: Checkout Envoy repository
       with:
@@ -211,7 +211,7 @@ jobs:
 
     - name: Check Docker SHAs
       id: build-images
-      uses: envoyproxy/toolshed/actions/docker/shas@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/docker/shas@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         images: |
            sha-ci: docker.io/envoyproxy/envoy-build:ci-${{ steps.build-tools.outputs.tag }}
@@ -249,7 +249,7 @@ jobs:
       name: Update SHAs
       working-directory: envoy
     - name: Create a PR
-      uses: envoyproxy/toolshed/actions/github/pr@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/pr@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         base: main
         body: Created by Envoy dependency bot

--- a/.github/workflows/envoy-release.yml
+++ b/.github/workflows/envoy-release.yml
@@ -60,14 +60,14 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
@@ -88,10 +88,10 @@ jobs:
       name: Check changelog summary
     - if: ${{ inputs.author }}
       name: Validate signoff email
-      uses: envoyproxy/toolshed/actions/email/validate@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/email/validate@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         email: ${{ inputs.author }}
-    - uses: envoyproxy/toolshed/actions/github/run@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/run@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Create release
       with:
         source: |
@@ -116,7 +116,7 @@ jobs:
       name: Release version
       id: release
     - name: Create a PR
-      uses: envoyproxy/toolshed/actions/github/pr@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/pr@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         base: ${{ github.ref_name }}
         commit: false
@@ -142,19 +142,19 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
         strip-prefix: release/
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/actions/github/run@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/run@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Re-open branch
       with:
         command: >-
@@ -169,7 +169,7 @@ jobs:
       name: Dev version
       id: dev
     - name: Create a PR
-      uses: envoyproxy/toolshed/actions/github/pr@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/pr@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         base: ${{ github.ref_name }}
         commit: false
@@ -193,20 +193,20 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}
         strip-prefix: release/
         token: ${{ steps.appauth.outputs.token }}
-    - uses: envoyproxy/toolshed/actions/github/run@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+    - uses: envoyproxy/toolshed/actions/github/run@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       name: Sync version histories
       with:
         command: >-
@@ -216,7 +216,7 @@ jobs:
           --
           --signoff="${{ env.COMMITTER_NAME }} <${{ env.COMMITTER_EMAIL }}>"
     - name: Create a PR
-      uses: envoyproxy/toolshed/actions/github/pr@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/pr@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         append-commit-message: true
         base: ${{ github.ref_name }}
@@ -243,13 +243,13 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
     - id: checkout
       name: Checkout Envoy repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         config: |
           fetch-depth: 0
@@ -279,13 +279,13 @@ jobs:
     steps:
     - id: appauth
       name: App auth
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         app_id: ${{ secrets.ENVOY_CI_PUBLISH_APP_ID }}
         key: ${{ secrets.ENVOY_CI_PUBLISH_APP_KEY }}
 
     - name: Checkout repository
-      uses: envoyproxy/toolshed/actions/github/checkout@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/github/checkout@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         committer-name: ${{ env.COMMITTER_NAME }}
         committer-email: ${{ env.COMMITTER_EMAIL }}

--- a/.github/workflows/envoy-sync.yml
+++ b/.github/workflows/envoy-sync.yml
@@ -42,13 +42,13 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
         fi
     - if: steps.tip.outputs.skip != 'true'
-      uses: envoyproxy/toolshed/actions/appauth@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/appauth@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       id: appauth
       with:
         app_id: ${{ secrets.ENVOY_CI_SYNC_APP_ID }}
         key: ${{ secrets.ENVOY_CI_SYNC_APP_KEY }}
     - if: steps.tip.outputs.skip != 'true'
-      uses: envoyproxy/toolshed/actions/dispatch@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+      uses: envoyproxy/toolshed/actions/dispatch@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       with:
         repository: "envoyproxy/${{ matrix.downstream }}"
         ref: main

--- a/.github/workflows/mobile-android_build.yml
+++ b/.github/workflows/mobile-android_build.yml
@@ -107,9 +107,9 @@ jobs:
       target: kotlin-hello-world
       runs-on: ubuntu-22.04
       steps-pre: |
-        - uses: envoyproxy/toolshed/actions/envoy/android/pre@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+        - uses: envoyproxy/toolshed/actions/envoy/android/pre@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       steps-post: |
-        - uses: envoyproxy/toolshed/actions/envoy/android/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+        - uses: envoyproxy/toolshed/actions/envoy/android/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
           with:
             apk: bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
             app: io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -152,7 +152,7 @@ jobs:
       target: ${{ matrix.target }}
       runs-on: ubuntu-22.04
       steps-pre: |
-        - uses: envoyproxy/toolshed/actions/envoy/android/pre@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+        - uses: envoyproxy/toolshed/actions/envoy/android/pre@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
       steps-post: ${{ matrix.steps-post }}
       timeout-minutes: 50
       trusted: ${{ needs.load.outputs.trusted && fromJSON(needs.load.outputs.trusted) || false }}
@@ -163,7 +163,7 @@ jobs:
         include:
         - name: java-hello-world
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/envoy/android/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/envoy/android/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 apk: bazel-bin/examples/java/hello_world/hello_envoy.apk
                 app: io.envoyproxy.envoymobile.helloenvoy/.MainActivity
@@ -186,7 +186,7 @@ jobs:
             --config=mobile-android-release
             //test/kotlin/apps/baseline:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/envoy/android/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/envoy/android/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 apk: bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoybaselinetest/.MainActivity
@@ -203,7 +203,7 @@ jobs:
             --config=mobile-android-release
             //test/kotlin/apps/experimental:hello_envoy_kt
           steps-post: |
-            - uses: envoyproxy/toolshed/actions/envoy/android/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+            - uses: envoyproxy/toolshed/actions/envoy/android/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
               with:
                 apk: bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
                 app: io.envoyproxy.envoymobile.helloenvoyexperimentaltest/.MainActivity

--- a/.github/workflows/mobile-ios_build.yml
+++ b/.github/workflows/mobile-ios_build.yml
@@ -103,7 +103,7 @@ jobs:
   #       source ./ci/mac_ci_setup.sh
   #       bazel shutdown
   #     steps-post: |
-  #       - uses: envoyproxy/toolshed/actions/envoy/ios/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+  #       - uses: envoyproxy/toolshed/actions/envoy/ios/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
   #         with:
   #           app: ${{ matrix.app }}
   #           args: ${{ matrix.args || '--config=mobile-ios' }}
@@ -148,7 +148,7 @@ jobs:
   #     source: |
   #       source ./ci/mac_ci_setup.sh
   #     steps-post: |
-  #       - uses: envoyproxy/toolshed/actions/envoy/ios/post@1f5b552c6749502b885cb8cf23549b929e745547  # actions-v0.4.17
+  #       - uses: envoyproxy/toolshed/actions/envoy/ios/post@3a721916b4cf6338784230c7b940a249d6a64341  # actions-v0.4.21
   #         with:
   #           app: ${{ matrix.app }}
   #           args: ${{ matrix.args || '--config=mobile-ios' }}


### PR DESCRIPTION
has many js/vuln updates including a yaml parser update that is more strict and broke a bunch of existing action calls