### PR TITLE
bazel: add bzlmod module extension scaffolds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,3 +30,15 @@ local_path_override(
     module_name = "envoy_mobile",
     path = "mobile",
 )
+
+# Dependencies not available via bazel_dep (non-BCR/non-registry).
+# The full use_repo list will be populated as deps are migrated to bzlmod.
+envoy_deps = use_extension("//bazel:extensions.bzl", "non_module_deps")
+
+# Envoy repository metadata (version, compiler config, container images).
+envoy_repo = use_extension("//bazel:extensions.bzl", "envoy_repo_ext")
+use_repo(envoy_repo, "envoy_repo")
+
+# LLVM/Clang and GCC RBE toolchain setup.
+envoy_toolchains = use_extension("//bazel:toolchain_extensions.bzl", "envoy_toolchains_ext")
+use_repo(envoy_toolchains, "llvm_toolchain")

--- a/bazel/extensions.bzl
+++ b/bazel/extensions.bzl
@@ -1,0 +1,71 @@
+"""Module extensions for Envoy dependencies not available via bazel_dep.
+
+These extensions wrap the repository-loading functions from Envoy's WORKSPACE-based
+build system. When bzlmod is enabled, MODULE.bazel uses these extensions instead of
+the WORKSPACE file's sequential loading chain.
+
+The envoy_toolchains extension lives in toolchain_extensions.bzl because
+toolchains.bzl has a top-level load from @envoy_repo, which is created by
+envoy_repo_ext below. Separating them ensures correct load ordering.
+"""
+
+load("//bazel:repo.bzl", "envoy_repo")
+load("//bazel:repositories.bzl", "envoy_dependencies")
+
+def _non_module_deps_impl(module_ctx):
+    """Implementation for non_module_deps extension.
+
+    Calls envoy_dependencies(bzlmod=True) which creates repositories not
+    available in BCR or the toolshed registry. It safely coexists with
+    bazel_dep entries because envoy_http_archive checks native.existing_rules()
+    before creating repositories.
+
+    Args:
+        module_ctx: Module extension context
+    """
+    envoy_dependencies(bzlmod = True)
+
+non_module_deps = module_extension(
+    implementation = _non_module_deps_impl,
+    doc = """
+    Extension for Envoy dependencies not available via bazel_dep.
+
+    This extension creates HTTP archive repositories for Envoy's C++ dependencies
+    (BoringSSL, c-ares, gRPC, protobuf, LLVM toolchain, etc.) that are not yet
+    available in BCR or the toolshed Bazel registry.
+
+    As dependencies are added to the registries, they should be migrated from this
+    extension to bazel_dep entries in MODULE.bazel.
+
+    For WORKSPACE mode, call envoy_dependencies() directly from WORKSPACE.
+    This extension should only be used in MODULE.bazel files.
+    """,
+)
+
+def _envoy_repo_impl(module_ctx):
+    """Implementation for envoy_repo_ext extension.
+
+    Creates the @envoy_repo repository which provides version metadata,
+    compiler configuration, and container image references used throughout
+    the build.
+
+    Args:
+        module_ctx: Module extension context
+    """
+    envoy_repo()
+
+envoy_repo_ext = module_extension(
+    implementation = _envoy_repo_impl,
+    doc = """
+    Extension for the @envoy_repo metadata repository.
+
+    This extension creates the @envoy_repo repository which exposes:
+    - version.bzl: VERSION and API_VERSION constants
+    - compiler.bzl: LLVM_PATH, USE_LOCAL_SYSROOT, etc.
+    - containers.bzl: CI container image references
+    - path.bzl: local repository path
+
+    For WORKSPACE mode, call envoy_repo() directly from WORKSPACE.
+    This extension should only be used in MODULE.bazel files.
+    """,
+)

--- a/bazel/toolchain_extensions.bzl
+++ b/bazel/toolchain_extensions.bzl
@@ -1,0 +1,38 @@
+"""Module extension for Envoy toolchain setup.
+
+This extension is in a separate file from extensions.bzl because toolchains.bzl
+has a top-level load from @envoy_repo//:compiler.bzl. The @envoy_repo repository
+is created by the envoy_repo_ext extension in extensions.bzl, so it must exist
+before this file can be loaded.
+
+In MODULE.bazel, use_extension for this file must appear after use_repo for
+envoy_repo from envoy_repo_ext.
+"""
+
+load("//bazel:toolchains.bzl", "envoy_toolchains")
+
+def _envoy_toolchains_impl(module_ctx):
+    """Implementation for envoy_toolchains_ext extension.
+
+    Registers the LLVM/Clang toolchain, GCC RBE toolchain, and sets up
+    platform-specific build configurations.
+
+    Args:
+        module_ctx: Module extension context
+    """
+    envoy_toolchains()
+
+envoy_toolchains_ext = module_extension(
+    implementation = _envoy_toolchains_impl,
+    doc = """
+    Extension for Envoy toolchain registration.
+
+    This extension sets up:
+    - LLVM/Clang toolchain via toolchains_llvm (hermetic or local)
+    - GCC RBE toolchain configuration
+    - Platform aliases for cross-compilation
+
+    For WORKSPACE mode, call envoy_toolchains() directly from WORKSPACE.
+    This extension should only be used in MODULE.bazel files.
+    """,
+)


### PR DESCRIPTION
Add `bazel/extensions.bzl` with `non_module_deps` and `envoy_repo_ext` extensions, and `bazel/toolchain_extensions.bzl` with `envoy_toolchains_ext`.

These wrap `envoy_dependencies(bzlmod=True)`, `envoy_repo()`, and `envoy_toolchains()` respectively, following the pattern established in `api/bazel/extensions.bzl`. The toolchains extension is in a separate file because `toolchains.bzl` has a top-level load from `@envoy_repo`, which must exist before the file can be loaded.

Wire up the extensions in `MODULE.bazel` with `use_extension` and `use_repo` calls. These are inert while `--noenable_bzlmod` is set in `.bazelrc`.

Part of #46539
