### PR TITLE
Update QUICHE from 0580a14c2 to 89d6d17ed

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -311,7 +311,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-07-22"
+  release_date: "2026-08-04"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -2861,6 +2861,23 @@ envoy_cc_library(
 )
 
 envoy_quic_cc_library(
+    name = "quic_core_ack_timestamp_list_lib",
+    srcs = ["quiche/quic/core/quic_ack_timestamp_list.cc"],
+    hdrs = ["quiche/quic/core/quic_ack_timestamp_list.h"],
+    deps = [
+        ":quic_core_data_lib",
+        ":quic_core_frames_frames_lib",
+        ":quic_core_time_lib",
+        ":quic_core_types_lib",
+        ":quiche_common_platform_export",
+        ":quiche_common_platform_logging",
+        "@abseil-cpp//absl/container:fixed_array",
+        "@abseil-cpp//absl/container:inlined_vector",
+        "@abseil-cpp//absl/types:span",
+    ],
+)
+
+envoy_quic_cc_library(
     name = "quic_core_framer_lib",
     srcs = ["quiche/quic/core/quic_framer.cc"],
     hdrs = [
@@ -2868,6 +2885,7 @@ envoy_quic_cc_library(
         "quiche/quic/core/scone.h",
     ],
     deps = [
+        ":quic_core_ack_timestamp_list_lib",
         ":quic_core_connection_id_generator_interface_lib",
         ":quic_core_constants_lib",
         ":quic_core_crypto_crypto_handshake_lib",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -553,8 +553,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "0580a14c23b7f7005abd2c18587f108ed6f1e93e",
-        sha256 = "30a8bbb156d5e3739dc19741837df2d8191d18dc0506727f08f2db5f88a72328",
+        version = "89d6d17edc0f0b79f38edf6fac9e5c8bf5f3cfd7",
+        sha256 = "d994da485d3e1821bcf20a0da5f38ee3d28bd8c0f00389a59adb7ce1196dbce7",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -577,10 +577,13 @@ TEST_P(EnvoyQuicClientSessionTest, StatelessResetOnProbingSocket) {
   EXPECT_NE(new_self_address->asString(), self_addr_->asString());
 
   // Send a STATELESS_RESET packet to the probing socket.
+  quic::StatelessResetToken reset_token =
+      GetQuicReloadableFlag(quic_check_alternate_reset_token)
+          ? frame.stateless_reset_token
+          : quic::QuicUtils::GenerateStatelessResetToken(quic::test::TestConnectionId());
   std::unique_ptr<quic::QuicEncryptedPacket> stateless_reset_packet =
       quic::QuicFramer::BuildIetfStatelessResetPacket(
-          frame.connection_id, /*received_packet_length*/ 1200,
-          quic::QuicUtils::GenerateStatelessResetToken(quic::test::TestConnectionId()));
+          frame.connection_id, /*received_packet_length*/ 1200, reset_token);
   Buffer::RawSlice slice;
   slice.mem_ = const_cast<char*>(stateless_reset_packet->data());
   slice.len_ = stateless_reset_packet->length();

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -582,8 +582,8 @@ TEST_P(EnvoyQuicClientSessionTest, StatelessResetOnProbingSocket) {
           ? frame.stateless_reset_token
           : quic::QuicUtils::GenerateStatelessResetToken(quic::test::TestConnectionId());
   std::unique_ptr<quic::QuicEncryptedPacket> stateless_reset_packet =
-      quic::QuicFramer::BuildIetfStatelessResetPacket(
-          frame.connection_id, /*received_packet_length*/ 1200, reset_token);
+      quic::QuicFramer::BuildIetfStatelessResetPacket(frame.connection_id,
+                                                      /*received_packet_length*/ 1200, reset_token);
   Buffer::RawSlice slice;
   slice.mem_ = const_cast<char*>(stateless_reset_packet->data());
   slice.len_ = stateless_reset_packet->length();


### PR DESCRIPTION
https://github.com/google/quiche/compare/0580a14c2..89d6d17ed

```
$ git log 0580a14c2..89d6d17ed --date=short --no-merges --format="%ad %al %s"

2026-08-04 apaseltiner Add type defs to Dictionary class for ease of use with templated code
2026-08-04 quiche-dev No public description
2026-08-04 wub Record dropped packets in QuicPacketReader.
2026-08-03 apaseltiner Allow lookups using std::string_view in ParameterisedIdentifier::Parameters
2026-08-03 apaseltiner Consolidate redundant structured-header item type checks
2026-08-03 apaseltiner Clean up quic_stream_priority.cc
2026-08-01 quiche-dev Fix 38 ClangInliner findings: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs. (38 times)
2026-07-31 apaseltiner Replace lone caller of deprecated TakeString method
2026-07-31 martinduke No public description
2026-07-31 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Fix 10 ClangInliner findings: * The use of this symbol has been deprecated and marked for inlining. The function being deprecated is testing::InvokeWithoutArgs. (10 times)
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 vasilvv Fix RelayTwoClientsQueueClose ASAN failures.
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 apaseltiner Add GetIf* methods to Item for each type
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-30 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() or std::extent_v where possible
2026-07-29 dschinazi Remove TODO
2026-07-29 ericorth Bonnet Tun Exchanger Refactor: Repurpose/cleanup Visitor for async exchanger
2026-07-29 vasilvv Split out REQUEST_UPDATE callback queue into a separate class.
2026-07-29 vasilvv Add support for ACK timestamp truncation.
2026-07-29 martinduke Prevent MoqtRelayTrackPublisher from calling OnNewFinAvailable multiple times.
2026-07-29 martinduke MoqtUniStream expects that MoqtTrackPublisher will not deliver empty object fragments. Fix MoqtRelayTrackPublisher (the only child class that can deliver fragments) to not do that, thus avoiding the QUICHE_BUG OutgoingSubgroupStream_empty_payload.
2026-07-29 quiche-dev Deprecate gfe2_restart_flag_quic_set_credential_ex_data.
2026-07-28 wub Roll back -gfe2_reloadable_flag_quic_fix_mtu_discovery.
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 rch Deprecate --gfe2_restart_flag_quic_shed_tls_handshake_config.
2026-07-27 vasilvv Refactor QUIC Receive Timestamp serialization into a separate class.
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-27 quiche-dev Add client manufacturer and ID attestation flag to AttestAndSignRequest.
2026-07-27 rch Deprecate --gfe2_reloadable_flag_quic_delete_config.
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size() where possible
2026-07-23 ericorth Bonnet Tun Exchanger Refactor: Drop the base class that barely did anything
2026-07-23 apaseltiner Add option to parse decimals and byte sequences strictly
2026-07-22 ericorth Bonnet Tun Exchanger Refactor: Divorce exchanger from QbonePacketWriter
```