### PR TITLE
Update googleurl to 94ff14 (2025-11-10)

### DIFF
--- a/bazel/external/googleurl.patch
+++ b/bazel/external/googleurl.patch
@@ -13,103 +13,20 @@ index 0174b6d..fb5b80d 100644
 -#error "Only clang-cl is supported on Windows, see https://crbug.com/988071"
 -#endif
 -
- // This is a wrapper around `__has_cpp_attribute`, which can be used to test for
- // the presence of an attribute. In case the compiler does not support this
- // macro it will simply evaluate to 0.
-@@ -398,7 +394,7 @@ inline constexpr bool AnalyzerAssumeTrue(bool arg) {
- #define CONSTINIT
- #endif
-
--#if defined(__clang__)
-+#if defined(__clang__) && HAS_CPP_ATTRIBUTE(gsl::Pointer)
- #define GSL_OWNER [[gsl::Owner]]
- #define GSL_POINTER [[gsl::Pointer]]
- #else
-diff --git a/base/containers/checked_iterators.h b/base/containers/checked_iterators.h
-index dc8d2ba..9306697 100644
---- a/base/containers/checked_iterators.h
-+++ b/base/containers/checked_iterators.h
-@@ -237,9 +237,32 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
- // [3] https://wg21.link/pointer.traits.optmem
--namespace std {
-
-+#ifdef SUPPORTS_CPP_17_CONTIGUOUS_ITERATOR
-+#if defined(_LIBCPP_VERSION)
-+
-+// TODO(crbug.com/1284275): Remove when C++20 is on by default, as the use
-+// of `iterator_concept` above should suffice.
-+_LIBCPP_BEGIN_NAMESPACE_STD
-+
-+// TODO(crbug.com/1449299): https://reviews.llvm.org/D150801 renamed this from
-+// `__is_cpp17_contiguous_iterator` to `__libcpp_is_contiguous_iterator`. Clean
-+// up the old spelling after libc++ rolls.
-+template <typename T>
-+struct __is_cpp17_contiguous_iterator;
- template <typename T>
- struct __is_cpp17_contiguous_iterator<::gurl_base::CheckedContiguousIterator<T>>
-     : true_type {};
-+template <typename T>
-+struct __libcpp_is_contiguous_iterator;
-+template <typename T>
-+struct __libcpp_is_contiguous_iterator<::gurl_base::CheckedContiguousIterator<T>>
-+    : true_type {};
-+
-+_LIBCPP_END_NAMESPACE_STD
-+
-+#endif
-+#endif
-+
-+namespace std {
-
- template <typename T>
- struct pointer_traits<::gurl_base::CheckedContiguousIterator<T>> {
-
-# TODO(keith): Remove unused parameter workarounds when https://quiche-review.googlesource.com/c/googleurl/+/11180 lands
-
+ // A wrapper around `__has_attribute()`, which is similar to the C++20-standard
+ // `__has_cpp_attribute()`, but tests for support for `__attribute__(())`s.
+ // Compilers that do not support this (e.g. MSVC) are also assumed not to
 diff --git a/base/numerics/clamped_math_impl.h b/base/numerics/clamped_math_impl.h
 index 10023f0..783f5da 100644
 --- a/base/numerics/clamped_math_impl.h
 +++ b/base/numerics/clamped_math_impl.h
 @@ -36,6 +36,7 @@ template <typename T,
-           typename std::enable_if<std::is_integral<T>::value &&
-                                   !std::is_signed<T>::value>::type* = nullptr>
+ template <typename T>
+   requires(std::unsigned_integral<T>)
  constexpr T SaturatedNegWrapper(T value) {
 +  (void)value; // unused
    return T(0);
  }
-
-diff --git a/base/numerics/safe_conversions.h b/base/numerics/safe_conversions.h
-index 4a9494e..ba44fa0 100644
---- a/base/numerics/safe_conversions.h
-+++ b/base/numerics/safe_conversions.h
-@@ -45,6 +45,7 @@ template <typename Dst, typename Src, typename Enable = void>
- struct IsValueInRangeFastOp {
-   static constexpr bool is_supported = false;
-   static constexpr bool Do(Src value) {
-+    (void)value; // unused
-     // Force a compile failure if instantiated.
-     return CheckOnFailure::template HandleFailure<bool>();
-   }
-@@ -164,6 +165,7 @@ template <typename Dst, typename Src, typename Enable = void>
- struct SaturateFastOp {
-   static constexpr bool is_supported = false;
-   static constexpr Dst Do(Src value) {
-+    (void)value; // unused
-     // Force a compile failure if instantiated.
-     return CheckOnFailure::template HandleFailure<Dst>();
-   }
-diff --git a/base/containers/span.h b/base/containers/span.h
-index 40e325f..c66c183 100644
---- a/base/containers/span.h
-+++ b/base/containers/span.h
-@@ -125,7 +125,7 @@ using EnableIfSpanCompatibleContainerAndSpanIsDynamic =
- template <size_t Extent>
- class ExtentStorage {
-  public:
--  constexpr explicit ExtentStorage(size_t size) noexcept {}
-+  constexpr explicit ExtentStorage(size_t /*size*/) noexcept {}
-   constexpr size_t size() const noexcept { return Extent; }
- };
 
 diff --git a/polyfills/third_party/perfetto/include/perfetto/tracing/traced_value.h b/polyfills/third_party/perfetto/include/perfetto/tracing/traced_value.h
 index 6d059f7..6339fa5 100644
@@ -130,7 +47,7 @@ index 5960d2a..08295ff 100644
 +++ b/build_config/build_config.bzl
 @@ -7,6 +7,7 @@ _default_copts = select({
      "//conditions:default": [
-         "-std=c++17",
+         "-std=c++20",
          "-fno-strict-aliasing",
 +        "-Wno-unused-parameter",
      ],
@@ -150,22 +67,6 @@ index 58ae144..467da0b 100644
  inline bool Is8BitChar(char16_t c) {
 
 # TODO(keith): Remove when https://quiche-review.googlesource.com/c/googleurl/+/11200 lands
-
-diff --git a/base/memory/raw_ptr_exclusion.h b/base/memory/raw_ptr_exclusion.h
-index f881c04..4e4f7df 100644
---- a/base/memory/raw_ptr_exclusion.h
-+++ b/base/memory/raw_ptr_exclusion.h
-@@ -8,7 +8,7 @@
- #include "polyfills/base/allocator/buildflags.h"
- #include "build/build_config.h"
-
--#if defined(OFFICIAL_BUILD) && !BUILDFLAG(FORCE_ENABLE_RAW_PTR_EXCLUSION)
-+#if !defined(__clang__) || (defined(OFFICIAL_BUILD) && !BUILDFLAG(FORCE_ENABLE_RAW_PTR_EXCLUSION))
- // The annotation changed compiler output and increased binary size so disable
- // for official builds.
- // TODO(crbug.com/1320670): Remove when issue is resolved.
-
-# TODO(keith): Remove when https://quiche-review.googlesource.com/c/googleurl/+/11300/1 lands
 
 diff --git a/build_config/BUILD b/build_config/BUILD
 index 78ac01d..eeef238 100644

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -559,8 +559,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         strip_prefix = "quiche-{version}",
     ),
     googleurl = dict(
-        version = "dd4080fec0b443296c0ed0036e1e776df8813aa7",
-        sha256 = "4ffa45a827646692e7b26e2a8c0dcbc1b1763a26def2fbbd82362970962a2fcf",
+        version = "94ff147fe0b96b4cca5d6d316b9af6210c0b8051",
+        sha256 = "d8a701123250e03b3c0865babdfc78540d66374db78f74aafd09bf08545c00bd",
         urls = ["https://github.com/google/gurl/archive/{version}.tar.gz"],
         strip_prefix = "gurl-{version}",
     ),

--- a/source/common/http/path_utility.cc
+++ b/source/common/http/path_utility.cc
@@ -3,7 +3,9 @@
 #include <optional>
 
 #include "source/common/common/logger.h"
+#include "source/common/runtime/runtime_features.h"
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
@@ -15,6 +17,12 @@ namespace Http {
 
 namespace {
 std::optional<std::string> canonicalizePath(absl::string_view original_path) {
+  if (!Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.allow_percentzerozero_in_url_path")) {
+    if (absl::StrContains(original_path, "%00")) {
+      return std::nullopt;
+    }
+  }
   std::string canonical_path;
   url::Component in_component(0, original_path.size());
   url::Component out_component;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -34,6 +34,7 @@
 // If issues are found that require a runtime feature to be disabled, it should be reported
 // ASAP by filing a bug on github. Overriding non-buggy code is strongly discouraged to avoid the
 // problem of the bugs being found after the old code path has been removed.
+RUNTIME_GUARD(envoy_reloadable_features_allow_percentzerozero_in_url_path);
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_cel_message_serialize_text_format);
 RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -524,6 +524,7 @@ envoy_cc_test(
     deps = [
         "//source/common/http:header_map_lib",
         "//source/common/http:path_utility_lib",
+        "//test/test_common:test_runtime_lib",
     ],
 )
 

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -622,6 +622,9 @@ TEST_F(HttpConnectionManagerImplTest, InvalidPathWithDualFilter) {
 
 // Invalid paths are rejected with 400.
 TEST_F(HttpConnectionManagerImplTest, PathFailedtoSanitize) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_percentzerozero_in_url_path", "false"}});
   setup();
   // Enable path sanitizer
   normalize_path_ = true;

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -2918,6 +2918,9 @@ TEST_F(ConnectionManagerUtilityTest, UnescapeSlashesAndChromiumNormalization) {
 
 // maybeNormalizePath() rejects request when chromium normalization fails after unescaping slashes.
 TEST_F(ConnectionManagerUtilityTest, UnescapeSlashesRedirectAndChromiumNormalizationFailure) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_percentzerozero_in_url_path", "false"}});
   ON_CALL(config_, shouldNormalizePath()).WillByDefault(Return(true));
   ON_CALL(config_, pathWithEscapedSlashesAction())
       .WillByDefault(Return(envoy::extensions::filters::network::http_connection_manager::v3::

--- a/test/common/http/path_utility_test.cc
+++ b/test/common/http/path_utility_test.cc
@@ -4,6 +4,7 @@
 
 #include "source/common/http/path_utility.h"
 
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -40,6 +41,9 @@ TEST_F(PathUtilityTest, AlreadyNormalPaths) {
 
 // Invalid paths are rejected.
 TEST_F(PathUtilityTest, InvalidPaths) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.allow_percentzerozero_in_url_path", "false"}});
   const std::vector<std::string> invalid_paths{"/xyz/.%00../abc", "/xyz/%00.%00./abc",
                                                "/xyz/AAAAA%%0000/abc"};
   for (const auto& path : invalid_paths) {

--- a/test/integration/default_header_validator_integration_test.cc
+++ b/test/integration/default_header_validator_integration_test.cc
@@ -383,7 +383,7 @@ TEST_P(DownstreamUhvIntegrationTest, MalformedUrlEncodedTripletsRejectedWithUhvO
   } else {
     waitForNextUpstreamRequest();
 
-    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z0with%XYbad%7Jencoding%A");
+    EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z%30with%XYbad%7Jencoding%A");
 
     // Send a headers only response.
     upstream_request_->encodeHeaders(default_response_headers_, true);
@@ -408,7 +408,7 @@ TEST_P(DownstreamUhvIntegrationTest, MalformedUrlEncodedTripletsAllowed) {
                                      {":authority", "host"}});
   waitForNextUpstreamRequest();
 
-  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z0with%XYbad%7Jencoding%");
+  EXPECT_EQ(upstream_request_->headers().getPathValue(), "/path%Z%30with%XYbad%7Jencoding%");
 
   // Send a headers only response.
   upstream_request_->encodeHeaders(default_response_headers_, true);
@@ -418,6 +418,8 @@ TEST_P(DownstreamUhvIntegrationTest, MalformedUrlEncodedTripletsAllowed) {
 // Without the `envoy.uhv.reject_percent_00` override UHV rejects requests with the %00
 // sequence.
 TEST_P(DownstreamUhvIntegrationTest, RejectPercent00) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_percentzerozero_in_url_path",
+                                    "false");
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) -> void { hcm.mutable_normalize_path()->set_value(true); });
@@ -437,6 +439,8 @@ TEST_P(DownstreamUhvIntegrationTest, RejectPercent00) {
 }
 
 TEST_P(DownstreamUhvIntegrationTest, UhvAllowsPercent00WithOverride) {
+  config_helper_.addRuntimeOverride("envoy.reloadable_features.allow_percentzerozero_in_url_path",
+                                    "false");
   config_helper_.addRuntimeOverride("envoy.uhv.reject_percent_00", "false");
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&


### PR DESCRIPTION
Google URL brings one behavioral change. The %00 is no longer an "invalid" escape sequence. Previous version failed canonicalization of the URL path containing %00 sequence.

We could add a runtime guard and reject paths with %00.

Risk Level: low (paths with %00 will now be accepted)
Testing: unit tests
Docs Changes: no
Release Notes: yes (TODO)
Platform Specific Features: yes
[Optional Runtime guard:]
