### PR TITLE
dynamic_modules: defer the in-module HTTP filter destroy

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__http-filter-deferred-destroy.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__http-filter-deferred-destroy.rst
@@ -1,0 +1,7 @@
+Fixed a use-after-free crash in the dynamic modules HTTP filter. An event hook that ends the
+stream, for example ``envoy_dynamic_module_callback_http_filter_recreate_stream``, tears the filter
+chain down on the module's own stack, which freed the in-module filter the hook was still running
+on. The in-module filter is now destroyed from the dispatcher's deferred deletion list, so
+``envoy_dynamic_module_on_http_filter_destroy`` runs once every other event hook has returned. The
+callbacks that need the torn-down stream no longer dereference it, and HTTP callouts started after
+the teardown are refused instead of outliving the filter.

--- a/changelogs/current/minor_behavior_changes/dynamic_modules__http-filter-destroy-hook-stream-access.rst
+++ b/changelogs/current/minor_behavior_changes/dynamic_modules__http-filter-destroy-hook-stream-access.rst
@@ -1,0 +1,4 @@
+``envoy_dynamic_module_on_http_filter_destroy`` now runs after the HTTP stream is gone, so the
+callbacks that need it, for example the ones reading the headers, the stream info or the buffered
+bodies, are no-ops. Modules that did end of stream bookkeeping from the destroy hook should do it
+from ``envoy_dynamic_module_on_http_filter_stream_complete`` instead.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -987,6 +987,9 @@ envoy_dynamic_module_on_http_filter_response_trailers(
  * envoy_dynamic_module_on_http_filter_stream_complete is called when the HTTP stream is complete.
  * This is called before envoy_dynamic_module_on_http_filter_destroy and access logs are flushed.
  *
+ * Unlike envoy_dynamic_module_on_http_filter_destroy, this can run while another event hook of the
+ * same filter is on the stack, because a hook that ends the stream completes it inline.
+ *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.
  * @param filter_module_ptr is the pointer to the in-module HTTP filter created by
@@ -999,6 +1002,15 @@ void envoy_dynamic_module_on_http_filter_stream_complete(
 /**
  * envoy_dynamic_module_on_http_filter_destroy is called when the HTTP filter is destroyed for each
  * HTTP stream.
+ *
+ * Envoy runs this from the worker dispatcher's deferred deletion list, so it is never called while
+ * another event hook of the same filter is on the stack. A hook can end the stream, for example via
+ * envoy_dynamic_module_callback_http_filter_recreate_stream, which tears the filter chain down
+ * before the hook returns. Envoy does not destroy the in-module filter before that hook returns,
+ * and the callbacks the module makes after the teardown are safe.
+ *
+ * By the time this is called the filter is already detached from the HTTP stream, so the callbacks
+ * that need it are no-ops.
  *
  * @param filter_module_ptr is the pointer to the in-module HTTP filter.
  */
@@ -3443,7 +3455,9 @@ void envoy_dynamic_module_callback_http_filter_send_go_away_and_close(
  * with new headers. This is useful for implementing internal redirects or request retries.
  *
  * After calling this function successfully, the current filter chain will be destroyed and a new
- * stream will be created. The filter should return StopIteration from the current event hook.
+ * stream will be created. The filter should return StopIteration from the current event hook. The
+ * in-module filter stays valid until the hook returns, and the callbacks the module makes after
+ * the teardown are safe and do not affect the recreated stream.
  *
  * @param filter_envoy_ptr is the pointer to the DynamicModuleHttpFilter object of the
  * corresponding HTTP filter.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -745,7 +745,11 @@ public:
   virtual void sendGoAwayAndClose(bool graceful) = 0;
 
   /**
-   * Recreates the current stream, optionally with replacement headers.
+   * Recreates the current stream, optionally with replacement headers. Returns false if the
+   * recreation could not be initiated, for example when the request body has not been fully
+   * received. On success the filter chain is destroyed before the current event hook returns and
+   * the filter should stop iteration. The filter itself stays valid until the hook returns, and
+   * the callbacks it makes after the teardown are safe and do not affect the recreated stream.
    */
   virtual bool recreateStream(std::span<const HeaderView> headers = {}) = 0;
 

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -365,8 +365,10 @@ type HttpFilterHandle interface {
 	// RecreateStream recreates the HTTP stream, optionally with new headers (or with the original
 	// headers if headers is nil). Useful for internal redirects or request retries. After a
 	// successful call, the current filter chain is destroyed and the filter SHOULD return Stop
-	// from the current callback. Returns false if recreation could not be initiated (e.g., the
-	// request body has not been fully received yet).
+	// from the current callback. The filter itself stays valid until the callback returns, and the
+	// methods it calls after the teardown are safe and do not affect the recreated stream.
+	// Returns false if recreation could not be initiated (e.g., the request body has not been fully
+	// received yet).
 	RecreateStream(headers [][2]string) bool
 
 	// RequestHeaders retrieves the request headers.

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -2104,6 +2104,9 @@ pub trait EnvoyHttpFilter {
   /// After calling this function successfully, the current filter chain will be destroyed and a new
   /// stream will be created. The filter should return StopIteration from the current event hook.
   ///
+  /// The filter itself stays valid until the hook returns, and the callbacks it makes after the
+  /// teardown are safe and do not affect the recreated stream.
+  ///
   /// * `headers` - Optional list of new headers for the recreated stream. If None, the original
   ///   headers will be reused.
   ///

--- a/source/extensions/filters/http/dynamic_modules/BUILD
+++ b/source/extensions/filters/http/dynamic_modules/BUILD
@@ -32,6 +32,8 @@ envoy_cc_library(
     hdrs = ["filter.h"],
     deps = [
         ":filter_config_lib",
+        "//envoy/event:dispatcher_interface",
+        "//source/common/event:deferred_task",
         "//source/common/tracing:null_span_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
     ],

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -206,11 +206,13 @@ const Buffer::Instance* getBufferByType(DynamicModuleHttpFilter* filter,
   case envoy_dynamic_module_type_http_body_type_ReceivedRequestBody:
     return filter->current_request_body_;
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody:
-    return filter->decoder_callbacks_->decodingBuffer();
+    return filter->decoder_callbacks_ != nullptr ? filter->decoder_callbacks_->decodingBuffer()
+                                                 : nullptr;
   case envoy_dynamic_module_type_http_body_type_ReceivedResponseBody:
     return filter->current_response_body_;
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody:
-    return filter->encoder_callbacks_->encodingBuffer();
+    return filter->encoder_callbacks_ != nullptr ? filter->encoder_callbacks_->encodingBuffer()
+                                                 : nullptr;
   default:
     return nullptr;
   }
@@ -1132,6 +1134,9 @@ bool envoy_dynamic_module_callback_http_append_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody: {
+    if (filter->decoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->decoder_callbacks_->decodingBuffer(); buffer != nullptr) {
       filter->decoder_callbacks_->modifyDecodingBuffer(
           [data_view](Buffer::Instance& buffer) { buffer.add(data_view); });
@@ -1150,6 +1155,9 @@ bool envoy_dynamic_module_callback_http_append_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody: {
+    if (filter->encoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->encoder_callbacks_->encodingBuffer(); buffer != nullptr) {
       filter->encoder_callbacks_->modifyEncodingBuffer(
           [data_view](Buffer::Instance& buffer) { buffer.add(data_view); });
@@ -1179,6 +1187,9 @@ bool envoy_dynamic_module_callback_http_drain_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedRequestBody: {
+    if (filter->decoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->decoder_callbacks_->decodingBuffer(); buffer != nullptr) {
       filter->decoder_callbacks_->modifyDecodingBuffer([number_of_bytes](Buffer::Instance& buffer) {
         auto size = std::min<uint64_t>(buffer.length(), number_of_bytes);
@@ -1197,6 +1208,9 @@ bool envoy_dynamic_module_callback_http_drain_body(
     return false;
   }
   case envoy_dynamic_module_type_http_body_type_BufferedResponseBody: {
+    if (filter->encoder_callbacks_ == nullptr) {
+      return false;
+    }
     if (auto buffer = filter->encoder_callbacks_->encodingBuffer(); buffer != nullptr) {
       filter->encoder_callbacks_->modifyEncodingBuffer([number_of_bytes](Buffer::Instance& buffer) {
         auto size = std::min<uint64_t>(buffer.length(), number_of_bytes);
@@ -1213,7 +1227,7 @@ bool envoy_dynamic_module_callback_http_drain_body(
 bool envoy_dynamic_module_callback_http_received_buffered_request_body(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (filter->current_request_body_ == nullptr) {
+  if (filter->current_request_body_ == nullptr || filter->decoder_callbacks_ == nullptr) {
     return false;
   }
   return filter->current_request_body_ == filter->decoder_callbacks_->decodingBuffer();
@@ -1222,7 +1236,7 @@ bool envoy_dynamic_module_callback_http_received_buffered_request_body(
 bool envoy_dynamic_module_callback_http_received_buffered_response_body(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
-  if (filter->current_response_body_ == nullptr) {
+  if (filter->current_response_body_ == nullptr || filter->encoder_callbacks_ == nullptr) {
     return false;
   }
   return filter->current_response_body_ == filter->encoder_callbacks_->encodingBuffer();
@@ -1772,6 +1786,9 @@ envoy_dynamic_module_type_http_filter_per_route_config_module_ptr
 envoy_dynamic_module_callback_get_most_specific_route_config(
     envoy_dynamic_module_type_http_filter_envoy_ptr filter_envoy_ptr) {
   auto filter = static_cast<DynamicModuleHttpFilter*>(filter_envoy_ptr);
+  if (filter->decoder_callbacks_ == nullptr) {
+    return nullptr;
+  }
   const auto* config =
       Http::Utility::resolveMostSpecificPerFilterConfig<DynamicModuleHttpPerRouteFilterConfig>(
           filter->decoder_callbacks_);

--- a/source/extensions/filters/http/dynamic_modules/filter.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter.cc
@@ -3,6 +3,10 @@
 #include <cstdint>
 #include <memory>
 
+#include "envoy/event/dispatcher.h"
+
+#include "source/common/event/deferred_task.h"
+
 #include "absl/container/inlined_vector.h"
 
 namespace Envoy {
@@ -10,7 +14,10 @@ namespace Extensions {
 namespace DynamicModules {
 namespace HttpFilters {
 
-DynamicModuleHttpFilter::~DynamicModuleHttpFilter() { destroy(); }
+DynamicModuleHttpFilter::~DynamicModuleHttpFilter() {
+  // In a well-formed filter chain onDestroy() has already run and this is a no-op.
+  destroy();
+}
 
 void DynamicModuleHttpFilter::initializeInModuleFilter() {
   ASSERT(in_module_filter_ == nullptr);
@@ -33,6 +40,8 @@ void DynamicModuleHttpFilter::onStreamComplete() {
 
 void DynamicModuleHttpFilter::onDestroy() {
   destroyed_ = true;
+  // Read before the cache is cleared below, because destroy() defers the module hook onto it.
+  OptRef<Event::Dispatcher> worker_dispatcher = makeOptRefFromPtr(dispatcher());
   // Clear the cached dispatcher so any concurrent foreign-thread `commit()` short-circuits.
   cached_dispatcher_.store(nullptr, std::memory_order_release);
   // Pair with the register in maybeRegisterDownstreamWatermarkCallbacks(); the underlying
@@ -41,15 +50,16 @@ void DynamicModuleHttpFilter::onDestroy() {
     decoder_callbacks_->removeDownstreamWatermarkCallbacks(*this);
     downstream_watermark_callbacks_registered_ = false;
   }
-  destroy();
+  destroy(worker_dispatcher);
 };
 
-void DynamicModuleHttpFilter::destroy() {
+void DynamicModuleHttpFilter::destroy(OptRef<Event::Dispatcher> dispatcher) {
   if (in_module_filter_ == nullptr) {
     return;
   }
 
-  config_->on_http_filter_destroy_(in_module_filter_);
+  // Detach from the module first so that nothing below can re-enter an event hook.
+  const envoy_dynamic_module_type_http_filter_module_ptr in_module_filter = in_module_filter_;
   in_module_filter_ = nullptr;
 
   // Cancel all pending one-shot callouts.
@@ -79,6 +89,20 @@ void DynamicModuleHttpFilter::destroy() {
   decoder_callbacks_ = nullptr;
   encoder_callbacks_ = nullptr;
   downstream_watermark_callbacks_registered_ = false;
+
+  // A module event hook can end the stream, which tears the filter chain down on the module's own
+  // stack, so the in-module filter has to outlive that hook. Deferring the destroy hook also keeps
+  // this filter alive, since the module can still call back into it from the hook.
+  if (dispatcher.has_value()) {
+    if (DynamicModuleHttpFilterSharedPtr self = weak_from_this().lock()) {
+      Event::DeferredTaskUtil::deferredRun(
+          *dispatcher, [self = std::move(self), in_module_filter]() {
+            self->config_->on_http_filter_destroy_(in_module_filter);
+          });
+      return;
+    }
+  }
+  config_->on_http_filter_destroy_(in_module_filter);
 }
 
 FilterHeadersStatus DynamicModuleHttpFilter::decodeHeaders(RequestHeaderMap&, bool end_of_stream) {
@@ -188,6 +212,10 @@ envoy_dynamic_module_type_http_callout_init_result
 DynamicModuleHttpFilter::sendHttpCallout(uint64_t* callout_id_out, absl::string_view cluster_name,
                                          Http::RequestMessagePtr&& message,
                                          uint64_t timeout_milliseconds) {
+  // A callout registered after destroy() has drained the pending ones would never be cancelled.
+  if (destroyed_) {
+    return envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest;
+  }
   Upstream::ThreadLocalCluster* cluster =
       config_->cluster_manager_.getThreadLocalCluster(cluster_name);
   if (!cluster) {
@@ -328,6 +356,10 @@ envoy_dynamic_module_type_http_callout_init_result
 DynamicModuleHttpFilter::startHttpStream(uint64_t* stream_id_out, absl::string_view cluster_name,
                                          Http::RequestMessagePtr&& message, bool end_stream,
                                          uint64_t timeout_milliseconds) {
+  // A stream started after destroy() has drained the pending ones would never be reset.
+  if (destroyed_) {
+    return envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest;
+  }
   // Get the cluster.
   Upstream::ThreadLocalCluster* cluster =
       config_->cluster_manager_.getThreadLocalCluster(cluster_name);

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -2,6 +2,9 @@
 
 #include <atomic>
 
+#include "envoy/common/optref.h"
+#include "envoy/event/dispatcher.h"
+
 #include "source/common/tracing/null_span_impl.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
@@ -260,11 +263,12 @@ private:
   void* thisAsVoidPtr() { return static_cast<void*>(this); }
 
   /**
-   * Called when filter is destroyed via onDestroy() or destructor. Forwards the call to the
-   * module via on_http_filter_destroy_ and resets in_module_filter_ to null. Subsequent calls are a
+   * Detaches from the module, cancels the pending callouts and streams, and destroys the in-module
+   * filter. When `dispatcher` is given the destroy hook runs from its deferred deletion list, so
+   * that the in-module filter outlives any module event hook on the stack. Subsequent calls are a
    * no-op.
    */
-  void destroy();
+  void destroy(OptRef<Event::Dispatcher> dispatcher = {});
 
   /**
    * Registers this filter for downstream watermark callbacks once both decoder callbacks have been

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -101,6 +101,7 @@ envoy_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/mocks/upstream:thread_local_cluster_mocks",
+        "//test/test_common:logging_lib",
         "//test/test_common:simulated_time_system_lib",
         "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
@@ -167,6 +168,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules:util",
         "//test/extensions/dynamic_modules/test_data/rust:http_integration_test_static",
         "//test/integration:http_integration_lib",
+        "//test/test_common:logging_lib",
         "@envoy_api//envoy/extensions/filters/http/dynamic_modules/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2365,6 +2365,32 @@ TEST(ABIImpl, BufferedResponseBody) {
             4);
 }
 
+// destroy() clears the stream callbacks before it hands the in-module filter to the dispatcher, so
+// every callback that needs them must be a no-op for the module hooks that still run in between.
+TEST(ABIImpl, StreamCallbacksAfterTeardown) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+
+  for (const auto body_type : {envoy_dynamic_module_type_http_body_type_BufferedRequestBody,
+                               envoy_dynamic_module_type_http_body_type_BufferedResponseBody}) {
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_get_body_chunks(&filter, body_type, nullptr));
+    EXPECT_EQ(envoy_dynamic_module_callback_http_get_body_chunks_size(&filter, body_type), 0);
+    EXPECT_EQ(envoy_dynamic_module_callback_http_get_body_size(&filter, body_type), 0);
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_drain_body(&filter, body_type, 0));
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_append_body(&filter, body_type, {nullptr, 0}));
+  }
+
+  // The current body pointers belong to the hook that set them, so they outlive the teardown and
+  // can still be set here.
+  Buffer::OwnedImpl body;
+  filter.current_request_body_ = &body;
+  filter.current_response_body_ = &body;
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_received_buffered_request_body(&filter));
+  EXPECT_FALSE(envoy_dynamic_module_callback_http_received_buffered_response_body(&filter));
+
+  EXPECT_EQ(envoy_dynamic_module_callback_get_most_specific_route_config(&filter), nullptr);
+}
+
 TEST(ABIImpl, ClearRouteCache) {
   Stats::SymbolTableImpl symbol_table;
   DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -15,6 +15,7 @@
 #include "test/mocks/tracing/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/simulated_time_system.h"
 #include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
@@ -721,6 +722,76 @@ TEST_P(DynamicModuleHttpLanguageTests, RecreateStream) {
   EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
 
   filter->onDestroy();
+}
+
+// The "destroy_logging" filter of the Rust test module logs when it is dropped, which makes the
+// point at which Envoy destroys the in-module filter observable.
+class DynamicModuleHttpFilterDestroyTest : public testing::Test {
+public:
+  DynamicModuleHttpFilterConfigSharedPtr newFilterConfig() {
+    auto dynamic_module = newDynamicModule(testSharedObjectPath("http", "rust"), false);
+    EXPECT_OK(dynamic_module);
+    auto filter_config_or_status = newDynamicModuleHttpFilterConfig(
+        "destroy_logging", "", DefaultMetricsNamespace, false, std::move(dynamic_module.value()),
+        *stats_store_.createScope(""), context_);
+    EXPECT_OK(filter_config_or_status);
+    return filter_config_or_status.value();
+  }
+
+  DynamicModuleHttpFilterSharedPtr newFilter() {
+    return std::make_shared<DynamicModuleHttpFilter>(newFilterConfig(), stats_store_.symbolTable(),
+                                                     0);
+  }
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  Stats::IsolatedStoreImpl stats_store_;
+};
+
+TEST_F(DynamicModuleHttpFilterDestroyTest, DeferredToDispatcher) {
+  auto filter = newFilter();
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  filter->setDecoderFilterCallbacks(callbacks);
+  filter->initializeInModuleFilter();
+
+  // A module event hook can tear its own filter chain down, so onDestroy() must hand the in-module
+  // filter to the dispatcher instead of destroying it underneath that hook.
+  EXPECT_LOG_NOT_CONTAINS("info", "destroy_logging filter dropped", { filter->onDestroy(); });
+  EXPECT_EQ(1, callbacks.dispatcher_.to_delete_.size());
+
+  // The filter chain calls onDestroy() once, but a second call must not queue a second destroy.
+  filter->onDestroy();
+  EXPECT_EQ(1, callbacks.dispatcher_.to_delete_.size());
+
+  // The pending destroy owns this filter too, so releasing the filter chain's reference leaves the
+  // module free to call back in until the dispatcher runs the deletion.
+  DynamicModuleHttpFilterWeakPtr weak_filter = filter;
+  filter.reset();
+  EXPECT_FALSE(weak_filter.expired());
+
+  EXPECT_LOG_CONTAINS_N_TIMES("info", "destroy_logging filter dropped", 1,
+                              { callbacks.dispatcher_.to_delete_.clear(); });
+  EXPECT_TRUE(weak_filter.expired());
+}
+
+TEST_F(DynamicModuleHttpFilterDestroyTest, InlineWithoutDispatcher) {
+  auto filter = newFilter();
+  filter->initializeInModuleFilter();
+
+  // A filter that never reached a chain has no dispatcher to defer to, so the in-module filter is
+  // destroyed inline from the destructor.
+  EXPECT_LOG_CONTAINS_N_TIMES("info", "destroy_logging filter dropped", 1, { filter.reset(); });
+}
+
+TEST_F(DynamicModuleHttpFilterDestroyTest, InlineWhenNotSharedOwned) {
+  DynamicModuleHttpFilter filter{newFilterConfig(), stats_store_.symbolTable(), 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  filter.setDecoderFilterCallbacks(callbacks);
+  filter.initializeInModuleFilter();
+
+  // Deferring hands the dispatcher a reference to this filter, so a filter that is not owned by a
+  // shared_ptr has to destroy the in-module filter inline even though a dispatcher is available.
+  EXPECT_LOG_CONTAINS_N_TIMES("info", "destroy_logging filter dropped", 1, { filter.onDestroy(); });
+  EXPECT_TRUE(callbacks.dispatcher_.to_delete_.empty());
 }
 
 TEST_P(DynamicModuleHttpLanguageTests, SocketOptionCallbacks) {
@@ -2379,6 +2450,19 @@ TEST(DynamicModuleHttpCalloutTest, CancelPendingRequest) {
                                                           stats_scope->symbolTable(), 0);
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
   filter->setDecoderFilterCallbacks(decoder_callbacks);
+
+  // The module can start a callout from on_http_filter_new_, which runs before the in-module filter
+  // is assigned, so the teardown guard below must not refuse it.
+  NiceMock<Http::MockAsyncClientRequest> new_filter_req(&cluster->async_client_);
+  EXPECT_CALL(cluster->async_client_, send_(_, _, _)).WillOnce(testing::Return(&new_filter_req));
+  uint64_t new_filter_id = 0;
+  auto new_filter_headers = std::make_unique<Http::TestRequestHeaderMapImpl>(
+      std::initializer_list<std::pair<std::string, std::string>>{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}});
+  auto new_filter_msg = std::make_unique<Http::RequestMessageImpl>(std::move(new_filter_headers));
+  EXPECT_EQ(filter->sendHttpCallout(&new_filter_id, "cluster", std::move(new_filter_msg), 1000),
+            envoy_dynamic_module_type_http_callout_init_result_Success);
+
   filter->initializeInModuleFilter();
 
   Http::AsyncClient::Callbacks* captured = nullptr;
@@ -2404,6 +2488,17 @@ TEST(DynamicModuleHttpCalloutTest, CancelPendingRequest) {
   // request.
   EXPECT_CALL(req, cancel());
   filter->onDestroy();
+
+  // A callout started after the teardown is refused before it reaches the cluster, so it cannot
+  // outlive the cancellation above.
+  testing::Mock::VerifyAndClearExpectations(&cluster->async_client_);
+  EXPECT_CALL(cluster->async_client_, send_(_, _, _)).Times(0);
+  auto late_headers = std::make_unique<Http::TestRequestHeaderMapImpl>(
+      std::initializer_list<std::pair<std::string, std::string>>{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}});
+  auto late_msg = std::make_unique<Http::RequestMessageImpl>(std::move(late_headers));
+  EXPECT_EQ(filter->sendHttpCallout(&id, "cluster", std::move(late_msg), 1000),
+            envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest);
 }
 
 TEST(DynamicModuleHttpStreamTest, HttpFilterHttpStreamCalloutOnComplete) {
@@ -2772,6 +2867,17 @@ TEST(DynamicModulesTest, HttpFilterResetHttpStream) {
 
   // Clean up properly.
   filter->onDestroy();
+
+  // A stream started after the teardown is refused before it reaches the cluster, so it cannot
+  // outlive the reset above.
+  testing::Mock::VerifyAndClearExpectations(&cluster->async_client_);
+  EXPECT_CALL(cluster->async_client_, start(_, _)).Times(0);
+  auto late_headers = std::make_unique<Http::TestRequestHeaderMapImpl>(
+      std::initializer_list<std::pair<std::string, std::string>>{
+          {":method", "GET"}, {":path", "/"}, {":authority", "host"}});
+  auto late_message = std::make_unique<Http::RequestMessageImpl>(std::move(late_headers));
+  EXPECT_EQ(filter->startHttpStream(&stream_id, "cluster", std::move(late_message), false, 1000),
+            envoy_dynamic_module_type_http_callout_init_result_CannotCreateRequest);
 }
 
 TEST(DynamicModulesTest, HttpFilterStartHttpStreamNoBodyEndStream) {

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -5,6 +5,7 @@
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/integration/http_integration.h"
+#include "test/test_common/logging.h"
 
 namespace Envoy {
 
@@ -529,6 +530,41 @@ TEST_P(DynamicModulesIntegrationTest, FilterStateObjectSurvivesRecreateStream) {
                           .get(Http::LowerCaseString("x-live-object-value"))[0]
                           ->value()
                           .getStringView());
+}
+
+// recreate_stream tears the filter chain down on the module's own stack. The in-module filter is
+// destroyed from the deferred deletion list, so the hook keeps using itself and calling back into
+// Envoy after the teardown. A synchronous destroy would have dropped the filter before its hook
+// resumed, so the first request would report a non-zero drop count. Each request builds a filter
+// for the original stream and one for the recreated stream, so the second request also pins down
+// that the dispatcher really runs the deferred destroy rather than dropping it.
+TEST_P(DynamicModulesIntegrationTest, ModuleUsesItselfAfterRecreateStream) {
+  if (GetParam() != "rust" && GetParam() != "rust_static") {
+    GTEST_SKIP() << "the use_self_after_teardown filter is only in the rust test module";
+  }
+  initializeFilter("use_self_after_teardown");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto sendRequestAndExpectRecreated = [this]() {
+    IntegrationStreamDecoderPtr response =
+        codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+    ASSERT_TRUE(response->waitForEndStream());
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+    auto recreated = response->headers().get(Http::LowerCaseString("x-recreated"));
+    ASSERT_FALSE(recreated.empty());
+    EXPECT_EQ("true", recreated[0]->value().getStringView());
+  };
+
+  constexpr absl::string_view log_line =
+      "recreated with state alive-torn-down after {} drops, header_set=true recreated=true "
+      "append=false drain=false route=false";
+  EXPECT_LOG_CONTAINS_ALL_OF(Envoy::ExpectedLogMessages({{"info", fmt::format(log_line, 0)},
+                                                         {"info", fmt::format(log_line, 2)}}),
+                             {
+                               sendRequestAndExpectRecreated();
+                               sendRequestAndExpectRecreated();
+                             });
 }
 
 TEST_P(DynamicModulesIntegrationTest, SendResponseFromOnRequestBody) {

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -83,6 +83,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "reset_stream" => Some(Box::new(ResetStreamFilterConfig {})),
     "send_go_away_and_close" => Some(Box::new(SendGoAwayAndCloseFilterConfig {})),
     "recreate_stream" => Some(Box::new(RecreateStreamFilterConfig {})),
+    "destroy_logging" => Some(Box::new(DestroyLoggingFilterConfig {})),
     "socket_option_callbacks" => Some(Box::new(SocketOptionCallbacksFilterConfig {})),
     "span_callbacks" => Some(Box::new(SpanCallbacksFilterConfig {})),
     "cluster_callbacks" => Some(Box::new(ClusterCallbacksFilterConfig {})),
@@ -644,6 +645,29 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for RecreateStreamFilter {
       envoy_filter.recreate_stream(Some(&[(":status", b"302"), ("location", b"/recreated"),]))
     );
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+}
+
+/// A HTTP filter configuration that implements
+/// [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilterConfig`] to observe when the in-module filter
+/// is destroyed.
+struct DestroyLoggingFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for DestroyLoggingFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(DestroyLoggingFilter {})
+  }
+}
+
+/// A HTTP filter that implements [`envoy_proxy_dynamic_modules_rust_sdk::HttpFilter`] and logs on
+/// drop so that the point at which Envoy destroys the in-module filter is observable.
+struct DestroyLoggingFilter {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for DestroyLoggingFilter {}
+
+impl Drop for DestroyLoggingFilter {
+  fn drop(&mut self) {
+    envoy_log_info!("destroy_logging filter dropped");
   }
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -1,7 +1,7 @@
 use abi::*;
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 use std::any::Any;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -175,6 +175,9 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     },
     "list_metadata_callbacks" => Some(Box::new(ListMetadataCallbacksFilterConfig {})),
     "filter_state_object_recreate" => Some(Box::new(FilterStateObjectRecreateFilterConfig {})),
+    "use_self_after_teardown" => Some(Box::new(UseSelfAfterTeardownFilterConfig {
+      dropped_filters: Arc::new(AtomicUsize::new(0)),
+    })),
     "upstream_connection_id" => Some(Box::new(UpstreamConnectionIdFilterConfig {})),
     "log_level" => Some(Box::new(LogLevelFilterConfig {})),
     _ => panic!("Unknown filter name: {name}"),
@@ -263,6 +266,74 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for FilterStateObjectRecreateFilter {
         abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
       },
     }
+  }
+}
+
+const RECREATED_HEADER: &str = "x-recreated";
+
+/// A HTTP filter that keeps using itself after recreate_stream has torn its own filter chain down.
+/// The counter lives in the config so that a filter can report how many filters Envoy had already
+/// destroyed by the time its own hook resumed.
+struct UseSelfAfterTeardownFilterConfig {
+  dropped_filters: Arc<AtomicUsize>,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for UseSelfAfterTeardownFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(UseSelfAfterTeardownFilter {
+      state: String::from("alive"),
+      dropped_filters: self.dropped_filters.clone(),
+    })
+  }
+}
+
+struct UseSelfAfterTeardownFilter {
+  state: String,
+  dropped_filters: Arc<AtomicUsize>,
+}
+
+impl Drop for UseSelfAfterTeardownFilter {
+  fn drop(&mut self) {
+    self.dropped_filters.fetch_add(1, Ordering::SeqCst);
+  }
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for UseSelfAfterTeardownFilter {
+  fn on_request_headers(
+    &mut self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    // The request headers are carried over to the recreated stream, so this marks the second pass.
+    if envoy_filter
+      .get_request_header_value(RECREATED_HEADER)
+      .is_some()
+    {
+      envoy_filter.send_response(200, &[(RECREATED_HEADER, b"true")], None, None);
+      return abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration;
+    }
+
+    let header_set = envoy_filter.set_request_header(RECREATED_HEADER, b"true");
+    let recreated = envoy_filter.recreate_stream(None);
+
+    // Everything below runs on a hook whose filter chain Envoy has already destroyed. Writing the
+    // state proves the allocation is intact, and a synchronous destroy would have counted this
+    // filter in the drops. Panics are swallowed at the FFI boundary, so every result the test needs
+    // to check goes to the log rather than to an assert.
+    self.state.push_str("-torn-down");
+    envoy_log_info!(
+      "recreated with state {} after {} drops, header_set={} recreated={} append={} drain={} \
+       route={}",
+      self.state,
+      self.dropped_filters.load(Ordering::SeqCst),
+      header_set,
+      recreated,
+      envoy_filter.append_buffered_request_body(b"ignored"),
+      envoy_filter.drain_buffered_response_body(1),
+      envoy_filter.get_most_specific_route_config().is_some()
+    );
+
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
   }
 }
 


### PR DESCRIPTION
## Description

This PR replaces the per-hook keep-alive from the earlier revision of this PR. As @wbpcode pointed out, the C++ filter lifetime is already handled by Envoy's generic deferred destroy, since the owning ActiveStream is deferred-deleted, so a DYM-specific keep-alive on every hook duplicated an existing mechanism.

What that mechanism cannot cover is the in-module filter object. It is owned by the module rather than by FilterManager, and `destroy()` was freeing it synchronously via `on_http_filter_destroy_`. A hook that ends the stream, for example `envoy_dynamic_module_callback_http_filter_recreate_stream`, tears the filter chain down on the module's own stack, so that call freed the object the module was still executing on.

The destroy hook would now run from the worker dispatcher's deferred deletion list. The deferred task also holds a reference to the C++ filter, so the module can still call back into Envoy from the remainder of the hook. Following the rest of the review, `onDestroy()` now completes all detach and cancel work before the module hook is queued, the module-facing callbacks that need the torn-down stream null-check it instead of dereferencing it, and HTTP callouts or streams started after the teardown are refused rather than outliving the cancellation.

---

**Commit Message:** dynamic_modules: defer the in-module HTTP filter destroy
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes**: Added