### PR TITLE
Allow more per-route config in McpFilter.

### DIFF
--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -162,7 +162,7 @@ message ParserConfig {
 
 // Per-route override configuration for MCP filter
 message McpOverride {
-  // Optional per-route traffic mode override
+  // Overrides the global traffic mode for this route.
   Mcp.TrafficMode traffic_mode = 1 [(validate.rules).enum = {defined_only: true}];
 
   // Optional per-route max request body size override.
@@ -170,19 +170,15 @@ message McpOverride {
   // It defaults to 8KB (8192 bytes) and the maximum allowed value is 10MB (10485760 bytes).
   google.protobuf.UInt32Value max_request_body_size = 2 [(validate.rules).uint32 = {lte: 10485760}];
 
-  // Optional per-route clear route cache override.
-  // When set, this overrides the global clear_route_cache setting for this route.
-  google.protobuf.BoolValue clear_route_cache = 3;
+  // Overrides the global clear_route_cache setting for this route.
+  bool clear_route_cache = 3;
 
-  // Optional per-route parser configuration override.
-  // When set, this overrides the global parser_config for this route.
+  // Overrides the global parser config for this route.
   ParserConfig parser_config = 4;
 
-  // Optional per-route request storage mode override.
-  // When set, this overrides the global request_storage_mode for this route.
+  // Overrides the global request storage mode for this route.
   Mcp.RequestStorageMode request_storage_mode = 5 [(validate.rules).enum = {defined_only: true}];
 
-  // Optional per-route reject duplicate keys override.
-  // When set, this overrides the global reject_duplicate_keys setting for this route.
-  google.protobuf.BoolValue reject_duplicate_keys = 6;
+  // Overrides the global reject_duplicate_keys setting for this route.
+  bool reject_duplicate_keys = 6;
 }

--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -161,6 +161,7 @@ message ParserConfig {
 }
 
 // Per-route override configuration for MCP filter
+// [#next-free-field: 7]
 message McpOverride {
   // Overrides the global traffic mode for this route.
   Mcp.TrafficMode traffic_mode = 1 [(validate.rules).enum = {defined_only: true}];

--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -169,4 +169,20 @@ message McpOverride {
   // When set, this overrides the global max_request_body_size for this route.
   // It defaults to 8KB (8192 bytes) and the maximum allowed value is 10MB (10485760 bytes).
   google.protobuf.UInt32Value max_request_body_size = 2 [(validate.rules).uint32 = {lte: 10485760}];
+
+  // Optional per-route clear route cache override.
+  // When set, this overrides the global clear_route_cache setting for this route.
+  google.protobuf.BoolValue clear_route_cache = 3;
+
+  // Optional per-route parser configuration override.
+  // When set, this overrides the global parser_config for this route.
+  ParserConfig parser_config = 4;
+
+  // Optional per-route request storage mode override.
+  // When set, this overrides the global request_storage_mode for this route.
+  Mcp.RequestStorageMode request_storage_mode = 5 [(validate.rules).enum = {defined_only: true}];
+
+  // Optional per-route reject duplicate keys override.
+  // When set, this overrides the global reject_duplicate_keys setting for this route.
+  google.protobuf.BoolValue reject_duplicate_keys = 6;
 }

--- a/changelogs/current/new_features/mcp__per_route.rst
+++ b/changelogs/current/new_features/mcp__per_route.rst
@@ -1,0 +1,1 @@
+``McpFilter`` now allows per-route config for ``clear_route_cache``, ``parser_config``, ``request_storage_mode``, and ``reject_duplicate_keys``.

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -282,12 +282,11 @@ bool McpFilter::rejectDuplicateKeys() const {
 }
 
 const McpOverrideConfig* McpFilter::routeOverride() const {
-  if (!route_override_resolved_) {
+  if (!route_override_.has_value()) {
     route_override_ =
         Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
-    route_override_resolved_ = true;
   }
-  return route_override_;
+  return *route_override_;
 }
 
 Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& headers,
@@ -330,7 +329,9 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
   }
 
   ENVOY_LOG(debug, "after the post check");
-  if (!is_mcp_request_ && shouldRejectRequest()) {
+  const auto* override_config =
+      Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
+  if (!is_mcp_request_ && shouldRejectRequest(override_config)) {
     config_->stats().requests_rejected_.inc();
     sendErrorReply("Only MCP traffic is allowed", Filters::Common::Mcp::Status::NoMcp);
     return Http::FilterHeadersStatus::StopIteration;
@@ -400,7 +401,7 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
     }
     auto final_status = parser_->finishParse();
     if (!final_status.ok()) {
-      if (truncated_by_limit && !shouldRejectRequest()) {
+      if (truncated_by_limit && !shouldRejectRequest(routeOverride())) {
         // PASS_THROUGH mode: size limit caused truncation, allow through.
         ENVOY_LOG(debug, "size limit hit in PASS_THROUGH mode; proceeding with partial parse");
         return completeParsing();
@@ -459,7 +460,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
-  if (!is_mcp_request_ && shouldRejectRequest()) {
+  if (!is_mcp_request_ && shouldRejectRequest(routeOverride())) {
     sendErrorReply("request must be a valid JSON-RPC 2.0 message for MCP",
                    Filters::Common::Mcp::Status::NotJsonRpc);
     return Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -227,8 +227,8 @@ uint32_t McpFilter::getMaxRequestBodySize() const {
 bool McpFilter::clearRouteCache() const {
   const auto* override_config = routeOverride();
 
-  if (override_config && override_config->clearRouteCache().has_value()) {
-    return override_config->clearRouteCache().value();
+  if (override_config) {
+    return override_config->clearRouteCache();
   }
 
   return config_->clearRouteCache();
@@ -237,8 +237,8 @@ bool McpFilter::clearRouteCache() const {
 const ParserConfig& McpFilter::parserConfig() const {
   const auto* override_config = routeOverride();
 
-  if (override_config && override_config->parserConfig().has_value()) {
-    return override_config->parserConfig().value();
+  if (override_config) {
+    return override_config->parserConfig();
   }
 
   return config_->parserConfig();
@@ -247,8 +247,8 @@ const ParserConfig& McpFilter::parserConfig() const {
 bool McpFilter::shouldStoreToDynamicMetadata() const {
   const auto* override_config = routeOverride();
 
-  if (override_config && override_config->requestStorageMode().has_value()) {
-    const auto mode = override_config->requestStorageMode().value();
+  if (override_config) {
+    const auto mode = override_config->requestStorageMode();
     return mode == envoy::extensions::filters::http::mcp::v3::Mcp::MODE_UNSPECIFIED ||
            mode == envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA ||
            mode ==
@@ -261,8 +261,8 @@ bool McpFilter::shouldStoreToDynamicMetadata() const {
 bool McpFilter::shouldStoreToFilterState() const {
   const auto* override_config = routeOverride();
 
-  if (override_config && override_config->requestStorageMode().has_value()) {
-    const auto mode = override_config->requestStorageMode().value();
+  if (override_config) {
+    const auto mode = override_config->requestStorageMode();
     return mode == envoy::extensions::filters::http::mcp::v3::Mcp::FILTER_STATE ||
            mode ==
                envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA_AND_FILTER_STATE;
@@ -274,19 +274,18 @@ bool McpFilter::shouldStoreToFilterState() const {
 bool McpFilter::rejectDuplicateKeys() const {
   const auto* override_config = routeOverride();
 
-  if (override_config && override_config->rejectDuplicateKeys().has_value()) {
-    return override_config->rejectDuplicateKeys().value();
+  if (override_config) {
+    return override_config->rejectDuplicateKeys();
   }
 
   return config_->rejectDuplicateKeys();
 }
 
 const McpOverrideConfig* McpFilter::routeOverride() const {
-  if (!route_override_.has_value()) {
-    route_override_ =
-        Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
-  }
-  return *route_override_;
+  // TODO(mkbehr): We can latch the McpOverrideConfig in order to do fewer route lookups. The
+  // McpOverrideConfig has lifetime equal to the route, so we'll need to take care not to keep a
+  // stale pointer if another filter clears the route cache.
+  return Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
 }
 
 Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& headers,
@@ -329,9 +328,7 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
   }
 
   ENVOY_LOG(debug, "after the post check");
-  const auto* override_config =
-      Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
-  if (!is_mcp_request_ && shouldRejectRequest(override_config)) {
+  if (!is_mcp_request_ && shouldRejectRequest()) {
     config_->stats().requests_rejected_.inc();
     sendErrorReply("Only MCP traffic is allowed", Filters::Common::Mcp::Status::NoMcp);
     return Http::FilterHeadersStatus::StopIteration;
@@ -401,7 +398,7 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
     }
     auto final_status = parser_->finishParse();
     if (!final_status.ok()) {
-      if (truncated_by_limit && !shouldRejectRequest(routeOverride())) {
+      if (truncated_by_limit && !shouldRejectRequest()) {
         // PASS_THROUGH mode: size limit caused truncation, allow through.
         ENVOY_LOG(debug, "size limit hit in PASS_THROUGH mode; proceeding with partial parse");
         return completeParsing();
@@ -460,7 +457,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
-  if (!is_mcp_request_ && shouldRejectRequest(routeOverride())) {
+  if (!is_mcp_request_ && shouldRejectRequest()) {
     sendErrorReply("request must be a valid JSON-RPC 2.0 message for MCP",
                    Filters::Common::Mcp::Status::NotJsonRpc);
     return Http::FilterDataStatus::StopIterationNoBuffer;

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -215,14 +215,79 @@ bool McpFilter::shouldRejectRequest() {
 }
 
 uint32_t McpFilter::getMaxRequestBodySize() const {
-  const auto* override_config =
-      Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
+  const auto* override_config = routeOverride();
 
   if (override_config && override_config->maxRequestBodySize().has_value()) {
     return override_config->maxRequestBodySize().value();
   }
 
   return config_->maxRequestBodySize();
+}
+
+bool McpFilter::clearRouteCache() const {
+  const auto* override_config = routeOverride();
+
+  if (override_config && override_config->clearRouteCache().has_value()) {
+    return override_config->clearRouteCache().value();
+  }
+
+  return config_->clearRouteCache();
+}
+
+const ParserConfig& McpFilter::parserConfig() const {
+  const auto* override_config = routeOverride();
+
+  if (override_config && override_config->parserConfig().has_value()) {
+    return override_config->parserConfig().value();
+  }
+
+  return config_->parserConfig();
+}
+
+bool McpFilter::shouldStoreToDynamicMetadata() const {
+  const auto* override_config = routeOverride();
+
+  if (override_config && override_config->requestStorageMode().has_value()) {
+    const auto mode = override_config->requestStorageMode().value();
+    return mode == envoy::extensions::filters::http::mcp::v3::Mcp::MODE_UNSPECIFIED ||
+           mode == envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA ||
+           mode ==
+               envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA_AND_FILTER_STATE;
+  }
+
+  return config_->shouldStoreToDynamicMetadata();
+}
+
+bool McpFilter::shouldStoreToFilterState() const {
+  const auto* override_config = routeOverride();
+
+  if (override_config && override_config->requestStorageMode().has_value()) {
+    const auto mode = override_config->requestStorageMode().value();
+    return mode == envoy::extensions::filters::http::mcp::v3::Mcp::FILTER_STATE ||
+           mode ==
+               envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA_AND_FILTER_STATE;
+  }
+
+  return config_->shouldStoreToFilterState();
+}
+
+bool McpFilter::rejectDuplicateKeys() const {
+  const auto* override_config = routeOverride();
+
+  if (override_config && override_config->rejectDuplicateKeys().has_value()) {
+    return override_config->rejectDuplicateKeys().value();
+  }
+
+  return config_->rejectDuplicateKeys();
+}
+
+const McpOverrideConfig* McpFilter::routeOverride() const {
+  if (!route_override_resolved_) {
+    route_override_ =
+        Http::Utility::resolveMostSpecificPerFilterConfig<McpOverrideConfig>(decoder_callbacks_);
+    route_override_resolved_ = true;
+  }
+  return route_override_;
 }
 
 Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& headers,
@@ -281,7 +346,7 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
   }
 
   if (!parser_) {
-    parser_ = std::make_unique<JsonPathParser>(config_->parserConfig());
+    parser_ = std::make_unique<JsonPathParser>(parserConfig());
   }
 
   if (parsing_complete_) {
@@ -361,7 +426,7 @@ void McpFilter::sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp
   status_ = status;
   is_mcp_request_ = false;
 
-  if (config_->shouldStoreToFilterState()) {
+  if (shouldStoreToFilterState()) {
     std::string method = parser_ ? parser_->getMethod() : "";
     Protobuf::Struct metadata = parser_ ? parser_->metadata() : Protobuf::Struct();
     auto filter_state_obj = std::make_shared<FilterStateObject>(method, metadata, is_mcp_request_,
@@ -372,7 +437,7 @@ void McpFilter::sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp
         StreamInfo::StreamSharingMayImpactPooling::None);
   }
 
-  if (config_->shouldStoreToDynamicMetadata()) {
+  if (shouldStoreToDynamicMetadata()) {
     Protobuf::Struct metadata = parser_ ? parser_->metadata() : Protobuf::Struct();
     setDynamicMetadataStatus(std::move(metadata));
   }
@@ -388,7 +453,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   ENVOY_LOG(debug, "parsing complete: is_mcp={}, bytes_parsed={}", is_mcp_request_, bytes_parsed_);
 
   // Check for duplicate keys — reject if configured.
-  if (parser_->hasDuplicateKeys() && config_->rejectDuplicateKeys()) {
+  if (parser_->hasDuplicateKeys() && rejectDuplicateKeys()) {
     config_->stats().duplicate_keys_rejected_.inc();
     sendErrorReply("duplicate JSON keys detected", Filters::Common::Mcp::Status::DuplicateKeys);
     return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -409,9 +474,10 @@ Http::FilterDataStatus McpFilter::completeParsing() {
         std::string(Filters::Common::Mcp::McpConstants::Methods::JSONRPC_RESPONSE));
   }
 
-  const std::string& group_metadata_key = config_->parserConfig().groupMetadataKey();
+  const ParserConfig& active_parser_config = parserConfig();
+  const std::string& group_metadata_key = active_parser_config.groupMetadataKey();
   if (!group_metadata_key.empty()) {
-    std::string method_group = config_->parserConfig().getMethodGroup(parser_->getMethod());
+    std::string method_group = active_parser_config.getMethodGroup(parser_->getMethod());
     (*metadata.mutable_fields())[group_metadata_key].set_string_value(method_group);
     ENVOY_LOG(debug, "MCP filter set method group: {}={}", group_metadata_key, method_group);
   }
@@ -436,7 +502,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   const bool should_store_metadata = has_metadata || is_exceeding_limit_;
 
   if (should_store_metadata) {
-    if (config_->shouldStoreToFilterState()) {
+    if (shouldStoreToFilterState()) {
       auto filter_state_obj = std::make_shared<FilterStateObject>(
           parser_->getMethod(), metadata, is_mcp_request_, is_exceeding_limit_, status_);
       decoder_callbacks_->streamInfo().filterState()->setData(
@@ -445,11 +511,11 @@ Http::FilterDataStatus McpFilter::completeParsing() {
           StreamInfo::StreamSharingMayImpactPooling::None);
     }
 
-    if (config_->shouldStoreToDynamicMetadata()) {
+    if (shouldStoreToDynamicMetadata()) {
       setDynamicMetadataStatus(std::move(metadata));
     }
 
-    if (config_->clearRouteCache()) {
+    if (clearRouteCache()) {
       if (auto cb = decoder_callbacks_->downstreamCallbacks(); cb.has_value()) {
         cb->clearRouteCache();
         ENVOY_LOG(debug, "MCP filter cleared route cache for metadata-based routing");

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -111,17 +111,50 @@ public:
         max_request_body_size_(
             proto_config.has_max_request_body_size()
                 ? std::optional<uint32_t>(proto_config.max_request_body_size().value())
-                : std::nullopt) {}
+                : std::nullopt),
+        clear_route_cache_(proto_config.has_clear_route_cache()
+                               ? std::optional<bool>(proto_config.clear_route_cache().value())
+                               : std::nullopt),
+        parser_config_(proto_config.has_parser_config()
+                           ? std::optional<ParserConfig>(
+                                 McpParserConfig::fromProto(proto_config.parser_config()))
+                           : std::nullopt),
+        request_storage_mode_(
+            proto_config.request_storage_mode() !=
+                    envoy::extensions::filters::http::mcp::v3::Mcp::MODE_UNSPECIFIED
+                ? std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>(
+                      proto_config.request_storage_mode())
+                : std::nullopt),
+        reject_duplicate_keys_(
+            proto_config.has_reject_duplicate_keys()
+                ? std::optional<bool>(proto_config.reject_duplicate_keys().value())
+                : std::nullopt) {
+    if (parser_config_.has_value() && reject_duplicate_keys_.has_value()) {
+      parser_config_->setRejectDuplicateKeys(reject_duplicate_keys_.value());
+    }
+  }
 
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode() const {
     return traffic_mode_;
   }
 
   std::optional<uint32_t> maxRequestBodySize() const { return max_request_body_size_; }
+  std::optional<bool> clearRouteCache() const { return clear_route_cache_; }
+  const std::optional<ParserConfig>& parserConfig() const { return parser_config_; }
+  std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>
+  requestStorageMode() const {
+    return request_storage_mode_;
+  }
+  std::optional<bool> rejectDuplicateKeys() const { return reject_duplicate_keys_; }
 
 private:
   const envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode traffic_mode_;
   const std::optional<uint32_t> max_request_body_size_;
+  const std::optional<bool> clear_route_cache_;
+  std::optional<ParserConfig> parser_config_;
+  const std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>
+      request_storage_mode_;
+  const std::optional<bool> reject_duplicate_keys_;
 };
 
 using McpFilterConfigSharedPtr = std::shared_ptr<McpFilterConfig>;
@@ -149,6 +182,12 @@ private:
   bool shouldRejectRequest();
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode();
   uint32_t getMaxRequestBodySize() const;
+  bool clearRouteCache() const;
+  const ParserConfig& parserConfig() const;
+  bool shouldStoreToDynamicMetadata() const;
+  bool shouldStoreToFilterState() const;
+  bool rejectDuplicateKeys() const;
+  const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);
   Http::FilterDataStatus completeParsing();
@@ -166,6 +205,8 @@ private:
   bool is_mcp_request_{false};
   bool is_json_post_request_{false};
   Filters::Common::Mcp::Status status_{Filters::Common::Mcp::Status::Ok};
+  mutable bool route_override_resolved_{false};
+  mutable const McpOverrideConfig* route_override_{nullptr};
 };
 
 } // namespace Mcp

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -205,8 +205,11 @@ private:
   bool is_mcp_request_{false};
   bool is_json_post_request_{false};
   Filters::Common::Mcp::Status status_{Filters::Common::Mcp::Status::Ok};
-  mutable bool route_override_resolved_{false};
-  mutable const McpOverrideConfig* route_override_{nullptr};
+  // Route-specific config, latched during decodeData. Empty if it hasn't yet
+  // been latched; nullptr if there is no route-specific config. Lifetime is the
+  // same as the route's lifetime; must not be dereferenced if clearRouteCache
+  // has been called after this was latched.
+  mutable std::optional<const McpOverrideConfig*> route_override_{std::nullopt};
 };
 
 } // namespace Mcp

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -112,26 +112,11 @@ public:
             proto_config.has_max_request_body_size()
                 ? std::optional<uint32_t>(proto_config.max_request_body_size().value())
                 : std::nullopt),
-        clear_route_cache_(proto_config.has_clear_route_cache()
-                               ? std::optional<bool>(proto_config.clear_route_cache().value())
-                               : std::nullopt),
-        parser_config_(proto_config.has_parser_config()
-                           ? std::optional<ParserConfig>(
-                                 McpParserConfig::fromProto(proto_config.parser_config()))
-                           : std::nullopt),
-        request_storage_mode_(
-            proto_config.request_storage_mode() !=
-                    envoy::extensions::filters::http::mcp::v3::Mcp::MODE_UNSPECIFIED
-                ? std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>(
-                      proto_config.request_storage_mode())
-                : std::nullopt),
-        reject_duplicate_keys_(
-            proto_config.has_reject_duplicate_keys()
-                ? std::optional<bool>(proto_config.reject_duplicate_keys().value())
-                : std::nullopt) {
-    if (parser_config_.has_value() && reject_duplicate_keys_.has_value()) {
-      parser_config_->setRejectDuplicateKeys(reject_duplicate_keys_.value());
-    }
+        clear_route_cache_(proto_config.clear_route_cache()),
+        parser_config_(McpParserConfig::fromProto(proto_config.parser_config())),
+        request_storage_mode_(proto_config.request_storage_mode()),
+        reject_duplicate_keys_(proto_config.reject_duplicate_keys()) {
+    parser_config_.setRejectDuplicateKeys(reject_duplicate_keys_);
   }
 
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode() const {
@@ -139,22 +124,20 @@ public:
   }
 
   std::optional<uint32_t> maxRequestBodySize() const { return max_request_body_size_; }
-  std::optional<bool> clearRouteCache() const { return clear_route_cache_; }
-  const std::optional<ParserConfig>& parserConfig() const { return parser_config_; }
-  std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>
-  requestStorageMode() const {
+  bool clearRouteCache() const { return clear_route_cache_; }
+  const ParserConfig& parserConfig() const { return parser_config_; }
+  envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode requestStorageMode() const {
     return request_storage_mode_;
   }
-  std::optional<bool> rejectDuplicateKeys() const { return reject_duplicate_keys_; }
+  bool rejectDuplicateKeys() const { return reject_duplicate_keys_; }
 
 private:
   const envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode traffic_mode_;
   const std::optional<uint32_t> max_request_body_size_;
-  const std::optional<bool> clear_route_cache_;
-  std::optional<ParserConfig> parser_config_;
-  const std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode>
-      request_storage_mode_;
-  const std::optional<bool> reject_duplicate_keys_;
+  const bool clear_route_cache_;
+  ParserConfig parser_config_;
+  const envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode request_storage_mode_;
+  const bool reject_duplicate_keys_;
 };
 
 using McpFilterConfigSharedPtr = std::shared_ptr<McpFilterConfig>;
@@ -180,6 +163,8 @@ private:
   bool isValidMcpPostRequest(const Http::RequestHeaderMap& headers) const;
   bool isValidMcpDeleteRequest(const Http::RequestHeaderMap& headers) const;
   bool shouldRejectRequest();
+  // Traffic mode after applying any per-route override. Latched on first access in decodeHeaders;
+  // we assume the route does not change during the request, so it is resolved only once.
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode();
   uint32_t getMaxRequestBodySize() const;
   bool clearRouteCache() const;
@@ -195,8 +180,6 @@ private:
 
   McpFilterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};
-  // Traffic mode after applying any per-route override. Latched on first access in decodeHeaders;
-  // we assume the route does not change during the request, so it is resolved only once.
   std::optional<envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode> traffic_mode_;
   uint32_t bytes_parsed_{0};
   bool parsing_complete_{false};
@@ -205,11 +188,6 @@ private:
   bool is_mcp_request_{false};
   bool is_json_post_request_{false};
   Filters::Common::Mcp::Status status_{Filters::Common::Mcp::Status::Ok};
-  // Route-specific config, latched during decodeData. Empty if it hasn't yet
-  // been latched; nullptr if there is no route-specific config. Lifetime is the
-  // same as the route's lifetime; must not be dereferenced if clearRouteCache
-  // has been called after this was latched.
-  mutable std::optional<const McpOverrideConfig*> route_override_{std::nullopt};
 };
 
 } // namespace Mcp

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -464,73 +464,16 @@ TEST_P(McpFilterIntegrationTest, PerRouteOverrideToReject) {
   EXPECT_EQ("404", response2->headers().getStatusValue());
 }
 
-// Test NOOP mode - non-MCP traffic passes through untouched
-TEST_P(McpFilterIntegrationTest, NoopModePassesThroughNonMcp) {
-  initializeFilter(R"EOF(
-    name: envoy.filters.http.mcp
-    typed_config:
-      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
-      traffic_mode: NOOP
-  )EOF");
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-
-  // Regular GET request should pass through, not be rejected.
-  auto response = codec_client_->makeRequestWithBody(
-      Http::TestRequestHeaderMapImpl{
-          {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}},
-      "");
-
-  waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_TRUE(upstream_request_->complete());
-  EXPECT_EQ("200", response->headers().getStatusValue());
-}
-
-// Test NOOP mode - invalid JSON-RPC is not inspected and passes through untouched
-TEST_P(McpFilterIntegrationTest, NoopModeIgnoresInvalidJsonRpc) {
-  initializeFilter(R"EOF(
-    name: envoy.filters.http.mcp
-    typed_config:
-      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
-      traffic_mode: NOOP
-  )EOF");
-
-  codec_client_ = makeHttpConnection(lookupPort("http"));
-
-  // A POST that would normally be inspected (and rejected in REJECT_NO_MCP mode) is left alone.
-  const std::string request_body = R"({"invalid": "not-jsonrpc"})";
-  auto response = codec_client_->makeRequestWithBody(
-      Http::TestRequestHeaderMapImpl{{":method", "POST"},
-                                     {":path", "/"},
-                                     {":scheme", "http"},
-                                     {":authority", "host"},
-                                     {"accept", "application/json"},
-                                     {"accept", "text/event-stream"},
-                                     {"content-type", "application/json"}},
-      request_body);
-
-  waitForNextUpstreamRequest();
-  // Body reaches upstream unmodified - the filter did not buffer or parse it.
-  EXPECT_EQ(request_body, upstream_request_->body().toString());
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_EQ("200", response->headers().getStatusValue());
-}
-
-// Test per-route override to NOOP disables an otherwise rejecting global config
-TEST_P(McpFilterIntegrationTest, PerRouteOverrideToNoop) {
+// Test per-route override to reject duplicate keys
+TEST_P(McpFilterIntegrationTest, PerRouteRejectDuplicateKeysOverride) {
   config_helper_.prependFilter(R"EOF(
     name: envoy.filters.http.mcp
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
-      traffic_mode: REJECT_NO_MCP
+      reject_duplicate_keys: false
   )EOF");
 
-  // Configure a specific route to NOOP, overriding the global REJECT_NO_MCP.
+  // Configure specific route to reject duplicate keys
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {
@@ -538,7 +481,7 @@ TEST_P(McpFilterIntegrationTest, PerRouteOverrideToNoop) {
         route->mutable_match()->set_path("/api/mcp");
 
         envoy::extensions::filters::http::mcp::v3::McpOverride mcp_override;
-        mcp_override.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::NOOP);
+        mcp_override.mutable_reject_duplicate_keys()->set_value(true);
         std::ignore =
             (*route->mutable_typed_per_filter_config())["envoy.filters.http.mcp"].PackFrom(
                 mcp_override);
@@ -547,19 +490,19 @@ TEST_P(McpFilterIntegrationTest, PerRouteOverrideToNoop) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  // Request to /api/mcp would be rejected under the global config, but the NOOP override
-  // lets the non-MCP GET pass through to the upstream.
-  auto response = codec_client_->makeRequestWithBody(
-      Http::TestRequestHeaderMapImpl{
-          {":method", "GET"}, {":path", "/api/mcp"}, {":scheme", "http"}, {":authority", "host"}},
-      "");
+  // Send request with duplicate JSON keys to overridden route -> should be rejected with 400
+  auto response1 = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/api/mcp"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"content-type", "application/json"},
+                                     {"accept", "application/json, text/event-stream, */*"}},
+      R"({"jsonrpc": "2.0", "method": "test", "id": 1, "id": 2})");
 
-  waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
-
-  ASSERT_TRUE(response->waitForEndStream());
-  EXPECT_TRUE(upstream_request_->complete());
-  EXPECT_EQ("200", response->headers().getStatusValue());
+  ASSERT_TRUE(response1->waitForEndStream());
+  EXPECT_FALSE(upstream_request_);
+  EXPECT_EQ("400", response1->headers().getStatusValue());
 }
 
 // Test that the filter can be disabled per-route using FilterConfig wrapper
@@ -847,6 +790,105 @@ TEST_P(McpFilterIntegrationTest, InvalidTracingHeadersNotInjected) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
+
+// Test NOOP mode - non-MCP traffic passes through untouched
+TEST_P(McpFilterIntegrationTest, NoopModePassesThroughNonMcp) {
+  initializeFilter(R"EOF(
+    name: envoy.filters.http.mcp
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
+      traffic_mode: NOOP
+  )EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Regular GET request should pass through, not be rejected.
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}},
+      "");
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test NOOP mode - invalid JSON-RPC is not inspected and passes through untouched
+TEST_P(McpFilterIntegrationTest, NoopModeIgnoresInvalidJsonRpc) {
+  initializeFilter(R"EOF(
+    name: envoy.filters.http.mcp
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
+      traffic_mode: NOOP
+  )EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // A POST that would normally be inspected (and rejected in REJECT_NO_MCP mode) is left alone.
+  const std::string request_body = R"({"invalid": "not-jsonrpc"})";
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"}},
+      request_body);
+
+  waitForNextUpstreamRequest();
+  // Body reaches upstream unmodified - the filter did not buffer or parse it.
+  EXPECT_EQ(request_body, upstream_request_->body().toString());
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Test per-route override to NOOP disables an otherwise rejecting global config
+TEST_P(McpFilterIntegrationTest, PerRouteOverrideToNoop) {
+  config_helper_.prependFilter(R"EOF(
+    name: envoy.filters.http.mcp
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
+      traffic_mode: REJECT_NO_MCP
+  )EOF");
+
+  // Configure a specific route to NOOP, overriding the global REJECT_NO_MCP.
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* route = hcm.mutable_route_config()->mutable_virtual_hosts(0)->mutable_routes(0);
+        route->mutable_match()->set_path("/api/mcp");
+
+        envoy::extensions::filters::http::mcp::v3::McpOverride mcp_override;
+        mcp_override.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::NOOP);
+        std::ignore =
+            (*route->mutable_typed_per_filter_config())["envoy.filters.http.mcp"].PackFrom(
+                mcp_override);
+      });
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  // Request to /api/mcp would be rejected under the global config, but the NOOP override
+  // lets the non-MCP GET pass through to the upstream.
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{
+          {":method", "GET"}, {":path", "/api/mcp"}, {":scheme", "http"}, {":authority", "host"}},
+      "");
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 
 } // namespace
 } // namespace Mcp

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -481,7 +481,7 @@ TEST_P(McpFilterIntegrationTest, PerRouteRejectDuplicateKeysOverride) {
         route->mutable_match()->set_path("/api/mcp");
 
         envoy::extensions::filters::http::mcp::v3::McpOverride mcp_override;
-        mcp_override.mutable_reject_duplicate_keys()->set_value(true);
+        mcp_override.set_reject_duplicate_keys(true);
         std::ignore =
             (*route->mutable_typed_per_filter_config())["envoy.filters.http.mcp"].PackFrom(
                 mcp_override);
@@ -888,7 +888,6 @@ TEST_P(McpFilterIntegrationTest, PerRouteOverrideToNoop) {
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
-
 
 } // namespace
 } // namespace Mcp

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -244,7 +244,7 @@ TEST_F(McpFilterTest, PerRouteOverride) {
   auto route_config = std::make_shared<McpOverrideConfig>(override_config);
 
   EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
-      .WillOnce(Return(route_config.get()));
+      .WillRepeatedly(Return(route_config.get()));
 
   Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {"accept", "text/html"}};
 

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -1544,7 +1544,7 @@ TEST_F(McpFilterTest, PerRouteClearRouteCache) {
 
   // Per-route config overrides clear route cache = true
   envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
-  override_config.mutable_clear_route_cache()->set_value(true);
+  override_config.set_clear_route_cache(true);
   auto route_config = std::make_shared<McpOverrideConfig>(override_config);
 
   EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
@@ -1580,7 +1580,7 @@ TEST_F(McpFilterTest, PerRouteRejectDuplicateKeys) {
 
   // Per-route config overrides reject duplicate keys = true
   envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
-  override_config.mutable_reject_duplicate_keys()->set_value(true);
+  override_config.set_reject_duplicate_keys(true);
   auto route_config = std::make_shared<McpOverrideConfig>(override_config);
 
   EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -1533,6 +1533,162 @@ TEST_F(McpFilterTest, PerRouteMaxBodySizeFallbackToGlobal) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 }
 
+// Test per-route clear route cache override
+TEST_F(McpFilterTest, PerRouteClearRouteCache) {
+  // Global config has clear route cache = false
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_clear_route_cache(false);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  // Per-route config overrides clear route cache = true
+  envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
+  override_config.mutable_clear_route_cache()->set_value(true);
+  auto route_config = std::make_shared<McpOverrideConfig>(override_config);
+
+  EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
+      .WillRepeatedly(Return(route_config.get()));
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+
+  filter_->decodeHeaders(headers, false);
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "test", "params": {"key": "value"}, "id": 1})";
+  Buffer::OwnedImpl buffer(json);
+
+  // Expect dynamic metadata to be set
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _));
+
+  // Expect route cache to be cleared (since override overrides it to true)
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+}
+
+// Test per-route reject duplicate keys override
+TEST_F(McpFilterTest, PerRouteRejectDuplicateKeys) {
+  // Global config has reject duplicate keys = false
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.mutable_reject_duplicate_keys()->set_value(false);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  // Per-route config overrides reject duplicate keys = true
+  envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
+  override_config.mutable_reject_duplicate_keys()->set_value(true);
+  auto route_config = std::make_shared<McpOverrideConfig>(override_config);
+
+  EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
+      .WillRepeatedly(Return(route_config.get()));
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+
+  filter_->decodeHeaders(headers, false);
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "test", "id": 1, "id": 2})";
+  Buffer::OwnedImpl buffer(json);
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest, "duplicate JSON keys detected", _, _, _));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, true));
+}
+
+// Test per-route request storage mode override
+TEST_F(McpFilterTest, PerRouteRequestStorageMode) {
+  // Global config has request storage mode = FILTER_STATE
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_request_storage_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::FILTER_STATE);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  // Per-route config overrides request storage mode = DYNAMIC_METADATA
+  envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
+  override_config.set_request_storage_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::DYNAMIC_METADATA);
+  auto route_config = std::make_shared<McpOverrideConfig>(override_config);
+
+  EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
+      .WillRepeatedly(Return(route_config.get()));
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+
+  filter_->decodeHeaders(headers, false);
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "test", "params": {"key": "value"}, "id": 1})";
+  Buffer::OwnedImpl buffer(json);
+
+  // Expect dynamic metadata to be set because override says DYNAMIC_METADATA
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _));
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+
+  // Expect filter state NOT to be set (global said FILTER_STATE, but override says
+  // DYNAMIC_METADATA)
+  const auto* filter_state_obj =
+      decoder_callbacks_.stream_info_.filterState()->getDataReadOnly<McpFilterStateObject>(
+          std::string(McpFilterStateObject::FilterStateKey));
+  EXPECT_EQ(filter_state_obj, nullptr);
+}
+
+// Test per-route parser config override
+TEST_F(McpFilterTest, PerRouteParserConfig) {
+  // Global config has default parser config (minimal extraction)
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  // Per-route config overrides parser_config
+  envoy::extensions::filters::http::mcp::v3::McpOverride override_config;
+  auto* parser_config = override_config.mutable_parser_config();
+  parser_config->set_group_metadata_key("method_group");
+  auto* method_rule = parser_config->add_methods();
+  method_rule->set_method("custom/override");
+  method_rule->set_group("custom_override_group");
+  method_rule->add_extraction_rules()->set_path("params.custom_val");
+
+  auto route_config = std::make_shared<McpOverrideConfig>(override_config);
+
+  EXPECT_CALL(decoder_callbacks_, mostSpecificPerFilterConfig())
+      .WillRepeatedly(Return(route_config.get()));
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+
+  filter_->decodeHeaders(headers, false);
+
+  std::string json =
+      R"({"jsonrpc": "2.0", "method": "custom/override", "params": {"custom_val": "hello"}, "id": 1})";
+  Buffer::OwnedImpl buffer(json);
+
+  // Expect dynamic metadata to be set with extracted field custom_val and group method_group
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce(Invoke([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_EQ(
+            "hello",
+            metadata.fields().at("params").struct_value().fields().at("custom_val").string_value());
+        EXPECT_EQ("custom_override_group", metadata.fields().at("method_group").string_value());
+      }));
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+}
+
 // Test method group added to dynamic metadata when configured
 TEST_F(McpFilterTest, MethodGroupAddedToMetadata) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;


### PR DESCRIPTION
Commit Message: Allow more per-route config in McpFilter.
Additional Description:
Changes `McpFilter` to allow per-route config for `clear_route_cache`, `parser_config`, `request_storage_mode`, and `reject_duplicate_keys`.

All new config will override the base filter config; `max_request_body_size` remains optional to avoid behavior changes.
Risk Level: Low
Testing: Unit and integration tests
Docs Changes: n/a
Release Notes: Yes
Platform Specific Features: n/a
[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md): xDS-gated config.

Generative AI was used to create this change. I have reviewed and understand the change.