### PR TITLE
router: keep ECDS filter config provider manager alive for its subscriptions

### DIFF
--- a/changelogs/current/bug_fixes/router__upstream-http-filter-config-provider-manager-lifetime.rst
+++ b/changelogs/current/bug_fixes/router__upstream-http-filter-config-provider-manager-lifetime.rst
@@ -1,0 +1,12 @@
+Fixed a use-after-free when :ref:`upstream_http_filters
+<envoy_v3_api_field_extensions.filters.http.router.v3.Router.upstream_http_filters>` are configured
+via :ref:`config_discovery
+<envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.HttpFilter.config_discovery>`
+(ECDS). The router held the upstream filter config provider manager, an unpinned singleton, only
+for the duration of its constructor, while the ECDS subscriptions it created retain a raw reference
+to that manager and dereference it when they are destroyed. If no cluster was keeping the singleton
+alive at the time the router configuration was built -- for example a statically configured
+listener with CDS-supplied clusters -- the manager was freed immediately and the subscriptions were
+left holding a dangling reference for the lifetime of the process. The router now retains the
+manager for as long as it owns the providers, matching how ``ClusterInfoImpl`` and the UDP proxy
+already hold it. The composite filter was hardened in the same way for ``dynamic_config`` actions.

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -108,7 +108,9 @@ FilterConfig::FilterConfig(Stats::StatName stat_prefix,
     // TODO(wbpcode): To validate the terminal filter is upstream codec filter by the proto.
     Server::Configuration::ServerFactoryContext& server_factory_ctx =
         context.serverFactoryContext();
-    std::shared_ptr<Http::UpstreamFilterConfigProviderManager> filter_config_provider_manager =
+    // Retained as a member: the manager is an unpinned singleton, and the ECDS subscriptions
+    // created below hold a raw reference to it that they dereference on destruction.
+    upstream_filter_config_provider_manager_ =
         Http::FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
             server_factory_ctx);
     std::string prefix = context.scope().symbolTable().toString(context.scope().prefix());
@@ -116,7 +118,7 @@ FilterConfig::FilterConfig(Stats::StatName stat_prefix,
         server_factory_ctx, context.initManager(), context.scope());
     Http::FilterChainHelper<Server::Configuration::UpstreamFactoryContext,
                             Server::Configuration::UpstreamHttpFilterConfigFactory>
-        helper(*filter_config_provider_manager, server_factory_ctx,
+        helper(*upstream_filter_config_provider_manager_, server_factory_ctx,
                context.serverFactoryContext().clusterManager(), *upstream_ctx_, prefix);
     SET_AND_RETURN_IF_NOT_OK(helper.processFilters(config.upstream_http_filters(),
                                                    "router upstream http", "router upstream http",

--- a/source/common/router/router.h
+++ b/source/common/router/router.h
@@ -280,6 +280,13 @@ public:
   Http::Context& http_context_;
   Stats::StatName zone_name_;
   Stats::StatName empty_stat_name_;
+  // The upstream filter config provider manager is an *unpinned* singleton, so it is kept alive
+  // only by its holders. Each dynamic (ECDS) provider in upstream_http_filter_factories_ owns a
+  // FilterConfigSubscription that holds a raw reference back to this manager and writes through it
+  // from its destructor, so the manager must outlive the factories below. Declared first so that it
+  // is destroyed last.
+  std::shared_ptr<Http::UpstreamFilterConfigProviderManager>
+      upstream_filter_config_provider_manager_;
   std::unique_ptr<Server::Configuration::UpstreamFactoryContext> upstream_ctx_;
   Http::FilterChainUtility::FilterFactoriesList upstream_http_filter_factories_;
 

--- a/source/extensions/filters/http/composite/action.h
+++ b/source/extensions/filters/http/composite/action.h
@@ -30,11 +30,14 @@ public:
   using FilterConfigProvider = std::function<OptRef<Http::FilterFactoryCb>()>;
 
   // Constructor for single filter which is either typed_config or dynamic_config.
+  // config_provider_manager is a keep-alive for dynamic_config actions; see the member comment
+  // below. It is nullptr for typed_config actions.
   explicit ExecuteFilterAction(
       FilterConfigProvider config_provider, const std::string& name,
       const std::optional<envoy::config::core::v3::RuntimeFractionalPercent>& sample,
-      Runtime::Loader& runtime)
-      : config_provider_(std::move(config_provider)), name_(name), sample_(sample),
+      Runtime::Loader& runtime, std::shared_ptr<void> config_provider_manager = nullptr)
+      : config_provider_manager_(std::move(config_provider_manager)),
+        config_provider_(std::move(config_provider)), name_(name), sample_(sample),
         runtime_(runtime), is_filter_chain_(false) {}
 
   // Constructor for filter chain (inline filter_chain).
@@ -70,6 +73,11 @@ public:
   const std::string& filterChainName() const { return name_; }
 
 private:
+  // For dynamic_config actions, keeps the filter config provider manager alive. The manager is an
+  // unpinned singleton, and the dynamic provider held by config_provider_ owns a
+  // FilterConfigSubscription that dereferences a raw reference to the manager from its destructor.
+  // Declared before config_provider_ so that it is destroyed after it.
+  std::shared_ptr<void> config_provider_manager_;
   // Used for single filter mode which is either typed_config or dynamic_config.
   FilterConfigProvider config_provider_;
   // Used for filter chain mode.
@@ -124,7 +132,7 @@ private:
             ? std::make_optional<envoy::config::core::v3::RuntimeFractionalPercent>(
                   composite_action.sample_percent())
             : std::nullopt,
-        runtime);
+        runtime, provider_manager);
   }
 
   Matcher::ActionConstSharedPtr createDynamicActionDownstream(

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -485,6 +485,7 @@ envoy_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//source/common/buffer:buffer_lib",
+        "//source/common/http:filter_chain_helper_lib",
         "//source/common/network:utility_lib",
         "//source/common/router:router_lib",
         "//source/common/upstream:upstream_includes",

--- a/test/common/router/router_upstream_filter_test.cc
+++ b/test/common/router/router_upstream_filter_test.cc
@@ -165,6 +165,45 @@ TEST_F(RouterUpstreamFilterTest, UpstreamFilter) {
   auto headers = run();
   EXPECT_FALSE(headers.get(Http::LowerCaseString("x-header-to-add")).empty());
 }
+
+// Regression test for a use-after-free at teardown. A dynamic (ECDS) upstream HTTP filter causes
+// FilterConfig to create a Filter::FilterConfigSubscription, which holds a raw reference to the
+// filter config provider manager and dereferences it from its destructor. That manager is an
+// *unpinned* singleton, so it survives only as long as something holds a strong reference to it:
+// FilterConfig must be that holder for the providers it owns.
+TEST_F(RouterUpstreamFilterTest, DynamicFilterKeepsConfigProviderManagerAlive) {
+  HttpFilter dynamic_filter;
+  dynamic_filter.set_name("dynamic-filter");
+  auto* config_discovery = dynamic_filter.mutable_config_discovery();
+  config_discovery->mutable_config_source()->mutable_ads();
+  config_discovery->add_type_urls(
+      "type.googleapis.com/test.integration.filters.AddHeaderEmptyFilterConfig");
+
+  HttpFilter codec_filter;
+  codec_filter.set_name("envoy.filters.http.upstream_codec");
+  envoy::extensions::filters::http::upstream_codec::v3::UpstreamCodec upstream_codec_config;
+  std::ignore = codec_filter.mutable_typed_config()->PackFrom(upstream_codec_config);
+
+  init({dynamic_filter, codec_filter});
+  ASSERT_NE(nullptr, config_);
+
+  // Looking the singleton up again returns the live instance if one exists and creates a fresh one
+  // otherwise. Binding it to a weak_ptr and letting the returned strong reference expire at the end
+  // of the statement therefore reports whether `config_` is keeping the manager alive: without that
+  // reference, the manager created during init() is already gone and every subscription it owns is
+  // left holding a dangling reference.
+  std::weak_ptr<Http::UpstreamFilterConfigProviderManager> manager =
+      Http::FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(
+          context_.server_factory_context_);
+  EXPECT_FALSE(manager.expired());
+
+  // Destroying the router config destroys the providers and their subscription, which writes
+  // through that reference. The manager must still be alive at that point (this is where ASAN
+  // reports the use-after-free without the fix) and may be released only afterwards.
+  router_.reset();
+  config_.reset();
+  EXPECT_TRUE(manager.expired());
+}
 } // namespace
 } // namespace Router
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: router: keep ECDS filter config provider manager alive for its subscriptions

Additional Description:

`Filter::FilterConfigSubscription` stores its provider manager as a raw reference and writes through
it from its destructor:

```cpp
// source/common/filter/config_discovery_impl.h
FilterConfigProviderManagerImplBase& filter_config_provider_manager_;

// source/common/filter/config_discovery_impl.cc
FilterConfigSubscription::~FilterConfigSubscription() {
  init_target_.ready();
  filter_config_provider_manager_.subscriptions_.erase(subscription_id_);
}
```

The manager must therefore outlive every subscription it created. The upstream HTTP filter config
provider manager is a singleton registered without `pin`, so `Singleton::ManagerImpl` retains only a
`weak_ptr` and the documented contract in `envoy/singleton/manager.h` applies:

> All code that uses singletons must store the shared_ptr for as long as the singleton is needed.

`ClusterInfoImpl` (`upstream_impl.h`) and `UdpProxyFilterConfigImpl` (`udp_proxy/config.h`) comply,
each holding the manager as a member declared before their filter factory lists.
`Router::FilterConfig` did not: it obtained the manager as a constructor-local `shared_ptr` and
dropped it on return, while the ECDS subscriptions created by `processFilters()` live on in
`upstream_http_filter_factories_`. When no other holder exists at that moment, the manager is
destroyed as the constructor returns and those subscriptions hold a dangling reference for the
remaining life of the process, dereferencing it on teardown.

`ClusterInfoImpl` creates this manager unconditionally, so an existing cluster normally masks the
defect. The reachable window is a router config built while no cluster exists — for example a
statically configured listener with CDS-supplied clusters.

This change retains the manager in a member declared before `upstream_http_filter_factories_`, so
reverse-declaration destruction tears down the providers and their subscriptions first and releases
the manager last, matching the existing `ClusterInfoImpl` and UDP proxy pattern.

Composite's `ExecuteFilterAction` has the same constructor-local pattern for `dynamic_config` actions
and is hardened identically. That instance is currently masked by `ClusterInfoImpl` holding the same
singleton, so it is defense-in-depth rather than a live defect.

Risk Level: Low — adds one member and promotes one constructor-local to it. No logic, ordering, or
behavior change on any request path.

Testing:

New regression test `RouterUpstreamFilterTest.DynamicFilterKeepsConfigProviderManagerAlive`.

| Configuration | Result |
| --- | --- |
| Pre-fix, no sanitizer | fails (`manager.expired()` is `true`) |
| Post-fix, no sanitizer | passes |
| Pre-fix, ASAN | `heap-use-after-free` (below) |
| Post-fix, ASAN | passes, no sanitizer findings |

`//test/extensions/filters/http/composite:filter_test` passes (60/60), covering the composite change.

AddressSanitizer against the unmodified code:

```
==2818==ERROR: AddressSanitizer: heap-use-after-free on address 0x60b000012558
READ of size 8 at 0x60b000012558 thread T0
    #0 absl::container_internal::raw_hash_set<FlatHashMapPolicy<std::string,
         std::weak_ptr<Envoy::Filter::FilterConfigSubscription>>>::AssertNotDebugCapacity()
    #1 ...::find<std::string>(std::string const&)
    #2 Envoy::Filter::FilterConfigSubscription::~FilterConfigSubscription()
    #4 Envoy::Filter::DynamicFilterConfigProviderImplBase::~DynamicFilterConfigProviderImplBase()
    #7 std::vector<Envoy::Http::FilterChainUtility::FilterFactoryProvider>::__destroy_vector
    #8 Envoy::Router::FilterConfig::~FilterConfig()

previously allocated by thread T0 here:
    #4 Envoy::Http::FilterChainUtility::createSingletonUpstreamFilterConfigProviderManager(...)
    #5 Envoy::Router::FilterConfig::FilterConfig(...)
```

The container in frame #0 is `FilterConfigProviderManagerImplBase::subscriptions_`.

One detail stated precisely: the "freed by" frame in this trace is the test's own re-lookup of the
singleton, not the constructor. Because the manager is created via `make_shared`, the *object* is
destructed when the constructor's local reference drops — running `~flat_hash_map` and releasing the
map's internal buffer — while the enclosing block survives until `Singleton::ManagerImpl` overwrites
its stale `weak_ptr`. Production therefore hits use-after-destruction of the same member slightly
earlier than this trace's free point. Same dangling reference, same container, different moment.

Sanitizer runs were performed on macOS/arm64 with Apple clang, because `--config=asan` currently
hardcodes an x86-64 Linux runtime path. Equivalent flags were used: `--copt=-fsanitize=address
--copt=-fno-omit-frame-pointer --copt=-O1 --linkopt=-fsanitize=address --strip=never
--dynamic_mode=off`.

Docs Changes: n/a

Release Notes: added `changelogs/current/bug_fixes/router__upstream-http-filter-config-provider-manager-lifetime.rst`

Platform Specific Features: n/a

---

Per the [generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41):
this investigation, patch, and test were produced with AI assistance (Claude). I have reviewed and
understand the change.
