### PR TITLE
Use PassthroughState pointer value as thread local storage key for peer metadata exchange

### DIFF
--- a/contrib/istio/filters/common/source/peer_metadata_registry.cc
+++ b/contrib/istio/filters/common/source/peer_metadata_registry.cc
@@ -20,7 +20,7 @@ namespace PeerMetadataShared {
 namespace {
 
 struct ThreadLocalRegistry : public ThreadLocal::ThreadLocalObject {
-  absl::flat_hash_map<uint64_t, std::string> values_;
+  absl::flat_hash_map<void*, std::string> values_;
 };
 
 class PeerMetadataRegistryImpl : public PeerMetadataRegistry, public Singleton::Instance {
@@ -30,13 +30,13 @@ public:
     tls_->set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalRegistry>(); });
   }
 
-  void setValue(uint64_t key, const std::string& value) override {
+  void setValue(void* key, const std::string& value) override {
     if (auto tls = tls_->get(); tls.has_value()) {
       tls->values_[key] = value;
     }
   }
 
-  std::optional<std::string> getValue(uint64_t key) const override {
+  std::optional<std::string> getValue(void* key) const override {
     if (auto tls = tls_->get(); tls.has_value()) {
       const auto it = tls->values_.find(key);
       if (it != tls->values_.end()) {
@@ -46,7 +46,7 @@ public:
     return std::nullopt;
   }
 
-  void removeValue(uint64_t key) override {
+  void removeValue(void* key) override {
     if (auto tls = tls_->get(); tls.has_value()) {
       tls->values_.erase(key);
     }

--- a/contrib/istio/filters/common/source/peer_metadata_registry.cc
+++ b/contrib/istio/filters/common/source/peer_metadata_registry.cc
@@ -20,7 +20,7 @@ namespace PeerMetadataShared {
 namespace {
 
 struct ThreadLocalRegistry : public ThreadLocal::ThreadLocalObject {
-  absl::flat_hash_map<std::string, std::string> values_;
+  absl::flat_hash_map<uint64_t, std::string> values_;
 };
 
 class PeerMetadataRegistryImpl : public PeerMetadataRegistry, public Singleton::Instance {
@@ -30,13 +30,13 @@ public:
     tls_->set([](Event::Dispatcher&) { return std::make_shared<ThreadLocalRegistry>(); });
   }
 
-  void setValue(absl::string_view key, const std::string& value) override {
+  void setValue(uint64_t key, const std::string& value) override {
     if (auto tls = tls_->get(); tls.has_value()) {
-      tls->values_[std::string(key)] = value;
+      tls->values_[key] = value;
     }
   }
 
-  std::optional<std::string> getValue(absl::string_view key) const override {
+  std::optional<std::string> getValue(uint64_t key) const override {
     if (auto tls = tls_->get(); tls.has_value()) {
       const auto it = tls->values_.find(key);
       if (it != tls->values_.end()) {
@@ -46,7 +46,7 @@ public:
     return std::nullopt;
   }
 
-  void removeValue(absl::string_view key) override {
+  void removeValue(uint64_t key) override {
     if (auto tls = tls_->get(); tls.has_value()) {
       tls->values_.erase(key);
     }

--- a/contrib/istio/filters/common/source/peer_metadata_registry.h
+++ b/contrib/istio/filters/common/source/peer_metadata_registry.h
@@ -23,16 +23,17 @@ namespace PeerMetadataShared {
 // its own map and reads/writes are lock-free. This only works as a hand-off
 // when the writing and reading filters run on the *same* worker thread (which
 // is the case for internal listener connections), and when both sides agree on
-// the key (the originating upstream connection ID).
+// the key (the address of the PassthroughState shared by the internal
+// user-space socket's two peers).
 class PeerMetadataRegistry {
 public:
   virtual ~PeerMetadataRegistry() = default;
 
-  virtual void setValue(absl::string_view key, const std::string& value) PURE;
+  virtual void setValue(uint64_t key, const std::string& value) PURE;
 
-  virtual std::optional<std::string> getValue(absl::string_view key) const PURE;
+  virtual std::optional<std::string> getValue(uint64_t key) const PURE;
 
-  virtual void removeValue(absl::string_view key) PURE;
+  virtual void removeValue(uint64_t key) PURE;
 };
 
 using PeerMetadataRegistrySharedPtr = std::shared_ptr<PeerMetadataRegistry>;

--- a/contrib/istio/filters/common/source/peer_metadata_registry.h
+++ b/contrib/istio/filters/common/source/peer_metadata_registry.h
@@ -29,11 +29,11 @@ class PeerMetadataRegistry {
 public:
   virtual ~PeerMetadataRegistry() = default;
 
-  virtual void setValue(uint64_t key, const std::string& value) PURE;
+  virtual void setValue(void* key, const std::string& value) PURE;
 
-  virtual std::optional<std::string> getValue(uint64_t key) const PURE;
+  virtual std::optional<std::string> getValue(void* key) const PURE;
 
-  virtual void removeValue(uint64_t key) PURE;
+  virtual void removeValue(void* key) PURE;
 };
 
 using PeerMetadataRegistrySharedPtr = std::shared_ptr<PeerMetadataRegistry>;

--- a/contrib/istio/filters/network/peer_metadata/source/BUILD
+++ b/contrib/istio/filters/network/peer_metadata/source/BUILD
@@ -17,6 +17,7 @@ envoy_cc_contrib_extension(
         "//contrib/istio/filters/common/source:peer_metadata_registry_lib",
         "//envoy/local_info:local_info_interface",
         "//envoy/network:address_interface",
+        "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
         "//envoy/runtime:runtime_interface",
         "//envoy/server:filter_config_interface",
@@ -30,6 +31,7 @@ envoy_cc_contrib_extension(
         "//source/common/tcp_proxy",
         "//source/extensions/filters/common/expr:cel_state_lib",
         "//source/extensions/filters/network/common:factory_base_lib",
+        "//source/extensions/io_socket/user_space:io_handle_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/peer_metadata/v3:pkg_cc_proto",
     ],
 )

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -232,7 +232,8 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
 
 bool Filter::storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata) {
   ASSERT(read_callbacks_);
-  if (registry_ == nullptr || tlsFilterExchangeDisabled(read_callbacks_->connection().streamInfo())) {
+  if (registry_ == nullptr ||
+      tlsFilterExchangeDisabled(read_callbacks_->connection().streamInfo())) {
     ENVOY_LOG(debug, "Thread local storage for filter exchange is disabled");
     return false;
   }
@@ -510,8 +511,8 @@ ConfigFactory::createFilterFactoryFromProtoTyped(const Config& config,
                                                  Server::Configuration::FactoryContext& context) {
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry =
       maybeGetRegistry(context.serverFactoryContext());
-  return [config, &context, registry = std::move(registry)](
-             Network::FilterManager& filter_manager) -> void {
+  return [config, &context,
+          registry = std::move(registry)](Network::FilterManager& filter_manager) -> void {
     const auto& local_info = context.serverFactoryContext().localInfo();
     filter_manager.addFilter(std::make_shared<Filter>(config, local_info, registry));
   };

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -52,27 +52,28 @@ bool discoveryDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
   return value.bool_value();
 }
 
-std::optional<uint64_t> getRegistryKey(Network::Connection& connection) {
+std::optional<void*> getRegistryKey(Network::Connection& connection) {
   const auto& socket = connection.getSocket();
   if (socket == nullptr) {
     return std::nullopt;
   }
   auto* handle = dynamic_cast<IoSocket::UserSpace::IoHandle*>(&socket->ioHandle());
-  if (handle == nullptr) {
+  if (handle == nullptr || handle->passthroughState() == nullptr) {
     return std::nullopt;
   }
-  return reinterpret_cast<uint64_t>(handle->passthroughState().get());
+  return handle->passthroughState().get();
 }
 
-// Layered-runtime boolean key that disables the PassthroughState-pointer registry
-// hand-off and falls back to the legacy in-byte-stream peer metadata exchange.
-constexpr char DisablePassthroughStateKeyRuntimeKey[] =
-    "envoy.contrib.peer_metadata.disable_passthrough_state_key";
+// Layered-runtime boolean key that enables the PassthroughState-pointer registry
+// hand-off. When disabled, the filters fall back to the legacy in-byte-stream
+// peer metadata exchange. Enabled by default.
+constexpr char EnablePassthroughStateKeyRuntimeKey[] =
+    "envoy.contrib.peer_metadata.enable_passthrough_state_key";
 
 // Whether to hand off peer metadata via the shared-PassthroughState-pointer
 // registry (default) rather than the legacy in-byte-stream exchange.
 bool usePassthroughStateKey(Server::Configuration::ServerFactoryContext& context) {
-  return !context.runtime().snapshot().getBoolean(DisablePassthroughStateKeyRuntimeKey, false);
+  return context.runtime().snapshot().getBoolean(EnablePassthroughStateKeyRuntimeKey, true);
 }
 
 // Layered-runtime boolean key that, when true, disables the thread-local registry hand-off. The
@@ -231,7 +232,7 @@ bool Filter::storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_met
     // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
     return false;
   }
-  const std::optional<uint64_t> key = getRegistryKey(read_callbacks_->connection());
+  const std::optional<void*> key = getRegistryKey(read_callbacks_->connection());
   if (!key) {
     ENVOY_LOG(warn, "No key available for peer metadata hand-off");
     return false;
@@ -367,7 +368,7 @@ bool UpstreamFilter::tryRegistryLookup() {
     // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
     return false;
   }
-  const std::optional<uint64_t> key = getRegistryKey(callbacks_->connection());
+  const std::optional<void*> key = getRegistryKey(callbacks_->connection());
   if (!key) {
     ENVOY_LOG(debug, "No registry key available for peer metadata lookup");
     return false;

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -1,5 +1,6 @@
 #include "contrib/istio/filters/network/peer_metadata/source/peer_metadata.h"
 
+#include <cstdint>
 #include <optional>
 
 #include "envoy/runtime/runtime.h"
@@ -10,6 +11,7 @@
 #include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/stream_info/uint64_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
+#include "source/extensions/io_socket/user_space/io_handle.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -50,13 +52,27 @@ bool discoveryDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
   return value.bool_value();
 }
 
-std::optional<std::string> getRegistryKey(const StreamInfo::FilterState& filter_state) {
-  const auto* connection_id = filter_state.getDataReadOnly<Router::StringAccessor>(
-      Filters::Common::PeerMetadataShared::ConnectionIdFilterStateKey);
-  if (connection_id == nullptr) {
+std::optional<uint64_t> getRegistryKey(Network::Connection& connection) {
+  const auto& socket = connection.getSocket();
+  if (socket == nullptr) {
     return std::nullopt;
   }
-  return std::string(connection_id->asString());
+  auto* handle = dynamic_cast<IoSocket::UserSpace::IoHandle*>(&socket->ioHandle());
+  if (handle == nullptr) {
+    return std::nullopt;
+  }
+  return reinterpret_cast<uint64_t>(handle->passthroughState().get());
+}
+
+// Layered-runtime boolean key that disables the PassthroughState-pointer registry
+// hand-off and falls back to the legacy in-byte-stream peer metadata exchange.
+constexpr char DisablePassthroughStateKeyRuntimeKey[] =
+    "envoy.contrib.peer_metadata.disable_passthrough_state_key";
+
+// Whether to hand off peer metadata via the shared-PassthroughState-pointer
+// registry (default) rather than the legacy in-byte-stream exchange.
+bool usePassthroughStateKey(Server::Configuration::ServerFactoryContext& context) {
+  return !context.runtime().snapshot().getBoolean(DisablePassthroughStateKeyRuntimeKey, false);
 }
 
 // Layered-runtime boolean key that, when true, disables the thread-local registry hand-off. The
@@ -83,8 +99,10 @@ maybeGetRegistry(Server::Configuration::ServerFactoryContext& context) {
 const uint32_t PeerMetadataHeader::magic_number = 0xabcd1234;
 
 Filter::Filter(const Config& config, const LocalInfo::LocalInfo& local_info,
-               Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry)
-    : config_(config), baggage_(baggageValue(local_info)), registry_(std::move(registry)) {}
+               Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
+               bool use_passthrough_state_key)
+    : config_(config), baggage_(baggageValue(local_info)), registry_(std::move(registry)),
+      use_passthrough_state_key_(use_passthrough_state_key) {}
 
 Network::FilterStatus Filter::onData(Buffer::Instance&, bool) {
   return Network::FilterStatus::Continue;
@@ -209,9 +227,13 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
 
 bool Filter::storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata) {
   ASSERT(read_callbacks_);
-  std::optional<std::string> key =
-      getRegistryKey(*read_callbacks_->connection().streamInfo().filterState());
+  if (!use_passthrough_state_key_) {
+    // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
+    return false;
+  }
+  const std::optional<uint64_t> key = getRegistryKey(read_callbacks_->connection());
   if (!key) {
+    ENVOY_LOG(warn, "No key available for peer metadata hand-off");
     return false;
   }
   if (registry_ == nullptr) {
@@ -256,8 +278,9 @@ void Filter::propagateNoPeerMetadata() {
 }
 
 UpstreamFilter::UpstreamFilter(
-    Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry)
-    : registry_(std::move(registry)) {}
+    Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
+    bool use_passthrough_state_key)
+    : registry_(std::move(registry)), use_passthrough_state_key_(use_passthrough_state_key) {}
 
 Network::FilterStatus UpstreamFilter::onData(Buffer::Instance& buffer, bool end_stream) {
   switch (state_) {
@@ -340,9 +363,13 @@ bool UpstreamFilter::disableDiscovery() const {
 
 bool UpstreamFilter::tryRegistryLookup() {
   ASSERT(callbacks_);
-  std::optional<std::string> key =
-      getRegistryKey(*callbacks_->connection().streamInfo().filterState());
+  if (!use_passthrough_state_key_) {
+    // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
+    return false;
+  }
+  const std::optional<uint64_t> key = getRegistryKey(callbacks_->connection());
   if (!key) {
+    ENVOY_LOG(debug, "No registry key available for peer metadata lookup");
     return false;
   }
   if (registry_ == nullptr) {
@@ -351,9 +378,8 @@ bool UpstreamFilter::tryRegistryLookup() {
   }
   auto value = registry_->getValue(*key);
   if (!value.has_value()) {
-    ENVOY_LOG(debug, "No peer metadata in registry for connection ID {}", *key);
-    populateNoPeerMetadata();
-    return true;
+    ENVOY_LOG(debug, "No peer metadata in registry for key {}", *key);
+    return false;
   }
 
   registry_->removeValue(*key);
@@ -488,10 +514,12 @@ ConfigFactory::createFilterFactoryFromProtoTyped(const Config& config,
                                                  Server::Configuration::FactoryContext& context) {
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry =
       maybeGetRegistry(context.serverFactoryContext());
-  return [config, &context,
-          registry = std::move(registry)](Network::FilterManager& filter_manager) -> void {
+  const bool use_passthrough_state_key = usePassthroughStateKey(context.serverFactoryContext());
+  return [config, &context, registry = std::move(registry),
+          use_passthrough_state_key](Network::FilterManager& filter_manager) -> void {
     const auto& local_info = context.serverFactoryContext().localInfo();
-    filter_manager.addFilter(std::make_shared<Filter>(config, local_info, registry));
+    filter_manager.addFilter(
+        std::make_shared<Filter>(config, local_info, registry, use_passthrough_state_key));
   };
 }
 
@@ -499,8 +527,11 @@ Network::FilterFactoryCb UpstreamConfigFactory::createFilterFactoryFromProto(
     const Protobuf::Message&, Server::Configuration::UpstreamFactoryContext& context) {
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry =
       maybeGetRegistry(context.serverFactoryContext());
-  return [registry = std::move(registry)](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(std::make_shared<UpstreamFilter>(registry));
+  const bool use_passthrough_state_key = usePassthroughStateKey(context.serverFactoryContext());
+  return [registry = std::move(registry),
+          use_passthrough_state_key](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(
+        std::make_shared<UpstreamFilter>(registry, use_passthrough_state_key));
   };
 }
 

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -52,6 +52,24 @@ bool discoveryDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
   return value.bool_value();
 }
 
+bool tlsFilterExchangeDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
+  const auto& value = ::Envoy::Config::Metadata::metadataValue(
+      &metadata, FilterNames::get().Name, FilterNames::get().EnableTLSFilterExchange);
+  return !value.bool_value();
+}
+
+bool tlsFilterExchangeDisabled(const StreamInfo::StreamInfo& stream_info) {
+  const auto upstream = stream_info.upstreamInfo();
+  if (!upstream) {
+    return false;
+  }
+  const auto host = upstream->upstreamHost();
+  if (!host) {
+    return false;
+  }
+  return tlsFilterExchangeDisabled(host->cluster().metadata());
+}
+
 std::optional<void*> getRegistryKey(Network::Connection& connection) {
   const auto& socket = connection.getSocket();
   if (socket == nullptr) {
@@ -62,18 +80,6 @@ std::optional<void*> getRegistryKey(Network::Connection& connection) {
     return std::nullopt;
   }
   return handle->passthroughState().get();
-}
-
-// Layered-runtime boolean key that enables the PassthroughState-pointer registry
-// hand-off. When disabled, the filters fall back to the legacy in-byte-stream
-// peer metadata exchange. Enabled by default.
-constexpr char EnablePassthroughStateKeyRuntimeKey[] =
-    "envoy.contrib.peer_metadata.enable_passthrough_state_key";
-
-// Whether to hand off peer metadata via the shared-PassthroughState-pointer
-// registry (default) rather than the legacy in-byte-stream exchange.
-bool usePassthroughStateKey(Server::Configuration::ServerFactoryContext& context) {
-  return context.runtime().snapshot().getBoolean(EnablePassthroughStateKeyRuntimeKey, true);
 }
 
 // Layered-runtime boolean key that, when true, disables the thread-local registry hand-off. The
@@ -100,10 +106,8 @@ maybeGetRegistry(Server::Configuration::ServerFactoryContext& context) {
 const uint32_t PeerMetadataHeader::magic_number = 0xabcd1234;
 
 Filter::Filter(const Config& config, const LocalInfo::LocalInfo& local_info,
-               Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
-               bool use_passthrough_state_key)
-    : config_(config), baggage_(baggageValue(local_info)), registry_(std::move(registry)),
-      use_passthrough_state_key_(use_passthrough_state_key) {}
+               Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry)
+    : config_(config), baggage_(baggageValue(local_info)), registry_(std::move(registry)) {}
 
 Network::FilterStatus Filter::onData(Buffer::Instance&, bool) {
   return Network::FilterStatus::Continue;
@@ -228,17 +232,13 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
 
 bool Filter::storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata) {
   ASSERT(read_callbacks_);
-  if (!use_passthrough_state_key_) {
-    // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
+  if (registry_ == nullptr || tlsFilterExchangeDisabled(read_callbacks_->connection().streamInfo())) {
+    ENVOY_LOG(debug, "Thread local storage for filter exchange is disabled");
     return false;
   }
   const std::optional<void*> key = getRegistryKey(read_callbacks_->connection());
   if (!key) {
     ENVOY_LOG(warn, "No key available for peer metadata hand-off");
-    return false;
-  }
-  if (registry_ == nullptr) {
-    ENVOY_LOG(debug, "No instance for registry");
     return false;
   }
   if (peer_metadata) {
@@ -279,9 +279,8 @@ void Filter::propagateNoPeerMetadata() {
 }
 
 UpstreamFilter::UpstreamFilter(
-    Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
-    bool use_passthrough_state_key)
-    : registry_(std::move(registry)), use_passthrough_state_key_(use_passthrough_state_key) {}
+    Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry)
+    : registry_(std::move(registry)) {}
 
 Network::FilterStatus UpstreamFilter::onData(Buffer::Instance& buffer, bool end_stream) {
   switch (state_) {
@@ -364,17 +363,13 @@ bool UpstreamFilter::disableDiscovery() const {
 
 bool UpstreamFilter::tryRegistryLookup() {
   ASSERT(callbacks_);
-  if (!use_passthrough_state_key_) {
-    // Pointer key disabled: fall back to the legacy in-byte-stream exchange.
+  if (registry_ == nullptr || tlsFilterExchangeDisabled(callbacks_->connection().streamInfo())) {
+    ENVOY_LOG(debug, "Thread local storage for filter exchange is disabled");
     return false;
   }
   const std::optional<void*> key = getRegistryKey(callbacks_->connection());
   if (!key) {
     ENVOY_LOG(debug, "No registry key available for peer metadata lookup");
-    return false;
-  }
-  if (registry_ == nullptr) {
-    ENVOY_LOG(debug, "No instance for registry");
     return false;
   }
   auto value = registry_->getValue(*key);
@@ -515,12 +510,10 @@ ConfigFactory::createFilterFactoryFromProtoTyped(const Config& config,
                                                  Server::Configuration::FactoryContext& context) {
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry =
       maybeGetRegistry(context.serverFactoryContext());
-  const bool use_passthrough_state_key = usePassthroughStateKey(context.serverFactoryContext());
-  return [config, &context, registry = std::move(registry),
-          use_passthrough_state_key](Network::FilterManager& filter_manager) -> void {
+  return [config, &context, registry = std::move(registry)](
+             Network::FilterManager& filter_manager) -> void {
     const auto& local_info = context.serverFactoryContext().localInfo();
-    filter_manager.addFilter(
-        std::make_shared<Filter>(config, local_info, registry, use_passthrough_state_key));
+    filter_manager.addFilter(std::make_shared<Filter>(config, local_info, registry));
   };
 }
 
@@ -528,11 +521,8 @@ Network::FilterFactoryCb UpstreamConfigFactory::createFilterFactoryFromProto(
     const Protobuf::Message&, Server::Configuration::UpstreamFactoryContext& context) {
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry =
       maybeGetRegistry(context.serverFactoryContext());
-  const bool use_passthrough_state_key = usePassthroughStateKey(context.serverFactoryContext());
-  return [registry = std::move(registry),
-          use_passthrough_state_key](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(
-        std::make_shared<UpstreamFilter>(registry, use_passthrough_state_key));
+  return [registry = std::move(registry)](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(std::make_shared<UpstreamFilter>(registry));
   };
 }
 

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -52,22 +52,11 @@ bool discoveryDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
   return value.bool_value();
 }
 
-bool tlsFilterExchangeDisabled(const ::envoy::config::core::v3::Metadata& metadata) {
-  const auto& value = ::Envoy::Config::Metadata::metadataValue(
-      &metadata, FilterNames::get().Name, FilterNames::get().EnableTLSFilterExchange);
-  return !value.bool_value();
-}
-
-bool tlsFilterExchangeDisabled(const StreamInfo::StreamInfo& stream_info) {
-  const auto upstream = stream_info.upstreamInfo();
-  if (!upstream) {
-    return false;
-  }
-  const auto host = upstream->upstreamHost();
-  if (!host) {
-    return false;
-  }
-  return tlsFilterExchangeDisabled(host->cluster().metadata());
+bool threadLocalMetadataExchangeDisabled(const StreamInfo::StreamInfo& stream_info) {
+  const auto& filterState = stream_info.filterState();
+  const StreamInfo::BoolAccessor* enable = filterState.getDataReadOnly<StreamInfo::BoolAccessor>(
+      FilterNames::get().EnableTLSFilterExchange);
+  return enable != nullptr && !enable->value();
 }
 
 std::optional<void*> getRegistryKey(Network::Connection& connection) {
@@ -233,7 +222,7 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
 bool Filter::storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata) {
   ASSERT(read_callbacks_);
   if (registry_ == nullptr ||
-      tlsFilterExchangeDisabled(read_callbacks_->connection().streamInfo())) {
+      threadLocalMetadataExchangeDisabled(read_callbacks_->connection().streamInfo())) {
     ENVOY_LOG(debug, "Thread local storage for filter exchange is disabled");
     return false;
   }
@@ -364,7 +353,8 @@ bool UpstreamFilter::disableDiscovery() const {
 
 bool UpstreamFilter::tryRegistryLookup() {
   ASSERT(callbacks_);
-  if (registry_ == nullptr || tlsFilterExchangeDisabled(callbacks_->connection().streamInfo())) {
+  if (registry_ == nullptr ||
+      threadLocalMetadataExchangeDisabled(callbacks_->connection().streamInfo())) {
     ENVOY_LOG(debug, "Thread local storage for filter exchange is disabled");
     return false;
   }

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -56,7 +56,7 @@ bool threadLocalMetadataExchangeDisabled(const StreamInfo::StreamInfo& stream_in
   const auto& filterState = stream_info.filterState();
   const StreamInfo::BoolAccessor* enable = filterState.getDataReadOnly<StreamInfo::BoolAccessor>(
       FilterNames::get().EnableTLSFilterExchange);
-  return enable != nullptr && !enable->value();
+  return enable == nullptr || !enable->value();
 }
 
 std::optional<void*> getRegistryKey(Network::Connection& connection) {

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
@@ -105,6 +105,7 @@ using Headers = ConstSingleton<HeaderValues>;
 struct FilterNameValues {
   const std::string Name = "istio.peer_metadata";
   const std::string DisableDiscoveryField = "disable_baggage_discovery";
+  const std::string EnableTLSFilterExchange = "enable_tls_filter_exchange";
 };
 
 using FilterNames = ConstSingleton<FilterNameValues>;
@@ -136,8 +137,7 @@ PACKED_STRUCT(struct PeerMetadataHeader {
 class Filter : public Network::Filter, Logger::Loggable<Logger::Id::filter> {
 public:
   Filter(const Config& config, const LocalInfo::LocalInfo& local_info,
-         Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
-         bool use_passthrough_state_key);
+         Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry);
 
   // Network::ReadFilter
   Network::FilterStatus onNewConnection() override;
@@ -154,8 +154,8 @@ private:
   std::optional<Envoy::Protobuf::Any> discoverPeerMetadata();
   // Store discovered peer metadata in the thread-local registry, keyed by the
   // shared PassthroughState pointer of the internal user-space socket. Returns
-  // false when the pointer key is disabled or unavailable, so the caller can
-  // fall back to the legacy in-byte-stream preamble exchange.
+  // false when no registry is allocated or the pointer key is unavailable, so
+  // the caller can fall back to the legacy in-byte-stream preamble exchange.
   bool storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata);
   // Legacy fallback: inject the peer metadata (or an empty marker) as a preamble
   // into the downstream data stream.
@@ -168,7 +168,6 @@ private:
   Config config_;
   std::string baggage_;
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry_;
-  const bool use_passthrough_state_key_;
 };
 
 /**
@@ -181,8 +180,7 @@ private:
  */
 class UpstreamFilter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  UpstreamFilter(Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
-                 bool use_passthrough_state_key);
+  UpstreamFilter(Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry);
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& buffer, bool end_stream) override;
@@ -193,9 +191,8 @@ private:
   bool disableDiscovery() const;
   // Look up peer metadata stored by the paired downstream filter, keyed by the
   // shared PassthroughState pointer of the internal user-space socket. Returns
-  // false when the pointer key is disabled or unavailable, or the TLS registry
-  // is not allocated, so the caller can fall back to the legacy in-byte-stream
-  // preamble exchange.
+  // false when no registry is allocated or the pointer key is unavailable, so
+  // the caller can fall back to the legacy in-byte-stream preamble exchange.
   bool tryRegistryLookup();
   // Legacy fallback: parse and strip the peer metadata preamble from the
   // upstream data stream.
@@ -214,7 +211,6 @@ private:
   PeerMetadataState state_ = PeerMetadataState::WaitingForData;
   Network::ReadFilterCallbacks* callbacks_{};
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry_;
-  const bool use_passthrough_state_key_;
 };
 
 /**

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
@@ -129,13 +129,15 @@ PACKED_STRUCT(struct PeerMetadataHeader {
  * baggage header information from filter state (we expect TCP Proxy to
  * populate it), collect other details that are missing from the baggage, i.e.
  * the upstream peer identity, and store the discovered peer metadata in a
- * thread-local registry keyed by the upstream connection ID, allowing the
- * upstream peer_metadata filter on the cluster side to retrieve it directly.
+ * thread-local registry keyed by the shared PassthroughState pointer of the
+ * internal user-space socket, allowing the upstream peer_metadata filter on the
+ * cluster side to retrieve it directly.
  */
 class Filter : public Network::Filter, Logger::Loggable<Logger::Id::filter> {
 public:
   Filter(const Config& config, const LocalInfo::LocalInfo& local_info,
-         Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry);
+         Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
+         bool use_passthrough_state_key);
 
   // Network::ReadFilter
   Network::FilterStatus onNewConnection() override;
@@ -151,9 +153,9 @@ private:
   bool disableDiscovery() const;
   std::optional<Envoy::Protobuf::Any> discoverPeerMetadata();
   // Store discovered peer metadata in the thread-local registry, keyed by the
-  // downstream connection ID from filter state. Returns false when there is no
-  // connection ID in filter state (registry hand-off unavailable), so the caller
-  // can fall back to the data-stream approach.
+  // shared PassthroughState pointer of the internal user-space socket. Returns
+  // false when the pointer key is disabled or unavailable, so the caller can
+  // fall back to the legacy in-byte-stream preamble exchange.
   bool storeInRegistry(const std::optional<Envoy::Protobuf::Any>& peer_metadata);
   // Legacy fallback: inject the peer metadata (or an empty marker) as a preamble
   // into the downstream data stream.
@@ -166,18 +168,21 @@ private:
   Config config_;
   std::string baggage_;
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry_;
+  const bool use_passthrough_state_key_;
 };
 
 /**
  * This is an upstream network filter complementing the filter above. It will
  * be installed in all the service clusters that communicate with upstream peers
  * via internal listeners. It reads peer metadata from the thread-local registry
- * (stored by the listener-side Filter keyed by this connection's ID) and
- * populates filter state for use by telemetry filters.
+ * (stored by the listener-side Filter keyed by the shared PassthroughState
+ * pointer of the internal user-space socket) and populates filter state for use
+ * by telemetry filters.
  */
 class UpstreamFilter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
 public:
-  UpstreamFilter(Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry);
+  UpstreamFilter(Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry,
+                 bool use_passthrough_state_key);
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& buffer, bool end_stream) override;
@@ -186,9 +191,11 @@ public:
 
 private:
   bool disableDiscovery() const;
-  // Look up peer metadata stored by the paired downstream filter, keyed by this
-  // connection's ID from filter state. Returns false when there is no connection
-  // ID in filter state or the TLS registry is not allocated.
+  // Look up peer metadata stored by the paired downstream filter, keyed by the
+  // shared PassthroughState pointer of the internal user-space socket. Returns
+  // false when the pointer key is disabled or unavailable, or the TLS registry
+  // is not allocated, so the caller can fall back to the legacy in-byte-stream
+  // preamble exchange.
   bool tryRegistryLookup();
   // Legacy fallback: parse and strip the peer metadata preamble from the
   // upstream data stream.
@@ -207,6 +214,7 @@ private:
   PeerMetadataState state_ = PeerMetadataState::WaitingForData;
   Network::ReadFilterCallbacks* callbacks_{};
   Filters::Common::PeerMetadataShared::PeerMetadataRegistrySharedPtr registry_;
+  const bool use_passthrough_state_key_;
 };
 
 /**

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.h
@@ -105,7 +105,7 @@ using Headers = ConstSingleton<HeaderValues>;
 struct FilterNameValues {
   const std::string Name = "istio.peer_metadata";
   const std::string DisableDiscoveryField = "disable_baggage_discovery";
-  const std::string EnableTLSFilterExchange = "enable_tls_filter_exchange";
+  const std::string EnableTLSFilterExchange = "istio.peer_metadata.enable_tls_filter_exchange";
 };
 
 using FilterNames = ConstSingleton<FilterNameValues>;

--- a/contrib/istio/filters/network/peer_metadata/test/BUILD
+++ b/contrib/istio/filters/network/peer_metadata/test/BUILD
@@ -16,6 +16,7 @@ envoy_cc_test(
         "//contrib/istio/filters/network/peer_metadata/source:config",
         "//envoy/router:string_accessor_interface",
         "//source/common/router:string_accessor_lib",
+        "//source/extensions/io_socket/user_space:io_handle_impl_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",
         "//test/mocks/ssl:ssl_mocks",

--- a/contrib/istio/filters/network/peer_metadata/test/BUILD
+++ b/contrib/istio/filters/network/peer_metadata/test/BUILD
@@ -16,6 +16,7 @@ envoy_cc_test(
         "//contrib/istio/filters/network/peer_metadata/source:config",
         "//envoy/router:string_accessor_interface",
         "//source/common/router:string_accessor_lib",
+        "//source/common/stream_info:bool_accessor_lib",
         "//source/extensions/io_socket/user_space:io_handle_impl_lib",
         "//test/mocks/local_info:local_info_mocks",
         "//test/mocks/network:network_mocks",

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -61,9 +61,9 @@ using ::testing::ReturnRef;
 // upstream (cluster-side) filter.
 class TestPeerMetadataRegistry : public Filters::Common::PeerMetadataShared::PeerMetadataRegistry {
 public:
-  void setValue(uint64_t key, const std::string& value) override { store_[key] = value; }
+  void setValue(void* key, const std::string& value) override { store_[key] = value; }
 
-  std::optional<std::string> getValue(uint64_t key) const override {
+  std::optional<std::string> getValue(void* key) const override {
     const auto it = store_.find(key);
     if (it == store_.end()) {
       return std::nullopt;
@@ -71,10 +71,10 @@ public:
     return it->second;
   }
 
-  void removeValue(uint64_t key) override { store_.erase(key); }
+  void removeValue(void* key) override { store_.erase(key); }
 
 private:
-  std::map<uint64_t, std::string> store_;
+  std::map<void*, std::string> store_;
 };
 
 // Serializes peer metadata the same way the listener-side filter stores it in
@@ -112,9 +112,9 @@ decodePeerMetadata(const std::string& serialized) {
 // PassthroughState. The IoHandle and its owning socket are stored in `io_handle`
 // and `socket` (which must outlive the connection), and the key the filter will
 // compute is returned.
-std::uint64_t wireUserSpaceSocket(NiceMock<Network::MockConnection>& connection,
-                                  Extensions::IoSocket::UserSpace::IoHandleImplPtr& io_handle,
-                                  Network::ConnectionSocketPtr& socket) {
+void* wireUserSpaceSocket(NiceMock<Network::MockConnection>& connection,
+                          Extensions::IoSocket::UserSpace::IoHandleImplPtr& io_handle,
+                          Network::ConnectionSocketPtr& socket) {
   auto pair = Extensions::IoSocket::UserSpace::IoHandleFactory::createIoHandlePair();
   io_handle = std::move(pair.first);
   auto owned_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
@@ -122,7 +122,7 @@ std::uint64_t wireUserSpaceSocket(NiceMock<Network::MockConnection>& connection,
   ON_CALL(Const(*owned_socket), ioHandle()).WillByDefault(ReturnRef(*io_handle));
   socket = std::move(owned_socket);
   ON_CALL(connection, getSocket()).WillByDefault(ReturnRef(socket));
-  return reinterpret_cast<std::uint64_t>(io_handle->passthroughState().get());
+  return io_handle->passthroughState().get();
 }
 
 // Which hand-off path the parameterized fixtures exercise. The path is selected
@@ -245,7 +245,7 @@ public:
   Buffer::OwnedImpl injected_write_data_;
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
-  std::uint64_t registry_key_{0};
+  void* registry_key_{nullptr};
   std::unique_ptr<Filter> filter_;
 };
 
@@ -441,7 +441,7 @@ public:
       std::make_shared<TestPeerMetadataRegistry>();
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
-  std::uint64_t registry_key_{0};
+  void* registry_key_{nullptr};
   std::unique_ptr<UpstreamFilter> filter_;
 };
 
@@ -451,8 +451,7 @@ class PeerMetadataUpstreamFilterTest : public PeerMetadataUpstreamFilterTestBase
                                        public ::testing::WithParamInterface<ExchangePath> {
 public:
   void initialize() {
-    PeerMetadataUpstreamFilterTestBase::initialize(GetParam() ==
-                                                   ExchangePath::ThreadLocalRegistry);
+    PeerMetadataUpstreamFilterTestBase::initialize(GetParam() == ExchangePath::ThreadLocalRegistry);
   }
 
   void deliverPeerMetadata(Buffer::Instance& data, absl::string_view baggage,

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -126,9 +126,9 @@ void* wireUserSpaceSocket(NiceMock<Network::MockConnection>& connection,
 }
 
 // Which hand-off path the parameterized fixtures exercise. The path is selected
-// by the use_passthrough_state_key feature flag: when enabled (default) the
-// shared PassthroughState pointer keys the thread-local registry; when disabled
-// the filters fall back to the legacy data-stream preamble exchange.
+// by whether a registry is present: with a registry the shared PassthroughState
+// pointer keys the thread-local registry; without one the filters fall back to
+// the legacy data-stream preamble exchange.
 enum class ExchangePath { DataStreamPreamble, ThreadLocalRegistry };
 
 // Readable parameter names for the path-parameterized fixtures below.
@@ -140,7 +140,7 @@ std::string modeName(const ::testing::TestParamInfo<ExchangePath>& info) {
 class PeerMetadataFilterTest : public ::testing::TestWithParam<ExchangePath> {
 public:
   // Builds a downstream Filter config. The exchange path is not selected by
-  // config; it is driven by the use_passthrough_state_key feature flag.
+  // config; it is driven by whether the filter is given a registry.
   Config makeConfig(absl::string_view baggage_key) {
     Config config;
     config.set_baggage_key(baggage_key);
@@ -186,7 +186,7 @@ public:
   }
 
   void initialize(const Config& config) {
-    const bool use_passthrough_state_key = GetParam() == ExchangePath::ThreadLocalRegistry;
+    const bool use_registry = GetParam() == ExchangePath::ThreadLocalRegistry;
 
     ON_CALL(local_info_, node()).WillByDefault(ReturnRef(node_metadata_));
 
@@ -201,12 +201,19 @@ public:
     ON_CALL(write_filter_callbacks_, injectWriteDataToFilterChain(_, _))
         .WillByDefault([this](Buffer::Instance& data, bool) { injected_write_data_.add(data); });
 
-    if (use_passthrough_state_key) {
+    if (use_registry) {
       registry_key_ =
           wireUserSpaceSocket(read_filter_callbacks_.connection_, io_handle_, connection_socket_);
+      // Enable the TLS filter exchange on the upstream host so storeInRegistry uses the registry.
+      upstream_host_ = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+      Protobuf::Struct md;
+      (*md.mutable_fields())[FilterNames::get().EnableTLSFilterExchange].set_bool_value(true);
+      (*upstream_host_->cluster_.metadata_.mutable_filter_metadata())[FilterNames::get().Name]
+          .MergeFrom(md);
+      stream_info_.upstreamInfo()->setUpstreamHost(upstream_host_);
     }
 
-    filter_ = std::make_unique<Filter>(config, local_info_, registry_, use_passthrough_state_key);
+    filter_ = std::make_unique<Filter>(config, local_info_, use_registry ? registry_ : nullptr);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->initializeWriteFilterCallbacks(write_filter_callbacks_);
   }
@@ -246,6 +253,7 @@ public:
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
   void* registry_key_{nullptr};
+  std::shared_ptr<NiceMock<Upstream::MockHostDescription>> upstream_host_;
   std::unique_ptr<Filter> filter_;
 };
 
@@ -380,17 +388,18 @@ std::shared_ptr<NiceMock<Upstream::MockHostDescription>> makeIpv4Host(absl::stri
 
 class PeerMetadataUpstreamFilterTestBase : public ::testing::Test {
 public:
-  void initialize(bool use_passthrough_state_key = false) {
+  void initialize(bool use_registry = false) {
+    use_registry_ = use_registry;
     ON_CALL(callbacks_.connection_, streamInfo()).WillByDefault(ReturnRef(stream_info_));
     ON_CALL(Const(callbacks_.connection_), streamInfo()).WillByDefault(ReturnRef(stream_info_));
 
     host_metadata_ = std::make_shared<::envoy::config::core::v3::Metadata>();
 
-    if (use_passthrough_state_key) {
+    if (use_registry) {
       registry_key_ = wireUserSpaceSocket(callbacks_.connection_, io_handle_, connection_socket_);
     }
 
-    filter_ = std::make_unique<UpstreamFilter>(registry_, use_passthrough_state_key);
+    filter_ = std::make_unique<UpstreamFilter>(use_registry ? registry_ : nullptr);
     filter_->initializeReadFilterCallbacks(callbacks_);
   }
 
@@ -430,6 +439,12 @@ public:
   void setUpstreamHost(const std::shared_ptr<NiceMock<Upstream::MockHostDescription>>& host) {
     upstream_host_ = host;
     ON_CALL(Const(*upstream_host_), metadata()).WillByDefault(Return(host_metadata_));
+    if (use_registry_) {
+      Protobuf::Struct md;
+      (*md.mutable_fields())[FilterNames::get().EnableTLSFilterExchange].set_bool_value(true);
+      (*upstream_host_->cluster_.metadata_.mutable_filter_metadata())[FilterNames::get().Name]
+          .MergeFrom(md);
+    }
     stream_info_.upstreamInfo()->setUpstreamHost(upstream_host_);
   }
 
@@ -442,6 +457,7 @@ public:
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
   void* registry_key_{nullptr};
+  bool use_registry_{false};
   std::unique_ptr<UpstreamFilter> filter_;
 };
 
@@ -579,7 +595,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
 // stored under that key. The upstream filter must fall back to marking the peer
 // as unknown by populating NoPeer.
 TEST_F(PeerMetadataUpstreamFilterTestBase, TestNoPeerPopulatedWhenRegistryEmpty) {
-  initialize(/*use_passthrough_state_key=*/true);
+  initialize(/*use_registry=*/true);
   setUpstreamHost(makeInternalListenerHost("connect_originate"));
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -24,6 +25,7 @@
 #include "source/common/network/address_impl.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
+#include "source/extensions/io_socket/user_space/io_handle_impl.h"
 
 #include "test/mocks/local_info/mocks.h"
 #include "test/mocks/network/mocks.h"
@@ -47,7 +49,6 @@ constexpr absl::string_view defaultIdentity = "spiffe://cluster.local/ns/default
 constexpr absl::string_view defaultBaggage =
     "k8s.deployment.name=server,service.name=server-service,service.version=v2,k8s.namespace.name="
     "default,k8s.cluster.name=cluster";
-constexpr absl::string_view defaultConnectionId = "1234";
 
 using ::testing::_;
 using ::testing::Const;
@@ -60,22 +61,20 @@ using ::testing::ReturnRef;
 // upstream (cluster-side) filter.
 class TestPeerMetadataRegistry : public Filters::Common::PeerMetadataShared::PeerMetadataRegistry {
 public:
-  void setValue(absl::string_view key, const std::string& value) override {
-    store_[std::string(key)] = value;
-  }
+  void setValue(uint64_t key, const std::string& value) override { store_[key] = value; }
 
-  std::optional<std::string> getValue(absl::string_view key) const override {
-    const auto it = store_.find(std::string(key));
+  std::optional<std::string> getValue(uint64_t key) const override {
+    const auto it = store_.find(key);
     if (it == store_.end()) {
       return std::nullopt;
     }
     return it->second;
   }
 
-  void removeValue(absl::string_view key) override { store_.erase(std::string(key)); }
+  void removeValue(uint64_t key) override { store_.erase(key); }
 
 private:
-  std::map<std::string, std::string> store_;
+  std::map<uint64_t, std::string> store_;
 };
 
 // Serializes peer metadata the same way the listener-side filter stores it in
@@ -108,10 +107,28 @@ decodePeerMetadata(const std::string& serialized) {
   return *metadata;
 }
 
-// Which hand-off path the parameterized fixtures exercise. With the mode field
-// removed, the path is selected at runtime by the presence (registry) or
-// absence (legacy data-stream preamble) of the downstream connection ID in
-// filter state.
+// Wires a real user-space IoHandle into `connection` so the source filter's
+// pointer-keyed registry path derives a stable key from the shared
+// PassthroughState. The IoHandle and its owning socket are stored in `io_handle`
+// and `socket` (which must outlive the connection), and the key the filter will
+// compute is returned.
+std::uint64_t wireUserSpaceSocket(NiceMock<Network::MockConnection>& connection,
+                                  Extensions::IoSocket::UserSpace::IoHandleImplPtr& io_handle,
+                                  Network::ConnectionSocketPtr& socket) {
+  auto pair = Extensions::IoSocket::UserSpace::IoHandleFactory::createIoHandlePair();
+  io_handle = std::move(pair.first);
+  auto owned_socket = std::make_unique<NiceMock<Network::MockConnectionSocket>>();
+  ON_CALL(*owned_socket, ioHandle()).WillByDefault(ReturnRef(*io_handle));
+  ON_CALL(Const(*owned_socket), ioHandle()).WillByDefault(ReturnRef(*io_handle));
+  socket = std::move(owned_socket);
+  ON_CALL(connection, getSocket()).WillByDefault(ReturnRef(socket));
+  return reinterpret_cast<std::uint64_t>(io_handle->passthroughState().get());
+}
+
+// Which hand-off path the parameterized fixtures exercise. The path is selected
+// by the use_passthrough_state_key feature flag: when enabled (default) the
+// shared PassthroughState pointer keys the thread-local registry; when disabled
+// the filters fall back to the legacy data-stream preamble exchange.
 enum class ExchangePath { DataStreamPreamble, ThreadLocalRegistry };
 
 // Readable parameter names for the path-parameterized fixtures below.
@@ -122,8 +139,8 @@ std::string modeName(const ::testing::TestParamInfo<ExchangePath>& info) {
 
 class PeerMetadataFilterTest : public ::testing::TestWithParam<ExchangePath> {
 public:
-  // Builds a downstream Filter config. The exchange path is no longer selected
-  // by config; it is driven at runtime by connection-ID presence.
+  // Builds a downstream Filter config. The exchange path is not selected by
+  // config; it is driven by the use_passthrough_state_key feature flag.
   Config makeConfig(absl::string_view baggage_key) {
     Config config;
     config.set_baggage_key(baggage_key);
@@ -169,6 +186,8 @@ public:
   }
 
   void initialize(const Config& config) {
+    const bool use_passthrough_state_key = GetParam() == ExchangePath::ThreadLocalRegistry;
+
     ON_CALL(local_info_, node()).WillByDefault(ReturnRef(node_metadata_));
 
     ON_CALL(read_filter_callbacks_.connection_, streamInfo())
@@ -182,29 +201,19 @@ public:
     ON_CALL(write_filter_callbacks_, injectWriteDataToFilterChain(_, _))
         .WillByDefault([this](Buffer::Instance& data, bool) { injected_write_data_.add(data); });
 
-    filter_ = std::make_unique<Filter>(config, local_info_, registry_);
+    if (use_passthrough_state_key) {
+      registry_key_ =
+          wireUserSpaceSocket(read_filter_callbacks_.connection_, io_handle_, connection_socket_);
+    }
+
+    filter_ = std::make_unique<Filter>(config, local_info_, registry_, use_passthrough_state_key);
     filter_->initializeReadFilterCallbacks(read_filter_callbacks_);
     filter_->initializeWriteFilterCallbacks(write_filter_callbacks_);
   }
 
-  void setConnectionId(absl::string_view id) {
-    stream_info_.filterState()->setData(
-        Filters::Common::PeerMetadataShared::ConnectionIdFilterStateKey,
-        std::make_shared<Router::StringAccessorImpl>(id),
-        StreamInfo::FilterState::LifeSpan::Connection);
-  }
-
-  // Sets the downstream connection ID (registry key) only for the registry
-  // path; its absence selects the legacy data-stream preamble path.
-  void maybeSetConnectionId() {
-    if (GetParam() == ExchangePath::ThreadLocalRegistry) {
-      setConnectionId(defaultConnectionId);
-    }
-  }
-
   std::optional<Istio::Common::WorkloadMetadataObject> propagatedPeerMetadata() {
     if (GetParam() == ExchangePath::ThreadLocalRegistry) {
-      const auto stored = registry_->getValue(defaultConnectionId);
+      const auto stored = registry_->getValue(registry_key_);
       if (!stored.has_value()) {
         return std::nullopt;
       }
@@ -234,6 +243,9 @@ public:
   std::shared_ptr<TestPeerMetadataRegistry> registry_ =
       std::make_shared<TestPeerMetadataRegistry>();
   Buffer::OwnedImpl injected_write_data_;
+  Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
+  Network::ConnectionSocketPtr connection_socket_;
+  std::uint64_t registry_key_{0};
   std::unique_ptr<Filter> filter_;
 };
 
@@ -273,8 +285,6 @@ TEST_P(PeerMetadataFilterTest, TestPeerMetadataDiscoveredAndPropagated) {
   std::vector<std::string> sans{identity};
   populateUpstreamSans(sans);
 
-  maybeSetConnectionId();
-
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
   Buffer::OwnedImpl data;
@@ -294,8 +304,6 @@ TEST_P(PeerMetadataFilterTest, TestNoFiltersStateFromTcpProxy) {
 
   std::vector<std::string> sans{identity};
   populateUpstreamSans(sans);
-
-  maybeSetConnectionId();
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
@@ -318,8 +326,6 @@ TEST_P(PeerMetadataFilterTest, TestNoBaggageHeaderFromTcpProxy) {
   std::vector<std::string> sans{identity};
   populateUpstreamSans(sans);
 
-  maybeSetConnectionId();
-
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
   Buffer::OwnedImpl data;
@@ -341,7 +347,6 @@ TEST_P(PeerMetadataFilterTest, TestDisablePeerDiscovery) {
   std::vector<std::string> sans{identity};
   populateUpstreamSans(sans);
 
-  maybeSetConnectionId();
   disablePeerDiscovery();
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
@@ -375,21 +380,18 @@ std::shared_ptr<NiceMock<Upstream::MockHostDescription>> makeIpv4Host(absl::stri
 
 class PeerMetadataUpstreamFilterTestBase : public ::testing::Test {
 public:
-  void initialize() {
+  void initialize(bool use_passthrough_state_key = false) {
     ON_CALL(callbacks_.connection_, streamInfo()).WillByDefault(ReturnRef(stream_info_));
     ON_CALL(Const(callbacks_.connection_), streamInfo()).WillByDefault(ReturnRef(stream_info_));
 
     host_metadata_ = std::make_shared<::envoy::config::core::v3::Metadata>();
 
-    filter_ = std::make_unique<UpstreamFilter>(registry_);
-    filter_->initializeReadFilterCallbacks(callbacks_);
-  }
+    if (use_passthrough_state_key) {
+      registry_key_ = wireUserSpaceSocket(callbacks_.connection_, io_handle_, connection_socket_);
+    }
 
-  void setConnectionId(absl::string_view id) {
-    stream_info_.filterState()->setData(
-        Filters::Common::PeerMetadataShared::ConnectionIdFilterStateKey,
-        std::make_shared<Router::StringAccessorImpl>(id),
-        StreamInfo::FilterState::LifeSpan::Connection);
+    filter_ = std::make_unique<UpstreamFilter>(registry_, use_passthrough_state_key);
+    filter_->initializeReadFilterCallbacks(callbacks_);
   }
 
   ::envoy::config::core::v3::Metadata& hostMetadata() { return *host_metadata_; }
@@ -437,6 +439,9 @@ public:
   std::shared_ptr<::envoy::config::core::v3::Metadata> host_metadata_;
   std::shared_ptr<TestPeerMetadataRegistry> registry_ =
       std::make_shared<TestPeerMetadataRegistry>();
+  Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
+  Network::ConnectionSocketPtr connection_socket_;
+  std::uint64_t registry_key_{0};
   std::unique_ptr<UpstreamFilter> filter_;
 };
 
@@ -445,11 +450,16 @@ public:
 class PeerMetadataUpstreamFilterTest : public PeerMetadataUpstreamFilterTestBase,
                                        public ::testing::WithParamInterface<ExchangePath> {
 public:
+  void initialize() {
+    PeerMetadataUpstreamFilterTestBase::initialize(GetParam() ==
+                                                   ExchangePath::ThreadLocalRegistry);
+  }
+
   void deliverPeerMetadata(Buffer::Instance& data, absl::string_view baggage,
                            absl::string_view identity) {
     const std::string serialized = encodePeerMetadata(baggage, identity);
     if (GetParam() == ExchangePath::ThreadLocalRegistry) {
-      registry_->setValue(defaultConnectionId, serialized);
+      registry_->setValue(registry_key_, serialized);
       return;
     }
     PeerMetadataHeader header{PeerMetadataHeader::magic_number,
@@ -461,20 +471,11 @@ public:
     data.drain(data.length());
     data.add(preamble);
   }
-
-  // Sets the downstream connection ID (registry key) only for the registry
-  // path; its absence selects the legacy data-stream preamble path.
-  void maybeSetConnectionId() {
-    if (GetParam() == ExchangePath::ThreadLocalRegistry) {
-      setConnectionId(defaultConnectionId);
-    }
-  }
 };
 
 TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataConsumedAndPropagated) {
   initialize();
   setUpstreamHost(makeInternalListenerHost("connect_originate"));
-  maybeSetConnectionId();
 
   Buffer::OwnedImpl data;
   data.add("application data");
@@ -487,7 +488,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataConsumedAndPropagated) {
   // data is untouched. Either way only the payload remains.
   EXPECT_EQ(data.toString(), "application data");
   // The registry entry (if any) is consumed once read.
-  EXPECT_FALSE(registry_->getValue(defaultConnectionId).has_value());
+  EXPECT_FALSE(registry_->getValue(registry_key_).has_value());
 
   const auto peer_info = peerInfoFromFilterState();
   ASSERT_TRUE(peer_info.has_value());
@@ -498,8 +499,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataConsumedAndPropagated) {
 TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedForUnknownInternalListeners) {
   initialize();
   setUpstreamHost(makeInternalListenerHost("not_connect_originate"));
-  maybeSetConnectionId();
-  registry_->setValue(defaultConnectionId, encodePeerMetadata(defaultBaggage, defaultIdentity));
+  registry_->setValue(registry_key_, encodePeerMetadata(defaultBaggage, defaultIdentity));
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
@@ -516,8 +516,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedForUnknownInte
 TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedForExternalHosts) {
   initialize();
   setUpstreamHost(makeIpv4Host("192.168.0.1"));
-  maybeSetConnectionId();
-  registry_->setValue(defaultConnectionId, encodePeerMetadata(defaultBaggage, defaultIdentity));
+  registry_->setValue(registry_key_, encodePeerMetadata(defaultBaggage, defaultIdentity));
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
@@ -540,8 +539,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   (*fields)[FilterNames::get().DisableDiscoveryField].set_bool_value(true);
   (*hostMetadata().mutable_filter_metadata())[FilterNames::get().Name].MergeFrom(metadata);
 
-  maybeSetConnectionId();
-  registry_->setValue(defaultConnectionId, encodePeerMetadata(defaultBaggage, defaultIdentity));
+  registry_->setValue(registry_key_, encodePeerMetadata(defaultBaggage, defaultIdentity));
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
@@ -550,7 +548,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   data.add(payload);
   EXPECT_EQ(filter_->onData(data, /*end_stream*/ false), Network::FilterStatus::Continue);
 
-  EXPECT_TRUE(registry_->getValue(defaultConnectionId).has_value());
+  EXPECT_TRUE(registry_->getValue(registry_key_).has_value());
   const auto peer_info = peerInfoFromFilterState();
   EXPECT_FALSE(peer_info.has_value());
 }
@@ -564,8 +562,7 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   (*fields2)[FilterNames::get().DisableDiscoveryField].set_bool_value(true);
   (*clusterMetadata().mutable_filter_metadata())[FilterNames::get().Name].MergeFrom(metadata2);
 
-  maybeSetConnectionId();
-  registry_->setValue(defaultConnectionId, encodePeerMetadata(defaultBaggage, defaultIdentity));
+  registry_->setValue(registry_key_, encodePeerMetadata(defaultBaggage, defaultIdentity));
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 
@@ -574,18 +571,17 @@ TEST_P(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   data.add(payload);
   EXPECT_EQ(filter_->onData(data, /*end_stream*/ false), Network::FilterStatus::Continue);
 
-  EXPECT_TRUE(registry_->getValue(defaultConnectionId).has_value());
+  EXPECT_TRUE(registry_->getValue(registry_key_).has_value());
   const auto peer_info = peerInfoFromFilterState();
   EXPECT_FALSE(peer_info.has_value());
 }
 
-// Registry hand-off is active (the downstream connection ID is present in filter
-// state) but nothing was ever stored under that key. The upstream filter must
-// fall back to marking the peer as unknown by populating NoPeer.
+// Registry hand-off is active (the pointer key is enabled) but nothing was ever
+// stored under that key. The upstream filter must fall back to marking the peer
+// as unknown by populating NoPeer.
 TEST_F(PeerMetadataUpstreamFilterTestBase, TestNoPeerPopulatedWhenRegistryEmpty) {
-  initialize();
+  initialize(/*use_passthrough_state_key=*/true);
   setUpstreamHost(makeInternalListenerHost("connect_originate"));
-  setConnectionId(defaultConnectionId);
 
   EXPECT_EQ(filter_->onNewConnection(), Network::FilterStatus::Continue);
 

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -24,6 +24,7 @@
 #include "source/common/http/utility.h"
 #include "source/common/network/address_impl.h"
 #include "source/common/router/string_accessor_impl.h"
+#include "source/common/stream_info/bool_accessor_impl.h"
 #include "source/common/tcp_proxy/tcp_proxy.h"
 #include "source/extensions/io_socket/user_space/io_handle_impl.h"
 
@@ -185,6 +186,23 @@ public:
         metadata);
   }
 
+  void configureThreadLocalExchange() {
+    const bool enable = GetParam() == ExchangePath::ThreadLocalRegistry;
+    if (enable) {
+      stream_info_.filterState()->setData(
+          FilterNames::get().EnableTLSFilterExchange,
+          std::make_shared<StreamInfo::BoolAccessorImpl>(true),
+          StreamInfo::FilterState::LifeSpan::Connection,
+          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
+    } else {
+      stream_info_.filterState()->setData(
+          FilterNames::get().EnableTLSFilterExchange,
+          std::make_shared<StreamInfo::BoolAccessorImpl>(false),
+          StreamInfo::FilterState::LifeSpan::Connection,
+          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
+    }
+  }
+
   void initialize(const Config& config) {
     const bool use_registry = GetParam() == ExchangePath::ThreadLocalRegistry;
 
@@ -204,13 +222,6 @@ public:
     if (use_registry) {
       registry_key_ =
           wireUserSpaceSocket(read_filter_callbacks_.connection_, io_handle_, connection_socket_);
-      // Enable the TLS filter exchange on the upstream host so storeInRegistry uses the registry.
-      upstream_host_ = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
-      Protobuf::Struct md;
-      (*md.mutable_fields())[FilterNames::get().EnableTLSFilterExchange].set_bool_value(true);
-      (*upstream_host_->cluster_.metadata_.mutable_filter_metadata())[FilterNames::get().Name]
-          .MergeFrom(md);
-      stream_info_.upstreamInfo()->setUpstreamHost(upstream_host_);
     }
 
     filter_ = std::make_unique<Filter>(config, local_info_, use_registry ? registry_ : nullptr);
@@ -253,7 +264,6 @@ public:
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
   void* registry_key_{nullptr};
-  std::shared_ptr<NiceMock<Upstream::MockHostDescription>> upstream_host_;
   std::unique_ptr<Filter> filter_;
 };
 
@@ -286,6 +296,7 @@ TEST_P(PeerMetadataFilterTest, TestPeerMetadataDiscoveredAndPropagated) {
 
   populateNodeMetadata("workload", "deployment", "workload-service", "v1", "default", "cluster");
   initialize(makeConfig(defaultBaggageKey));
+  configureThreadLocalExchange();
 
   Http::TestResponseHeaderMapImpl headers{{Headers::get().Baggage.get(), baggage}};
   populateTcpProxyResponseHeaders(headers);
@@ -309,6 +320,7 @@ TEST_P(PeerMetadataFilterTest, TestNoFiltersStateFromTcpProxy) {
 
   populateNodeMetadata("workload", "deployment", "workload-service", "v1", "default", "cluster");
   initialize(makeConfig(defaultBaggageKey));
+  configureThreadLocalExchange();
 
   std::vector<std::string> sans{identity};
   populateUpstreamSans(sans);
@@ -327,6 +339,7 @@ TEST_P(PeerMetadataFilterTest, TestNoBaggageHeaderFromTcpProxy) {
 
   populateNodeMetadata("workload", "deployment", "workload-service", "v1", "default", "cluster");
   initialize(makeConfig(defaultBaggageKey));
+  configureThreadLocalExchange();
 
   Http::TestResponseHeaderMapImpl headers{{"bibbage", baggage}};
   populateTcpProxyResponseHeaders(headers);
@@ -348,6 +361,7 @@ TEST_P(PeerMetadataFilterTest, TestDisablePeerDiscovery) {
 
   populateNodeMetadata("workload", "deployment", "workload-service", "v1", "default", "cluster");
   initialize(makeConfig(defaultBaggageKey));
+  configureThreadLocalExchange();
 
   Http::TestResponseHeaderMapImpl headers{{Headers::get().Baggage.get(), baggage}};
   populateTcpProxyResponseHeaders(headers);
@@ -389,14 +403,24 @@ std::shared_ptr<NiceMock<Upstream::MockHostDescription>> makeIpv4Host(absl::stri
 class PeerMetadataUpstreamFilterTestBase : public ::testing::Test {
 public:
   void initialize(bool use_registry = false) {
-    use_registry_ = use_registry;
     ON_CALL(callbacks_.connection_, streamInfo()).WillByDefault(ReturnRef(stream_info_));
     ON_CALL(Const(callbacks_.connection_), streamInfo()).WillByDefault(ReturnRef(stream_info_));
 
     host_metadata_ = std::make_shared<::envoy::config::core::v3::Metadata>();
 
     if (use_registry) {
+      stream_info_.filterState()->setData(
+          FilterNames::get().EnableTLSFilterExchange,
+          std::make_shared<StreamInfo::BoolAccessorImpl>(true),
+          StreamInfo::FilterState::LifeSpan::Connection,
+          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
       registry_key_ = wireUserSpaceSocket(callbacks_.connection_, io_handle_, connection_socket_);
+    } else {
+      stream_info_.filterState()->setData(
+          FilterNames::get().EnableTLSFilterExchange,
+          std::make_shared<StreamInfo::BoolAccessorImpl>(false),
+          StreamInfo::FilterState::LifeSpan::Connection,
+          StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
     }
 
     filter_ = std::make_unique<UpstreamFilter>(use_registry ? registry_ : nullptr);
@@ -439,12 +463,6 @@ public:
   void setUpstreamHost(const std::shared_ptr<NiceMock<Upstream::MockHostDescription>>& host) {
     upstream_host_ = host;
     ON_CALL(Const(*upstream_host_), metadata()).WillByDefault(Return(host_metadata_));
-    if (use_registry_) {
-      Protobuf::Struct md;
-      (*md.mutable_fields())[FilterNames::get().EnableTLSFilterExchange].set_bool_value(true);
-      (*upstream_host_->cluster_.metadata_.mutable_filter_metadata())[FilterNames::get().Name]
-          .MergeFrom(md);
-    }
     stream_info_.upstreamInfo()->setUpstreamHost(upstream_host_);
   }
 
@@ -457,7 +475,6 @@ public:
   Extensions::IoSocket::UserSpace::IoHandleImplPtr io_handle_;
   Network::ConnectionSocketPtr connection_socket_;
   void* registry_key_{nullptr};
-  bool use_registry_{false};
   std::unique_ptr<UpstreamFilter> filter_;
 };
 


### PR DESCRIPTION
Commit Message:

This pull request introduces a new mechanism for Istio peer_metadata filters communicating across an internal socket/listener to exchange peer metadata information through thread local storage.

The previous implementation would do inject peer metadata into the data stream directly, but that does not work when internal transport socket wraps a PROXY or TLS socket because those aren't prepared to use handle the arbitrary data injected into the data stream.

To fix that problem we tried to use thread local storage instead of injecting data into the data stream and used downstream connection ID as a shared key in the thread local storage that both filters are aware of, but that approach does not work well when multiple requests are multiplexed over the same downstream HTTP2 connection - they would share the same downstream connection ID and will use the same key for thread local storage, even if the destinations are different.

The new implementation in this PR uses thread local storage, just like the approach above, but instead of using downstream connection ID it uses PassthroughState pointer value as a key. PassthroughState pointer is basically allocated per upstream connection, so that addresses the issue with multiplexed requests - as we get a unique key per upstream connection after endpoint selection and multiplexing decisions have been made already.

Additional Description:
Risk Level: low - feature is specific to Istio and does not touch core Envoy, and it's disabled by default.
Testing: integration tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
