### PR TITLE
network_ext_proc: support connection attributes and filter state

### DIFF
--- a/api/envoy/extensions/filters/network/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/network/ext_proc/v3/ext_proc.proto
@@ -34,7 +34,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 //
 // By using the filter's processing mode, you can selectively choose which data
 // directions to process (read, write or both), allowing for efficient processing.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message NetworkExternalProcessor {
   // The gRPC service that will process network traffic.
   // This service must implement the NetworkExternalProcessor service
@@ -64,6 +64,14 @@ message NetworkExternalProcessor {
 
   // Options related to the sending and receiving of dynamic metadata.
   MetadataOptions metadata_options = 6;
+
+  // The data plane provides a number of :ref:`attributes <arch_overview_attributes>`
+  // for expressive policies. Each attribute name provided in this field will be
+  // evaluated against the connection and filter state and populated in the
+  // :ref:`ProcessingRequest.attributes <envoy_v3_api_field_service.network_ext_proc.v3.ProcessingRequest.attributes>` field.
+  // See the :ref:`attribute documentation <arch_overview_attributes>`
+  // for the list of supported attributes and their types.
+  repeated string connection_attributes = 7;
 }
 
 // Options for controlling processing behavior.

--- a/api/envoy/service/network_ext_proc/v3/network_external_processor.proto
+++ b/api/envoy/service/network_ext_proc/v3/network_external_processor.proto
@@ -72,7 +72,6 @@ message Data {
 // ProcessingRequest contains data sent from Envoy to the external processing server.
 // Each request contains either read data (from client) or write data (to client)
 // along with optional metadata and attributes.
-// [#next-free-field: 5]
 message ProcessingRequest {
   // ReadData contains the network data intercepted in the request path (client to server).
   // This is sent to the external processor when data arrives from the downstream client.

--- a/api/envoy/service/network_ext_proc/v3/network_external_processor.proto
+++ b/api/envoy/service/network_ext_proc/v3/network_external_processor.proto
@@ -71,7 +71,8 @@ message Data {
 
 // ProcessingRequest contains data sent from Envoy to the external processing server.
 // Each request contains either read data (from client) or write data (to client)
-// along with optional metadata.
+// along with optional metadata and attributes.
+// [#next-free-field: 5]
 message ProcessingRequest {
   // ReadData contains the network data intercepted in the request path (client to server).
   // This is sent to the external processor when data arrives from the downstream client.
@@ -90,6 +91,11 @@ message ProcessingRequest {
   // The metadata is not automatically propagated from request to response.
   // The external processor must include any needed metadata in its response.
   config.core.v3.Metadata metadata = 3;
+
+  // The values of properties selected by the ``connection_attributes``
+  // list in the configuration. Each entry in the list is populated
+  // from the standard :ref:`attributes <arch_overview_attributes>` supported in the data plane.
+  map<string, google.protobuf.Struct> attributes = 4;
 }
 
 // ProcessingResponse contains the response from the external processing server to Envoy.

--- a/changelogs/current/new_features/network_ext_proc__connection-attributes.rst
+++ b/changelogs/current/new_features/network_ext_proc__connection-attributes.rst
@@ -1,0 +1,5 @@
+Added support for evaluating CEL connection attributes and filter state in network external processor.
+Configured via :ref:`connection_attributes
+<envoy_v3_api_field_extensions.filters.network.ext_proc.v3.NetworkExternalProcessor.connection_attributes>`
+and sent in :ref:`ProcessingRequest.attributes
+<envoy_v3_api_field_service.network_ext_proc.v3.ProcessingRequest.attributes>`.

--- a/docs/root/configuration/listeners/network_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/ext_proc_filter.rst
@@ -55,6 +55,15 @@ to forward selected dynamic metadata namespaces to the external processor:
 * ``untyped`` namespaces are sent as ``google.protobuf.Struct``.
 * ``typed`` namespaces are sent as ``google.protobuf.Any``.
 
+Connection attributes
+---------------------
+
+Use
+:ref:`connection_attributes <envoy_v3_api_field_extensions.filters.network.ext_proc.v3.NetworkExternalProcessor.connection_attributes>`
+to evaluate CEL expressions against the connection's stream info and filter state (e.g. ``connection.id``, ``connection.mtls``, ``filter_state['authority']``).
+The evaluated attributes will be included in the initial
+:ref:`ProcessingRequest.attributes <envoy_v3_api_field_service.network_ext_proc.v3.ProcessingRequest.attributes>` message.
+
 Example
 -------
 

--- a/source/extensions/filters/network/ext_proc/BUILD
+++ b/source/extensions/filters/network/ext_proc/BUILD
@@ -23,14 +23,44 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "matching_utils_lib",
+    srcs = ["matching_utils.cc"],
+    hdrs = ["matching_utils.h"],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "-DUSE_CEL_PARSER",
+        ],
+    }),
+    tags = ["skip_on_windows"],
+    deps = [
+        "//envoy/local_info:local_info_interface",
+        "//source/common/protobuf",
+        "//source/extensions/filters/common/expr:evaluator_lib",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/status",
+        "@cel-cpp//eval/public:cel_expr_builder_factory",
+    ] + select(
+        {
+            "//bazel:windows_x86_64": [],
+            "//conditions:default": [
+                "@cel-cpp//parser",
+            ],
+        },
+    ),
+)
+
+envoy_cc_library(
     name = "ext_proc_lib",
     srcs = ["ext_proc.cc"],
     hdrs = ["ext_proc.h"],
     deps = [
         ":client_lib",
+        ":matching_utils_lib",
         "//envoy/network:connection_interface",
         "//envoy/network:filter_interface",
         "//envoy/upstream:cluster_manager_interface",
+        "//source/extensions/filters/common/expr:evaluator_lib",
         "//source/extensions/filters/network:well_known_names",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/ext_proc/v3:pkg_cc_proto",
@@ -44,7 +74,9 @@ envoy_cc_extension(
     hdrs = ["config.h"],
     deps = [
         ":client_lib",
+        ":matching_utils_lib",
         "//envoy/registry",
+        "//source/extensions/filters/common/expr:evaluator_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "//source/extensions/filters/network/ext_proc:ext_proc_lib",

--- a/source/extensions/filters/network/ext_proc/config.cc
+++ b/source/extensions/filters/network/ext_proc/config.cc
@@ -8,6 +8,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/registry/registry.h"
 
+#include "source/extensions/filters/common/expr/evaluator.h"
 #include "source/extensions/filters/network/ext_proc/ext_proc.h"
 
 namespace Envoy {
@@ -42,8 +43,14 @@ Network::FilterFactoryCb NetworkExtProcConfigFactory::createFilterFactoryFromPro
   if (!result.ok()) {
     throw EnvoyException(std::string(result.message()));
   }
-  ConfigConstSharedPtr ext_proc_config =
-      std::make_shared<const Config>(proto_config, context.scope());
+  absl::Status creation_status = absl::OkStatus();
+  ConfigConstSharedPtr ext_proc_config = std::make_shared<const Config>(
+      proto_config, context.scope(),
+      Envoy::Extensions::Filters::Common::Expr::getBuilder(context.serverFactoryContext()),
+      &context.serverFactoryContext().localInfo(), creation_status);
+  if (!creation_status.ok()) {
+    throw EnvoyException(std::string(creation_status.message()));
+  }
 
   return [ext_proc_config, &context](Network::FilterManager& filter_manager) -> void {
     auto client = createExternalProcessorClient(

--- a/source/extensions/filters/network/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/network/ext_proc/ext_proc.cc
@@ -91,6 +91,34 @@ void NetworkExtProcLoggingInfo::setConnectionInfo(const Network::Connection* con
   }
 }
 
+Config::Config(
+    const envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor& config,
+    Stats::Scope& scope, Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder,
+    const LocalInfo::LocalInfo* local_info, absl::Status& creation_status)
+    : failure_mode_allow_(config.failure_mode_allow()), processing_mode_(config.processing_mode()),
+      grpc_service_(config.grpc_service()),
+      untyped_forwarding_namespaces_(
+          config.metadata_options().forwarding_namespaces().untyped().begin(),
+          config.metadata_options().forwarding_namespaces().untyped().end()),
+      typed_forwarding_namespaces_(
+          config.metadata_options().forwarding_namespaces().typed().begin(),
+          config.metadata_options().forwarding_namespaces().typed().end()),
+      untyped_receiving_namespaces_(
+          config.metadata_options().receiving_namespaces().untyped().begin(),
+          config.metadata_options().receiving_namespaces().untyped().end()),
+      stats_(generateStats(config.stat_prefix(), scope)),
+      message_timeout_(std::chrono::milliseconds(
+          PROTOBUF_GET_MS_OR_DEFAULT(config, message_timeout, DefaultMessageTimeoutMs))),
+      expression_manager_(builder, local_info, config.connection_attributes(), creation_status) {}
+
+Config::Config(
+    const envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor& config,
+    Stats::Scope& scope)
+    : Config(config, scope, nullptr, nullptr, []() -> absl::Status& {
+        static absl::Status* status = new absl::Status(absl::OkStatus());
+        return *status;
+      }()) {}
+
 NetworkExtProcFilter::NetworkExtProcFilter(ConfigConstSharedPtr config,
                                            ExternalProcessorClientPtr&& client)
     : config_(config), stats_(config->stats()), client_(std::move(client)),
@@ -311,6 +339,7 @@ void NetworkExtProcFilter::sendRequest(Buffer::Instance& data, bool end_stream, 
   // Prepare the request message
   ProcessingRequest request;
   addDynamicMetadata(request);
+  addAttributes(request);
 
   if (is_read) {
     auto* read_data = request.mutable_read_data();
@@ -585,6 +614,21 @@ void NetworkExtProcFilter::addDynamicMetadata(ProcessingRequest& req) {
       !forwarding_metadata.typed_filter_metadata().empty()) {
     *req.mutable_metadata() = std::move(forwarding_metadata);
   }
+}
+
+void NetworkExtProcFilter::addAttributes(ProcessingRequest& req) {
+  if (attributes_sent_ || !config_->expressionManager().hasConnectionExpr()) {
+    return;
+  }
+
+  auto activation_ptr = Filters::Common::Expr::createActivation(
+      config_->expressionManager().localInfo(), read_callbacks_->connection().streamInfo(), nullptr,
+      nullptr, nullptr);
+  auto attributes = config_->expressionManager().evaluateConnectionAttributes(*activation_ptr);
+
+  attributes_sent_ = true;
+  (*req.mutable_attributes())[NetworkFilterNames::get().NetworkExternalProcessor] =
+      std::move(attributes);
 }
 
 } // namespace ExtProc

--- a/source/extensions/filters/network/ext_proc/ext_proc.h
+++ b/source/extensions/filters/network/ext_proc/ext_proc.h
@@ -13,6 +13,7 @@
 #include "envoy/service/network_ext_proc/v3/network_external_processor.pb.h"
 
 #include "source/extensions/filters/network/ext_proc/client_impl.h"
+#include "source/extensions/filters/network/ext_proc/matching_utils.h"
 
 #include "absl/container/flat_hash_set.h"
 
@@ -97,21 +98,12 @@ private:
 class Config {
 public:
   Config(const envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor& config,
-         Stats::Scope& scope)
-      : failure_mode_allow_(config.failure_mode_allow()),
-        processing_mode_(config.processing_mode()), grpc_service_(config.grpc_service()),
-        untyped_forwarding_namespaces_(
-            config.metadata_options().forwarding_namespaces().untyped().begin(),
-            config.metadata_options().forwarding_namespaces().untyped().end()),
-        typed_forwarding_namespaces_(
-            config.metadata_options().forwarding_namespaces().typed().begin(),
-            config.metadata_options().forwarding_namespaces().typed().end()),
-        untyped_receiving_namespaces_(
-            config.metadata_options().receiving_namespaces().untyped().begin(),
-            config.metadata_options().receiving_namespaces().untyped().end()),
-        stats_(generateStats(config.stat_prefix(), scope)),
-        message_timeout_(std::chrono::milliseconds(
-            PROTOBUF_GET_MS_OR_DEFAULT(config, message_timeout, DefaultMessageTimeoutMs))) {};
+         Stats::Scope& scope,
+         Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder,
+         const LocalInfo::LocalInfo* local_info, absl::Status& creation_status);
+
+  Config(const envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor& config,
+         Stats::Scope& scope);
 
   bool failureModeAllow() const { return failure_mode_allow_; }
 
@@ -137,6 +129,8 @@ public:
 
   const std::chrono::milliseconds& messageTimeout() const { return message_timeout_; }
 
+  const ExpressionManager& expressionManager() const { return expression_manager_; }
+
 private:
   static constexpr uint64_t DefaultMessageTimeoutMs = 200;
 
@@ -153,6 +147,7 @@ private:
   const absl::flat_hash_set<std::string> untyped_receiving_namespaces_;
   NetworkExtProcStats stats_;
   const std::chrono::milliseconds message_timeout_;
+  const ExpressionManager expression_manager_;
 };
 
 using ConfigConstSharedPtr = std::shared_ptr<const Config>;
@@ -254,6 +249,7 @@ private:
 
   void sendRequest(Envoy::Buffer::Instance& data, bool end_stream, bool is_read);
   void addDynamicMetadata(ProcessingRequest& req);
+  void addAttributes(ProcessingRequest& req);
 
   Envoy::Network::FilterStatus handleStreamError();
   void closeConnection(const std::string& reason, Network::ConnectionCloseType close_type);
@@ -280,6 +276,7 @@ private:
   NetworkExtProcLoggingInfo* logging_info_{nullptr};
 
   bool processing_complete_{false};
+  bool attributes_sent_{false};
 
   bool read_pending_{false};
   bool write_pending_{false};

--- a/source/extensions/filters/network/ext_proc/matching_utils.cc
+++ b/source/extensions/filters/network/ext_proc/matching_utils.cc
@@ -1,0 +1,101 @@
+#include "source/extensions/filters/network/ext_proc/matching_utils.h"
+
+#include <memory>
+#include <string>
+
+#if defined(USE_CEL_PARSER)
+#include "parser/parser.h"
+#endif
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ExtProc {
+
+absl::flat_hash_map<std::string, ExpressionManager::CelExpression>
+ExpressionManager::initExpressions(const Protobuf::RepeatedPtrField<std::string>& matchers,
+                                   absl::Status& creation_status) {
+  absl::flat_hash_map<std::string, ExpressionManager::CelExpression> expressions;
+#if defined(USE_CEL_PARSER)
+  for (const auto& matcher : matchers) {
+    if (!creation_status.ok()) {
+      return expressions;
+    }
+    if (expressions.contains(matcher)) {
+      continue;
+    }
+    const absl::StatusOr<cel::expr::ParsedExpr> parse_status =
+        google::api::expr::parser::Parse(matcher);
+    if (!parse_status.ok()) {
+      creation_status = absl::InvalidArgumentError("Unable to parse descriptor expression: " +
+                                                   parse_status.status().ToString());
+      return expressions;
+    }
+
+    const auto& parsed_expr = parse_status.value();
+    const cel::expr::Expr& cel_expr = parsed_expr.expr();
+    auto compiled_expression =
+        Extensions::Filters::Common::Expr::CompiledExpression::Create(builder_, cel_expr);
+    if (!compiled_expression.ok()) {
+      creation_status = absl::InvalidArgumentError(
+          absl::StrCat("failed to create an expression: ", compiled_expression.status().message()));
+      return expressions;
+    }
+    expressions.emplace(matcher, std::move(compiled_expression.value()));
+  }
+#else
+  ENVOY_LOG(warn, "CEL expression parsing is not available for use in this environment."
+                  " Attempted to parse " +
+                      std::to_string(matchers.size()) + " expressions");
+#endif
+  return expressions;
+}
+
+Protobuf::Struct
+ExpressionManager::evaluateAttributes(const Filters::Common::Expr::Activation& activation,
+                                      const absl::flat_hash_map<std::string, CelExpression>& expr) {
+  Protobuf::Struct proto;
+
+  if (expr.empty()) {
+    return proto;
+  }
+
+  for (const auto& hash_entry : expr) {
+    Protobuf::Arena arena;
+    const absl::StatusOr<google::api::expr::runtime::CelValue>& result =
+        hash_entry.second.evaluate(activation, &arena);
+    if (!result.ok()) {
+      continue;
+    }
+
+    if (result.value().IsError()) {
+      ENVOY_LOG(trace, "error evaluating cel expression {}", hash_entry.first);
+      continue;
+    }
+
+    Protobuf::Value value;
+    switch (result.value().type()) {
+    case google::api::expr::runtime::CelValue::Type::kBool:
+      value.set_bool_value(result.value().BoolOrDie());
+      break;
+    case google::api::expr::runtime::CelValue::Type::kInt64:
+      value.set_number_value(result.value().Int64OrDie());
+      break;
+    case google::api::expr::runtime::CelValue::Type::kUint64:
+      value.set_number_value(result.value().Uint64OrDie());
+      break;
+    default:
+      value.set_string_value(Filters::Common::Expr::print(result.value()));
+    }
+
+    auto proto_mut_fields = proto.mutable_fields();
+    (*proto_mut_fields)[hash_entry.first] = value;
+  }
+
+  return proto;
+}
+
+} // namespace ExtProc
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/ext_proc/matching_utils.h
+++ b/source/extensions/filters/network/ext_proc/matching_utils.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "envoy/local_info/local_info.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/common/expr/evaluator.h"
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "cel/expr/syntax.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ExtProc {
+
+class ExpressionManager : public Logger::Loggable<Logger::Id::ext_proc> {
+  friend class ExpressionManagerTestAccessor;
+
+public:
+  using CelExpression = Filters::Common::Expr::CompiledExpression;
+
+  ExpressionManager(Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder,
+                    const LocalInfo::LocalInfo* local_info,
+                    const Protobuf::RepeatedPtrField<std::string>& connection_attributes,
+                    absl::Status& creation_status)
+      : builder_(builder), local_info_(local_info),
+        connection_expr_(initExpressions(connection_attributes, creation_status)) {}
+
+  bool hasConnectionExpr() const { return !connection_expr_.empty(); }
+
+  Protobuf::Struct
+  evaluateConnectionAttributes(const Filters::Common::Expr::Activation& activation) const {
+    return evaluateAttributes(activation, connection_expr_);
+  }
+
+  static Protobuf::Struct
+  evaluateAttributes(const Filters::Common::Expr::Activation& activation,
+                     const absl::flat_hash_map<std::string, CelExpression>& expr);
+
+  const LocalInfo::LocalInfo* localInfo() const { return local_info_; }
+
+private:
+  absl::flat_hash_map<std::string, CelExpression>
+  initExpressions(const Protobuf::RepeatedPtrField<std::string>& matchers,
+                  absl::Status& creation_status);
+
+  const Extensions::Filters::Common::Expr::BuilderInstanceSharedConstPtr builder_;
+  const LocalInfo::LocalInfo* local_info_{nullptr};
+  const absl::flat_hash_map<std::string, CelExpression> connection_expr_;
+};
+
+} // namespace ExtProc
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/network/ext_proc/BUILD
+++ b/test/extensions/filters/network/ext_proc/BUILD
@@ -19,11 +19,34 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "matching_utils_test",
+    srcs = ["matching_utils_test.cc"],
+    copts = select({
+        "//bazel:windows_x86_64": [],
+        "//conditions:default": [
+            "-DUSE_CEL_PARSER",
+        ],
+    }),
+    deps = [
+        "//source/common/protobuf",
+        "//source/extensions/filters/common/expr:evaluator_lib",
+        "//source/extensions/filters/network/ext_proc:matching_utils_lib",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "ext_proc_test",
     srcs = ["ext_proc_test.cc"],
     deps = [
+        "//source/common/router:string_accessor_lib",
+        "//source/extensions/filters/common/expr:cel_state_lib",
+        "//source/extensions/filters/common/expr:evaluator_lib",
         "//source/extensions/filters/network/ext_proc:ext_proc_lib",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/network/ext_proc/config_test.cc
+++ b/test/extensions/filters/network/ext_proc/config_test.cc
@@ -164,6 +164,47 @@ TEST(NetworkExtProcConfigFactoryTest, DefaultProcessingMode) {
   EXPECT_NO_THROW(auto cb = factory.createFilterFactoryFromProto(proto_config, context));
 }
 
+// Test config with valid connection_attributes.
+TEST(NetworkExtProcConfigTest, ConfigWithConnectionAttributes) {
+  const std::string yaml_string = R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  stat_prefix: "test_ext_proc"
+  connection_attributes:
+  - "connection.id"
+  - "filter_state['authority']"
+  )EOF";
+
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NetworkExtProcConfigFactory factory;
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(proto_config, context).value();
+  Network::MockFilterManager filter_manager;
+  EXPECT_CALL(filter_manager, addFilter(_));
+  cb(filter_manager);
+}
+
+// Test config with invalid CEL expression in connection_attributes.
+TEST(NetworkExtProcConfigTest, ConfigWithInvalidConnectionAttributes) {
+  const std::string yaml_string = R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  stat_prefix: "test_ext_proc"
+  connection_attributes:
+  - "invalid syntax && =="
+  )EOF";
+
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NetworkExtProcConfigFactory factory;
+  EXPECT_THROW_WITH_REGEX(auto cb = factory.createFilterFactoryFromProto(proto_config, context),
+                          EnvoyException, "Unable to parse descriptor expression");
+}
+
 } // namespace
 } // namespace ExtProc
 } // namespace NetworkFilters

--- a/test/extensions/filters/network/ext_proc/ext_proc_test.cc
+++ b/test/extensions/filters/network/ext_proc/ext_proc_test.cc
@@ -1,7 +1,10 @@
+#include "source/common/router/string_accessor_impl.h"
+#include "source/extensions/filters/common/expr/evaluator.h"
 #include "source/extensions/filters/network/ext_proc/ext_proc.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/utility.h"
@@ -1650,6 +1653,152 @@ TEST_F(NetworkExtProcFilterTest, ReceiveDynamicMetadataNotAllowed) {
   EXPECT_CALL(stream_info_, setDynamicMetadata("other-namespace", _)).Times(0);
 
   filter_->onReceiveMessage(std::move(response));
+}
+
+TEST_F(NetworkExtProcFilterTest, SendRequestWithConnectionAttributes) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor config;
+  config.set_failure_mode_allow(false);
+  config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");
+  config.add_connection_attributes("connection.mtls");
+  config.add_connection_attributes("connection.id");
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  auto builder = Filters::Common::Expr::getBuilder(server_context);
+  absl::Status creation_status = absl::OkStatus();
+  auto filter_config = std::make_shared<Config>(config, scope_, builder,
+                                                &server_context.local_info_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  auto client = std::make_unique<NiceMock<MockExternalProcessorClient>>();
+  client_ = client.get();
+  filter_ = std::make_unique<NetworkExtProcFilter>(filter_config, std::move(client));
+  filter_->initializeReadFilterCallbacks(read_callbacks_);
+  filter_->initializeWriteFilterCallbacks(write_callbacks_);
+
+  auto stream = std::make_unique<NiceMock<MockExternalProcessorStream>>();
+  auto* stream_ptr = stream.get();
+  EXPECT_CALL(*client_, start(_, _, _, _))
+      .WillOnce([&](ExternalProcessorCallbacks&, const Grpc::GrpcServiceConfigWithHashKey&,
+                    Http::AsyncClient::StreamOptions&,
+                    Http::StreamFilterSidestreamWatermarkCallbacks&) -> ExternalProcessorStreamPtr {
+        return std::move(stream);
+      });
+
+  stream_info_.downstream_connection_info_provider_->setConnectionID(12345);
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_CALL(*stream_ptr, send(_, false)).WillOnce([](ProcessingRequest&& req, bool) {
+    EXPECT_TRUE(req.has_read_data());
+    EXPECT_EQ("hello", req.read_data().data());
+    EXPECT_EQ(1, req.attributes().size());
+    auto proto_struct = req.attributes().at("envoy.filters.network.ext_proc");
+    EXPECT_EQ(proto_struct.fields().at("connection.mtls").bool_value(), false);
+    EXPECT_EQ(proto_struct.fields().at("connection.id").number_value(), 12345);
+  });
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+}
+
+TEST_F(NetworkExtProcFilterTest, SendRequestWithFilterStateStringAccessor) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor config;
+  config.set_failure_mode_allow(false);
+  config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");
+  config.add_connection_attributes("filter_state['authority']");
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  auto builder = Filters::Common::Expr::getBuilder(server_context);
+  absl::Status creation_status = absl::OkStatus();
+  auto filter_config = std::make_shared<Config>(config, scope_, builder,
+                                                &server_context.local_info_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  auto client = std::make_unique<NiceMock<MockExternalProcessorClient>>();
+  client_ = client.get();
+  filter_ = std::make_unique<NetworkExtProcFilter>(filter_config, std::move(client));
+  filter_->initializeReadFilterCallbacks(read_callbacks_);
+  filter_->initializeWriteFilterCallbacks(write_callbacks_);
+
+  stream_info_.filter_state_->setData(
+      "authority", std::make_shared<Router::StringAccessorImpl>("example.com:443"),
+      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto stream = std::make_unique<NiceMock<MockExternalProcessorStream>>();
+  auto* stream_ptr = stream.get();
+  EXPECT_CALL(*client_, start(_, _, _, _))
+      .WillOnce([&](ExternalProcessorCallbacks&, const Grpc::GrpcServiceConfigWithHashKey&,
+                    Http::AsyncClient::StreamOptions&,
+                    Http::StreamFilterSidestreamWatermarkCallbacks&) -> ExternalProcessorStreamPtr {
+        return std::move(stream);
+      });
+
+  Buffer::OwnedImpl data("payload");
+  EXPECT_CALL(*stream_ptr, send(_, false)).WillOnce([](ProcessingRequest&& req, bool) {
+    EXPECT_TRUE(req.has_read_data());
+    EXPECT_EQ(1, req.attributes().size());
+    auto proto_struct = req.attributes().at("envoy.filters.network.ext_proc");
+    EXPECT_EQ(proto_struct.fields().at("filter_state['authority']").string_value(),
+              "example.com:443");
+  });
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+}
+
+TEST_F(NetworkExtProcFilterTest, ConnectionAttributesSentOnlyOnce) {
+  envoy::extensions::filters::network::ext_proc::v3::NetworkExternalProcessor config;
+  config.set_failure_mode_allow(false);
+  config.mutable_grpc_service()->mutable_envoy_grpc()->set_cluster_name("ext_proc_server");
+  config.add_connection_attributes("filter_state['authority']");
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  auto builder = Filters::Common::Expr::getBuilder(server_context);
+  absl::Status creation_status = absl::OkStatus();
+  auto filter_config = std::make_shared<Config>(config, scope_, builder,
+                                                &server_context.local_info_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  auto client = std::make_unique<NiceMock<MockExternalProcessorClient>>();
+  client_ = client.get();
+  filter_ = std::make_unique<NetworkExtProcFilter>(filter_config, std::move(client));
+  filter_->initializeReadFilterCallbacks(read_callbacks_);
+  filter_->initializeWriteFilterCallbacks(write_callbacks_);
+
+  stream_info_.filter_state_->setData("authority",
+                                      std::make_shared<Router::StringAccessorImpl>("foo.bar.com"),
+                                      StreamInfo::FilterState::LifeSpan::Connection);
+
+  auto stream = std::make_unique<NiceMock<MockExternalProcessorStream>>();
+  auto* stream_ptr = stream.get();
+  EXPECT_CALL(*client_, start(_, _, _, _))
+      .WillOnce([&](ExternalProcessorCallbacks&, const Grpc::GrpcServiceConfigWithHashKey&,
+                    Http::AsyncClient::StreamOptions&,
+                    Http::StreamFilterSidestreamWatermarkCallbacks&) -> ExternalProcessorStreamPtr {
+        return std::move(stream);
+      });
+
+  Buffer::OwnedImpl data1("chunk1");
+  EXPECT_CALL(*stream_ptr, send(_, false)).WillOnce([](ProcessingRequest&& req, bool) {
+    EXPECT_EQ(1, req.attributes().size());
+    auto proto_struct = req.attributes().at("envoy.filters.network.ext_proc");
+    EXPECT_EQ(proto_struct.fields().at("filter_state['authority']").string_value(), "foo.bar.com");
+  });
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data1, false));
+
+  // Receive response for first chunk to resume iteration
+  auto response = std::make_unique<envoy::service::network_ext_proc::v3::ProcessingResponse>();
+  response->mutable_read_data()->set_data("chunk1");
+  response->set_data_processing_status(
+      envoy::service::network_ext_proc::v3::ProcessingResponse::UNMODIFIED);
+  filter_->onReceiveMessage(std::move(response));
+
+  // Send second chunk
+  Buffer::OwnedImpl data2("chunk2");
+  EXPECT_CALL(*stream_ptr, send(_, false)).WillOnce([](ProcessingRequest&& req, bool) {
+    // Attributes should NOT be present on subsequent requests
+    EXPECT_EQ(0, req.attributes().size());
+  });
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data2, false));
 }
 
 } // namespace

--- a/test/extensions/filters/network/ext_proc/matching_utils_test.cc
+++ b/test/extensions/filters/network/ext_proc/matching_utils_test.cc
@@ -1,0 +1,109 @@
+#include "source/common/protobuf/protobuf.h"
+#include "source/extensions/filters/common/expr/evaluator.h"
+#include "source/extensions/filters/network/ext_proc/matching_utils.h"
+
+#include "test/mocks/server/server_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace ExtProc {
+namespace {
+
+#ifdef USE_CEL_PARSER
+
+class ExpressionManagerTest : public testing::Test {
+protected:
+  ExpressionManagerTest() {
+    auto builder = Filters::Common::Expr::getBuilder(context_);
+    Protobuf::RepeatedPtrField<std::string> connection_matchers;
+    absl::Status creation_status = absl::OkStatus();
+    expression_manager_ = std::make_unique<ExpressionManager>(builder, &context_.local_info_,
+                                                              connection_matchers, creation_status);
+    EXPECT_TRUE(creation_status.ok());
+  }
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  std::unique_ptr<ExpressionManager> expression_manager_;
+};
+
+TEST_F(ExpressionManagerTest, SimpleExpression) {
+  EXPECT_FALSE(expression_manager_->hasConnectionExpr());
+}
+
+TEST_F(ExpressionManagerTest, InvalidExpression) {
+  Protobuf::RepeatedPtrField<std::string> connection_matchers;
+  connection_matchers.Add("undefined_func()");
+  auto builder = Filters::Common::Expr::getBuilder(context_);
+  absl::Status creation_status = absl::OkStatus();
+  ExpressionManager test_manager(builder, &context_.local_info_, connection_matchers,
+                                 creation_status);
+  EXPECT_FALSE(creation_status.ok());
+}
+
+TEST_F(ExpressionManagerTest, RepeatedMatchers) {
+  Protobuf::RepeatedPtrField<std::string> connection_matchers;
+  connection_matchers.Add("true");
+  connection_matchers.Add("true");
+  auto builder = Filters::Common::Expr::getBuilder(context_);
+  absl::Status creation_status = absl::OkStatus();
+  ExpressionManager test_manager(builder, &context_.local_info_, connection_matchers,
+                                 creation_status);
+  ASSERT_TRUE(creation_status.ok());
+  EXPECT_TRUE(test_manager.hasConnectionExpr());
+}
+
+TEST_F(ExpressionManagerTest, EvaluateAttributesEmpty) {
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  auto activation = Filters::Common::Expr::createActivation(&context_.local_info_, stream_info,
+                                                            nullptr, nullptr, nullptr);
+  auto result = ExpressionManager::evaluateAttributes(*activation, {});
+  EXPECT_TRUE(result.fields().empty());
+}
+
+TEST_F(ExpressionManagerTest, EvaluateAttributesValues) {
+  Protobuf::RepeatedPtrField<std::string> connection_matchers;
+  connection_matchers.Add("connection.mtls");
+  connection_matchers.Add("connection.id");
+  auto builder = Filters::Common::Expr::getBuilder(context_);
+  absl::Status creation_status = absl::OkStatus();
+  ExpressionManager test_manager(builder, &context_.local_info_, connection_matchers,
+                                 creation_status);
+  ASSERT_TRUE(creation_status.ok());
+  EXPECT_TRUE(test_manager.hasConnectionExpr());
+
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.downstream_connection_info_provider_->setConnectionID(12345);
+  auto activation = Filters::Common::Expr::createActivation(&context_.local_info_, stream_info,
+                                                            nullptr, nullptr, nullptr);
+  auto result = test_manager.evaluateConnectionAttributes(*activation);
+  EXPECT_EQ(result.fields().at("connection.mtls").bool_value(), false);
+  EXPECT_EQ(result.fields().at("connection.id").number_value(), 12345);
+}
+
+#else
+
+TEST(ExpressionManagerTest, CelUnavailableTest) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  auto builder = Filters::Common::Expr::getBuilder(context);
+  Protobuf::RepeatedPtrField<std::string> connection_matchers;
+  connection_matchers.Add("true");
+
+  // When CEL is not available, this should log a warning but not throw
+  absl::Status creation_status = absl::OkStatus();
+  ExpressionManager manager(builder, &context.local_info_, connection_matchers, creation_status);
+  EXPECT_FALSE(manager.hasConnectionExpr());
+}
+
+#endif // USE_CEL_PARSER
+
+} // namespace
+} // namespace ExtProc
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Add connection_attributes CEL expression evaluation to the Network External Processor filter, allowing connection attributes and filter state (e.g. filter_state['...'], connection.id, connection.mtls) to be evaluated and sent to the external processor in ProcessingRequest.attributes.

Commit Message:
Additional Description:
Risk Level: low
Testing: 
Docs Changes:
Release Notes:
